### PR TITLE
Make setup parse helpers nullable-aware

### DIFF
--- a/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
@@ -71,7 +71,7 @@ internal static partial class SetupRunner {
         Console.WriteLine("  INTELLIGENCEX_OPENAI_ACCOUNT_ID");
     }
 
-    private static bool ParseBool(string value, bool fallback) {
+    private static bool ParseBool(string? value, bool fallback) {
         if (string.IsNullOrWhiteSpace(value)) {
             return fallback;
         }
@@ -82,7 +82,7 @@ internal static partial class SetupRunner {
         };
     }
 
-    private static double ParseDouble(string value, double fallback) {
+    private static double ParseDouble(string? value, double fallback) {
         if (string.IsNullOrWhiteSpace(value)) {
             return fallback;
         }
@@ -92,7 +92,7 @@ internal static partial class SetupRunner {
         return fallback;
     }
 
-    private static int ParseInt(string value, int fallback) {
+    private static int ParseInt(string? value, int fallback) {
         if (string.IsNullOrWhiteSpace(value)) {
             return fallback;
         }


### PR DESCRIPTION
## Summary
- change `SetupRunner` parse helper signatures to accept nullable input:
  - `ParseBool(string? value, bool fallback)`
  - `ParseDouble(string? value, double fallback)`
  - `ParseInt(string? value, int fallback)`
- preserve existing behavior (methods already handled null/whitespace defensively)
- aligns signatures with nullability expectations in call sites and stricter analysis contexts

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
