### PR TITLE
Add setup workflow upgrade stability regression

### DIFF
--- a/IntelligenceX.Cli/Setup/SetupRunner.FilePlanning.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.FilePlanning.cs
@@ -75,6 +75,13 @@ internal static partial class SetupRunner {
         return plan.Content ?? string.Empty;
     }
 
+    // Test helper for workflow upgrade coverage against existing workflow content.
+    internal static string BuildWorkflowYamlFromSeedForTests(string[] args, string seedContent) {
+        var options = SetupOptions.Parse(args);
+        var plan = PlanWorkflowChange(options, seedContent);
+        return plan.Content ?? string.Empty;
+    }
+
     private static string? ReadConfigOverride(SetupOptions options) {
         if (!string.IsNullOrWhiteSpace(options.ConfigJson)) {
             return options.ConfigJson;

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -233,6 +233,43 @@ internal static partial class Program {
         AssertEqual(true, packsNode!.Count > 0, "config json merge analysis.packs has values");
     }
 
+    private static void TestSetupWorkflowUpgradePreservesCustomSectionsOutsideManagedBlock() {
+        var seed = """
+name: IntelligenceX Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  custom_pre:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo pre
+  # INTELLIGENCEX:BEGIN
+  review:
+    uses: evotecit/github-actions/.github/workflows/review-intelligencex.yml@master
+    with:
+      provider: openai
+      model: gpt-5.3-codex
+  # INTELLIGENCEX:END
+  custom_post:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo post
+""";
+
+        var content = SetupRunner.BuildWorkflowYamlFromSeedForTests(
+            new[] { "--provider", "copilot" },
+            seed);
+
+        AssertContainsText(content, "custom_pre:", "workflow upgrade keeps custom_pre");
+        AssertContainsText(content, "custom_post:", "workflow upgrade keeps custom_post");
+        AssertContainsText(content, "provider: copilot", "workflow upgrade updates managed provider");
+        AssertContainsText(content, "# INTELLIGENCEX:BEGIN", "workflow upgrade keeps managed begin marker");
+        AssertContainsText(content, "# INTELLIGENCEX:END", "workflow upgrade keeps managed end marker");
+    }
+
     private static void TestGitHubRepoDetectorParsesRemoteUrls() {
         AssertEqual("owner/repo", GitHubRepoDetector.ParseRepoFromRemoteUrl("https://github.com/owner/repo.git"), "https git");
         AssertEqual("owner/repo", GitHubRepoDetector.ParseRepoFromRemoteUrl("https://github.com/owner/repo"), "https no git");

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -56,6 +56,8 @@ internal static partial class Program {
         failed += Run("Setup analysis defaults packs to all-50", TestSetupAnalysisDefaultsPacksToAll50);
         failed += Run("Setup config build honors analysis gate", TestSetupBuildConfigJsonHonorsAnalysisGateOnNewConfig);
         failed += Run("Setup config merge preserves review settings when enabling analysis", TestSetupBuildConfigJsonMergePreservesReviewSettingsWhenEnablingAnalysis);
+        failed += Run("Setup workflow upgrade preserves custom sections outside managed block",
+            TestSetupWorkflowUpgradePreservesCustomSectionsOutsideManagedBlock);
         failed += Run("CLI dispatch no-args interactive runs manage", TestCliDispatchNoArgsInteractiveRunsManage);
         failed += Run("CLI dispatch no-args non-interactive shows help", TestCliDispatchNoArgsNonInteractiveShowsHelp);
         failed += Run("CLI dispatch manage command routes to manage", TestCliDispatchManageCommandRoutesToManage);


### PR DESCRIPTION
## Summary
- add a setup regression test that validates managed-block workflow upgrades preserve user-defined jobs outside `INTELLIGENCEX` markers
- add a narrow test helper (`BuildWorkflowYamlFromSeedForTests`) to drive workflow planning from seeded content in tests
- verify managed section still updates expected values (`provider: copilot`) while custom sections remain intact

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
