### PR TITLE
Tighten website audit nav required links

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -103,7 +103,7 @@
       "navCanonicalPath": "index.html",
       "navCanonicalSelector": "header nav.ix-nav",
       "navCanonicalRequired": true,
-      "navRequiredLinks": "/",
+      "navRequiredLinks": "/,/docs/,/api/",
       "failOnCategories": "nav,link,asset,rendered-console-error,rendered-request-failure",
       "rendered": true,
       "renderedEnsureInstalled": false,


### PR DESCRIPTION
Require Home/Docs/API links in nav audit checks and keep existing canonical/rendered enforcement.\n\nValidation: ./Website/build.ps1 (audit nav-checked 314, nav-ignored 1, mismatches 0).