### PR TITLE
Tighten resolver smoke tests with GraphQL payload checks

### DIFF
--- a/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.cs
@@ -355,9 +355,34 @@ internal static partial class Program {
         AssertEqual(true, resolvedThreadIdObserved, "auto resolve missing inline targets thread1");
     }
 
+    private static void TestResolveThreadPayloadParserRejectsInvalidJson() {
+        var emptyPayloadResult = TryGetResolveThreadIdFromGraphQlPayload(string.Empty, out var emptyPayloadThreadId);
+        AssertEqual(false, emptyPayloadResult, "resolve payload empty rejected");
+        AssertEqual<string?>(null, emptyPayloadThreadId, "resolve payload empty id");
+
+        var malformedPayloadResult = TryGetResolveThreadIdFromGraphQlPayload("{not-json}", out var malformedPayloadThreadId);
+        AssertEqual(false, malformedPayloadResult, "resolve payload malformed rejected");
+        AssertEqual<string?>(null, malformedPayloadThreadId, "resolve payload malformed id");
+
+        const string noThreadIdPayload = "{\"query\":\"mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id } } }\",\"variables\":{}}";
+        var noThreadIdResult = TryGetResolveThreadIdFromGraphQlPayload(noThreadIdPayload, out var noThreadId);
+        AssertEqual(false, noThreadIdResult, "resolve payload missing id rejected");
+        AssertEqual<string?>(null, noThreadId, "resolve payload missing id value");
+    }
+
     private static bool TryGetResolveThreadIdFromGraphQlPayload(string body, out string? threadId) {
         threadId = null;
-        var payload = JsonLite.Parse(body)?.AsObject();
+        if (string.IsNullOrWhiteSpace(body)) {
+            return false;
+        }
+        JsonObject? payload;
+        try {
+            payload = JsonLite.Parse(body).AsObject();
+        } catch (FormatException) {
+            return false;
+        } catch (ArgumentNullException) {
+            return false;
+        }
         if (payload is null) {
             return false;
         }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -49,6 +49,7 @@ internal static partial class Program {
         failed += Run("Thread assessment prompt smoke", TestThreadAssessmentPromptSmoke);
         failed += Run("Auto-resolve stale threads smoke", TestAutoResolveStaleThreadsSmoke);
         failed += Run("Auto-resolve missing inline empty keys", TestAutoResolveMissingInlineEmptyKeys);
+        failed += Run("Resolve thread payload parser rejects invalid JSON", TestResolveThreadPayloadParserRejectsInvalidJson);
         failed += Run("Auto-resolve missing inline gate empty set", TestAutoResolveMissingInlineGateAllowsEmptySet);
         failed += Run("Auto-resolve missing inline gate null set", TestAutoResolveMissingInlineGateRejectsNull);
         failed += Run("Auto-resolve missing inline gate empty mapped keys", TestAutoResolveMissingInlineGateRejectsEmptyWhenInlineCommentsPresent);


### PR DESCRIPTION
## Summary
- replace substring-only resolver detection in reviewer smoke tests with GraphQL JSON payload parsing
- assert resolver payload shape includes `resolveReviewThread` query and expected `variables.id` value
- add explicit payload-observed assertions for stale-thread and missing-inline auto-resolve smoke tests

## Validation
- dotnet run --project IntelligenceX.Tests/IntelligenceX.Tests.csproj --framework net8.0 --configuration Release
- dotnet run --project IntelligenceX.Tests/IntelligenceX.Tests.csproj --framework net10.0 --configuration Release
