### PR TITLE
Add tool alias metadata support with registry and serialization tests

### DIFF
--- a/IntelligenceX.Tests/Program.Core.cs
+++ b/IntelligenceX.Tests/Program.Core.cs
@@ -122,6 +122,70 @@ internal static partial class Program {
         AssertSequenceEqual(new[] { "Alpha", "beta", "zeta" }, names, "tool definition order");
     }
 
+    private static void TestToolDefinitionAliasMergesTags() {
+        var canonical = new ToolDefinition(
+            name: "ad_search",
+            description: "Search Active Directory",
+            tags: new[] { "ad", "ldap" });
+        var alias = canonical.CreateAliasDefinition(
+            aliasName: "ad_find",
+            tags: new[] { "discovery" });
+
+        AssertEqual("ad_find", alias.Name, "alias name");
+        AssertEqual("ad_search", alias.AliasOf, "alias canonical");
+        AssertEqual("Search Active Directory", alias.Description, "alias description");
+        AssertSequenceEqual(new[] { "ad", "ldap", "discovery" }, alias.Tags.ToArray(), "alias tags");
+    }
+
+    private static void TestToolRegistryRegistersAliasesFromDefinition() {
+        var registry = new ToolRegistry();
+        var tool = new ConfiguredTool(new ToolDefinition(
+            name: "ad_search",
+            description: "Search Active Directory",
+            aliases: new[] {
+                new ToolAliasDefinition("ad_find", tags: new[] { "search" }),
+                new ToolAliasDefinition("ad_lookup")
+            }));
+
+        registry.Register(tool);
+
+        AssertEqual(true, registry.TryGet("ad_search", out var canonical), "canonical registered");
+        AssertEqual(true, registry.TryGet("ad_find", out var aliasFind), "alias ad_find registered");
+        AssertEqual(true, registry.TryGet("ad_lookup", out var aliasLookup), "alias ad_lookup registered");
+        AssertEqual(true, ReferenceEquals(canonical, aliasFind), "ad_find maps to canonical tool instance");
+        AssertEqual(true, ReferenceEquals(canonical, aliasLookup), "ad_lookup maps to canonical tool instance");
+
+        var definitions = registry.GetDefinitions().ToDictionary(static d => d.Name, StringComparer.OrdinalIgnoreCase);
+        AssertEqual("ad_search", definitions["ad_search"].CanonicalName, "canonical canonical name");
+        AssertEqual("ad_search", definitions["ad_find"].CanonicalName, "ad_find canonical name");
+        AssertEqual("ad_search", definitions["ad_lookup"].CanonicalName, "ad_lookup canonical name");
+    }
+
+    private static void TestToolRegistryRegisterAliasWithOverrides() {
+        var registry = new ToolRegistry();
+        var tool = new ConfiguredTool(new ToolDefinition(
+            name: "system_info",
+            description: "Read system summary",
+            tags: new[] { "system", "inventory" }));
+
+        registry.Register(tool);
+        registry.RegisterAlias(
+            aliasName: "host_info",
+            targetToolName: "system_info",
+            description: "Read host details",
+            tags: new[] { "host" });
+
+        AssertEqual(true, registry.TryGet("host_info", out var aliasTool), "registered alias");
+        AssertEqual(true, ReferenceEquals(tool, aliasTool), "alias maps to canonical tool instance");
+
+        var definitions = registry.GetDefinitions().ToDictionary(static d => d.Name, StringComparer.OrdinalIgnoreCase);
+        var aliasDef = definitions["host_info"];
+        AssertEqual("system_info", aliasDef.AliasOf, "aliasOf");
+        AssertEqual("system_info", aliasDef.CanonicalName, "canonical name");
+        AssertEqual("Read host details", aliasDef.Description, "alias description");
+        AssertSequenceEqual(new[] { "system", "inventory", "host" }, aliasDef.Tags.ToArray(), "alias merged tags");
+    }
+
     private static void TestToolRunnerMaxRounds() {
         using var client = CreateToolRunnerClient(BuildToolCallTurn(("call_1", "echo")));
         var registry = new ToolRegistry();

--- a/IntelligenceX.Tests/Program.Infrastructure.cs
+++ b/IntelligenceX.Tests/Program.Infrastructure.cs
@@ -228,6 +228,18 @@ internal static partial class Program {
         }
     }
 
+    private sealed class ConfiguredTool : ITool {
+        public ConfiguredTool(ToolDefinition definition) {
+            Definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        }
+
+        public ToolDefinition Definition { get; }
+
+        public Task<string> InvokeAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+            return Task.FromResult("ok");
+        }
+    }
+
     private static JsonArray CallChatInputToJson(ChatInput input) {
         var method = typeof(ChatInput).GetMethod("ToJson", BindingFlags.NonPublic | BindingFlags.Instance);
         if (method is null) {

--- a/IntelligenceX.Tests/Program.OpenAI.NativeToolSchema.cs
+++ b/IntelligenceX.Tests/Program.OpenAI.NativeToolSchema.cs
@@ -255,6 +255,29 @@ internal static partial class Program {
         AssertEqual(true, nestedFunctionSchema.TryGetValue("input_schema", out _), "input_schema present");
     }
 
+    private static void TestNativeToolSchemaSerializationIncludesTagsInDescription() {
+        var ix = typeof(IntelligenceXClient).Assembly;
+        var transportType = ix.GetType("IntelligenceX.OpenAI.Native.OpenAINativeTransport", throwOnError: true)!;
+
+        var enumType = transportType.GetNestedType("ToolWireFormat", BindingFlags.NonPublic);
+        AssertNotNull(enumType, "ToolWireFormat enum");
+
+        var serialize = transportType.GetMethod("SerializeToolDefinition", BindingFlags.NonPublic | BindingFlags.Static);
+        AssertNotNull(serialize, "SerializeToolDefinition method");
+
+        var tool = new ToolDefinition(
+            name: "ad_search",
+            description: "Search Active Directory.",
+            parameters: new JsonObject().Add("type", "object"),
+            tags: new[] { "ad", "ldap" });
+
+        var customParameters = Enum.Parse(enumType!, "CustomParameters");
+        var serialized = (JsonObject)serialize!.Invoke(null, new object?[] { tool, customParameters })!;
+        var description = serialized.GetString("description") ?? string.Empty;
+        AssertContainsText(description, "Search Active Directory.", "description");
+        AssertContainsText(description, "tags: ad, ldap", "description");
+    }
+
     private static string DetectFallbackKind(string message) {
         var ix = typeof(IntelligenceXClient).Assembly;
         var transportType = ix.GetType("IntelligenceX.OpenAI.Native.OpenAINativeTransport", throwOnError: true)!;

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -23,6 +23,9 @@ internal static partial class Program {
         failed += Run("Tool output input", TestToolOutputInput);
         failed += Run("Turn response_id parsing", TestTurnResponseIdParsing);
         failed += Run("Tool definitions ordered", TestToolDefinitionOrdering);
+        failed += Run("Tool definition alias merges tags", TestToolDefinitionAliasMergesTags);
+        failed += Run("Tool registry registers aliases from definition", TestToolRegistryRegistersAliasesFromDefinition);
+        failed += Run("Tool registry register alias override", TestToolRegistryRegisterAliasWithOverrides);
         failed += Run("Tool runner max rounds", TestToolRunnerMaxRounds);
         failed += Run("Tool runner unregistered tool", TestToolRunnerUnregisteredTool);
         failed += Run("Tool runner parallel execution", TestToolRunnerParallelExecution);
@@ -42,6 +45,7 @@ internal static partial class Program {
         failed += Run("Native tool schema fallback uses structured error data", TestNativeToolSchemaFallbackUsesStructuredErrorData);
         failed += Run("Native tool schema fallback ignores unrelated", TestNativeToolSchemaFallbackIgnoresUnrelated);
         failed += Run("Native tool schema serialization switches field name", TestNativeToolSchemaSerializationSwitchesFieldName);
+        failed += Run("Native tool schema serialization includes tags in description", TestNativeToolSchemaSerializationIncludesTagsInDescription);
         failed += Run("Native request body omits previous_response_id", TestNativeRequestBodyOmitsPreviousResponseId);
 #if !NET472
         failed += Run("Setup args reject skip+update", TestSetupArgsRejectSkipUpdate);

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.Requests.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.Requests.cs
@@ -140,8 +140,9 @@ internal sealed partial class OpenAINativeTransport {
             case ToolWireFormat.FunctionNestedParameters: {
                 var function = new JsonObject()
                     .Add("name", tool.Name);
-                if (!string.IsNullOrWhiteSpace(tool.Description)) {
-                    function.Add("description", tool.Description);
+                var description = tool.GetDescriptionWithTags();
+                if (!string.IsNullOrWhiteSpace(description)) {
+                    function.Add("description", description);
                 }
                 if (tool.Parameters is not null) {
                     function.Add(toolWireFormat == ToolWireFormat.FunctionNestedInputSchema ? "input_schema" : "parameters", tool.Parameters);
@@ -156,8 +157,9 @@ internal sealed partial class OpenAINativeTransport {
                 var obj = new JsonObject()
                     .Add("type", "custom")
                     .Add("name", tool.Name);
-                if (!string.IsNullOrWhiteSpace(tool.Description)) {
-                    obj.Add("description", tool.Description);
+                var description = tool.GetDescriptionWithTags();
+                if (!string.IsNullOrWhiteSpace(description)) {
+                    obj.Add("description", description);
                 }
                 if (tool.Parameters is not null) {
                     // ChatGPT native API has historically accepted either `parameters` or `input_schema` for custom tools.
@@ -172,8 +174,9 @@ internal sealed partial class OpenAINativeTransport {
                 var obj = new JsonObject()
                     .Add("type", "function")
                     .Add("name", tool.Name);
-                if (!string.IsNullOrWhiteSpace(tool.Description)) {
-                    obj.Add("description", tool.Description);
+                var description = tool.GetDescriptionWithTags();
+                if (!string.IsNullOrWhiteSpace(description)) {
+                    obj.Add("description", description);
                 }
                 if (tool.Parameters is not null) {
                     obj.Add(toolWireFormat == ToolWireFormat.FunctionFlatInputSchema ? "input_schema" : "parameters", tool.Parameters);

--- a/IntelligenceX/Tools/ToolAliasDefinition.cs
+++ b/IntelligenceX/Tools/ToolAliasDefinition.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace IntelligenceX.Tools;
+
+/// <summary>
+/// Describes an alias exposed for a tool definition.
+/// </summary>
+public sealed class ToolAliasDefinition {
+    /// <summary>
+    /// Initializes a new alias definition.
+    /// </summary>
+    /// <param name="name">Alias tool name.</param>
+    /// <param name="description">Optional alias-specific description override.</param>
+    /// <param name="tags">Optional alias tags merged with canonical tool tags.</param>
+    public ToolAliasDefinition(string name, string? description = null, IReadOnlyList<string>? tags = null) {
+        if (string.IsNullOrWhiteSpace(name)) {
+            throw new ArgumentException("Alias name cannot be empty.", nameof(name));
+        }
+
+        Name = name.Trim();
+        Description = description;
+        Tags = NormalizeTags(tags);
+    }
+
+    /// <summary>
+    /// Gets the alias name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the alias-specific description override.
+    /// </summary>
+    public string? Description { get; }
+
+    /// <summary>
+    /// Gets alias tags.
+    /// </summary>
+    public IReadOnlyList<string> Tags { get; }
+
+    private static IReadOnlyList<string> NormalizeTags(IReadOnlyList<string>? tags) {
+        if (tags is null || tags.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        var list = new List<string>(tags.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var tag in tags) {
+            if (string.IsNullOrWhiteSpace(tag)) {
+                continue;
+            }
+
+            var normalized = tag.Trim();
+            if (seen.Add(normalized)) {
+                list.Add(normalized);
+            }
+        }
+
+        return list.Count == 0 ? Array.Empty<string>() : list.ToArray();
+    }
+}

--- a/IntelligenceX/Tools/ToolDefinition.cs
+++ b/IntelligenceX/Tools/ToolDefinition.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using IntelligenceX.Json;
 
 namespace IntelligenceX.Tools;
@@ -13,13 +15,30 @@ public sealed class ToolDefinition {
     /// <param name="name">Tool name.</param>
     /// <param name="description">Tool description.</param>
     /// <param name="parameters">JSON schema for tool parameters.</param>
-    public ToolDefinition(string name, string? description = null, JsonObject? parameters = null) {
+    /// <param name="tags">Optional tags used for model/tooling guidance.</param>
+    /// <param name="aliases">Optional aliases that should invoke the same tool implementation.</param>
+    /// <param name="aliasOf">Optional canonical tool name when this definition is an alias.</param>
+    public ToolDefinition(
+        string name,
+        string? description = null,
+        JsonObject? parameters = null,
+        IReadOnlyList<string>? tags = null,
+        IReadOnlyList<ToolAliasDefinition>? aliases = null,
+        string? aliasOf = null) {
         if (string.IsNullOrWhiteSpace(name)) {
             throw new ArgumentException("Tool name cannot be empty.", nameof(name));
         }
-        Name = name;
+        Name = name.Trim();
+        if (!string.IsNullOrWhiteSpace(aliasOf) &&
+            string.Equals(Name, aliasOf!.Trim(), StringComparison.OrdinalIgnoreCase)) {
+            throw new ArgumentException("Alias cannot reference itself.", nameof(aliasOf));
+        }
+
         Description = description;
         Parameters = parameters;
+        Tags = NormalizeTags(tags);
+        Aliases = NormalizeAliases(aliases, Name);
+        AliasOf = string.IsNullOrWhiteSpace(aliasOf) ? null : aliasOf!.Trim();
     }
 
     /// <summary>
@@ -34,4 +53,145 @@ public sealed class ToolDefinition {
     /// Gets the JSON schema for tool parameters.
     /// </summary>
     public JsonObject? Parameters { get; }
+
+    /// <summary>
+    /// Gets optional tags associated with this tool definition.
+    /// </summary>
+    public IReadOnlyList<string> Tags { get; }
+
+    /// <summary>
+    /// Gets optional aliases exposed for this tool definition.
+    /// </summary>
+    public IReadOnlyList<ToolAliasDefinition> Aliases { get; }
+
+    /// <summary>
+    /// Gets the canonical tool name when this definition represents an alias.
+    /// </summary>
+    public string? AliasOf { get; }
+
+    /// <summary>
+    /// Gets the canonical tool name for this definition.
+    /// </summary>
+    public string CanonicalName => AliasOf ?? Name;
+
+    /// <summary>
+    /// Creates an alias definition derived from the current canonical definition.
+    /// </summary>
+    /// <param name="aliasName">Alias tool name.</param>
+    /// <param name="description">Optional alias-specific description override.</param>
+    /// <param name="tags">Optional alias tags merged with canonical tags.</param>
+    public ToolDefinition CreateAliasDefinition(string aliasName, string? description = null, IReadOnlyList<string>? tags = null) {
+        if (string.IsNullOrWhiteSpace(aliasName)) {
+            throw new ArgumentException("Alias name cannot be empty.", nameof(aliasName));
+        }
+
+        var normalizedAliasName = aliasName.Trim();
+        if (string.Equals(normalizedAliasName, CanonicalName, StringComparison.OrdinalIgnoreCase)) {
+            throw new ArgumentException("Alias name cannot match canonical tool name.", nameof(aliasName));
+        }
+
+        var mergedTags = MergeTags(Tags, tags);
+        return new ToolDefinition(
+            name: normalizedAliasName,
+            description: string.IsNullOrWhiteSpace(description) ? Description : description,
+            parameters: Parameters,
+            tags: mergedTags,
+            aliases: null,
+            aliasOf: CanonicalName);
+    }
+
+    /// <summary>
+    /// Returns description text augmented with tag hints.
+    /// </summary>
+    public string? GetDescriptionWithTags() {
+        var baseDescription = string.IsNullOrWhiteSpace(Description) ? null : Description!.Trim();
+        if (Tags.Count == 0) {
+            return baseDescription;
+        }
+
+        var tagsText = $"tags: {string.Join(", ", Tags)}";
+        return string.IsNullOrWhiteSpace(baseDescription)
+            ? tagsText
+            : $"{baseDescription} [{tagsText}]";
+    }
+
+    private static IReadOnlyList<string> NormalizeTags(IReadOnlyList<string>? tags) {
+        if (tags is null || tags.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        var list = new List<string>(tags.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var tag in tags) {
+            if (string.IsNullOrWhiteSpace(tag)) {
+                continue;
+            }
+
+            var normalized = tag.Trim();
+            if (seen.Add(normalized)) {
+                list.Add(normalized);
+            }
+        }
+
+        return list.Count == 0 ? Array.Empty<string>() : list.ToArray();
+    }
+
+    private static IReadOnlyList<ToolAliasDefinition> NormalizeAliases(
+        IReadOnlyList<ToolAliasDefinition>? aliases,
+        string canonicalName) {
+        if (aliases is null || aliases.Count == 0) {
+            return Array.Empty<ToolAliasDefinition>();
+        }
+
+        var list = new List<ToolAliasDefinition>(aliases.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var alias in aliases) {
+            if (alias is null) {
+                continue;
+            }
+            if (string.Equals(alias.Name, canonicalName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            if (seen.Add(alias.Name)) {
+                list.Add(alias);
+            }
+        }
+
+        return list.Count == 0 ? Array.Empty<ToolAliasDefinition>() : list.ToArray();
+    }
+
+    private static IReadOnlyList<string> MergeTags(IReadOnlyList<string> first, IReadOnlyList<string>? second) {
+        if ((first is null || first.Count == 0) && (second is null || second.Count == 0)) {
+            return Array.Empty<string>();
+        }
+
+        var merged = new List<string>((first?.Count ?? 0) + (second?.Count ?? 0));
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (first is not null) {
+            foreach (var tag in first) {
+                if (string.IsNullOrWhiteSpace(tag)) {
+                    continue;
+                }
+                var normalized = tag.Trim();
+                if (seen.Add(normalized)) {
+                    merged.Add(normalized);
+                }
+            }
+        }
+
+        if (second is not null) {
+            foreach (var tag in second) {
+                if (string.IsNullOrWhiteSpace(tag)) {
+                    continue;
+                }
+                var normalized = tag.Trim();
+                if (seen.Add(normalized)) {
+                    merged.Add(normalized);
+                }
+            }
+        }
+
+        return merged.Count == 0 ? Array.Empty<string>() : merged.ToArray();
+    }
 }

--- a/IntelligenceX/Tools/ToolRegistry.cs
+++ b/IntelligenceX/Tools/ToolRegistry.cs
@@ -9,6 +9,7 @@ namespace IntelligenceX.Tools;
 /// </summary>
 public sealed class ToolRegistry {
     private readonly Dictionary<string, ITool> _tools = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, ToolDefinition> _definitions = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Registers a tool.
@@ -27,10 +28,17 @@ public sealed class ToolRegistry {
         if (tool is null) {
             throw new ArgumentNullException(nameof(tool));
         }
-        if (!replaceExisting && _tools.ContainsKey(tool.Definition.Name)) {
-            throw new InvalidOperationException($"Tool '{tool.Definition.Name}' is already registered.");
+
+        var definition = tool.Definition;
+        if (replaceExisting) {
+            RemoveCanonicalEntries(definition.CanonicalName);
         }
-        _tools[tool.Definition.Name] = tool;
+
+        RegisterEntry(tool, definition, replaceExisting);
+        foreach (var alias in definition.Aliases) {
+            var aliasDefinition = definition.CreateAliasDefinition(alias.Name, alias.Description, alias.Tags);
+            RegisterEntry(tool, aliasDefinition, replaceExisting);
+        }
     }
 
     /// <summary>
@@ -39,11 +47,64 @@ public sealed class ToolRegistry {
     public bool TryGet(string name, out ITool tool) => _tools.TryGetValue(name, out tool!);
 
     /// <summary>
+    /// Registers an alias for an already-registered tool.
+    /// </summary>
+    /// <param name="aliasName">Alias name.</param>
+    /// <param name="targetToolName">Existing canonical or alias tool name to map to.</param>
+    /// <param name="description">Optional alias-specific description override.</param>
+    /// <param name="tags">Optional alias tags merged with canonical tags.</param>
+    /// <param name="replaceExisting">Replace an existing registration that uses <paramref name="aliasName"/>.</param>
+    public void RegisterAlias(
+        string aliasName,
+        string targetToolName,
+        string? description = null,
+        IReadOnlyList<string>? tags = null,
+        bool replaceExisting = false) {
+        if (string.IsNullOrWhiteSpace(aliasName)) {
+            throw new ArgumentException("Alias name cannot be empty.", nameof(aliasName));
+        }
+        if (string.IsNullOrWhiteSpace(targetToolName)) {
+            throw new ArgumentException("Target tool name cannot be empty.", nameof(targetToolName));
+        }
+
+        if (!_tools.TryGetValue(targetToolName, out var tool) || !_definitions.TryGetValue(targetToolName, out var targetDefinition)) {
+            throw new InvalidOperationException($"Tool '{targetToolName}' is not registered.");
+        }
+
+        var aliasDefinition = targetDefinition.CreateAliasDefinition(aliasName, description, tags);
+        RegisterEntry(tool, aliasDefinition, replaceExisting);
+    }
+
+    /// <summary>
     /// Returns tool definitions for the registry.
     /// </summary>
     public IReadOnlyList<ToolDefinition> GetDefinitions()
-        => _tools.Values
-            .Select(tool => tool.Definition)
+        => _definitions.Values
             .OrderBy(definition => definition.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
+
+    private void RegisterEntry(ITool tool, ToolDefinition definition, bool replaceExisting) {
+        if (!replaceExisting && _tools.ContainsKey(definition.Name)) {
+            throw new InvalidOperationException($"Tool '{definition.Name}' is already registered.");
+        }
+
+        _tools[definition.Name] = tool;
+        _definitions[definition.Name] = definition;
+    }
+
+    private void RemoveCanonicalEntries(string canonicalName) {
+        if (string.IsNullOrWhiteSpace(canonicalName)) {
+            return;
+        }
+
+        var toRemove = _definitions
+            .Where(static kv => !string.IsNullOrWhiteSpace(kv.Key))
+            .Where(kv => string.Equals(kv.Value.CanonicalName, canonicalName, StringComparison.OrdinalIgnoreCase))
+            .Select(kv => kv.Key)
+            .ToArray();
+        foreach (var key in toRemove) {
+            _definitions.Remove(key);
+            _tools.Remove(key);
+        }
+    }
 }


### PR DESCRIPTION
Summary: add ToolAliasDefinition and alias/tag metadata in ToolDefinition, extend ToolRegistry with alias registration and canonical definition tracking, serialize descriptions with tags for native tool requests, and add regression tests for alias behavior and schema serialization. Validation: dotnet test IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release and dotnet run IntelligenceX.Tests -c Release -f net8.0 (new alias tests pass).