### PR TITLE
Website: enforce /docs/ in required routes audit

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -106,7 +106,7 @@
       "navCanonicalRequired": true,
       "navRequiredLinks": "/,/docs/,/api/",
       "minNavCoveragePercent": 99,
-      "requiredRoutes": "/,/404.html,/api/",
+      "requiredRoutes": "/,/docs/,/404.html,/api/",
       "failOnCategories": "nav,link,asset,rendered-console-error,rendered-request-failure",
       "rendered": true,
       "renderedEnsureInstalled": false,
@@ -122,3 +122,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
Summary: add /docs/ to requiredRoutes audit. Validation: ./build.ps1 passes; audit reports required-routes 4.