### PR TITLE
ci(website): use PSPublishModule main branch

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: EvotecIT/PSPublishModule
-          ref: v2-speedgonzales
+          ref: main
           path: PSPublishModule
 
       - name: Build PowerForge.Web.Cli


### PR DESCRIPTION
## Summary
- update website deploy workflow to checkout EvotecIT/PSPublishModule@main
- remove dependency on renamed/deleted PSPublishModule branch names

## Validation
- workflow syntax unchanged except branch ref swap