### PR TITLE
Docs: add .NET library quickstart

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -19,6 +19,7 @@ Use the docs by area so the library, reviewer, CLI, and PowerShell guidance stay
 
 ## .NET library
 - Overview + examples: `library/overview.md`
+- Quickstart: `library/quickstart.md`
 - Providers: `library/providers.md`
 
 ## PowerShell module

--- a/Docs/library/overview.md
+++ b/Docs/library/overview.md
@@ -2,6 +2,7 @@
 
 The core library provides a Codex app-server client, ChatGPT auth helpers, and a lightweight Copilot client.
 
+Quickstart: `./quickstart.md`  
 Providers: `./providers.md`
 
 ## Quick start (app-server)

--- a/Docs/library/quickstart.md
+++ b/Docs/library/quickstart.md
@@ -1,0 +1,46 @@
+# .NET Library Quickstart
+
+## Native ChatGPT (OAuth)
+
+```csharp
+using IntelligenceX.OpenAI;
+
+await using var client = await IntelligenceXClient.ConnectAsync(new IntelligenceXClientOptions {
+    TransportKind = OpenAITransportKind.Native
+});
+
+await client.LoginChatGptAndWaitAsync(url => Console.WriteLine(url));
+var turn = await client.ChatAsync("Summarize this PR.");
+Console.WriteLine(turn.Outputs.Count);
+```
+
+## App-server (Codex)
+
+```csharp
+using IntelligenceX.OpenAI.AppServer;
+
+await using var client = await AppServerClient.StartAsync(new AppServerOptions {
+    ExecutablePath = "codex",
+    Arguments = "app-server"
+});
+
+await client.InitializeAsync(new ClientInfo("IntelligenceX", "Demo", "0.1.0"));
+var login = await client.StartChatGptLoginAsync();
+Console.WriteLine(login.AuthUrl);
+await client.WaitForLoginCompletionAsync(login.LoginId);
+
+var thread = await client.StartThreadAsync("gpt-5.2-codex");
+await client.StartTurnAsync(thread.Id, "Hello from IntelligenceX");
+```
+
+## Usage & credits
+
+```csharp
+using IntelligenceX.OpenAI.Native;
+using IntelligenceX.OpenAI.Usage;
+
+using var usage = new ChatGptUsageService(new OpenAINativeOptions());
+var report = await usage.GetReportAsync(includeEvents: true);
+Console.WriteLine(report.Snapshot.RateLimit?.PrimaryWindow?.UsedPercent);
+Console.WriteLine(report.Snapshot.Credits?.Balance);
+```


### PR DESCRIPTION
Adds a dedicated library quickstart page and links it from the docs index and library overview.