### PR TITLE
Docs: add STATIC.md roadmap for static policy analysis

### DIFF
--- a/STATIC.md
+++ b/STATIC.md
@@ -2,7 +2,7 @@
 
 This document tracks our end-to-end plan for first-party static policy analysis in IntelligenceX: catalog + packs, CI gates, triage workflows, issue tracking, AI assessment, and (optionally) auto-fix PRs.
 
-Last updated: 2026-02-08 (manual)
+Last updated: 2026-02-08 (update when milestones/defaults change)
 
 ## Goals
 
@@ -10,6 +10,12 @@ Last updated: 2026-02-08 (manual)
 - Make static outcomes first-class: clear gating rules, stable identifiers, and deterministic outputs.
 - Run as our GitHub App identity (BYO App supported) with least privilege and an auditable action trail.
 - Keep AI additive: AI helps triage and suggest fixes, but static policy remains deterministic and enforceable.
+
+## Non-goals
+
+- Replacing GitHub CodeQL or other first-party security tooling.
+- Auto-fixing by default (autofix is opt-in and gated to trusted contexts).
+- Making merge gates depend on AI availability.
 
 ## Principles
 
@@ -42,8 +48,7 @@ Outcome: a required check that can block merges without AI.
 - [ ] Add `intelligencex analyze gate` to evaluate outcomes and exit non-zero on violations.
 - [ ] Add gate configuration in `.intelligencex/reviewer.json` (thresholds by severity/type, allowlists, hotspots handling).
 - [ ] Add GitHub Actions step that runs the gate and produces clear failure output.
-- [ ] Decide default gate policy for the repo.
-    Policy options (not tasks): block on `vulnerability` at `warning+`; block on `bug` at `error+`; block on `security-hotspot` when `to-review` exists.
+- [ ] Decide default gate policy for the repo. Options: block on `vulnerability` at `warning+`; block on `bug` at `error+`; block on `security-hotspot` when `to-review` exists.
 
 Definition of done:
 
@@ -69,11 +74,7 @@ Definition of done:
 Outcome: policy outcomes are trackable beyond a single PR.
 
 - [ ] Add `intelligencex analyze issues sync` (creates/updates/closes issues).
-- [ ] Define grouping key strategy.
-    - Grouping options:
-        - One issue per rule.
-        - One issue per rule + path group.
-        - One issue per hotspot key.
+- [ ] Define grouping key strategy. Options: one issue per rule; one issue per rule + path group; one issue per hotspot key.
 - [ ] Add a scheduled workflow on the default branch to sync issues (recommended).
 - [ ] Add labels and templates (for example `static-analysis`, `security-hotspot`, `accepted-risk`).
 
@@ -103,10 +104,7 @@ Outcome: safe automation that proposes fixes via PRs under GitHub App identity.
 - [ ] Add `intelligencex autofix` runner.
 - [ ] Define “autofixable rules” pack (small initial set).
 - [ ] Implement deterministic fixes first (formatters/codemods), AI patching second.
-- [ ] Add workflow triggers restricted to trusted contexts.
-    - Trigger options:
-        - `workflow_dispatch` only.
-        - Same-repo PRs only (no forks).
+- [ ] Add workflow triggers restricted to trusted contexts. Options: `workflow_dispatch` only; same-repo PRs only (no forks).
 
 Definition of done:
 
@@ -128,14 +126,6 @@ Optional:
 
 ## Open Questions (Need Decisions)
 
-- What should block merges by default.
-    - Options:
-        - `vulnerability` only.
-        - `vulnerability + bug`.
-        - All enabled rules at `warning+`.
-- How should hotspots affect gating.
-    - Options:
-        - Gate on `to-review` hotspots.
-        - Gate only on explicit `accepted-risk` policy violations.
-        - Do not gate, only report.
-- Issue grouping strategy (rule vs rule+path vs hotspot key).
+- What should block merges by default. Options: `vulnerability` only; `vulnerability + bug`; all enabled rules at `warning+`.
+- How should hotspots affect gating. Options: gate on `to-review` hotspots; gate only on explicit `accepted-risk` policy violations; do not gate, only report.
+- Issue grouping strategy. Options: rule; rule+path; hotspot key.


### PR DESCRIPTION
Adds STATIC.md to track end-to-end plan/status for static policy analysis: catalog/packs, CI gates, issue sync, AI assessment, and optional auto-fix PRs.