### PR TITLE
feat: cache GitHub review context

### DIFF
--- a/IntelligenceX.Reviewer/GitHubClient.cs
+++ b/IntelligenceX.Reviewer/GitHubClient.cs
@@ -12,6 +12,9 @@ namespace IntelligenceX.Reviewer;
 
 internal sealed class GitHubClient : IDisposable {
     private readonly HttpClient _http;
+    private readonly Dictionary<string, PullRequestContext> _pullRequestCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, IReadOnlyList<PullRequestFile>> _pullRequestFilesCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, IReadOnlyList<PullRequestFile>> _compareFilesCache = new(StringComparer.OrdinalIgnoreCase);
 
     public GitHubClient(string token, string? baseUrl = null) {
         _http = new HttpClient {
@@ -25,6 +28,10 @@ internal sealed class GitHubClient : IDisposable {
 
     public async Task<IReadOnlyList<PullRequestFile>> GetPullRequestFilesAsync(string owner, string repo, int number,
         CancellationToken cancellationToken) {
+        var cacheKey = BuildPullRequestKey(owner, repo, number);
+        if (_pullRequestFilesCache.TryGetValue(cacheKey, out var cached)) {
+            return cached;
+        }
         var files = new List<PullRequestFile>();
         var page = 1;
         while (true) {
@@ -49,11 +56,16 @@ internal sealed class GitHubClient : IDisposable {
             }
             page++;
         }
+        _pullRequestFilesCache[cacheKey] = files;
         return files;
     }
 
     public async Task<PullRequestContext> GetPullRequestAsync(string owner, string repo, int number,
         CancellationToken cancellationToken) {
+        var cacheKey = BuildPullRequestKey(owner, repo, number);
+        if (_pullRequestCache.TryGetValue(cacheKey, out var cached)) {
+            return cached;
+        }
         var json = await GetJsonAsync($"/repos/{owner}/{repo}/pulls/{number}", cancellationToken)
             .ConfigureAwait(false);
         var obj = json.AsObject();
@@ -82,7 +94,9 @@ internal sealed class GitHubClient : IDisposable {
             }
         }
 
-        return new PullRequestContext(repoFullName, owner, repo, prNumber, title, body, draft, headSha, baseSha, labels);
+        var context = new PullRequestContext(repoFullName, owner, repo, prNumber, title, body, draft, headSha, baseSha, labels);
+        _pullRequestCache[cacheKey] = context;
+        return context;
     }
 
     public async Task<IReadOnlyList<PullRequestFile>> GetCompareFilesAsync(string owner, string repo, string baseSha, string headSha,
@@ -92,6 +106,10 @@ internal sealed class GitHubClient : IDisposable {
         }
         if (string.Equals(baseSha, headSha, StringComparison.OrdinalIgnoreCase)) {
             return Array.Empty<PullRequestFile>();
+        }
+        var compareKey = BuildCompareKey(owner, repo, baseSha, headSha);
+        if (_compareFilesCache.TryGetValue(compareKey, out var cached)) {
+            return cached;
         }
 
         var files = new List<PullRequestFile>();
@@ -137,6 +155,7 @@ internal sealed class GitHubClient : IDisposable {
         if (truncated) {
             Console.Error.WriteLine("Compare API results truncated after 2000 files. Consider using pull request files endpoint for full coverage.");
         }
+        _compareFilesCache[compareKey] = files;
         return files;
     }
 
@@ -490,5 +509,13 @@ internal sealed class GitHubClient : IDisposable {
             return string.Empty;
         }
         return $"{segments[^2]}/{segments[^1]}";
+    }
+
+    private static string BuildPullRequestKey(string owner, string repo, int number) {
+        return $"{owner}/{repo}#{number}";
+    }
+
+    private static string BuildCompareKey(string owner, string repo, string baseSha, string headSha) {
+        return $"{owner}/{repo}@{baseSha}..{headSha}";
     }
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -79,6 +79,7 @@ internal static class Program {
         failed += Run("Review intent respects focus", TestReviewIntentRespectsFocus);
         failed += Run("Triage-only loads threads", TestTriageOnlyLoadsThreads);
         failed += Run("Review code host env", TestReviewCodeHostEnv);
+        failed += Run("GitHub context cache", TestGitHubContextCache);
         failed += Run("Azure auth scheme env", TestAzureAuthSchemeEnv);
         failed += Run("Azure auth scheme invalid env", TestAzureAuthSchemeInvalidEnv);
         failed += Run("Review threads diff range normalize", TestReviewThreadsDiffRangeNormalize);
@@ -776,6 +777,54 @@ internal static class Program {
         } finally {
             Environment.SetEnvironmentVariable("REVIEW_CODE_HOST", previous);
         }
+    }
+
+    private static void TestGitHubContextCache() {
+        var prHits = 0;
+        var filesHits = 0;
+        var compareHits = 0;
+
+        const string prJson = "{"
+            + "\"title\":\"Test\",\"body\":\"Body\",\"draft\":false,\"number\":1,"
+            + "\"head\":{\"sha\":\"headsha\"},"
+            + "\"base\":{\"sha\":\"basesha\",\"repo\":{\"full_name\":\"owner/repo\"}},"
+            + "\"labels\":[{\"name\":\"bug\"}]"
+            + "}";
+        const string filesJson = "[{\"filename\":\"src/A.cs\",\"status\":\"modified\",\"patch\":\"@@\"}]";
+        const string compareJson = "{\"files\":[{\"filename\":\"src/A.cs\",\"status\":\"modified\",\"patch\":\"@@\"}]}";
+
+        using var server = new LocalHttpServer(request => {
+            if (request.Path.StartsWith("/repos/owner/repo/pulls/1/files", StringComparison.OrdinalIgnoreCase)) {
+                filesHits++;
+                return new HttpResponse(filesJson);
+            }
+            if (request.Path.StartsWith("/repos/owner/repo/pulls/1", StringComparison.OrdinalIgnoreCase)) {
+                prHits++;
+                return new HttpResponse(prJson);
+            }
+            if (request.Path.Contains("/repos/owner/repo/compare/", StringComparison.OrdinalIgnoreCase)) {
+                compareHits++;
+                return new HttpResponse(compareJson);
+            }
+            return null;
+        });
+
+        using var client = new GitHubClient("token", server.BaseUri.ToString().TrimEnd('/'));
+        var pr1 = client.GetPullRequestAsync("owner", "repo", 1, CancellationToken.None).GetAwaiter().GetResult();
+        var pr2 = client.GetPullRequestAsync("owner", "repo", 1, CancellationToken.None).GetAwaiter().GetResult();
+        AssertEqual(1, prHits, "pr cache hits");
+
+        var files1 = client.GetPullRequestFilesAsync("owner", "repo", 1, CancellationToken.None).GetAwaiter().GetResult();
+        var files2 = client.GetPullRequestFilesAsync("owner", "repo", 1, CancellationToken.None).GetAwaiter().GetResult();
+        AssertEqual(1, filesHits, "files cache hits");
+
+        var compare1 = client.GetCompareFilesAsync("owner", "repo", "base", "head", CancellationToken.None).GetAwaiter().GetResult();
+        var compare2 = client.GetCompareFilesAsync("owner", "repo", "base", "head", CancellationToken.None).GetAwaiter().GetResult();
+        AssertEqual(1, compareHits, "compare cache hits");
+
+        AssertEqual(pr1.Title, pr2.Title, "pr cache data");
+        AssertEqual(files1.Count, files2.Count, "files cache data");
+        AssertEqual(compare1.Count, compare2.Count, "compare cache data");
     }
 
     private static void TestAzureAuthSchemeEnv() {

--- a/TODO.md
+++ b/TODO.md
@@ -68,7 +68,7 @@ Status: Draft (needs priorities + owners)
 
 ### Phase 6 — Performance + cost
 - [ ] Add response streaming where supported (show partial progress).
-- [ ] Add cache for context artifacts (diff, file lists, PR metadata).
+- [x] Add cache for context artifacts (diff, file lists, PR metadata).
 - [ ] Add concurrency controls to avoid API throttling.
 - [ ] Consider shared HttpClient/IHttpClientFactory for Azure DevOps client.
 - [ ] Add token budgeting per file/group with hard caps.


### PR DESCRIPTION
## Summary
- cache GitHub PR metadata, file lists, and compare results during a run
- add test coverage for context caching
- mark context cache TODO complete

## Testing
- dotnet build C:\\Support\\GitHub\\IntelligenceX-wt-context-cache
- dotnet run --project C:\\Support\\GitHub\\IntelligenceX-wt-context-cache\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0