### PR TITLE
Tools: add OkFlat output envelope

### DIFF
--- a/IntelligenceX/Tools/ToolOutputEnvelope.cs
+++ b/IntelligenceX/Tools/ToolOutputEnvelope.cs
@@ -13,6 +13,45 @@ namespace IntelligenceX.Tools;
 /// </remarks>
 public static class ToolOutputEnvelope {
     /// <summary>
+    /// Creates a success envelope (<c>ok=true</c>) where tool-specific fields are placed at the root level.
+    /// </summary>
+    /// <remarks>
+    /// This is useful for UI render hints that point to root-level paths (for example <c>render.rows_path="events"</c>).
+    /// Prefer this method for new tools unless you explicitly need a nested <c>data</c> payload.
+    /// </remarks>
+    /// <param name="root">Optional tool-specific fields to merge into the root object.</param>
+    /// <param name="meta">Optional metadata (paging, truncation, counts, etc.).</param>
+    /// <param name="summaryMarkdown">Optional human-readable markdown summary for UI display.</param>
+    /// <param name="render">Optional UI render hints (tables, columns, types, etc.).</param>
+    public static JsonObject OkFlatObject(JsonObject? root = null, JsonObject? meta = null, string? summaryMarkdown = null, JsonObject? render = null) {
+        var obj = new JsonObject().Add("ok", true);
+
+        if (root is not null) {
+            foreach (var kv in root) {
+                obj.Add(kv.Key, kv.Value);
+            }
+        }
+
+        if (meta is not null) {
+            obj.Add("meta", meta);
+        }
+        if (!string.IsNullOrWhiteSpace(summaryMarkdown)) {
+            obj.Add("summary_markdown", summaryMarkdown);
+        }
+        if (render is not null) {
+            obj.Add("render", render);
+        }
+
+        return obj;
+    }
+
+    /// <summary>
+    /// Serializes a flat success envelope (<c>ok=true</c>) as JSON.
+    /// </summary>
+    public static string OkFlat(JsonObject? root = null, JsonObject? meta = null, string? summaryMarkdown = null, JsonObject? render = null)
+        => JsonLite.Serialize(OkFlatObject(root, meta, summaryMarkdown, render));
+
+    /// <summary>
     /// Creates a success envelope (<c>ok=true</c>).
     /// </summary>
     /// <param name="data">Optional data payload.</param>
@@ -81,4 +120,3 @@ public static class ToolOutputEnvelope {
     public static string Error(string errorCode, string error, IEnumerable<string>? hints = null, bool isTransient = false)
         => JsonLite.Serialize(ErrorObject(errorCode, error, hints, isTransient));
 }
-


### PR DESCRIPTION
Adds ToolOutputEnvelope.OkFlat/OkFlatObject for tools that place primary arrays/fields at the root level (so render hints can reference root-level rows_path/content_path).\n\nNo behavior changes to existing Ok/Error helpers; this is additive.