### PR TITLE
Add regression assertion for directory IO catch block

### DIFF
--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
@@ -17,6 +17,9 @@ internal static partial class Program {
         AssertContainsText(script, "System.Collections.Generic.List[object]", "powershell runner uses typed list result aggregation");
         AssertContainsText(script, "catch [System.UnauthorizedAccessException]", "powershell runner handles expected access exceptions");
         AssertContainsText(script, "catch [System.IO.IOException]", "powershell runner handles expected io exceptions");
+        AssertContainsText(script,
+            "catch [System.IO.IOException] {\n            continue\n        }\n\n        try {\n            foreach ($file in [System.IO.Directory]::EnumerateFiles($current))",
+            "powershell runner handles io exceptions in directory enumeration");
         AssertContainsText(script, "if ($analysisPaths.Length -gt 0)", "powershell runner handles empty path list");
         AssertContainsText(script, "foreach ($analysisPath in $analysisPaths)", "powershell runner iterates filtered paths");
         AssertContainsText(script, "Invoke-ScriptAnalyzer -Path $analysisPath", "powershell runner invokes analyzer per path");


### PR DESCRIPTION
## Summary
- add a focused test assertion that verifies the generated PowerShell runner script includes `catch [System.IO.IOException]` in the directory-enumeration catch chain (before file enumeration starts)

## Why
We recently added `IOException` handling for directory enumeration in `Get-AnalyzerPaths`. This test locks that behavior so future script refactors do not accidentally drop the catch path.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
