### PR TITLE
Harden analyzer + setup subprocess reliability

### DIFF
--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.cs
@@ -57,19 +57,7 @@ internal static partial class AnalyzeRunCommand {
         var tempScript = Path.Combine(Path.GetTempPath(), "ix-pssa-" + Guid.NewGuid().ToString("N") + ".ps1");
         try {
             File.WriteAllText(tempScript, BuildPowerShellRunnerScript());
-            var args = new List<string> {
-                "-NoLogo",
-                "-NoProfile",
-                "-NonInteractive",
-                "-File",
-                tempScript,
-                "-Workspace",
-                workspace,
-                "-OutFile",
-                findingsPath,
-                "-SettingsPath",
-                settingsPath
-            };
+            var args = BuildPowerShellRunnerArgs(tempScript, workspace, findingsPath, settingsPath, options.Strict);
             var result = await RunProcessAsync(options.PowerShellCommand, args, workspace).ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(result.StdOut)) {
                 Console.WriteLine(result.StdOut.Trim());
@@ -88,6 +76,41 @@ internal static partial class AnalyzeRunCommand {
             TryDeleteFile(tempScript);
         }
     }
+
+    internal static IReadOnlyList<string> BuildPowerShellRunnerArgsForTests(
+        string tempScript,
+        string workspace,
+        string findingsPath,
+        string settingsPath,
+        bool strict) {
+        return BuildPowerShellRunnerArgs(tempScript, workspace, findingsPath, settingsPath, strict);
+    }
+
+    private static List<string> BuildPowerShellRunnerArgs(
+        string tempScript,
+        string workspace,
+        string findingsPath,
+        string settingsPath,
+        bool strict) {
+        var args = new List<string> {
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-File",
+            tempScript,
+            "-Workspace",
+            workspace,
+            "-OutFile",
+            findingsPath,
+            "-SettingsPath",
+            settingsPath
+        };
+        if (strict) {
+            args.Add("-FailOnAnalyzerErrors");
+        }
+        return args;
+    }
+
     private static TemporaryFileScope? PrepareEditorConfigOverride(AnalysisSettings settings, string workspace,
         string? generatedEditorConfig, List<string> warnings) {
         if (string.IsNullOrWhiteSpace(generatedEditorConfig) || !File.Exists(generatedEditorConfig)) {

--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.cs
@@ -262,11 +262,16 @@ internal static partial class AnalyzeRunCommand {
         Console.WriteLine("                         [--dotnet-command <path>] [--framework <tfm>] [--pwsh-command <path>] [--strict]");
     }
 
+    internal static string BuildPowerShellRunnerScriptForTests() {
+        return BuildPowerShellRunnerScript();
+    }
+
     private static string BuildPowerShellRunnerScript() {
         return @"param(
     [Parameter(Mandatory=$true)][string]$Workspace,
     [Parameter(Mandatory=$true)][string]$OutFile,
-    [Parameter()][string]$SettingsPath
+    [Parameter()][string]$SettingsPath,
+    [Parameter()][switch]$FailOnAnalyzerErrors
 )
 $ErrorActionPreference = 'Stop'
 
@@ -284,7 +289,25 @@ if ($SettingsPath -and (Test-Path -LiteralPath $SettingsPath)) {
     $invoke['Settings'] = $SettingsPath
 }
 
-$results = Invoke-ScriptAnalyzer @invoke
+$invokeErrors = @()
+$results = @()
+try {
+    $results = @(Invoke-ScriptAnalyzer @invoke -ErrorAction Continue -ErrorVariable +invokeErrors)
+} catch {
+    $invokeErrors += $_
+}
+
+$sawInvokeErrors = $false
+foreach ($invokeError in $invokeErrors) {
+    $sawInvokeErrors = $true
+    $errorText = if ($invokeError.Exception -and $invokeError.Exception.Message) {
+        $invokeError.Exception.Message
+    } else {
+        [string]$invokeError
+    }
+    [Console]::Error.WriteLine('PSScriptAnalyzer engine error: ' + $errorText)
+}
+
 $items = @()
 foreach ($result in $results) {
     if (-not $result.ScriptPath -or -not $result.Message) {
@@ -315,7 +338,11 @@ if ($directory -and -not (Test-Path -LiteralPath $directory)) {
     items = $items
 } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $OutFile -Encoding UTF8
 
-Write-Output ('PSScriptAnalyzer findings: ' + $items.Count)";
+Write-Output ('PSScriptAnalyzer findings: ' + $items.Count)
+if ($sawInvokeErrors -and $FailOnAnalyzerErrors) {
+    [Console]::Error.WriteLine('PSScriptAnalyzer reported one or more engine errors.')
+    exit 2
+}";
     }
 
     private sealed class AnalyzeRunOptions {

--- a/IntelligenceX.Cli/Setup/Web/WebApi.SetupRunner.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebApi.SetupRunner.cs
@@ -108,9 +108,12 @@ internal sealed partial class WebApi {
     }
 
     private static readonly SemaphoreSlim ConsoleLock = new(1, 1);
+    private static readonly TimeSpan ConsoleLockTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan SetupProcessTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan ProcessShutdownGracePeriod = TimeSpan.FromSeconds(2);
 
     private async Task<SetupResponse> RunSetupAsync(string[] args) {
-        if (!await ConsoleLock.WaitAsync(TimeSpan.FromMinutes(2)).ConfigureAwait(false)) {
+        if (!await ConsoleLock.WaitAsync(ConsoleLockTimeout).ConfigureAwait(false)) {
             return new SetupResponse {
                 ExitCode = 1,
                 Error = "Setup is busy. Please retry in a moment."
@@ -147,26 +150,105 @@ internal sealed partial class WebApi {
                 psi.ArgumentList.Add(arg);
             }
 
-            using var process = Process.Start(psi);
-            if (process is null) {
+            var result = await RunProcessWithTimeoutAsync(psi, SetupProcessTimeout).ConfigureAwait(false);
+            if (!result.Started) {
                 return new SetupResponse {
                     ExitCode = 1,
-                    Error = "Failed to start setup process."
+                    Error = result.Error
                 };
             }
 
-            var outputTask = process.StandardOutput.ReadToEndAsync();
-            var errorTask = process.StandardError.ReadToEndAsync();
-            await Task.WhenAll(outputTask, errorTask, process.WaitForExitAsync()).ConfigureAwait(false);
-
-            var code = process.ExitCode;
             return new SetupResponse {
-                ExitCode = code,
-                Output = await outputTask.ConfigureAwait(false),
-                Error = await errorTask.ConfigureAwait(false)
+                ExitCode = result.ExitCode,
+                Output = result.Output,
+                Error = result.Error
             };
         } finally {
             ConsoleLock.Release();
         }
     }
+
+    internal static async Task<(int ExitCode, string StdOut, string StdErr, bool TimedOut)> RunSetupProcessForTests(
+        string fileName,
+        IReadOnlyList<string> args,
+        int timeoutMs) {
+        var psi = new ProcessStartInfo {
+            FileName = fileName,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = Environment.CurrentDirectory
+        };
+        foreach (var arg in args ?? Array.Empty<string>()) {
+            psi.ArgumentList.Add(arg);
+        }
+
+        var timeout = timeoutMs <= 0 ? TimeSpan.FromMilliseconds(1) : TimeSpan.FromMilliseconds(timeoutMs);
+        var result = await RunProcessWithTimeoutAsync(psi, timeout).ConfigureAwait(false);
+        return (result.ExitCode, result.Output, result.Error, result.TimedOut);
+    }
+
+    private static async Task<SetupProcessResult> RunProcessWithTimeoutAsync(ProcessStartInfo psi, TimeSpan timeout) {
+        Process? process;
+        try {
+            process = Process.Start(psi);
+        } catch (Exception ex) {
+            return new SetupProcessResult(false, 1, string.Empty,
+                $"Failed to start setup process: {ex.Message}", false);
+        }
+        if (process is null) {
+            return new SetupProcessResult(false, 1, string.Empty, "Failed to start setup process.", false);
+        }
+
+        using (process) {
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
+            var completionTask = Task.WhenAll(outputTask, errorTask, process.WaitForExitAsync());
+            var timedOut = false;
+            try {
+                await completionTask.WaitAsync(timeout).ConfigureAwait(false);
+            } catch (TimeoutException) {
+                timedOut = true;
+                TryKillProcess(process);
+                try {
+                    await Task.WhenAny(completionTask, Task.Delay(ProcessShutdownGracePeriod)).ConfigureAwait(false);
+                } catch {
+                    // Best effort drain after timeout.
+                }
+            } catch (Exception ex) {
+                var output = outputTask.IsCompletedSuccessfully ? outputTask.Result : string.Empty;
+                var error = errorTask.IsCompletedSuccessfully ? errorTask.Result : string.Empty;
+                var message = string.IsNullOrWhiteSpace(error)
+                    ? ex.Message
+                    : error.TrimEnd() + Environment.NewLine + ex.Message;
+                return new SetupProcessResult(true, 1, output, message, false);
+            }
+
+            var finalOutput = outputTask.IsCompletedSuccessfully ? outputTask.Result : string.Empty;
+            var finalError = errorTask.IsCompletedSuccessfully ? errorTask.Result : string.Empty;
+            if (timedOut) {
+                var timeoutMessage =
+                    $"Setup process timed out after {Math.Max(1, (int)Math.Ceiling(timeout.TotalSeconds))}s.";
+                finalError = string.IsNullOrWhiteSpace(finalError)
+                    ? timeoutMessage
+                    : finalError.TrimEnd() + Environment.NewLine + timeoutMessage;
+                return new SetupProcessResult(true, 124, finalOutput, finalError, true);
+            }
+
+            return new SetupProcessResult(true, process.ExitCode, finalOutput, finalError, false);
+        }
+    }
+
+    private static void TryKillProcess(Process process) {
+        try {
+            if (!process.HasExited) {
+                process.Kill(entireProcessTree: true);
+            }
+        } catch {
+            // Best effort cleanup on timeout.
+        }
+    }
+
+    private sealed record SetupProcessResult(bool Started, int ExitCode, string Output, string Error, bool TimedOut);
 }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
@@ -1,0 +1,50 @@
+namespace IntelligenceX.Tests;
+
+#if INTELLIGENCEX_REVIEWER
+internal static partial class Program {
+    private static void TestAnalyzeRunPowerShellScriptCapturesEngineErrors() {
+        var script = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.BuildPowerShellRunnerScriptForTests();
+
+        AssertContainsText(script, "[switch]$FailOnAnalyzerErrors", "powershell runner strict switch parameter");
+        AssertContainsText(script, "-ErrorAction Continue -ErrorVariable +invokeErrors",
+            "powershell runner captures non-terminating engine errors");
+        AssertContainsText(script, "if ($sawInvokeErrors -and $FailOnAnalyzerErrors)",
+            "powershell runner strict-mode failure gate");
+        AssertContainsText(script, "exit 2", "powershell runner strict-mode engine error exit code");
+    }
+
+    private static void TestAnalyzeRunPowerShellStrictArgsIncludeFailSwitch() {
+        var strictArgs = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.BuildPowerShellRunnerArgsForTests(
+            tempScript: "runner.ps1",
+            workspace: "workspace",
+            findingsPath: "findings.json",
+            settingsPath: "PSScriptAnalyzerSettings.psd1",
+            strict: true);
+        var nonStrictArgs = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.BuildPowerShellRunnerArgsForTests(
+            tempScript: "runner.ps1",
+            workspace: "workspace",
+            findingsPath: "findings.json",
+            settingsPath: "PSScriptAnalyzerSettings.psd1",
+            strict: false);
+
+        var strictHasSwitch = false;
+        foreach (var arg in strictArgs) {
+            if (string.Equals(arg, "-FailOnAnalyzerErrors", StringComparison.Ordinal)) {
+                strictHasSwitch = true;
+                break;
+            }
+        }
+
+        var nonStrictHasSwitch = false;
+        foreach (var arg in nonStrictArgs) {
+            if (string.Equals(arg, "-FailOnAnalyzerErrors", StringComparison.Ordinal)) {
+                nonStrictHasSwitch = true;
+                break;
+            }
+        }
+
+        AssertEqual(true, strictHasSwitch, "powershell strict args include fail switch");
+        AssertEqual(false, nonStrictHasSwitch, "powershell non-strict args omit fail switch");
+    }
+}
+#endif

--- a/IntelligenceX.Tests/Program.Setup.Web.cs
+++ b/IntelligenceX.Tests/Program.Setup.Web.cs
@@ -1,0 +1,26 @@
+namespace IntelligenceX.Tests;
+
+internal static partial class Program {
+#if !NET472
+    private static void TestWebSetupRunProcessTimeoutReturnsPromptly() {
+        var command = Environment.ProcessPath;
+        if (string.IsNullOrWhiteSpace(command)) {
+            command = "dotnet";
+        }
+
+        var timer = Stopwatch.StartNew();
+        var result = IntelligenceX.Cli.Setup.Web.WebApi.RunSetupProcessForTests(
+            command!,
+            new[] { "--help" },
+            timeoutMs: 1).GetAwaiter().GetResult();
+        timer.Stop();
+
+        AssertEqual(true, result.TimedOut, "web setup timeout flag");
+        AssertEqual(124, result.ExitCode, "web setup timeout exit code");
+        AssertContainsText(result.StdErr, "timed out", "web setup timeout stderr");
+        if (timer.Elapsed > TimeSpan.FromSeconds(10)) {
+            throw new InvalidOperationException($"Expected timeout test to return promptly, got {timer.Elapsed}.");
+        }
+    }
+#endif
+}

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -61,6 +61,7 @@ internal static partial class Program {
         failed += Run("Manage external command captures help tail line", TestManageRunExternalCommandCapturesHelpTailLine);
         failed += Run("Manage external command start failure returns promptly", TestManageRunExternalCommandStartFailureReturnsPromptly);
         failed += Run("Manage external command non-timeout failure is not timeout", TestManageRunExternalCommandNonTimeoutFailureIsNotTimeout);
+        failed += Run("Web setup subprocess timeout returns promptly", TestWebSetupRunProcessTimeoutReturnsPromptly);
         failed += Run("Manage GitHub CLI status token authenticated", TestManageGitHubCliStatusWithTokenIsAuthenticated);
         failed += Run("Manage GitHub CLI status exit code zero authenticated", TestManageGitHubCliStatusExitCodeZeroAuthenticated);
         failed += Run("Manage GitHub CLI status exit code non-zero unauthenticated", TestManageGitHubCliStatusExitCodeNonZeroUnauthenticated);
@@ -180,6 +181,8 @@ internal static partial class Program {
         failed += Run("Todo bot feedback parse existing", TestBotFeedbackParseExistingPrBlockExtractsTasks);
         failed += Run("Todo bot feedback merge", TestBotFeedbackMergePreservesManualCheckedStateAndOrder);
         failed += Run("Todo bot feedback update section", TestBotFeedbackUpdateSectionIsDeterministicAndNoDuplicates);
+        failed += Run("Analyze run PowerShell script captures engine errors", TestAnalyzeRunPowerShellScriptCapturesEngineErrors);
+        failed += Run("Analyze run PowerShell strict args include fail switch", TestAnalyzeRunPowerShellStrictArgsIncludeFailSwitch);
         failed += Run("Analyze run disabled writes empty findings", TestAnalyzeRunDisabledWritesEmptyFindings);
         failed += Run("Analyze run internal file size rule", TestAnalyzeRunInternalFileSizeRule);
         failed += Run("Analyze run internal findings use catalog tool metadata",


### PR DESCRIPTION
## Summary
- Harden `analyze run` PowerShell path to capture non-terminating `Invoke-ScriptAnalyzer` engine errors and keep non-strict runs stable.
- Add strict-mode fail wiring for engine errors (`-FailOnAnalyzerErrors`) while preserving findings output behavior.
- Add timeout/kill handling for web setup subprocess execution to avoid hanging requests.
- Add regression tests for PowerShell runner script/args and web setup timeout path.

## Why
- We observed flaky `analyze run` behavior where PSScriptAnalyzer could emit engine errors and intermittently fail CI/automation.
- Web setup subprocess execution had no timeout guard, so a stuck child process could block setup calls indefinitely.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- analyze validate-catalog --workspace .`
- `dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- analyze run --config .intelligencex/reviewer.json --out artifacts --framework net8.0` (repeated 5x, all exit code 0)
