### PR TITLE
feat: add opt-in reviewer provider fallback

### DIFF
--- a/Docs/cli/commands/reviewer.md
+++ b/Docs/cli/commands/reviewer.md
@@ -17,6 +17,7 @@ intelligencex reviewer run --provider azure --azure-org my-org --azure-project m
 ## Reviewer run options
 
 - `--provider <openai|codex|copilot|azure>`
+- `--provider-fallback <openai|codex|copilot>`
 - `--code-host <github|azure>`
 - `--azure-org <org>`
 - `--azure-project <project>`

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -58,6 +58,19 @@ Unknown properties emit warnings; invalid types or enum values fail the run.
 
 Note: set `maxFiles` to `0` to disable file count limits; the reviewer will still trim individual patches using `maxPatchChars`.
 
+## Provider fallback example
+
+Use `providerFallback` to opt into a secondary provider when the primary provider fails.
+
+```json
+{
+  "review": {
+    "provider": "openai",
+    "providerFallback": "copilot"
+  }
+}
+```
+
 ## Auto-resolve + triage example
 
 ```json
@@ -309,7 +322,8 @@ Use `directHeaders` to attach custom headers required by your gateway.
 Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source control.
 
 ## Common knobs
-- `provider`: `openai` or `copilot`
+- `provider`: `openai`, `codex` (alias for OpenAI), or `copilot`
+- `providerFallback`: optional fallback provider (`openai`, `codex`, or `copilot`)
 - `model`: model name for the selected provider
 - `reasoningEffort`: `minimal|low|medium|high|xhigh` (when set to low/medium/high, the header shows a reasoning level label)
 - `mode`: `inline`, `summary`, or `hybrid`

--- a/IntelligenceX.Reviewer/Program.cs
+++ b/IntelligenceX.Reviewer/Program.cs
@@ -340,6 +340,11 @@ public static class ReviewerApp {
 
             var reviewBody = await runner.RunAsync(prompt, onPartial, TimeSpan.FromSeconds(settings.ProgressUpdateSeconds),
                 cancellationToken).ConfigureAwait(false);
+            var effectiveProvider = runner.EffectiveProvider;
+            if (runner.FallbackActivated && settings.Diagnostics) {
+                Console.Error.WriteLine(
+                    $"Provider fallback activated: {settings.Provider.ToString().ToLowerInvariant()} -> {effectiveProvider.ToString().ToLowerInvariant()}.");
+            }
 
             var reviewFailed = ReviewDiagnostics.IsFailureBody(reviewBody);
             var inlineAllowed = inlineSupported && !reviewFailed && allowWrites;
@@ -384,7 +389,7 @@ public static class ReviewerApp {
             if (allowWrites && settings.ReviewThreadsAutoResolveSummaryAlways && string.IsNullOrWhiteSpace(autoResolveSummary)) {
                 autoResolveSummary = triageResult.FallbackSummary;
             }
-            var usageLine = await TryBuildUsageLineAsync(settings).ConfigureAwait(false);
+            var usageLine = await TryBuildUsageLineAsync(settings, effectiveProvider).ConfigureAwait(false);
             var findingsBlock = settings.StructuredFindings ? ReviewFindingsBuilder.Build(inlineComments) : string.Empty;
             var commentBody = ReviewFormatter.BuildComment(context, summaryBody, settings, inlineSupported, inlineSuppressed,
                 autoResolveSummary, budgetNote, usageLine, findingsBlock);
@@ -556,6 +561,7 @@ public static class ReviewerApp {
 
     private sealed class RunOptions {
         public string? Provider { get; set; }
+        public string? ProviderFallback { get; set; }
         public string? CodeHost { get; set; }
         public string? AzureOrg { get; set; }
         public string? AzureProject { get; set; }
@@ -592,6 +598,8 @@ public static class ReviewerApp {
     private static readonly RunOptionSpec[] RunOptionSpecs = {
         new RunOptionSpec("--provider", "<openai|codex|copilot|azure>", "AI provider or Azure DevOps code host (aliases: azuredevops, azure-devops, ado)", true,
             (options, value) => options.Provider = value),
+        new RunOptionSpec("--provider-fallback", "<openai|codex|copilot>", "Optional fallback AI provider when the primary provider fails", true,
+            (options, value) => options.ProviderFallback = value),
         new RunOptionSpec("--code-host", "<github|azure>", "Override code host (azure/azuredevops supported)", true,
             (options, value) => options.CodeHost = value),
         new RunOptionSpec("--azure-org", "<org>", "Azure DevOps organization", true,
@@ -633,6 +641,10 @@ public static class ReviewerApp {
         if (!string.IsNullOrWhiteSpace(options.Provider) && !IsValidProvider(options.Provider)) {
             options.Errors.Add($"Unsupported provider '{options.Provider}'. Use openai, codex, copilot, or azure/azuredevops.");
         }
+        if (!string.IsNullOrWhiteSpace(options.ProviderFallback) && !IsValidAiProvider(options.ProviderFallback)) {
+            options.Errors.Add(
+                $"Unsupported provider fallback '{options.ProviderFallback}'. Use openai, codex, or copilot.");
+        }
         if (!string.IsNullOrWhiteSpace(options.CodeHost) && !IsValidCodeHost(options.CodeHost)) {
             options.Errors.Add($"Unsupported code host '{options.CodeHost}'. Use github or azure/azuredevops.");
         }
@@ -654,8 +666,12 @@ public static class ReviewerApp {
     }
 
     private static bool IsValidProvider(string provider) {
-        return ReviewProviderContracts.TryParseProviderAlias(provider, out _) ||
+        return IsValidAiProvider(provider) ||
                IsAzureProvider(provider);
+    }
+
+    private static bool IsValidAiProvider(string provider) {
+        return ReviewProviderContracts.TryParseProviderAlias(provider, out _);
     }
 
     private static bool IsAzureProvider(string provider) {
@@ -680,6 +696,10 @@ public static class ReviewerApp {
                     codeHost = "azure";
                 }
             }
+        }
+        var providerFallback = options.ProviderFallback?.Trim();
+        if (!string.IsNullOrWhiteSpace(providerFallback)) {
+            Environment.SetEnvironmentVariable("REVIEW_PROVIDER_FALLBACK", providerFallback);
         }
         if (!string.IsNullOrWhiteSpace(codeHost)) {
             Environment.SetEnvironmentVariable("REVIEW_CODE_HOST", codeHost);
@@ -1384,11 +1404,11 @@ public static class ReviewerApp {
         return new ThreadTriageResult(summary, triageBody, fallbackSummary);
     }
 
-    private static async Task<string> TryBuildUsageLineAsync(ReviewSettings settings) {
+    private static async Task<string> TryBuildUsageLineAsync(ReviewSettings settings, ReviewProvider providerKind) {
         if (!settings.ReviewUsageSummary) {
             return string.Empty;
         }
-        var provider = ReviewProviderContracts.Get(settings.Provider);
+        var provider = ReviewProviderContracts.Get(providerKind);
         if (!provider.SupportsUsageApi) {
             return string.Empty;
         }

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -38,6 +38,10 @@ internal static class ReviewConfigLoader {
         if (!string.IsNullOrWhiteSpace(provider)) {
             settings.Provider = ReviewProviderContracts.ParseProviderOrDefault(provider, settings.Provider);
         }
+        var providerFallback = reviewObj.GetString("providerFallback");
+        if (ReviewProviderContracts.TryParseProviderAlias(providerFallback, out var parsedFallback)) {
+            settings.ProviderFallback = parsedFallback;
+        }
 
         var codeHost = reviewObj.GetString("codeHost");
         if (!string.IsNullOrWhiteSpace(codeHost)) {

--- a/IntelligenceX.Reviewer/ReviewRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewRunner.cs
@@ -23,9 +23,12 @@ internal sealed class ReviewRunner {
         Timeout = Timeout.InfiniteTimeSpan
     };
     private readonly ReviewSettings _settings;
+    public ReviewProvider EffectiveProvider { get; private set; }
+    public bool FallbackActivated { get; private set; }
 
     public ReviewRunner(ReviewSettings settings) {
         _settings = settings;
+        EffectiveProvider = settings.Provider;
     }
 
     private IntelligenceXClientOptions BuildClientOptions() {
@@ -49,12 +52,81 @@ internal sealed class ReviewRunner {
 
     public async Task<string> RunAsync(string prompt, Func<string, Task>? onPartial, TimeSpan? updateInterval,
         CancellationToken cancellationToken) {
-        var provider = ReviewProviderContracts.Get(_settings.Provider);
-        return provider.Provider switch {
-            ReviewProvider.Copilot => await RunCopilotAsync(prompt, onPartial, updateInterval, cancellationToken).ConfigureAwait(false),
-            ReviewProvider.OpenAI => await RunOpenAiWithRetryAsync(prompt, onPartial, updateInterval, cancellationToken).ConfigureAwait(false),
-            _ => throw new NotSupportedException($"Unsupported review provider '{provider.Provider}'.")
-        };
+        var primaryProvider = ReviewProviderContracts.Get(_settings.Provider).Provider;
+        var fallbackProvider = ResolveFallbackProvider(primaryProvider, _settings.ProviderFallback);
+        EffectiveProvider = primaryProvider;
+        FallbackActivated = false;
+
+        Exception? primaryException = null;
+        string? primaryFailureBody = null;
+        try {
+            var primaryResult = await RunWithProviderAsync(primaryProvider, prompt, onPartial, updateInterval, cancellationToken)
+                .ConfigureAwait(false);
+            if (!fallbackProvider.HasValue || !ShouldFallbackOnResult(primaryResult)) {
+                return primaryResult;
+            }
+            primaryFailureBody = primaryResult;
+            if (_settings.Diagnostics) {
+                Console.Error.WriteLine(
+                    $"Primary provider '{primaryProvider.ToString().ToLowerInvariant()}' returned a fail-open body; attempting fallback provider '{fallbackProvider.Value.ToString().ToLowerInvariant()}'.");
+            }
+        } catch (Exception ex) when (!cancellationToken.IsCancellationRequested && fallbackProvider.HasValue) {
+            primaryException = ex;
+            if (_settings.Diagnostics) {
+                Console.Error.WriteLine(
+                    $"Primary provider '{primaryProvider.ToString().ToLowerInvariant()}' failed ({ex.GetType().Name}); attempting fallback provider '{fallbackProvider.Value.ToString().ToLowerInvariant()}'.");
+            }
+        }
+
+        if (!fallbackProvider.HasValue) {
+            if (primaryException is not null) {
+                ExceptionDispatchInfo.Capture(primaryException).Throw();
+            }
+            return primaryFailureBody ?? string.Empty;
+        }
+
+        try {
+            var fallbackResult = await RunWithProviderAsync(fallbackProvider.Value, prompt, onPartial, updateInterval, cancellationToken)
+                .ConfigureAwait(false);
+            EffectiveProvider = fallbackProvider.Value;
+            FallbackActivated = true;
+            return fallbackResult;
+        } catch {
+            if (primaryException is not null) {
+                ExceptionDispatchInfo.Capture(primaryException).Throw();
+            }
+            if (primaryFailureBody is not null) {
+                EffectiveProvider = primaryProvider;
+                return primaryFailureBody;
+            }
+            throw;
+        }
+    }
+
+    internal static ReviewProvider? ResolveFallbackProvider(ReviewProvider primaryProvider, ReviewProvider? configuredFallback) {
+        if (!configuredFallback.HasValue || configuredFallback.Value == primaryProvider) {
+            return null;
+        }
+        return configuredFallback.Value;
+    }
+
+    internal static bool ShouldFallbackOnResult(string? result) {
+        return !string.IsNullOrWhiteSpace(result) && ReviewDiagnostics.IsFailureBody(result);
+    }
+
+    private async Task<string> RunWithProviderAsync(ReviewProvider provider, string prompt, Func<string, Task>? onPartial,
+        TimeSpan? updateInterval, CancellationToken cancellationToken) {
+        var previousProvider = _settings.Provider;
+        _settings.Provider = provider;
+        try {
+            return provider switch {
+                ReviewProvider.Copilot => await RunCopilotAsync(prompt, onPartial, updateInterval, cancellationToken).ConfigureAwait(false),
+                ReviewProvider.OpenAI => await RunOpenAiWithRetryAsync(prompt, onPartial, updateInterval, cancellationToken).ConfigureAwait(false),
+                _ => throw new NotSupportedException($"Unsupported review provider '{provider}'.")
+            };
+        } finally {
+            _settings.Provider = previousProvider;
+        }
     }
 
     private async Task<string> RunOpenAiWithRetryAsync(string prompt, Func<string, Task>? onPartial, TimeSpan? updateInterval,

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -70,6 +70,7 @@ internal sealed class ReviewSettings {
 
     public string Mode { get; set; } = "hybrid";
     public ReviewProvider Provider { get; set; } = ReviewProvider.OpenAI;
+    public ReviewProvider? ProviderFallback { get; set; }
     public ReviewCodeHost CodeHost { get; set; } = ReviewCodeHost.GitHub;
     public string? Profile { get; set; }
     /// <summary>
@@ -336,6 +337,10 @@ internal sealed class ReviewSettings {
         var provider = GetInput("provider", "REVIEW_PROVIDER");
         if (!string.IsNullOrWhiteSpace(provider)) {
             settings.Provider = ParseProvider(provider);
+        }
+        var providerFallback = GetInput("provider_fallback", "REVIEW_PROVIDER_FALLBACK");
+        if (!string.IsNullOrWhiteSpace(providerFallback)) {
+            settings.ProviderFallback = ParseProviderNullable(providerFallback);
         }
 
         var mode = GetInput("mode", "REVIEW_MODE");
@@ -950,6 +955,12 @@ internal sealed class ReviewSettings {
 
     private static ReviewProvider ParseProvider(string value) {
         return ReviewProviderContracts.ParseProviderOrDefault(value, ReviewProvider.OpenAI);
+    }
+
+    private static ReviewProvider? ParseProviderNullable(string value) {
+        return ReviewProviderContracts.TryParseProviderAlias(value, out var provider)
+            ? provider
+            : null;
     }
 
     private static ReviewCodeHost ParseCodeHost(string value) {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -104,6 +104,9 @@ internal static class Program {
         failed += Run("Review provider alias parsing", TestReviewProviderAliasParsing);
         failed += Run("Review provider contract capabilities", TestReviewProviderContractCapabilities);
         failed += Run("Review provider config alias", TestReviewProviderConfigAlias);
+        failed += Run("Review provider fallback env", TestReviewProviderFallbackEnv);
+        failed += Run("Review provider fallback config", TestReviewProviderFallbackConfig);
+        failed += Run("Review provider fallback plan", TestReviewProviderFallbackPlan);
         failed += Run("Triage-only loads threads", TestTriageOnlyLoadsThreads);
         failed += Run("Review code host env", TestReviewCodeHostEnv);
         failed += Run("GitHub context cache", TestGitHubContextCache);
@@ -1243,6 +1246,52 @@ internal static class Program {
                 File.Delete(path);
             }
         }
+    }
+
+    private static void TestReviewProviderFallbackEnv() {
+        var previousProvider = Environment.GetEnvironmentVariable("REVIEW_PROVIDER");
+        var previousFallback = Environment.GetEnvironmentVariable("REVIEW_PROVIDER_FALLBACK");
+        try {
+            Environment.SetEnvironmentVariable("REVIEW_PROVIDER", "openai");
+            Environment.SetEnvironmentVariable("REVIEW_PROVIDER_FALLBACK", "copilot");
+            var settings = ReviewSettings.FromEnvironment();
+            AssertEqual(ReviewProvider.OpenAI, settings.Provider, "provider fallback env primary");
+            AssertEqual(ReviewProvider.Copilot, settings.ProviderFallback, "provider fallback env value");
+
+            Environment.SetEnvironmentVariable("REVIEW_PROVIDER_FALLBACK", "azure");
+            settings = ReviewSettings.FromEnvironment();
+            AssertEqual(null, settings.ProviderFallback, "provider fallback env invalid");
+        } finally {
+            Environment.SetEnvironmentVariable("REVIEW_PROVIDER", previousProvider);
+            Environment.SetEnvironmentVariable("REVIEW_PROVIDER_FALLBACK", previousFallback);
+        }
+    }
+
+    private static void TestReviewProviderFallbackConfig() {
+        var previous = Environment.GetEnvironmentVariable("REVIEW_CONFIG_PATH");
+        var path = Path.Combine(Path.GetTempPath(), $"intelligencex-review-{Guid.NewGuid():N}.json");
+        try {
+            File.WriteAllText(path, "{ \"review\": { \"provider\": \"openai\", \"providerFallback\": \"copilot\" } }");
+            Environment.SetEnvironmentVariable("REVIEW_CONFIG_PATH", path);
+            var settings = new ReviewSettings();
+            ReviewConfigLoader.Apply(settings);
+            AssertEqual(ReviewProvider.OpenAI, settings.Provider, "provider fallback config primary");
+            AssertEqual(ReviewProvider.Copilot, settings.ProviderFallback, "provider fallback config value");
+        } finally {
+            Environment.SetEnvironmentVariable("REVIEW_CONFIG_PATH", previous);
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    private static void TestReviewProviderFallbackPlan() {
+        AssertEqual(null, ReviewRunner.ResolveFallbackProvider(ReviewProvider.OpenAI, null), "provider fallback none");
+        AssertEqual(null, ReviewRunner.ResolveFallbackProvider(ReviewProvider.OpenAI, ReviewProvider.OpenAI), "provider fallback same");
+        AssertEqual(ReviewProvider.Copilot, ReviewRunner.ResolveFallbackProvider(ReviewProvider.OpenAI, ReviewProvider.Copilot),
+            "provider fallback selected");
+        AssertEqual(false, ReviewRunner.ShouldFallbackOnResult("Regular review content"), "provider fallback regular output");
+        AssertEqual(true, ReviewRunner.ShouldFallbackOnResult($"x {ReviewDiagnostics.FailureMarker} y"), "provider fallback failure marker");
     }
 
     private static void TestReviewCodeHostEnv() {

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -9,6 +9,7 @@
       "additionalProperties": true,
       "properties": {
         "provider": { "type": "string", "enum": ["openai", "copilot", "codex"] },
+        "providerFallback": { "type": "string", "enum": ["openai", "copilot", "codex"] },
         "codeHost": { "type": "string", "enum": ["github", "azure", "azuredevops", "azure-devops", "ado"] },
         "profile": { "type": "string" },
         "intent": { "type": "string", "enum": ["security", "performance", "perf", "maintainability"] },

--- a/TODO.md
+++ b/TODO.md
@@ -53,7 +53,7 @@ Status: In progress
 ### Phase 5 — Provider abstraction
 - [x] Centralize provider contracts (capabilities, limits, streaming, auth).
 - [x] Add provider capability flags (usage API, reasoning level, streaming).
-- [ ] Add opt-in provider fallback (e.g., OpenAI → Copilot).
+- [x] Add opt-in provider fallback (e.g., OpenAI → Copilot).
 - [ ] Add provider health checks and circuit breaker.
 
 ### Phase 5.5 — Code host support (Azure DevOps Services)


### PR DESCRIPTION
## Summary
- add opt-in provider fallback support (`providerFallback` / `REVIEW_PROVIDER_FALLBACK` / `--provider-fallback`)
- implement runtime fallback in `ReviewRunner` when the primary provider throws or returns a fail-open body
- track and use effective provider after fallback for usage-summary gating
- extend schema/docs for fallback configuration and CLI usage
- add tests for fallback env/config parsing and fallback plan logic
- mark `Add opt-in provider fallback (e.g., OpenAI → Copilot)` as completed in `TODO.md`

## Testing
- `dotnet build IntelligenceX.sln -c Release` (pass)
- `dotnet IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`

Notes:
- New fallback tests added in this PR pass:
  - `Review provider fallback env`
  - `Review provider fallback config`
  - `Review provider fallback plan`
- Existing baseline failures on `origin/master` remain unchanged:
  - `Auto-resolve missing inline empty keys`
  - `Diff range compare truncation`
  - `Secrets audit records`
  - `Prepare files max files zero`
  - `Prepare files max files negative`
