### PR TITLE
RPC: cleanup pending calls on cancel/send failure

### DIFF
--- a/IntelligenceX.Tests/Program.Core.cs
+++ b/IntelligenceX.Tests/Program.Core.cs
@@ -264,6 +264,52 @@ internal static partial class Program {
         AssertNotNull(ex.Hint, "exception hint");
     }
 
+    private static int GetRpcPendingCount(JsonRpcClient client) {
+        var field = typeof(JsonRpcClient).GetField("_pending", BindingFlags.NonPublic | BindingFlags.Instance);
+        AssertNotNull(field, "_pending field");
+        var value = field!.GetValue(client);
+        AssertNotNull(value, "_pending value");
+        var prop = value!.GetType().GetProperty("Count", BindingFlags.Public | BindingFlags.Instance);
+        AssertNotNull(prop, "_pending.Count property");
+        return (int)(prop!.GetValue(value) ?? 0);
+    }
+
+    private static void TestRpcCallCancellationCleansPending() {
+        var client = new JsonRpcClient(_ => Task.CompletedTask);
+        long id = 0;
+        client.CallStarted += (_, args) => id = args.RequestId ?? 0;
+
+        var protocolError = false;
+        client.ProtocolError += (_, _) => protocolError = true;
+
+        using var cts = new CancellationTokenSource();
+        var task = client.CallAsync("test", (JsonValue?)null, cts.Token);
+        cts.Cancel();
+
+        AssertThrows<OperationCanceledException>(() => task.GetAwaiter().GetResult(), "rpc call canceled");
+        AssertEqual(0, GetRpcPendingCount(client), "pending empty after cancellation");
+
+        // Late responses to a locally-canceled call should be ignored (not treated as protocol errors).
+        client.HandleLine($"{{\"id\":{id},\"result\":123}}");
+        AssertEqual(false, protocolError, "late response ignored");
+    }
+
+    private static void TestRpcCallSendFailureCleansPending() {
+        var sendEx = new InvalidOperationException("send failed");
+        var client = new JsonRpcClient(_ => Task.FromException(sendEx));
+        var callCompleted = false;
+        client.CallCompleted += (_, args) => callCompleted = !args.Success;
+
+        long id = 0;
+        client.CallStarted += (_, args) => id = args.RequestId ?? 0;
+
+        AssertThrows<InvalidOperationException>(() => client.CallAsync("test", (JsonValue?)null, CancellationToken.None).GetAwaiter().GetResult(),
+            "rpc send failure");
+        AssertEqual(true, id > 0, "id assigned");
+        AssertEqual(true, callCompleted, "call completed fired");
+        AssertEqual(0, GetRpcPendingCount(client), "pending empty after send failure");
+    }
+
     private static void TestHeaderTransportMessage() {
         var payload = "{\"method\":\"ping\"}";
         var header = $"Content-Length: {Encoding.UTF8.GetByteCount(payload)}\r\n\r\n";

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -10,6 +10,8 @@ internal static partial class Program {
         failed += Run("RPC unknown shape", TestRpcUnknownShape);
         failed += Run("RPC notification", TestRpcNotification);
         failed += Run("RPC error hints", TestRpcErrorHints);
+        failed += Run("RPC call cancellation cleans pending", TestRpcCallCancellationCleansPending);
+        failed += Run("RPC call send failure cleans pending", TestRpcCallSendFailureCleansPending);
         failed += Run("Header transport message", TestHeaderTransportMessage);
         failed += Run("Header transport truncated", TestHeaderTransportTruncated);
         failed += Run("Config load invalid JSON", TestConfigLoadInvalidJsonThrows);

--- a/IntelligenceX/Rpc/JsonRpcClient.cs
+++ b/IntelligenceX/Rpc/JsonRpcClient.cs
@@ -49,15 +49,29 @@ internal sealed class JsonRpcClient : IDisposable {
         var tcs = new TaskCompletionSource<JsonValue?>(TaskCreationOptions.RunContinuationsAsynchronously);
         _pending.TryAdd(id, new PendingCall(method, tcs));
 
-        using var ctr = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
-        await SendRequestAsync(id, method, @params).ConfigureAwait(false);
-
         try {
+            using var ctr = cancellationToken.Register(() => {
+                if (_pending.TryRemove(id, out var pending)) {
+                    pending.Tcs.TrySetCanceled(cancellationToken);
+                } else {
+                    tcs.TrySetCanceled(cancellationToken);
+                }
+            });
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try {
+                await SendRequestAsync(id, method, @params).ConfigureAwait(false);
+            } catch {
+                _pending.TryRemove(id, out _);
+                throw;
+            }
+
             var result = await tcs.Task.ConfigureAwait(false);
             var duration = DateTime.UtcNow - started;
             CallCompleted?.Invoke(this, new RpcCallCompletedEventArgs(method, duration, true, null, id));
             return result;
         } catch (Exception ex) {
+            _pending.TryRemove(id, out _);
             var duration = DateTime.UtcNow - started;
             CallCompleted?.Invoke(this, new RpcCallCompletedEventArgs(method, duration, false, ex, id));
             throw;
@@ -127,6 +141,8 @@ internal sealed class JsonRpcClient : IDisposable {
                 pending.Tcs.TrySetResult(resultValue);
                 return;
             }
+            // Unknown response id. This can happen with late responses for locally-canceled calls.
+            return;
         }
 
         ProtocolError?.Invoke(this, new FormatException("Unknown JSON-RPC message shape."));


### PR DESCRIPTION
Fix JsonRpcClient pending-call leaks and improve behavior for cancellation and send failures.

Changes:
- Remove pending entries on cancellation and on send failures
- Ensure CallCompleted fires on send failures as well
- Ignore unknown response IDs (can happen for late responses after local cancellation)
- Add tests covering cancellation and send failure cleanup