### PR TITLE
Clarify analysis gate semantics in onboarding

### DIFF
--- a/IntelligenceX.Cli/Setup/Web/Assets/index.html
+++ b/IntelligenceX.Cli/Setup/Web/Assets/index.html
@@ -278,11 +278,11 @@
             <h3 style="margin: 12px 0 8px 0;">Static analysis</h3>
             <div class="row">
               <label class="inline"><input type="checkbox" id="analysisEnabled" /> Enable static analysis</label>
-              <label class="inline"><input type="checkbox" id="analysisGate" /> Fail PR on findings</label>
+              <label class="inline"><input type="checkbox" id="analysisGate" /> Fail PR on findings (vulnerability/bug at warning+)</label>
             </div>
             <label>Analysis pack ids (comma-separated)</label>
             <input id="analysisPacks" placeholder="(default: all-50)" />
-            <p class="hint" id="analysisHint">Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50.</p>
+            <p class="hint" id="analysisHint">Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50. Gate semantics/docs: Docs/reviewer/static-analysis.md</p>
 
             <label>Branch name (optional)</label>
             <input id="branchName" placeholder="setup/intelligencex" />

--- a/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
+++ b/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
@@ -1123,7 +1123,7 @@ function updateAnalysisControls() {
   const hint = $('analysisHint');
   if (hint) {
     hint.textContent = applicable
-      ? 'Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50.'
+      ? 'Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50. Gate semantics/docs: Docs/reviewer/static-analysis.md'
       : 'Static analysis settings apply only when generating config from presets (no Config JSON/path override).';
   }
 }

--- a/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
@@ -296,6 +296,7 @@ internal static class WizardPrompts {
     }
 
     public static bool PromptAnalysisGateEnabled(bool current) {
+        AnsiConsole.MarkupLine("[grey]Gate semantics: fail when enabled rules report vulnerability/bug findings at warning+ severity. Docs: Docs/reviewer/static-analysis.md[/]");
         return AnsiConsole.Confirm("Fail CI on static analysis findings?", current);
     }
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,7 @@ Goal: reviewer + static analysis + onboarding (CLI + Web) feel "done" end-to-end
 - [ ] Ensure thread triage does not repeatedly re-suggest already-addressed items; prefer dedupe and summary stability over rewriting.
 
 ### Phase D — Static Analysis Productization
-- [ ] Wizard: explain analysis gate semantics (which types/severities fail the check) and link to docs.
+- [x] Wizard: explain analysis gate semantics (which types/severities fail the check) and link to docs.
 - [ ] Add "list packs" affordance in onboarding (CLI and Web) so users can browse available packs.
 - [ ] Provide an optional "export analyzer config" path for IDE support (explicit opt-in, never default).
 - [ ] Add a CI guardrail: `intelligencex analyze validate-catalog` and pack integrity checks run on every PR that touches Analysis/Catalog or Analysis/Packs.


### PR DESCRIPTION
## Summary
- clarify static-analysis gate semantics in onboarding UX for both CLI wizard and web setup UI
- add explicit wording that gate failures are for vulnerability/bug findings at warning+ severity
- include docs pointer to `Docs/reviewer/static-analysis.md` in both surfaces
- mark the related roadmap item complete in `TODO.md`

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
