### PR TITLE
Add tiered analysis packs and rule inventory formats

### DIFF
--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -44,6 +44,14 @@ jobs:
           app-id: ${{ env.INTELLIGENCEX_APP_ID }}
           private-key: ${{ env.INTELLIGENCEX_APP_KEY }}
 
+      - name: Validate analysis catalog
+        run: dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- analyze validate-catalog --workspace .
+
+      - name: Export rule inventory
+        run: |
+          mkdir -p artifacts
+          dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- analyze list-rules --workspace . --format markdown --pack all-50 > artifacts/analysis-rules.md
+
       - name: Run static analysis
         run: dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- analyze run --config .intelligencex/reviewer.json --out artifacts --framework net8.0
 

--- a/.intelligencex/reviewer.json
+++ b/.intelligencex/reviewer.json
@@ -2,9 +2,7 @@
   "analysis": {
     "enabled": true,
     "packs": [
-      "csharp-default",
-      "powershell-default",
-      "intelligencex-maintainability-default"
+      "all-50"
     ],
     "configMode": "respect",
     "results": {

--- a/Analysis/Catalog/README.md
+++ b/Analysis/Catalog/README.md
@@ -13,3 +13,14 @@ Pack files support:
 Validate catalog integrity before CI rollouts:
 
 `intelligencex analyze validate-catalog --workspace <repo-root>`
+
+List built-in rules (inventory):
+
+- Plain text (default): `intelligencex analyze list-rules --workspace <repo-root>`
+- Markdown table: `intelligencex analyze list-rules --workspace <repo-root> --format markdown`
+- JSON: `intelligencex analyze list-rules --workspace <repo-root> --format json`
+
+Filter inventory by packs (includes applied):
+
+- `intelligencex analyze list-rules --workspace <repo-root> --pack all-50`
+- `intelligencex analyze list-rules --workspace <repo-root> --packs csharp-100,powershell-100`

--- a/Analysis/Packs/README.md
+++ b/Analysis/Packs/README.md
@@ -1,3 +1,30 @@
 # Analysis Packs
 
-Packs are curated rule sets. Each pack lists rule IDs and optional severity overrides.
+Packs are curated rule sets built from rule IDs and optional includes/overrides.
+
+## Conventions
+
+- Keep one concern per file (one pack definition per JSON file).
+- Prefer stable, explicit pack IDs (for example `csharp-50`, `all-100`).
+- Use `includes` to compose tiers instead of duplicating large `rules` arrays.
+- Keep language packs separate from cross-language aggregate packs.
+
+## Built-in packs
+
+- Language defaults:
+  - `csharp-default`
+  - `powershell-default`
+  - `intelligencex-maintainability-default`
+- Language tiers:
+  - `csharp-50`, `csharp-100`, `csharp-500`
+  - `powershell-50`, `powershell-100`, `powershell-500`
+  - `intelligencex-maintainability-50`, `intelligencex-maintainability-100`, `intelligencex-maintainability-500`
+- Cross-language tiers:
+  - `all-50`, `all-100`, `all-500`
+- Compatibility alias:
+  - `all-default` (currently includes `all-50`)
+
+## Notes on 50/100/500 tiers
+
+Tier names define target growth and policy intent, not a hard count today. Current catalogs may contain fewer rules.
+As new rules are added, extend language tiers and aggregate tiers via `includes` without breaking existing pack IDs.

--- a/Analysis/Packs/all-100.json
+++ b/Analysis/Packs/all-100.json
@@ -1,0 +1,11 @@
+{
+  "id": "all-100",
+  "label": "All Standard (100)",
+  "description": "Cross-language standard pack. Includes each language standard tier.",
+  "includes": [
+    "csharp-100",
+    "powershell-100",
+    "intelligencex-maintainability-100"
+  ],
+  "rules": []
+}

--- a/Analysis/Packs/all-50.json
+++ b/Analysis/Packs/all-50.json
@@ -1,0 +1,11 @@
+{
+  "id": "all-50",
+  "label": "All Essentials (50)",
+  "description": "Cross-language baseline pack. Includes each language essentials tier.",
+  "includes": [
+    "csharp-50",
+    "powershell-50",
+    "intelligencex-maintainability-50"
+  ],
+  "rules": []
+}

--- a/Analysis/Packs/all-500.json
+++ b/Analysis/Packs/all-500.json
@@ -1,0 +1,11 @@
+{
+  "id": "all-500",
+  "label": "All Strict (500)",
+  "description": "Cross-language strict pack. Includes each language strict tier.",
+  "includes": [
+    "csharp-500",
+    "powershell-500",
+    "intelligencex-maintainability-500"
+  ],
+  "rules": []
+}

--- a/Analysis/Packs/all-default.json
+++ b/Analysis/Packs/all-default.json
@@ -1,11 +1,9 @@
 {
   "id": "all-default",
   "label": "All Default",
-  "description": "Includes all built-in default packs.",
+  "description": "Compatibility alias for the current cross-language essentials tier.",
   "includes": [
-    "csharp-default",
-    "powershell-default",
-    "intelligencex-maintainability-default"
+    "all-50"
   ],
   "rules": []
 }

--- a/Analysis/Packs/csharp-100.json
+++ b/Analysis/Packs/csharp-100.json
@@ -1,0 +1,7 @@
+{
+  "id": "csharp-100",
+  "label": "C# Standard (100)",
+  "description": "C# standard pack for broader coverage. Extends csharp-50 as new rules are added.",
+  "includes": ["csharp-50"],
+  "rules": []
+}

--- a/Analysis/Packs/csharp-50.json
+++ b/Analysis/Packs/csharp-50.json
@@ -1,0 +1,7 @@
+{
+  "id": "csharp-50",
+  "label": "C# Essentials (50)",
+  "description": "C# baseline pack for small-to-medium repositories. Grows toward ~50 rules as catalog expands.",
+  "includes": ["csharp-default"],
+  "rules": []
+}

--- a/Analysis/Packs/csharp-500.json
+++ b/Analysis/Packs/csharp-500.json
@@ -1,0 +1,7 @@
+{
+  "id": "csharp-500",
+  "label": "C# Strict (500)",
+  "description": "C# strict pack for deep coverage at scale. Extends csharp-100 over time.",
+  "includes": ["csharp-100"],
+  "rules": []
+}

--- a/Analysis/Packs/intelligencex-maintainability-100.json
+++ b/Analysis/Packs/intelligencex-maintainability-100.json
@@ -1,0 +1,7 @@
+{
+  "id": "intelligencex-maintainability-100",
+  "label": "IntelligenceX Maintainability Standard (100)",
+  "description": "Internal maintainability standard pack for broader coverage. Extends intelligencex-maintainability-50.",
+  "includes": ["intelligencex-maintainability-50"],
+  "rules": []
+}

--- a/Analysis/Packs/intelligencex-maintainability-50.json
+++ b/Analysis/Packs/intelligencex-maintainability-50.json
@@ -1,0 +1,7 @@
+{
+  "id": "intelligencex-maintainability-50",
+  "label": "IntelligenceX Maintainability Essentials (50)",
+  "description": "Internal maintainability baseline pack. Grows toward ~50 checks as the internal catalog expands.",
+  "includes": ["intelligencex-maintainability-default"],
+  "rules": []
+}

--- a/Analysis/Packs/intelligencex-maintainability-500.json
+++ b/Analysis/Packs/intelligencex-maintainability-500.json
@@ -1,0 +1,7 @@
+{
+  "id": "intelligencex-maintainability-500",
+  "label": "IntelligenceX Maintainability Strict (500)",
+  "description": "Internal maintainability strict pack for deep coverage at scale. Extends intelligencex-maintainability-100.",
+  "includes": ["intelligencex-maintainability-100"],
+  "rules": []
+}

--- a/Analysis/Packs/powershell-100.json
+++ b/Analysis/Packs/powershell-100.json
@@ -1,0 +1,7 @@
+{
+  "id": "powershell-100",
+  "label": "PowerShell Standard (100)",
+  "description": "PowerShell standard pack for broader coverage. Extends powershell-50 as new rules are added.",
+  "includes": ["powershell-50"],
+  "rules": []
+}

--- a/Analysis/Packs/powershell-50.json
+++ b/Analysis/Packs/powershell-50.json
@@ -1,0 +1,7 @@
+{
+  "id": "powershell-50",
+  "label": "PowerShell Essentials (50)",
+  "description": "PowerShell baseline pack for small-to-medium repositories. Grows toward ~50 rules as catalog expands.",
+  "includes": ["powershell-default"],
+  "rules": []
+}

--- a/Analysis/Packs/powershell-500.json
+++ b/Analysis/Packs/powershell-500.json
@@ -1,0 +1,7 @@
+{
+  "id": "powershell-500",
+  "label": "PowerShell Strict (500)",
+  "description": "PowerShell strict pack for deep coverage at scale. Extends powershell-100 over time.",
+  "includes": ["powershell-100"],
+  "rules": []
+}

--- a/Docs/cli/overview.md
+++ b/Docs/cli/overview.md
@@ -15,6 +15,8 @@ intelligencex reviewer run
 intelligencex reviewer resolve-threads
 intelligencex analyze run --config .intelligencex/reviewer.json --out artifacts
 intelligencex analyze export-config --out artifacts/analysis-config
+intelligencex analyze validate-catalog
+intelligencex analyze list-rules --format markdown --pack all-50
 intelligencex usage
 ```
 

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -221,7 +221,7 @@ Enable analysis summaries and inline findings sourced from SARIF or Intelligence
 {
   "analysis": {
     "enabled": true,
-    "packs": ["csharp-default", "powershell-default", "intelligencex-maintainability-default"],
+    "packs": ["all-50"],
     "configMode": "respect",
     "disabledRules": ["CA2000"],
     "severityOverrides": { "CA1062": "error" },

--- a/Docs/reviewer/static-analysis.md
+++ b/Docs/reviewer/static-analysis.md
@@ -11,7 +11,7 @@ This document proposes how IntelligenceX can offer default static analysis rules
 
 ## User Experience (Onboarding)
 - The wizard offers a single toggle: "Enable static analysis (recommended)."
-- Users select one or more packs (for example `csharp-default`, `powershell-default`, `intelligencex-maintainability-default`).
+- Users select one or more packs (for example `all-50`, `all-100`, `all-500`).
 - Users can optionally toggle individual rules and change severities.
 - The wizard writes the `analysis` section into `.intelligencex/reviewer.json`.
 
@@ -23,7 +23,7 @@ All enablement decisions live in `.intelligencex/reviewer.json`. Analyzer tool c
 {
   "analysis": {
     "enabled": true,
-    "packs": ["csharp-default", "powershell-default", "intelligencex-maintainability-default"],
+    "packs": ["all-50"],
     "disabledRules": ["CA2000"],
     "severityOverrides": { "CA1062": "error" },
     "configMode": "respect",
@@ -76,6 +76,18 @@ Proposed layout:
 - `Analysis/Packs/csharp-default.json`
 - `Analysis/Packs/powershell-default.json`
 - `Analysis/Packs/intelligencex-maintainability-default.json`
+- `Analysis/Packs/csharp-50.json`
+- `Analysis/Packs/csharp-100.json`
+- `Analysis/Packs/csharp-500.json`
+- `Analysis/Packs/powershell-50.json`
+- `Analysis/Packs/powershell-100.json`
+- `Analysis/Packs/powershell-500.json`
+- `Analysis/Packs/intelligencex-maintainability-50.json`
+- `Analysis/Packs/intelligencex-maintainability-100.json`
+- `Analysis/Packs/intelligencex-maintainability-500.json`
+- `Analysis/Packs/all-50.json`
+- `Analysis/Packs/all-100.json`
+- `Analysis/Packs/all-500.json`
 - `Analysis/Packs/all-default.json`
 
 Example pack:
@@ -95,10 +107,17 @@ Packs can include other packs to build tiers without duplicating rule lists:
 {
   "id": "all-default",
   "label": "All Default",
-  "includes": ["csharp-default", "powershell-default", "intelligencex-maintainability-default"],
+  "includes": ["all-50"],
   "rules": []
 }
 ```
+
+Recommended tier selection:
+- `all-50`: baseline/default onboarding tier.
+- `all-100`: broader coverage with higher review noise.
+- `all-500`: strict tier for mature repositories and dedicated cleanup cycles.
+
+Today, the built-in catalog has fewer than 50 total rules. Tier IDs are forward-compatible aliases that grow via `includes` as catalog coverage expands.
 
 ## Temporary Analyzer Config Generation
 During analysis runs, configs are generated to a temporary directory and cleaned up at the end. Examples:
@@ -110,6 +129,7 @@ During analysis runs, configs are generated to a temporary directory and cleaned
 `intelligencex analyze run` executes analysis for configured packs and emits findings artifacts for the reviewer.
 `intelligencex analyze export-config` remains available for teams that explicitly want committed analyzer configs for IDE support.
 `intelligencex analyze validate-catalog` validates rules/packs integrity (duplicates, bad refs, cycles, invalid severities).
+`intelligencex analyze list-rules` prints the built-in rule inventory (`--format text|markdown|json`) and supports pack-scoped views (`--pack` / `--packs`).
 
 Current built-in runners in `analyze run`:
 - C#: Roslyn via `dotnet build` (SARIF output).
@@ -126,15 +146,15 @@ Review comments now include analysis execution context and outcomes even when no
 ```text
 ### Static Analysis Policy 🧭
 - Config mode: respect
-- Packs: C# Default, PowerShell Default, IntelligenceX Maintainability
+- Packs: All Essentials (50)
 - Rules: 5 enabled
 - Rule list display: up to 10 items per section
-- Enabled rules preview: CA2000 (Dispose objects before losing scope), CA1822 (Mark members as static), PSAvoidUsingWriteHost (Avoid using Write-Host) (truncated)
+- Enabled rules preview: CA2000 (Dispose objects before losing scope), CA1062 (Validate arguments of public methods), SA1600 (Elements should be documented), PSAvoidUsingWriteHost (Avoid using Write-Host), IXLOC001 (Source files should stay below 700 lines)
 - Result files: 2 input patterns, 2 matched, 2 parsed, 0 failed
 - Status: pass ✅
 - Rule outcomes: 0 with findings, 5 clean
 - Failing rules: none
-- Clean rules: CA2000 (Dispose objects before losing scope), CA1822 (Mark members as static), SA1600 (Elements should be documented), PSAvoidUsingWriteHost (Avoid using Write-Host), IXLOC001 (Source files should stay below 700 lines)
+- Clean rules: CA2000 (Dispose objects before losing scope), CA1062 (Validate arguments of public methods), SA1600 (Elements should be documented), PSAvoidUsingWriteHost (Avoid using Write-Host), IXLOC001 (Source files should stay below 700 lines)
 - Outside-pack rules: none
 
 ### Static Analysis 🔎

--- a/IntelligenceX.Cli/Analysis/AnalyzeRunner.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunner.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -91,15 +92,39 @@ internal static class AnalyzeRunner {
     }
 
     private static Task<int> ListRulesAsync(string[] args) {
-        var workspace = ParseWorkspace(args);
-        var catalog = AnalysisCatalogLoader.LoadFromWorkspace(ResolveWorkspace(workspace));
-        if (catalog.Rules.Count == 0) {
+        var options = ParseListRulesArgs(args);
+        if (options.Error is not null) {
+            Console.WriteLine(options.Error);
+            return Task.FromResult(1);
+        }
+
+        var catalog = AnalysisCatalogLoader.LoadFromWorkspace(ResolveWorkspace(options.Workspace));
+        var (rules, warnings) = ResolveListRules(catalog, options.Packs);
+        foreach (var warning in warnings) {
+            Console.WriteLine($"Warning: {warning}");
+        }
+        if (rules.Count == 0) {
             Console.WriteLine("No rules found.");
             return Task.FromResult(0);
         }
-        foreach (var rule in catalog.Rules.Values.OrderBy(rule => rule.Id, StringComparer.OrdinalIgnoreCase)) {
-            Console.WriteLine($"{rule.Id} [{rule.Language}] {rule.Title}");
+
+        switch (options.Format) {
+            case "text":
+                foreach (var rule in rules) {
+                    Console.WriteLine($"{rule.Id} [{rule.Language}] {rule.Title}");
+                }
+                break;
+            case "markdown":
+                PrintRulesMarkdown(rules);
+                break;
+            case "json":
+                PrintRulesJson(rules);
+                break;
+            default:
+                Console.WriteLine($"Unsupported format '{options.Format}'. Use text, markdown, or json.");
+                return Task.FromResult(1);
         }
+
         return Task.FromResult(0);
     }
 
@@ -146,6 +171,132 @@ internal static class AnalyzeRunner {
         return null;
     }
 
+    private static ListRulesOptions ParseListRulesArgs(string[] args) {
+        var options = new ListRulesOptions();
+        for (var i = 0; i < args.Length; i++) {
+            var arg = args[i];
+            if (arg.Equals("--workspace", StringComparison.OrdinalIgnoreCase)) {
+                if (i + 1 >= args.Length) {
+                    options.Error = "Missing value for --workspace.";
+                    return options;
+                }
+                options.Workspace = args[++i];
+                continue;
+            }
+            if (arg.Equals("--format", StringComparison.OrdinalIgnoreCase)) {
+                if (i + 1 >= args.Length) {
+                    options.Error = "Missing value for --format.";
+                    return options;
+                }
+                options.Format = (args[++i] ?? string.Empty).Trim().ToLowerInvariant();
+                continue;
+            }
+            if (arg.Equals("--pack", StringComparison.OrdinalIgnoreCase)) {
+                if (i + 1 >= args.Length) {
+                    options.Error = "Missing value for --pack.";
+                    return options;
+                }
+                AddPackValues(options.Packs, args[++i]);
+                continue;
+            }
+            if (arg.Equals("--packs", StringComparison.OrdinalIgnoreCase)) {
+                if (i + 1 >= args.Length) {
+                    options.Error = "Missing value for --packs.";
+                    return options;
+                }
+                AddPackValues(options.Packs, args[++i]);
+                continue;
+            }
+            options.Error = $"Unknown option '{arg}' for list-rules.";
+            return options;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Format)) {
+            options.Format = "text";
+        }
+        if (!options.Format.Equals("text", StringComparison.OrdinalIgnoreCase) &&
+            !options.Format.Equals("markdown", StringComparison.OrdinalIgnoreCase) &&
+            !options.Format.Equals("json", StringComparison.OrdinalIgnoreCase)) {
+            options.Error = $"Unsupported format '{options.Format}'. Use text, markdown, or json.";
+        }
+        return options;
+    }
+
+    private static void AddPackValues(ICollection<string> packs, string? raw) {
+        if (packs is null || string.IsNullOrWhiteSpace(raw)) {
+            return;
+        }
+        var values = raw.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var value in values) {
+            var normalized = value.Trim();
+            if (!string.IsNullOrWhiteSpace(normalized)) {
+                packs.Add(normalized);
+            }
+        }
+    }
+
+    private static (IReadOnlyList<AnalysisRule> Rules, IReadOnlyList<string> Warnings) ResolveListRules(
+        AnalysisCatalog catalog, IReadOnlyList<string> packIds) {
+        if (catalog is null) {
+            return (Array.Empty<AnalysisRule>(), Array.Empty<string>());
+        }
+        if (packIds is null || packIds.Count == 0) {
+            return (catalog.Rules.Values
+                .OrderBy(rule => rule.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList(), Array.Empty<string>());
+        }
+
+        var settings = new AnalysisSettings {
+            Packs = packIds
+        };
+        var policy = AnalysisPolicyBuilder.Build(settings, catalog);
+        var rules = policy.Rules.Values
+            .Select(item => item.Rule)
+            .Where(rule => rule is not null)
+            .GroupBy(rule => rule.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .OrderBy(rule => rule.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return (rules, policy.Warnings);
+    }
+
+    private static void PrintRulesMarkdown(IReadOnlyList<AnalysisRule> rules) {
+        Console.WriteLine("| ID | Language | Tool | Tool Rule ID | Default Severity | Category | Title | Docs |");
+        Console.WriteLine("| --- | --- | --- | --- | --- | --- | --- | --- |");
+        foreach (var rule in rules) {
+            var docs = string.IsNullOrWhiteSpace(rule.Docs)
+                ? string.Empty
+                : $"[link]({rule.Docs})";
+            Console.WriteLine(
+                $"| {EscapeMarkdown(rule.Id)} | {EscapeMarkdown(rule.Language)} | {EscapeMarkdown(rule.Tool)} | {EscapeMarkdown(rule.ToolRuleId)} | {EscapeMarkdown(rule.DefaultSeverity)} | {EscapeMarkdown(rule.Category)} | {EscapeMarkdown(rule.Title)} | {EscapeMarkdown(docs)} |");
+        }
+    }
+
+    private static void PrintRulesJson(IReadOnlyList<AnalysisRule> rules) {
+        var items = rules.Select(rule => new Dictionary<string, object?> {
+            ["id"] = rule.Id,
+            ["language"] = rule.Language,
+            ["tool"] = rule.Tool,
+            ["toolRuleId"] = rule.ToolRuleId,
+            ["title"] = rule.Title,
+            ["description"] = rule.Description,
+            ["category"] = rule.Category,
+            ["defaultSeverity"] = rule.DefaultSeverity,
+            ["docs"] = rule.Docs
+        }).ToList();
+        Console.WriteLine(JsonLite.Serialize(items));
+    }
+
+    private static string EscapeMarkdown(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return string.Empty;
+        }
+        var text = value.Replace("|", "\\|")
+            .Replace("\r", " ")
+            .Replace("\n", " ");
+        return text;
+    }
+
     internal static string ResolveWorkspace(string? workspace) {
         if (!string.IsNullOrWhiteSpace(workspace)) {
             return Path.GetFullPath(workspace);
@@ -175,7 +326,7 @@ internal static class AnalyzeRunner {
         AnalyzeRunCommand.PrintHelp();
         Console.WriteLine("  intelligencex analyze export-config --out <dir> [--config <path>] [--workspace <path>]");
         Console.WriteLine("  intelligencex analyze list-packs [--workspace <path>]");
-        Console.WriteLine("  intelligencex analyze list-rules [--workspace <path>]");
+        Console.WriteLine("  intelligencex analyze list-rules [--workspace <path>] [--format text|markdown|json] [--pack <id>] [--packs <id1,id2>]");
         Console.WriteLine("  intelligencex analyze validate-catalog [--workspace <path>]");
     }
 
@@ -188,5 +339,12 @@ internal static class AnalyzeRunner {
         return value.Equals("help", StringComparison.OrdinalIgnoreCase) ||
                value.Equals("-h", StringComparison.OrdinalIgnoreCase) ||
                value.Equals("--help", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class ListRulesOptions {
+        public string? Workspace { get; set; }
+        public string Format { get; set; } = "text";
+        public List<string> Packs { get; } = new List<string>();
+        public string? Error { get; set; }
     }
 }

--- a/IntelligenceX.Cli/Program.cs
+++ b/IntelligenceX.Cli/Program.cs
@@ -59,7 +59,7 @@ internal static class Program {
         Console.WriteLine("  analyze run             Execute configured analysis packs and emit findings");
         Console.WriteLine("  analyze export-config   Export analyzer configs from reviewer.json");
         Console.WriteLine("  analyze list-packs      List available rule packs");
-        Console.WriteLine("  analyze list-rules      List available rules");
+        Console.WriteLine("  analyze list-rules      List available rules (text/markdown/json, optional pack filter)");
         Console.WriteLine("  analyze validate-catalog Validate rules/packs integrity");
         Console.WriteLine();
         Console.WriteLine("Reviewer commands:");

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisCatalogAndPolicy.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisCatalogAndPolicy.cs
@@ -317,6 +317,128 @@ internal static partial class Program {
         }
     }
 
+    private static void TestAnalyzeListRulesMarkdownFormat() {
+        var workspace = ResolveWorkspaceRoot();
+        var (exitCode, output) = RunAnalyzeAndCaptureOutput(new[] {
+            "list-rules",
+            "--workspace",
+            workspace,
+            "--format",
+            "markdown"
+        });
+        AssertEqual(0, exitCode, "analyze list-rules markdown exit");
+        AssertContainsText(output, "| ID | Language | Tool | Tool Rule ID | Default Severity | Category | Title | Docs |",
+            "analyze list-rules markdown header");
+        AssertContainsText(output, "CA2000", "analyze list-rules markdown includes CA2000");
+        AssertContainsText(output, "PSAvoidUsingWriteHost", "analyze list-rules markdown includes powershell rule");
+    }
+
+    private static void TestAnalyzeListRulesJsonWithPackFilter() {
+        var temp = Path.Combine(Path.GetTempPath(), "ix-analyze-list-rules-json-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        try {
+            var rulesDir = Path.Combine(temp, "Analysis", "Catalog", "rules", "internal");
+            var packsDir = Path.Combine(temp, "Analysis", "Packs");
+            Directory.CreateDirectory(rulesDir);
+            Directory.CreateDirectory(packsDir);
+
+            File.WriteAllText(Path.Combine(rulesDir, "IX001.json"), """
+{
+  "id": "IX001",
+  "language": "internal",
+  "tool": "IntelligenceX",
+  "title": "Rule one",
+  "description": "Rule one"
+}
+""");
+            File.WriteAllText(Path.Combine(rulesDir, "IX002.json"), """
+{
+  "id": "IX002",
+  "language": "internal",
+  "tool": "IntelligenceX",
+  "title": "Rule two",
+  "description": "Rule two"
+}
+""");
+            File.WriteAllText(Path.Combine(rulesDir, "IX003.json"), """
+{
+  "id": "IX003",
+  "language": "internal",
+  "tool": "IntelligenceX",
+  "title": "Rule three",
+  "description": "Rule three"
+}
+""");
+
+            File.WriteAllText(Path.Combine(packsDir, "core.json"), """
+{
+  "id": "core",
+  "label": "Core",
+  "rules": ["IX001"]
+}
+""");
+            File.WriteAllText(Path.Combine(packsDir, "standard.json"), """
+{
+  "id": "standard",
+  "label": "Standard",
+  "includes": ["core"],
+  "rules": ["IX002"]
+}
+""");
+            File.WriteAllText(Path.Combine(packsDir, "strict.json"), """
+{
+  "id": "strict",
+  "label": "Strict",
+  "includes": ["standard"],
+  "rules": ["IX003"]
+}
+""");
+
+            var (exitCode, output) = RunAnalyzeAndCaptureOutput(new[] {
+                "list-rules",
+                "--workspace",
+                temp,
+                "--pack",
+                "strict",
+                "--format",
+                "json"
+            });
+
+            AssertEqual(0, exitCode, "analyze list-rules json exit");
+            var parsed = JsonLite.Parse(output.Trim())?.AsArray();
+            AssertNotNull(parsed, "analyze list-rules json payload");
+            var ids = new List<string>();
+            foreach (var item in parsed!) {
+                var obj = item.AsObject();
+                if (obj is null) {
+                    continue;
+                }
+                var id = obj.GetString("id");
+                if (!string.IsNullOrWhiteSpace(id)) {
+                    ids.Add(id!);
+                }
+            }
+            ids.Sort(StringComparer.OrdinalIgnoreCase);
+            AssertSequenceEqual(new[] { "IX001", "IX002", "IX003" }, ids, "analyze list-rules json pack includes");
+        } finally {
+            if (Directory.Exists(temp)) {
+                Directory.Delete(temp, true);
+            }
+        }
+    }
+
+    private static void TestAnalyzeListRulesInvalidFormat() {
+        var (exitCode, output) = RunAnalyzeAndCaptureOutput(new[] {
+            "list-rules",
+            "--workspace",
+            ResolveWorkspaceRoot(),
+            "--format",
+            "yaml"
+        });
+        AssertEqual(1, exitCode, "analyze list-rules invalid format exit");
+        AssertContainsText(output, "Unsupported format 'yaml'", "analyze list-rules invalid format message");
+    }
+
     private static void TestAnalysisCatalogRuleDocsPath() {
         var temp = Path.Combine(Path.GetTempPath(), "ix-analysis-docs-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(temp);
@@ -352,6 +474,19 @@ internal static partial class Program {
             if (Directory.Exists(temp)) {
                 Directory.Delete(temp, true);
             }
+        }
+    }
+
+    private static (int ExitCode, string Output) RunAnalyzeAndCaptureOutput(string[] args) {
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try {
+            var exitCode = IntelligenceX.Cli.Analysis.AnalyzeRunner.RunAsync(args).GetAwaiter().GetResult();
+            writer.Flush();
+            return (exitCode, writer.ToString());
+        } finally {
+            Console.SetOut(originalOut);
         }
     }
 

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -82,6 +82,9 @@ internal static partial class Program {
         failed += Run("Analysis catalog validator detects invalid catalog", TestAnalysisCatalogValidatorDetectsInvalidCatalog);
         failed += Run("Analysis catalog validator detects missing rule metadata", TestAnalysisCatalogValidatorDetectsMissingRuleMetadata);
         failed += Run("Analyze validate-catalog command", TestAnalyzeValidateCatalogCommand);
+        failed += Run("Analyze list-rules markdown format", TestAnalyzeListRulesMarkdownFormat);
+        failed += Run("Analyze list-rules json with pack filter", TestAnalyzeListRulesJsonWithPackFilter);
+        failed += Run("Analyze list-rules invalid format", TestAnalyzeListRulesInvalidFormat);
         failed += Run("Analyze run disabled writes empty findings", TestAnalyzeRunDisabledWritesEmptyFindings);
         failed += Run("Analyze run internal file size rule", TestAnalyzeRunInternalFileSizeRule);
         failed += Run("Analyze run internal findings use catalog tool metadata",


### PR DESCRIPTION
## Summary
- add scalable tiered analysis packs (`50/100/500`) for C#, PowerShell, and IntelligenceX maintainability using pack `includes`
- keep backward compatibility by mapping `all-default` to `all-50`
- extend `intelligencex analyze list-rules` with:
  - `--format text|markdown|json`
  - `--pack <id>` and `--packs <id1,id2>` (include-aware effective rule inventory)
- add CI guardrail + artifact generation in reviewer workflow:
  - `analyze validate-catalog`
  - markdown rules inventory artifact (`artifacts/analysis-rules.md`)
- switch repo default reviewer config to tiered pack selection (`all-50`)

## Why
- gives a clear path to scale from small baselines to strict policy without churn in rule IDs
- makes built-in analyzer/rule inventory visible and scriptable
- enforces catalog integrity early in CI before analysis/review steps

## Testing
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet build IntelligenceX/IntelligenceX.csproj -c Release -p:TargetFrameworks=netstandard2.0`
- `dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- analyze validate-catalog --workspace <worktree>`
- `dotnet run --project IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release --framework net8.0`

## Notes
- current built-in catalog still has 5 rules; `50/100/500` tiers are forward-compatible aliases that grow via `includes` as more rules are added.
