### PR TITLE
Docs: enforce review headings + clarify TODO merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,25 @@
 * text=auto
 
 ###############################################################################
+# Repository line endings
+#
+# Keep cross-platform content as LF to avoid CRLF-only diffs and tooling drift.
+# Keep PowerShell scripts as CRLF for Windows-native editing.
+###############################################################################
+*.md    text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf
+*.json  text eol=lf
+*.css   text eol=lf
+*.js    text eol=lf
+*.ts    text eol=lf
+*.html  text eol=lf
+*.cs    text eol=lf
+*.csproj text eol=lf
+*.sln   text eol=lf
+*.ps1   text eol=crlf
+
+###############################################################################
 # Set default behavior for command prompt diff.
 #
 # This is need for earlier builds of msysgit that does not have it on by

--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -15,6 +15,9 @@ Notes:
 - Tasks are grouped by PR and kept in collapsible `<details>` blocks.
 - Re-running the sync should be safe and should avoid noisy diffs.
 - This is a repo-level backlog file (not “a TODO for a single PR”). Each PR gets its own collapsible block.
+- Existing PR blocks are matched by PR number and updated in-place.
+- Task items are merged by task text (case-insensitive) so manual checkbox state in `TODO.md` is preserved. If a bot rewords an item, it will appear as a new task.
+- The sync does not delete tasks that disappeared from a PR review; remove them manually if they become stale/noise.
 
 ## Optional: create issues for unchecked items
 

--- a/Docs/reviewer/review-output.md
+++ b/Docs/reviewer/review-output.md
@@ -2,6 +2,8 @@
 
 The IntelligenceX reviewer posts a structured Markdown comment on each PR. The sections are intentionally split into merge blockers vs suggestions.
 
+The reviewer uses H2 headings (`## ...`) for each required section to keep the output easy to scan and tooling-friendly.
+
 ## Merge blockers vs suggestions
 
 Merge blockers:

--- a/IntelligenceX.Reviewer/Templates/ReviewPrompt.Long.md
+++ b/IntelligenceX.Reviewer/Templates/ReviewPrompt.Long.md
@@ -25,13 +25,13 @@ replacement text
 Only use suggestions when you are confident the replacement is correct and limited to the referenced lines.
 Only include inline comments for merge-blocking items from Todo List and Critical Issues. Do not add inline comments for style-only nits.
 
-{{SummaryStabilityBlock}}Return your review in markdown with these sections (use the emoji shown):
-- Summary 📝
-- Todo List ✅
-- Critical Issues ⚠️ (if any)
-- Other Issues 🧯
-- Other Reviews 🧩 (if provided)
-- Tests / Coverage 🧪
+{{SummaryStabilityBlock}}Return your review in markdown using H2 headings exactly as shown (use the emoji):
+- ## Summary 📝
+- ## Todo List ✅
+- ## Critical Issues ⚠️ (if any)
+- ## Other Issues 🧯
+- ## Other Reviews 🧩 (if provided)
+- ## Tests / Coverage 🧪
 {{NextStepsSection}}
 In Todo List, include only merge-blocking items as markdown checkboxes. If there are no merge-blocking items, write "None.".
 Critical Issues are merge-blocking. Other Issues are non-blocking suggestions.

--- a/IntelligenceX.Reviewer/Templates/ReviewPrompt.Medium.md
+++ b/IntelligenceX.Reviewer/Templates/ReviewPrompt.Medium.md
@@ -25,13 +25,13 @@ replacement text
 Only use suggestions when you are confident the replacement is correct and limited to the referenced lines.
 Only include inline comments for merge-blocking items from Todo List and Critical Issues. Do not add inline comments for style-only nits.
 
-{{SummaryStabilityBlock}}Return your review in markdown with these sections (use the emoji shown):
-- Summary 📝
-- Todo List ✅
-- Critical Issues ⚠️ (if any)
-- Other Issues 🧯
-- Other Reviews 🧩 (if provided)
-- Tests / Coverage 🧪
+{{SummaryStabilityBlock}}Return your review in markdown using H2 headings exactly as shown (use the emoji):
+- ## Summary 📝
+- ## Todo List ✅
+- ## Critical Issues ⚠️ (if any)
+- ## Other Issues 🧯
+- ## Other Reviews 🧩 (if provided)
+- ## Tests / Coverage 🧪
 {{NextStepsSection}}
 In Todo List, include only merge-blocking items as markdown checkboxes. If there are no merge-blocking items, write "None.".
 Critical Issues are merge-blocking. Other Issues are non-blocking suggestions.

--- a/IntelligenceX.Reviewer/Templates/ReviewPrompt.Short.md
+++ b/IntelligenceX.Reviewer/Templates/ReviewPrompt.Short.md
@@ -24,13 +24,13 @@ replacement text
 Only use suggestions when you are confident the replacement is correct and limited to the referenced lines.
 Only include inline comments for merge-blocking items from Todo List and Critical Issues. Do not add inline comments for style-only nits.
 
-{{SummaryStabilityBlock}}Return your review in markdown with these sections (use the emoji shown):
-- Summary 📝
-- Todo List ✅
-- Critical Issues ⚠️ (if any)
-- Other Issues 🧯
-- Other Reviews 🧩 (if provided)
-- Tests / Coverage 🧪
+{{SummaryStabilityBlock}}Return your review in markdown using H2 headings exactly as shown (use the emoji):
+- ## Summary 📝
+- ## Todo List ✅
+- ## Critical Issues ⚠️ (if any)
+- ## Other Issues 🧯
+- ## Other Reviews 🧩 (if provided)
+- ## Tests / Coverage 🧪
 {{NextStepsSection}}
 In Todo List, include only merge-blocking items as markdown checkboxes. If there are no merge-blocking items, write "None.".
 Critical Issues are merge-blocking. Other Issues are non-blocking suggestions.


### PR DESCRIPTION
Follow-up docs tweaks:
- Require H2 (##) headings for reviewer sections.
- Clarify TODO sync merge keys/behavior.
- Add .gitattributes eol rules to reduce CRLF-only diffs.