### PR TITLE
Expand web setup analysis validation tests

### DIFF
--- a/IntelligenceX.UnitTests/WebSetupAnalysisValidatorTests.cs
+++ b/IntelligenceX.UnitTests/WebSetupAnalysisValidatorTests.cs
@@ -24,6 +24,44 @@ public sealed class WebSetupAnalysisValidatorTests {
     }
 
     [Fact]
+    public void UpdateSecret_WithAnalysisFields_Fails() {
+        // update-secret requests are non-setup mode in WebApi and must reject analysis options.
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: false,
+            withConfig: true,
+            hasConfigOverride: false,
+            analysisEnabled: true,
+            analysisGateEnabled: null,
+            analysisPacks: null,
+            normalizedEnabled: out _,
+            normalizedGateEnabled: out _,
+            normalizedPacks: out _,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+
+    [Fact]
+    public void Cleanup_WithAnalysisFields_Fails() {
+        // cleanup requests are non-setup mode in WebApi and must reject analysis options.
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: false,
+            withConfig: true,
+            hasConfigOverride: false,
+            analysisEnabled: null,
+            analysisGateEnabled: null,
+            analysisPacks: "all-50",
+            normalizedEnabled: out _,
+            normalizedGateEnabled: out _,
+            normalizedPacks: out _,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+
+    [Fact]
     public void WithoutConfig_WithAnalysisFields_Fails() {
         var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
             isSetup: true,
@@ -96,6 +134,42 @@ public sealed class WebSetupAnalysisValidatorTests {
     }
 
     [Fact]
+    public void AnalysisEnabledFalse_GateEnabled_Fails() {
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: true,
+            withConfig: true,
+            hasConfigOverride: false,
+            analysisEnabled: false,
+            analysisGateEnabled: true,
+            analysisPacks: null,
+            normalizedEnabled: out _,
+            normalizedGateEnabled: out _,
+            normalizedPacks: out _,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.Contains("require", error ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AnalysisEnabledNull_PacksProvided_Fails() {
+        var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
+            isSetup: true,
+            withConfig: true,
+            hasConfigOverride: false,
+            analysisEnabled: null,
+            analysisGateEnabled: null,
+            analysisPacks: "all-50",
+            normalizedEnabled: out _,
+            normalizedGateEnabled: out _,
+            normalizedPacks: out _,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.Contains("require", error ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void AnalysisEnabledTrue_InvalidPacks_Fails() {
         var ok = WebSetupAnalysisValidator.TryValidateAndNormalize(
             isSetup: true,
@@ -155,4 +229,3 @@ public sealed class WebSetupAnalysisValidatorTests {
         Assert.Null(normalizedPacks);
     }
 }
-

--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,7 @@ Goal: reviewer + static analysis + onboarding (CLI + Web) feel "done" end-to-end
 - [x] Add tests for setup plan generation: ensure enabling analysis produces `analysis` in reviewer.json and does not regress existing review settings.
 - [x] Add tests for config merge behavior (existing reviewer.json + enable analysis preserves unrelated user keys).
 - [x] Add unit tests for `SetupAnalysisPacks.TryNormalizeCsv` (empty/default, invalid chars, max ids/length, dedupe).
-- [ ] Add tests for web setup validation: analysis fields rejected when not applicable (config override, update-secret/cleanup), and rejected when `analysisEnabled != true` but gate/packs provided.
+- [x] Add tests for web setup validation: analysis fields rejected when not applicable (config override, update-secret/cleanup), and rejected when `analysisEnabled != true` but gate/packs provided.
 
 ## Engine Roadmap
 Status: In progress


### PR DESCRIPTION
## Summary
- expand `WebSetupAnalysisValidatorTests` to explicitly cover non-setup modes used by web onboarding flows
  - `update-secret` requests reject analysis options
  - `cleanup` requests reject analysis options
- strengthen `analysisEnabled != true` rejection coverage by adding:
  - `analysisEnabled=false` + `analysisGateEnabled`
  - `analysisEnabled=null` + `analysisPacks`
- mark the corresponding web setup validation backlog checkbox complete in `TODO.md`

## Validation
- `dotnet test IntelligenceX.UnitTests/IntelligenceX.UnitTests.csproj -c Release`
