### PR TITLE
feat: explain kept threads on auto-resolve

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -284,6 +284,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `includeReviewThreads`: include existing review threads in context
 - `triageOnly`: run thread triage only (skip full review)
 - `reviewThreadsAutoResolve*`: auto-resolve rules for bot threads
+- `reviewThreadsAutoResolveAIReply`: reply on kept threads to explain why they were not resolved (includes resolve failures)
 - `azureOrg`/`azureProject`/`azureRepo`: Azure DevOps identifiers
 - `azureBaseUrl`: override Azure DevOps base URL (defaults to `SYSTEM_COLLECTIONURI` or `https://dev.azure.com/{org}`)
 - `azureTokenEnv`: env var name that contains the ADO token (default `SYSTEM_ACCESSTOKEN` if set)

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -851,6 +851,7 @@ public static class ReviewerApp {
         }
 
         var byId = assessments.ToDictionary(a => a.Id, StringComparer.OrdinalIgnoreCase);
+        var replyMap = new Dictionary<string, ThreadAssessment>(StringComparer.OrdinalIgnoreCase);
         var resolved = new List<ThreadAssessment>();
         var kept = new List<ThreadAssessment>();
         var failed = new List<ThreadAssessment>();
@@ -859,6 +860,7 @@ public static class ReviewerApp {
                 case "comment":
                 case "keep":
                     kept.Add(assessment);
+                    replyMap[assessment.Id] = assessment;
                     break;
             }
         }
@@ -878,7 +880,9 @@ public static class ReviewerApp {
                 continue;
             }
             var error = result.Error ?? "unknown error";
-            failed.Add(new ThreadAssessment(assessment.Id, "keep", $"{assessment.Reason} (resolve failed: {error})"));
+            var failedAssessment = new ThreadAssessment(assessment.Id, "keep", $"{assessment.Reason} (resolve failed: {error})");
+            failed.Add(failedAssessment);
+            replyMap[assessment.Id] = failedAssessment;
             Console.Error.WriteLine($"Failed to resolve review thread {thread.Id}: {error}");
         }
 
@@ -888,8 +892,8 @@ public static class ReviewerApp {
 
         var commentPosted = false;
         var triageBody = BuildThreadAssessmentComment(resolved, kept, context.HeadSha, diffNote);
-        if (settings.ReviewThreadsAutoResolveAIReply && kept.Count > 0) {
-            await ReplyToKeptThreadsAsync(github, context, candidates, byId, context.HeadSha, diffNote, settings, cancellationToken)
+        if (settings.ReviewThreadsAutoResolveAIReply && replyMap.Count > 0) {
+            await ReplyToKeptThreadsAsync(github, context, candidates, replyMap, context.HeadSha, diffNote, settings, cancellationToken)
                 .ConfigureAwait(false);
         }
         if (allowCommentPost && settings.ReviewThreadsAutoResolveAIPostComment &&

--- a/TODO.md
+++ b/TODO.md
@@ -44,7 +44,7 @@ Status: Draft (needs priorities + owners)
 
 ### Phase 4 — Thread triage + auto-resolve
 - [ ] Keep thread triage in main review comment (configurable placement).
-- [ ] Support "explain why not resolved" replies (optional).
+- [x] Support "explain why not resolved" replies (optional).
 - [ ] Add diff-based auto-resolve checks (explicit evidence required).
 - [ ] Add per-bot policies (auto-resolve only for our bot by default).
 - [ ] Add PR comment summarizing what was auto-resolved.


### PR DESCRIPTION
## Summary
- Ensure auto-resolve replies include reasons for kept threads and resolve failures
- Use reply map for kept/failed assessments when posting explanations
- Document explain-why-not-resolved option and update roadmap

## Testing
- dotnet run --project C:\\Support\\GitHub\\IntelligenceX-wt-thread-triage-explain\\IntelligenceX.Tests\\IntelligenceX.Tests.csproj -c Release --framework net8.0