### PR TITLE
Auth: fail closed on invalid INTELLIGENCEX_AUTH_KEY

### DIFF
--- a/IntelligenceX.Tests/Program.OpenAI.Auth.cs
+++ b/IntelligenceX.Tests/Program.OpenAI.Auth.cs
@@ -1,7 +1,10 @@
 using System;
+using System.IO;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.OpenAI;
+using IntelligenceX.OpenAI.Auth;
 using IntelligenceX.OpenAI.AppServer;
 using IntelligenceX.OpenAI.AppServer.Models;
 using IntelligenceX.OpenAI.Chat;
@@ -61,6 +64,43 @@ internal static partial class Program {
             client.EnsureChatGptLoginAsync(cancellationToken: cts.Token).GetAwaiter().GetResult();
         }, "EnsureChatGptLoginAsync cancellation");
     }
+
+#if NET8_0_OR_GREATER
+    private static void TestAuthStoreInvalidKeyThrows() {
+        AssertThrows<InvalidOperationException>(() => {
+            _ = new FileAuthBundleStore(path: Path.Combine(Path.GetTempPath(), $"ix-auth-{Guid.NewGuid():N}.json"), encryptionKeyBase64: "nope");
+        }, "invalid auth key throws");
+    }
+
+    private static void TestAuthStoreEncryptedRoundtrip() {
+        var path = Path.Combine(Path.GetTempPath(), $"ix-auth-{Guid.NewGuid():N}.json");
+        var key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        try {
+            var store = new FileAuthBundleStore(path: path, encryptionKeyBase64: key);
+            var bundle = new AuthBundle("openai", "access", "refresh", DateTimeOffset.UtcNow.AddHours(1)) {
+                AccountId = "acct"
+            };
+            store.SaveAsync(bundle, CancellationToken.None).GetAwaiter().GetResult();
+
+            var content = File.ReadAllText(path);
+            AssertEqual(true, content.StartsWith("{\"encrypted\":true", StringComparison.OrdinalIgnoreCase), "encrypted envelope written");
+
+            var loaded = store.GetAsync("openai", accountId: "acct", cancellationToken: CancellationToken.None).GetAwaiter().GetResult();
+            AssertNotNull(loaded, "loaded bundle");
+            AssertEqual("access", loaded!.AccessToken, "access token");
+            AssertEqual("refresh", loaded.RefreshToken, "refresh token");
+            AssertEqual("acct", loaded.AccountId, "account id");
+        } finally {
+            try {
+                if (File.Exists(path)) {
+                    File.Delete(path);
+                }
+            } catch {
+                // best-effort cleanup
+            }
+        }
+    }
+#endif
 
     private enum FakeAccountMode {
         Ok,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -30,6 +30,10 @@ internal static partial class Program {
         failed += Run("Ensure ChatGPT login triggers when missing", TestEnsureChatGptLoginTriggersLoginWhenMissing);
         failed += Run("Ensure ChatGPT login force triggers", TestEnsureChatGptLoginForceTriggersLogin);
         failed += Run("Ensure ChatGPT login cancellation propagates", TestEnsureChatGptLoginCancellationPropagates);
+#if NET8_0_OR_GREATER
+        failed += Run("Auth store invalid key throws", TestAuthStoreInvalidKeyThrows);
+        failed += Run("Auth store encrypted roundtrip", TestAuthStoreEncryptedRoundtrip);
+#endif
         failed += Run("Native tool schema fallback detects tools[n]", TestNativeToolSchemaFallbackDetectsIndex);
         failed += Run("Native tool schema fallback detects tools.n", TestNativeToolSchemaFallbackDetectsDotIndex);
         failed += Run("Native tool_choice matches wire format", TestNativeToolChoiceSerializationMatchesWireFormat);

--- a/IntelligenceX/Providers/OpenAI/Auth/FileAuthBundleStore.cs
+++ b/IntelligenceX/Providers/OpenAI/Auth/FileAuthBundleStore.cs
@@ -137,12 +137,16 @@ public sealed class FileAuthBundleStore : IAuthBundleStore {
         if (string.IsNullOrWhiteSpace(keyBase64)) {
             return null;
         }
+        byte[] bytes;
         try {
-            var bytes = Convert.FromBase64String(keyBase64);
-            return bytes.Length == 32 ? bytes : null;
-        } catch {
-            return null;
+            bytes = Convert.FromBase64String(keyBase64);
+        } catch (Exception ex) {
+            throw new InvalidOperationException("INTELLIGENCEX_AUTH_KEY must be base64 and decode to 32 bytes.", ex);
         }
+        if (bytes.Length != 32) {
+            throw new InvalidOperationException("INTELLIGENCEX_AUTH_KEY must be base64 and decode to 32 bytes.");
+        }
+        return bytes;
     }
 
     private static bool IsEncrypted(string content) {


### PR DESCRIPTION
Today FileAuthBundleStore silently disables encryption when INTELLIGENCEX_AUTH_KEY is set but invalid (bad base64 / wrong length). That can lead to unencrypted writes without warning.

This PR:
- Validates INTELLIGENCEX_AUTH_KEY strictly (must be base64 and decode to 32 bytes); throws otherwise
- Adds tests for invalid key and encrypted roundtrip (NET8+ only)