### PR TITLE
Fix GitHub Pages 404 deployment validation and PSPublishModule ref

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: EvotecIT/PSPublishModule
-          ref: 3113a997da2cc01b20461e27f48c106f75b9e1a9
+          ref: v2-speedgonzales
           path: PSPublishModule
 
       - name: Build PowerForge.Web.Cli
@@ -42,6 +42,14 @@ jobs:
       - name: Build website
         working-directory: Website
         run: dotnet ../PSPublishModule/PowerForge.Web.Cli/bin/Release/net10.0/PowerForge.Web.Cli.dll pipeline --config pipeline.json
+
+      - name: Verify website output
+        run: |
+          test -f Website/_site/.nojekyll
+          test -f Website/_site/index.html
+          test -f Website/_site/docs/index.html
+          test -f Website/_site/404.html
+          grep -q '<link rel=stylesheet' Website/_site/404.html
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- switch website build to PSPublishModule branch 2-speedgonzales (instead of an old pinned commit)
- add explicit website artifact checks before upload
- require root Website/_site/404.html and confirm stylesheet markup is present

## Why
- live https://intelligencex.dev/fdsf was showing default GitHub Pages 404 because deployed artifact did not contain the expected root custom 404 output

## Validation
- ./Website/build.ps1 -SkipBuildTool
- confirmed Website/_site/404.html exists
- confirmed Website/_site/404.html contains stylesheet link markup