### PR TITLE
Clamp legacy baseline line parsing in analyze gate

### DIFF
--- a/IntelligenceX.Cli/Analysis/AnalyzeGateBaseline.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeGateBaseline.cs
@@ -114,7 +114,7 @@ internal static class AnalyzeGateBaseline {
             if (string.IsNullOrWhiteSpace(key)) {
                 key = BuildBaselineKey(new AnalysisFinding(
                     Path: obj.GetString("path") ?? string.Empty,
-                    Line: (int)(obj.GetInt64("line") ?? 0),
+                    Line: ReadLineForBaselineItem(obj),
                     Message: obj.GetString("message") ?? string.Empty,
                     Severity: obj.GetString("severity") ?? "unknown",
                     RuleId: obj.GetString("ruleId"),
@@ -181,6 +181,17 @@ internal static class AnalyzeGateBaseline {
         return trimmed.Substring(0, first + 1) +
                NormalizePathForBaselineKey(path) +
                trimmed.Substring(second);
+    }
+
+    private static int ReadLineForBaselineItem(JsonObject obj) {
+        var line = obj.GetInt64("line");
+        if (!line.HasValue || line.Value <= 0) {
+            return 0;
+        }
+        if (line.Value >= int.MaxValue) {
+            return int.MaxValue;
+        }
+        return (int)line.Value;
     }
 
     private static string FormatExceptionMessage(Exception ex) {

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Baseline.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Baseline.cs
@@ -215,6 +215,77 @@ internal static partial class Program {
         }
     }
 
+    private static void TestAnalyzeGateNewIssuesOnlyLargeLegacyLineDoesNotWrapToZero() {
+        var temp = Path.Combine(Path.GetTempPath(), "ix-analyze-gate-baseline-line-clamp-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        try {
+            SeedMinimalGateCatalog(temp);
+            Directory.CreateDirectory(Path.Combine(temp, "artifacts"));
+            Directory.CreateDirectory(Path.Combine(temp, ".intelligencex"));
+
+            File.WriteAllText(Path.Combine(temp, "artifacts", "intelligencex.findings.json"), """
+{
+  "schema": "intelligencex.findings.v1",
+  "items": [
+    {
+      "path": "src/test.cs",
+      "line": 0,
+      "severity": "warning",
+      "message": "Broken.",
+      "ruleId": "IX001",
+      "tool": "IntelligenceX"
+    }
+  ]
+}
+""");
+            File.WriteAllText(Path.Combine(temp, ".intelligencex", "analysis-baseline.json"), """
+{
+  "schema": "intelligencex.findings.v1",
+  "items": [
+    {
+      "path": "src/test.cs",
+      "line": 9223372036854775807,
+      "severity": "warning",
+      "message": "Broken.",
+      "ruleId": "IX001",
+      "tool": "IntelligenceX"
+    }
+  ]
+}
+""");
+            var configPath = Path.Combine(temp, ".intelligencex", "reviewer.json");
+            File.WriteAllText(configPath, """
+{
+  "analysis": {
+    "enabled": true,
+    "packs": ["all-50"],
+    "gate": {
+      "enabled": true,
+      "newIssuesOnly": true,
+      "baselinePath": ".intelligencex/analysis-baseline.json",
+      "failOnUnavailable": true
+    },
+    "results": { "inputs": ["artifacts/intelligencex.findings.json"] }
+  }
+}
+""");
+
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
+            var exit = IntelligenceX.Cli.Analysis.AnalyzeRunner.RunAsync(new[] {
+                "gate",
+                "--workspace", temp,
+                "--config", configPath
+            }).GetAwaiter().GetResult();
+            AssertEqual(2, exit, "analyze gate large legacy line does not wrap and suppress line 0 finding");
+        } finally {
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
+            if (Directory.Exists(temp)) {
+                Directory.Delete(temp, true);
+            }
+        }
+    }
+
     private static void TestAnalyzeGateNewIssuesOnlyMissingBaselineIsUnavailable() {
         var temp = Path.Combine(Path.GetTempPath(), "ix-analyze-gate-baseline-missing-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(temp);

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -173,6 +173,8 @@ internal static partial class Program {
         failed += Run("Analyze gate new-only suppresses baseline findings", TestAnalyzeGateNewIssuesOnlySuppressesBaselineFindings);
         failed += Run("Analyze gate new-only fails for new findings", TestAnalyzeGateNewIssuesOnlyFailsForNewFindings);
         failed += Run("Analyze gate new-only missing baseline schema logs inference", TestAnalyzeGateNewIssuesOnlyMissingSchemaLogsInference);
+        failed += Run("Analyze gate new-only large legacy line does not wrap to zero",
+            TestAnalyzeGateNewIssuesOnlyLargeLegacyLineDoesNotWrapToZero);
         failed += Run("Analyze gate new-only missing baseline unavailable", TestAnalyzeGateNewIssuesOnlyMissingBaselineIsUnavailable);
         failed += Run("Analyze gate new-only missing baseline can pass when unavailable allowed",
             TestAnalyzeGateNewIssuesOnlyMissingBaselineCanPassWhenUnavailableAllowed);


### PR DESCRIPTION
## Summary
- harden legacy baseline line parsing by clamping `items[].line` to a safe int range when reconstructing baseline keys
- prevent overflow wrapping from large legacy `line` values that could incorrectly normalize to line `0`
- add regression test proving huge legacy line values do not suppress real line `0` findings in `newIssuesOnly` mode

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
