### PR TITLE
feat: add GitHub API concurrency limit

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -268,6 +268,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `reviewDiffRange`: `current`, `pr-base`, or `first-review`
 - `outputStyle`: rendering style preset
 - `reviewUsageSummary`: append usage line to the footer (ChatGPT auth only)
+- `githubMaxConcurrency`: limit concurrent GitHub API requests (default 4)
 - `languageHints`: include language-aware hint block in the prompt
 - `reviewBudgetSummary`: include a note when review context is truncated
 - `retryCount`: total attempts for provider requests

--- a/IntelligenceX.Reviewer/GitHubClient.cs
+++ b/IntelligenceX.Reviewer/GitHubClient.cs
@@ -11,12 +11,17 @@ using IntelligenceX.Json;
 namespace IntelligenceX.Reviewer;
 
 internal sealed class GitHubClient : IDisposable {
+    private const int DefaultMaxConcurrency = 4;
     private readonly HttpClient _http;
     private readonly Dictionary<string, PullRequestContext> _pullRequestCache = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, IReadOnlyList<PullRequestFile>> _pullRequestFilesCache = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, IReadOnlyList<PullRequestFile>> _compareFilesCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SemaphoreSlim _requestGate;
+    private readonly int _maxConcurrency;
 
-    public GitHubClient(string token, string? baseUrl = null) {
+    public GitHubClient(string token, string? baseUrl = null, int maxConcurrency = DefaultMaxConcurrency) {
+        _maxConcurrency = Math.Max(1, maxConcurrency);
+        _requestGate = new SemaphoreSlim(_maxConcurrency, _maxConcurrency);
         _http = new HttpClient {
             BaseAddress = new Uri(baseUrl ?? "https://api.github.com")
         };
@@ -25,6 +30,8 @@ internal sealed class GitHubClient : IDisposable {
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         _http.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
     }
+
+    internal int MaxConcurrency => _maxConcurrency;
 
     public async Task<IReadOnlyList<PullRequestFile>> GetPullRequestFilesAsync(string owner, string repo, int number,
         CancellationToken cancellationToken) {
@@ -448,53 +455,65 @@ internal sealed class GitHubClient : IDisposable {
             .ConfigureAwait(false);
     }
 
-    public void Dispose() => _http.Dispose();
+    public void Dispose() {
+        _http.Dispose();
+        _requestGate.Dispose();
+    }
 
     private async Task<JsonValue> GetJsonAsync(string url, CancellationToken cancellationToken) {
-        using var response = await _http.GetAsync(url, cancellationToken).ConfigureAwait(false);
-        var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode) {
-            throw new InvalidOperationException($"GitHub API request failed ({(int)response.StatusCode}): {content}");
-        }
-        return JsonLite.Parse(content) ?? JsonValue.Null;
+        return await WithGateAsync(async () => {
+            using var response = await _http.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) {
+                throw new InvalidOperationException($"GitHub API request failed ({(int)response.StatusCode}): {content}");
+            }
+            return JsonLite.Parse(content) ?? JsonValue.Null;
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<JsonValue> PostJsonAsync(string url, JsonObject payload, CancellationToken cancellationToken) {
-        var json = JsonLite.Serialize(JsonValue.From(payload));
-        using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var response = await _http.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
-        var responseText = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode) {
-            throw new InvalidOperationException($"GitHub API request failed ({(int)response.StatusCode}): {responseText}");
-        }
-        return JsonLite.Parse(responseText) ?? JsonValue.Null;
+        return await WithGateAsync(async () => {
+            var json = JsonLite.Serialize(JsonValue.From(payload));
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+            using var response = await _http.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
+            var responseText = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) {
+                throw new InvalidOperationException($"GitHub API request failed ({(int)response.StatusCode}): {responseText}");
+            }
+            return JsonLite.Parse(responseText) ?? JsonValue.Null;
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<JsonValue> PostGraphQlAsync(JsonObject payload, CancellationToken cancellationToken) {
-        var json = JsonLite.Serialize(JsonValue.From(payload));
-        using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var response = await _http.PostAsync("/graphql", content, cancellationToken).ConfigureAwait(false);
-        var responseText = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode) {
-            throw new InvalidOperationException($"GitHub API request failed ({(int)response.StatusCode}): {responseText}");
-        }
-        var parsed = JsonLite.Parse(responseText) ?? JsonValue.Null;
-        var errors = parsed.AsObject()?.GetArray("errors");
-        if (errors is not null && errors.Count > 0) {
-            throw new InvalidOperationException($"GitHub GraphQL request returned errors: {responseText}");
-        }
-        return parsed;
+        return await WithGateAsync(async () => {
+            var json = JsonLite.Serialize(JsonValue.From(payload));
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+            using var response = await _http.PostAsync("/graphql", content, cancellationToken).ConfigureAwait(false);
+            var responseText = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) {
+                throw new InvalidOperationException($"GitHub API request failed ({(int)response.StatusCode}): {responseText}");
+            }
+            var parsed = JsonLite.Parse(responseText) ?? JsonValue.Null;
+            var errors = parsed.AsObject()?.GetArray("errors");
+            if (errors is not null && errors.Count > 0) {
+                throw new InvalidOperationException($"GitHub GraphQL request returned errors: {responseText}");
+            }
+            return parsed;
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task PatchJsonAsync(string url, JsonObject payload, CancellationToken cancellationToken) {
-        var json = JsonLite.Serialize(JsonValue.From(payload));
-        using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var request = new HttpRequestMessage(new HttpMethod("PATCH"), url) { Content = content };
-        using var response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode) {
-            var responseText = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException($"GitHub API request failed ({(int)response.StatusCode}): {responseText}");
-        }
+        await WithGateAsync(async () => {
+            var json = JsonLite.Serialize(JsonValue.From(payload));
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+            using var request = new HttpRequestMessage(new HttpMethod("PATCH"), url) { Content = content };
+            using var response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) {
+                var responseText = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                throw new InvalidOperationException($"GitHub API request failed ({(int)response.StatusCode}): {responseText}");
+            }
+            return 0;
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private static string ParseRepoFullName(string url) {
@@ -517,5 +536,14 @@ internal sealed class GitHubClient : IDisposable {
 
     private static string BuildCompareKey(string owner, string repo, string baseSha, string headSha) {
         return $"{owner}/{repo}@{baseSha}..{headSha}";
+    }
+
+    private async Task<T> WithGateAsync<T>(Func<Task<T>> action, CancellationToken cancellationToken) {
+        await _requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            return await action().ConfigureAwait(false);
+        } finally {
+            _requestGate.Release();
+        }
     }
 }

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -77,8 +77,10 @@ public static class ReviewerApp {
                 fallbackToken = null;
             }
 
-            using var github = new GitHubClient(token);
-            using var fallbackGithub = string.IsNullOrWhiteSpace(fallbackToken) ? null : new GitHubClient(fallbackToken);
+            using var github = new GitHubClient(token, maxConcurrency: settings.GitHubMaxConcurrency);
+            using var fallbackGithub = string.IsNullOrWhiteSpace(fallbackToken)
+                ? null
+                : new GitHubClient(fallbackToken, maxConcurrency: settings.GitHubMaxConcurrency);
             PullRequestContext? context = null;
             var eventPath = Environment.GetEnvironmentVariable("GITHUB_EVENT_PATH");
             if (!string.IsNullOrWhiteSpace(eventPath) && File.Exists(eventPath)) {

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -246,6 +246,7 @@ internal static class ReviewConfigLoader {
         settings.MaxCommentChars = ReadInt(obj, "maxCommentChars", settings.MaxCommentChars);
         settings.MaxComments = ReadInt(obj, "maxComments", settings.MaxComments);
         settings.CommentSearchLimit = ReadInt(obj, "commentSearchLimit", settings.CommentSearchLimit);
+        settings.GitHubMaxConcurrency = Math.Max(1, ReadInt(obj, "githubMaxConcurrency", settings.GitHubMaxConcurrency));
         settings.ContextDenyEnabled = ReadBool(obj, "contextDenyEnabled", settings.ContextDenyEnabled);
         var contextDenyPatterns = ReadStringList(obj, "contextDenyPatterns");
         if (contextDenyPatterns is not null) {

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -196,6 +196,7 @@ internal sealed class ReviewSettings {
     public int MaxCommentChars { get; set; } = 4000;
     public int MaxComments { get; set; } = 20;
     public int CommentSearchLimit { get; set; } = 500;
+    public int GitHubMaxConcurrency { get; set; } = 4;
     public bool ContextDenyEnabled { get; set; } = true;
     public IReadOnlyList<string> ContextDenyPatterns { get; set; } = DefaultContextDenyPatterns;
     public bool IncludeRelatedPrs { get; set; }
@@ -796,6 +797,10 @@ internal sealed class ReviewSettings {
         var commentSearchLimit = GetInput("comment_search_limit", "REVIEW_COMMENT_SEARCH_LIMIT");
         if (!string.IsNullOrWhiteSpace(commentSearchLimit)) {
             settings.CommentSearchLimit = ParsePositiveInt(commentSearchLimit, settings.CommentSearchLimit);
+        }
+        var githubConcurrency = GetInput("github_max_concurrency", "REVIEW_GITHUB_MAX_CONCURRENCY");
+        if (!string.IsNullOrWhiteSpace(githubConcurrency)) {
+            settings.GitHubMaxConcurrency = ParsePositiveInt(githubConcurrency, settings.GitHubMaxConcurrency);
         }
         var includeRelatedPrs = GetInput("include_related_prs", "REVIEW_INCLUDE_RELATED_PRS");
         if (!string.IsNullOrWhiteSpace(includeRelatedPrs)) {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -90,6 +90,8 @@ internal static class Program {
         failed += Run("Triage-only loads threads", TestTriageOnlyLoadsThreads);
         failed += Run("Review code host env", TestReviewCodeHostEnv);
         failed += Run("GitHub context cache", TestGitHubContextCache);
+        failed += Run("GitHub concurrency env", TestGitHubConcurrencyEnv);
+        failed += Run("GitHub client concurrency", TestGitHubClientConcurrency);
         failed += Run("Azure auth scheme env", TestAzureAuthSchemeEnv);
         failed += Run("Azure auth scheme invalid env", TestAzureAuthSchemeInvalidEnv);
         failed += Run("Review threads diff range normalize", TestReviewThreadsDiffRangeNormalize);
@@ -964,6 +966,22 @@ internal static class Program {
         AssertEqual(pr1.Title, pr2.Title, "pr cache data");
         AssertEqual(files1.Count, files2.Count, "files cache data");
         AssertEqual(compare1.Count, compare2.Count, "compare cache data");
+    }
+
+    private static void TestGitHubConcurrencyEnv() {
+        var previous = Environment.GetEnvironmentVariable("REVIEW_GITHUB_MAX_CONCURRENCY");
+        try {
+            Environment.SetEnvironmentVariable("REVIEW_GITHUB_MAX_CONCURRENCY", "2");
+            var settings = ReviewSettings.FromEnvironment();
+            AssertEqual(2, settings.GitHubMaxConcurrency, "github concurrency env");
+        } finally {
+            Environment.SetEnvironmentVariable("REVIEW_GITHUB_MAX_CONCURRENCY", previous);
+        }
+    }
+
+    private static void TestGitHubClientConcurrency() {
+        using var client = new GitHubClient("token", "https://api.github.com", 2);
+        AssertEqual(2, client.MaxConcurrency, "github client concurrency");
     }
 
     private static void TestAzureAuthSchemeEnv() {

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -57,6 +57,7 @@
         "maxCommentChars": { "type": "integer", "minimum": 0 },
         "maxComments": { "type": "integer", "minimum": 0 },
         "commentSearchLimit": { "type": "integer", "minimum": 1 },
+        "githubMaxConcurrency": { "type": "integer", "minimum": 1 },
         "contextDenyEnabled": { "type": "boolean" },
         "contextDenyPatterns": { "type": "array", "items": { "type": "string" } },
         "maxFiles": { "type": "integer", "minimum": 0 },

--- a/TODO.md
+++ b/TODO.md
@@ -69,7 +69,7 @@ Status: Draft (needs priorities + owners)
 ### Phase 6 — Performance + cost
 - [ ] Add response streaming where supported (show partial progress).
 - [x] Add cache for context artifacts (diff, file lists, PR metadata).
-- [ ] Add concurrency controls to avoid API throttling.
+- [x] Add concurrency controls to avoid API throttling.
 - [x] Consider shared HttpClient/IHttpClientFactory for Azure DevOps client.
 - [ ] Add token budgeting per file/group with hard caps.
 - [x] Add optional "budget exceeded" summary behavior.


### PR DESCRIPTION
Add a configurable concurrency gate for GitHub API calls to reduce rate limiting. Includes settings/env/schema/docs/tests updates.