### PR TITLE
Tests: seed xUnit project for CI coverage

### DIFF
--- a/IntelligenceX.UnitTests/AuthStoreTests.cs
+++ b/IntelligenceX.UnitTests/AuthStoreTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using IntelligenceX.OpenAI.Auth;
+using Xunit;
+
+namespace IntelligenceX.UnitTests;
+
+public sealed class AuthStoreTests {
+    [Fact]
+    public void InvalidKey_Throws() {
+        Assert.Throws<InvalidOperationException>(() => {
+            _ = new FileAuthBundleStore(path: Path.Combine(Path.GetTempPath(), $"ix-auth-{Guid.NewGuid():N}.json"), encryptionKeyBase64: "nope");
+        });
+    }
+
+    [Fact]
+    public async Task EncryptedRoundtrip_Works() {
+        var path = Path.Combine(Path.GetTempPath(), $"ix-auth-{Guid.NewGuid():N}.json");
+        var key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        try {
+            var store = new FileAuthBundleStore(path: path, encryptionKeyBase64: key);
+            var bundle = new AuthBundle("openai", "access", "refresh", DateTimeOffset.UtcNow.AddHours(1)) {
+                AccountId = "acct"
+            };
+            await store.SaveAsync(bundle);
+
+            var payload = File.ReadAllText(path);
+            Assert.StartsWith("{\"encrypted\":true", payload, StringComparison.OrdinalIgnoreCase);
+
+            var loaded = await store.GetAsync("openai", accountId: "acct");
+            Assert.NotNull(loaded);
+            Assert.Equal("access", loaded!.AccessToken);
+            Assert.Equal("refresh", loaded.RefreshToken);
+            Assert.Equal("acct", loaded.AccountId);
+        } finally {
+            try {
+                if (File.Exists(path)) {
+                    File.Delete(path);
+                }
+            } catch {
+                // best-effort cleanup
+            }
+        }
+    }
+}

--- a/IntelligenceX.UnitTests/IntelligenceX.UnitTests.csproj
+++ b/IntelligenceX.UnitTests/IntelligenceX.UnitTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../IntelligenceX/IntelligenceX.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" PrivateAssets="all" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/IntelligenceX.UnitTests/PathSafetyTests.cs
+++ b/IntelligenceX.UnitTests/PathSafetyTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using IntelligenceX.Utils;
+using Xunit;
+
+namespace IntelligenceX.UnitTests;
+
+public sealed class PathSafetyTests {
+    [Fact]
+    public void EnsureUnderRoot_BlocksSymlinkTraversal_WhenSupported() {
+        var root = Path.Combine(Path.GetTempPath(), $"ix-workspace-{Guid.NewGuid():N}");
+        var outside = Path.Combine(Path.GetTempPath(), $"ix-outside-{Guid.NewGuid():N}");
+        try {
+            Directory.CreateDirectory(root);
+            Directory.CreateDirectory(outside);
+
+            var outsideFile = Path.Combine(outside, "outside.txt");
+            File.WriteAllText(outsideFile, "x");
+
+            var linkDir = Path.Combine(root, "link");
+            try {
+                Directory.CreateSymbolicLink(linkDir, outside);
+            } catch {
+                // Symlink creation can be restricted (notably on some Windows environments).
+                // Treat as non-actionable.
+                return;
+            }
+
+            var escapedPath = Path.Combine(linkDir, "outside.txt");
+            Assert.True(File.Exists(escapedPath));
+            Assert.Throws<InvalidOperationException>(() => PathSafety.EnsureUnderRoot(escapedPath, root));
+        } finally {
+            try {
+                if (Directory.Exists(root)) {
+                    Directory.Delete(root, recursive: true);
+                }
+            } catch {
+                // best-effort cleanup
+            }
+            try {
+                if (Directory.Exists(outside)) {
+                    Directory.Delete(outside, recursive: true);
+                }
+            } catch {
+                // best-effort cleanup
+            }
+        }
+    }
+}

--- a/IntelligenceX.UnitTests/RpcClientTests.cs
+++ b/IntelligenceX.UnitTests/RpcClientTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+using IntelligenceX.Rpc;
+using Xunit;
+
+namespace IntelligenceX.UnitTests;
+
+public sealed class RpcClientTests {
+    private static int GetPendingCount(JsonRpcClient client) {
+        var field = typeof(JsonRpcClient).GetField("_pending", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(field);
+        var value = field!.GetValue(client);
+        Assert.NotNull(value);
+        var prop = value!.GetType().GetProperty("Count", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(prop);
+        return (int)(prop!.GetValue(value) ?? 0);
+    }
+
+    [Fact]
+    public void CallAsync_Cancellation_CleansPending_AndLateResponseIsIgnored() {
+        var client = new JsonRpcClient(_ => Task.CompletedTask);
+        long id = 0;
+        client.CallStarted += (_, args) => id = args.RequestId ?? 0;
+
+        var protocolError = false;
+        client.ProtocolError += (_, _) => protocolError = true;
+
+        using var cts = new CancellationTokenSource();
+        var task = client.CallAsync("test", (JsonValue?)null, cts.Token);
+        cts.Cancel();
+
+        Assert.ThrowsAny<OperationCanceledException>(() => task.GetAwaiter().GetResult());
+        Assert.Equal(0, GetPendingCount(client));
+
+        client.HandleLine($"{{\"id\":{id},\"result\":123}}");
+        Assert.False(protocolError);
+    }
+}

--- a/IntelligenceX.sln
+++ b/IntelligenceX.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelligenceX.Reviewer", "I
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelligenceX.Cli", "IntelligenceX.Cli\IntelligenceX.Cli.csproj", "{3CC3EC98-2F2B-41FE-95B1-2E56ECC94A92}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelligenceX.UnitTests", "IntelligenceX.UnitTests\IntelligenceX.UnitTests.csproj", "{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +99,18 @@ Global
 		{3CC3EC98-2F2B-41FE-95B1-2E56ECC94A92}.Release|x64.Build.0 = Release|Any CPU
 		{3CC3EC98-2F2B-41FE-95B1-2E56ECC94A92}.Release|x86.ActiveCfg = Release|Any CPU
 		{3CC3EC98-2F2B-41FE-95B1-2E56ECC94A92}.Release|x86.Build.0 = Release|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Debug|x64.Build.0 = Debug|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Debug|x86.Build.0 = Debug|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Release|x64.ActiveCfg = Release|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Release|x64.Build.0 = Release|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Release|x86.ActiveCfg = Release|Any CPU
+		{D34B52A9-4A01-4F0C-AD2D-F7BC213167D1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/IntelligenceX/Properties/AssemblyInfo.cs
+++ b/IntelligenceX/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("IntelligenceX.Tests")]
+[assembly: InternalsVisibleTo("IntelligenceX.UnitTests")]


### PR DESCRIPTION
Add a small xUnit test project (net8.0/net10.0) so `dotnet test` actually executes tests and produces `coverage.cobertura.xml` for CI/Codecov.

Includes a few high-value tests (RPC cancellation behavior, auth store encryption key validation/roundtrip, PathSafety symlink traversal guard) and wires InternalsVisibleTo for the new test assembly.