### PR TITLE
ci: always run macos tests

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -99,7 +99,6 @@ jobs:
                   verbose: true
 
     test-macos:
-        if: ${{ vars.INTELLIGENCEX_ENABLE_MACOS == 'true' }}
         name: 'macOS'
         runs-on: [self-hosted, macos]
         timeout-minutes: 20


### PR DESCRIPTION
## Summary\n- remove macOS job gating variable so tests always run on self-hosted macOS runners\n\n## Testing\n- not run (workflow change only)