### PR TITLE
Add no-analysis setup preset handling

### DIFF
--- a/IntelligenceX.Cli/Setup/Host/SetupArgsBuilder.cs
+++ b/IntelligenceX.Cli/Setup/Host/SetupArgsBuilder.cs
@@ -95,12 +95,14 @@ internal static class SetupArgsBuilder {
             args.Add(plan.AnalysisEnabled.Value ? "true" : "false");
         }
 
-        if (plan.AnalysisGateEnabled.HasValue) {
+        var analysisAllowsGateAndPacks = plan.AnalysisEnabled != false;
+
+        if (analysisAllowsGateAndPacks && plan.AnalysisGateEnabled.HasValue) {
             args.Add("--analysis-gate");
             args.Add(plan.AnalysisGateEnabled.Value ? "true" : "false");
         }
 
-        if (!string.IsNullOrWhiteSpace(plan.AnalysisPacks)) {
+        if (analysisAllowsGateAndPacks && !string.IsNullOrWhiteSpace(plan.AnalysisPacks)) {
             args.Add("--analysis-packs");
             args.Add(plan.AnalysisPacks);
         }
@@ -149,4 +151,3 @@ internal static class SetupArgsBuilder {
         return args.ToArray();
     }
 }
-

--- a/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
@@ -7,6 +7,8 @@ using Spectre.Console;
 namespace IntelligenceX.Cli.Setup.Wizard;
 
 internal static class WizardPrompts {
+    internal const string DisableAnalysisSelection = "__disable_analysis__";
+
     public static string PromptRepo(string? current) {
         var prompt = new TextPrompt<string>("Repository (owner/name):")
             .Validate(value => value.Contains('/')
@@ -249,6 +251,7 @@ internal static class WizardPrompts {
             "(default: all-50)",
             "all-100",
             "all-500",
+            "none (disable static analysis)",
             "all-security-default",
             "powershell-50",
             "custom (enter pack ids)"
@@ -265,6 +268,9 @@ internal static class WizardPrompts {
                 .AddChoices(choices));
         if (string.Equals(selected, "(default: all-50)", StringComparison.Ordinal)) {
             return null;
+        }
+        if (string.Equals(selected, "none (disable static analysis)", StringComparison.Ordinal)) {
+            return DisableAnalysisSelection;
         }
         if (selected.StartsWith("(keep current:", StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(current)) {
             return current;

--- a/IntelligenceX.Cli/Setup/Wizard/WizardRunner.Helpers.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/WizardRunner.Helpers.cs
@@ -32,6 +32,12 @@ internal static partial class WizardRunner {
         }
 
         state.AnalysisPacks = WizardPrompts.PromptAnalysisPacks(state.AnalysisPacks);
+        if (string.Equals(state.AnalysisPacks, WizardPrompts.DisableAnalysisSelection, StringComparison.Ordinal)) {
+            state.AnalysisEnabled = false;
+            state.AnalysisGateEnabled = null;
+            state.AnalysisPacks = null;
+            return;
+        }
         state.AnalysisGateEnabled = WizardPrompts.PromptAnalysisGateEnabled(state.AnalysisGateEnabled ?? false);
     }
 

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -25,6 +25,20 @@ internal static partial class Program {
         }, args, "setup args analysis");
     }
 
+    private static void TestSetupArgsDisableAnalysisOmitsGateAndPacks() {
+        var plan = new SetupPlan("owner/repo") {
+            AnalysisEnabled = false,
+            AnalysisGateEnabled = true,
+            AnalysisPacks = "all-100"
+        };
+
+        var args = SetupArgsBuilder.FromPlan(plan);
+        AssertSequenceEqual(new[] {
+            "--repo", "owner/repo",
+            "--analysis-enabled", "false"
+        }, args, "setup args analysis disabled");
+    }
+
     private static void TestSetupAnalysisDisableWritesFalse() {
         var root = new System.Text.Json.Nodes.JsonObject();
         SetupAnalysisConfig.Apply(

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -46,6 +46,7 @@ internal static partial class Program {
 #if !NET472
         failed += Run("Setup args reject skip+update", TestSetupArgsRejectSkipUpdate);
         failed += Run("Setup args include analysis options", TestSetupArgsIncludeAnalysisOptions);
+        failed += Run("Setup args disable analysis omits gate and packs", TestSetupArgsDisableAnalysisOmitsGateAndPacks);
         failed += Run("Setup analysis disable writes enabled=false", TestSetupAnalysisDisableWritesFalse);
         failed += Run("Setup analysis defaults packs to all-50", TestSetupAnalysisDefaultsPacksToAll50);
         failed += Run("Setup config build honors analysis gate", TestSetupBuildConfigJsonHonorsAnalysisGateOnNewConfig);

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@ Goal: reviewer + static analysis + onboarding (CLI + Web) feel "done" end-to-end
 
 ### Phase B — Setup Output (Workflow + reviewer.json)
 - [x] Setup config writer: include `analysis` section in `.intelligencex/reviewer.json` when static analysis is enabled (create + merge paths).
-- [ ] Setup presets: define recommended tiers for analysis packs (`all-50`, `all-100`, `all-500`) and a "no analysis" option.
+- [x] Setup presets: define recommended tiers for analysis packs (`all-50`, `all-100`, `all-500`) and a "no analysis" option.
 - [ ] Ensure workflow/config generation stays stable across upgrades (managed block upgrades do not delete user customization outside managed block).
 
 ### Phase C — Review Reliability (Reduce Churn, Increase Continuity)


### PR DESCRIPTION
## Summary
- add an explicit `none (disable static analysis)` choice in CLI setup wizard analysis pack presets
- when that choice is selected, clear analysis gate/packs and treat analysis as disabled
- harden setup arg building so `--analysis-gate`/`--analysis-packs` are omitted when `--analysis-enabled false`
- add regression test for disabled-analysis arg generation behavior
- mark the setup presets roadmap item complete in `TODO.md`

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
