### PR TITLE
Website: add -Watch to build script

### DIFF
--- a/Website/build.ps1
+++ b/Website/build.ps1
@@ -26,6 +26,10 @@
 .PARAMETER Skip
     Skip the specified pipeline tasks (comma/semicolon separated), for example: optimize,audit.
 
+.PARAMETER Watch
+    Run the pipeline in watch mode (rebuild on file changes).
+    When combined with `-Serve`, starts the static server and keeps rebuilding in the foreground.
+
 .PARAMETER Port
     Server port (default: 8080).
 
@@ -40,6 +44,7 @@
 
 param(
     [switch]$Serve,
+    [switch]$Watch,
     [switch]$Dev,
     [switch]$Fast,
     [switch]$NoDev,
@@ -131,26 +136,51 @@ function Assert-SiteOutput {
 try {
     $UseDev = ($Dev -or ($Serve -and -not $NoDev))
     $UseFast = ($Fast -or ($Serve -and -not $NoFast))
-    $pipelineArgs = @('pipeline', '--config', 'pipeline.json', '--profile')
+
+    $pipelineArgsBase = @('pipeline', '--config', 'pipeline.json', '--profile')
     if ($UseDev) {
-        $pipelineArgs += '--dev'
+        $pipelineArgsBase += '--dev'
     } elseif ($UseFast) {
-        $pipelineArgs += '--fast'
+        $pipelineArgsBase += '--fast'
     }
     if ($Only -and $Only.Count -gt 0) {
-        $pipelineArgs += @('--only', ($Only -join ','))
+        $pipelineArgsBase += @('--only', ($Only -join ','))
     }
     if ($Skip -and $Skip.Count -gt 0) {
-        $pipelineArgs += @('--skip', ($Skip -join ','))
+        $pipelineArgsBase += @('--skip', ($Skip -join ','))
+    }
+
+    $pipelineArgs = @($pipelineArgsBase)
+    if ($Watch) {
+        $pipelineArgs += '--watch'
     }
 
     if ($Serve) {
         Write-Host 'Building website...' -ForegroundColor Cyan
-        & $PowerForge @PowerForgeArgs @pipelineArgs
+        if ($Watch) {
+            # Ensure _site exists before we start the server.
+            & $PowerForge @PowerForgeArgs @pipelineArgsBase
+        } else {
+            & $PowerForge @PowerForgeArgs @pipelineArgs
+        }
         if ($LASTEXITCODE -ne 0) { throw "Build failed (exit code $LASTEXITCODE)" }
         Assert-SiteOutput -SiteRoot (Join-Path $PSScriptRoot '_site')
         Write-Host "Starting dev server on http://localhost:$Port ..." -ForegroundColor Cyan
-        & $PowerForge @PowerForgeArgs serve --path _site --port $Port
+
+        $serveArgs = @($PowerForgeArgs + @('serve', '--path', '_site', '--port', $Port))
+        $serveProcess = Start-Process -FilePath $PowerForge -ArgumentList $serveArgs -NoNewWindow -PassThru
+        try {
+            if ($Watch) {
+                Write-Host 'Watching for changes...' -ForegroundColor Cyan
+                & $PowerForge @PowerForgeArgs @pipelineArgs
+            } else {
+                Wait-Process -Id $serveProcess.Id
+            }
+        } finally {
+            if ($serveProcess -and -not $serveProcess.HasExited) {
+                Stop-Process -Id $serveProcess.Id -Force -ErrorAction SilentlyContinue
+            }
+        }
     } else {
         Write-Host 'Building website...' -ForegroundColor Cyan
         & $PowerForge @PowerForgeArgs @pipelineArgs


### PR DESCRIPTION
Adds -Watch to run powerforge-web pipeline --watch. With -Serve -Watch, starts the static server and keeps rebuilding in the foreground (Ctrl+C stops watch; script terminates server).