### PR TITLE
Harden static analysis policy load path and preview tests

### DIFF
--- a/IntelligenceX.Reviewer/AnalysisPolicyBuilder.cs
+++ b/IntelligenceX.Reviewer/AnalysisPolicyBuilder.cs
@@ -15,8 +15,8 @@ internal static class AnalysisPolicyBuilder {
         CatalogUnavailable
     }
 
-    private static readonly StringComparer CaseInsensitiveComparer = StringComparer.OrdinalIgnoreCase;
-    private static readonly StringComparer CaseSensitiveComparer = StringComparer.Ordinal;
+    private static readonly StringComparer OrdinalIgnoreCaseComparer = StringComparer.OrdinalIgnoreCase;
+    private static readonly StringComparer OrdinalComparer = StringComparer.Ordinal;
 
     private sealed record PolicyContext(
         IReadOnlyList<string> BaseLines,
@@ -73,7 +73,7 @@ internal static class AnalysisPolicyBuilder {
             Array.Empty<string>(),
             null,
             Array.Empty<string>(),
-            new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(CaseInsensitiveComparer)));
+            new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(OrdinalIgnoreCaseComparer)));
         unavailableReason = "analysis catalog unavailable";
         if (settings?.Analysis?.Enabled != true || settings.Analysis?.Results?.ShowPolicy != true) {
             return PolicyContextBuildResult.Disabled;
@@ -87,13 +87,13 @@ internal static class AnalysisPolicyBuilder {
         }
 
         var disabledSet = new HashSet<string>(settings.Analysis.DisabledRules ?? Array.Empty<string>(),
-            CaseInsensitiveComparer);
+            OrdinalIgnoreCaseComparer);
         var overrideMap = settings.Analysis.SeverityOverrides is null
-            ? new Dictionary<string, string>(CaseInsensitiveComparer)
-            : new Dictionary<string, string>(settings.Analysis.SeverityOverrides, CaseInsensitiveComparer);
+            ? new Dictionary<string, string>(OrdinalIgnoreCaseComparer)
+            : new Dictionary<string, string>(settings.Analysis.SeverityOverrides, OrdinalIgnoreCaseComparer);
 
         var packSummaries = new List<string>();
-        var selectedRuleIds = new HashSet<string>(CaseInsensitiveComparer);
+        var selectedRuleIds = new HashSet<string>(OrdinalIgnoreCaseComparer);
         var selectedRules = new List<string>();
         var missingPacks = new List<string>();
         foreach (var packId in packs) {
@@ -204,21 +204,21 @@ internal static class AnalysisPolicyBuilder {
     private static void AddRuleConfigurationLines(ICollection<string> lines, IReadOnlyCollection<string> disabled,
         IReadOnlyDictionary<string, string> overrides) {
         if (disabled.Count > 0) {
-            var disabledList = disabled.OrderBy(item => item, CaseSensitiveComparer)
-                .Take(AnalysisPolicyFormatting.MaxPreviewItems)
+            var disabledList = disabled.OrderBy(item => item, OrdinalComparer)
+                .Take(AnalysisPolicyFormatting.MaxRulePreviewItems)
                 .ToList();
-            var suffix = disabled.Count > disabledList.Count ? AnalysisPolicyFormatting.TruncatedSuffix : string.Empty;
+            var suffix = disabled.Count > disabledList.Count ? AnalysisPolicyFormatting.TruncatedPreviewSuffix : string.Empty;
             lines.Add($"- Disabled: {string.Join(", ", disabledList)}{suffix}");
         }
 
         if (overrides.Count > 0) {
             var overrideList = overrides
-                .OrderBy(item => item.Key, CaseSensitiveComparer)
-                .Take(AnalysisPolicyFormatting.MaxPreviewItems)
+                .OrderBy(item => item.Key, OrdinalComparer)
+                .Take(AnalysisPolicyFormatting.MaxRulePreviewItems)
                 .Select(item => $"{item.Key}={item.Value}")
                 .ToList();
             var suffix = overrides.Count > overrideList.Count
-                ? AnalysisPolicyFormatting.TruncatedSuffix
+                ? AnalysisPolicyFormatting.TruncatedPreviewSuffix
                 : string.Empty;
             lines.Add($"- Overrides: {string.Join(", ", overrideList)}{suffix}");
         }
@@ -255,10 +255,10 @@ internal static class AnalysisPolicyBuilder {
         }
 
         var preview = enabledRules
-            .Take(AnalysisPolicyFormatting.MaxPreviewItems)
+            .Take(AnalysisPolicyFormatting.MaxRulePreviewItems)
             .Select(ruleId => DescribeRuleForPreview(ruleId, catalog))
             .ToList();
-        var suffix = enabledRules.Count > preview.Count ? AnalysisPolicyFormatting.TruncatedSuffix : string.Empty;
+        var suffix = enabledRules.Count > preview.Count ? AnalysisPolicyFormatting.TruncatedPreviewSuffix : string.Empty;
         lines.Add($"- Enabled rules preview: {string.Join(", ", preview)}{suffix}");
     }
 
@@ -283,18 +283,18 @@ internal static class AnalysisPolicyBuilder {
         var normalizedEnabledRules = enabledRules
             .Select(NormalizeRuleId)
             .OfType<string>()
-            .Distinct(CaseInsensitiveComparer)
+            .Distinct(OrdinalIgnoreCaseComparer)
             .ToList();
         var enabledSet = new HashSet<string>(
             normalizedEnabledRules,
-            CaseInsensitiveComparer);
+            OrdinalIgnoreCaseComparer);
 
         var resolvedFindings = findings ?? Array.Empty<AnalysisFinding>();
         var findingRuleCounts = resolvedFindings
             .Select(finding => NormalizeRuleId(finding.RuleId))
             .OfType<string>()
-            .GroupBy(normalizedRuleId => normalizedRuleId, CaseInsensitiveComparer)
-            .ToDictionary(group => group.Key, group => group.Count(), CaseInsensitiveComparer);
+            .GroupBy(normalizedRuleId => normalizedRuleId, OrdinalIgnoreCaseComparer)
+            .ToDictionary(group => group.Key, group => group.Count(), OrdinalIgnoreCaseComparer);
 
         if (enabledSet.Count == 0 && findingRuleCounts.Count == 0) {
             lines.Add("- Status: unavailable ℹ️");
@@ -318,13 +318,13 @@ internal static class AnalysisPolicyBuilder {
         AddRuleCountPreviewLine(lines, "Failing rules", impactedEnabledRules
             .Select(ruleId => new KeyValuePair<string, int>(ruleId, findingRuleCounts[ruleId]))
             .OrderByDescending(item => item.Value)
-            .ThenBy(item => item.Key, CaseSensitiveComparer)
+            .ThenBy(item => item.Key, OrdinalComparer)
             .ToList(), catalog);
         AddRulePreviewLine(lines, "Clean rules", cleanEnabledRules, catalog);
         AddRuleCountPreviewLine(lines, "Outside-pack rules", findingRuleCounts
             .Where(item => !enabledSet.Contains(item.Key))
             .OrderByDescending(item => item.Value)
-            .ThenBy(item => item.Key, CaseSensitiveComparer)
+            .ThenBy(item => item.Key, OrdinalComparer)
             .ToList(), catalog);
     }
 
@@ -336,10 +336,10 @@ internal static class AnalysisPolicyBuilder {
         }
 
         var preview = ruleIds
-            .Take(AnalysisPolicyFormatting.MaxPreviewItems)
+            .Take(AnalysisPolicyFormatting.MaxRulePreviewItems)
             .Select(ruleId => DescribeRuleForPreview(ruleId, catalog))
             .ToList();
-        var suffix = ruleIds.Count > preview.Count ? AnalysisPolicyFormatting.TruncatedSuffix : string.Empty;
+        var suffix = ruleIds.Count > preview.Count ? AnalysisPolicyFormatting.TruncatedPreviewSuffix : string.Empty;
         lines.Add($"- {label}: {string.Join(", ", preview)}{suffix}");
     }
 
@@ -351,10 +351,10 @@ internal static class AnalysisPolicyBuilder {
         }
 
         var preview = ruleCounts
-            .Take(AnalysisPolicyFormatting.MaxPreviewItems)
+            .Take(AnalysisPolicyFormatting.MaxRulePreviewItems)
             .Select(item => $"{DescribeRuleForPreview(item.Key, catalog)}={item.Value}")
             .ToList();
-        var suffix = ruleCounts.Count > preview.Count ? AnalysisPolicyFormatting.TruncatedSuffix : string.Empty;
+        var suffix = ruleCounts.Count > preview.Count ? AnalysisPolicyFormatting.TruncatedPreviewSuffix : string.Empty;
         lines.Add($"- {label}: {string.Join(", ", preview)}{suffix}");
     }
 
@@ -380,7 +380,8 @@ internal static class AnalysisPolicyBuilder {
         if (info.LengthInTextElements <= AnalysisPolicyFormatting.MaxUnavailableReasonTextElements) {
             return resolved;
         }
-        return info.SubstringByTextElements(0, AnalysisPolicyFormatting.MaxUnavailableReasonTextElements) + "...";
+        return info.SubstringByTextElements(0, AnalysisPolicyFormatting.MaxUnavailableReasonTextElements) +
+               AnalysisPolicyFormatting.TruncationEllipsis;
     }
 
     private static string? NormalizeRuleId(string? ruleId) {
@@ -396,6 +397,7 @@ internal static class AnalysisPolicyBuilder {
         if (info.LengthInTextElements <= AnalysisPolicyFormatting.MaxRulePreviewTitleTextElements) {
             return resolved;
         }
-        return info.SubstringByTextElements(0, AnalysisPolicyFormatting.MaxRulePreviewTitleTextElements) + "...";
+        return info.SubstringByTextElements(0, AnalysisPolicyFormatting.MaxRulePreviewTitleTextElements) +
+               AnalysisPolicyFormatting.TruncationEllipsis;
     }
 }

--- a/IntelligenceX.Reviewer/AnalysisPolicyFormatting.cs
+++ b/IntelligenceX.Reviewer/AnalysisPolicyFormatting.cs
@@ -1,8 +1,9 @@
 namespace IntelligenceX.Reviewer;
 
 internal static class AnalysisPolicyFormatting {
-    internal const int MaxPreviewItems = 10;
+    internal const int MaxRulePreviewItems = 10;
     internal const int MaxUnavailableReasonTextElements = 120;
     internal const int MaxRulePreviewTitleTextElements = 80;
-    internal const string TruncatedSuffix = " (truncated)";
+    internal const string TruncatedPreviewSuffix = " (truncated)";
+    internal const string TruncationEllipsis = "...";
 }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisLoadReporting.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisLoadReporting.cs
@@ -1,0 +1,213 @@
+namespace IntelligenceX.Tests;
+
+#if INTELLIGENCEX_REVIEWER
+internal static partial class Program {
+    private static void TestAnalysisSummaryShowsZeroFindings() {
+        var results = new AnalysisResultsSettings {
+            Summary = true,
+            MinSeverity = "warning"
+        };
+        var report = new AnalysisLoadReport(2, 1, 1, 0);
+
+        var summary = IntelligenceX.Reviewer.AnalysisSummaryBuilder.BuildSummary(Array.Empty<AnalysisFinding>(), results, report);
+        AssertContainsText(summary, "### Static Analysis 🔎", "analysis summary header");
+        AssertContainsText(summary, "Findings: 0", "analysis summary no findings");
+    }
+
+    private static void TestAnalysisSummaryShowsZeroFindingsWithoutLoadReport() {
+        var results = new AnalysisResultsSettings {
+            Summary = true,
+            MinSeverity = "warning"
+        };
+
+        var summary = IntelligenceX.Reviewer.AnalysisSummaryBuilder.BuildSummary(Array.Empty<AnalysisFinding>(), results, null);
+        AssertContainsText(summary, "### Static Analysis 🔎", "analysis summary no report header");
+        AssertContainsText(summary, "Findings: 0", "analysis summary no report findings");
+    }
+
+    private static void TestAnalysisSummaryShowsUnavailableWhenNoInputFiles() {
+        var results = new AnalysisResultsSettings {
+            Summary = true,
+            MinSeverity = "warning"
+        };
+        var report = new AnalysisLoadReport(2, 0, 0, 0);
+
+        var summary = IntelligenceX.Reviewer.AnalysisSummaryBuilder.BuildSummary(Array.Empty<AnalysisFinding>(), results, report);
+        AssertContainsText(summary, "Findings: unavailable", "analysis summary unavailable");
+    }
+
+    private static void TestAnalysisLoadReportCountsParsedForZeroFindingsAcrossFormats() {
+        var temp = Path.Combine(Path.GetTempPath(), "ix-analysis-loader-zero-findings-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        try {
+            var artifactsDir = Path.Combine(temp, "artifacts");
+            Directory.CreateDirectory(artifactsDir);
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
+
+            void AssertCase(string fileName, string content, string label) {
+                var filePath = Path.Combine(artifactsDir, fileName);
+                File.WriteAllText(filePath, content);
+
+                var settings = new ReviewSettings();
+                settings.Analysis.Enabled = true;
+                settings.Analysis.Results.Inputs = new[] { $"artifacts/{fileName}" };
+
+                var result = IntelligenceX.Reviewer.AnalysisFindingsLoader.LoadWithReport(settings, Array.Empty<PullRequestFile>());
+                AssertEqual(1, result.Report.ResolvedInputFiles, $"analysis load zero-findings resolved {label}");
+                AssertEqual(1, result.Report.ParsedInputFiles, $"analysis load zero-findings parsed {label}");
+                AssertEqual(0, result.Report.FailedInputFiles, $"analysis load zero-findings failed {label}");
+                AssertEqual(0, result.Findings.Count, $"analysis load zero-findings findings {label}");
+            }
+
+            AssertCase("zero.findings.json",
+                "{ \"schema\": \"intelligencex.findings.v1\", \"items\": [] }",
+                "findings-json-empty-items");
+            AssertCase("zero-empty-runs.sarif",
+                "{ \"version\": \"2.1.0\", \"runs\": [] }",
+                "sarif-empty-runs");
+            AssertCase("zero-empty-results.sarif",
+                "{ \"version\": \"2.1.0\", \"runs\": [ { \"tool\": { \"driver\": { \"name\": \"demo\" } }, \"results\": [] } ] }",
+                "sarif-empty-results");
+        } finally {
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
+            if (Directory.Exists(temp)) {
+                Directory.Delete(temp, true);
+            }
+        }
+    }
+
+    private static void TestAnalysisLoadReportDoesNotDoubleCountFailedFiles() {
+        var temp = Path.Combine(Path.GetTempPath(), "ix-analysis-loader-report-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        try {
+            var artifactsDir = Path.Combine(temp, "artifacts");
+            Directory.CreateDirectory(artifactsDir);
+            var lockedFile = Path.Combine(artifactsDir, "locked.findings.json");
+            File.WriteAllText(lockedFile, "{ \"schema\": \"intelligencex.findings.v1\", \"items\": [] }");
+
+            var settings = new ReviewSettings();
+            settings.Analysis.Enabled = true;
+            settings.Analysis.Results.Inputs = new[] { "artifacts/locked.findings.json" };
+
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
+
+            using var stream = new FileStream(lockedFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            var result = IntelligenceX.Reviewer.AnalysisFindingsLoader.LoadWithReport(settings, Array.Empty<PullRequestFile>());
+
+            AssertEqual(1, result.Report.ResolvedInputFiles, "analysis load resolved files");
+            AssertEqual(0, result.Report.ParsedInputFiles, "analysis load parsed files");
+            AssertEqual(1, result.Report.FailedInputFiles, "analysis load failed files");
+        } finally {
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
+            if (Directory.Exists(temp)) {
+                Directory.Delete(temp, true);
+            }
+        }
+    }
+
+    private static void TestAnalysisLoadReportDoesNotCountEmptyFilesAsParsed() {
+        var temp = Path.Combine(Path.GetTempPath(), "ix-analysis-loader-empty-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        try {
+            var artifactsDir = Path.Combine(temp, "artifacts");
+            Directory.CreateDirectory(artifactsDir);
+            var emptyFile = Path.Combine(artifactsDir, "empty.findings.json");
+            File.WriteAllText(emptyFile, string.Empty);
+
+            var settings = new ReviewSettings();
+            settings.Analysis.Enabled = true;
+            settings.Analysis.Results.Inputs = new[] { "artifacts/empty.findings.json" };
+
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
+
+            var result = IntelligenceX.Reviewer.AnalysisFindingsLoader.LoadWithReport(settings, Array.Empty<PullRequestFile>());
+            AssertEqual(1, result.Report.ResolvedInputFiles, "analysis load empty file resolved");
+            AssertEqual(0, result.Report.ParsedInputFiles, "analysis load empty file parsed");
+            AssertEqual(0, result.Report.FailedInputFiles, "analysis load empty file failed");
+        } finally {
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
+            if (Directory.Exists(temp)) {
+                Directory.Delete(temp, true);
+            }
+        }
+    }
+
+    private static void TestAnalysisLoadReportDeduplicatesResolvedFilesAcrossInputs() {
+        var temp = Path.Combine(Path.GetTempPath(), "ix-analysis-loader-dedupe-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        try {
+            var artifactsDir = Path.Combine(temp, "artifacts");
+            Directory.CreateDirectory(artifactsDir);
+            var successFile = Path.Combine(artifactsDir, "success.findings.json");
+            var badFile = Path.Combine(artifactsDir, "bad.findings.json");
+            File.WriteAllText(successFile, "{ \"schema\": \"intelligencex.findings.v1\", \"items\": [ { \"path\": \"src/FileA.cs\", \"line\": 5, \"severity\": \"warning\", \"message\": \"ok\", \"ruleId\": \"IXTEST001\", \"tool\": \"Roslyn\" } ] }");
+            File.WriteAllText(badFile, "{");
+
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
+
+            void AssertCase(string[] inputs, string nameSuffix) {
+                var settings = new ReviewSettings();
+                settings.Analysis.Enabled = true;
+                settings.Analysis.Results.Inputs = inputs;
+
+                var result = IntelligenceX.Reviewer.AnalysisFindingsLoader.LoadWithReport(settings, Array.Empty<PullRequestFile>());
+                AssertEqual(2, result.Report.ResolvedInputFiles, $"analysis load dedupe resolved files {nameSuffix}");
+                AssertEqual(1, result.Report.ParsedInputFiles, $"analysis load dedupe parsed files {nameSuffix}");
+                AssertEqual(1, result.Report.FailedInputFiles, $"analysis load dedupe failed files {nameSuffix}");
+                AssertEqual(1, result.Findings.Count, $"analysis load dedupe findings count {nameSuffix}");
+            }
+
+            AssertCase(new[] {
+                "artifacts/*.findings.json",
+                "artifacts/success.findings.json",
+                "artifacts/bad.findings.json"
+            }, "glob-first");
+            AssertCase(new[] {
+                "artifacts/bad.findings.json",
+                "artifacts/success.findings.json",
+                "artifacts/*.findings.json"
+            }, "glob-last");
+        } finally {
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
+            if (Directory.Exists(temp)) {
+                Directory.Delete(temp, true);
+            }
+        }
+    }
+
+    private static void TestAnalysisLoadReportCountsSingleFailureForDuplicateBadInput() {
+        var temp = Path.Combine(Path.GetTempPath(), "ix-analysis-loader-dup-bad-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        try {
+            var artifactsDir = Path.Combine(temp, "artifacts");
+            Directory.CreateDirectory(artifactsDir);
+            var badFile = Path.Combine(artifactsDir, "bad.findings.json");
+            File.WriteAllText(badFile, "{");
+
+            var settings = new ReviewSettings();
+            settings.Analysis.Enabled = true;
+            settings.Analysis.Results.Inputs = new[] {
+                "artifacts/bad.findings.json",
+                "artifacts/*.findings.json"
+            };
+
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
+
+            var result = IntelligenceX.Reviewer.AnalysisFindingsLoader.LoadWithReport(settings, Array.Empty<PullRequestFile>());
+            AssertEqual(1, result.Report.ResolvedInputFiles, "analysis load duplicate bad resolved");
+            AssertEqual(0, result.Report.ParsedInputFiles, "analysis load duplicate bad parsed");
+            AssertEqual(1, result.Report.FailedInputFiles, "analysis load duplicate bad failed");
+        } finally {
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
+            if (Directory.Exists(temp)) {
+                Directory.Delete(temp, true);
+            }
+        }
+    }
+}
+#endif

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisPolicyTestGroup.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisPolicyTestGroup.cs
@@ -1,0 +1,34 @@
+namespace IntelligenceX.Tests;
+
+#if INTELLIGENCEX_REVIEWER
+internal static partial class Program {
+    private static int RunAnalysisPolicyReportingTests() {
+        var failed = 0;
+        failed += Run("Analysis policy reports outcomes", TestAnalysisPolicyReportsRuleOutcomes);
+        failed += Run("Analysis policy unavailable summary", TestAnalysisPolicyBuildUnavailablePolicy);
+        failed += Run("Analysis policy catalog load fail fallback", TestAnalysisPolicyBuildsUnavailableWhenCatalogLoadFails);
+        failed += Run("Analysis unavailable policy catalog fallback", TestAnalysisPolicyUnavailableUsesCatalogFallbackWhenCatalogLoadFails);
+        failed += Run("Analysis policy unavailable packs normalized", TestAnalysisPolicyCatalogUnavailableNormalizesPackDisplay);
+        failed += Run("Analysis policy rethrows unexpected catalog errors", TestAnalysisPolicyDoesNotSwallowUnexpectedCatalogLoadExceptions);
+        failed += Run("Analysis load failure embeds policy when summary disabled", TestAnalysisLoadFailureEmbedsPolicyWhenSummaryDisabled);
+        failed += Run("Analysis load failure skips output when disabled", TestAnalysisLoadFailureSkipsOutputWhenPolicyAndSummaryDisabled);
+        failed += Run("Analysis policy no result files unavailable", TestAnalysisPolicyShowsUnavailableWhenNoResultFiles);
+        failed += Run("Analysis policy outside-pack findings partial", TestAnalysisPolicyMarksPartialWhenOnlyOutsidePackFindingsExist);
+        failed += Run("Analysis policy no enabled rules unavailable", TestAnalysisPolicyShowsUnavailableWhenNoEnabledRulesAndNoFindings);
+        failed += Run("Analysis policy preview truncates and id fallback", TestAnalysisPolicyEnabledRulePreviewTruncatesAndFallsBackToId);
+        failed += Run("Analysis policy preview supports non-BMP unicode", TestAnalysisPolicyEnabledRulePreviewSupportsNonBmpUnicodeTitles);
+        failed += Run("Analysis policy enabled rules with outside findings partial", TestAnalysisPolicyMarksPartialWhenOnlyOutsideFindingsAndEnabledRulesExist);
+        failed += Run("Analysis policy null findings pass", TestAnalysisPolicyHandlesNullFindingsWhenReportExists);
+        failed += Run("Analysis policy deterministic outcome ordering", TestAnalysisPolicyRuleOutcomePreviewsUseDeterministicOrdering);
+        failed += Run("Analysis summary zero findings", TestAnalysisSummaryShowsZeroFindings);
+        failed += Run("Analysis summary zero findings without report", TestAnalysisSummaryShowsZeroFindingsWithoutLoadReport);
+        failed += Run("Analysis summary unavailable when no input files", TestAnalysisSummaryShowsUnavailableWhenNoInputFiles);
+        failed += Run("Analysis loader parses zero findings across formats", TestAnalysisLoadReportCountsParsedForZeroFindingsAcrossFormats);
+        failed += Run("Analysis loader does not double count failed files", TestAnalysisLoadReportDoesNotDoubleCountFailedFiles);
+        failed += Run("Analysis loader ignores empty files in parsed count", TestAnalysisLoadReportDoesNotCountEmptyFilesAsParsed);
+        failed += Run("Analysis loader deduplicates resolved files", TestAnalysisLoadReportDeduplicatesResolvedFilesAcrossInputs);
+        failed += Run("Analysis loader duplicate bad input failure count", TestAnalysisLoadReportCountsSingleFailureForDuplicateBadInput);
+        return failed;
+    }
+}
+#endif

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisReporting.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisReporting.cs
@@ -23,6 +23,7 @@ internal static partial class Program {
 
             var policy = IntelligenceX.Reviewer.AnalysisPolicyBuilder.BuildPolicy(settings,
                 new AnalysisLoadResult(findings, report));
+            AssertContainsText(policy, "### Static Analysis Policy 🧭", "analysis policy header");
             AssertPolicyLineEquals(policy, "Status", "fail ❌", "analysis policy status");
             AssertPolicyLineEquals(policy, "Rule outcomes", "1 with findings, 1 clean, 1 outside enabled packs",
                 "analysis policy outcomes");
@@ -316,7 +317,7 @@ internal static partial class Program {
 
             var longTitle = "Rule 3 " + new string('X', 120);
             var ruleIds = new List<string>();
-            for (var i = 1; i <= AnalysisPolicyFormatting.MaxPreviewItems + 1; i++) {
+            for (var i = 1; i <= AnalysisPolicyFormatting.MaxRulePreviewItems + 1; i++) {
                 var id = $"IXPREV{i:000}";
                 var title = i == 2 ? string.Empty : (i == 3 ? longTitle : $"Rule {i}");
                 ruleIds.Add(id);
@@ -360,7 +361,7 @@ internal static partial class Program {
             AssertContainsText(preview, "IXPREV010 (Rule 10)", "analysis policy preview includes boundary rule");
             AssertEqual(false, preview.Contains("IXPREV011", StringComparison.Ordinal),
                 "analysis policy preview excludes overflow rules");
-            AssertEqual(1, CountOccurrences(preview, AnalysisPolicyFormatting.TruncatedSuffix),
+            AssertEqual(1, CountOccurrences(preview, AnalysisPolicyFormatting.TruncatedPreviewSuffix),
                 "analysis policy preview single truncation marker");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
@@ -532,214 +533,6 @@ internal static partial class Program {
         }
     }
 
-    private static void TestAnalysisSummaryShowsZeroFindings() {
-        var results = new AnalysisResultsSettings {
-            Summary = true,
-            MinSeverity = "warning"
-        };
-        var report = new AnalysisLoadReport(2, 1, 1, 0);
-
-        var summary = IntelligenceX.Reviewer.AnalysisSummaryBuilder.BuildSummary(Array.Empty<AnalysisFinding>(), results, report);
-        AssertContainsText(summary, "### Static Analysis 🔎", "analysis summary header");
-        AssertContainsText(summary, "Findings: 0", "analysis summary no findings");
-    }
-
-    private static void TestAnalysisSummaryShowsZeroFindingsWithoutLoadReport() {
-        var results = new AnalysisResultsSettings {
-            Summary = true,
-            MinSeverity = "warning"
-        };
-
-        var summary = IntelligenceX.Reviewer.AnalysisSummaryBuilder.BuildSummary(Array.Empty<AnalysisFinding>(), results, null);
-        AssertContainsText(summary, "### Static Analysis 🔎", "analysis summary no report header");
-        AssertContainsText(summary, "Findings: 0", "analysis summary no report findings");
-    }
-
-    private static void TestAnalysisSummaryShowsUnavailableWhenNoInputFiles() {
-        var results = new AnalysisResultsSettings {
-            Summary = true,
-            MinSeverity = "warning"
-        };
-        var report = new AnalysisLoadReport(2, 0, 0, 0);
-
-        var summary = IntelligenceX.Reviewer.AnalysisSummaryBuilder.BuildSummary(Array.Empty<AnalysisFinding>(), results, report);
-        AssertContainsText(summary, "Findings: unavailable", "analysis summary unavailable");
-    }
-
-    private static void TestAnalysisLoadReportCountsParsedForZeroFindingsAcrossFormats() {
-        var temp = Path.Combine(Path.GetTempPath(), "ix-analysis-loader-zero-findings-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(temp);
-        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
-        try {
-            var artifactsDir = Path.Combine(temp, "artifacts");
-            Directory.CreateDirectory(artifactsDir);
-            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
-
-            void AssertCase(string fileName, string content, string label) {
-                var filePath = Path.Combine(artifactsDir, fileName);
-                File.WriteAllText(filePath, content);
-
-                var settings = new ReviewSettings();
-                settings.Analysis.Enabled = true;
-                settings.Analysis.Results.Inputs = new[] { $"artifacts/{fileName}" };
-
-                var result = IntelligenceX.Reviewer.AnalysisFindingsLoader.LoadWithReport(settings, Array.Empty<PullRequestFile>());
-                AssertEqual(1, result.Report.ResolvedInputFiles, $"analysis load zero-findings resolved {label}");
-                AssertEqual(1, result.Report.ParsedInputFiles, $"analysis load zero-findings parsed {label}");
-                AssertEqual(0, result.Report.FailedInputFiles, $"analysis load zero-findings failed {label}");
-                AssertEqual(0, result.Findings.Count, $"analysis load zero-findings findings {label}");
-            }
-
-            AssertCase("zero.findings.json",
-                "{ \"schema\": \"intelligencex.findings.v1\", \"items\": [] }",
-                "findings-json-empty-items");
-            AssertCase("zero-empty-runs.sarif",
-                "{ \"version\": \"2.1.0\", \"runs\": [] }",
-                "sarif-empty-runs");
-            AssertCase("zero-empty-results.sarif",
-                "{ \"version\": \"2.1.0\", \"runs\": [ { \"tool\": { \"driver\": { \"name\": \"demo\" } }, \"results\": [] } ] }",
-                "sarif-empty-results");
-        } finally {
-            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-        }
-    }
-
-    private static void TestAnalysisLoadReportDoesNotDoubleCountFailedFiles() {
-        var temp = Path.Combine(Path.GetTempPath(), "ix-analysis-loader-report-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(temp);
-        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
-        try {
-            var artifactsDir = Path.Combine(temp, "artifacts");
-            Directory.CreateDirectory(artifactsDir);
-            var lockedFile = Path.Combine(artifactsDir, "locked.findings.json");
-            File.WriteAllText(lockedFile, "{ \"schema\": \"intelligencex.findings.v1\", \"items\": [] }");
-
-            var settings = new ReviewSettings();
-            settings.Analysis.Enabled = true;
-            settings.Analysis.Results.Inputs = new[] { "artifacts/locked.findings.json" };
-
-            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
-
-            using var stream = new FileStream(lockedFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-            var result = IntelligenceX.Reviewer.AnalysisFindingsLoader.LoadWithReport(settings, Array.Empty<PullRequestFile>());
-
-            AssertEqual(1, result.Report.ResolvedInputFiles, "analysis load resolved files");
-            AssertEqual(0, result.Report.ParsedInputFiles, "analysis load parsed files");
-            AssertEqual(1, result.Report.FailedInputFiles, "analysis load failed files");
-        } finally {
-            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-        }
-    }
-
-    private static void TestAnalysisLoadReportDoesNotCountEmptyFilesAsParsed() {
-        var temp = Path.Combine(Path.GetTempPath(), "ix-analysis-loader-empty-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(temp);
-        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
-        try {
-            var artifactsDir = Path.Combine(temp, "artifacts");
-            Directory.CreateDirectory(artifactsDir);
-            var emptyFile = Path.Combine(artifactsDir, "empty.findings.json");
-            File.WriteAllText(emptyFile, string.Empty);
-
-            var settings = new ReviewSettings();
-            settings.Analysis.Enabled = true;
-            settings.Analysis.Results.Inputs = new[] { "artifacts/empty.findings.json" };
-
-            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
-
-            var result = IntelligenceX.Reviewer.AnalysisFindingsLoader.LoadWithReport(settings, Array.Empty<PullRequestFile>());
-            AssertEqual(1, result.Report.ResolvedInputFiles, "analysis load empty file resolved");
-            AssertEqual(0, result.Report.ParsedInputFiles, "analysis load empty file parsed");
-            AssertEqual(0, result.Report.FailedInputFiles, "analysis load empty file failed");
-        } finally {
-            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-        }
-    }
-
-    private static void TestAnalysisLoadReportDeduplicatesResolvedFilesAcrossInputs() {
-        var temp = Path.Combine(Path.GetTempPath(), "ix-analysis-loader-dedupe-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(temp);
-        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
-        try {
-            var artifactsDir = Path.Combine(temp, "artifacts");
-            Directory.CreateDirectory(artifactsDir);
-            var successFile = Path.Combine(artifactsDir, "success.findings.json");
-            var badFile = Path.Combine(artifactsDir, "bad.findings.json");
-            File.WriteAllText(successFile, "{ \"schema\": \"intelligencex.findings.v1\", \"items\": [ { \"path\": \"src/FileA.cs\", \"line\": 5, \"severity\": \"warning\", \"message\": \"ok\", \"ruleId\": \"IXTEST001\", \"tool\": \"Roslyn\" } ] }");
-            File.WriteAllText(badFile, "{");
-
-            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
-
-            void AssertCase(string[] inputs, string nameSuffix) {
-                var settings = new ReviewSettings();
-                settings.Analysis.Enabled = true;
-                settings.Analysis.Results.Inputs = inputs;
-
-                var result = IntelligenceX.Reviewer.AnalysisFindingsLoader.LoadWithReport(settings, Array.Empty<PullRequestFile>());
-                AssertEqual(2, result.Report.ResolvedInputFiles, $"analysis load dedupe resolved files {nameSuffix}");
-                AssertEqual(1, result.Report.ParsedInputFiles, $"analysis load dedupe parsed files {nameSuffix}");
-                AssertEqual(1, result.Report.FailedInputFiles, $"analysis load dedupe failed files {nameSuffix}");
-                AssertEqual(1, result.Findings.Count, $"analysis load dedupe findings count {nameSuffix}");
-            }
-
-            AssertCase(new[] {
-                "artifacts/*.findings.json",
-                "artifacts/success.findings.json",
-                "artifacts/bad.findings.json"
-            }, "glob-first");
-            AssertCase(new[] {
-                "artifacts/bad.findings.json",
-                "artifacts/success.findings.json",
-                "artifacts/*.findings.json"
-            }, "glob-last");
-        } finally {
-            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-        }
-    }
-
-    private static void TestAnalysisLoadReportCountsSingleFailureForDuplicateBadInput() {
-        var temp = Path.Combine(Path.GetTempPath(), "ix-analysis-loader-dup-bad-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(temp);
-        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
-        try {
-            var artifactsDir = Path.Combine(temp, "artifacts");
-            Directory.CreateDirectory(artifactsDir);
-            var badFile = Path.Combine(artifactsDir, "bad.findings.json");
-            File.WriteAllText(badFile, "{");
-
-            var settings = new ReviewSettings();
-            settings.Analysis.Enabled = true;
-            settings.Analysis.Results.Inputs = new[] {
-                "artifacts/bad.findings.json",
-                "artifacts/*.findings.json"
-            };
-
-            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
-
-            var result = IntelligenceX.Reviewer.AnalysisFindingsLoader.LoadWithReport(settings, Array.Empty<PullRequestFile>());
-            AssertEqual(1, result.Report.ResolvedInputFiles, "analysis load duplicate bad resolved");
-            AssertEqual(0, result.Report.ParsedInputFiles, "analysis load duplicate bad parsed");
-            AssertEqual(1, result.Report.FailedInputFiles, "analysis load duplicate bad failed");
-        } finally {
-            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-        }
-    }
-
     private static void AssertPolicyLineEquals(string policy, string label, string expectedValue, string name) {
         var actualValue = GetPolicyLineValue(policy, label, name);
         AssertEqual(expectedValue, actualValue, name);
@@ -776,7 +569,8 @@ internal static partial class Program {
         if (info.LengthInTextElements <= AnalysisPolicyFormatting.MaxRulePreviewTitleTextElements) {
             return resolved;
         }
-        return info.SubstringByTextElements(0, AnalysisPolicyFormatting.MaxRulePreviewTitleTextElements) + "...";
+        return info.SubstringByTextElements(0, AnalysisPolicyFormatting.MaxRulePreviewTitleTextElements) +
+               AnalysisPolicyFormatting.TruncationEllipsis;
     }
 
     private static void WriteAnalysisCatalogFixture(string root) {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -87,51 +87,7 @@ internal static partial class Program {
             TestAnalyzeRunInternalFileSizeRuleWarnsOnUnknownTagPrefixes);
         failed += Run("Analyze run internal generated header scan can be disabled",
             TestAnalyzeRunInternalFileSizeRuleGeneratedHeaderScanCanBeDisabled);
-        failed += Run("Analysis policy reports rule outcomes", TestAnalysisPolicyReportsRuleOutcomes);
-        failed += Run("Analysis policy builds unavailable status", TestAnalysisPolicyBuildUnavailablePolicy);
-        failed += Run("Analysis policy builds unavailable when catalog load fails",
-            TestAnalysisPolicyBuildsUnavailableWhenCatalogLoadFails);
-        failed += Run("Analysis policy unavailable uses catalog fallback when catalog load fails",
-            TestAnalysisPolicyUnavailableUsesCatalogFallbackWhenCatalogLoadFails);
-        failed += Run("Analysis policy catalog unavailable normalizes pack display",
-            TestAnalysisPolicyCatalogUnavailableNormalizesPackDisplay);
-        failed += Run("Analysis policy does not swallow unexpected catalog load exceptions",
-            TestAnalysisPolicyDoesNotSwallowUnexpectedCatalogLoadExceptions);
-        failed += Run("Analysis load failure embeds policy when summary disabled",
-            TestAnalysisLoadFailureEmbedsPolicyWhenSummaryDisabled);
-        failed += Run("Analysis load failure skips output when policy and summary disabled",
-            TestAnalysisLoadFailureSkipsOutputWhenPolicyAndSummaryDisabled);
-        failed += Run("Analysis policy shows unavailable when no result files",
-            TestAnalysisPolicyShowsUnavailableWhenNoResultFiles);
-        failed += Run("Analysis policy marks partial when only outside-pack findings exist",
-            TestAnalysisPolicyMarksPartialWhenOnlyOutsidePackFindingsExist);
-        failed += Run("Analysis policy shows unavailable when no enabled rules and no findings",
-            TestAnalysisPolicyShowsUnavailableWhenNoEnabledRulesAndNoFindings);
-        failed += Run("Analysis policy enabled preview truncates and falls back to id",
-            TestAnalysisPolicyEnabledRulePreviewTruncatesAndFallsBackToId);
-        failed += Run("Analysis policy enabled preview supports non-BMP unicode titles",
-            TestAnalysisPolicyEnabledRulePreviewSupportsNonBmpUnicodeTitles);
-        failed += Run("Analysis policy marks partial when only outside findings and enabled rules exist",
-            TestAnalysisPolicyMarksPartialWhenOnlyOutsideFindingsAndEnabledRulesExist);
-        failed += Run("Analysis policy handles null findings when report exists",
-            TestAnalysisPolicyHandlesNullFindingsWhenReportExists);
-        failed += Run("Analysis policy rule outcome previews use deterministic ordering",
-            TestAnalysisPolicyRuleOutcomePreviewsUseDeterministicOrdering);
-        failed += Run("Analysis summary shows zero findings", TestAnalysisSummaryShowsZeroFindings);
-        failed += Run("Analysis summary shows zero findings without load report",
-            TestAnalysisSummaryShowsZeroFindingsWithoutLoadReport);
-        failed += Run("Analysis summary shows unavailable when no input files",
-            TestAnalysisSummaryShowsUnavailableWhenNoInputFiles);
-        failed += Run("Analysis load report counts parsed for zero findings across formats",
-            TestAnalysisLoadReportCountsParsedForZeroFindingsAcrossFormats);
-        failed += Run("Analysis load report does not double count failed files",
-            TestAnalysisLoadReportDoesNotDoubleCountFailedFiles);
-        failed += Run("Analysis load report does not count empty files as parsed",
-            TestAnalysisLoadReportDoesNotCountEmptyFilesAsParsed);
-        failed += Run("Analysis load report deduplicates resolved files across inputs",
-            TestAnalysisLoadReportDeduplicatesResolvedFilesAcrossInputs);
-        failed += Run("Analysis load report counts single failure for duplicate bad input",
-            TestAnalysisLoadReportCountsSingleFailureForDuplicateBadInput);
+        failed += RunAnalysisPolicyReportingTests();
         failed += Run("Structured findings block", TestStructuredFindingsBlock);
         failed += Run("Trim patch hunk boundary", TestTrimPatchStopsAtHunkBoundary);
         failed += Run("Trim patch tail hunk", TestTrimPatchKeepsTailHunk);

--- a/TODO.md
+++ b/TODO.md
@@ -319,6 +319,10 @@ Collapsed by PR. Includes only explicit checklist items found in bot reviews/com
 - [x] Add regression coverage for non-BMP Unicode preview title truncation behavior. Links: user request in Codex thread (2026-02-06), https://github.com/EvotecIT/IntelligenceX/pull/115
 - [x] Centralize preview formatting constants for policy/test alignment. Links: user request in Codex thread (2026-02-06), https://github.com/EvotecIT/IntelligenceX/pull/115
 - [x] Normalize unavailable-policy pack display to skip blank pack IDs and preserve trimmed values. Links: https://github.com/EvotecIT/IntelligenceX/pull/115#discussion_r2775613244
+- [x] Keep one lightweight `AssertContainsText` header assertion alongside strict line assertions for policy output stability. Links: https://github.com/EvotecIT/IntelligenceX/pull/115#discussion_r2775620847
+- [x] Group analysis-policy test registration into a dedicated helper (`RunAnalysisPolicyReportingTests`) to reduce main-runner churn. Links: https://github.com/EvotecIT/IntelligenceX/pull/115#discussion_r2775620879
+- [x] Complete constant migration and behavior-oriented naming (`MaxRulePreviewItems`, `TruncatedPreviewSuffix`, `TruncationEllipsis`) in policy builder and tests. Links: https://github.com/EvotecIT/IntelligenceX/pull/115#discussion_r2775620920, https://github.com/EvotecIT/IntelligenceX/pull/115#discussion_r2775625708
+- [x] Split oversized analysis reporting tests into topic files to satisfy internal LOC maintainability rule (`IXLOC001`). Links: https://github.com/EvotecIT/IntelligenceX/pull/115
 </details>
 <details>
 <summary>PR #85 Static analysis catalog + CLI export</summary>


### PR DESCRIPTION
## Summary
- narrow static-analysis catalog load exception handling in policy builder (no blanket catch)
- render an explicit `Status: unavailable` policy block when catalog load fails instead of returning empty output
- reduce mutable state exposure in policy context by storing immutable/read-only collections
- centralize preview formatting constants in `AnalysisPolicyFormatting` and reuse in policy builder + tests
- make preview/title handling null-safe and keep deterministic ordering culture-invariant with ordinal comparers for sorted output
- strengthen analysis policy tests with structured line assertions and add new regressions for:
  - catalog load failure fallback behavior
  - unexpected exception propagation
  - non-BMP unicode title truncation stability
  - truncation marker behavior on preview lines

## Validation
- `dotnet build IntelligenceX.sln -c Release` ✅
- `dotnet run --project IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release -f net8.0 --no-build` ⚠️ existing unrelated baseline failures remain (`Auto-resolve missing inline empty keys`, `Failure summary comment update` timeout, `Diff range compare truncation`, `Secrets audit records`, `Prepare files max files zero`, `Prepare files max files negative`)
- new static-analysis policy tests pass in the same run
