### PR TITLE
Harden setup workflow-upgrade regression assertions

### DIFF
--- a/IntelligenceX.Cli/Setup/SetupRunner.FilePlanning.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.FilePlanning.cs
@@ -79,7 +79,7 @@ internal static partial class SetupRunner {
     internal static string BuildWorkflowYamlFromSeedForTests(string[] args, string seedContent) {
         var options = SetupOptions.Parse(args);
         var plan = PlanWorkflowChange(options, seedContent);
-        return plan.Content ?? string.Empty;
+        return plan.Content ?? seedContent;
     }
 
     private static string? ReadConfigOverride(SetupOptions options) {

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -268,6 +268,17 @@ jobs:
         AssertContainsText(content, "provider: copilot", "workflow upgrade updates managed provider");
         AssertContainsText(content, "# INTELLIGENCEX:BEGIN", "workflow upgrade keeps managed begin marker");
         AssertContainsText(content, "# INTELLIGENCEX:END", "workflow upgrade keeps managed end marker");
+        AssertEqual(1, CountOccurrences(content, "# INTELLIGENCEX:BEGIN"),
+            "workflow upgrade has single managed begin marker");
+        AssertEqual(1, CountOccurrences(content, "# INTELLIGENCEX:END"),
+            "workflow upgrade has single managed end marker");
+        AssertEqual(1, CountOccurrences(content, "provider: copilot"),
+            "workflow upgrade has single provider override");
+
+        var secondPass = SetupRunner.BuildWorkflowYamlFromSeedForTests(
+            new[] { "--provider", "copilot" },
+            content);
+        AssertEqual(content, secondPass, "workflow upgrade idempotent on second pass");
     }
 
     private static void TestGitHubRepoDetectorParsesRemoteUrls() {


### PR DESCRIPTION
## Summary
- strengthen `TestSetupWorkflowUpgradePreservesCustomSectionsOutsideManagedBlock` with:
  - uniqueness checks for managed markers and provider override
  - idempotency check for a second upgrade pass on already-upgraded content
- adjust workflow seed test helper so no-op plans return original seed content (instead of empty), allowing reliable idempotency assertions

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
