### PR TITLE
Handle IO exceptions during directory enumeration

### DIFF
--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.cs
@@ -342,6 +342,8 @@ function Get-AnalyzerPaths {
             continue
         } catch [System.IO.DirectoryNotFoundException] {
             continue
+        } catch [System.IO.IOException] {
+            continue
         }
 
         try {


### PR DESCRIPTION
## Summary
- add missing `catch [System.IO.IOException]` around `EnumerateDirectories($current)` in the PowerShell analyzer traversal loop
- keep directory traversal behavior consistent with file enumeration and attribute-read paths

## Why
`Get-AnalyzerPaths` already handled `IOException` in related traversal/attribute blocks, but not in the outer directory-enumeration catch chain. This could terminate traversal prematurely on transient filesystem IO errors.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
