### PR TITLE
Docs: clarify Dependabot identity + thread states

### DIFF
--- a/.intelligencex/reviewer.json
+++ b/.intelligencex/reviewer.json
@@ -33,6 +33,7 @@
   "review": {
     "maxFiles": 30,
     "maxPatchChars": 20000,
+    "reviewThreadsAutoResolveStale": true,
     "reviewThreadsAutoResolveAIReply": true,
     "reviewUsageSummary": true,
     "reviewUsageSummaryCacheMinutes": 10,

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -465,6 +465,15 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `reviewThreadsAutoResolveDiffRange` supports `current`, `pr-base`, or `first-review`.
 - Thread assessment ids are trimmed, expected to be unique, and keyed case-insensitively; missing ids are skipped and duplicate ids keep the last occurrence (with warnings).
 
+## Review thread states (active/resolved/stale)
+
+GitHub can mark a review thread as:
+- active: still anchored to the current diff
+- stale: shown as "Outdated" in the GitHub UI (the diff hunk changed), but the thread may still be unresolved
+- resolved: explicitly resolved (hidden/collapsed by default)
+
+Important: **Outdated does not mean resolved**. Outdated only means the diff context changed. If you want to reduce PR noise from bot-only outdated threads, enable `reviewThreadsAutoResolveStale` to auto-resolve stale threads that contain only bot comments.
+
 ## Auto-resolve troubleshooting
 If you see `Resource not accessible by integration` when resolving threads:
 - Re-authorize or reinstall the GitHub App after permission changes.

--- a/Docs/reviewer/security-trust.md
+++ b/Docs/reviewer/security-trust.md
@@ -41,6 +41,13 @@ The CLI prints the base64 auth store for manual paste into GitHub secrets.
 
 All changes are made via PRs by default.
 
+## Dependabot PR limitation (GitHub Actions secrets)
+
+For Dependabot PRs, GitHub typically does not expose repository secrets to workflows triggered by `pull_request`.
+If your reviewer workflow relies on GitHub App secrets (app id/private key) to post as a branded bot identity, those
+secrets may be unavailable on Dependabot PR runs. In that case the reviewer will fall back to `GITHUB_TOKEN`, and PR
+comments will appear authored by `github-actions`.
+
 ## Secret handling options
 
 - Auto-upload secrets via the CLI or wizard (`--set-github-secret`).


### PR DESCRIPTION
Documents two recurring sources of confusion:

- Dependabot PRs: reviewer may comment as github-actions when GitHub Actions secrets (app key/id) are unavailable.
- Review threads: "Outdated" (stale) is not the same as resolved; enables reviewThreadsAutoResolveStale in this repo config to reduce bot-only stale thread noise.

Files:
- Docs/reviewer/security-trust.md
- Docs/reviewer/configuration.md
- .intelligencex/reviewer.json
