### PR TITLE
feat: require diff evidence for thread auto-resolve

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -66,6 +66,7 @@ Unknown properties emit warnings; invalid types or enum values fail the run.
     "reviewDiffRange": "current",
     "includeReviewThreads": true,
     "reviewThreadsAutoResolveAI": true,
+    "reviewThreadsAutoResolveRequireEvidence": true,
     "reviewThreadsAutoResolveAIPostComment": true,
     "reviewThreadsAutoResolveAISummary": true,
     "reviewThreadsAutoResolveBotLogins": [
@@ -303,6 +304,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `triageOnly`: run thread triage only (skip full review)
 - `reviewThreadsAutoResolve*`: auto-resolve rules for bot threads
 - `reviewThreadsAutoResolveAIReply`: reply on kept threads to explain why they were not resolved (includes resolve failures)
+- `reviewThreadsAutoResolveRequireEvidence`: require a diff evidence snippet to resolve threads
 - `azureOrg`/`azureProject`/`azureRepo`: Azure DevOps identifiers
 - `azureBaseUrl`: override Azure DevOps base URL (defaults to `SYSTEM_COLLECTIONURI` or `https://dev.azure.com/{org}`)
 - `azureTokenEnv`: env var name that contains the ADO token (default `SYSTEM_ACCESSTOKEN` if set)

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -884,6 +884,8 @@ public static class ReviewerApp {
 
         var byId = assessments.ToDictionary(a => a.Id, StringComparer.OrdinalIgnoreCase);
         var replyMap = new Dictionary<string, ThreadAssessment>(StringComparer.OrdinalIgnoreCase);
+        var patchIndex = BuildInlinePatchIndex(files);
+        var patchLookup = BuildPatchLookup(files, settings.MaxPatchChars);
         var resolved = new List<ThreadAssessment>();
         var kept = new List<ThreadAssessment>();
         var failed = new List<ThreadAssessment>();
@@ -905,6 +907,14 @@ public static class ReviewerApp {
             if (!byId.TryGetValue(thread.Id, out var assessment) || assessment.Action != "resolve") {
                 continue;
             }
+            if (settings.ReviewThreadsAutoResolveRequireEvidence &&
+                !HasValidResolveEvidence(assessment.Evidence, thread, patchIndex, patchLookup, settings.MaxPatchChars)) {
+                var missingEvidence = new ThreadAssessment(assessment.Id, "keep",
+                    $"{assessment.Reason} (missing diff evidence)", assessment.Evidence);
+                kept.Add(missingEvidence);
+                replyMap[assessment.Id] = missingEvidence;
+                continue;
+            }
             var result = await TryResolveThreadAsync(github, fallbackGithub, thread.Id, cancellationToken).ConfigureAwait(false);
             if (result.Resolved) {
                 resolvedCount++;
@@ -912,7 +922,8 @@ public static class ReviewerApp {
                 continue;
             }
             var error = result.Error ?? "unknown error";
-            var failedAssessment = new ThreadAssessment(assessment.Id, "keep", $"{assessment.Reason} (resolve failed: {error})");
+            var failedAssessment = new ThreadAssessment(assessment.Id, "keep", $"{assessment.Reason} (resolve failed: {error})",
+                assessment.Evidence);
             failed.Add(failedAssessment);
             replyMap[assessment.Id] = failedAssessment;
             Console.Error.WriteLine($"Failed to resolve review thread {thread.Id}: {error}");
@@ -1149,7 +1160,8 @@ public static class ReviewerApp {
         sb.AppendLine("If diff context shows `<file patch>`, it is the file-level diff because line-level context was unavailable.");
         sb.AppendLine();
         sb.AppendLine("Return JSON only in this format:");
-        sb.AppendLine("{\"threads\":[{\"id\":\"...\",\"action\":\"resolve|keep|comment\",\"reason\":\"...\"}]}");
+        sb.AppendLine("{\"threads\":[{\"id\":\"...\",\"action\":\"resolve|keep|comment\",\"reason\":\"...\",\"evidence\":\"...\"}]}");
+        sb.AppendLine("When resolving, evidence must quote a line from the diff context (e.g., \"42: fixed null check\").");
         sb.AppendLine();
         sb.AppendLine($"PR: {context.Owner}/{context.Repo} #{context.Number}");
         if (!string.IsNullOrWhiteSpace(context.Title)) {
@@ -1601,7 +1613,8 @@ public static class ReviewerApp {
                 action = "keep";
             }
             var reason = thread.GetString("reason") ?? string.Empty;
-            result.Add(new ThreadAssessment(id.Trim(), action, reason.Trim()));
+            var evidence = thread.GetString("evidence") ?? string.Empty;
+            result.Add(new ThreadAssessment(id.Trim(), action, reason.Trim(), evidence.Trim()));
         }
         return result;
     }
@@ -1621,7 +1634,27 @@ public static class ReviewerApp {
         return value?.AsObject();
     }
 
-    private sealed record ThreadAssessment(string Id, string Action, string Reason);
+    private sealed record ThreadAssessment(string Id, string Action, string Reason, string Evidence);
+
+    private static bool HasValidResolveEvidence(string? evidence, PullRequestReviewThread thread,
+        Dictionary<string, List<PatchLine>> patchIndex, IReadOnlyDictionary<string, string> patchLookup,
+        int maxPatchChars) {
+        if (string.IsNullOrWhiteSpace(evidence)) {
+            return false;
+        }
+        if (!TryGetThreadLocation(thread, out var path, out var line)) {
+            return false;
+        }
+        var context = BuildThreadDiffContext(patchIndex, patchLookup, path, line, maxPatchChars);
+        if (string.IsNullOrWhiteSpace(context) || context == "<unavailable>") {
+            return false;
+        }
+        var normalized = evidence.Trim().Trim('"');
+        if (normalized.Length == 0) {
+            return false;
+        }
+        return context.Contains(normalized, StringComparison.OrdinalIgnoreCase);
+    }
 
     private static async Task<(bool Resolved, string? Error)> TryResolveThreadAsync(GitHubClient github,
         GitHubClient? fallbackGithub, string threadId, CancellationToken cancellationToken) {

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -241,6 +241,8 @@ internal static class ReviewConfigLoader {
         }
         settings.ReviewThreadsAutoResolveMax = ReadNonNegativeInt(obj, "reviewThreadsAutoResolveMax", settings.ReviewThreadsAutoResolveMax);
         settings.ReviewThreadsAutoResolveAI = ReadBool(obj, "reviewThreadsAutoResolveAI", settings.ReviewThreadsAutoResolveAI);
+        settings.ReviewThreadsAutoResolveRequireEvidence = ReadBool(obj, "reviewThreadsAutoResolveRequireEvidence",
+            settings.ReviewThreadsAutoResolveRequireEvidence);
         settings.ReviewThreadsAutoResolveAIPostComment = ReadBool(obj, "reviewThreadsAutoResolveAIPostComment", settings.ReviewThreadsAutoResolveAIPostComment);
         settings.ReviewThreadsAutoResolveAIEmbed = ReadBool(obj, "reviewThreadsAutoResolveAIEmbed", settings.ReviewThreadsAutoResolveAIEmbed);
         settings.ReviewThreadsAutoResolveAISummary = ReadBool(obj, "reviewThreadsAutoResolveAISummary", settings.ReviewThreadsAutoResolveAISummary);

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -187,6 +187,10 @@ internal sealed class ReviewSettings {
     public string ReviewThreadsAutoResolveDiffRange { get; set; } = "current";
     public int ReviewThreadsAutoResolveMax { get; set; } = 10;
     public bool ReviewThreadsAutoResolveAI { get; set; } = true;
+    /// <summary>
+    /// Require explicit diff evidence to auto-resolve review threads.
+    /// </summary>
+    public bool ReviewThreadsAutoResolveRequireEvidence { get; set; } = true;
     public bool ReviewThreadsAutoResolveAIPostComment { get; set; }
     public bool ReviewThreadsAutoResolveAIEmbed { get; set; } = true;
     public bool ReviewThreadsAutoResolveAISummary { get; set; } = true;
@@ -773,6 +777,10 @@ internal sealed class ReviewSettings {
         var reviewThreadsAutoResolveAi = GetInput("review_threads_auto_resolve_ai", "REVIEW_THREADS_AUTO_RESOLVE_AI", "REVIEW_REVIEW_THREADS_AUTO_RESOLVE_AI");
         if (!string.IsNullOrWhiteSpace(reviewThreadsAutoResolveAi)) {
             settings.ReviewThreadsAutoResolveAI = ParseBoolean(reviewThreadsAutoResolveAi, settings.ReviewThreadsAutoResolveAI);
+        }
+        var reviewThreadsAutoResolveRequireEvidence = GetInput("review_threads_auto_resolve_require_evidence", "REVIEW_THREADS_AUTO_RESOLVE_REQUIRE_EVIDENCE", "REVIEW_REVIEW_THREADS_AUTO_RESOLVE_REQUIRE_EVIDENCE");
+        if (!string.IsNullOrWhiteSpace(reviewThreadsAutoResolveRequireEvidence)) {
+            settings.ReviewThreadsAutoResolveRequireEvidence = ParseBoolean(reviewThreadsAutoResolveRequireEvidence, settings.ReviewThreadsAutoResolveRequireEvidence);
         }
         var reviewThreadsAutoResolveAiPost = GetInput("review_threads_auto_resolve_ai_post_comment", "REVIEW_THREADS_AUTO_RESOLVE_AI_POST_COMMENT", "REVIEW_REVIEW_THREADS_AUTO_RESOLVE_AI_POST_COMMENT");
         if (!string.IsNullOrWhiteSpace(reviewThreadsAutoResolveAiPost)) {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -71,6 +71,7 @@ internal static class Program {
         failed += Run("Review thread inline key", TestReviewThreadInlineKey);
         failed += Run("Review thread inline key bots only", TestReviewThreadInlineKeyBotsOnly);
         failed += Run("GitHub event fork parsing", TestGitHubEventForkParsing);
+        failed += Run("Thread assessment evidence parse", TestThreadAssessmentEvidenceParse);
         failed += Run("Review retry transient", TestReviewRetryTransient);
         failed += Run("Review retry non-transient", TestReviewRetryNonTransient);
         failed += Run("Review retry rethrows", TestReviewRetryRethrows);
@@ -604,6 +605,32 @@ internal static class Program {
         AssertEqual(true, context.IsFromFork, "fork detection");
         AssertEqual("fork/repo", context.HeadRepoFullName, "head repo");
         AssertEqual("CONTRIBUTOR", context.AuthorAssociation, "author association");
+    }
+
+    private static void TestThreadAssessmentEvidenceParse() {
+        const string json = "{\"threads\":[{\"id\":\"t1\",\"action\":\"resolve\",\"reason\":\"fixed\",\"evidence\":\"42: added guard\"}]}";
+        var method = typeof(ReviewerApp).GetMethod("ParseThreadAssessments", BindingFlags.NonPublic | BindingFlags.Static);
+        if (method is null) {
+            throw new InvalidOperationException("ParseThreadAssessments not found.");
+        }
+        var result = method.Invoke(null, new object?[] { json }) as System.Collections.IEnumerable;
+        if (result is null) {
+            throw new InvalidOperationException("ParseThreadAssessments result invalid.");
+        }
+        object? first = null;
+        foreach (var item in result) {
+            first = item;
+            break;
+        }
+        if (first is null) {
+            throw new InvalidOperationException("No assessment parsed.");
+        }
+        var evidenceProp = first.GetType().GetProperty("Evidence");
+        if (evidenceProp is null) {
+            throw new InvalidOperationException("Evidence property not found.");
+        }
+        var evidence = evidenceProp.GetValue(first) as string;
+        AssertEqual("42: added guard", evidence ?? string.Empty, "evidence");
     }
 
     private static void TestReviewRetryTransient() {

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -49,6 +49,7 @@
         "reviewThreadsAutoResolveDiffRange": { "type": "string", "enum": ["current", "pr-base", "first-review"] },
         "reviewThreadsAutoResolveMax": { "type": "integer", "minimum": 0 },
         "reviewThreadsAutoResolveAI": { "type": "boolean" },
+        "reviewThreadsAutoResolveRequireEvidence": { "type": "boolean" },
         "reviewThreadsAutoResolveAIPostComment": { "type": "boolean" },
         "reviewThreadsAutoResolveAIEmbed": { "type": "boolean" },
         "reviewThreadsAutoResolveAISummary": { "type": "boolean" },

--- a/TODO.md
+++ b/TODO.md
@@ -45,7 +45,7 @@ Status: Draft (needs priorities + owners)
 ### Phase 4 — Thread triage + auto-resolve
 - [ ] Keep thread triage in main review comment (configurable placement).
 - [x] Support "explain why not resolved" replies (optional).
-- [ ] Add diff-based auto-resolve checks (explicit evidence required).
+- [x] Add diff-based auto-resolve checks (explicit evidence required).
 - [ ] Add per-bot policies (auto-resolve only for our bot by default).
 - [ ] Add PR comment summarizing what was auto-resolved.
 


### PR DESCRIPTION
## Summary
- Require explicit diff evidence before auto-resolving review threads
- Extend thread assessment schema with evidence field and validation
- Add config/env/schema/docs support for reviewThreadsAutoResolveRequireEvidence
- Add tests for evidence parsing

## Testing
- dotnet run --project C:\\Support\\GitHub\\IntelligenceX-wt-thread-triage-evidence\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0