### PR TITLE
feat: configurable generated file globs

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -332,6 +332,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `skipPaths`: if **all** changed files in a PR match these globs, skip reviewing the entire PR
 - `skipBinaryFiles`: skip binary assets (images, archives, executables) from review context (default true)
 - `skipGeneratedFiles`: skip generated files (build output, generated sources) from review context (default true)
+- `generatedFileGlobs`: extra glob patterns to treat as generated files (appended to defaults)
 - `includePaths`: only review files matching these globs
 - `excludePaths`: ignore files matching these globs
 - `allowWorkflowChanges`: allow reviews to run when `.github/workflows/*` changes are present
@@ -353,6 +354,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 **Path filter order of operations**
 1. `skipPaths` is evaluated first at the PR level. If **every** changed file matches `skipPaths`, the PR is skipped.
 2. If the PR is not skipped, `skipBinaryFiles`/`skipGeneratedFiles` (when enabled) remove binary and generated files from the review list.
+   `generatedFileGlobs` extends the default generated-file patterns.
 3. `includePaths` (if set) selects which changed files are eligible for review.
 4. Finally, `excludePaths` (if set) removes any remaining files from review.
 

--- a/IntelligenceX.Reviewer/AzureDevOpsReviewRunner.cs
+++ b/IntelligenceX.Reviewer/AzureDevOpsReviewRunner.cs
@@ -57,7 +57,7 @@ internal static class AzureDevOpsReviewRunner {
         }
 
         var filtered = ReviewerApp.FilterFilesByPaths(files, settings.IncludePaths, settings.ExcludePaths,
-            settings.SkipBinaryFiles, settings.SkipGeneratedFiles);
+            settings.SkipBinaryFiles, settings.SkipGeneratedFiles, settings.GeneratedFileGlobs);
         if (filtered.Count == 0) {
             Console.WriteLine("No files matched include/exclude filters.");
             return 0;

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -253,7 +253,7 @@ public static class ReviewerApp {
             var (reviewFiles, diffNote) = await ResolveReviewFilesAsync(github, context, settings, files, cancellationToken)
                 .ConfigureAwait(false);
             reviewFiles = FilterFilesByPaths(reviewFiles, settings.IncludePaths, settings.ExcludePaths,
-                settings.SkipBinaryFiles, settings.SkipGeneratedFiles);
+                settings.SkipBinaryFiles, settings.SkipGeneratedFiles, settings.GeneratedFileGlobs);
             if (reviewFiles.Count == 0) {
                 progress.Context = ReviewProgressState.Complete;
                 Console.WriteLine("No files matched include/exclude filters.");
@@ -685,7 +685,8 @@ public static class ReviewerApp {
     /// </summary>
     internal static IReadOnlyList<PullRequestFile> FilterFilesByPaths(IReadOnlyList<PullRequestFile> files,
         IReadOnlyList<string> includePaths, IReadOnlyList<string> excludePaths,
-        bool skipBinaryFiles = false, bool skipGeneratedFiles = false) {
+        bool skipBinaryFiles = false, bool skipGeneratedFiles = false,
+        IReadOnlyList<string>? generatedFileGlobs = null) {
         if (files.Count == 0) {
             return files;
         }
@@ -696,13 +697,16 @@ public static class ReviewerApp {
         if (!hasInclude && !hasExclude && !skipBinaryFiles && !skipGeneratedFiles) {
             return files;
         }
+        var effectiveGeneratedGlobs = skipGeneratedFiles
+            ? ResolveGeneratedGlobs(generatedFileGlobs)
+            : Array.Empty<string>();
         var filtered = new List<PullRequestFile>();
         foreach (var file in files) {
             var filename = file.Filename.Replace('\\', '/');
             if (skipBinaryFiles && IsBinaryFile(filename)) {
                 continue;
             }
-            if (skipGeneratedFiles && IsGeneratedFile(filename)) {
+            if (skipGeneratedFiles && IsGeneratedFile(filename, effectiveGeneratedGlobs)) {
                 continue;
             }
             if (hasInclude && !includePaths.Any(pattern => GlobMatcher.IsMatch(pattern, filename))) {
@@ -727,11 +731,21 @@ public static class ReviewerApp {
         return BinaryExtensions.Contains(extension);
     }
 
-    private static bool IsGeneratedFile(string path) {
+    private static IReadOnlyList<string> ResolveGeneratedGlobs(IReadOnlyList<string>? generatedFileGlobs) {
+        if (generatedFileGlobs is null || generatedFileGlobs.Count == 0) {
+            return GeneratedGlobs;
+        }
+        var combined = new List<string>(GeneratedGlobs.Count + generatedFileGlobs.Count);
+        combined.AddRange(GeneratedGlobs);
+        combined.AddRange(generatedFileGlobs);
+        return combined;
+    }
+
+    private static bool IsGeneratedFile(string path, IReadOnlyList<string> generatedGlobs) {
         if (string.IsNullOrWhiteSpace(path)) {
             return false;
         }
-        return GeneratedGlobs.Any(pattern => GlobMatcher.IsMatch(pattern, path));
+        return generatedGlobs.Any(pattern => GlobMatcher.IsMatch(pattern, path));
     }
 
     private static async Task<(IReadOnlyList<PullRequestFile> Files, string DiffNote)> ResolveReviewFilesAsync(
@@ -994,7 +1008,7 @@ public static class ReviewerApp {
                     return (false, Array.Empty<PullRequestFile>(), $"{label} diff empty");
                 }
                 var filtered = FilterFilesByPaths(compareFiles, settings.IncludePaths, settings.ExcludePaths,
-                    settings.SkipBinaryFiles, settings.SkipGeneratedFiles);
+                    settings.SkipBinaryFiles, settings.SkipGeneratedFiles, settings.GeneratedFileGlobs);
                 var note = $"{label} → head ({ShortSha(baseSha)}..{ShortSha(context.HeadSha)})";
                 if (filtered.Count == 0) {
                     note += " (filtered empty)";

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -137,6 +137,11 @@ internal static class ReviewConfigLoader {
             settings.SkipPaths = skipPaths;
         }
 
+        var generatedFileGlobs = ReadStringList(obj, "generatedFileGlobs");
+        if (generatedFileGlobs is not null) {
+            settings.GeneratedFileGlobs = generatedFileGlobs;
+        }
+
         var includePaths = ReadStringList(obj, "includePaths");
         if (includePaths is not null) {
             settings.IncludePaths = includePaths;

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -144,6 +144,10 @@ internal sealed class ReviewSettings {
     /// </summary>
     public bool SkipGeneratedFiles { get; set; } = true;
     /// <summary>
+    /// Additional glob patterns to treat as generated files. These are appended to the built-in defaults.
+    /// </summary>
+    public IReadOnlyList<string> GeneratedFileGlobs { get; set; } = Array.Empty<string>();
+    /// <summary>
     /// Glob-style patterns specifying which changed files should be considered for review.
     /// If non-empty, only files matching these patterns are eligible for review.
     /// </summary>
@@ -460,6 +464,11 @@ internal sealed class ReviewSettings {
         var skipGeneratedFiles = GetInput("skip_generated_files", "SKIP_GENERATED_FILES");
         if (!string.IsNullOrWhiteSpace(skipGeneratedFiles)) {
             settings.SkipGeneratedFiles = ParseBoolean(skipGeneratedFiles, settings.SkipGeneratedFiles);
+        }
+
+        var generatedFileGlobs = GetInput("generated_file_globs", "GENERATED_FILE_GLOBS");
+        if (!string.IsNullOrWhiteSpace(generatedFileGlobs)) {
+            settings.GeneratedFileGlobs = ParseList(generatedFileGlobs, settings.GeneratedFileGlobs);
         }
 
         var includePaths = GetInput("include_paths", "INCLUDE_PATHS");

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -127,8 +127,10 @@ internal static class Program {
         failed += Run("Filter files glob patterns", TestFilterFilesGlobPatterns);
         failed += Run("Filter files empty filters", TestFilterFilesEmptyFilters);
         failed += Run("Filter files skip binary", TestFilterFilesSkipBinary);
+        failed += Run("Filter files skip binary case-insensitive", TestFilterFilesSkipBinaryCaseInsensitive);
         failed += Run("Filter files skip generated", TestFilterFilesSkipGenerated);
         failed += Run("Filter files skip before include", TestFilterFilesSkipBeforeInclude);
+        failed += Run("Filter files generated globs extend", TestFilterFilesGeneratedGlobsExtend);
         failed += Run("Workflow changes detection", TestWorkflowChangesDetection);
         failed += Run("Secrets audit records", TestSecretsAuditRecords);
         failed += Run("Prompt language hints", TestPromptBuilderLanguageHints);
@@ -1820,6 +1822,13 @@ internal static class Program {
         AssertSequenceEqual(new[] { "src/app.cs", "docs/readme.md" }, GetFilenames(filtered), "skip binary");
     }
 
+    private static void TestFilterFilesSkipBinaryCaseInsensitive() {
+        var files = BuildFiles("src/app.cs", "assets/Logo.PNG");
+        var filtered = ReviewerApp.FilterFilesByPaths(files, Array.Empty<string>(), Array.Empty<string>(),
+            skipBinaryFiles: true, skipGeneratedFiles: false);
+        AssertSequenceEqual(new[] { "src/app.cs" }, GetFilenames(filtered), "skip binary case-insensitive");
+    }
+
     private static void TestFilterFilesSkipGenerated() {
         var files = BuildFiles("src/app.cs", "src/obj/Debug/net8.0/app.g.cs", "dist/app.min.js",
             "node_modules/lib/index.js", "src/Generated/Auto.generated.cs");
@@ -1833,6 +1842,13 @@ internal static class Program {
         var filtered = ReviewerApp.FilterFilesByPaths(files, new[] { "**/*.png", "**/*.cs" }, Array.Empty<string>(),
             skipBinaryFiles: true, skipGeneratedFiles: true);
         AssertSequenceEqual(new[] { "src/app.cs" }, GetFilenames(filtered), "skip before include");
+    }
+
+    private static void TestFilterFilesGeneratedGlobsExtend() {
+        var files = BuildFiles("snapshots/ui.snap", "src/app.cs");
+        var filtered = ReviewerApp.FilterFilesByPaths(files, Array.Empty<string>(), Array.Empty<string>(),
+            skipBinaryFiles: false, skipGeneratedFiles: true, generatedFileGlobs: new[] { "**/*.snap" });
+        AssertSequenceEqual(new[] { "src/app.cs" }, GetFilenames(filtered), "generated globs extend");
     }
 
     private static void TestWorkflowChangesDetection() {

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -91,6 +91,7 @@
         "skipPaths": { "type": "array", "items": { "type": "string" } },
         "skipBinaryFiles": { "type": "boolean" },
         "skipGeneratedFiles": { "type": "boolean" },
+        "generatedFileGlobs": { "type": "array", "items": { "type": "string" } },
         "includePaths": { "type": "array", "items": { "type": "string" } },
         "excludePaths": { "type": "array", "items": { "type": "string" } },
         "redactPii": { "type": "boolean" },


### PR DESCRIPTION
## Summary
- add review.generatedFileGlobs to extend generated-file patterns (config/env/schema/docs)
- pass generatedFileGlobs through filter pipeline (GitHub + ADO)
- add tests for case-insensitive binary extensions and custom generated globs

## Testing
- dotnet build IntelligenceX.sln --configuration Release