### PR TITLE
Tests: analysis packs + web setup validation

### DIFF
--- a/IntelligenceX.Cli/Setup/Web/WebApi.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebApi.cs
@@ -523,44 +523,27 @@ internal sealed class WebApi {
 
         // Analysis flags are only honored when the setup flow is generating/merging reviewer.json.
         // If the user provides a full config override (configJson/configPath), these flags would be ignored by SetupRunner,
-        // so we also ignore them here to avoid misleading behavior.
+        // so reject them here to avoid misleading behavior and hard-to-debug no-op requests.
         var isSetup = !request.Cleanup && !request.UpdateSecret;
         var hasConfigOverride = !string.IsNullOrWhiteSpace(request.ConfigJson) || !string.IsNullOrWhiteSpace(request.ConfigPath);
-        var analysisApplies = isSetup && request.WithConfig && !hasConfigOverride;
-        var hasAnyAnalysis =
-            request.AnalysisEnabled.HasValue ||
-            request.AnalysisGateEnabled.HasValue ||
-            !string.IsNullOrWhiteSpace(request.AnalysisPacks);
-        if (!analysisApplies) {
-            if (hasAnyAnalysis) {
-                context.Response.StatusCode = 400;
-                await WriteJsonAsync(context, new {
-                    error = "Static analysis options are only supported for setup when generating config from presets (withConfig=true and no configJson/configPath override)."
-                }).ConfigureAwait(false);
-                return;
-            }
-            request.AnalysisEnabled = null;
-            request.AnalysisGateEnabled = null;
-            request.AnalysisPacks = null;
-        } else if (request.AnalysisEnabled == true) {
-            if (!SetupAnalysisPacks.TryNormalizeCsv(request.AnalysisPacks, out var normalizedPacks, out var packsError)) {
-                context.Response.StatusCode = 400;
-                await WriteJsonAsync(context, new { error = packsError }).ConfigureAwait(false);
-                return;
-            }
-            request.AnalysisPacks = normalizedPacks;
-        } else {
-            if (request.AnalysisGateEnabled.HasValue || !string.IsNullOrWhiteSpace(request.AnalysisPacks)) {
-                context.Response.StatusCode = 400;
-                await WriteJsonAsync(context, new {
-                    error = "analysisGateEnabled/analysisPacks require analysisEnabled=true."
-                }).ConfigureAwait(false);
-                return;
-            }
-            // Prevent accidental or malicious argv "flag injection" by ensuring these are never forwarded when disabled/unset.
-            request.AnalysisGateEnabled = null;
-            request.AnalysisPacks = null;
+        if (!WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: isSetup,
+            withConfig: request.WithConfig,
+            hasConfigOverride: hasConfigOverride,
+            analysisEnabled: request.AnalysisEnabled,
+            analysisGateEnabled: request.AnalysisGateEnabled,
+            analysisPacks: request.AnalysisPacks,
+            normalizedEnabled: out var normalizedEnabled,
+            normalizedGateEnabled: out var normalizedGateEnabled,
+            normalizedPacks: out var normalizedPacks,
+            error: out var analysisError)) {
+            context.Response.StatusCode = 400;
+            await WriteJsonAsync(context, new { error = analysisError }).ConfigureAwait(false);
+            return;
         }
+        request.AnalysisEnabled = normalizedEnabled;
+        request.AnalysisGateEnabled = normalizedGateEnabled;
+        request.AnalysisPacks = normalizedPacks;
 
         var repos = request.Repos is not null && request.Repos.Count > 0
             ? request.Repos

--- a/IntelligenceX.Cli/Setup/Web/WebSetupAnalysisValidator.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebSetupAnalysisValidator.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace IntelligenceX.Cli.Setup.Web;
+
+internal static class WebSetupAnalysisValidator {
+    public static bool TryValidateAndNormalize(
+        bool isSetup,
+        bool withConfig,
+        bool hasConfigOverride,
+        bool? analysisEnabled,
+        bool? analysisGateEnabled,
+        string? analysisPacks,
+        out bool? normalizedEnabled,
+        out bool? normalizedGateEnabled,
+        out string? normalizedPacks,
+        out string? error) {
+        error = null;
+        normalizedEnabled = null;
+        normalizedGateEnabled = null;
+        normalizedPacks = null;
+
+        var hasAnyAnalysis =
+            analysisEnabled.HasValue ||
+            analysisGateEnabled.HasValue ||
+            !string.IsNullOrWhiteSpace(analysisPacks);
+
+        var analysisApplies = isSetup && withConfig && !hasConfigOverride;
+        if (!analysisApplies) {
+            if (hasAnyAnalysis) {
+                error = "Static analysis options are only supported for setup when generating config from presets (withConfig=true and no configJson/configPath override).";
+                return false;
+            }
+            return true;
+        }
+
+        normalizedEnabled = analysisEnabled;
+        if (analysisEnabled == true) {
+            normalizedGateEnabled = analysisGateEnabled;
+            if (!SetupAnalysisPacks.TryNormalizeCsv(analysisPacks, out normalizedPacks, out error)) {
+                return false;
+            }
+            return true;
+        }
+
+        if (analysisGateEnabled.HasValue || !string.IsNullOrWhiteSpace(analysisPacks)) {
+            error = "analysisGateEnabled/analysisPacks require analysisEnabled=true.";
+            return false;
+        }
+
+        // Ensure no stray values accidentally override defaults.
+        normalizedGateEnabled = null;
+        normalizedPacks = null;
+        return true;
+    }
+}
+

--- a/IntelligenceX.UnitTests/SetupAnalysisPacksTests.cs
+++ b/IntelligenceX.UnitTests/SetupAnalysisPacksTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using IntelligenceX.Cli.Setup;
+using Xunit;
+
+namespace IntelligenceX.UnitTests;
+
+public sealed class SetupAnalysisPacksTests {
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(",")]
+    [InlineData(" , , ")]
+    public void TryNormalizeCsv_Empty_ReturnsDefaults(string? raw) {
+        var ok = SetupAnalysisPacks.TryNormalizeCsv(raw, out var normalized, out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Null(normalized);
+    }
+
+    [Fact]
+    public void TryNormalizeCsv_TrimsAndDedupes() {
+        var ok = SetupAnalysisPacks.TryNormalizeCsv(" all-50 , powershell-50,all-50 ", out var normalized, out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Equal("all-50,powershell-50", normalized);
+    }
+
+    [Theory]
+    [InlineData("--force")]
+    [InlineData("-x")]
+    [InlineData(" all 50 ")]
+    [InlineData("all-50\npowershell-50")]
+    [InlineData("\"all-50\"")]
+    [InlineData("all-50, powershell-50;rm -rf")]
+    [InlineData("all-50, powershell-50/extra")]
+    [InlineData("all-50, _bad")]
+    [InlineData("bad-")]
+    public void TryNormalizeCsv_InvalidIds_Fails(string raw) {
+        var ok = SetupAnalysisPacks.TryNormalizeCsv(raw, out var normalized, out var error);
+
+        Assert.False(ok);
+        Assert.Null(normalized);
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+
+    [Fact]
+    public void TryNormalizeCsv_TooManyIds_Fails() {
+        var ids = Enumerable.Range(0, 101).Select(i => $"id{i}");
+        var raw = string.Join(",", ids);
+
+        var ok = SetupAnalysisPacks.TryNormalizeCsv(raw, out var normalized, out var error);
+
+        Assert.False(ok);
+        Assert.Null(normalized);
+        Assert.Contains("Too many", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryNormalizeCsv_TooLong_Fails() {
+        // 100 ids of length 30 -> >2048 when comma-joined
+        var ids = Enumerable.Range(0, 100).Select(i => $"id{i:D3}_" + new string('a', 24));
+        var raw = string.Join(",", ids);
+
+        var ok = SetupAnalysisPacks.TryNormalizeCsv(raw, out var normalized, out var error);
+
+        Assert.False(ok);
+        Assert.Null(normalized);
+        Assert.Contains("too long", error, StringComparison.OrdinalIgnoreCase);
+    }
+}
+

--- a/IntelligenceX.UnitTests/WebSetupAnalysisValidatorTests.cs
+++ b/IntelligenceX.UnitTests/WebSetupAnalysisValidatorTests.cs
@@ -1,0 +1,158 @@
+using System;
+using IntelligenceX.Cli.Setup.Web;
+using Xunit;
+
+namespace IntelligenceX.UnitTests;
+
+public sealed class WebSetupAnalysisValidatorTests {
+    [Fact]
+    public void NotSetup_WithAnalysisFields_Fails() {
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: false,
+            withConfig: true,
+            hasConfigOverride: false,
+            analysisEnabled: true,
+            analysisGateEnabled: null,
+            analysisPacks: null,
+            normalizedEnabled: out _,
+            normalizedGateEnabled: out _,
+            normalizedPacks: out _,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+
+    [Fact]
+    public void WithoutConfig_WithAnalysisFields_Fails() {
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: true,
+            withConfig: false,
+            hasConfigOverride: false,
+            analysisEnabled: true,
+            analysisGateEnabled: null,
+            analysisPacks: null,
+            normalizedEnabled: out _,
+            normalizedGateEnabled: out _,
+            normalizedPacks: out _,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+
+    [Fact]
+    public void WithConfigOverride_WithAnalysisFields_Fails() {
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: true,
+            withConfig: true,
+            hasConfigOverride: true,
+            analysisEnabled: true,
+            analysisGateEnabled: null,
+            analysisPacks: null,
+            normalizedEnabled: out _,
+            normalizedGateEnabled: out _,
+            normalizedPacks: out _,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+
+    [Fact]
+    public void AnalysisEnabledNull_GateEnabled_Fails() {
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: true,
+            withConfig: true,
+            hasConfigOverride: false,
+            analysisEnabled: null,
+            analysisGateEnabled: true,
+            analysisPacks: null,
+            normalizedEnabled: out _,
+            normalizedGateEnabled: out _,
+            normalizedPacks: out _,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.Contains("require", error ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AnalysisEnabledFalse_PacksProvided_Fails() {
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: true,
+            withConfig: true,
+            hasConfigOverride: false,
+            analysisEnabled: false,
+            analysisGateEnabled: null,
+            analysisPacks: "all-50",
+            normalizedEnabled: out _,
+            normalizedGateEnabled: out _,
+            normalizedPacks: out _,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.Contains("require", error ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AnalysisEnabledTrue_InvalidPacks_Fails() {
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: true,
+            withConfig: true,
+            hasConfigOverride: false,
+            analysisEnabled: true,
+            analysisGateEnabled: null,
+            analysisPacks: "--force",
+            normalizedEnabled: out _,
+            normalizedGateEnabled: out _,
+            normalizedPacks: out _,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.Contains("Invalid pack id", error ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AnalysisEnabledTrue_NormalizesPacks() {
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: true,
+            withConfig: true,
+            hasConfigOverride: false,
+            analysisEnabled: true,
+            analysisGateEnabled: true,
+            analysisPacks: " all-50,all-50 , powershell-50 ",
+            normalizedEnabled: out var normalizedEnabled,
+            normalizedGateEnabled: out var normalizedGate,
+            normalizedPacks: out var normalizedPacks,
+            error: out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.True(normalizedEnabled);
+        Assert.True(normalizedGate);
+        Assert.Equal("all-50,powershell-50", normalizedPacks);
+    }
+
+    [Fact]
+    public void AnalysisApplicable_NoFields_IsOk() {
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: true,
+            withConfig: true,
+            hasConfigOverride: false,
+            analysisEnabled: null,
+            analysisGateEnabled: null,
+            analysisPacks: null,
+            normalizedEnabled: out var normalizedEnabled,
+            normalizedGateEnabled: out var normalizedGate,
+            normalizedPacks: out var normalizedPacks,
+            error: out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Null(normalizedEnabled);
+        Assert.Null(normalizedGate);
+        Assert.Null(normalizedPacks);
+    }
+}
+


### PR DESCRIPTION
Adds unit tests for SetupAnalysisPacks.TryNormalizeCsv and the web onboarding analysis validation rules. Also refactors WebApi to use a small shared validator to keep behavior testable and consistent.