### PR TITLE
OpenAI native: fix custom tool schema field

### DIFF
--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.cs
@@ -470,7 +470,8 @@ internal sealed class OpenAINativeTransport : IOpenAITransport {
             obj.Add("description", tool.Description);
         }
         if (tool.Parameters is not null) {
-            obj.Add("parameters", tool.Parameters);
+            // OpenAI Responses API expects custom tools to use `input_schema` (not `parameters`).
+            obj.Add("input_schema", tool.Parameters);
         }
         return obj;
     }


### PR DESCRIPTION
Fixes OpenAI native transport request serialization: custom tools must use input_schema (not parameters). This resolves API errors like Unknown parameter: tools[0].parameters when enabling native tool calling.