### PR TITLE
fix: sanitize Azure DevOps error payloads

### DIFF
--- a/IntelligenceX.Reviewer/AzureDevOpsClient.cs
+++ b/IntelligenceX.Reviewer/AzureDevOpsClient.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Json;
@@ -19,6 +20,11 @@ internal sealed class AzureDevOpsClient : IDisposable {
     private const int RootCommentId = 0;
     private const int CommentTypeText = 1;
     private const int ThreadStatusActive = 1;
+    private static readonly Regex SensitiveTokenPattern =
+        new Regex("(?i)(authorization|token|pat)\\s*[:=]\\s*(?:bearer\\s+|basic\\s+)?[^\\s,;]+",
+            RegexOptions.Compiled);
+    private static readonly Regex SensitiveSchemePattern =
+        new Regex("(?i)\\b(bearer|basic)\\s+[^\\s,;]+", RegexOptions.Compiled);
     private readonly HttpClient _http;
 
     /// <summary>
@@ -173,7 +179,7 @@ internal sealed class AzureDevOpsClient : IDisposable {
         using var response = await _http.GetAsync(url, cancellationToken).ConfigureAwait(false);
         var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode) {
-            throw new InvalidOperationException($"Azure DevOps API request failed ({(int)response.StatusCode}): {content}");
+            throw new InvalidOperationException($"Azure DevOps API request failed ({(int)response.StatusCode}): {SanitizeErrorContent(content)}");
         }
         return JsonLite.Parse(content) ?? JsonValue.Null;
     }
@@ -183,7 +189,7 @@ internal sealed class AzureDevOpsClient : IDisposable {
         using var response = await _http.GetAsync(url, cancellationToken).ConfigureAwait(false);
         var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode) {
-            throw new InvalidOperationException($"Azure DevOps API request failed ({(int)response.StatusCode}): {content}");
+            throw new InvalidOperationException($"Azure DevOps API request failed ({(int)response.StatusCode}): {SanitizeErrorContent(content)}");
         }
 
         var token = TryGetContinuationToken(response);
@@ -207,7 +213,7 @@ internal sealed class AzureDevOpsClient : IDisposable {
         using var response = await _http.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
         var responseText = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode) {
-            throw new InvalidOperationException($"Azure DevOps API request failed ({(int)response.StatusCode}): {responseText}");
+            throw new InvalidOperationException($"Azure DevOps API request failed ({(int)response.StatusCode}): {SanitizeErrorContent(responseText)}");
         }
         return JsonLite.Parse(responseText) ?? JsonValue.Null;
     }
@@ -218,6 +224,55 @@ internal sealed class AzureDevOpsClient : IDisposable {
     }
 
     private static string Escape(string value) => Uri.EscapeDataString(value ?? string.Empty);
+
+    private static string SanitizeErrorContent(string? content) {
+        if (string.IsNullOrWhiteSpace(content)) {
+            return "empty response";
+        }
+
+        var text = content.Trim();
+        if (TryExtractJsonMessage(text, out var message)) {
+            text = message;
+        }
+
+        text = text.Replace("\r", " ").Replace("\n", " ").Trim();
+        text = SensitiveTokenPattern.Replace(text, "$1: ***");
+        text = SensitiveSchemePattern.Replace(text, "$1 ***");
+
+        const int maxLength = 400;
+        if (text.Length > maxLength) {
+            text = text.Substring(0, maxLength) + "...";
+        }
+
+        return text;
+    }
+
+    private static bool TryExtractJsonMessage(string text, out string message) {
+        message = string.Empty;
+        JsonValue? value;
+        try {
+            value = JsonLite.Parse(text);
+        } catch {
+            return false;
+        }
+
+        var obj = value?.AsObject();
+        if (obj is null) {
+            return false;
+        }
+
+        var result = obj.GetString("message")
+                     ?? obj.GetString("Message")
+                     ?? obj.GetString("errorMessage")
+                     ?? obj.GetString("error");
+
+        if (string.IsNullOrWhiteSpace(result)) {
+            return false;
+        }
+
+        message = result.Trim();
+        return true;
+    }
 }
 
 internal sealed record AzureDevOpsPullRequest(int PullRequestId, string Title, string? Description, bool IsDraft,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -96,6 +96,7 @@ internal static class Program {
         failed += Run("Prompt language hints disabled", TestPromptBuilderLanguageHintsDisabled);
         failed += Run("Azure DevOps changes pagination", TestAzureDevOpsChangesPagination);
         failed += Run("Azure DevOps diff note zero iterations", TestAzureDevOpsDiffNoteZeroIterations);
+        failed += Run("Azure DevOps error sanitization", TestAzureDevOpsErrorSanitization);
         failed += Run("Context deny invalid regex", TestContextDenyInvalidRegex);
         failed += Run("Context deny timeout", TestContextDenyTimeout);
         failed += Run("Review summary parser", TestReviewSummaryParser);
@@ -1180,6 +1181,15 @@ internal static class Program {
         AssertEqual("pull request changes", note, "ado diff note zero");
     }
 
+    private static void TestAzureDevOpsErrorSanitization() {
+        var errorJson = "{\"message\":\"Authorization: Bearer abc123\"}";
+        var sanitized = CallAzureDevOpsSanitize(errorJson);
+        AssertContainsText(sanitized, "***", "sanitized token");
+        if (sanitized.Contains("abc123", StringComparison.OrdinalIgnoreCase)) {
+            throw new InvalidOperationException("Expected token value to be redacted.");
+        }
+    }
+
     private static PullRequestFile[] BuildFiles(params string[] paths) {
         var files = new PullRequestFile[paths.Length];
         for (var i = 0; i < paths.Length; i++) {
@@ -1191,6 +1201,15 @@ internal static class Program {
     private static PullRequestContext BuildContext() {
         return new PullRequestContext("owner/repo", "owner", "repo", 1, "Test title", "Test body", false, "head", "base",
             Array.Empty<string>());
+    }
+
+    private static string CallAzureDevOpsSanitize(string content) {
+        var method = typeof(AzureDevOpsClient).GetMethod("SanitizeErrorContent", BindingFlags.NonPublic | BindingFlags.Static);
+        if (method is null) {
+            throw new InvalidOperationException("SanitizeErrorContent method not found.");
+        }
+        var result = method.Invoke(null, new object?[] { content }) as string;
+        return result ?? string.Empty;
     }
 
     private static IReadOnlyList<string> GetFilenames(IReadOnlyList<PullRequestFile> files) {

--- a/TODO.md
+++ b/TODO.md
@@ -76,7 +76,7 @@ Status: Draft (needs priorities + owners)
 
 ### Phase 7 — Security + trust
 - [ ] Redact sensitive data before prompt (secrets, tokens, private keys).
-- [ ] Sanitize Azure DevOps API error payloads in logs.
+- [x] Sanitize Azure DevOps API error payloads in logs.
 - [ ] Add "untrusted PR" guardrails (no secret access, no write actions).
 - [ ] Add workflow integrity check (block self-modifying workflow runs).
 - [ ] Add audit logging for secrets usage.


### PR DESCRIPTION
## Summary
- sanitize Azure DevOps error content before logging/throwing
- add tests for sanitization behavior
- mark TODO item done

## Testing
- dotnet build C:\\Support\\GitHub\\IntelligenceX-wt-ado-sanitize
- dotnet run --project C:\\Support\\GitHub\\IntelligenceX-wt-ado-sanitize\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0