### PR TITLE
CI: disable Claude; make CodeQL manual-only while private

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,17 +1,12 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  # Disabled (no automatic triggers).
+  workflow_dispatch:
 
 jobs:
   claude-review:
+    if: ${{ false }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,26 +1,12 @@
 name: Claude Code
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+  # Disabled (no automatic triggers).
+  workflow_dispatch:
 
 jobs:
   claude:
-    if: |
-      github.actor != 'intelligencex-review' &&
-      github.actor != 'intelligencex-review[bot]' &&
-      (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-      )
+    if: ${{ false }}
     runs-on: [self-hosted, ubuntu]
     permissions:
       contents: read
@@ -59,4 +45,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,8 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [master]
-  pull_request:
+  # Disabled by default while private (to avoid noise + runner pressure).
+  # Re-enable when public / when Code Security is enabled.
   workflow_dispatch:
 
 permissions:
@@ -12,7 +11,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # While the repo is private, Code Security may be disabled; skip CodeQL to avoid noisy failing checks.
+    # Safety: even if someone manually dispatches while private, skip.
     if: ${{ !github.event.repository.private }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Disables Claude workflows (no auto triggers) and removes CodeQL automatic triggers while the repo is private, so we don't burn the Ubuntu self-hosted runner on non-essential checks.\n\nNote: no in-repo Copilot review workflow/config was found; Copilot reviews are likely coming from a GitHub setting/app.