### PR TITLE
feat: block self-modifying workflow runs

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -220,6 +220,19 @@ or have other safeguards in place.
 Set `untrustedPrAllowSecrets` to `true` to allow reviews on forked PRs. Set `untrustedPrAllowWrites` to `true`
 to allow posting comments or resolving threads on untrusted PRs (default is `false`).
 
+## Workflow integrity guardrail
+
+By default the reviewer skips PRs that modify GitHub Actions workflows. This prevents self-modifying workflow runs.
+Set `allowWorkflowChanges` (or `REVIEW_ALLOW_WORKFLOW_CHANGES=true`) to override.
+
+```json
+{
+  "review": {
+    "allowWorkflowChanges": true
+  }
+}
+```
+
 ## Output style example
 
 ```json
@@ -299,6 +312,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `skipPaths`: if **all** changed files in a PR match these globs, skip reviewing the entire PR
 - `includePaths`: only review files matching these globs
 - `excludePaths`: ignore files matching these globs
+- `allowWorkflowChanges`: allow reviews to run when `.github/workflows/*` changes are present
 - `includeReviewThreads`: include existing review threads in context
 - `triageOnly`: run thread triage only (skip full review)
 - `reviewThreadsAutoResolve*`: auto-resolve rules for bot threads

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -133,6 +133,19 @@ public static class ReviewerApp {
                 return 0;
             }
 
+            var files = await github.GetPullRequestFilesAsync(context.Owner, context.Repo, context.Number, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (files.Count == 0) {
+                Console.WriteLine("No files to review.");
+                return 0;
+            }
+
+            if (!settings.AllowWorkflowChanges && HasWorkflowChanges(files)) {
+                Console.WriteLine("Workflow file changes detected; skipping review. Set allowWorkflowChanges or REVIEW_ALLOW_WORKFLOW_CHANGES=true to override.");
+                return 0;
+            }
+
             if (allowWrites) {
                 context = await CleanupService.RunAsync(github, context, settings, cancellationToken)
                     .ConfigureAwait(false);
@@ -153,13 +166,6 @@ public static class ReviewerApp {
             var progress = new ReviewProgress {
                 StatusLine = "Starting review."
             };
-            var files = await github.GetPullRequestFilesAsync(context.Owner, context.Repo, context.Number, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (files.Count == 0) {
-                Console.WriteLine("No files to review.");
-                return 0;
-            }
 
             if (ShouldSkipByPaths(files, settings.SkipPaths)) {
                 Console.WriteLine("Skipping pull request due to path filter.");
@@ -476,6 +482,27 @@ public static class ReviewerApp {
             }
         }
         return allMatch;
+    }
+
+    internal static bool HasWorkflowChanges(IReadOnlyList<PullRequestFile> files) {
+        foreach (var file in files) {
+            if (IsWorkflowPath(file.Filename)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool IsWorkflowPath(string? path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return false;
+        }
+        var normalized = path.Replace('\\', '/').TrimStart('/');
+        if (!normalized.StartsWith(".github/workflows/", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+        return normalized.EndsWith(".yml", StringComparison.OrdinalIgnoreCase) ||
+               normalized.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase);
     }
 
     private static (IReadOnlyList<PullRequestFile> Files, string BudgetNote) PrepareFiles(IReadOnlyList<PullRequestFile> files,

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -182,6 +182,7 @@ internal static class ReviewConfigLoader {
         settings.OverwriteSummaryOnNewCommit = ReadBool(obj, "overwriteSummaryOnNewCommit", settings.OverwriteSummaryOnNewCommit);
         settings.SummaryStability = ReadBool(obj, "summaryStability", settings.SummaryStability);
         settings.SkipDraft = ReadBool(obj, "skipDraft", settings.SkipDraft);
+        settings.AllowWorkflowChanges = ReadBool(obj, "allowWorkflowChanges", settings.AllowWorkflowChanges);
         settings.RedactPii = ReadBool(obj, "redactPii", settings.RedactPii);
         settings.ProgressUpdates = ReadBool(obj, "progressUpdates", settings.ProgressUpdates);
         settings.Diagnostics = ReadBool(obj, "diagnostics", settings.Diagnostics);

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -143,6 +143,10 @@ internal sealed class ReviewSettings {
     /// Matching files are removed from the review list but do not skip the entire PR.
     /// </summary>
     public IReadOnlyList<string> ExcludePaths { get; set; } = Array.Empty<string>();
+    /// <summary>
+    /// When false, pull requests that modify workflow files are skipped to prevent self-modifying workflow runs.
+    /// </summary>
+    public bool AllowWorkflowChanges { get; set; }
     /// Controls which diff range is used to build the review context.
     /// <list type="bullet">
     /// <item><description><c>current</c>: use the current PR files.</description></item>
@@ -426,6 +430,11 @@ internal sealed class ReviewSettings {
         var excludePaths = GetInput("exclude_paths", "EXCLUDE_PATHS");
         if (!string.IsNullOrWhiteSpace(excludePaths)) {
             settings.ExcludePaths = ParseList(excludePaths, settings.ExcludePaths);
+        }
+
+        var allowWorkflowChanges = GetInput("allow_workflow_changes", "REVIEW_ALLOW_WORKFLOW_CHANGES");
+        if (!string.IsNullOrWhiteSpace(allowWorkflowChanges)) {
+            settings.AllowWorkflowChanges = ParseBoolean(allowWorkflowChanges, settings.AllowWorkflowChanges);
         }
 
         var reviewDiffRange = GetInput("review_diff_range", "REVIEW_DIFF_RANGE");

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -106,6 +106,7 @@ internal static class Program {
         failed += Run("Filter files include+exclude", TestFilterFilesIncludeExclude);
         failed += Run("Filter files glob patterns", TestFilterFilesGlobPatterns);
         failed += Run("Filter files empty filters", TestFilterFilesEmptyFilters);
+        failed += Run("Workflow changes detection", TestWorkflowChangesDetection);
         failed += Run("Prompt language hints", TestPromptBuilderLanguageHints);
         failed += Run("Prompt language hints disabled", TestPromptBuilderLanguageHintsDisabled);
         failed += Run("Redaction defaults", TestRedactionDefaults);
@@ -1355,6 +1356,14 @@ internal static class Program {
         var files = BuildFiles("src/app.cs", "docs/readme.md");
         var filtered = ReviewerApp.FilterFilesByPaths(files, Array.Empty<string>(), Array.Empty<string>());
         AssertSequenceEqual(new[] { "src/app.cs", "docs/readme.md" }, GetFilenames(filtered), "empty filters");
+    }
+
+    private static void TestWorkflowChangesDetection() {
+        var withWorkflow = BuildFiles(".github/workflows/ci.yml", "src/app.cs");
+        AssertEqual(true, ReviewerApp.HasWorkflowChanges(withWorkflow), "workflow changes detected");
+
+        var withoutWorkflow = BuildFiles(".github/workflows/README.md", "src/app.cs");
+        AssertEqual(false, ReviewerApp.HasWorkflowChanges(withoutWorkflow), "workflow changes ignored");
     }
 
     private static void TestPromptBuilderLanguageHints() {

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -78,6 +78,7 @@
         "preflight": { "type": "boolean" },
         "preflightTimeoutSeconds": { "type": "integer", "minimum": 1 },
         "skipDraft": { "type": "boolean" },
+        "allowWorkflowChanges": { "type": "boolean" },
         "overwriteSummaryOnNewCommit": { "type": "boolean" },
         "summaryStability": { "type": "boolean" },
         "skipTitles": { "type": "array", "items": { "type": "string" } },

--- a/TODO.md
+++ b/TODO.md
@@ -78,7 +78,7 @@ Status: Draft (needs priorities + owners)
 - [x] Redact sensitive data before prompt (secrets, tokens, private keys).
 - [x] Sanitize Azure DevOps API error payloads in logs.
 - [x] Add "untrusted PR" guardrails (no secret access, no write actions).
-- [ ] Add workflow integrity check (block self-modifying workflow runs).
+- [x] Add workflow integrity check (block self-modifying workflow runs).
 - [ ] Add audit logging for secrets usage.
 
 ### Phase 8 — Testing + validation


### PR DESCRIPTION
## Summary
- Skip reviews for PRs that modify workflow files unless explicitly allowed
- Add allowWorkflowChanges config/env support and schema/docs
- Add tests for workflow change detection

## Testing
- dotnet run --project C:\\Support\\GitHub\\IntelligenceX-wt-ado-pr-full-changes\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0