### PR TITLE
Json: AddRange helpers for JsonArray

### DIFF
--- a/IntelligenceX/Json/JsonArray.cs
+++ b/IntelligenceX/Json/JsonArray.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -27,6 +28,32 @@ public sealed class JsonArray : IEnumerable<JsonValue> {
     /// </summary>
     public JsonArray Add(JsonValue value) {
         _values.Add(value);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds multiple JSON values to the array.
+    /// </summary>
+    /// <param name="values">Values to append.</param>
+    public JsonArray AddRange(IEnumerable<JsonValue> values) {
+        if (values is null) {
+            throw new ArgumentNullException(nameof(values));
+        }
+        _values.AddRange(values);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds multiple CLR values to the array by mapping them to JSON values.
+    /// </summary>
+    /// <param name="values">Values to append.</param>
+    public JsonArray AddRange(IEnumerable<object?> values) {
+        if (values is null) {
+            throw new ArgumentNullException(nameof(values));
+        }
+        foreach (var value in values) {
+            _values.Add(JsonMapper.FromObject(value));
+        }
         return this;
     }
 

--- a/IntelligenceX/Json/JsonObjectExtensions.cs
+++ b/IntelligenceX/Json/JsonObjectExtensions.cs
@@ -33,4 +33,21 @@ public static class JsonObjectExtensions {
         }
         return additional.Count == 0 ? null : additional;
     }
+
+    /// <summary>
+    /// Adds the array property only when the value is not null and contains at least one element.
+    /// </summary>
+    /// <param name="obj">Target JSON object.</param>
+    /// <param name="key">Property name.</param>
+    /// <param name="value">Array to add when non-empty.</param>
+    /// <returns>The same instance for fluent chaining.</returns>
+    public static JsonObject AddIfNotEmpty(this JsonObject obj, string key, JsonArray? value) {
+        if (obj is null) {
+            throw new ArgumentNullException(nameof(obj));
+        }
+        if (value is not null && value.Count > 0) {
+            obj.Add(key, value);
+        }
+        return obj;
+    }
 }


### PR DESCRIPTION
Adds additive convenience APIs to reduce boilerplate in tool packs:
- JsonArray.AddRange(IEnumerable<JsonValue>)
- JsonArray.AddRange(IEnumerable<object?>) (maps via JsonMapper)
- JsonObjectExtensions.AddIfNotEmpty(key, JsonArray?)