### PR TITLE
CI: skip CodeQL while private

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,9 +12,9 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # While the repo is private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
-    # When public, use GitHub-hosted runners by default.
-    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
+    # While the repo is private, Code Security may be disabled; skip CodeQL to avoid noisy failing checks.
+    if: ${{ !github.event.repository.private }}
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
CodeQL is currently noisy/failing while the repo is private and Code Security is disabled. This change skips the CodeQL job when the repo is private, avoiding queued Linux runner usage and failing checks. When the repo becomes public, CodeQL runs automatically on ubuntu-latest.