### PR TITLE
feat: always summarize thread auto-resolve

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -69,6 +69,7 @@ Unknown properties emit warnings; invalid types or enum values fail the run.
     "reviewThreadsAutoResolveRequireEvidence": true,
     "reviewThreadsAutoResolveAIPostComment": true,
     "reviewThreadsAutoResolveAISummary": true,
+    "reviewThreadsAutoResolveSummaryAlways": true,
     "reviewThreadsAutoResolveBotLogins": [
       "intelligencex-review",
       "copilot-pull-request-reviewer"
@@ -319,6 +320,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `reviewThreadsAutoResolve*`: auto-resolve rules for bot threads
 - `reviewThreadsAutoResolveAIReply`: reply on kept threads to explain why they were not resolved (includes resolve failures)
 - `reviewThreadsAutoResolveRequireEvidence`: require a diff evidence snippet to resolve threads
+- `reviewThreadsAutoResolveSummaryAlways`: always append a triage summary line to the main review comment
 - `azureOrg`/`azureProject`/`azureRepo`: Azure DevOps identifiers
 - `azureBaseUrl`: override Azure DevOps base URL (defaults to `SYSTEM_COLLECTIONURI` or `https://dev.azure.com/{org}`)
 - `azureTokenEnv`: env var name that contains the ADO token (default `SYSTEM_ACCESSTOKEN` if set)

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -283,6 +283,9 @@ public static class ReviewerApp {
             }
             var inlineSuppressed = inlineSupported && !inlineAllowed;
             var autoResolveSummary = allowWrites && settings.ReviewThreadsAutoResolveAISummary ? triageResult.SummaryLine : string.Empty;
+            if (allowWrites && settings.ReviewThreadsAutoResolveSummaryAlways && string.IsNullOrWhiteSpace(autoResolveSummary)) {
+                autoResolveSummary = triageResult.FallbackSummary;
+            }
             var usageLine = await TryBuildUsageLineAsync(settings).ConfigureAwait(false);
             var findingsBlock = settings.StructuredFindings ? ReviewFindingsBuilder.Build(inlineComments) : string.Empty;
             var commentBody = ReviewFormatter.BuildComment(context, summaryBody, settings, inlineSupported, inlineSuppressed,
@@ -981,7 +984,8 @@ public static class ReviewerApp {
         if (commentPosted) {
             summary += " Triage comment posted.";
         }
-        return new ThreadTriageResult(summary, triageBody);
+        var fallbackSummary = BuildFallbackTriageSummary(resolved, kept);
+        return new ThreadTriageResult(summary, triageBody, fallbackSummary);
     }
 
     private static async Task<string> TryBuildUsageLineAsync(ReviewSettings settings) {
@@ -1544,6 +1548,20 @@ public static class ReviewerApp {
         return sb.ToString().TrimEnd();
     }
 
+    private static string BuildFallbackTriageSummary(IReadOnlyList<ThreadAssessment> resolved,
+        IReadOnlyList<ThreadAssessment> kept) {
+        if (resolved.Count == 0 && kept.Count == 0) {
+            return string.Empty;
+        }
+        if (resolved.Count > 0 && kept.Count == 0) {
+            return $"Auto-resolve: resolved {resolved.Count} thread(s).";
+        }
+        if (resolved.Count == 0 && kept.Count > 0) {
+            return $"Auto-resolve: kept {kept.Count} thread(s).";
+        }
+        return $"Auto-resolve: resolved {resolved.Count}, kept {kept.Count} thread(s).";
+    }
+
     private static async Task ReplyToKeptThreadsAsync(GitHubClient github, PullRequestContext context,
         IReadOnlyList<PullRequestReviewThread> candidates, IReadOnlyDictionary<string, ThreadAssessment> assessments,
         string? headSha, string? diffNote, ReviewSettings settings, CancellationToken cancellationToken) {
@@ -1614,8 +1632,8 @@ public static class ReviewerApp {
         return sb.ToString().TrimEnd();
     }
 
-    private readonly record struct ThreadTriageResult(string SummaryLine, string EmbeddedBlock) {
-        public static ThreadTriageResult Empty => new(string.Empty, string.Empty);
+    private readonly record struct ThreadTriageResult(string SummaryLine, string EmbeddedBlock, string FallbackSummary) {
+        public static ThreadTriageResult Empty => new(string.Empty, string.Empty, string.Empty);
     }
 
     private static List<ThreadAssessment> ParseThreadAssessments(string output) {

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -247,6 +247,8 @@ internal static class ReviewConfigLoader {
         settings.ReviewThreadsAutoResolveAIPostComment = ReadBool(obj, "reviewThreadsAutoResolveAIPostComment", settings.ReviewThreadsAutoResolveAIPostComment);
         settings.ReviewThreadsAutoResolveAIEmbed = ReadBool(obj, "reviewThreadsAutoResolveAIEmbed", settings.ReviewThreadsAutoResolveAIEmbed);
         settings.ReviewThreadsAutoResolveAISummary = ReadBool(obj, "reviewThreadsAutoResolveAISummary", settings.ReviewThreadsAutoResolveAISummary);
+        settings.ReviewThreadsAutoResolveSummaryAlways = ReadBool(obj, "reviewThreadsAutoResolveSummaryAlways",
+            settings.ReviewThreadsAutoResolveSummaryAlways);
         settings.ReviewThreadsAutoResolveAIReply = ReadBool(obj, "reviewThreadsAutoResolveAIReply", settings.ReviewThreadsAutoResolveAIReply);
         settings.MaxCommentChars = ReadInt(obj, "maxCommentChars", settings.MaxCommentChars);
         settings.MaxComments = ReadInt(obj, "maxComments", settings.MaxComments);

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -200,6 +200,10 @@ internal sealed class ReviewSettings {
     public bool ReviewThreadsAutoResolveAISummary { get; set; } = true;
     public bool ReviewThreadsAutoResolveAIReply { get; set; }
     /// <summary>
+    /// When enabled, always append the auto-resolve summary line to the main review comment.
+    /// </summary>
+    public bool ReviewThreadsAutoResolveSummaryAlways { get; set; }
+    /// <summary>
     /// When enabled, only run thread triage/auto-resolve without generating a full review comment.
     /// </summary>
     public bool TriageOnly { get; set; }
@@ -802,6 +806,12 @@ internal sealed class ReviewSettings {
         var reviewThreadsAutoResolveAiSummary = GetInput("review_threads_auto_resolve_ai_summary", "REVIEW_THREADS_AUTO_RESOLVE_AI_SUMMARY", "REVIEW_REVIEW_THREADS_AUTO_RESOLVE_AI_SUMMARY");
         if (!string.IsNullOrWhiteSpace(reviewThreadsAutoResolveAiSummary)) {
             settings.ReviewThreadsAutoResolveAISummary = ParseBoolean(reviewThreadsAutoResolveAiSummary, settings.ReviewThreadsAutoResolveAISummary);
+        }
+        var reviewThreadsAutoResolveSummaryAlways = GetInput("review_threads_auto_resolve_summary_always",
+            "REVIEW_THREADS_AUTO_RESOLVE_SUMMARY_ALWAYS", "REVIEW_REVIEW_THREADS_AUTO_RESOLVE_SUMMARY_ALWAYS");
+        if (!string.IsNullOrWhiteSpace(reviewThreadsAutoResolveSummaryAlways)) {
+            settings.ReviewThreadsAutoResolveSummaryAlways =
+                ParseBoolean(reviewThreadsAutoResolveSummaryAlways, settings.ReviewThreadsAutoResolveSummaryAlways);
         }
         var reviewThreadsAutoResolveAiReply = GetInput("review_threads_auto_resolve_ai_reply", "REVIEW_THREADS_AUTO_RESOLVE_AI_REPLY", "REVIEW_REVIEW_THREADS_AUTO_RESOLVE_AI_REPLY");
         if (!string.IsNullOrWhiteSpace(reviewThreadsAutoResolveAiReply)) {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -72,6 +72,7 @@ internal static class Program {
         failed += Run("Review thread inline key bots only", TestReviewThreadInlineKeyBotsOnly);
         failed += Run("GitHub event fork parsing", TestGitHubEventForkParsing);
         failed += Run("Thread assessment evidence parse", TestThreadAssessmentEvidenceParse);
+        failed += Run("Thread triage fallback summary", TestThreadTriageFallbackSummary);
         failed += Run("Review retry transient", TestReviewRetryTransient);
         failed += Run("Review retry non-transient", TestReviewRetryNonTransient);
         failed += Run("Review retry rethrows", TestReviewRetryRethrows);
@@ -632,6 +633,44 @@ internal static class Program {
         }
         var evidence = evidenceProp.GetValue(first) as string;
         AssertEqual("42: added guard", evidence ?? string.Empty, "evidence");
+    }
+
+    private static void TestThreadTriageFallbackSummary() {
+        var method = typeof(ReviewerApp).GetMethod("BuildFallbackTriageSummary",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        if (method is null) {
+            throw new InvalidOperationException("BuildFallbackTriageSummary not found.");
+        }
+        var assessment = CreateThreadAssessment("1");
+        var resolved = CreateThreadAssessmentArray(assessment, 1);
+        var kept = CreateThreadAssessmentArray(null, 0);
+        var summary = method.Invoke(null, new object?[] { resolved, kept }) as string;
+        AssertEqual("Auto-resolve: resolved 1 thread(s).", summary ?? string.Empty, "summary resolved");
+    }
+
+    private static object CreateThreadAssessment(string id) {
+        var type = typeof(ReviewerApp).GetNestedType("ThreadAssessment", BindingFlags.NonPublic);
+        if (type is null) {
+            throw new InvalidOperationException("ThreadAssessment type not found.");
+        }
+        var ctor = type.GetConstructor(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+            null, new[] { typeof(string), typeof(string), typeof(string) }, null);
+        if (ctor is null) {
+            throw new InvalidOperationException("ThreadAssessment constructor not found.");
+        }
+        return ctor.Invoke(new object[] { id, "resolve", "ok" });
+    }
+
+    private static Array CreateThreadAssessmentArray(object? item, int length) {
+        var type = typeof(ReviewerApp).GetNestedType("ThreadAssessment", BindingFlags.NonPublic);
+        if (type is null) {
+            throw new InvalidOperationException("ThreadAssessment type not found.");
+        }
+        var array = Array.CreateInstance(type, length);
+        if (item is not null && length > 0) {
+            array.SetValue(item, 0);
+        }
+        return array;
     }
 
     private static void TestReviewRetryTransient() {

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -53,6 +53,7 @@
         "reviewThreadsAutoResolveAIPostComment": { "type": "boolean" },
         "reviewThreadsAutoResolveAIEmbed": { "type": "boolean" },
         "reviewThreadsAutoResolveAISummary": { "type": "boolean" },
+        "reviewThreadsAutoResolveSummaryAlways": { "type": "boolean" },
         "reviewThreadsAutoResolveAIReply": { "type": "boolean" },
         "includeRelatedPrs": { "type": "boolean" },
         "maxCommentChars": { "type": "integer", "minimum": 0 },


### PR DESCRIPTION
## Summary
- Add optional always-on triage summary line in main review comment
- Add reviewThreadsAutoResolveSummaryAlways setting (config/env/schema/docs)
- Add fallback summary builder + test coverage

## Testing
- dotnet run --project C:\\Support\\GitHub\\IntelligenceX-wt-thread-triage-summarize\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0