### PR TITLE
Fix docs edit action placement and API source edit URLs

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -38,7 +38,7 @@
       "template": "docs",
       "nav": "./site.json",
       "css": "/css/api.css",
-      "sourceRoot": "../IntelligenceX",
+      "sourceRoot": "..",
       "sourceUrl": "https://github.com/EvotecIT/IntelligenceX/blob/master/{path}#L{line}",
       "headerHtml": "./themes/intelligencex/partials/api-header.html",
       "footerHtml": "./themes/intelligencex/partials/api-footer.html"

--- a/Website/static/css/docs.css
+++ b/Website/static/css/docs.css
@@ -57,6 +57,12 @@
   -webkit-backdrop-filter: blur(10px);
 }
 .docs-article-header { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--pf-border); }
+.docs-article-header-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
 [data-theme="light"] .docs-article {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(241, 245, 249, 0.8));
 }
@@ -66,6 +72,8 @@
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  margin: 0;
+  flex: 1;
 }
 .docs-article-desc { font-size: 1.05rem; color: var(--pf-muted); margin: 0; }
 .docs-article-body h2 { margin-top: 2.5rem; padding-top: 1.5rem; border-top: 1px solid var(--pf-border); }
@@ -81,6 +89,18 @@
 .docs-edit-link { display: inline-flex; align-items: center; gap: 0.5rem; font-size: 0.85rem; color: var(--pf-muted); }
 .docs-edit-link:hover { color: var(--pf-accent); }
 .docs-edit-link svg { flex-shrink: 0; }
+.docs-edit-link-top {
+  white-space: nowrap;
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--pf-border);
+  background: var(--pf-card-bg);
+  text-decoration: none;
+}
+.docs-edit-link-top:hover {
+  border-color: var(--pf-accent);
+  background: var(--pf-glow-primary);
+}
 
 /* ===== Docs Markdown Body (engine wrapper) ===== */
 .docs-main .markdown-body table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.9rem; }
@@ -106,4 +126,5 @@
   .docs-sidebar { position: static; height: auto; border-right: none; border-bottom: 1px solid var(--pf-border); padding: 1rem; border-radius: var(--pf-radius); }
   .docs-main { padding: 1rem; }
   .docs-article { padding: 1.5rem; border-radius: var(--pf-radius); }
+  .docs-article-header-top { flex-direction: column; align-items: flex-start; }
 }

--- a/Website/themes/intelligencex/layouts/docs.html
+++ b/Website/themes/intelligencex/layouts/docs.html
@@ -24,7 +24,15 @@
     <main class="docs-main">
       <article class="docs-article">
         <header class="docs-article-header">
-          <h1>{{ page.title }}</h1>
+          <div class="docs-article-header-top">
+            <h1>{{ page.title }}</h1>
+            {{ if page.edit_url }}
+            <a href="{{ page.edit_url }}" target="_blank" rel="noopener noreferrer" class="docs-edit-link docs-edit-link-top">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+              Edit on GitHub
+            </a>
+            {{ end }}
+          </div>
           {{ if page.description }}
           <p class="docs-article-desc">{{ page.description }}</p>
           {{ end }}
@@ -32,14 +40,6 @@
         <div class="docs-article-body">
 {{ content }}
         </div>
-        <footer class="docs-article-footer">
-          {{ if page.edit_url }}
-          <a href="{{ page.edit_url }}" target="_blank" rel="noopener" class="docs-edit-link">
-            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
-            Edit this page on GitHub
-          </a>
-          {{ end }}
-        </footer>
       </article>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- move docs edit action from footer to header in docs layout for better visibility
- style header edit action as a compact pill button
- fix API docs source mapping by setting sourceRoot to repository root (..)

## Why
- edit action was easy to miss at the very bottom of long docs pages
- API edit links were missing the IntelligenceX/ path segment and resolved to GitHub 404

## Validation
- Website/build.ps1 passed (build, apidocs, optimize, audit)
- generated API edit links now point to .../edit/master/IntelligenceX/...
- docs pages now show Edit on GitHub in page header