### PR TITLE
Harden PowerShell runner script assertion

### DIFF
--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
@@ -17,8 +17,12 @@ internal static partial class Program {
         AssertContainsText(script, "System.Collections.Generic.List[object]", "powershell runner uses typed list result aggregation");
         AssertContainsText(script, "catch [System.UnauthorizedAccessException]", "powershell runner handles expected access exceptions");
         AssertContainsText(script, "catch [System.IO.IOException]", "powershell runner handles expected io exceptions");
+        var compactScript = string.Join(" ", script.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
         AssertContainsText(script,
-            "catch [System.IO.IOException] {\n            continue\n        }\n\n        try {\n            foreach ($file in [System.IO.Directory]::EnumerateFiles($current))",
+            "foreach ($file in [System.IO.Directory]::EnumerateFiles($current))",
+            "powershell runner enumerates files");
+        AssertContainsText(compactScript,
+            "catch [System.IO.IOException] { continue } try { foreach ($file in [System.IO.Directory]::EnumerateFiles($current))",
             "powershell runner handles io exceptions in directory enumeration");
         AssertContainsText(script, "if ($analysisPaths.Length -gt 0)", "powershell runner handles empty path list");
         AssertContainsText(script, "foreach ($analysisPath in $analysisPaths)", "powershell runner iterates filtered paths");


### PR DESCRIPTION
## Summary
- harden `TestAnalyzeRunPowerShellScriptCapturesEngineErrors` by removing a brittle exact-newline string assertion
- normalize script whitespace in-test and assert the catch/continue/file-enumeration token sequence
- add an explicit file-enumeration presence assertion to keep intent clear

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
