### PR TITLE
OpenAI: EnsureChatGptLoginAsync + non-throwing prompt

### DIFF
--- a/Docs/library/overview.md
+++ b/Docs/library/overview.md
@@ -38,7 +38,7 @@ var options = new IntelligenceXClientOptions {
 options.NativeOptions.UserAgent = "IntelligenceX/0.1.0";
 await using var client = await IntelligenceXClient.ConnectAsync(options);
 
-await client.LoginChatGptAndWaitAsync(url => Console.WriteLine(url));
+await client.EnsureChatGptLoginAsync(onUrl: url => Console.WriteLine(url));
 var turn = await client.ChatAsync("Summarize the latest PR");
 Console.WriteLine(turn.Outputs.Count);
 ```

--- a/Docs/library/quickstart.md
+++ b/Docs/library/quickstart.md
@@ -9,7 +9,7 @@ await using var client = await IntelligenceXClient.ConnectAsync(new Intelligence
     TransportKind = OpenAITransportKind.Native
 });
 
-await client.LoginChatGptAndWaitAsync(url => Console.WriteLine(url));
+await client.EnsureChatGptLoginAsync(onUrl: url => Console.WriteLine(url));
 var turn = await client.ChatAsync("Summarize this PR.");
 Console.WriteLine(turn.Outputs.Count);
 ```

--- a/Docs/library/tools.md
+++ b/Docs/library/tools.md
@@ -48,7 +48,7 @@ var options = new IntelligenceXClientOptions {
     TransportKind = OpenAITransportKind.Native
 };
 using var client = await IntelligenceXClient.ConnectAsync(options);
-await client.LoginChatGptAndWaitAsync(url => Console.WriteLine(url));
+await client.EnsureChatGptLoginAsync(onUrl: url => Console.WriteLine(url));
 
 var registry = new ToolRegistry();
 registry.Register(new EchoTool());

--- a/IntelligenceX.Examples/ExampleHelpers.cs
+++ b/IntelligenceX.Examples/ExampleHelpers.cs
@@ -34,12 +34,10 @@ internal static class ExampleHelpers {
     }
 
     public static async Task EnsureChatGptLoginAsync(IntelligenceXClient client) {
-        try {
-            await client.GetAccountAsync().ConfigureAwait(false);
-            return;
-        } catch (InvalidOperationException ex) when (IsAuthMissing(ex)) {
-            await LoginChatGptAsync(client).ConfigureAwait(false);
-        }
+        await client.EnsureChatGptLoginAsync(onUrl: url => {
+            Console.WriteLine($"Open this URL to login: {url}");
+            TryOpenUrl(url);
+        }).ConfigureAwait(false);
     }
 
     public static async Task LoginApiKeyAsync(IntelligenceXClient client) {
@@ -77,9 +75,5 @@ internal static class ExampleHelpers {
         }
     }
 
-    private static bool IsAuthMissing(InvalidOperationException ex) {
-        var message = ex.Message ?? string.Empty;
-        return message.IndexOf("not logged in", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               message.IndexOf("login", StringComparison.OrdinalIgnoreCase) >= 0;
-    }
+    // Auth-missing detection lives in the main library (IntelligenceXClient.EnsureChatGptLoginAsync).
 }

--- a/IntelligenceX.Examples/ExampleImagesAndFiles.cs
+++ b/IntelligenceX.Examples/ExampleImagesAndFiles.cs
@@ -12,7 +12,7 @@ internal sealed class ExampleImagesAndFiles : IExample {
 
     public async Task RunAsync() {
         await using var ix = await IntelligenceXClient.ConnectAsync().ConfigureAwait(false);
-        await ix.LoginChatGptAndWaitAsync(url => Console.WriteLine($"Open: {url}")).ConfigureAwait(false);
+        await ix.EnsureChatGptLoginAsync(onUrl: url => Console.WriteLine($"Open: {url}")).ConfigureAwait(false);
         using var sub = ix.SubscribeDelta(Console.Write);
 
         var imagePath = Path.Combine(Environment.CurrentDirectory, "example.png");

--- a/IntelligenceX.Examples/ExampleTelemetry.cs
+++ b/IntelligenceX.Examples/ExampleTelemetry.cs
@@ -16,7 +16,7 @@ internal sealed class ExampleTelemetry : IExample {
         client.LoginCompleted += (_, args) => Console.WriteLine($"Login completed: {args.LoginType}");
         client.StandardErrorReceived += (_, line) => Console.WriteLine($"STDERR: {line}");
 
-        await client.LoginChatGptAndWaitAsync(url => Console.WriteLine($"Login URL: {url}")).ConfigureAwait(false);
+        await client.EnsureChatGptLoginAsync(onUrl: url => Console.WriteLine($"Login URL: {url}")).ConfigureAwait(false);
         await client.ChatAsync("Hello from telemetry example.").ConfigureAwait(false);
     }
 }

--- a/IntelligenceX.PowerShell/CmdletInvokeIntelligenceXChat.cs
+++ b/IntelligenceX.PowerShell/CmdletInvokeIntelligenceXChat.cs
@@ -296,7 +296,7 @@ public sealed class CmdletInvokeIntelligenceXChat : IntelligenceXCmdlet {
                     }
                     await client.LoginApiKeyAsync(key, CancelToken).ConfigureAwait(false);
                 } else {
-                    await client.LoginChatGptAndWaitAsync(url => {
+                    await client.EnsureChatGptLoginAsync(onUrl: url => {
                         WriteVerbose($"Login URL: {url}");
                         if (OpenBrowser.IsPresent) {
                             TryOpenUrl(url);

--- a/IntelligenceX/Providers/OpenAI/IntelligenceXClient.cs
+++ b/IntelligenceX/Providers/OpenAI/IntelligenceXClient.cs
@@ -194,6 +194,37 @@ public sealed class IntelligenceXClient : IDisposable
     }
 
     /// <summary>
+    /// Ensures a valid ChatGPT login is available by using cached credentials when possible and falling back to the OAuth flow.
+    /// </summary>
+    /// <param name="forceLogin">When true, always runs the login flow even if cached credentials appear valid.</param>
+    /// <param name="onUrl">Callback for the login URL.</param>
+    /// <param name="onPrompt">Callback for interactive prompts.</param>
+    /// <param name="useLocalListener">Whether to use a local listener.</param>
+    /// <param name="timeout">Optional timeout.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task EnsureChatGptLoginAsync(bool forceLogin = false, Action<string>? onUrl = null, Func<string, Task<string>>? onPrompt = null,
+        bool useLocalListener = true, TimeSpan? timeout = null, CancellationToken cancellationToken = default) {
+        if (!forceLogin) {
+            try {
+                _ = await GetAccountAsync(cancellationToken).ConfigureAwait(false);
+                return;
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (InvalidOperationException ex) when (IsAuthMissing(ex)) {
+                // Not logged in (or token expired). Fall back to login flow.
+            }
+        }
+
+        await LoginChatGptAndWaitAsync(onUrl, onPrompt, useLocalListener, timeout, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool IsAuthMissing(InvalidOperationException ex) {
+        var message = ex.Message ?? string.Empty;
+        return message.IndexOf("not logged in", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               message.IndexOf("login", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    /// <summary>
     /// Logs in using an API key (app-server transport only).
     /// </summary>
     /// <param name="apiKey">API key.</param>

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeAuthManager.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeAuthManager.cs
@@ -87,11 +87,17 @@ internal sealed class OpenAINativeAuthManager {
             throw new InvalidOperationException(
                 "ChatGPT login requires user input. Provide a prompt handler or run interactively.");
         }
+
         Console.WriteLine(prompt);
-        var input = Console.ReadLine();
-        if (string.IsNullOrWhiteSpace(input)) {
-            throw new InvalidOperationException("Authorization code was not provided.");
+        while (true) {
+            Console.Write("> ");
+            var input = Console.ReadLine();
+            if (!string.IsNullOrWhiteSpace(input)) {
+                return Task.FromResult(input.Trim());
+            }
+
+            // Keep reprompting instead of failing the whole login flow.
+            Console.WriteLine("Authorization code was not provided. Paste the redirect URL or authorization code.");
         }
-        return Task.FromResult(input);
     }
 }


### PR DESCRIPTION
Adds IntelligenceXClient.EnsureChatGptLoginAsync to reuse cached ChatGPT auth (via GetAccount) and only run OAuth login when needed.

Also makes the native default console prompt reprompt on empty input instead of throwing, which prevents apps from crashing if the user hits Enter.

Updates docs/examples and the PowerShell chat cmdlet to use Ensure.