### PR TITLE
Refine legacy baseline line parsing boundary semantics

### DIFF
--- a/IntelligenceX.Cli/Analysis/AnalyzeGateBaseline.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeGateBaseline.cs
@@ -188,7 +188,7 @@ internal static class AnalyzeGateBaseline {
         if (!line.HasValue || line.Value <= 0) {
             return 0;
         }
-        if (line.Value >= int.MaxValue) {
+        if (line.Value > int.MaxValue) {
             return int.MaxValue;
         }
         return (int)line.Value;

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Baseline.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Baseline.cs
@@ -286,6 +286,77 @@ internal static partial class Program {
         }
     }
 
+    private static void TestAnalyzeGateNewIssuesOnlyLegacyLineIntMaxMatchesIntMaxFinding() {
+        var temp = Path.Combine(Path.GetTempPath(), "ix-analyze-gate-baseline-line-intmax-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        var previousWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        try {
+            SeedMinimalGateCatalog(temp);
+            Directory.CreateDirectory(Path.Combine(temp, "artifacts"));
+            Directory.CreateDirectory(Path.Combine(temp, ".intelligencex"));
+
+            File.WriteAllText(Path.Combine(temp, "artifacts", "intelligencex.findings.json"), """
+{
+  "schema": "intelligencex.findings.v1",
+  "items": [
+    {
+      "path": "src/test.cs",
+      "line": 2147483647,
+      "severity": "warning",
+      "message": "Broken.",
+      "ruleId": "IX001",
+      "tool": "IntelligenceX"
+    }
+  ]
+}
+""");
+            File.WriteAllText(Path.Combine(temp, ".intelligencex", "analysis-baseline.json"), """
+{
+  "schema": "intelligencex.findings.v1",
+  "items": [
+    {
+      "path": "src/test.cs",
+      "line": 2147483647,
+      "severity": "warning",
+      "message": "Broken.",
+      "ruleId": "IX001",
+      "tool": "IntelligenceX"
+    }
+  ]
+}
+""");
+            var configPath = Path.Combine(temp, ".intelligencex", "reviewer.json");
+            File.WriteAllText(configPath, """
+{
+  "analysis": {
+    "enabled": true,
+    "packs": ["all-50"],
+    "gate": {
+      "enabled": true,
+      "newIssuesOnly": true,
+      "baselinePath": ".intelligencex/analysis-baseline.json",
+      "failOnUnavailable": true
+    },
+    "results": { "inputs": ["artifacts/intelligencex.findings.json"] }
+  }
+}
+""");
+
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", temp);
+            var exit = IntelligenceX.Cli.Analysis.AnalyzeRunner.RunAsync(new[] {
+                "gate",
+                "--workspace", temp,
+                "--config", configPath
+            }).GetAwaiter().GetResult();
+            AssertEqual(0, exit, "analyze gate preserves int-max legacy line and suppresses matching finding");
+        } finally {
+            Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
+            if (Directory.Exists(temp)) {
+                Directory.Delete(temp, true);
+            }
+        }
+    }
+
     private static void TestAnalyzeGateNewIssuesOnlyMissingBaselineIsUnavailable() {
         var temp = Path.Combine(Path.GetTempPath(), "ix-analyze-gate-baseline-missing-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(temp);

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -175,6 +175,8 @@ internal static partial class Program {
         failed += Run("Analyze gate new-only missing baseline schema logs inference", TestAnalyzeGateNewIssuesOnlyMissingSchemaLogsInference);
         failed += Run("Analyze gate new-only large legacy line does not wrap to zero",
             TestAnalyzeGateNewIssuesOnlyLargeLegacyLineDoesNotWrapToZero);
+        failed += Run("Analyze gate new-only legacy line int-max matches int-max finding",
+            TestAnalyzeGateNewIssuesOnlyLegacyLineIntMaxMatchesIntMaxFinding);
         failed += Run("Analyze gate new-only missing baseline unavailable", TestAnalyzeGateNewIssuesOnlyMissingBaselineIsUnavailable);
         failed += Run("Analyze gate new-only missing baseline can pass when unavailable allowed",
             TestAnalyzeGateNewIssuesOnlyMissingBaselineCanPassWhenUnavailableAllowed);


### PR DESCRIPTION
## Summary
- apply precision tweak in legacy baseline line parser: clamp only when `line > int.MaxValue` (not `>=`)
- preserve exact `int.MaxValue` as a normal in-range value
- add regression test confirming `int.MaxValue` baseline line still suppresses matching `int.MaxValue` findings in `newIssuesOnly` mode

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
