### PR TITLE
CI: Self-hosted by default while private

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,8 +18,9 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    # Prefer GitHub-hosted runners for PR checks to avoid blocking when self-hosted runners are unavailable.
-    runs-on: ubuntu-latest
+    # While the repo is private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
+    # When public, use GitHub-hosted runners by default.
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
     permissions:
       contents: read
       pull-requests: write
@@ -53,7 +54,8 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        if: steps.changes.outputs.claude_workflows != 'true'
+        if: steps.changes.outputs.claude_workflows != 'true' && secrets.CLAUDE_CODE_OAUTH_TOKEN != ''
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -88,6 +90,10 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+
+      - name: Skip Claude Code Review (not configured)
+        if: steps.changes.outputs.claude_workflows != 'true' && secrets.CLAUDE_CODE_OAUTH_TOKEN == ''
+        run: echo "Skipping Claude Code Review because CLAUDE_CODE_OAUTH_TOKEN is not configured."
 
       - name: Skip Claude Code Review (workflow modified in PR)
         if: steps.changes.outputs.claude_workflows == 'true'

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -17,8 +17,9 @@ on:
 jobs:
   # INTELLIGENCEX:BEGIN
   review:
-    # Prefer GitHub-hosted runners for PR checks to avoid blocking when self-hosted runners are unavailable.
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","ubuntu"]') }}
+    # While the repo is private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
+    # When public, use GitHub-hosted runners by default.
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -74,8 +74,9 @@ jobs:
 
     test-ubuntu:
         name: 'Ubuntu'
-        # Prefer GitHub-hosted runners for PR checks to avoid blocking when self-hosted runners are unavailable.
-        runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || (github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]')) }}
+        # While the repo is private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
+        # When public, use GitHub-hosted runners by default.
+        runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
         timeout-minutes: 20
         steps:
             - name: Checkout code


### PR DESCRIPTION
- Run PR checks on self-hosted runners when the repository is private (avoid GitHub-hosted spend limits)
- Keep GitHub-hosted defaults for when the repository becomes public
- Make Claude Code Review optional (skip if token missing; continue-on-error so premium/auth issues don't block)
