### PR TITLE
feat: usage summary line

### DIFF
--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -943,6 +943,16 @@ public static class ReviewerApp {
             lines.Add(secondary);
         }
 
+        var codePrimary = FormatRateLimitLine(snapshot.CodeReviewRateLimit?.PrimaryWindow, "code review limit");
+        if (!string.IsNullOrWhiteSpace(codePrimary)) {
+            lines.Add(codePrimary);
+        }
+
+        var codeSecondary = FormatRateLimitLine(snapshot.CodeReviewRateLimit?.SecondaryWindow, "code review limit (secondary)");
+        if (!string.IsNullOrWhiteSpace(codeSecondary)) {
+            lines.Add(codeSecondary);
+        }
+
         if (snapshot.Credits is not null) {
             if (snapshot.Credits.Unlimited) {
                 lines.Add("credits: unlimited");
@@ -956,13 +966,7 @@ public static class ReviewerApp {
         if (lines.Count == 0) {
             return string.Empty;
         }
-
-        var sb = new StringBuilder();
-        sb.AppendLine("Usage:");
-        foreach (var line in lines) {
-            sb.AppendLine($"- {line}");
-        }
-        return sb.ToString().TrimEnd();
+        return "Usage: " + string.Join(" | ", lines);
     }
 
     private static string? FormatRateLimitLine(ChatGptRateLimitWindow? window, string fallbackLabel) {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -93,6 +93,7 @@ internal static class Program {
         failed += Run("Context deny invalid regex", TestContextDenyInvalidRegex);
         failed += Run("Context deny timeout", TestContextDenyTimeout);
         failed += Run("Review summary parser", TestReviewSummaryParser);
+        failed += Run("Review usage summary line", TestReviewUsageSummaryLine);
 #endif
 
         Console.WriteLine(failed == 0 ? "All tests passed." : $"{failed} test(s) failed.");
@@ -801,6 +802,15 @@ internal static class Program {
         return result ?? string.Empty;
     }
 
+    private static string CallFormatUsageSummary(ChatGptUsageSnapshot snapshot) {
+        var method = typeof(ReviewerApp).GetMethod("FormatUsageSummary", BindingFlags.NonPublic | BindingFlags.Static);
+        if (method is null) {
+            throw new InvalidOperationException("FormatUsageSummary method not found.");
+        }
+        var result = method.Invoke(null, new object?[] { snapshot }) as string;
+        return result ?? string.Empty;
+    }
+
     private static ReviewContextExtras CallBuildExtrasAsync(GitHubClient github, PullRequestContext context,
         ReviewSettings settings, bool forceReviewThreads) {
         var method = typeof(ReviewerApp).GetMethod("BuildExtrasAsync", BindingFlags.NonPublic | BindingFlags.Static);
@@ -1115,6 +1125,24 @@ internal static class Program {
         AssertEqual(true, ok, "malformed then valid");
         AssertEqual("deadbeef", commit, "malformed then valid commit");
     }
+
+    private static void TestReviewUsageSummaryLine() {
+        const string json = "{"
+            + "\"plan_type\":\"pro\","
+            + "\"rate_limit\":{\"allowed\":true,\"limit_reached\":false,"
+            + "\"primary_window\":{\"used_percent\":12.5,\"limit_window_seconds\":18000,\"reset_after_seconds\":120}},"
+            + "\"code_review_rate_limit\":{\"allowed\":true,\"limit_reached\":false,"
+            + "\"primary_window\":{\"used_percent\":25.0,\"limit_window_seconds\":18000,\"reset_after_seconds\":120}},"
+            + "\"credits\":{\"has_credits\":true,\"unlimited\":false,\"balance\":4.52}"
+            + "}";
+        var obj = JsonLite.Parse(json).AsObject();
+        AssertNotNull(obj, "usage summary json");
+        var snapshot = ChatGptUsageSnapshot.FromJson(obj!);
+        var line = CallFormatUsageSummary(snapshot);
+        AssertContainsText(line, "Usage:", "usage summary prefix");
+        AssertContainsText(line, "5h limit", "usage window label");
+        AssertEqual(false, line.IndexOf("\n", StringComparison.Ordinal) >= 0, "usage summary is single line");
+    }
 #endif
 
     private static void AssertEqual<T>(T expected, T? actual, string name) {
@@ -1142,6 +1170,12 @@ internal static class Program {
             }
         }
         throw new InvalidOperationException($"Expected {name} to contain '{expected}'.");
+    }
+
+    private static void AssertContainsText(string value, string expected, string name) {
+        if (string.IsNullOrWhiteSpace(value) || value.IndexOf(expected, StringComparison.Ordinal) < 0) {
+            throw new InvalidOperationException($"Expected {name} to contain '{expected}'.");
+        }
     }
 
     private static void AssertNotNull(object? value, string name) {

--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,7 @@ Status: Draft (needs priorities + owners)
 
 ### Phase 3 — Review output + UX
 - [x] Add optional "reasoning level" label in header (low/medium/high) when provider supports it.
-- [ ] Add optional usage/limits line near model header (opt-in; ChatGPT auth).
+ - [x] Add optional usage/limits line near model header (opt-in; ChatGPT auth).
 - [x] Add structured findings schema for bots/automation (severity + file + line).
 - [x] Add summary stability (avoid noisy rewording across reruns).
 - [x] Add “triage mode” that only checks open threads.


### PR DESCRIPTION
## Summary\n- render ChatGPT usage/limits as a single line for the review header\n- include code review rate limits when available\n- add test for usage summary line formatting\n- mark usage/limits TODO complete\n\n## Testing\n- dotnet build\n- dotnet run --project .\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0