### PR TITLE
Harden web setup dry-run and verification output handling

### DIFF
--- a/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
+++ b/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
@@ -733,7 +733,10 @@ function formatResults(data) {
             const actual = safeCheck && safeCheck.actual != null
               ? String(safeCheck.actual)
               : 'n/a';
-            const note = safeCheck && safeCheck.note ? ` (${String(safeCheck.note)})` : '';
+            const checkNoteText = safeCheck && safeCheck.note != null
+              ? String(safeCheck.note).trim()
+              : '';
+            const note = checkNoteText.length > 0 ? ` (${checkNoteText})` : '';
             const checkName = safeCheck && safeCheck.name ? String(safeCheck.name) : 'check';
             lines.push(`- ${checkName}: ${checkStatus} (expected ${expected}, actual ${actual})${note}`);
           });

--- a/IntelligenceX.Cli/Setup/Web/WebApi.Setup.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebApi.Setup.cs
@@ -203,7 +203,6 @@ internal sealed partial class WebApi {
             }
 
             foreach (var repo in repos) {
-                var effectiveDryRun = dryRun || request.DryRun;
                 var args = BuildSetupArgsForRepo(request, dryRun, repo);
                 var withConfig = ResolveWithConfigFromArgs(args);
                 var secretOrgForRepo = ResolveSecretOrgForRepo(repo, request.SecretOrg);
@@ -218,7 +217,7 @@ internal sealed partial class WebApi {
                     SkipSecret = request.SkipSecret,
                     ManualSecret = request.ManualSecret,
                     KeepSecret = request.KeepSecret,
-                    DryRun = effectiveDryRun,
+                    DryRun = requestDryRun,
                     ExitSuccess = result.ExitCode == 0,
                     ExpectOrgSecret = orgSecretContext.ExpectOrgSecret,
                     SecretOrg = orgSecretContext.SecretOrg,

--- a/IntelligenceX.Cli/Setup/Wizard/GitHubRepoClient.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/GitHubRepoClient.cs
@@ -177,9 +177,12 @@ internal sealed class GitHubRepoClient : IDisposable {
         } catch (OperationCanceledException) {
             // Preserve cancellation semantics for callers that enforce timeouts/cancellation tokens.
             throw;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"GitHub secret lookup failed: {ex.GetType().Name}: {ex.Message}");
-            return SecretLookupResult.Unknown("GitHub secret lookup failed due to an unexpected client error.");
+        } catch (HttpRequestException ex) {
+            Trace.TraceWarning($"GitHub secret lookup HTTP failure: {ex.Message}");
+            return SecretLookupResult.Unknown("GitHub secret lookup failed due to an HTTP client error.");
+        } catch (InvalidOperationException ex) {
+            Trace.TraceWarning($"GitHub secret lookup client failure: {ex.Message}");
+            return SecretLookupResult.Unknown("GitHub secret lookup failed due to an HTTP client configuration error.");
         }
     }
 


### PR DESCRIPTION
## Summary
- remove duplicate dry-run recomputation in web setup apply loop and consistently use request-level effective dry-run for post-apply verification context
- narrow secret lookup exception handling to known HTTP/client error types while preserving cancellation behavior
- normalize web wizard verification check note rendering to trim whitespace and avoid empty note suffixes

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
