### PR TITLE
Docs: tool packs + app/repo goals

### DIFF
--- a/Docs/_index.md
+++ b/Docs/_index.md
@@ -34,6 +34,7 @@ Welcome to the IntelligenceX documentation.
 - [Quickstart](/docs/library/quickstart/)
 - [Providers](/docs/library/providers/)
 - [Tool Calling](/docs/library/tools/)
+- [Tool Packs](/docs/library/tool-packs/)
 - [API Reference](/api/)
 
 ## PowerShell Module
@@ -47,3 +48,7 @@ Welcome to the IntelligenceX documentation.
 - [Troubleshooting](/docs/troubleshooting/)
 - [FAQ](/docs/faq/)
 - [Screenshots (Planned)](/docs/screenshots/)
+
+## Apps (Planned)
+
+- [Windows Tray Chat App](/docs/apps/windows-tray-chat/)

--- a/Docs/apps/windows-tray-chat.md
+++ b/Docs/apps/windows-tray-chat.md
@@ -1,0 +1,36 @@
+# Windows Tray Chat App (Planned)
+
+Goal: a Windows systray app with a chat-like interface that can run tools (files, Event Log, AD, etc.) and render rich outputs (tables, code blocks, expandable tool traces).
+
+Recommended split:
+- Core library: `EvotecIT/IntelligenceX` (public)
+- Tool packs: `EvotecIT/IntelligenceX.Tools` (private until stable; publish selectively later)
+- App repo: `EvotecIT/IntelligenceX.Chat` (or `EvotecIT/IntelligenceX.Desktop`) (can be public)
+
+## UI stack recommendation (Windows)
+
+If you want it to feel native and look premium:
+- Windows App SDK + WinUI 3
+- Tray integration: `H.NotifyIcon` (WinUI 3 compatible)
+- Markdown rendering: WebView2-based markdown renderer (for GitHub-flavored tables) or a dedicated WinUI markdown control if it supports tables
+
+Why:
+- WinUI 3 has the best Windows-native typography/layout.
+- WebView2 makes table rendering easy and consistent.
+
+## App architecture
+
+- One local “agent host” process:
+  - `IntelligenceX.OpenAI` (or other provider) for chat
+  - `ToolRegistry` populated from selected tool packs
+- UI connects to host via local HTTP/Named Pipes (keep the UI thin).
+- Tool execution produces:
+  - human-facing summary
+  - machine-readable JSON artifact (for follow-up tool calls)
+
+## Tool packs (Windows-only examples)
+
+Keep these out of the core repo and out of cross-platform packs:
+- `IntelligenceX.Tools.ActiveDirectory` (ADPlayground)
+- `IntelligenceX.Tools.EventLog` (EventViewerX / PSEventViewer)
+

--- a/Docs/library/overview.md
+++ b/Docs/library/overview.md
@@ -5,6 +5,7 @@ The core library provides a Codex app-server client, ChatGPT auth helpers, and a
 Quickstart: [Library Quickstart](/docs/library/quickstart/)  
 Providers: [Provider Setup](/docs/library/providers/)  
 Tools: [Tool Calling](/docs/library/tools/)
+Tool packs: [Tool Packs](/docs/library/tool-packs/)
 
 ## Quick start (app-server)
 

--- a/Docs/library/tool-packs.md
+++ b/Docs/library/tool-packs.md
@@ -1,0 +1,45 @@
+# Tool Packs (Provider-Agnostic)
+
+IntelligenceX tool packs are **optional** libraries that implement `ITool` and can be plugged into any provider/tool-calling loop.
+
+Core idea:
+- The **stable contract** lives in the main `IntelligenceX` repo under the `IntelligenceX.Tools` namespace (`ITool`, `ToolRegistry`, schema types).
+- **Tool implementations** live in separate packages (ideally separate repos) so downstream users do not carry dependencies they do not need.
+
+## Repository split
+
+- `EvotecIT/IntelligenceX`
+  - Provider clients (`IntelligenceX.OpenAI.*`, `IntelligenceX.Copilot.*`)
+  - Tool contract (`IntelligenceX.Tools` namespace)
+  - Provider-specific tool-calling orchestration (for example `IntelligenceX.OpenAI.ToolCalling`)
+
+- `EvotecIT/IntelligenceX.Tools` (tool packs)
+  - `IntelligenceX.Tools.FileSystem` (cross-platform)
+  - `IntelligenceX.Tools.Email` (depends on Mailozaurr/MailKit/MimeKit)
+  - `IntelligenceX.Tools.System` (OS-specific helpers; keep isolated)
+  - Future Windows-only packs (recommended): `IntelligenceX.Tools.ActiveDirectory`, `IntelligenceX.Tools.EventLog`, etc.
+
+## Dependency policy (non-negotiable)
+
+- `IntelligenceX` core packages must **not** take dependencies on tool-pack libraries.
+- Each tool pack should depend only on:
+  - `IntelligenceX` (the tool contract), and
+  - its own runtime dependencies (MailKit, etc.).
+- Windows-only capabilities must be isolated by:
+  - separate package and `net8.0-windows` target (or runtime OS checks), and
+  - no transitive dependency pulled into cross-platform packs.
+
+## AOT guidance
+
+Tool packs should *aim* to be AOT-friendly when feasible:
+- Prefer `System.Text.Json` source generation where you own DTOs.
+- Avoid reflection-based serialization in hot paths.
+- Avoid `Assembly.LoadFrom` and dynamic code generation.
+
+Note: Some third-party dependencies may not be fully AOT-safe; this is a per-pack tradeoff and should be documented in the pack README.
+
+## Naming
+
+- Tool packs: `IntelligenceX.Tools.<Domain>` (no provider name in the package/namespace).
+- Provider integrations stay provider-namespaced: `IntelligenceX.OpenAI.*`, `IntelligenceX.Copilot.*`, etc.
+

--- a/Docs/library/tools.md
+++ b/Docs/library/tools.md
@@ -1,7 +1,12 @@
-# Tool Calling (OpenAI Native)
+# Tool Calling
 
 Native tool calling lets the model request local tool execution and continue the response chain with tool outputs.
 Use `ToolRunner` for the simplest flow or drive the loop manually if you need full control.
+
+Notes:
+- The tool **contract** is provider-agnostic (`IntelligenceX.Tools` namespace).
+- Tool-calling orchestration is provider-specific (for example `IntelligenceX.OpenAI.ToolCalling`).
+- Tool implementations should live in separate tool-pack packages. See: `Docs/library/tool-packs.md`.
 
 ## Example tool
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Status: Active development | APIs in flux | Actions in beta
 - CLI + local web wizard for onboarding and auth
 - .NET library for Codex app-server + Copilot JSON-RPC
 - PowerShell module (binary cmdlets)
+- Optional tool contract + tool calling, with tool packs living in a separate repo (`EvotecIT/IntelligenceX.Tools`)
 
 ## Choose your path
 
@@ -25,6 +26,7 @@ Status: Active development | APIs in flux | Actions in beta
 - CLI tools: `Docs/cli/overview.md`
 - .NET library: `Docs/library/overview.md`
 - PowerShell module: `Docs/powershell/overview.md`
+- Tool packs: `Docs/library/tool-packs.md`
 
 ## Quick start (Reviewer)
 


### PR DESCRIPTION
Clarifies tool-pack boundaries and repo split (core vs tool packs), adds a Tool Packs doc, and captures a planned Windows tray chat app direction.

Also updates the docs index and README to point at these.