### PR TITLE
feat: add default redaction patterns

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -183,6 +183,25 @@ Use this to skip the main review and only assess existing review threads.
 }
 ```
 
+## Redaction (secrets)
+
+When `redactPii` is enabled, the reviewer applies default redaction patterns for common secrets
+(private keys, GitHub tokens, AWS access keys, JWTs, Authorization headers, and generic key/value secrets).
+Override the defaults by setting `redactionPatterns`.
+
+```json
+{
+  "review": {
+    "redactPii": true,
+    "redactionPatterns": [
+      "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]+?-----END [A-Z ]*PRIVATE KEY-----",
+      "\\bgh[pousr]_[A-Za-z0-9]{36}\\b"
+    ],
+    "redactionReplacement": "[REDACTED]"
+  }
+}
+```
+
 ## Output style example
 
 ```json

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -57,6 +57,16 @@ internal sealed class ReviewSettings {
         "intelligencex-review",
         "copilot-pull-request-reviewer"
     };
+    private static readonly IReadOnlyList<string> DefaultRedactionPatterns = new[] {
+        "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]+?-----END [A-Z ]*PRIVATE KEY-----",
+        "\\b(AKIA|ASIA)[0-9A-Z]{16}\\b",
+        "\\bgh[pousr]_[A-Za-z0-9]{36}\\b",
+        "\\bgithub_pat_[A-Za-z0-9_]{20,}\\b",
+        "\\bxox[baprs]-[A-Za-z0-9-]+\\b",
+        "\\beyJ[a-zA-Z0-9_-]{10,}\\.[a-zA-Z0-9_-]{10,}\\.[a-zA-Z0-9_-]{10,}\\b",
+        "(?i)authorization\\s*:\\s*(bearer|basic)\\s+[^\\s]+",
+        "(?i)\\b(api[_-]?key|secret|token|password|passwd|pwd)\\b\\s*[:=]\\s*['\\\"]?[^\\s'\\\"]+"
+    };
 
     public string Mode { get; set; } = "hybrid";
     public ReviewProvider Provider { get; set; } = ReviewProvider.OpenAI;
@@ -146,7 +156,7 @@ internal sealed class ReviewSettings {
     public int MaxInlineComments { get; set; } = 10;
     public string? SeverityThreshold { get; set; }
     public bool RedactPii { get; set; }
-    public IReadOnlyList<string> RedactionPatterns { get; set; } = Array.Empty<string>();
+    public IReadOnlyList<string> RedactionPatterns { get; set; } = DefaultRedactionPatterns;
     public string RedactionReplacement { get; set; } = "[REDACTED]";
     public int WaitSeconds { get; set; } = 60;
     public int IdleSeconds { get; set; } = 5;

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -95,6 +95,7 @@ internal static class Program {
         failed += Run("Filter files empty filters", TestFilterFilesEmptyFilters);
         failed += Run("Prompt language hints", TestPromptBuilderLanguageHints);
         failed += Run("Prompt language hints disabled", TestPromptBuilderLanguageHintsDisabled);
+        failed += Run("Redaction defaults", TestRedactionDefaults);
         failed += Run("Review budget note", TestReviewBudgetNote);
         failed += Run("Review budget note empty", TestReviewBudgetNoteEmpty);
         failed += Run("Review budget note comment", TestReviewBudgetNoteComment);
@@ -1195,6 +1196,13 @@ internal static class Program {
         if (prompt.Contains("Language hints:", StringComparison.OrdinalIgnoreCase)) {
             throw new InvalidOperationException("Expected language hints to be omitted.");
         }
+    }
+
+    private static void TestRedactionDefaults() {
+        var settings = new ReviewSettings { RedactPii = true };
+        var input = "Authorization: Bearer abc123";
+        var output = Redaction.Apply(input, settings.RedactionPatterns, settings.RedactionReplacement);
+        AssertEqual(settings.RedactionReplacement, output, "redaction default match");
     }
 
     private static void TestReviewBudgetNote() {

--- a/TODO.md
+++ b/TODO.md
@@ -75,7 +75,7 @@ Status: Draft (needs priorities + owners)
 - [x] Add optional "budget exceeded" summary behavior.
 
 ### Phase 7 — Security + trust
-- [ ] Redact sensitive data before prompt (secrets, tokens, private keys).
+- [x] Redact sensitive data before prompt (secrets, tokens, private keys).
 - [x] Sanitize Azure DevOps API error payloads in logs.
 - [ ] Add "untrusted PR" guardrails (no secret access, no write actions).
 - [ ] Add workflow integrity check (block self-modifying workflow runs).


### PR DESCRIPTION
Enable default redaction patterns for common secrets (tokens, private keys, JWTs) when redactPii is true, add docs and a test, and mark the roadmap item complete.