### PR TITLE
Tool calling: support function_call outputs in native transport

### DIFF
--- a/IntelligenceX.Tests/Program.Core.cs
+++ b/IntelligenceX.Tests/Program.Core.cs
@@ -16,6 +16,21 @@ internal static partial class Program {
         AssertEqual("call_1", calls[0].CallId, "tool call id");
         AssertEqual("wsl_status", calls[0].Name, "tool call name");
         AssertEqual("Ubuntu", calls[0].Arguments?.GetString("name"), "tool call arg");
+
+        var functionCall = new JsonObject()
+            .Add("type", "function_call")
+            .Add("call_id", "call_2")
+            .Add("function", new JsonObject().Add("name", "ad_whoami"))
+            .Add("arguments", "{\"x\":1}");
+        var turn2 = TurnInfo.FromJson(new JsonObject()
+            .Add("id", "turn2")
+            .Add("output", new JsonArray().Add(functionCall)));
+
+        var calls2 = ToolCallParser.Extract(turn2);
+        AssertEqual(1, calls2.Count, "function call count");
+        AssertEqual("call_2", calls2[0].CallId, "function call id");
+        AssertEqual("ad_whoami", calls2[0].Name, "function call name");
+        AssertEqual(1, (int)(calls2[0].Arguments?.GetInt64("x") ?? 0), "function call arg");
     }
 
     private static void TestToolCallParsingInvalidJson() {

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.cs
@@ -304,7 +304,8 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
                     var type = item.GetString("type");
                     if (string.Equals(type, "message", StringComparison.Ordinal) ||
                         string.Equals(type, "custom_tool_call", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(type, "tool_call", StringComparison.OrdinalIgnoreCase)) {
+                        string.Equals(type, "tool_call", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(type, "function_call", StringComparison.OrdinalIgnoreCase)) {
                         state.Messages.Add(item);
                     }
                 }
@@ -559,7 +560,8 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
                 continue;
             }
             if (string.Equals(type, "custom_tool_call", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(type, "tool_call", StringComparison.OrdinalIgnoreCase)) {
+                string.Equals(type, "tool_call", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(type, "function_call", StringComparison.OrdinalIgnoreCase)) {
                 outputs.Add(item);
                 continue;
             }

--- a/IntelligenceX/Tools/ToolCall.cs
+++ b/IntelligenceX/Tools/ToolCall.cs
@@ -42,12 +42,17 @@ public sealed class ToolCall {
     internal static ToolCall? FromJson(JsonObject obj) {
         var type = obj.GetString("type");
         if (!string.Equals(type, "custom_tool_call", StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(type, "tool_call", StringComparison.OrdinalIgnoreCase)) {
+            !string.Equals(type, "tool_call", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(type, "function_call", StringComparison.OrdinalIgnoreCase)) {
             return null;
         }
 
         var callId = obj.GetString("call_id") ?? obj.GetString("tool_call_id") ?? obj.GetString("id");
         var name = obj.GetString("name");
+        if (string.IsNullOrWhiteSpace(name)) {
+            name = obj.GetObject("function")?.GetString("name") ??
+                   obj.GetObject("tool")?.GetString("name");
+        }
         if (string.IsNullOrWhiteSpace(callId) || string.IsNullOrWhiteSpace(name)) {
             return null;
         }


### PR DESCRIPTION
ChatGPT native fallback can surface tool calls as unction_call. This adds support end-to-end:
- parse unction_call in ToolCall.FromJson (including nested function.name)
- treat unction_call as a tool-call output item in native output parsing + history tracking
- add test coverage.