### PR TITLE
Website: bind docs edit link to page.edit_url

### DIFF
--- a/Website/themes/intelligencex/layouts/docs.html
+++ b/Website/themes/intelligencex/layouts/docs.html
@@ -33,8 +33,8 @@
 {{ content }}
         </div>
         <footer class="docs-article-footer">
-          {{ if edit_url }}
-          <a href="{{ edit_url }}" target="_blank" rel="noopener" class="docs-edit-link">
+          {{ if page.edit_url }}
+          <a href="{{ page.edit_url }}" target="_blank" rel="noopener" class="docs-edit-link">
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
             Edit this page on GitHub
           </a>


### PR DESCRIPTION
Fix docs footer edit link binding to use page.edit_url so GitHub edit links render for docs sourced from ../Docs.