### PR TITLE
feat: add untrusted PR guardrails

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -202,6 +202,24 @@ Override the defaults by setting `redactionPatterns`.
 }
 ```
 
+## Untrusted PR guardrails (forks)
+
+When a pull request comes from a fork, the reviewer treats it as untrusted. By default it **skips** the review
+to avoid accessing secrets. You can override this behavior explicitly if you are using `pull_request_target`
+or have other safeguards in place.
+
+```json
+{
+  "review": {
+    "untrustedPrAllowSecrets": false,
+    "untrustedPrAllowWrites": false
+  }
+}
+```
+
+Set `untrustedPrAllowSecrets` to `true` to allow reviews on forked PRs. Set `untrustedPrAllowWrites` to `true`
+to allow posting comments or resolving threads on untrusted PRs (default is `false`).
+
 ## Output style example
 
 ```json

--- a/IntelligenceX.Reviewer/AzureDevOpsReviewRunner.cs
+++ b/IntelligenceX.Reviewer/AzureDevOpsReviewRunner.cs
@@ -66,8 +66,10 @@ internal static class AzureDevOpsReviewRunner {
         if (!settings.ReviewBudgetSummary) {
             budgetNote = string.Empty;
         }
-        var context = new PullRequestContext($"{pr.Project}/{pr.RepositoryName}", pr.Project, pr.RepositoryName,
-            pr.PullRequestId, pr.Title, pr.Description, pr.IsDraft, pr.SourceCommit, pr.TargetCommit, Array.Empty<string>());
+        var repoFullName = $"{pr.Project}/{pr.RepositoryName}";
+        var context = new PullRequestContext(repoFullName, pr.Project, pr.RepositoryName,
+            pr.PullRequestId, pr.Title, pr.Description, pr.IsDraft, pr.SourceCommit, pr.TargetCommit, Array.Empty<string>(),
+            repoFullName, false, null);
         var diffNote = BuildDiffNote(iterationIds);
         var prompt = PromptBuilder.Build(context, limited, settings, diffNote, null, inlineSupported: false);
         if (settings.RedactPii) {

--- a/IntelligenceX.Reviewer/CleanupService.cs
+++ b/IntelligenceX.Reviewer/CleanupService.cs
@@ -64,7 +64,8 @@ internal static class CleanupService {
             await ApplyEditAsync(github, context, result, newTitle, newBody, cleanup, commentSearchLimit, cancellationToken)
                 .ConfigureAwait(false);
             return new PullRequestContext(context.RepoFullName, context.Owner, context.Repo, context.Number,
-                newTitle, newBody, context.Draft, context.HeadSha, context.BaseSha, context.Labels);
+                newTitle, newBody, context.Draft, context.HeadSha, context.BaseSha, context.Labels,
+                context.HeadRepoFullName, context.IsFork, context.AuthorAssociation);
         }
 
         if (cleanup.Mode == CleanupMode.Comment || cleanup.Mode == CleanupMode.Hybrid) {

--- a/IntelligenceX.Reviewer/GitHubClient.cs
+++ b/IntelligenceX.Reviewer/GitHubClient.cs
@@ -84,10 +84,16 @@ internal sealed class GitHubClient : IDisposable {
         var body = obj.GetString("body");
         var draft = obj.GetBoolean("draft");
         var prNumber = (int)(obj.GetInt64("number") ?? number);
-        var headSha = obj.GetObject("head")?.GetString("sha");
-        var baseSha = obj.GetObject("base")?.GetString("sha");
-        var repoFullName = obj.GetObject("base")?.GetObject("repo")?.GetString("full_name")
+        var head = obj.GetObject("head");
+        var baseRef = obj.GetObject("base");
+        var headSha = head?.GetString("sha");
+        var baseSha = baseRef?.GetString("sha");
+        var repoFullName = baseRef?.GetObject("repo")?.GetString("full_name")
             ?? $"{owner}/{repo}";
+        var headRepo = head?.GetObject("repo");
+        var headRepoFullName = headRepo?.GetString("full_name");
+        var isFork = headRepo?.GetBoolean("fork") ?? false;
+        var authorAssociation = obj.GetString("author_association");
 
         var labels = new List<string>();
         var labelsArray = obj.GetArray("labels");
@@ -101,7 +107,8 @@ internal sealed class GitHubClient : IDisposable {
             }
         }
 
-        var context = new PullRequestContext(repoFullName, owner, repo, prNumber, title, body, draft, headSha, baseSha, labels);
+        var context = new PullRequestContext(repoFullName, owner, repo, prNumber, title, body, draft, headSha, baseSha,
+            labels, headRepoFullName, isFork, authorAssociation);
         _pullRequestCache[cacheKey] = context;
         return context;
     }

--- a/IntelligenceX.Reviewer/GitHubEventParser.cs
+++ b/IntelligenceX.Reviewer/GitHubEventParser.cs
@@ -23,8 +23,14 @@ internal static class GitHubEventParser {
         var body = pr.GetString("body");
         var draft = pr.GetBoolean("draft");
         var number = (int)(pr.GetInt64("number") ?? 0);
-        var headSha = pr.GetObject("head")?.GetString("sha");
-        var baseSha = pr.GetObject("base")?.GetString("sha");
+        var head = pr.GetObject("head");
+        var baseRef = pr.GetObject("base");
+        var headSha = head?.GetString("sha");
+        var baseSha = baseRef?.GetString("sha");
+        var headRepo = head?.GetObject("repo");
+        var headRepoFullName = headRepo?.GetString("full_name");
+        var isFork = headRepo?.GetBoolean("fork") ?? false;
+        var authorAssociation = pr.GetString("author_association");
 
         var labels = new List<string>();
         var labelsArray = pr.GetArray("labels");
@@ -39,7 +45,8 @@ internal static class GitHubEventParser {
         }
 
         var (owner, repo) = SplitRepo(repoFullName);
-        return new PullRequestContext(repoFullName, owner, repo, number, title, body, draft, headSha, baseSha, labels);
+        return new PullRequestContext(repoFullName, owner, repo, number, title, body, draft, headSha, baseSha,
+            labels, headRepoFullName, isFork, authorAssociation);
     }
 
     private static (string owner, string repo) SplitRepo(string fullName) {

--- a/IntelligenceX.Reviewer/GitHubModels.cs
+++ b/IntelligenceX.Reviewer/GitHubModels.cs
@@ -5,7 +5,8 @@ namespace IntelligenceX.Reviewer;
 
 internal sealed class PullRequestContext {
     public PullRequestContext(string repoFullName, string owner, string repo, int number, string title, string? body,
-        bool draft, string? headSha, string? baseSha, IReadOnlyList<string> labels) {
+        bool draft, string? headSha, string? baseSha, IReadOnlyList<string> labels, string? headRepoFullName,
+        bool isFork, string? authorAssociation) {
         RepoFullName = repoFullName;
         Owner = owner;
         Repo = repo;
@@ -16,6 +17,9 @@ internal sealed class PullRequestContext {
         HeadSha = headSha;
         BaseSha = baseSha;
         Labels = labels;
+        HeadRepoFullName = headRepoFullName;
+        IsFork = isFork;
+        AuthorAssociation = authorAssociation;
     }
 
     public string RepoFullName { get; }
@@ -28,6 +32,13 @@ internal sealed class PullRequestContext {
     public string? HeadSha { get; }
     public string? BaseSha { get; }
     public IReadOnlyList<string> Labels { get; }
+    public string? HeadRepoFullName { get; }
+    public bool IsFork { get; }
+    public string? AuthorAssociation { get; }
+    public bool IsFromFork =>
+        IsFork ||
+        (!string.IsNullOrWhiteSpace(HeadRepoFullName) &&
+         !string.Equals(HeadRepoFullName, RepoFullName, StringComparison.OrdinalIgnoreCase));
 }
 
 internal sealed class PullRequestFile {

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -61,9 +61,6 @@ public static class ReviewerApp {
                 }
                 return await AzureDevOpsReviewRunner.RunAsync(settings, cancellationToken).ConfigureAwait(false);
             }
-            if (!await ValidateAuthAsync(settings).ConfigureAwait(false)) {
-                return 1;
-            }
             var token = Environment.GetEnvironmentVariable("INTELLIGENCEX_GITHUB_TOKEN")
                 ?? Environment.GetEnvironmentVariable("GITHUB_TOKEN");
 
@@ -105,6 +102,24 @@ public static class ReviewerApp {
                     .ConfigureAwait(false);
             }
 
+            var isUntrusted = context.IsFromFork;
+            if (isUntrusted) {
+                Console.WriteLine("Untrusted pull request detected (fork).");
+                if (!settings.UntrustedPrAllowSecrets) {
+                    Console.WriteLine("Skipping review to avoid secret access. Set review.untrustedPrAllowSecrets=true to override.");
+                    return 0;
+                }
+            }
+
+            if (!await ValidateAuthAsync(settings).ConfigureAwait(false)) {
+                return 1;
+            }
+
+            var allowWrites = !isUntrusted || settings.UntrustedPrAllowWrites;
+            if (!allowWrites && isUntrusted) {
+                Console.WriteLine("Write actions disabled for untrusted pull requests.");
+            }
+
             if (settings.SkipDraft && context.Draft) {
                 Console.WriteLine("Skipping draft pull request.");
                 return 0;
@@ -118,8 +133,12 @@ public static class ReviewerApp {
                 return 0;
             }
 
-            context = await CleanupService.RunAsync(github, context, settings, cancellationToken)
-                .ConfigureAwait(false);
+            if (allowWrites) {
+                context = await CleanupService.RunAsync(github, context, settings, cancellationToken)
+                    .ConfigureAwait(false);
+            } else {
+                Console.WriteLine("Skipping cleanup for untrusted pull request.");
+            }
 
             IssueComment? existingSummary = null;
             string? previousSummary = null;
@@ -165,6 +184,10 @@ public static class ReviewerApp {
             var extras = await BuildExtrasAsync(github, fallbackGithub, context, settings, cancellationToken, settings.TriageOnly)
                 .ConfigureAwait(false);
             if (settings.TriageOnly) {
+                if (!allowWrites) {
+                    Console.WriteLine("Skipping thread triage for untrusted pull request.");
+                    return 0;
+                }
                 var triageRunner = new ReviewRunner(settings);
                 var (triageOnlyFiles, triageOnlyNote) = await ResolveThreadTriageFilesAsync(github, context, settings, allFiles, cancellationToken)
                     .ConfigureAwait(false);
@@ -193,7 +216,7 @@ public static class ReviewerApp {
             }
 
             long? commentId = null;
-            if (settings.ProgressUpdates) {
+            if (allowWrites && settings.ProgressUpdates) {
                 var progressBody = ReviewFormatter.BuildProgressComment(context, settings, progress, null, inlineSupported);
                 commentId = await CreateOrUpdateProgressCommentAsync(github, context, settings, progressBody, cancellationToken)
                     .ConfigureAwait(false);
@@ -204,7 +227,7 @@ public static class ReviewerApp {
             progress.StatusLine = "Generating review findings.";
 
             Func<string, Task>? onPartial = null;
-            if (settings.ProgressUpdates && commentId.HasValue) {
+            if (allowWrites && settings.ProgressUpdates && commentId.HasValue) {
                 onPartial = async partial => {
                     var body = ReviewFormatter.BuildProgressComment(context, settings, progress, partial, inlineSupported);
                     await github.UpdateIssueCommentAsync(context.Owner, context.Repo, commentId.Value, body, cancellationToken)
@@ -216,7 +239,7 @@ public static class ReviewerApp {
                 cancellationToken).ConfigureAwait(false);
 
             var reviewFailed = ReviewDiagnostics.IsFailureBody(reviewBody);
-            var inlineAllowed = inlineSupported && !reviewFailed;
+            var inlineAllowed = inlineSupported && !reviewFailed && allowWrites;
             var inlineComments = Array.Empty<InlineReviewComment>();
             var summaryBody = reviewBody;
             if (inlineAllowed) {
@@ -240,17 +263,20 @@ public static class ReviewerApp {
                 }
             }
 
-            var (triageFiles, triageNote) = await ResolveThreadTriageFilesAsync(github, context, settings, allFiles, cancellationToken)
-                .ConfigureAwait(false);
-            var triageResult = await MaybeAutoResolveAssessedThreadsAsync(github, fallbackGithub, runner, context, triageFiles,
-                    settings, extras, reviewFailed, triageNote, cancellationToken, false,
-                    settings.ReviewThreadsAutoResolveAIPostComment)
-                .ConfigureAwait(false);
-            if (settings.ReviewThreadsAutoResolveAIEmbed && !string.IsNullOrWhiteSpace(triageResult.EmbeddedBlock)) {
-                summaryBody = summaryBody.TrimEnd() + "\n\n" + triageResult.EmbeddedBlock.Trim();
+            var triageResult = ThreadTriageResult.Empty;
+            if (allowWrites) {
+                var (triageFiles, triageNote) = await ResolveThreadTriageFilesAsync(github, context, settings, allFiles, cancellationToken)
+                    .ConfigureAwait(false);
+                triageResult = await MaybeAutoResolveAssessedThreadsAsync(github, fallbackGithub, runner, context, triageFiles,
+                        settings, extras, reviewFailed, triageNote, cancellationToken, false,
+                        settings.ReviewThreadsAutoResolveAIPostComment)
+                    .ConfigureAwait(false);
+                if (settings.ReviewThreadsAutoResolveAIEmbed && !string.IsNullOrWhiteSpace(triageResult.EmbeddedBlock)) {
+                    summaryBody = summaryBody.TrimEnd() + "\n\n" + triageResult.EmbeddedBlock.Trim();
+                }
             }
             var inlineSuppressed = inlineSupported && !inlineAllowed;
-            var autoResolveSummary = settings.ReviewThreadsAutoResolveAISummary ? triageResult.SummaryLine : string.Empty;
+            var autoResolveSummary = allowWrites && settings.ReviewThreadsAutoResolveAISummary ? triageResult.SummaryLine : string.Empty;
             var usageLine = await TryBuildUsageLineAsync(settings).ConfigureAwait(false);
             var findingsBlock = settings.StructuredFindings ? ReviewFindingsBuilder.Build(inlineComments) : string.Empty;
             var commentBody = ReviewFormatter.BuildComment(context, summaryBody, settings, inlineSupported, inlineSuppressed,
@@ -258,6 +284,12 @@ public static class ReviewerApp {
             progress.Review = ReviewProgressState.Complete;
             progress.Finalize = ReviewProgressState.InProgress;
             progress.StatusLine = "Finalizing summary.";
+
+            if (!allowWrites) {
+                Console.WriteLine("Skipping GitHub writes for untrusted pull request.");
+                Console.WriteLine(commentBody);
+                return 0;
+            }
 
             if (commentId.HasValue) {
                 await github.UpdateIssueCommentAsync(context.Owner, context.Repo, commentId.Value, commentBody, cancellationToken)

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -192,6 +192,8 @@ internal static class ReviewConfigLoader {
         settings.ReviewUsageSummary = ReadBool(obj, "reviewUsageSummary", settings.ReviewUsageSummary);
         settings.StructuredFindings = ReadBool(obj, "structuredFindings", settings.StructuredFindings);
         settings.TriageOnly = ReadBool(obj, "triageOnly", settings.TriageOnly);
+        settings.UntrustedPrAllowSecrets = ReadBool(obj, "untrustedPrAllowSecrets", settings.UntrustedPrAllowSecrets);
+        settings.UntrustedPrAllowWrites = ReadBool(obj, "untrustedPrAllowWrites", settings.UntrustedPrAllowWrites);
     }
 
     private static void ApplyCommentMode(JsonObject obj, ReviewSettings settings) {

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -158,6 +158,8 @@ internal sealed class ReviewSettings {
     public bool RedactPii { get; set; }
     public IReadOnlyList<string> RedactionPatterns { get; set; } = DefaultRedactionPatterns;
     public string RedactionReplacement { get; set; } = "[REDACTED]";
+    public bool UntrustedPrAllowSecrets { get; set; }
+    public bool UntrustedPrAllowWrites { get; set; }
     public int WaitSeconds { get; set; } = 60;
     public int IdleSeconds { get; set; } = 5;
     public bool ProgressUpdates { get; set; } = true;
@@ -464,6 +466,16 @@ internal sealed class ReviewSettings {
         var redactionReplacement = GetInput("redaction_replacement", "REDACTION_REPLACEMENT");
         if (!string.IsNullOrWhiteSpace(redactionReplacement)) {
             settings.RedactionReplacement = redactionReplacement!;
+        }
+
+        var untrustedAllowSecrets = GetInput("untrusted_pr_allow_secrets", "REVIEW_UNTRUSTED_PR_ALLOW_SECRETS");
+        if (!string.IsNullOrWhiteSpace(untrustedAllowSecrets)) {
+            settings.UntrustedPrAllowSecrets = ParseBoolean(untrustedAllowSecrets, settings.UntrustedPrAllowSecrets);
+        }
+
+        var untrustedAllowWrites = GetInput("untrusted_pr_allow_writes", "REVIEW_UNTRUSTED_PR_ALLOW_WRITES");
+        if (!string.IsNullOrWhiteSpace(untrustedAllowWrites)) {
+            settings.UntrustedPrAllowWrites = ParseBoolean(untrustedAllowWrites, settings.UntrustedPrAllowWrites);
         }
 
         var promptTemplate = GetInput("prompt_template", "REVIEW_PROMPT_TEMPLATE");

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -70,6 +70,7 @@ internal static class Program {
         failed += Run("Inline comments snippet header", TestInlineCommentsSnippetHeader);
         failed += Run("Review thread inline key", TestReviewThreadInlineKey);
         failed += Run("Review thread inline key bots only", TestReviewThreadInlineKeyBotsOnly);
+        failed += Run("GitHub event fork parsing", TestGitHubEventForkParsing);
         failed += Run("Review retry transient", TestReviewRetryTransient);
         failed += Run("Review retry non-transient", TestReviewRetryNonTransient);
         failed += Run("Review retry rethrows", TestReviewRetryRethrows);
@@ -582,6 +583,29 @@ internal static class Program {
         AssertEqual(false, ok, "inline key bots only");
     }
 
+    private static void TestGitHubEventForkParsing() {
+        var root = new JsonObject()
+            .Add("repository", new JsonObject().Add("full_name", "base/repo"))
+            .Add("pull_request", new JsonObject()
+                .Add("title", "Test")
+                .Add("number", 1)
+                .Add("draft", false)
+                .Add("author_association", "CONTRIBUTOR")
+                .Add("head", new JsonObject()
+                    .Add("sha", "head")
+                    .Add("repo", new JsonObject()
+                        .Add("full_name", "fork/repo")
+                        .Add("fork", true)))
+                .Add("base", new JsonObject()
+                    .Add("sha", "base")));
+
+        var context = GitHubEventParser.ParsePullRequest(root);
+        AssertEqual(true, context.IsFork, "fork flag");
+        AssertEqual(true, context.IsFromFork, "fork detection");
+        AssertEqual("fork/repo", context.HeadRepoFullName, "head repo");
+        AssertEqual("CONTRIBUTOR", context.AuthorAssociation, "author association");
+    }
+
     private static void TestReviewRetryTransient() {
         var attempts = 0;
         var result = ReviewRunner.ReviewRetryPolicy.RunAsync(() => {
@@ -1019,7 +1043,8 @@ internal static class Program {
             ReviewThreadsMax = 5,
             ReviewThreadsMaxComments = 2
         };
-        var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Title", null, false, "head", "base", Array.Empty<string>());
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Title", null, false, "head", "base",
+            Array.Empty<string>(), "owner/repo", false, null);
         var extras = CallBuildExtrasAsync(github, context, settings, true);
         AssertEqual(1, extras.ReviewThreads.Count, "triage-only forces thread load");
     }
@@ -1371,7 +1396,7 @@ internal static class Program {
 
     private static void TestReviewBudgetNoteComment() {
         var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Test title", "Test body", false, "head",
-            "base", Array.Empty<string>());
+            "base", Array.Empty<string>(), "owner/repo", false, null);
         var settings = new ReviewSettings();
         var comment = ReviewFormatter.BuildComment(context, "Body", settings, inlineSupported: false, inlineSuppressed: false,
             autoResolveNote: string.Empty, budgetNote: "Review context truncated: showing first 1 of 2 files.",
@@ -1434,7 +1459,7 @@ internal static class Program {
 
     private static PullRequestContext BuildContext() {
         return new PullRequestContext("owner/repo", "owner", "repo", 1, "Test title", "Test body", false, "head", "base",
-            Array.Empty<string>());
+            Array.Empty<string>(), "owner/repo", false, null);
     }
 
     private static string CallAzureDevOpsSanitize(string content) {

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -88,6 +88,8 @@
         "redactPii": { "type": "boolean" },
         "redactionPatterns": { "type": "array", "items": { "type": "string" } },
         "redactionReplacement": { "type": "string" },
+        "untrustedPrAllowSecrets": { "type": "boolean" },
+        "untrustedPrAllowWrites": { "type": "boolean" },
         "failOpen": { "type": "boolean" },
         "failOpenTransientOnly": { "type": "boolean" },
         "promptTemplate": { "type": "string" },

--- a/TODO.md
+++ b/TODO.md
@@ -77,7 +77,7 @@ Status: Draft (needs priorities + owners)
 ### Phase 7 — Security + trust
 - [x] Redact sensitive data before prompt (secrets, tokens, private keys).
 - [x] Sanitize Azure DevOps API error payloads in logs.
-- [ ] Add "untrusted PR" guardrails (no secret access, no write actions).
+- [x] Add "untrusted PR" guardrails (no secret access, no write actions).
 - [ ] Add workflow integrity check (block self-modifying workflow runs).
 - [ ] Add audit logging for secrets usage.
 


### PR DESCRIPTION
## Summary
- Detect fork/untrusted PRs and gate writes/secrets in reviewer flow
- Add config/settings/schema support for untrusted PR allowances
- Document guardrails and update roadmap
- Add tests for fork parsing

## Testing
- dotnet run --project C:\\Support\\GitHub\\IntelligenceX-wt-untrusted\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0