### PR TITLE
feat: configurable triage embed placement

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -69,8 +69,8 @@ Unknown properties emit warnings; invalid types or enum values fail the run.
     "reviewThreadsAutoResolveRequireEvidence": true,
     "reviewThreadsAutoResolveAIPostComment": true,
     "reviewThreadsAutoResolveSummaryComment": true,
-    "reviewThreadsAutoResolveAISummary": true,
-    "reviewThreadsAutoResolveSummaryAlways": true,
+    "reviewThreadsAutoResolveAIEmbedPlacement": "bottom",
+    "reviewThreadsAutoResolveAISummary": true,    "reviewThreadsAutoResolveSummaryAlways": true,
     "reviewThreadsAutoResolveBotLogins": [
       "intelligencex-review",
       "copilot-pull-request-reviewer"
@@ -323,7 +323,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `reviewThreadsAutoResolveRequireEvidence`: require a diff evidence snippet to resolve threads
 - `reviewThreadsAutoResolveSummaryAlways`: always append a triage summary line to the main review comment
 - `reviewThreadsAutoResolveSummaryComment`: post a standalone summary comment for auto-resolve decisions
-- `azureOrg`/`azureProject`/`azureRepo`: Azure DevOps identifiers
+- `reviewThreadsAutoResolveAIEmbedPlacement`: `top` or `bottom` placement for embedded triage blocks- `azureOrg`/`azureProject`/`azureRepo`: Azure DevOps identifiers
 - `azureBaseUrl`: override Azure DevOps base URL (defaults to `SYSTEM_COLLECTIONURI` or `https://dev.azure.com/{org}`)
 - `azureTokenEnv`: env var name that contains the ADO token (default `SYSTEM_ACCESSTOKEN` if set)
 - `azureAuthScheme`: `bearer` (System.AccessToken/JWT) or `basic`/`pat`

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -278,7 +278,8 @@ public static class ReviewerApp {
                         settings.ReviewThreadsAutoResolveAIPostComment)
                     .ConfigureAwait(false);
                 if (settings.ReviewThreadsAutoResolveAIEmbed && !string.IsNullOrWhiteSpace(triageResult.EmbeddedBlock)) {
-                    summaryBody = summaryBody.TrimEnd() + "\n\n" + triageResult.EmbeddedBlock.Trim();
+                    summaryBody = ApplyEmbedPlacement(summaryBody, triageResult.EmbeddedBlock,
+                        settings.ReviewThreadsAutoResolveAIEmbedPlacement);
                 }
             }
             var inlineSuppressed = inlineSupported && !inlineAllowed;
@@ -545,6 +546,19 @@ public static class ReviewerApp {
             return string.Empty;
         }
         return $"Review context truncated: {string.Join("; ", parts)}.";
+    }
+
+    private static string ApplyEmbedPlacement(string reviewBody, string embedBlock, string placement) {
+        var embed = embedBlock.Trim();
+        if (embed.Length == 0) {
+            return reviewBody;
+        }
+        var body = string.IsNullOrWhiteSpace(reviewBody) ? string.Empty : reviewBody.Trim();
+        var normalizedPlacement = ReviewSettings.NormalizeEmbedPlacement(placement, "bottom");
+        if (normalizedPlacement == "top") {
+            return string.IsNullOrWhiteSpace(body) ? embed : embed + "\n\n" + body;
+        }
+        return string.IsNullOrWhiteSpace(body) ? embed : body + "\n\n" + embed;
     }
 
     /// <summary>

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -246,6 +246,11 @@ internal static class ReviewConfigLoader {
             settings.ReviewThreadsAutoResolveRequireEvidence);
         settings.ReviewThreadsAutoResolveAIPostComment = ReadBool(obj, "reviewThreadsAutoResolveAIPostComment", settings.ReviewThreadsAutoResolveAIPostComment);
         settings.ReviewThreadsAutoResolveAIEmbed = ReadBool(obj, "reviewThreadsAutoResolveAIEmbed", settings.ReviewThreadsAutoResolveAIEmbed);
+        var embedPlacement = obj.GetString("reviewThreadsAutoResolveAIEmbedPlacement");
+        if (!string.IsNullOrWhiteSpace(embedPlacement)) {
+            settings.ReviewThreadsAutoResolveAIEmbedPlacement =
+                ReviewSettings.NormalizeEmbedPlacement(embedPlacement, settings.ReviewThreadsAutoResolveAIEmbedPlacement);
+        }
         settings.ReviewThreadsAutoResolveAISummary = ReadBool(obj, "reviewThreadsAutoResolveAISummary", settings.ReviewThreadsAutoResolveAISummary);
         settings.ReviewThreadsAutoResolveSummaryAlways = ReadBool(obj, "reviewThreadsAutoResolveSummaryAlways",
             settings.ReviewThreadsAutoResolveSummaryAlways);

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -197,6 +197,10 @@ internal sealed class ReviewSettings {
     public bool ReviewThreadsAutoResolveRequireEvidence { get; set; } = true;
     public bool ReviewThreadsAutoResolveAIPostComment { get; set; }
     public bool ReviewThreadsAutoResolveAIEmbed { get; set; } = true;
+    /// <summary>
+    /// Placement for embedded thread triage blocks in the main review comment.
+    /// </summary>
+    public string ReviewThreadsAutoResolveAIEmbedPlacement { get; set; } = "bottom";
     public bool ReviewThreadsAutoResolveAISummary { get; set; } = true;
     public bool ReviewThreadsAutoResolveAIReply { get; set; }
     /// <summary>
@@ -806,6 +810,12 @@ internal sealed class ReviewSettings {
         if (!string.IsNullOrWhiteSpace(reviewThreadsAutoResolveAiEmbed)) {
             settings.ReviewThreadsAutoResolveAIEmbed = ParseBoolean(reviewThreadsAutoResolveAiEmbed, settings.ReviewThreadsAutoResolveAIEmbed);
         }
+        var reviewThreadsAutoResolveEmbedPlacement = GetInput("review_threads_auto_resolve_ai_embed_placement",
+            "REVIEW_THREADS_AUTO_RESOLVE_AI_EMBED_PLACEMENT", "REVIEW_REVIEW_THREADS_AUTO_RESOLVE_AI_EMBED_PLACEMENT");
+        if (!string.IsNullOrWhiteSpace(reviewThreadsAutoResolveEmbedPlacement)) {
+            settings.ReviewThreadsAutoResolveAIEmbedPlacement =
+                NormalizeEmbedPlacement(reviewThreadsAutoResolveEmbedPlacement, settings.ReviewThreadsAutoResolveAIEmbedPlacement);
+        }
         var reviewThreadsAutoResolveAiSummary = GetInput("review_threads_auto_resolve_ai_summary", "REVIEW_THREADS_AUTO_RESOLVE_AI_SUMMARY", "REVIEW_REVIEW_THREADS_AUTO_RESOLVE_AI_SUMMARY");
         if (!string.IsNullOrWhiteSpace(reviewThreadsAutoResolveAiSummary)) {
             settings.ReviewThreadsAutoResolveAISummary = ParseBoolean(reviewThreadsAutoResolveAiSummary, settings.ReviewThreadsAutoResolveAISummary);
@@ -974,6 +984,18 @@ internal sealed class ReviewSettings {
             "current" or "pr" or "pr-files" or "pr_files" => "current",
             "pr-base" or "pr_base" or "base" or "prbase" => "pr-base",
             "first-review" or "first_review" or "first-reviewed" or "firstreview" or "first" => "first-review",
+            _ => fallback
+        };
+    }
+
+    internal static string NormalizeEmbedPlacement(string? value, string fallback) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return fallback;
+        }
+        var normalized = value.Trim().ToLowerInvariant();
+        return normalized switch {
+            "top" or "header" or "above" => "top",
+            "bottom" or "footer" or "below" => "bottom",
             _ => fallback
         };
     }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -75,7 +75,7 @@ internal static class Program {
         failed += Run("Thread triage fallback summary", TestThreadTriageFallbackSummary);
         failed += Run("Review thread inline key allowlist", TestReviewThreadInlineKeyAllowlist);
         failed += Run("Thread auto-resolve summary comment", TestThreadAutoResolveSummaryComment);
-        failed += Run("Review retry transient", TestReviewRetryTransient);
+        failed += Run("Thread triage embed placement", TestThreadTriageEmbedPlacement);        failed += Run("Review retry transient", TestReviewRetryTransient);
         failed += Run("Review retry non-transient", TestReviewRetryNonTransient);
         failed += Run("Review retry rethrows", TestReviewRetryRethrows);
         failed += Run("Review retry extra attempt", TestReviewRetryExtraAttempt);
@@ -698,6 +698,21 @@ internal static class Program {
         var thread = new PullRequestReviewThread("id", false, false, 1, new[] { comment });
         var ok = ReviewerApp.TryGetInlineThreadKey(thread, settings, out _);
         AssertEqual(false, ok, "inline key allowlist");
+    }
+
+    private static void TestThreadTriageEmbedPlacement() {
+        var method = typeof(ReviewerApp).GetMethod("ApplyEmbedPlacement", BindingFlags.NonPublic | BindingFlags.Static);
+        if (method is null) {
+            throw new InvalidOperationException("ApplyEmbedPlacement not found.");
+        }
+        var top = method.Invoke(null, new object?[] { "Body", "Triage", "top" }) as string;
+        AssertEqual("Triage\n\nBody", top ?? string.Empty, "embed top");
+
+        var bottom = method.Invoke(null, new object?[] { "Body", "Triage", "bottom" }) as string;
+        AssertEqual("Body\n\nTriage", bottom ?? string.Empty, "embed bottom");
+
+        var fallback = method.Invoke(null, new object?[] { "Body", "Triage", "unknown" }) as string;
+        AssertEqual("Body\n\nTriage", fallback ?? string.Empty, "embed fallback");
     }
 
     private static void TestReviewRetryTransient() {

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -52,6 +52,7 @@
         "reviewThreadsAutoResolveRequireEvidence": { "type": "boolean" },
         "reviewThreadsAutoResolveAIPostComment": { "type": "boolean" },
         "reviewThreadsAutoResolveAIEmbed": { "type": "boolean" },
+        "reviewThreadsAutoResolveAIEmbedPlacement": { "type": "string", "enum": ["top", "bottom", "header", "footer", "above", "below"] },
         "reviewThreadsAutoResolveAISummary": { "type": "boolean" },
         "reviewThreadsAutoResolveSummaryAlways": { "type": "boolean" },
         "reviewThreadsAutoResolveAIReply": { "type": "boolean" },


### PR DESCRIPTION
## Summary
- Add configurable placement for embedded thread triage blocks (top/bottom)
- Add reviewThreadsAutoResolveAIEmbedPlacement setting (config/env/schema/docs)
- Add tests for embed placement and update roadmap

## Testing
- dotnet run --project C:\\Support\\GitHub\\IntelligenceX-wt-thread-triage-placement\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0