### PR TITLE
Harden GitHub repo client injected HttpClient lifecycle

### DIFF
--- a/IntelligenceX.Cli/Setup/Wizard/GitHubRepoClient.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/GitHubRepoClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -12,20 +13,27 @@ namespace IntelligenceX.Cli.Setup.Wizard;
 
 internal sealed class GitHubRepoClient : IDisposable {
     private readonly HttpClient _http;
+    private readonly bool _ownsHttpClient;
 
     public GitHubRepoClient(string token, string apiBaseUrl) {
         _http = new HttpClient {
             BaseAddress = new Uri(apiBaseUrl)
         };
+        _ownsHttpClient = true;
         ConfigureDefaultHeaders(_http, token);
     }
 
-    internal GitHubRepoClient(HttpClient httpClient, string token = "test-token") {
+    internal GitHubRepoClient(HttpClient httpClient, string token = "test-token", bool ownsHttpClient = false) {
         _http = httpClient;
+        _ownsHttpClient = ownsHttpClient;
         ConfigureDefaultHeaders(_http, token);
     }
 
-    public void Dispose() => _http.Dispose();
+    public void Dispose() {
+        if (_ownsHttpClient) {
+            _http.Dispose();
+        }
+    }
 
     public async Task<List<RepositoryInfo>> ListRepositoriesAsync() {
         var repos = new List<RepositoryInfo>();
@@ -151,9 +159,18 @@ internal sealed class GitHubRepoClient : IDisposable {
     }
 
     private static void ConfigureDefaultHeaders(HttpClient http, string token) {
-        http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("IntelligenceX.Cli", "1.0"));
-        http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        if (!http.DefaultRequestHeaders.UserAgent.Any(value =>
+                string.Equals(value.Product?.Name, "IntelligenceX.Cli", StringComparison.OrdinalIgnoreCase))) {
+            http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("IntelligenceX.Cli", "1.0"));
+        }
+        if (!http.DefaultRequestHeaders.Accept.Any(value =>
+                string.Equals(value.MediaType, "application/vnd.github+json", StringComparison.OrdinalIgnoreCase))) {
+            http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        }
         http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (http.DefaultRequestHeaders.Contains("X-GitHub-Api-Version")) {
+            http.DefaultRequestHeaders.Remove("X-GitHub-Api-Version");
+        }
         http.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
     }
 

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -540,6 +540,22 @@ jobs:
         AssertEqual(null, file, "repo client file fetch invalid base64");
     }
 
+    private static void TestGitHubRepoClientFileFetchMissingShaReturnsNull() {
+        using var client = CreateGitHubRepoClientForTests((_, _) => {
+            var payload = """
+{
+  "content": "e30="
+}
+""";
+            return Task.FromResult(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK) {
+                Content = new System.Net.Http.StringContent(payload)
+            });
+        });
+
+        var file = client.TryGetFileAsync("owner", "repo", ".intelligencex/reviewer.json", "main").GetAwaiter().GetResult();
+        AssertEqual(null, file, "repo client file fetch missing sha");
+    }
+
     private static void TestGitHubRepoClientInjectedHttpClientAppliesDefaultHeaders() {
         System.Net.Http.HttpRequestMessage? capturedRequest = null;
         using var client = CreateGitHubRepoClientForTests((request, _) => {
@@ -558,6 +574,50 @@ jobs:
             capturedRequest.Headers.TryGetValues("X-GitHub-Api-Version", out var values)
             && values.Contains("2022-11-28"),
             "repo client injected headers api version");
+    }
+
+    private static void TestGitHubRepoClientReusedInjectedHttpClientRemainsIdempotent() {
+        var requests = new List<System.Net.Http.HttpRequestMessage>();
+        using var http = new System.Net.Http.HttpClient(new DelegateHttpMessageHandler((request, _) => {
+            requests.Add(request);
+            return Task.FromResult(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.NotFound));
+        })) {
+            BaseAddress = new Uri("https://api.github.com")
+        };
+
+        using (var first = new IntelligenceX.Cli.Setup.Wizard.GitHubRepoClient(http, token: "token-one")) {
+            var firstResult = first.TryRepoSecretExistsAsync("owner", "repo", "INTELLIGENCEX_AUTH_B64").GetAwaiter().GetResult();
+            AssertEqual("missing", firstResult.Status, "repo client reused injected first status");
+        }
+
+        using (var second = new IntelligenceX.Cli.Setup.Wizard.GitHubRepoClient(http, token: "token-two")) {
+            var secondResult = second.TryRepoSecretExistsAsync("owner", "repo", "INTELLIGENCEX_AUTH_B64").GetAwaiter().GetResult();
+            AssertEqual("missing", secondResult.Status, "repo client reused injected second status");
+        }
+
+        AssertEqual(true, requests.Count >= 2, "repo client reused injected requests captured");
+        var lastRequest = requests[requests.Count - 1];
+        AssertEqual("token-two", lastRequest.Headers.Authorization?.Parameter, "repo client reused injected latest auth token");
+
+        var userAgentCount = 0;
+        foreach (var _ in lastRequest.Headers.UserAgent) {
+            userAgentCount++;
+        }
+        AssertEqual(1, userAgentCount, "repo client reused injected user-agent count");
+
+        var acceptCount = 0;
+        foreach (var _ in lastRequest.Headers.Accept) {
+            acceptCount++;
+        }
+        AssertEqual(1, acceptCount, "repo client reused injected accept count");
+
+        var versionCount = 0;
+        if (lastRequest.Headers.TryGetValues("X-GitHub-Api-Version", out var apiVersions)) {
+            foreach (var _ in apiVersions) {
+                versionCount++;
+            }
+        }
+        AssertEqual(1, versionCount, "repo client reused injected api version count");
     }
 
     private static IntelligenceX.Cli.Setup.Wizard.GitHubRepoClient CreateGitHubRepoClientForTests(

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -97,6 +97,8 @@ internal static partial class Program {
         failed += Run("GitHub repo client file fetch cancellation propagates", TestGitHubRepoClientFileFetchCancellationPropagates);
         failed += Run("GitHub repo client file fetch invalid base64 returns null", TestGitHubRepoClientFileFetchInvalidBase64ReturnsNull);
         failed += Run("GitHub repo client injected http client applies default headers", TestGitHubRepoClientInjectedHttpClientAppliesDefaultHeaders);
+        failed += Run("GitHub repo client reused injected http client remains idempotent", TestGitHubRepoClientReusedInjectedHttpClientRemainsIdempotent);
+        failed += Run("GitHub repo client file fetch missing sha returns null", TestGitHubRepoClientFileFetchMissingShaReturnsNull);
         failed += Run("GitHub secrets reject empty value", TestGitHubSecretsRejectEmptyValue);
         failed += Run("Release reviewer env token", TestReleaseReviewerEnvToken);
         failed += Run("CI path safety rejects non-existent directory leaf", TestCiPathSafetyUnderRootPhysicalRejectsNonexistentDirectoryLeaf);


### PR DESCRIPTION
## Summary
- make injected `HttpClient` non-owning by default to avoid disposing shared clients from test seams
- make default GitHub headers idempotent on reused injected clients (no duplicate `User-Agent`/`Accept`/API-version accumulation)
- keep auth header deterministic for each constructed client
- add setup harness tests for reused injected client idempotency/lifecycle and missing `sha` payload behavior in file fetch

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
