### PR TITLE
docs: sync binary/generated backlog status

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -31,7 +31,7 @@ Status: In progress
 ### Phase 2 — Context quality
 - [x] Add diff-range strategy options (current/pr-base/first-review) with default.
 - [x] Add file filters (include/exclude globs).
-- [ ] Add binary/generated file skipping.
+- [x] Add binary/generated file skipping.
 - [x] Add smart chunking (keep related hunks together; avoid orphaned changes).
 - [x] Add language-aware hints (prompt includes detected languages).
 - [x] Add "review intent" presets (security/perf/maintainability).


### PR DESCRIPTION
## Summary
- mark `Add binary/generated file skipping` as complete in `TODO.md`
- aligns backlog with already merged work in PR #77 and PR #79

## Testing
- not run (docs-only)