### PR TITLE
fix: prevent reviewer from asking for files

### DIFF
--- a/IntelligenceX.Reviewer/Templates/ReviewPrompt.Long.md
+++ b/IntelligenceX.Reviewer/Templates/ReviewPrompt.Long.md
@@ -1,5 +1,6 @@
 You are a senior software engineer performing a code review for a GitHub pull request.
 Focus on correctness, security, performance, and maintainability.
+Assume you have full access to the repository and PR context. Do not ask the author to provide files or code.
 
 {{ProfileBlock}}{{StrictnessBlock}}{{StyleBlock}}{{ToneBlock}}{{FocusBlock}}{{PersonaBlock}}{{NotesBlock}}{{SeverityBlock}}Review length: {{Length}}
 Review mode: {{Mode}}

--- a/IntelligenceX.Reviewer/Templates/ReviewPrompt.Medium.md
+++ b/IntelligenceX.Reviewer/Templates/ReviewPrompt.Medium.md
@@ -1,5 +1,6 @@
 You are a senior software engineer performing a code review for a GitHub pull request.
 Focus on correctness, security, performance, and maintainability.
+Assume you have full access to the repository and PR context. Do not ask the author to provide files or code.
 
 {{ProfileBlock}}{{StrictnessBlock}}{{StyleBlock}}{{ToneBlock}}{{FocusBlock}}{{PersonaBlock}}{{NotesBlock}}{{SeverityBlock}}Review length: {{Length}}
 Review mode: {{Mode}}

--- a/IntelligenceX.Reviewer/Templates/ReviewPrompt.Short.md
+++ b/IntelligenceX.Reviewer/Templates/ReviewPrompt.Short.md
@@ -1,4 +1,5 @@
 You are reviewing a pull request. Be concise and focus on correctness, security, and maintainability.
+Assume you have full access to the repository and PR context. Do not ask the author to provide files or code.
 
 {{ProfileBlock}}{{StrictnessBlock}}{{StyleBlock}}{{ToneBlock}}{{FocusBlock}}{{PersonaBlock}}{{NotesBlock}}{{SeverityBlock}}Review length: {{Length}}
 Review mode: {{Mode}}


### PR DESCRIPTION
Add explicit prompt instruction that reviewer has full repo context and should not ask for files.