### PR TITLE
feat: add review budget summary note

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -153,6 +153,16 @@ Use this to skip the main review and only assess existing review threads.
 }
 ```
 
+## Budget summary note
+
+```json
+{
+  "review": {
+    "reviewBudgetSummary": true
+  }
+}
+```
+
 ## Structured findings (automation)
 
 ```json
@@ -240,6 +250,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `outputStyle`: rendering style preset
 - `reviewUsageSummary`: append usage line to the footer (ChatGPT auth only)
 - `languageHints`: include language-aware hint block in the prompt
+- `reviewBudgetSummary`: include a note when review context is truncated
 - `retryCount`: total attempts for provider requests
 - `retryBackoffMultiplier`: exponential backoff multiplier (default 2.0)
 - `retryJitterMinMs`/`retryJitterMaxMs`: retry jitter bounds

--- a/IntelligenceX.Reviewer/AzureDevOpsReviewRunner.cs
+++ b/IntelligenceX.Reviewer/AzureDevOpsReviewRunner.cs
@@ -62,7 +62,10 @@ internal static class AzureDevOpsReviewRunner {
             return 0;
         }
 
-        var limited = LimitFiles(filtered, settings.MaxFiles);
+        var (limited, budgetNote) = LimitFiles(filtered, settings.MaxFiles, settings.MaxPatchChars);
+        if (!settings.ReviewBudgetSummary) {
+            budgetNote = string.Empty;
+        }
         var context = new PullRequestContext($"{pr.Project}/{pr.RepositoryName}", pr.Project, pr.RepositoryName,
             pr.PullRequestId, pr.Title, pr.Description, pr.IsDraft, pr.SourceCommit, pr.TargetCommit, Array.Empty<string>());
         var diffNote = BuildDiffNote(iterationIds);
@@ -74,7 +77,7 @@ internal static class AzureDevOpsReviewRunner {
         var runner = new ReviewRunner(settings);
         var reviewBody = await runner.RunAsync(prompt, null, null, cancellationToken).ConfigureAwait(false);
         var commentBody = ReviewFormatter.BuildComment(context, reviewBody, settings, inlineSupported: false,
-            inlineSuppressed: false, autoResolveNote: string.Empty, usageLine: string.Empty, findingsBlock: string.Empty);
+            inlineSuppressed: false, autoResolveNote: string.Empty, budgetNote, usageLine: string.Empty, findingsBlock: string.Empty);
 
         await client.CreatePullRequestThreadAsync(project, repositoryId, pr.PullRequestId, commentBody, cancellationToken)
             .ConfigureAwait(false);
@@ -95,11 +98,14 @@ internal static class AzureDevOpsReviewRunner {
         return true;
     }
 
-    private static IReadOnlyList<PullRequestFile> LimitFiles(IReadOnlyList<PullRequestFile> files, int maxFiles) {
+    private static (IReadOnlyList<PullRequestFile> Files, string BudgetNote) LimitFiles(IReadOnlyList<PullRequestFile> files,
+        int maxFiles, int maxPatchChars) {
         if (maxFiles <= 0 || files.Count <= maxFiles) {
-            return files;
+            return (files, ReviewerApp.BuildBudgetNote(files.Count, files.Count, 0, maxPatchChars));
         }
-        return files.Take(maxFiles).ToList();
+        var limited = files.Take(maxFiles).ToList();
+        var note = ReviewerApp.BuildBudgetNote(files.Count, limited.Count, 0, maxPatchChars);
+        return (limited, note);
     }
 
     internal static string BuildDiffNote(IReadOnlyList<int> iterationIds) {

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -181,7 +181,10 @@ public static class ReviewerApp {
             var inlineSupported = !string.Equals(settings.Mode, "summary", StringComparison.OrdinalIgnoreCase) &&
                                   settings.MaxInlineComments > 0 &&
                                   !string.IsNullOrWhiteSpace(context.HeadSha);
-            var limitedFiles = PrepareFiles(files, settings.MaxFiles, settings.MaxPatchChars);
+            var (limitedFiles, budgetNote) = PrepareFiles(files, settings.MaxFiles, settings.MaxPatchChars);
+            if (!settings.ReviewBudgetSummary) {
+                budgetNote = string.Empty;
+            }
             var prompt = PromptBuilder.Build(context, limitedFiles, settings, diffNote, extras, inlineSupported, previousSummary);
             if (settings.RedactPii) {
                 prompt = Redaction.Apply(prompt, settings.RedactionPatterns, settings.RedactionReplacement);
@@ -249,7 +252,7 @@ public static class ReviewerApp {
             var usageLine = await TryBuildUsageLineAsync(settings).ConfigureAwait(false);
             var findingsBlock = settings.StructuredFindings ? ReviewFindingsBuilder.Build(inlineComments) : string.Empty;
             var commentBody = ReviewFormatter.BuildComment(context, summaryBody, settings, inlineSupported, inlineSuppressed,
-                autoResolveSummary, usageLine, findingsBlock);
+                autoResolveSummary, budgetNote, usageLine, findingsBlock);
             progress.Review = ReviewProgressState.Complete;
             progress.Finalize = ReviewProgressState.InProgress;
             progress.StatusLine = "Finalizing summary.";
@@ -441,8 +444,10 @@ public static class ReviewerApp {
         return allMatch;
     }
 
-    private static IReadOnlyList<PullRequestFile> PrepareFiles(IReadOnlyList<PullRequestFile> files, int maxFiles, int maxPatchChars) {
+    private static (IReadOnlyList<PullRequestFile> Files, string BudgetNote) PrepareFiles(IReadOnlyList<PullRequestFile> files,
+        int maxFiles, int maxPatchChars) {
         var list = new List<PullRequestFile>();
+        var truncatedPatches = 0;
         var count = 0;
         foreach (var file in files) {
             if (count >= maxFiles) {
@@ -450,12 +455,32 @@ public static class ReviewerApp {
             }
             var patch = file.Patch;
             if (!string.IsNullOrWhiteSpace(patch)) {
-                patch = TrimPatch(patch, maxPatchChars);
+                var trimmed = TrimPatch(patch, maxPatchChars);
+                if (!string.Equals(trimmed, patch, StringComparison.Ordinal)) {
+                    truncatedPatches++;
+                }
+                patch = trimmed;
             }
             list.Add(new PullRequestFile(file.Filename, file.Status, patch));
             count++;
         }
-        return list;
+        var budgetNote = BuildBudgetNote(files.Count, list.Count, truncatedPatches, maxPatchChars);
+        return (list, budgetNote);
+    }
+
+    internal static string BuildBudgetNote(int totalFiles, int includedFiles, int truncatedPatches, int maxPatchChars) {
+        var parts = new List<string>();
+        if (totalFiles > includedFiles) {
+            parts.Add($"showing first {includedFiles} of {totalFiles} files");
+        }
+        if (truncatedPatches > 0) {
+            var label = truncatedPatches == 1 ? "patch" : "patches";
+            parts.Add($"{truncatedPatches} {label} trimmed to {maxPatchChars} chars");
+        }
+        if (parts.Count == 0) {
+            return string.Empty;
+        }
+        return $"Review context truncated: {string.Join("; ", parts)}.";
     }
 
     /// <summary>

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -177,6 +177,7 @@ internal static class ReviewConfigLoader {
     private static void ApplyBooleans(JsonObject obj, ReviewSettings settings) {
         settings.IncludeNextSteps = ReadBool(obj, "includeNextSteps", settings.IncludeNextSteps);
         settings.IncludeLanguageHints = ReadBool(obj, "languageHints", settings.IncludeLanguageHints);
+        settings.ReviewBudgetSummary = ReadBool(obj, "reviewBudgetSummary", settings.ReviewBudgetSummary);
         settings.OverwriteSummary = ReadBool(obj, "overwriteSummary", settings.OverwriteSummary);
         settings.OverwriteSummaryOnNewCommit = ReadBool(obj, "overwriteSummaryOnNewCommit", settings.OverwriteSummaryOnNewCommit);
         settings.SummaryStability = ReadBool(obj, "summaryStability", settings.SummaryStability);

--- a/IntelligenceX.Reviewer/ReviewFormatter.cs
+++ b/IntelligenceX.Reviewer/ReviewFormatter.cs
@@ -12,7 +12,7 @@ internal static class ReviewFormatter {
     private const string ProgressTemplateName = "ReviewProgress.md";
 
     public static string BuildComment(PullRequestContext context, string reviewBody, ReviewSettings settings, bool inlineSupported,
-        bool inlineSuppressed, string? autoResolveNote, string? usageLine, string? findingsBlock) {
+        bool inlineSuppressed, string? autoResolveNote, string? budgetNote, string? usageLine, string? findingsBlock) {
         var inlineNote = string.Empty;
         if (!inlineSupported && settings.Mode != "summary") {
             inlineNote = "> Inline comments are not enabled yet; posting summary only.\n";
@@ -22,6 +22,9 @@ internal static class ReviewFormatter {
         var autoResolveLine = string.IsNullOrWhiteSpace(autoResolveNote)
             ? string.Empty
             : FormatBlockQuote(autoResolveNote);
+        var budgetLine = string.IsNullOrWhiteSpace(budgetNote)
+            ? string.Empty
+            : FormatBlockQuote(budgetNote);
 
         var body = string.IsNullOrWhiteSpace(reviewBody)
             ? "_No review content was produced._"
@@ -47,6 +50,7 @@ internal static class ReviewFormatter {
             ["ReasoningLabel"] = reasoningLabel,
             ["InlineNote"] = inlineNote,
             ["AutoResolveNote"] = autoResolveLine,
+            ["BudgetNote"] = budgetLine,
             ["ReviewBody"] = body,
             ["Model"] = settings.Model,
             ["Length"] = settings.Length.ToString().ToLowerInvariant(),

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -102,6 +102,9 @@ internal sealed class ReviewSettings {
     /// Adds a short language-aware hints block to the review prompt.
     /// </summary>
     public bool IncludeLanguageHints { get; set; } = true;
+    /// When enabled, include a summary note if review context was truncated by file or patch limits.
+    /// </summary>
+    public bool ReviewBudgetSummary { get; set; } = true;
     public string? PromptTemplate { get; set; }
     public string? PromptTemplatePath { get; set; }
     public string? SummaryTemplate { get; set; }
@@ -670,6 +673,10 @@ internal sealed class ReviewSettings {
         var languageHints = GetInput("language_hints", "REVIEW_LANGUAGE_HINTS");
         if (!string.IsNullOrWhiteSpace(languageHints)) {
             settings.IncludeLanguageHints = ParseBoolean(languageHints, settings.IncludeLanguageHints);
+        }
+        var budgetSummary = GetInput("review_budget_summary", "REVIEW_BUDGET_SUMMARY");
+        if (!string.IsNullOrWhiteSpace(budgetSummary)) {
+            settings.ReviewBudgetSummary = ParseBoolean(budgetSummary, settings.ReviewBudgetSummary);
         }
 
         var commentMode = GetInput("comment_mode", "REVIEW_COMMENT_MODE");

--- a/IntelligenceX.Reviewer/Templates/ReviewSummary.md
+++ b/IntelligenceX.Reviewer/Templates/ReviewSummary.md
@@ -6,6 +6,7 @@ Reviewing PR #{{Number}}: **{{Title}}**
 
 {{InlineNote}}
 {{AutoResolveNote}}
+{{BudgetNote}}
 {{ReviewBody}}
 
 _Model: {{Model}} | Length: {{Length}} | Mode: {{Mode}}{{ReasoningLine}}_

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -94,6 +94,9 @@ internal static class Program {
         failed += Run("Filter files empty filters", TestFilterFilesEmptyFilters);
         failed += Run("Prompt language hints", TestPromptBuilderLanguageHints);
         failed += Run("Prompt language hints disabled", TestPromptBuilderLanguageHintsDisabled);
+        failed += Run("Review budget note", TestReviewBudgetNote);
+        failed += Run("Review budget note empty", TestReviewBudgetNoteEmpty);
+        failed += Run("Review budget note comment", TestReviewBudgetNoteComment);
         failed += Run("Azure DevOps changes pagination", TestAzureDevOpsChangesPagination);
         failed += Run("Azure DevOps diff note zero iterations", TestAzureDevOpsDiffNoteZeroIterations);
         failed += Run("Context deny invalid regex", TestContextDenyInvalidRegex);
@@ -1142,6 +1145,27 @@ internal static class Program {
         if (prompt.Contains("Language hints:", StringComparison.OrdinalIgnoreCase)) {
             throw new InvalidOperationException("Expected language hints to be omitted.");
         }
+    }
+
+    private static void TestReviewBudgetNote() {
+        var note = ReviewerApp.BuildBudgetNote(10, 5, 2, 4000);
+        AssertContainsText(note, "first 5 of 10 files", "budget note files");
+        AssertContainsText(note, "2 patches trimmed to 4000 chars", "budget note patches");
+    }
+
+    private static void TestReviewBudgetNoteEmpty() {
+        var note = ReviewerApp.BuildBudgetNote(5, 5, 0, 4000);
+        AssertEqual(string.Empty, note, "budget note empty");
+    }
+
+    private static void TestReviewBudgetNoteComment() {
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Test title", "Test body", false, "head",
+            "base", Array.Empty<string>());
+        var settings = new ReviewSettings();
+        var comment = ReviewFormatter.BuildComment(context, "Body", settings, inlineSupported: false, inlineSuppressed: false,
+            autoResolveNote: string.Empty, budgetNote: "Review context truncated: showing first 1 of 2 files.",
+            usageLine: string.Empty, findingsBlock: string.Empty);
+        AssertContainsText(comment, "Review context truncated", "budget note comment");
     }
 
     private static void TestAzureDevOpsChangesPagination() {

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -27,6 +27,7 @@
         "reasoningSummary": { "type": "string", "enum": ["auto", "concise", "detailed", "off"] },
         "reviewUsageSummary": { "type": "boolean" },
         "languageHints": { "type": "boolean" },
+        "reviewBudgetSummary": { "type": "boolean" },
         "reviewUsageSummaryCacheMinutes": { "type": "integer", "minimum": 0 },
         "reviewUsageSummaryTimeoutSeconds": { "type": "integer", "minimum": 1 },
         "structuredFindings": { "type": "boolean" },

--- a/TODO.md
+++ b/TODO.md
@@ -72,7 +72,7 @@ Status: Draft (needs priorities + owners)
 - [ ] Add concurrency controls to avoid API throttling.
 - [ ] Consider shared HttpClient/IHttpClientFactory for Azure DevOps client.
 - [ ] Add token budgeting per file/group with hard caps.
-- [ ] Add optional "budget exceeded" summary behavior.
+- [x] Add optional "budget exceeded" summary behavior.
 
 ### Phase 7 — Security + trust
 - [ ] Redact sensitive data before prompt (secrets, tokens, private keys).


### PR DESCRIPTION
## Summary
- add budget summary note when file or patch limits truncate review context
- wire config/env/schema/docs for reviewBudgetSummary
- add tests for budget note output

## Testing
- dotnet build C:\\Support\\GitHub\\IntelligenceX-wt-budget-note
- dotnet run --project C:\\Support\\GitHub\\IntelligenceX-wt-budget-note\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0