### PR TITLE
Add list-packs affordance to setup onboarding

### DIFF
--- a/IntelligenceX.Cli/Setup/Web/Assets/index.html
+++ b/IntelligenceX.Cli/Setup/Web/Assets/index.html
@@ -282,7 +282,7 @@
             </div>
             <label>Analysis pack ids (comma-separated)</label>
             <input id="analysisPacks" placeholder="(default: all-50)" />
-            <p class="hint" id="analysisHint">Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50. Gate semantics/docs: Docs/reviewer/static-analysis.md</p>
+            <p class="hint" id="analysisHint">Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50. Browse packs: `intelligencex analyze list-rules --workspace &lt;repo-root&gt; --format markdown`. Gate semantics/docs: Docs/reviewer/static-analysis.md</p>
 
             <label>Branch name (optional)</label>
             <input id="branchName" placeholder="setup/intelligencex" />

--- a/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
+++ b/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
@@ -1123,7 +1123,7 @@ function updateAnalysisControls() {
   const hint = $('analysisHint');
   if (hint) {
     hint.textContent = applicable
-      ? 'Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50. Gate semantics/docs: Docs/reviewer/static-analysis.md'
+      ? 'Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50. Browse packs: intelligencex analyze list-rules --workspace <repo-root> --format markdown. Gate semantics/docs: Docs/reviewer/static-analysis.md'
       : 'Static analysis settings apply only when generating config from presets (no Config JSON/path override).';
   }
 }

--- a/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
@@ -247,39 +247,47 @@ internal static class WizardPrompts {
     }
 
     public static string? PromptAnalysisPacks(string? current) {
-        var choices = new List<string> {
-            "(default: all-50)",
-            "all-100",
-            "all-500",
-            "none (disable static analysis)",
-            "all-security-default",
-            "powershell-50",
-            "custom (enter pack ids)"
-        };
-        if (!string.IsNullOrWhiteSpace(current) &&
-            !choices.Contains(current, StringComparer.Ordinal) &&
-            !string.Equals(current, "all-50", StringComparison.Ordinal)) {
-            choices.Insert(1, $"(keep current: {current})");
-        }
-        var selected = AnsiConsole.Prompt(
-            new SelectionPrompt<string>()
-                .Title("Static analysis pack(s):")
-                .PageSize(10)
-                .AddChoices(choices));
-        if (string.Equals(selected, "(default: all-50)", StringComparison.Ordinal)) {
-            return null;
-        }
-        if (string.Equals(selected, "none (disable static analysis)", StringComparison.Ordinal)) {
-            return DisableAnalysisSelection;
-        }
-        if (selected.StartsWith("(keep current:", StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(current)) {
-            return current;
-        }
-        if (!string.Equals(selected, "custom (enter pack ids)", StringComparison.Ordinal)) {
-            return selected;
-        }
-
         while (true) {
+            var choices = new List<string> {
+                "(default: all-50)",
+                "all-100",
+                "all-500",
+                "none (disable static analysis)",
+                "all-security-default",
+                "powershell-50",
+                "list available packs",
+                "custom (enter pack ids)"
+            };
+            if (!string.IsNullOrWhiteSpace(current) &&
+                !choices.Contains(current, StringComparer.Ordinal) &&
+                !string.Equals(current, "all-50", StringComparison.Ordinal)) {
+                choices.Insert(1, $"(keep current: {current})");
+            }
+            var selected = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Static analysis pack(s):")
+                    .PageSize(10)
+                    .AddChoices(choices));
+            if (string.Equals(selected, "(default: all-50)", StringComparison.Ordinal)) {
+                return null;
+            }
+            if (string.Equals(selected, "none (disable static analysis)", StringComparison.Ordinal)) {
+                return DisableAnalysisSelection;
+            }
+            if (selected.StartsWith("(keep current:", StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(current)) {
+                return current;
+            }
+            if (string.Equals(selected, "list available packs", StringComparison.Ordinal)) {
+                AnsiConsole.MarkupLine("[grey]Browse available packs:[/]");
+                AnsiConsole.MarkupLine("[grey]  intelligencex analyze list-rules --workspace . --format markdown[/]");
+                AnsiConsole.MarkupLine("[grey]  intelligencex analyze list-rules --workspace . --pack all-50[/]");
+                AnsiConsole.MarkupLine("[grey]Docs: Docs/reviewer/static-analysis.md[/]");
+                continue;
+            }
+            if (!string.Equals(selected, "custom (enter pack ids)", StringComparison.Ordinal)) {
+                return selected;
+            }
+
             var currentHint = string.IsNullOrWhiteSpace(current) ? string.Empty : $" (current: {current})";
             var prompt = new TextPrompt<string>($"Pack ids (comma-separated, empty for default){currentHint}:")
                 .AllowEmpty();

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@ Goal: reviewer + static analysis + onboarding (CLI + Web) feel "done" end-to-end
 
 ### Phase D — Static Analysis Productization
 - [x] Wizard: explain analysis gate semantics (which types/severities fail the check) and link to docs.
-- [ ] Add "list packs" affordance in onboarding (CLI and Web) so users can browse available packs.
+- [x] Add "list packs" affordance in onboarding (CLI and Web) so users can browse available packs.
 - [ ] Provide an optional "export analyzer config" path for IDE support (explicit opt-in, never default).
 - [ ] Add a CI guardrail: `intelligencex analyze validate-catalog` and pack integrity checks run on every PR that touches Analysis/Catalog or Analysis/Packs.
 


### PR DESCRIPTION
## Summary
- add a `list available packs` option in CLI setup analysis pack selection
- show concrete `intelligencex analyze list-rules ...` commands and static-analysis docs pointer when selected
- mirror the same list-rules guidance in Web setup analysis hint text
- mark the matching productization TODO item as complete

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
