### PR TITLE
fix: tool definitions determinism

### DIFF
--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -44,6 +44,8 @@ internal static class Program {
         failed += Run("Tool call parsing", TestToolCallParsing);
         failed += Run("Tool call invalid JSON", TestToolCallParsingInvalidJson);
         failed += Run("Tool output input", TestToolOutputInput);
+        failed += Run("Turn response_id parsing", TestTurnResponseIdParsing);
+        failed += Run("Tool definitions ordered", TestToolDefinitionOrdering);
 #if !NET472
         failed += Run("Setup args reject skip+update", TestSetupArgsRejectSkipUpdate);
         failed += Run("GitHub secrets reject empty value", TestGitHubSecretsRejectEmptyValue);
@@ -168,6 +170,27 @@ internal static class Program {
         AssertEqual("custom_tool_call_output", item!.GetString("type"), "tool output type");
         AssertEqual("call_42", item.GetString("call_id"), "tool output call id");
         AssertEqual("ok", item.GetString("output"), "tool output value");
+    }
+
+    private static void TestTurnResponseIdParsing() {
+        var turn = TurnInfo.FromJson(new JsonObject()
+            .Add("id", "turn-response")
+            .Add("response_id", "resp_snake"));
+        AssertEqual("resp_snake", turn.ResponseId, "response_id");
+    }
+
+    private static void TestToolDefinitionOrdering() {
+        var registry = new ToolRegistry();
+        registry.Register(new TestTool("zeta"));
+        registry.Register(new TestTool("Alpha"));
+        registry.Register(new TestTool("beta"));
+
+        var names = new List<string>();
+        foreach (var definition in registry.GetDefinitions()) {
+            names.Add(definition.Name);
+        }
+
+        AssertSequenceEqual(new[] { "Alpha", "beta", "zeta" }, names, "tool definition order");
     }
 
     private static int Run(string name, Action test) {
@@ -1058,6 +1081,18 @@ internal static class Program {
     private static void AssertNotNull(object? value, string name) {
         if (value is null) {
             throw new InvalidOperationException($"Expected {name} to be non-null.");
+        }
+    }
+
+    private sealed class TestTool : ITool {
+        public TestTool(string name) {
+            Definition = new ToolDefinition(name, "test tool");
+        }
+
+        public ToolDefinition Definition { get; }
+
+        public Task<string> InvokeAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+            return Task.FromResult(string.Empty);
         }
     }
 

--- a/IntelligenceX/Providers/OpenAI/AppServer/Models/TurnInfo.cs
+++ b/IntelligenceX/Providers/OpenAI/AppServer/Models/TurnInfo.cs
@@ -67,11 +67,12 @@ public sealed class TurnInfo {
         var id = turnObj.GetString("id") ?? string.Empty;
         var status = turnObj.GetString("status");
         var responseId = turnObj.GetString("responseId")
+                         ?? turnObj.GetString("response_id")
                          ?? turnObj.GetObject("response")?.GetString("id");
         var outputs = TurnOutput.FromTurn(turnObj);
         var images = TurnOutput.FilterImages(outputs);
         var additional = turnObj.ExtractAdditional(
-            "id", "status", "responseId", "output", "outputs", "response", "result");
+            "id", "status", "responseId", "response_id", "output", "outputs", "response", "result");
         return new TurnInfo(id, responseId, status, outputs, images, turnObj, additional);
     }
 }

--- a/IntelligenceX/Providers/OpenAI/Tools/ToolRegistry.cs
+++ b/IntelligenceX/Providers/OpenAI/Tools/ToolRegistry.cs
@@ -42,5 +42,8 @@ public sealed class ToolRegistry {
     /// Returns tool definitions for the registry.
     /// </summary>
     public IReadOnlyList<ToolDefinition> GetDefinitions()
-        => _tools.Values.Select(tool => tool.Definition).ToList();
+        => _tools.Values
+            .Select(tool => tool.Definition)
+            .OrderBy(definition => definition.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
 }


### PR DESCRIPTION
## Summary\n- parse snake_case response_id on turn payloads\n- return tool definitions in deterministic order\n- add tests for response_id parsing and tool ordering\n\n## Testing\n- dotnet build\n- dotnet run --project .\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0