### PR TITLE
EditorConfig: align line endings with .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,8 +12,12 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = false
+
+# PowerShell scripts
+[*.ps1]
+end_of_line = crlf
 
 #### .NET Code Actions ####
 


### PR DESCRIPTION
Fix a line-ending policy conflict that causes churn:
- .gitattributes enforces LF for *.cs, but .editorconfig asked editors to write CRLF

This PR sets end_of_line=lf for C# and explicitly sets end_of_line=crlf for *.ps1 to match .gitattributes.