### PR TITLE
CLI: add doctor onboarding preflight

### DIFF
--- a/IntelligenceX.Cli/Auth/AuthStoreUtils.cs
+++ b/IntelligenceX.Cli/Auth/AuthStoreUtils.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace IntelligenceX.Cli.Auth;
+
+internal sealed record AuthStoreEntry(string Provider, string? AccountId, DateTimeOffset? ExpiresAt);
+
+internal static class AuthStoreUtils {
+    public static string DecryptAuthStoreIfNeeded(string content) {
+        if (string.IsNullOrWhiteSpace(content)) {
+            return content;
+        }
+        var trimmed = content.TrimStart();
+        if (!trimmed.StartsWith("{\"encrypted\":", StringComparison.OrdinalIgnoreCase)) {
+            return content;
+        }
+
+        var keyBase64 = Environment.GetEnvironmentVariable("INTELLIGENCEX_AUTH_KEY");
+        if (string.IsNullOrWhiteSpace(keyBase64)) {
+            throw new InvalidOperationException("Auth store is encrypted but INTELLIGENCEX_AUTH_KEY is not set.");
+        }
+        byte[] key;
+        try {
+            key = Convert.FromBase64String(keyBase64);
+        } catch {
+            throw new InvalidOperationException("INTELLIGENCEX_AUTH_KEY must be base64.");
+        }
+        if (key.Length != 32) {
+            throw new InvalidOperationException("INTELLIGENCEX_AUTH_KEY must decode to 32 bytes.");
+        }
+
+        using var doc = JsonDocument.Parse(content);
+        var root = doc.RootElement;
+        var nonce = Convert.FromBase64String(root.GetProperty("nonce").GetString() ?? string.Empty);
+        var cipher = Convert.FromBase64String(root.GetProperty("ciphertext").GetString() ?? string.Empty);
+        var tag = Convert.FromBase64String(root.GetProperty("tag").GetString() ?? string.Empty);
+        var plain = new byte[cipher.Length];
+        using var aes = new AesGcm(key, 16);
+        aes.Decrypt(nonce, cipher, tag, plain);
+        return Encoding.UTF8.GetString(plain);
+    }
+
+    public static List<AuthStoreEntry> ParseAuthStoreEntries(string json) {
+        var list = new List<AuthStoreEntry>();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        if (root.ValueKind != JsonValueKind.Object) {
+            return list;
+        }
+        if (root.TryGetProperty("bundles", out var bundles) && bundles.ValueKind == JsonValueKind.Object) {
+            foreach (var prop in bundles.EnumerateObject()) {
+                if (prop.Value.ValueKind != JsonValueKind.Object) {
+                    continue;
+                }
+                var provider = prop.Value.TryGetProperty("provider", out var p) ? p.GetString() : null;
+                if (string.IsNullOrWhiteSpace(provider)) {
+                    continue;
+                }
+                var accountId = prop.Value.TryGetProperty("account_id", out var a) ? a.GetString() : null;
+                DateTimeOffset? expiresAt = null;
+                if (prop.Value.TryGetProperty("expires_at", out var exp) && exp.ValueKind == JsonValueKind.Number &&
+                    exp.TryGetInt64(out var expMs) && expMs > 0) {
+                    expiresAt = DateTimeOffset.FromUnixTimeMilliseconds(expMs);
+                }
+                list.Add(new AuthStoreEntry(provider!, accountId, expiresAt));
+            }
+            return list;
+        }
+
+        // Single-bundle format (supported by reviewer env ingestion).
+        if (root.TryGetProperty("provider", out var providerProp) && providerProp.ValueKind == JsonValueKind.String) {
+            var provider = providerProp.GetString();
+            var accountId = root.TryGetProperty("account_id", out var a) ? a.GetString() : null;
+            DateTimeOffset? expiresAt = null;
+            if (root.TryGetProperty("expires_at", out var exp) && exp.ValueKind == JsonValueKind.Number &&
+                exp.TryGetInt64(out var expMs) && expMs > 0) {
+                expiresAt = DateTimeOffset.FromUnixTimeMilliseconds(expMs);
+            }
+            if (!string.IsNullOrWhiteSpace(provider)) {
+                list.Add(new AuthStoreEntry(provider!, accountId, expiresAt));
+            }
+        }
+        return list;
+    }
+}
+

--- a/IntelligenceX.Cli/Doctor/DoctorRunner.cs
+++ b/IntelligenceX.Cli/Doctor/DoctorRunner.cs
@@ -1,0 +1,424 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using IntelligenceX.Cli.Auth;
+using IntelligenceX.OpenAI;
+using IntelligenceX.OpenAI.Auth;
+
+namespace IntelligenceX.Cli.Doctor;
+
+internal static class DoctorRunner {
+    private sealed class Options {
+        public string Workspace { get; set; } = Environment.CurrentDirectory;
+        public string? ConfigPath { get; set; }
+        public string? Repo { get; set; }
+        public bool SkipOpenAi { get; set; }
+        public bool SkipGitHub { get; set; }
+        public bool ShowHelp { get; set; }
+    }
+
+    private sealed class ReviewConfig {
+        public string Provider { get; set; } = "openai";
+        public string Model { get; set; } = "gpt-5.3-codex";
+        public OpenAITransportKind Transport { get; set; } = OpenAITransportKind.Native;
+        public string? OpenAiAccountId { get; set; }
+    }
+
+    public static async Task<int> RunAsync(string[] args) {
+        var options = ParseOptions(args);
+        if (options.ShowHelp) {
+            PrintHelp();
+            return 0;
+        }
+
+        var failures = 0;
+        var warnings = 0;
+
+        var workspace = options.Workspace;
+        if (string.IsNullOrWhiteSpace(workspace) || !Directory.Exists(workspace)) {
+            Console.Error.WriteLine("[FAIL] Workspace not found.");
+            return 1;
+        }
+
+        var configPath = ResolveConfigPath(options, workspace);
+        var config = TryLoadReviewConfig(configPath, out var configError);
+        if (config is null) {
+            warnings++;
+            Console.Error.WriteLine($"[WARN] Reviewer config not loaded ({configError}).");
+            Console.Error.WriteLine("       Expected .intelligencex/reviewer.json or pass --config <path>.");
+        } else {
+            Console.WriteLine($"[OK] Reviewer config: {configPath}");
+            Console.WriteLine($"     Provider={config.Provider}; Transport={config.Transport}; Model={config.Model}");
+        }
+
+        if (!options.SkipOpenAi) {
+            var requiresAuthStore = config is null
+                ? false
+                : RequiresOpenAiAuthStore(config.Provider, config.Transport);
+            if (requiresAuthStore) {
+                var (ok, warnCount, errorMessage) = CheckOpenAiAuthStore(config!);
+                warnings += warnCount;
+                if (!ok) {
+                    failures++;
+                    Console.Error.WriteLine($"[FAIL] {errorMessage}");
+                }
+            } else {
+                Console.WriteLine("[OK] OpenAI auth store: not required for current config.");
+            }
+        }
+
+        if (!options.SkipGitHub) {
+            var githubFailures = await CheckGitHubAsync(options.Repo).ConfigureAwait(false);
+            failures += githubFailures.Failures;
+            warnings += githubFailures.Warnings;
+        }
+
+        if (failures == 0 && warnings == 0) {
+            Console.WriteLine("[OK] Doctor checks passed.");
+            return 0;
+        }
+        if (failures == 0) {
+            Console.WriteLine("[OK] Doctor checks passed with warnings.");
+            return 0;
+        }
+        Console.Error.WriteLine("[FAIL] Doctor checks failed.");
+        return 1;
+    }
+
+    private static string ResolveConfigPath(Options options, string workspace) {
+        if (!string.IsNullOrWhiteSpace(options.ConfigPath)) {
+            return options.ConfigPath!;
+        }
+        return Path.Combine(workspace, ".intelligencex", "reviewer.json");
+    }
+
+    private static ReviewConfig? TryLoadReviewConfig(string path, out string error) {
+        error = "file not found";
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
+            return null;
+        }
+        try {
+            var text = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(text)) {
+                error = "empty file";
+                return null;
+            }
+            using var doc = JsonDocument.Parse(text);
+            var root = doc.RootElement;
+            var review = root;
+            if (root.ValueKind == JsonValueKind.Object &&
+                root.TryGetProperty("review", out var reviewObj) &&
+                reviewObj.ValueKind == JsonValueKind.Object) {
+                review = reviewObj;
+            }
+
+            var config = new ReviewConfig();
+            if (TryGetString(review, "provider", out var provider) && !string.IsNullOrWhiteSpace(provider)) {
+                config.Provider = provider!;
+            }
+
+            // Prefer schema-aligned "model" but keep legacy fallback.
+            if (TryGetString(review, "model", out var model) && !string.IsNullOrWhiteSpace(model)) {
+                config.Model = model!;
+            } else if (TryGetString(review, "openaiModel", out var legacyModel) && !string.IsNullOrWhiteSpace(legacyModel)) {
+                config.Model = legacyModel!;
+            }
+
+            if (TryGetString(review, "openaiTransport", out var transportStr) && !string.IsNullOrWhiteSpace(transportStr)) {
+                config.Transport = ParseTransportOrDefault(transportStr!, config.Transport);
+            } else if (TryGetString(review, "openaiTransportKind", out var transportKind) && !string.IsNullOrWhiteSpace(transportKind)) {
+                config.Transport = ParseTransportOrDefault(transportKind!, config.Transport);
+            }
+
+            if (TryGetString(review, "openaiAccountId", out var accountId) && !string.IsNullOrWhiteSpace(accountId)) {
+                config.OpenAiAccountId = accountId!;
+            } else if (TryGetString(review, "authAccountId", out var authAccountId) && !string.IsNullOrWhiteSpace(authAccountId)) {
+                config.OpenAiAccountId = authAccountId!;
+            }
+
+            error = string.Empty;
+            return config;
+        } catch (Exception ex) {
+            error = ex.Message;
+            return null;
+        }
+    }
+
+    private static bool TryGetString(JsonElement obj, string name, out string? value) {
+        value = null;
+        if (obj.ValueKind != JsonValueKind.Object) {
+            return false;
+        }
+        if (!obj.TryGetProperty(name, out var prop)) {
+            return false;
+        }
+        if (prop.ValueKind != JsonValueKind.String) {
+            return false;
+        }
+        value = prop.GetString();
+        return true;
+    }
+
+    private static OpenAITransportKind ParseTransportOrDefault(string value, OpenAITransportKind fallback) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return fallback;
+        }
+        return value.Trim().ToLowerInvariant() switch {
+            "native" => OpenAITransportKind.Native,
+            "appserver" or "app-server" or "codex" => OpenAITransportKind.AppServer,
+            _ => fallback
+        };
+    }
+
+    private static bool RequiresOpenAiAuthStore(string provider, OpenAITransportKind transport) {
+        if (string.IsNullOrWhiteSpace(provider)) {
+            return false;
+        }
+        var p = provider.Trim().ToLowerInvariant();
+        var isOpenAi = p is "openai" or "codex" or "chatgpt";
+        if (!isOpenAi) {
+            return false;
+        }
+        // Native transport uses ChatGPT OAuth auth store.
+        return transport == OpenAITransportKind.Native;
+    }
+
+    private static (bool Ok, int Warnings, string ErrorMessage) CheckOpenAiAuthStore(ReviewConfig config) {
+        var authPath = AuthPaths.ResolveAuthPath();
+        if (!File.Exists(authPath)) {
+            return (false, 0,
+                $"Missing OpenAI auth store at {authPath}. Run `intelligencex auth login` (or set INTELLIGENCEX_AUTH_B64 in CI).");
+        }
+        string raw;
+        try {
+            raw = File.ReadAllText(authPath);
+        } catch (Exception ex) {
+            return (false, 0, $"Failed to read OpenAI auth store: {ex.Message}");
+        }
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return (false, 0, "OpenAI auth store is empty.");
+        }
+
+        List<AuthStoreEntry> entries;
+        try {
+            var json = AuthStoreUtils.DecryptAuthStoreIfNeeded(raw);
+            entries = AuthStoreUtils.ParseAuthStoreEntries(json);
+        } catch (Exception ex) {
+            return (false, 0, $"Failed to load OpenAI auth store: {ex.Message}");
+        }
+        if (entries.Count == 0) {
+            return (false, 0, "No auth bundles found in OpenAI auth store.");
+        }
+
+        var relevant = entries.Where(e =>
+                string.Equals(e.Provider, "openai-codex", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(e.Provider, "openai", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(e.Provider, "chatgpt", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (relevant.Count == 0) {
+            return (false, 0, $"No OpenAI bundles found in auth store ({authPath}).");
+        }
+
+        var selectedAccount = FirstNonEmpty(
+            config.OpenAiAccountId,
+            Environment.GetEnvironmentVariable("INTELLIGENCEX_OPENAI_ACCOUNT_ID"));
+        if (!string.IsNullOrWhiteSpace(selectedAccount)) {
+            var has = relevant.Any(e => string.Equals(e.AccountId, selectedAccount, StringComparison.OrdinalIgnoreCase));
+            if (!has) {
+                return (false, 0, $"No OpenAI bundle found for account '{selectedAccount}' in {authPath}. Run `intelligencex auth list`.");
+            }
+        }
+
+        var warnings = 0;
+        var byAccount = relevant
+            .Select(e => string.IsNullOrWhiteSpace(e.AccountId) ? "-" : e.AccountId!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (byAccount.Count > 1 && string.IsNullOrWhiteSpace(selectedAccount)) {
+            warnings++;
+            Console.Error.WriteLine("[WARN] Multiple ChatGPT accounts found in auth store.");
+            Console.Error.WriteLine($"       Accounts: {string.Join(", ", byAccount)}");
+            Console.Error.WriteLine("       Set review.openaiAccountId in .intelligencex/reviewer.json or INTELLIGENCEX_OPENAI_ACCOUNT_ID.");
+        }
+
+        var soon = DateTimeOffset.UtcNow.AddDays(7);
+        var expiring = relevant.Where(e => e.ExpiresAt.HasValue && e.ExpiresAt.Value <= soon).ToList();
+        if (expiring.Count > 0) {
+            warnings++;
+            var min = expiring.Min(e => e.ExpiresAt!.Value).ToUniversalTime().ToString("u");
+            Console.Error.WriteLine($"[WARN] OpenAI access token expires soon (min expiry {min}). If reviews start failing, re-run `intelligencex auth login`.");
+        }
+
+        Console.WriteLine($"[OK] OpenAI auth store: {authPath}");
+        return (true, warnings, string.Empty);
+    }
+
+    private sealed class GitHubCheckResult {
+        public int Failures { get; set; }
+        public int Warnings { get; set; }
+    }
+
+    private static async Task<GitHubCheckResult> CheckGitHubAsync(string? repo) {
+        var result = new GitHubCheckResult();
+        var token = FirstNonEmpty(
+            Environment.GetEnvironmentVariable("INTELLIGENCEX_GITHUB_TOKEN"),
+            Environment.GetEnvironmentVariable("GITHUB_TOKEN"),
+            Environment.GetEnvironmentVariable("GH_TOKEN"));
+        if (string.IsNullOrWhiteSpace(token)) {
+            result.Warnings++;
+            Console.Error.WriteLine("[WARN] No GitHub token found (INTELLIGENCEX_GITHUB_TOKEN/GITHUB_TOKEN/GH_TOKEN). Skipping GitHub API checks.");
+            return result;
+        }
+
+        using var http = new HttpClient();
+        http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("IntelligenceX", "doctor"));
+        http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Basic token validity + scope visibility.
+        using (var response = await http.GetAsync("https://api.github.com/user").ConfigureAwait(false)) {
+            if (!response.IsSuccessStatusCode) {
+                result.Failures++;
+                var detail = await ReadResponseSnippetAsync(response).ConfigureAwait(false);
+                Console.Error.WriteLine($"[FAIL] GitHub token check failed ({(int)response.StatusCode}). {detail}");
+                PrintGitHubHeaders(response);
+                return result;
+            }
+            var scopes = TryGetHeader(response, "X-OAuth-Scopes");
+            if (!string.IsNullOrWhiteSpace(scopes)) {
+                Console.WriteLine($"[OK] GitHub token scopes: {scopes}");
+            } else {
+                Console.WriteLine("[OK] GitHub token: valid (scopes header not provided).");
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo) || !repo.Contains('/')) {
+            result.Warnings++;
+            Console.Error.WriteLine("[WARN] --repo not provided. Skipping repo permission probes.");
+            return result;
+        }
+        var parts = repo.Split('/', 2);
+        var owner = parts[0];
+        var name = parts[1];
+        if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(name)) {
+            result.Warnings++;
+            Console.Error.WriteLine("[WARN] Invalid --repo value. Expected owner/name.");
+            return result;
+        }
+
+        // Non-destructive probes that correlate well with setup requirements.
+        await ProbeGitHubAsync(http, $"https://api.github.com/repos/{owner}/{name}", "Repo access", result).ConfigureAwait(false);
+        await ProbeGitHubAsync(http, $"https://api.github.com/repos/{owner}/{name}/actions/secrets/public-key", "Actions secrets access", result)
+            .ConfigureAwait(false);
+        await ProbeGitHubAsync(http, $"https://api.github.com/repos/{owner}/{name}/actions/workflows", "Workflows access", result)
+            .ConfigureAwait(false);
+
+        return result;
+    }
+
+    private static async Task ProbeGitHubAsync(HttpClient http, string url, string label, GitHubCheckResult result) {
+        using var response = await http.GetAsync(url).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode) {
+            Console.WriteLine($"[OK] GitHub: {label}");
+            return;
+        }
+        // 404 can mean the token doesn't have access, or repo/feature absent.
+        result.Warnings++;
+        var detail = await ReadResponseSnippetAsync(response).ConfigureAwait(false);
+        Console.Error.WriteLine($"[WARN] GitHub: {label} probe failed ({(int)response.StatusCode}). {detail}");
+        PrintGitHubHeaders(response);
+    }
+
+    private static void PrintGitHubHeaders(HttpResponseMessage response) {
+        var accepted = TryGetHeader(response, "X-Accepted-GitHub-Permissions");
+        if (!string.IsNullOrWhiteSpace(accepted)) {
+            Console.Error.WriteLine($"       X-Accepted-GitHub-Permissions: {accepted}");
+        }
+        var scopes = TryGetHeader(response, "X-OAuth-Scopes");
+        if (!string.IsNullOrWhiteSpace(scopes)) {
+            Console.Error.WriteLine($"       X-OAuth-Scopes: {scopes}");
+        }
+    }
+
+    private static string? TryGetHeader(HttpResponseMessage response, string name) {
+        return response.Headers.TryGetValues(name, out var values) ? values.FirstOrDefault() : null;
+    }
+
+    private static async Task<string> ReadResponseSnippetAsync(HttpResponseMessage response) {
+        try {
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(body)) {
+                return string.Empty;
+            }
+            // Keep logs concise.
+            body = body.Trim();
+            return body.Length > 240 ? body.Substring(0, 240) + "…" : body;
+        } catch {
+            return string.Empty;
+        }
+    }
+
+    private static string? FirstNonEmpty(params string?[] values) {
+        foreach (var v in values) {
+            if (!string.IsNullOrWhiteSpace(v)) {
+                return v.Trim();
+            }
+        }
+        return null;
+    }
+
+    private static Options ParseOptions(string[] args) {
+        var options = new Options();
+        for (var i = 0; i < args.Length; i++) {
+            var arg = args[i];
+            switch (arg) {
+                case "-h":
+                case "--help":
+                    options.ShowHelp = true;
+                    break;
+                case "--workspace":
+                    if (i + 1 < args.Length) {
+                        options.Workspace = args[++i];
+                    }
+                    break;
+                case "--config":
+                    if (i + 1 < args.Length) {
+                        options.ConfigPath = args[++i];
+                    }
+                    break;
+                case "--repo":
+                    if (i + 1 < args.Length) {
+                        options.Repo = args[++i];
+                    }
+                    break;
+                case "--skip-openai":
+                    options.SkipOpenAi = true;
+                    break;
+                case "--skip-github":
+                    options.SkipGitHub = true;
+                    break;
+                default:
+                    Console.Error.WriteLine($"Unknown option: {arg}");
+                    options.ShowHelp = true;
+                    break;
+            }
+        }
+        return options;
+    }
+
+    private static void PrintHelp() {
+        Console.WriteLine("Usage: intelligencex doctor [options]");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --workspace <path>     Workspace root (default: current directory)");
+        Console.WriteLine("  --config <path>        Reviewer config path (default: <workspace>/.intelligencex/reviewer.json)");
+        Console.WriteLine("  --repo <owner/name>    Optional GitHub repo for permission probes");
+        Console.WriteLine("  --skip-openai          Skip OpenAI auth store checks");
+        Console.WriteLine("  --skip-github          Skip GitHub token/API checks");
+    }
+}

--- a/IntelligenceX.Cli/Program.cs
+++ b/IntelligenceX.Cli/Program.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using IntelligenceX.Cli.Auth;
 using IntelligenceX.Cli.Usage;
 using IntelligenceX.OpenAI.Auth;
 
@@ -28,6 +29,7 @@ internal static class Program {
             "analyze" => await Analysis.AnalyzeRunner.RunAsync(rest).ConfigureAwait(false),
             "reviewer" => await RunReviewerAsync(rest).ConfigureAwait(false),
             "setup" => await RunSetupAsync(rest).ConfigureAwait(false),
+            "doctor" => await Doctor.DoctorRunner.RunAsync(rest).ConfigureAwait(false),
             "release" => await RunReleaseAsync(rest).ConfigureAwait(false),
             "usage" => await UsageRunner.RunAsync(rest).ConfigureAwait(false),
             "help" or "-h" or "--help" => PrintHelpReturn(),
@@ -50,6 +52,7 @@ internal static class Program {
         Console.WriteLine("  intelligencex setup [options]");
         Console.WriteLine("  intelligencex setup wizard [options]");
         Console.WriteLine("  intelligencex setup web [url]");
+        Console.WriteLine("  intelligencex doctor [options]");
         Console.WriteLine("  intelligencex release <command>");
         Console.WriteLine("  intelligencex usage [options]");
         Console.WriteLine();
@@ -71,6 +74,9 @@ internal static class Program {
         Console.WriteLine();
         Console.WriteLine("Setup:");
         Console.WriteLine("  setup            Configure GitHub Actions workflow and secrets");
+        Console.WriteLine();
+        Console.WriteLine("Doctor:");
+        Console.WriteLine("  doctor           Preflight checks for auth/config/GitHub access");
         Console.WriteLine();
         Console.WriteLine("Release commands:");
         Console.WriteLine("  release notes    Generate release notes from git tags/commits");
@@ -231,8 +237,8 @@ internal static class Program {
                 return 1;
             }
 
-            var json = DecryptAuthStoreIfNeeded(raw);
-            var entries = ParseAuthStoreEntries(json);
+            var json = AuthStoreUtils.DecryptAuthStoreIfNeeded(raw);
+            var entries = AuthStoreUtils.ParseAuthStoreEntries(json);
             if (entries.Count == 0) {
                 Console.Error.WriteLine("No auth bundles found.");
                 return 1;
@@ -437,7 +443,7 @@ internal static class Program {
             Console.Error.WriteLine("Auth store is empty.");
             return 1;
         }
-        var json = DecryptAuthStoreIfNeeded(raw);
+        var json = AuthStoreUtils.DecryptAuthStoreIfNeeded(raw);
         var node = JsonNode.Parse(json) as JsonObject;
         if (node is null) {
             Console.Error.WriteLine("Auth store content is invalid.");
@@ -801,85 +807,6 @@ internal static class Program {
         }
 
         return options;
-    }
-
-    private sealed record AuthStoreEntry(string Provider, string? AccountId, DateTimeOffset? ExpiresAt);
-
-    private static string DecryptAuthStoreIfNeeded(string content) {
-        if (string.IsNullOrWhiteSpace(content)) {
-            return content;
-        }
-        var trimmed = content.TrimStart();
-        if (!trimmed.StartsWith("{\"encrypted\":", StringComparison.OrdinalIgnoreCase)) {
-            return content;
-        }
-
-        var keyBase64 = Environment.GetEnvironmentVariable("INTELLIGENCEX_AUTH_KEY");
-        if (string.IsNullOrWhiteSpace(keyBase64)) {
-            throw new InvalidOperationException("Auth store is encrypted but INTELLIGENCEX_AUTH_KEY is not set.");
-        }
-        byte[] key;
-        try {
-            key = Convert.FromBase64String(keyBase64);
-        } catch {
-            throw new InvalidOperationException("INTELLIGENCEX_AUTH_KEY must be base64.");
-        }
-        if (key.Length != 32) {
-            throw new InvalidOperationException("INTELLIGENCEX_AUTH_KEY must decode to 32 bytes.");
-        }
-
-        using var doc = JsonDocument.Parse(content);
-        var root = doc.RootElement;
-        var nonce = Convert.FromBase64String(root.GetProperty("nonce").GetString() ?? string.Empty);
-        var cipher = Convert.FromBase64String(root.GetProperty("ciphertext").GetString() ?? string.Empty);
-        var tag = Convert.FromBase64String(root.GetProperty("tag").GetString() ?? string.Empty);
-        var plain = new byte[cipher.Length];
-        using var aes = new AesGcm(key, 16);
-        aes.Decrypt(nonce, cipher, tag, plain);
-        return Encoding.UTF8.GetString(plain);
-    }
-
-    private static List<AuthStoreEntry> ParseAuthStoreEntries(string json) {
-        var list = new List<AuthStoreEntry>();
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-        if (root.ValueKind != JsonValueKind.Object) {
-            return list;
-        }
-        if (root.TryGetProperty("bundles", out var bundles) && bundles.ValueKind == JsonValueKind.Object) {
-            foreach (var prop in bundles.EnumerateObject()) {
-                if (prop.Value.ValueKind != JsonValueKind.Object) {
-                    continue;
-                }
-                var provider = prop.Value.TryGetProperty("provider", out var p) ? p.GetString() : null;
-                if (string.IsNullOrWhiteSpace(provider)) {
-                    continue;
-                }
-                var accountId = prop.Value.TryGetProperty("account_id", out var a) ? a.GetString() : null;
-                DateTimeOffset? expiresAt = null;
-                if (prop.Value.TryGetProperty("expires_at", out var exp) && exp.ValueKind == JsonValueKind.Number &&
-                    exp.TryGetInt64(out var expMs) && expMs > 0) {
-                    expiresAt = DateTimeOffset.FromUnixTimeMilliseconds(expMs);
-                }
-                list.Add(new AuthStoreEntry(provider!, accountId, expiresAt));
-            }
-            return list;
-        }
-
-        // Single-bundle format (supported by reviewer env ingestion).
-        if (root.TryGetProperty("provider", out var providerProp) && providerProp.ValueKind == JsonValueKind.String) {
-            var provider = providerProp.GetString();
-            var accountId = root.TryGetProperty("account_id", out var a) ? a.GetString() : null;
-            DateTimeOffset? expiresAt = null;
-            if (root.TryGetProperty("expires_at", out var exp) && exp.ValueKind == JsonValueKind.Number &&
-                exp.TryGetInt64(out var expMs) && expMs > 0) {
-                expiresAt = DateTimeOffset.FromUnixTimeMilliseconds(expMs);
-            }
-            if (!string.IsNullOrWhiteSpace(provider)) {
-                list.Add(new AuthStoreEntry(provider!, accountId, expiresAt));
-            }
-        }
-        return list;
     }
 
     private static void TryOpenBrowser(string url) {

--- a/IntelligenceX.Tests/Program.Doctor.cs
+++ b/IntelligenceX.Tests/Program.Doctor.cs
@@ -1,0 +1,116 @@
+namespace IntelligenceX.Tests;
+
+internal static partial class Program {
+#if !NET472
+    private static void TestDoctorHelp() {
+        var (exitCode, output) = RunDoctorAndCaptureOutput(new[] { "--help" });
+        AssertEqual(0, exitCode, "doctor help exit");
+        AssertContainsText(output, "Usage: intelligencex doctor", "doctor help usage");
+        AssertContainsText(output, "--workspace", "doctor help workspace");
+    }
+
+    private static void TestDoctorMissingAuthStoreFails() {
+        var previousAuthPath = Environment.GetEnvironmentVariable("INTELLIGENCEX_AUTH_PATH");
+        try {
+            var temp = Path.Combine(Path.GetTempPath(), "ix-tests-doctor-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(temp);
+            Directory.CreateDirectory(Path.Combine(temp, ".intelligencex"));
+
+            File.WriteAllText(Path.Combine(temp, ".intelligencex", "reviewer.json"), """
+{
+  "review": {
+    "provider": "openai",
+    "openaiTransport": "native",
+    "model": "gpt-5.3-codex"
+  }
+}
+""");
+
+            var authPath = Path.Combine(temp, "auth.json");
+            Environment.SetEnvironmentVariable("INTELLIGENCEX_AUTH_PATH", authPath);
+
+            var (exitCode, output) = RunDoctorAndCaptureOutput(new[] {
+                "--workspace", temp,
+                "--skip-github"
+            });
+
+            AssertEqual(1, exitCode, "doctor missing auth store exit");
+            AssertContainsText(output, "Missing OpenAI auth store", "doctor missing auth store message");
+        } finally {
+            Environment.SetEnvironmentVariable("INTELLIGENCEX_AUTH_PATH", previousAuthPath);
+        }
+    }
+
+    private static void TestDoctorMultipleBundlesWarns() {
+        var previousAuthPath = Environment.GetEnvironmentVariable("INTELLIGENCEX_AUTH_PATH");
+        try {
+            var temp = Path.Combine(Path.GetTempPath(), "ix-tests-doctor-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(temp);
+            Directory.CreateDirectory(Path.Combine(temp, ".intelligencex"));
+
+            File.WriteAllText(Path.Combine(temp, ".intelligencex", "reviewer.json"), """
+{
+  "review": {
+    "provider": "openai",
+    "openaiTransport": "native",
+    "model": "gpt-5.3-codex"
+  }
+}
+""");
+
+            var authPath = Path.Combine(temp, "auth.json");
+            Environment.SetEnvironmentVariable("INTELLIGENCEX_AUTH_PATH", authPath);
+            File.WriteAllText(authPath, """
+{
+  "version": 1,
+  "bundles": {
+    "openai-codex:acc-a": {
+      "provider": "openai-codex",
+      "access_token": "t",
+      "refresh_token": "r",
+      "account_id": "acc-a",
+      "expires_at": 4102444800000
+    },
+    "openai-codex:acc-b": {
+      "provider": "openai-codex",
+      "access_token": "t",
+      "refresh_token": "r",
+      "account_id": "acc-b",
+      "expires_at": 4102444800000
+    }
+  }
+}
+""");
+
+            var (exitCode, output) = RunDoctorAndCaptureOutput(new[] {
+                "--workspace", temp,
+                "--skip-github"
+            });
+
+            AssertEqual(0, exitCode, "doctor multiple bundles exit");
+            AssertContainsText(output, "Multiple ChatGPT accounts found", "doctor multiple bundles warning");
+        } finally {
+            Environment.SetEnvironmentVariable("INTELLIGENCEX_AUTH_PATH", previousAuthPath);
+        }
+    }
+
+    private static (int ExitCode, string Output) RunDoctorAndCaptureOutput(string[] args) {
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        using var outWriter = new StringWriter();
+        using var errWriter = new StringWriter();
+        Console.SetOut(outWriter);
+        Console.SetError(errWriter);
+        try {
+            var exitCode = IntelligenceX.Cli.Doctor.DoctorRunner.RunAsync(args).GetAwaiter().GetResult();
+            outWriter.Flush();
+            errWriter.Flush();
+            return (exitCode, outWriter.ToString() + errWriter.ToString());
+        } finally {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+#endif
+}
+

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -90,6 +90,9 @@ internal static partial class Program {
         failed += Run("Analyze list-rules help", TestAnalyzeListRulesHelp);
         failed += Run("Analyze list-rules json warnings to stderr", TestAnalyzeListRulesJsonWarningsToStderr);
         failed += Run("Analyze list-rules json empty outputs array", TestAnalyzeListRulesJsonEmptyOutputsArray);
+        failed += Run("Doctor help", TestDoctorHelp);
+        failed += Run("Doctor missing auth store fails", TestDoctorMissingAuthStoreFails);
+        failed += Run("Doctor multiple bundles warns", TestDoctorMultipleBundlesWarns);
         failed += Run("Analyze run disabled writes empty findings", TestAnalyzeRunDisabledWritesEmptyFindings);
         failed += Run("Analyze run internal file size rule", TestAnalyzeRunInternalFileSizeRule);
         failed += Run("Analyze run internal findings use catalog tool metadata",


### PR DESCRIPTION
Adds `intelligencex doctor` to preflight the onboarding surface area:

- Loads `.intelligencex/reviewer.json` (or `--config`) and summarizes provider/transport/model.
- Validates OpenAI native auth store presence, encryption key requirement, multi-account selection, and near-expiry warnings.
- Optionally probes GitHub token + repo permissions (`--repo owner/name`) via non-destructive GETs and prints accepted-permissions/scope headers when available.

Tests:
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release
