### PR TITLE
OpenAI native: keep history client-side (omit previous_response_id)

### DIFF
--- a/IntelligenceX.Tests/Program.OpenAI.NativeRequestBody.cs
+++ b/IntelligenceX.Tests/Program.OpenAI.NativeRequestBody.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using IntelligenceX.Json;
+using IntelligenceX.OpenAI;
+using IntelligenceX.OpenAI.Chat;
+
+namespace IntelligenceX.Tests;
+
+internal static partial class Program {
+    private static void TestNativeRequestBodyOmitsPreviousResponseId() {
+        var ix = typeof(IntelligenceXClient).Assembly;
+        var optionsType = ix.GetType("IntelligenceX.OpenAI.Native.OpenAINativeOptions", throwOnError: true)!;
+        var transportType = ix.GetType("IntelligenceX.OpenAI.Native.OpenAINativeTransport", throwOnError: true)!;
+
+        var options = Activator.CreateInstance(optionsType);
+        AssertNotNull(options, "OpenAINativeOptions");
+
+        var transport = Activator.CreateInstance(transportType, options);
+        AssertNotNull(transport, "OpenAINativeTransport");
+
+        var wireEnum = transportType.GetNestedType("ToolWireFormat", BindingFlags.NonPublic);
+        AssertNotNull(wireEnum, "ToolWireFormat enum");
+        var customParameters = Enum.Parse(wireEnum!, "CustomParameters");
+
+        var method = transportType.GetMethod("BuildRequestBody", BindingFlags.Instance | BindingFlags.NonPublic);
+        AssertNotNull(method, "BuildRequestBody method");
+
+        var messages = new List<JsonObject>();
+        var chatOptions = new ChatOptions {
+            PreviousResponseId = "prev_123"
+        };
+
+        var body = (JsonObject)method!.Invoke(transport, new object?[] { "gpt-5.3-codex", messages, "session", chatOptions, customParameters })!;
+        var prev = body.GetString("previous_response_id");
+        AssertEqual(true, prev is null, "previous_response_id is omitted");
+    }
+}
+

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -35,6 +35,7 @@ internal static partial class Program {
         failed += Run("Native tool schema fallback uses structured error data", TestNativeToolSchemaFallbackUsesStructuredErrorData);
         failed += Run("Native tool schema fallback ignores unrelated", TestNativeToolSchemaFallbackIgnoresUnrelated);
         failed += Run("Native tool schema serialization switches field name", TestNativeToolSchemaSerializationSwitchesFieldName);
+        failed += Run("Native request body omits previous_response_id", TestNativeRequestBodyOmitsPreviousResponseId);
 #if !NET472
         failed += Run("Setup args reject skip+update", TestSetupArgsRejectSkipUpdate);
         failed += Run("GitHub repo detector parses remote urls", TestGitHubRepoDetectorParsesRemoteUrls);

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.Requests.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.Requests.cs
@@ -68,9 +68,8 @@ internal sealed partial class OpenAINativeTransport {
             body.Add("include", include);
         }
 
-        if (!string.IsNullOrWhiteSpace(options.PreviousResponseId)) {
-            body.Add("previous_response_id", options.PreviousResponseId);
-        }
+        // ChatGPT-native "responses" backend has been observed to reject previous_response_id.
+        // We keep conversation state client-side via NativeThreadState.Messages.
 
         if (options.Tools is not null && options.Tools.Count > 0) {
             var tools = new JsonArray();

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.cs
@@ -165,13 +165,10 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
         }
 
         var inputItems = await BuildInputItemsAsync(input, cancellationToken).ConfigureAwait(false);
-        var trackMessages = options.PreviousResponseId is null;
-        var requestMessages = trackMessages
-            ? new List<JsonObject>(state.Messages.Count + inputItems.Count)
-            : new List<JsonObject>(inputItems.Count);
-        if (trackMessages) {
-            requestMessages.AddRange(state.Messages);
-        }
+        // ChatGPT-native transport maintains history client-side; always include thread messages.
+        var trackMessages = true;
+        var requestMessages = new List<JsonObject>(state.Messages.Count + inputItems.Count);
+        requestMessages.AddRange(state.Messages);
         requestMessages.AddRange(inputItems);
 
         var body = BuildRequestBody(resolvedModel, requestMessages, state.SessionId, options);
@@ -292,13 +289,28 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
         }
 
         var assistantText = ExtractAssistantText(outputs);
-        var assistantMessage = BuildAssistantMessage(assistantText, state);
 
         if (trackMessages) {
             if (inputItems.Count > 0) {
                 state.Messages.AddRange(inputItems);
             }
-            state.Messages.Add(assistantMessage);
+            // Preserve assistant tool calls in history so tool outputs can be sent without previous_response_id.
+            if (completedResponse is not null && completedResponse.GetArray("output") is { Count: > 0 } historyOutputs) {
+                foreach (var itemValue in historyOutputs) {
+                    var item = itemValue.AsObject();
+                    if (item is null) {
+                        continue;
+                    }
+                    var type = item.GetString("type");
+                    if (string.Equals(type, "message", StringComparison.Ordinal) ||
+                        string.Equals(type, "custom_tool_call", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(type, "tool_call", StringComparison.OrdinalIgnoreCase)) {
+                        state.Messages.Add(item);
+                    }
+                }
+            } else {
+                state.Messages.Add(BuildAssistantMessage(assistantText, state));
+            }
         }
         state.UpdatePreview(TruncatePreview(assistantText));
 


### PR DESCRIPTION
Fixes ChatGPT native backend rejecting previous_response_id by keeping conversation/tool-call history client-side:
- do not send previous_response_id in native requests
- always include NativeThreadState.Messages as input
- persist assistant tool-call output items in history
Adds a regression test ensuring previous_response_id is omitted.