### PR TITLE
CI: default to GitHub-hosted runners (avoid self-hosted deadlocks)

### DIFF
--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -18,9 +18,10 @@ jobs:
   # INTELLIGENCEX:BEGIN
   analysis:
     name: Static Analysis Gate
-    # While the repo is private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
-    # When public, use GitHub-hosted runners by default.
-    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
+    # Default to GitHub-hosted runners, even for private repos, to avoid CI deadlocks when no
+    # self-hosted runners are available. Opt-in to self-hosted by setting:
+    #   vars.IX_ENABLE_UBUNTU_SELF_HOSTED=true
+    runs-on: ${{ fromJSON((github.event.repository.private && vars.IX_ENABLE_UBUNTU_SELF_HOSTED == 'true') && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
     permissions:
       actions: write
       contents: read
@@ -68,9 +69,10 @@ jobs:
     name: AI Review (Fail-Open)
     needs: [analysis]
     if: always()
-    # While the repo is private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
-    # When public, use GitHub-hosted runners by default.
-    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
+    # Default to GitHub-hosted runners, even for private repos, to avoid CI deadlocks when no
+    # self-hosted runners are available. Opt-in to self-hosted by setting:
+    #   vars.IX_ENABLE_UBUNTU_SELF_HOSTED=true
+    runs-on: ${{ fromJSON((github.event.repository.private && vars.IX_ENABLE_UBUNTU_SELF_HOSTED == 'true') && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -75,15 +75,16 @@ jobs:
                   fail_ci_if_error: false
                   verbose: true
 
-    test-ubuntu:
-        name: 'Ubuntu'
-        # While the repo is private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
-        # When public, use GitHub-hosted runners by default.
-        runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
-        timeout-minutes: 20
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+	    test-ubuntu:
+	        name: 'Ubuntu'
+	        # Default to GitHub-hosted runners, even for private repos, to avoid CI deadlocks when no
+	        # self-hosted runners are available. Opt-in to self-hosted by setting:
+	        #   vars.IX_ENABLE_UBUNTU_SELF_HOSTED=true
+	        runs-on: ${{ fromJSON((github.event.repository.private && vars.IX_ENABLE_UBUNTU_SELF_HOSTED == 'true') && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
+	        timeout-minutes: 20
+	        steps:
+	            - name: Checkout code
+	              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Setup .NET
               uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ This file defines how automated agents should operate in this repo. Follow it fo
 - Work in a dedicated worktree + branch per task.
 - Do not touch the Website PR or website work unless explicitly requested.
 - Do not use destructive git commands (`reset --hard`, `checkout --`).
+- Avoid CI deadlocks: for private repos, ensure PR workflows can run on GitHub-hosted runners unless
+  the repo explicitly opts into self-hosted via repo `vars` (see workflow comments).
 
 **Worktree + Branch**
 1. Create a worktree for every task: `git worktree add -b <branch> <path> origin/master`.


### PR DESCRIPTION
Fixes PRs getting stuck in queued state when the repo is private but no self-hosted runners are available.

Changes:
- Default Ubuntu jobs to GitHub-hosted runners.
- Opt-in to self-hosted Ubuntu by setting repo variable: IX_ENABLE_UBUNTU_SELF_HOSTED=true.

Notes:
- Windows already required explicit opt-in (IX_ENABLE_WINDOWS_SELF_HOSTED).
