### PR TITLE
Onboarding: surface Dependabot bot-identity limitation

### DIFF
--- a/IntelligenceX.Cli/Setup/Web/Assets/index.html
+++ b/IntelligenceX.Cli/Setup/Web/Assets/index.html
@@ -57,6 +57,7 @@
             <li><span class="check">&#x2713;</span> Sign in without creating tokens manually</li>
             <li><span class="check">&#x2713;</span> Pre-fill settings when creating your own GitHub App</li>
           </ul>
+          <p class="trust-note"><strong>Dependabot note:</strong> Dependabot PR workflows usually cannot access repository secrets, so review comments may appear as <code>github-actions</code> instead of your app bot.</p>
           <p class="trust-note">We don't store your credentials or access repos without your approval. Everything runs locally.</p>
         </div>
 

--- a/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
+++ b/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
@@ -1184,9 +1184,10 @@ function confirmApply() {
   if (repos.length === 0) { write('Select repos first.'); return; }
   if (!getToken()) { write('Token required.'); return; }
 
+  const dependabotNote = '\n\nDependabot note: PR workflows usually cannot access repo secrets, so comments may appear as github-actions instead of your app bot.';
   const msg = repos.length === 1
-    ? `Apply changes to ${repos[0]}?\n\nThis will create a PR with the workflow and upload secrets.`
-    : `Apply changes to ${repos.length} repositories?\n\nThis will create PRs with the workflow and upload secrets.`;
+    ? `Apply changes to ${repos[0]}?\n\nThis will create a PR with the workflow and upload secrets.${dependabotNote}`
+    : `Apply changes to ${repos.length} repositories?\n\nThis will create PRs with the workflow and upload secrets.${dependabotNote}`;
 
   if (!confirm(msg)) return;
   doApply();

--- a/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
@@ -41,6 +41,8 @@ internal static class WizardPrompts {
             "[grey]We use the IntelligenceX GitHub App to simplify setup:[/]\n" +
             "[green]✓[/] Sign in without creating tokens manually\n" +
             "[green]✓[/] Pre-fill settings when creating your own GitHub App\n\n" +
+            "[yellow]Dependabot note:[/] Dependabot PR workflows usually cannot access repo secrets.\n" +
+            "For those runs, review comments may appear as [grey]github-actions[/] instead of your app bot.\n\n" +
             "[grey]We don't store your credentials or access repos without\n" +
             "your approval. Everything runs locally.[/]\n\n" +
             "[dim]Override with: INTELLIGENCEX_GITHUB_CLIENT_ID env var[/]") {

--- a/TODO.md
+++ b/TODO.md
@@ -14,13 +14,13 @@ Goal: reviewer + static analysis + onboarding (CLI + Web) feel "done" end-to-end
 - [ ] Review comment always includes reviewed SHA and an explicit diff-range label (base -> head).
 - [ ] Static analysis runs before review, publishes artifacts, and the review comment always renders analysis status (pass/unavailable) even when findings are zero.
 - [ ] Static analysis gate behavior is predictable: failing types/severities are documented and match observed CI results.
-- [ ] Dependabot identity limitation is documented and visible during onboarding (reviews may be authored by `github-actions`).
+- [x] Dependabot identity limitation is documented and visible during onboarding (reviews may be authored by `github-actions`).
 
 ### Phase A — Onboarding UX (CLI + Web)
 - [x] CLI wizard: add "Enable static analysis" toggle and pack picker (default `all-50`).
 - [x] Web UI: add "Enable static analysis" toggle and pack picker (default `all-50`).
 - [ ] CLI + Web: show a final "Effective config" preview (review + analysis) before Apply.
-- [ ] CLI + Web: surface the Dependabot secrets limitation in the UI copy (why bot identity may differ).
+- [x] CLI + Web: surface the Dependabot secrets limitation in the UI copy (why bot identity may differ).
 - [ ] CLI + Web: add a post-Apply "Verify" step (workflow present, config present if requested, required secrets present, last runs links).
 
 ### Phase B — Setup Output (Workflow + reviewer.json)


### PR DESCRIPTION
## Summary\n- add explicit Dependabot/secrets limitation note to CLI wizard trust panel\n- add the same note to web onboarding trust panel and apply confirmation dialog\n- update roadmap checkboxes in TODO for this completed onboarding visibility item\n\n## Validation\n- dotnet build IntelligenceX.sln -c Release\n- dotnet test IntelligenceX.sln -c Release