### PR TITLE
Use doctor stage for final website validation

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -125,7 +125,7 @@
       "renderedInclude": "index.html,docs/**,faq/**,changelog/**,api/index.html",
       "renderedExclude": "docs/api/**,api-docs/**",
       "summary": true,
-      "summaryPath": "./_reports/audit-summary.json",
+      "summaryPath": "./_reports/doctor-summary.json",
       "summaryMaxIssues": 50,
       "checkUtf8": true,
       "checkMetaCharset": true,


### PR DESCRIPTION
## Summary
- switch final website validation step from `audit` to `doctor`
- keep existing nav/link/asset/rendered gating settings
- avoid duplicate work by setting `noBuild: true` and `noVerify: true`
- rename report artifact to `./_reports/doctor-summary.json`

## Why
This uses the unified `doctor` stage while preserving existing gating strictness and improving pipeline clarity.