### PR TITLE
CI: only upload coverage when produced

### DIFF
--- a/.github/workflows/test-dotnet-hosted.yml
+++ b/.github/workflows/test-dotnet-hosted.yml
@@ -59,8 +59,7 @@ jobs:
 
             - name: Upload coverage reports
               uses: actions/upload-artifact@v4
-              if: always()
+              if: ${{ always() && hashFiles('**/coverage.cobertura.xml') != '' }}
               with:
                   name: coverage-reports-${{ matrix.os }}
                   path: '**/coverage.cobertura.xml'
-

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -61,12 +61,13 @@ jobs:
 
             - name: Upload coverage reports
               uses: actions/upload-artifact@v4
-              if: always()
+              if: ${{ always() && hashFiles('**/coverage.cobertura.xml') != '' }}
               with:
                   name: coverage-reports-windows
                   path: '**/coverage.cobertura.xml'
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
+              if: ${{ hashFiles('**/coverage.cobertura.xml') != '' }}
               with:
                   files: '**/coverage.cobertura.xml'
                   fail_ci_if_error: false
@@ -113,6 +114,7 @@ jobs:
                   path: '**/*.trx'
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
+              if: ${{ hashFiles('**/coverage.cobertura.xml') != '' }}
               with:
                   files: '**/coverage.cobertura.xml'
                   fail_ci_if_error: false
@@ -159,6 +161,7 @@ jobs:
                   path: '**/*.trx'
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
+              if: ${{ hashFiles('**/coverage.cobertura.xml') != '' }}
               with:
                   files: '**/coverage.cobertura.xml'
                   fail_ci_if_error: false


### PR DESCRIPTION
CI was warning on Windows because '**/coverage.cobertura.xml' often doesn't exist (our tests are primarily executed via the harness).

This PR makes coverage artifact upload and Codecov upload conditional on coverage actually being present, so the pipeline stays quiet while still supporting future coverage generation.