### PR TITLE
feat: post auto-resolve summary comment

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -68,6 +68,7 @@ Unknown properties emit warnings; invalid types or enum values fail the run.
     "reviewThreadsAutoResolveAI": true,
     "reviewThreadsAutoResolveRequireEvidence": true,
     "reviewThreadsAutoResolveAIPostComment": true,
+    "reviewThreadsAutoResolveSummaryComment": true,
     "reviewThreadsAutoResolveAISummary": true,
     "reviewThreadsAutoResolveSummaryAlways": true,
     "reviewThreadsAutoResolveBotLogins": [
@@ -321,6 +322,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `reviewThreadsAutoResolveAIReply`: reply on kept threads to explain why they were not resolved (includes resolve failures)
 - `reviewThreadsAutoResolveRequireEvidence`: require a diff evidence snippet to resolve threads
 - `reviewThreadsAutoResolveSummaryAlways`: always append a triage summary line to the main review comment
+- `reviewThreadsAutoResolveSummaryComment`: post a standalone summary comment for auto-resolve decisions
 - `azureOrg`/`azureProject`/`azureRepo`: Azure DevOps identifiers
 - `azureBaseUrl`: override Azure DevOps base URL (defaults to `SYSTEM_COLLECTIONURI` or `https://dev.azure.com/{org}`)
 - `azureTokenEnv`: env var name that contains the ADO token (default `SYSTEM_ACCESSTOKEN` if set)

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -976,6 +976,12 @@ public static class ReviewerApp {
                 .ConfigureAwait(false);
             commentPosted = true;
         }
+        if (settings.ReviewThreadsAutoResolveSummaryComment && !commentPosted && (resolved.Count > 0 || kept.Count > 0)) {
+            var body = BuildThreadAutoResolveSummaryComment(resolved, kept, context.HeadSha, diffNote);
+            await github.CreateIssueCommentAsync(context.Owner, context.Repo, context.Number, body, cancellationToken)
+                .ConfigureAwait(false);
+            commentPosted = true;
+        }
 
         if (resolvedCount == 0 && kept.Count == 0) {
             return ThreadTriageResult.Empty;
@@ -1560,6 +1566,37 @@ public static class ReviewerApp {
             return $"Auto-resolve: kept {kept.Count} thread(s).";
         }
         return $"Auto-resolve: resolved {resolved.Count}, kept {kept.Count} thread(s).";
+    }
+
+    private static string BuildThreadAutoResolveSummaryComment(IReadOnlyList<ThreadAssessment> resolved,
+        IReadOnlyList<ThreadAssessment> kept, string? headSha, string? diffNote) {
+        var sb = new StringBuilder();
+        sb.AppendLine("<!-- intelligencex:thread-autoresolve-summary -->");
+        sb.AppendLine("### IntelligenceX auto-resolve summary");
+        if (!string.IsNullOrWhiteSpace(headSha)) {
+            var trimmed = headSha.Length > 7 ? headSha.Substring(0, 7) : headSha;
+            sb.AppendLine($"_Assessed commit: `{trimmed}`_");
+            sb.AppendLine();
+        }
+        if (!string.IsNullOrWhiteSpace(diffNote)) {
+            sb.AppendLine($"_Diff range: {diffNote}_");
+            sb.AppendLine();
+        }
+        if (resolved.Count > 0) {
+            sb.AppendLine("Resolved:");
+            foreach (var item in resolved) {
+                sb.AppendLine($"- {item.Id}: {item.Reason}");
+            }
+            sb.AppendLine();
+        }
+        if (kept.Count > 0) {
+            sb.AppendLine("Kept:");
+            foreach (var item in kept) {
+                sb.AppendLine($"- {item.Id}: {item.Reason}");
+            }
+            sb.AppendLine();
+        }
+        return sb.ToString().TrimEnd();
     }
 
     private static async Task ReplyToKeptThreadsAsync(GitHubClient github, PullRequestContext context,

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -250,6 +250,8 @@ internal static class ReviewConfigLoader {
         settings.ReviewThreadsAutoResolveSummaryAlways = ReadBool(obj, "reviewThreadsAutoResolveSummaryAlways",
             settings.ReviewThreadsAutoResolveSummaryAlways);
         settings.ReviewThreadsAutoResolveAIReply = ReadBool(obj, "reviewThreadsAutoResolveAIReply", settings.ReviewThreadsAutoResolveAIReply);
+        settings.ReviewThreadsAutoResolveSummaryComment = ReadBool(obj, "reviewThreadsAutoResolveSummaryComment",
+            settings.ReviewThreadsAutoResolveSummaryComment);
         settings.MaxCommentChars = ReadInt(obj, "maxCommentChars", settings.MaxCommentChars);
         settings.MaxComments = ReadInt(obj, "maxComments", settings.MaxComments);
         settings.CommentSearchLimit = ReadInt(obj, "commentSearchLimit", settings.CommentSearchLimit);

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -203,6 +203,9 @@ internal sealed class ReviewSettings {
     /// When enabled, always append the auto-resolve summary line to the main review comment.
     /// </summary>
     public bool ReviewThreadsAutoResolveSummaryAlways { get; set; }
+    /// Post a standalone summary comment listing auto-resolved and kept threads.
+    /// </summary>
+    public bool ReviewThreadsAutoResolveSummaryComment { get; set; }
     /// <summary>
     /// When enabled, only run thread triage/auto-resolve without generating a full review comment.
     /// </summary>
@@ -816,6 +819,12 @@ internal sealed class ReviewSettings {
         var reviewThreadsAutoResolveAiReply = GetInput("review_threads_auto_resolve_ai_reply", "REVIEW_THREADS_AUTO_RESOLVE_AI_REPLY", "REVIEW_REVIEW_THREADS_AUTO_RESOLVE_AI_REPLY");
         if (!string.IsNullOrWhiteSpace(reviewThreadsAutoResolveAiReply)) {
             settings.ReviewThreadsAutoResolveAIReply = ParseBoolean(reviewThreadsAutoResolveAiReply, settings.ReviewThreadsAutoResolveAIReply);
+        }
+        var reviewThreadsAutoResolveSummaryComment = GetInput("review_threads_auto_resolve_summary_comment",
+            "REVIEW_THREADS_AUTO_RESOLVE_SUMMARY_COMMENT", "REVIEW_REVIEW_THREADS_AUTO_RESOLVE_SUMMARY_COMMENT");
+        if (!string.IsNullOrWhiteSpace(reviewThreadsAutoResolveSummaryComment)) {
+            settings.ReviewThreadsAutoResolveSummaryComment =
+                ParseBoolean(reviewThreadsAutoResolveSummaryComment, settings.ReviewThreadsAutoResolveSummaryComment);
         }
         var contextDenyEnabled = GetInput("context_deny_enabled", "REVIEW_CONTEXT_DENY_ENABLED");
         if (!string.IsNullOrWhiteSpace(contextDenyEnabled)) {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -74,6 +74,7 @@ internal static class Program {
         failed += Run("Thread assessment evidence parse", TestThreadAssessmentEvidenceParse);
         failed += Run("Thread triage fallback summary", TestThreadTriageFallbackSummary);
         failed += Run("Review thread inline key allowlist", TestReviewThreadInlineKeyAllowlist);
+        failed += Run("Thread auto-resolve summary comment", TestThreadAutoResolveSummaryComment);
         failed += Run("Review retry transient", TestReviewRetryTransient);
         failed += Run("Review retry non-transient", TestReviewRetryNonTransient);
         failed += Run("Review retry rethrows", TestReviewRetryRethrows);
@@ -647,6 +648,19 @@ internal static class Program {
         var kept = CreateThreadAssessmentArray(null, 0);
         var summary = method.Invoke(null, new object?[] { resolved, kept }) as string;
         AssertEqual("Auto-resolve: resolved 1 thread(s).", summary ?? string.Empty, "summary resolved");
+    }
+
+    private static void TestThreadAutoResolveSummaryComment() {
+        var method = typeof(ReviewerApp).GetMethod("BuildThreadAutoResolveSummaryComment",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        if (method is null) {
+            throw new InvalidOperationException("BuildThreadAutoResolveSummaryComment not found.");
+        }
+        var resolved = CreateThreadAssessmentArray(CreateThreadAssessment("1"), 1);
+        var kept = CreateThreadAssessmentArray(null, 0);
+        var summary = method.Invoke(null, new object?[] { resolved, kept, "abcdef1234567890", "current PR files" }) as string;
+        AssertContainsText(summary ?? string.Empty, "auto-resolve summary", "summary header");
+        AssertContainsText(summary ?? string.Empty, "Resolved:", "summary resolved label");
     }
 
     private static object CreateThreadAssessment(string id) {

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -55,6 +55,7 @@
         "reviewThreadsAutoResolveAISummary": { "type": "boolean" },
         "reviewThreadsAutoResolveSummaryAlways": { "type": "boolean" },
         "reviewThreadsAutoResolveAIReply": { "type": "boolean" },
+        "reviewThreadsAutoResolveSummaryComment": { "type": "boolean" },
         "includeRelatedPrs": { "type": "boolean" },
         "maxCommentChars": { "type": "integer", "minimum": 0 },
         "maxComments": { "type": "integer", "minimum": 0 },


### PR DESCRIPTION
## Summary
- Add optional standalone summary comment for thread auto-resolve decisions
- Add reviewThreadsAutoResolveSummaryComment setting (config/env/schema/docs)
- Add summary comment builder test and update roadmap

## Testing
- dotnet run --project C:\\Support\\GitHub\\IntelligenceX-wt-thread-auto-resolve-summary\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0