### PR TITLE
Harden GitHub repo client error handling and add regression tests

### DIFF
--- a/IntelligenceX.Cli/Setup/Wizard/GitHubRepoClient.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/GitHubRepoClient.cs
@@ -20,8 +20,9 @@ internal sealed class GitHubRepoClient : IDisposable {
         ConfigureDefaultHeaders(_http, token);
     }
 
-    internal GitHubRepoClient(HttpClient httpClient) {
+    internal GitHubRepoClient(HttpClient httpClient, string token = "test-token") {
         _http = httpClient;
+        ConfigureDefaultHeaders(_http, token);
     }
 
     public void Dispose() => _http.Dispose();

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -540,12 +540,33 @@ jobs:
         AssertEqual(null, file, "repo client file fetch invalid base64");
     }
 
+    private static void TestGitHubRepoClientInjectedHttpClientAppliesDefaultHeaders() {
+        System.Net.Http.HttpRequestMessage? capturedRequest = null;
+        using var client = CreateGitHubRepoClientForTests((request, _) => {
+            capturedRequest = request;
+            return Task.FromResult(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.NotFound));
+        }, token: "injected-token");
+
+        var result = client.TryRepoSecretExistsAsync("owner", "repo", "INTELLIGENCEX_AUTH_B64").GetAwaiter().GetResult();
+        AssertEqual("missing", result.Status, "repo client injected headers lookup status");
+        AssertNotNull(capturedRequest, "repo client injected headers captured request");
+        AssertEqual("Bearer", capturedRequest!.Headers.Authorization?.Scheme, "repo client injected headers auth scheme");
+        AssertEqual("injected-token", capturedRequest.Headers.Authorization?.Parameter, "repo client injected headers auth token");
+        AssertEqual(true, capturedRequest.Headers.UserAgent.ToString().Contains("IntelligenceX.Cli"), "repo client injected headers user agent");
+        AssertEqual(true, capturedRequest.Headers.Accept.ToString().Contains("application/vnd.github+json"), "repo client injected headers accept");
+        AssertEqual(true,
+            capturedRequest.Headers.TryGetValues("X-GitHub-Api-Version", out var values)
+            && values.Contains("2022-11-28"),
+            "repo client injected headers api version");
+    }
+
     private static IntelligenceX.Cli.Setup.Wizard.GitHubRepoClient CreateGitHubRepoClientForTests(
-        Func<System.Net.Http.HttpRequestMessage, CancellationToken, Task<System.Net.Http.HttpResponseMessage>> sendAsync) {
+        Func<System.Net.Http.HttpRequestMessage, CancellationToken, Task<System.Net.Http.HttpResponseMessage>> sendAsync,
+        string token = "test-token") {
         var http = new System.Net.Http.HttpClient(new DelegateHttpMessageHandler(sendAsync)) {
             BaseAddress = new Uri("https://api.github.com")
         };
-        return new IntelligenceX.Cli.Setup.Wizard.GitHubRepoClient(http);
+        return new IntelligenceX.Cli.Setup.Wizard.GitHubRepoClient(http, token);
     }
 
     private sealed class DelegateHttpMessageHandler : System.Net.Http.HttpMessageHandler {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -96,6 +96,7 @@ internal static partial class Program {
         failed += Run("GitHub repo client secret lookup cancellation propagates", TestGitHubRepoClientSecretLookupCancellationPropagates);
         failed += Run("GitHub repo client file fetch cancellation propagates", TestGitHubRepoClientFileFetchCancellationPropagates);
         failed += Run("GitHub repo client file fetch invalid base64 returns null", TestGitHubRepoClientFileFetchInvalidBase64ReturnsNull);
+        failed += Run("GitHub repo client injected http client applies default headers", TestGitHubRepoClientInjectedHttpClientAppliesDefaultHeaders);
         failed += Run("GitHub secrets reject empty value", TestGitHubSecretsRejectEmptyValue);
         failed += Run("Release reviewer env token", TestReleaseReviewerEnvToken);
         failed += Run("CI path safety rejects non-existent directory leaf", TestCiPathSafetyUnderRootPhysicalRejectsNonexistentDirectoryLeaf);


### PR DESCRIPTION
## Summary
- preserve cancellation semantics in `GitHubRepoClient.TryGetFileAsync` by no longer swallowing `OperationCanceledException`
- narrow `TryGetFileAsync` exception handling to expected HTTP/JSON/base64/client/payload failure paths
- add an internal `HttpClient` constructor seam for deterministic harness tests of repo client behavior
- add targeted setup harness tests for secret lookup status/error mapping and file fetch cancellation/base64 handling

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
