### PR TITLE
Restore web onboarding and placeholder docs pages

### DIFF
--- a/Docs/_index.md
+++ b/Docs/_index.md
@@ -46,3 +46,4 @@ Welcome to the IntelligenceX documentation.
 - [Examples](/docs/examples/)
 - [Troubleshooting](/docs/troubleshooting/)
 - [FAQ](/docs/faq/)
+- [Screenshots (Planned)](/docs/screenshots/)

--- a/Docs/reviewer/web-onboarding.md
+++ b/Docs/reviewer/web-onboarding.md
@@ -1,0 +1,24 @@
+# Web Onboarding Flow
+
+This flow runs locally and never uploads tokens to a backend.
+
+## Overview
+
+The web onboarding flow guides you through GitHub auth, repo selection, and reviewer setup.
+
+## Steps
+
+1. Start the local wizard:
+
+```powershell
+intelligencex setup web
+```
+
+2. Authenticate with GitHub (device flow, token, or GitHub App).
+3. Select repositories.
+4. Plan changes and review the summary.
+5. Apply changes (PRs are created by default).
+
+## Status
+
+This page tracks onboarding UX direction and expected flow. It is safe to publish as documentation-in-progress.

--- a/Docs/screenshots.md
+++ b/Docs/screenshots.md
@@ -1,0 +1,12 @@
+# Screenshots (Planned)
+
+Placeholders for upcoming screenshots used in onboarding and setup docs.
+
+## Planned captures
+
+- setup-web-start.png
+- setup-web-plan.png
+- setup-web-apply.png
+- setup-web-success.png
+
+This page is intentionally lightweight until final screenshots are available.

--- a/Docs/toc.json
+++ b/Docs/toc.json
@@ -9,6 +9,7 @@
       { "title": "Overview", "href": "/docs/reviewer/overview/" },
       { "title": "Onboarding Wizard", "href": "/docs/reviewer/onboarding-wizard/" },
       { "title": "Web Setup UI", "href": "/docs/reviewer/setup-web/" },
+      { "title": "Web Onboarding Flow", "href": "/docs/reviewer/web-onboarding/" },
       { "title": "Configuration", "href": "/docs/reviewer/configuration/" },
       { "title": "Security & Trust", "href": "/docs/reviewer/security-trust/" },
       { "title": "Static Analysis", "href": "/docs/reviewer/static-analysis/" }
@@ -43,7 +44,8 @@
     "title": "Guides",
     "items": [
       { "title": "Examples", "href": "/docs/examples/" },
-      { "title": "Troubleshooting", "href": "/docs/troubleshooting/" }
+      { "title": "Troubleshooting", "href": "/docs/troubleshooting/" },
+      { "title": "Screenshots (Planned)", "href": "/docs/screenshots/" }
     ]
   }
 ]

--- a/Website/site.json
+++ b/Website/site.json
@@ -26,7 +26,7 @@
       "UseToc": true,
       "TocFile": "../Docs/toc.json",
       "Include": ["*.md", "**/*.md"],
-      "Exclude": ["cli/commands/**", "screenshots/**", "reviewer/review-smoke.md", "reviewer/web-onboarding.md"]
+      "Exclude": ["cli/commands/**", "screenshots/**", "reviewer/review-smoke.md"]
     }
   ],
   "Head": {


### PR DESCRIPTION
## Summary
- restore `Docs/reviewer/web-onboarding.md` as published docs-in-progress content
- add `Docs/screenshots.md` as a lightweight placeholders page for upcoming screenshots
- include both pages in docs navigation (`Docs/toc.json` and `Docs/_index.md`)
- allow `reviewer/web-onboarding.md` in website docs collection by removing it from excludes

## Validation
- `./Website/build.ps1 -SkipBuildTool`
- confirmed output pages exist:
  - `/docs/reviewer/web-onboarding/`
  - `/docs/screenshots/`