### PR TITLE
CI: Prefer self-hosted runners while private

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
 
     # While the repo is private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
     # When public, use GitHub-hosted runners by default.
-    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ jobs:
     name: Analyze (${{ matrix.language }})
     # While the repo is private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
     # When public, use GitHub-hosted runners by default.
-    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -19,7 +19,7 @@ jobs:
   review:
     # While the repo is private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
     # When public, use GitHub-hosted runners by default.
-    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -76,7 +76,7 @@ jobs:
         name: 'Ubuntu'
         # While the repo is private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
         # When public, use GitHub-hosted runners by default.
-        runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]') }}
+        runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
         timeout-minutes: 20
         steps:
             - name: Checkout code


### PR DESCRIPTION
Switch PR/test/reviewer workflows to run on self-hosted runners when the repository is private, falling back to GitHub-hosted when public.

Also adds a CodeQL workflow that can run on self-hosted runners while private.

Note: if GitHub 'CodeQL default setup' is enabled, you may want to disable it after this merges to avoid duplicate checks (and to stop GitHub-hosted CodeQL from failing when spend limits block hosted runners).