### PR TITLE
feat: enforce bot allowlist for auto-resolve

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -334,7 +334,8 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 3. Finally, `excludePaths` (if set) removes any remaining files from review.
 
 ## Auto-resolve notes
-- `reviewThreadsAutoResolveBotLogins` defaults to `intelligencex-review` and `copilot-pull-request-reviewer`.
+- `reviewThreadsAutoResolveBotLogins` defaults to `intelligencex-review` and `copilot-pull-request-reviewer`. When set,
+  it acts as an allowlist for auto-resolve; set an empty list to fall back to generic bot detection.
 - `reviewThreadsAutoResolveDiffRange` supports `current`, `pr-base`, or `first-review`.
 
 ## Full example

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -1735,7 +1735,7 @@ public static class ReviewerApp {
             if (string.IsNullOrWhiteSpace(comment.Author)) {
                 return false;
             }
-            if (!IsBotAuthor(comment.Author, settings)) {
+            if (!IsAutoResolveBot(comment.Author, settings)) {
                 return false;
             }
         }
@@ -1874,6 +1874,29 @@ public static class ReviewerApp {
         }
         return trimmedAuthor.Equals("github-actions", StringComparison.OrdinalIgnoreCase) ||
             trimmedAuthor.Equals("intelligencex-review", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsAutoResolveBot(string author, ReviewSettings settings) {
+        if (string.IsNullOrWhiteSpace(author)) {
+            return false;
+        }
+        var normalizedAuthor = NormalizeBotLogin(author.Trim());
+        if (settings.ReviewThreadsAutoResolveBotLogins.Count > 0) {
+            foreach (var login in settings.ReviewThreadsAutoResolveBotLogins) {
+                if (string.IsNullOrWhiteSpace(login)) {
+                    continue;
+                }
+                var normalizedLogin = NormalizeBotLogin(login);
+                if (string.IsNullOrWhiteSpace(normalizedLogin)) {
+                    continue;
+                }
+                if (string.Equals(normalizedAuthor, normalizedLogin, StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return IsBotAuthor(author, settings);
     }
 
     private static string NormalizeBotLogin(string login) {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -73,6 +73,7 @@ internal static class Program {
         failed += Run("GitHub event fork parsing", TestGitHubEventForkParsing);
         failed += Run("Thread assessment evidence parse", TestThreadAssessmentEvidenceParse);
         failed += Run("Thread triage fallback summary", TestThreadTriageFallbackSummary);
+        failed += Run("Review thread inline key allowlist", TestReviewThreadInlineKeyAllowlist);
         failed += Run("Review retry transient", TestReviewRetryTransient);
         failed += Run("Review retry non-transient", TestReviewRetryNonTransient);
         failed += Run("Review retry rethrows", TestReviewRetryRethrows);
@@ -671,6 +672,18 @@ internal static class Program {
             array.SetValue(item, 0);
         }
         return array;
+    }
+
+    private static void TestReviewThreadInlineKeyAllowlist() {
+        var settings = new ReviewSettings {
+            ReviewThreadsAutoResolveBotsOnly = true,
+            ReviewThreadsAutoResolveBotLogins = new[] { "intelligencex-review" }
+        };
+        var comment = new PullRequestReviewThreadComment(null, null, $"{ReviewFormatter.InlineMarker}\nFix it.",
+            "dependabot[bot]", "src/Foo.cs", 10);
+        var thread = new PullRequestReviewThread("id", false, false, 1, new[] { comment });
+        var ok = ReviewerApp.TryGetInlineThreadKey(thread, settings, out _);
+        AssertEqual(false, ok, "inline key allowlist");
     }
 
     private static void TestReviewRetryTransient() {

--- a/TODO.md
+++ b/TODO.md
@@ -43,11 +43,11 @@ Status: Draft (needs priorities + owners)
 - [x] Add “triage mode” that only checks open threads.
 
 ### Phase 4 — Thread triage + auto-resolve
-- [ ] Keep thread triage in main review comment (configurable placement).
+- [x] Keep thread triage in main review comment (configurable placement).
 - [x] Support "explain why not resolved" replies (optional).
 - [x] Add diff-based auto-resolve checks (explicit evidence required).
-- [ ] Add per-bot policies (auto-resolve only for our bot by default).
-- [ ] Add PR comment summarizing what was auto-resolved.
+- [x] Add per-bot policies (auto-resolve only for our bot by default).
+- [x] Add PR comment summarizing what was auto-resolved.
 
 ### Phase 5 — Provider abstraction
 - [ ] Centralize provider contracts (capabilities, limits, streaming, auth).


### PR DESCRIPTION
## Summary
- Enforce reviewThreadsAutoResolveBotLogins as an allowlist for auto-resolve
- Keep generic bot detection for non-auto-resolve contexts
- Add test for allowlist behavior and update docs/TODO

## Testing
- dotnet run --project C:\\Support\\GitHub\\IntelligenceX-wt-thread-bot-allowlist\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0