### PR TITLE
Add first PR rollout verification skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -7,6 +7,7 @@ Repo-local skills that make agents more consistent across onboarding, setup, ana
 - `intelligencex-analysis-gate`: Use for analysis catalog/packs/gate/run behavior and reliability work.
 - `intelligencex-pr-unblock-loop`: Use for PR triage, CI failure classification, and merge-blocker closure loops.
 - `intelligencex-reviewer-bootstrap`: Use for reviewer bootstrap (`reviewer.json` + workflow YAML) dry-runs and validation.
+- `intelligencex-first-pr-rollout`: Use to verify first post-onboarding PR rollout signals (workflow, checks, sticky summary, analysis sections).
 
 ## Shared Rules
 - Always use a dedicated `codex/*` branch and worktree.

--- a/.agents/skills/intelligencex-first-pr-rollout/SKILL.md
+++ b/.agents/skills/intelligencex-first-pr-rollout/SKILL.md
@@ -1,0 +1,32 @@
+# Skill: intelligencex-first-pr-rollout
+
+Use this skill to verify the first live reviewer run after onboarding/setup is healthy and complete.
+
+## Trigger Phrases
+- "first PR rollout"
+- "verify onboarding worked"
+- "post-setup verification"
+- "check reviewer is live"
+- "sticky summary verification"
+
+## Strict Execution Order
+1. Capture rollout snapshot for target repo + PR
+2. Verify workflow/config presence on default branch
+3. Verify PR checks reached expected conclusions
+4. Verify reviewer sticky summary includes reviewed SHA + diff-range label
+5. Verify static analysis status blocks are present when expected
+6. Publish a concise pass/fail report with exact artifacts paths
+
+## Commands
+- Run verification:
+  - `.agents/skills/intelligencex-first-pr-rollout/scripts/verify-first-pr-rollout.sh --repo <owner/name> --pr <number> --require-config --require-analysis-sections`
+
+## Fail-Fast Rules
+- Stop if GitHub auth is missing.
+- Stop if reviewer workflow is missing on default branch.
+- Stop if required checks are missing/failed.
+- Stop if sticky summary marker or reviewed SHA/diff-range labels are missing.
+
+## References
+- `references/acceptance-criteria.md`
+- `references/report-template.md`

--- a/.agents/skills/intelligencex-first-pr-rollout/references/acceptance-criteria.md
+++ b/.agents/skills/intelligencex-first-pr-rollout/references/acceptance-criteria.md
@@ -1,0 +1,19 @@
+# First PR Rollout Acceptance Criteria
+
+## Repo State
+- `.github/workflows/review-intelligencex.yml` exists on default branch.
+- Managed block markers are present (`INTELLIGENCEX:BEGIN` / `INTELLIGENCEX:END`).
+- `.intelligencex/reviewer.json` exists when onboarding used `--with-config`.
+
+## PR Checks
+- `Static Analysis Gate`: `SUCCESS`.
+- `AI Review (Fail-Open)`: `SUCCESS`.
+- Main test job (for this repo usually `Ubuntu`): `SUCCESS`.
+
+## Reviewer Output
+- Sticky summary marker exists: `<!-- intelligencex:summary -->`.
+- Summary includes `Reviewed commit:`.
+- Summary/triage includes `Diff range:`.
+- If analysis is enabled, comment includes:
+  - `### Static Analysis Policy`
+  - `### Static Analysis`

--- a/.agents/skills/intelligencex-first-pr-rollout/references/report-template.md
+++ b/.agents/skills/intelligencex-first-pr-rollout/references/report-template.md
@@ -1,0 +1,30 @@
+# First PR Rollout Report
+
+## Target
+- Repo:
+- PR:
+
+## Repo Checks
+- Workflow present:
+- Managed block valid:
+- Reviewer config present (if required):
+
+## PR Checks
+- Static Analysis Gate:
+- AI Review (Fail-Open):
+- Ubuntu:
+
+## Reviewer Comment Signals
+- Sticky marker:
+- Reviewed commit:
+- Diff range:
+- Static analysis sections:
+
+## Artifacts
+- Snapshot dir:
+- `pr.json`:
+- `checks.txt`:
+- `comments.txt`:
+
+## Verdict
+- PASS / FAIL

--- a/.agents/skills/intelligencex-first-pr-rollout/scripts/verify-first-pr-rollout.sh
+++ b/.agents/skills/intelligencex-first-pr-rollout/scripts/verify-first-pr-rollout.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 --repo <owner/name> --pr <number> [--out-dir <dir>] [--require-config] [--require-analysis-sections]
+
+Examples:
+  $0 --repo EvotecIT/IntelligenceX --pr 210 --require-config --require-analysis-sections
+USAGE
+}
+
+REPO=""
+PR=""
+OUT_DIR="artifacts/first-pr-rollout"
+REQUIRE_CONFIG=0
+REQUIRE_ANALYSIS_SECTIONS=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --pr)
+      PR="${2:-}"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --require-config)
+      REQUIRE_CONFIG=1
+      shift
+      ;;
+    --require-analysis-sections)
+      REQUIRE_ANALYSIS_SECTIONS=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown arg: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$REPO" || -z "$PR" ]]; then
+  echo "ERROR: --repo and --pr are required" >&2
+  usage >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI is required" >&2
+  exit 1
+fi
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ERROR: rg is required" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh auth status failed; login required" >&2
+  exit 1
+fi
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+SAFE_REPO="${REPO//\//_}"
+RUN_DIR="$OUT_DIR/${SAFE_REPO}-pr${PR}-${STAMP}"
+mkdir -p "$RUN_DIR"
+
+PR_JSON="$RUN_DIR/pr.json"
+CHECKS_TXT="$RUN_DIR/checks.txt"
+COMMENTS_TXT="$RUN_DIR/comments.txt"
+WORKFLOW_YAML="$RUN_DIR/workflow.review-intelligencex.yml"
+REVIEWER_JSON="$RUN_DIR/reviewer.json"
+
+# Snapshot PR and checks
+if ! gh pr view "$PR" --repo "$REPO" --json number,url,state,mergeable,mergeStateStatus,statusCheckRollup > "$PR_JSON"; then
+  echo "ERROR: failed to fetch PR metadata" >&2
+  exit 1
+fi
+if ! gh pr checks "$PR" --repo "$REPO" > "$CHECKS_TXT"; then
+  # keep output for diagnostics even when exit code is non-zero
+  true
+fi
+if ! gh pr view "$PR" --repo "$REPO" --json comments --jq '.comments[].body' > "$COMMENTS_TXT"; then
+  echo "ERROR: failed to fetch PR comments" >&2
+  exit 1
+fi
+
+# Resolve default branch
+DEFAULT_BRANCH="$(gh repo view "$REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')"
+if [[ -z "$DEFAULT_BRANCH" || "$DEFAULT_BRANCH" == "null" ]]; then
+  echo "ERROR: failed to resolve default branch" >&2
+  exit 1
+fi
+
+# Fetch workflow and reviewer config from default branch
+if ! gh api "repos/$REPO/contents/.github/workflows/review-intelligencex.yml?ref=$DEFAULT_BRANCH" --jq '.content' \
+  | tr -d '\n' | base64 --decode > "$WORKFLOW_YAML"; then
+  echo "ERROR: reviewer workflow not found on $DEFAULT_BRANCH" >&2
+  exit 1
+fi
+
+gh api "repos/$REPO/contents/.intelligencex/reviewer.json?ref=$DEFAULT_BRANCH" --jq '.content' \
+  | tr -d '\n' | base64 --decode > "$REVIEWER_JSON" 2>/dev/null || true
+
+# Validate managed workflow shape (reuse bootstrap validator)
+VALIDATOR="$ROOT/.agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.sh"
+if [[ -x "$VALIDATOR" ]]; then
+  "$VALIDATOR" "$WORKFLOW_YAML"
+else
+  if ! rg -q '# INTELLIGENCEX:BEGIN' "$WORKFLOW_YAML"; then
+    echo "ERROR: workflow missing INTELLIGENCEX:BEGIN" >&2
+    exit 1
+  fi
+  if ! rg -q '# INTELLIGENCEX:END' "$WORKFLOW_YAML"; then
+    echo "ERROR: workflow missing INTELLIGENCEX:END" >&2
+    exit 1
+  fi
+fi
+
+if [[ "$REQUIRE_CONFIG" -eq 1 && ! -s "$REVIEWER_JSON" ]]; then
+  echo "ERROR: reviewer config required but missing on default branch" >&2
+  exit 1
+fi
+
+# Verify required check conclusions (allow case variants)
+require_check_success() {
+  local check_name="$1"
+  local conclusion
+  conclusion="$(gh pr view "$PR" --repo "$REPO" --json statusCheckRollup \
+    --jq ".statusCheckRollup[] | select(.name == \"$check_name\") | .conclusion" | head -n1 || true)"
+
+  if [[ -z "$conclusion" ]]; then
+    echo "ERROR: required check not found: $check_name" >&2
+    exit 1
+  fi
+
+  local norm
+  norm="$(printf '%s' "$conclusion" | tr '[:lower:]' '[:upper:]')"
+  if [[ "$norm" != "SUCCESS" ]]; then
+    echo "ERROR: check '$check_name' is not SUCCESS (got: $conclusion)" >&2
+    exit 1
+  fi
+}
+
+require_check_success "Static Analysis Gate"
+require_check_success "AI Review (Fail-Open)"
+require_check_success "Ubuntu"
+
+# Reviewer comment markers
+if ! rg -q '<!-- intelligencex:summary -->' "$COMMENTS_TXT"; then
+  echo "ERROR: reviewer sticky summary marker not found" >&2
+  exit 1
+fi
+if ! rg -q 'Reviewed commit:' "$COMMENTS_TXT"; then
+  echo "ERROR: reviewed commit label not found in comments" >&2
+  exit 1
+fi
+if ! rg -q 'Diff range:' "$COMMENTS_TXT"; then
+  echo "ERROR: diff range label not found in comments" >&2
+  exit 1
+fi
+
+if [[ "$REQUIRE_ANALYSIS_SECTIONS" -eq 1 ]]; then
+  if ! rg -q '### Static Analysis Policy' "$COMMENTS_TXT"; then
+    echo "ERROR: Static Analysis Policy section not found" >&2
+    exit 1
+  fi
+  if ! rg -q '### Static Analysis' "$COMMENTS_TXT"; then
+    echo "ERROR: Static Analysis section not found" >&2
+    exit 1
+  fi
+fi
+
+echo "OK: first PR rollout verification passed"
+echo "repo=$REPO"
+echo "pr=$PR"
+echo "default_branch=$DEFAULT_BRANCH"
+echo "snapshot_dir=$RUN_DIR"
+echo "pr_json=$PR_JSON"
+echo "checks_txt=$CHECKS_TXT"
+echo "comments_txt=$COMMENTS_TXT"
+echo "workflow_yaml=$WORKFLOW_YAML"
+if [[ -s "$REVIEWER_JSON" ]]; then
+  echo "reviewer_json=$REVIEWER_JSON"
+else
+  echo "reviewer_json=missing"
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ When an agent is assigned a PR to improve or unblock, it must iterate until merg
 - Preferred skills by task type:
   - Onboarding/setup UX and flows: `/.agents/skills/intelligencex-onboarding-setup/SKILL.md`
   - Reviewer bootstrap (`reviewer.json` + workflow YAML): `/.agents/skills/intelligencex-reviewer-bootstrap/SKILL.md`
+  - First PR rollout verification: `/.agents/skills/intelligencex-first-pr-rollout/SKILL.md`
   - Analysis/catalog/gate work: `/.agents/skills/intelligencex-analysis-gate/SKILL.md`
   - PR unblock/merge loop: `/.agents/skills/intelligencex-pr-unblock-loop/SKILL.md`
 - Follow each skill's strict execution order and helper scripts before posting PR updates.


### PR DESCRIPTION
## Summary
- Add a new repo-local skill: `intelligencex-first-pr-rollout`.
- Include acceptance criteria + report template for post-onboarding rollout verification.
- Add runnable verifier script:
  - checks reviewer workflow presence/managed block on default branch
  - verifies required PR checks are green
  - verifies sticky summary markers (`Reviewed commit`, `Diff range`)
  - optionally enforces static-analysis sections and reviewer config presence
- Wire the skill into `.agents/skills/README.md` and `AGENTS.md` discovery list.

## Validation
- `bash -n .agents/skills/intelligencex-first-pr-rollout/scripts/verify-first-pr-rollout.sh`
- `./.agents/skills/intelligencex-first-pr-rollout/scripts/verify-first-pr-rollout.sh --repo EvotecIT/IntelligenceX --pr 210 --require-config --require-analysis-sections`
