### PR TITLE
Add setup config generation merge regression test

### DIFF
--- a/IntelligenceX.Cli/Setup/SetupRunner.FilePlanning.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.FilePlanning.cs
@@ -68,6 +68,13 @@ internal static partial class SetupRunner {
     [Obsolete("Use BuildReviewerConfigJson for production and new call sites.")]
     internal static string BuildReviewerConfigJsonForTests(string[] args) => BuildReviewerConfigJson(args);
 
+    // Test helper for merge coverage against existing reviewer.json content.
+    internal static string BuildReviewerConfigJsonFromSeedForTests(string[] args, string seedContent) {
+        var options = SetupOptions.Parse(args);
+        var plan = PlanConfigChange(options, existingReviewerContent: seedContent, seedContent: seedContent);
+        return plan.Content ?? string.Empty;
+    }
+
     private static string? ReadConfigOverride(SetupOptions options) {
         if (!string.IsNullOrWhiteSpace(options.ConfigJson)) {
             return options.ConfigJson;

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -79,6 +79,54 @@ internal static partial class Program {
         AssertEqual(true, gate!["enabled"]?.GetValue<bool>(), "analysis.gate.enabled");
     }
 
+    private static void TestSetupBuildConfigJsonMergePreservesReviewSettingsWhenEnablingAnalysis() {
+        var seed = """
+{
+  "review": {
+    "provider": "openai",
+    "openaiTransport": "native",
+    "model": "gpt-5-mini",
+    "profile": "security",
+    "mode": "summary",
+    "commentMode": "sticky",
+    "includeIssueComments": false,
+    "includeReviewComments": true,
+    "includeRelatedPullRequests": false,
+    "progressUpdates": false,
+    "diagnostics": false,
+    "preflight": true,
+    "preflightTimeoutSeconds": 30,
+    "customReviewFlag": "keep-me"
+  }
+}
+""";
+
+        var content = SetupRunner.BuildReviewerConfigJsonFromSeedForTests(
+            new[] { "--analysis-enabled", "true", "--analysis-gate", "true" },
+            seed);
+        AssertNotNull(content, "config json merge content");
+
+        var root = System.Text.Json.Nodes.JsonNode.Parse(content) as System.Text.Json.Nodes.JsonObject;
+        AssertNotNull(root, "config json merge root");
+
+        var review = root!["review"] as System.Text.Json.Nodes.JsonObject;
+        AssertNotNull(review, "config json merge review");
+        AssertEqual("keep-me", review!["customReviewFlag"]?.GetValue<string>(), "config json merge keeps custom review key");
+        AssertEqual("security", review["profile"]?.GetValue<string>(), "config json merge keeps existing profile");
+
+        var analysis = root["analysis"] as System.Text.Json.Nodes.JsonObject;
+        AssertNotNull(analysis, "config json merge analysis object");
+        AssertEqual(true, analysis!["enabled"]?.GetValue<bool>(), "config json merge analysis.enabled");
+
+        var gate = analysis["gate"] as System.Text.Json.Nodes.JsonObject;
+        AssertNotNull(gate, "config json merge analysis.gate");
+        AssertEqual(true, gate!["enabled"]?.GetValue<bool>(), "config json merge analysis.gate.enabled");
+
+        var packsNode = analysis["packs"] as System.Text.Json.Nodes.JsonArray;
+        AssertNotNull(packsNode, "config json merge analysis.packs");
+        AssertEqual(true, packsNode!.Count > 0, "config json merge analysis.packs has values");
+    }
+
     private static void TestGitHubRepoDetectorParsesRemoteUrls() {
         AssertEqual("owner/repo", GitHubRepoDetector.ParseRepoFromRemoteUrl("https://github.com/owner/repo.git"), "https git");
         AssertEqual("owner/repo", GitHubRepoDetector.ParseRepoFromRemoteUrl("https://github.com/owner/repo"), "https no git");

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -49,6 +49,7 @@ internal static partial class Program {
         failed += Run("Setup analysis disable writes enabled=false", TestSetupAnalysisDisableWritesFalse);
         failed += Run("Setup analysis defaults packs to all-50", TestSetupAnalysisDefaultsPacksToAll50);
         failed += Run("Setup config build honors analysis gate", TestSetupBuildConfigJsonHonorsAnalysisGateOnNewConfig);
+        failed += Run("Setup config merge preserves review settings when enabling analysis", TestSetupBuildConfigJsonMergePreservesReviewSettingsWhenEnablingAnalysis);
         failed += Run("CLI dispatch no-args interactive runs manage", TestCliDispatchNoArgsInteractiveRunsManage);
         failed += Run("CLI dispatch no-args non-interactive shows help", TestCliDispatchNoArgsNonInteractiveShowsHelp);
         failed += Run("CLI dispatch manage command routes to manage", TestCliDispatchManageCommandRoutesToManage);

--- a/TODO.md
+++ b/TODO.md
@@ -45,7 +45,7 @@ Goal: reviewer + static analysis + onboarding (CLI + Web) feel "done" end-to-end
 - [ ] Add screenshots (CLI + Web) for the "Configure" step and the "Verify" step.
 
 ### Phase F — End-To-End Tests
-- [ ] Add tests for setup plan generation: ensure enabling analysis produces `analysis` in reviewer.json and does not regress existing review settings.
+- [x] Add tests for setup plan generation: ensure enabling analysis produces `analysis` in reviewer.json and does not regress existing review settings.
 - [x] Add tests for config merge behavior (existing reviewer.json + enable analysis preserves unrelated user keys).
 - [x] Add unit tests for `SetupAnalysisPacks.TryNormalizeCsv` (empty/default, invalid chars, max ids/length, dedupe).
 - [ ] Add tests for web setup validation: analysis fields rejected when not applicable (config override, update-secret/cleanup), and rejected when `analysisEnabled != true` but gate/packs provided.


### PR DESCRIPTION
## Summary
- add seeded-config test helper `SetupRunner.BuildReviewerConfigJsonFromSeedForTests` for merge-coverage scenarios
- add regression test `TestSetupBuildConfigJsonMergePreservesReviewSettingsWhenEnablingAnalysis`
  - verifies enabling analysis on existing reviewer config keeps existing review settings/custom keys
  - verifies analysis section is produced with gate enabled and packs present
- register the new test in the custom test harness
- mark the corresponding Phase F setup-plan generation test item complete in `TODO.md`

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
