### PR TITLE
CI: don't fail when CodeQL code scanning is disabled

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
+        # Repo settings can disable code scanning (e.g., private repos without Code Security enabled).
+        # Keep CI green while still attempting analysis when available.
+        continue-on-error: true


### PR DESCRIPTION
CodeQL analysis jobs can fail on repos where code scanning isn't enabled (common for private repos without Code Security). Mark the analyze step as non-fatal so CI remains usable.