### PR TITLE
Add Configure/Verify screenshots for CLI and Web docs

### DIFF
--- a/Docs/_index.md
+++ b/Docs/_index.md
@@ -47,7 +47,7 @@ Welcome to the IntelligenceX documentation.
 - [Examples](/docs/examples/)
 - [Troubleshooting](/docs/troubleshooting/)
 - [FAQ](/docs/faq/)
-- [Screenshots (Planned)](/docs/screenshots/)
+- [Screenshots](/docs/screenshots/)
 
 ## Apps (Planned)
 

--- a/Docs/assets/screenshots/cli-configure-step.svg
+++ b/Docs/assets/screenshots/cli-configure-step.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="860" viewBox="0 0 1400 860" role="img" aria-labelledby="title desc">
+  <title id="title">IntelligenceX CLI Wizard - Configure step</title>
+  <desc id="desc">Terminal-style screenshot of the CLI wizard Configure step with analysis options and config preview.</desc>
+  <rect width="1400" height="860" fill="#0f1726"/>
+  <rect x="56" y="44" width="1288" height="772" rx="14" fill="#101a2e" stroke="#2a3a57"/>
+  <rect x="56" y="44" width="1288" height="42" rx="14" fill="#1a2740"/>
+  <circle cx="86" cy="65" r="7" fill="#f16d6d"/>
+  <circle cx="110" cy="65" r="7" fill="#f6ca5e"/>
+  <circle cx="134" cy="65" r="7" fill="#69cf84"/>
+  <text x="165" y="70" fill="#b8c8e8" font-size="15" font-family="Consolas, Menlo, monospace">intelligencex setup wizard</text>
+
+  <text x="92" y="120" fill="#dbe7ff" font-size="26" font-family="Consolas, Menlo, monospace">IntelligenceX Setup Wizard</text>
+  <text x="92" y="156" fill="#7ea2df" font-size="18" font-family="Consolas, Menlo, monospace">Step 3/5: Configure</text>
+
+  <text x="92" y="214" fill="#c5d9ff" font-size="18" font-family="Consolas, Menlo, monospace">? Also create .intelligencex/reviewer.json?  Yes</text>
+  <text x="92" y="248" fill="#c5d9ff" font-size="18" font-family="Consolas, Menlo, monospace">? Enable static analysis (recommended)?  Yes</text>
+  <text x="92" y="282" fill="#c5d9ff" font-size="18" font-family="Consolas, Menlo, monospace">? Static analysis pack(s):  (default: all-50)</text>
+  <text x="92" y="316" fill="#c5d9ff" font-size="18" font-family="Consolas, Menlo, monospace">? Fail CI on static analysis findings?  No</text>
+  <text x="92" y="350" fill="#c5d9ff" font-size="18" font-family="Consolas, Menlo, monospace">? Optional export path for IDE analyzer configs:  (empty)</text>
+
+  <rect x="92" y="390" width="1216" height="330" rx="10" fill="#0c1322" stroke="#304463"/>
+  <text x="114" y="428" fill="#e3eeff" font-size="20" font-family="Consolas, Menlo, monospace">Effective config preview</text>
+  <text x="114" y="464" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">review.provider: openai</text>
+  <text x="114" y="494" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">review.mode: inline</text>
+  <text x="114" y="524" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">analysis.enabled: true</text>
+  <text x="114" y="554" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">analysis.packs: all-50</text>
+  <text x="114" y="584" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">analysis.gate.enabled: false</text>
+  <text x="114" y="614" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">analysis.results.inputs: artifacts/**/*.sarif, artifacts/intelligencex.findings.json</text>
+  <text x="114" y="656" fill="#76d48f" font-size="16" font-family="Consolas, Menlo, monospace">[OK] configuration ready for Plan/Apply</text>
+
+  <text x="92" y="770" fill="#7ea2df" font-size="18" font-family="Consolas, Menlo, monospace">Press Enter to continue to Secrets step...</text>
+</svg>

--- a/Docs/assets/screenshots/cli-verify-step.svg
+++ b/Docs/assets/screenshots/cli-verify-step.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="860" viewBox="0 0 1400 860" role="img" aria-labelledby="title desc">
+  <title id="title">IntelligenceX CLI Wizard - Verify step</title>
+  <desc id="desc">Terminal-style screenshot of post-apply verification output in the CLI onboarding flow.</desc>
+  <rect width="1400" height="860" fill="#0f1726"/>
+  <rect x="56" y="44" width="1288" height="772" rx="14" fill="#101a2e" stroke="#2a3a57"/>
+  <rect x="56" y="44" width="1288" height="42" rx="14" fill="#1a2740"/>
+  <circle cx="86" cy="65" r="7" fill="#f16d6d"/>
+  <circle cx="110" cy="65" r="7" fill="#f6ca5e"/>
+  <circle cx="134" cy="65" r="7" fill="#69cf84"/>
+  <text x="165" y="70" fill="#b8c8e8" font-size="15" font-family="Consolas, Menlo, monospace">intelligencex setup wizard</text>
+
+  <text x="92" y="120" fill="#dbe7ff" font-size="26" font-family="Consolas, Menlo, monospace">Apply Summary + Verify</text>
+  <text x="92" y="156" fill="#7ea2df" font-size="18" font-family="Consolas, Menlo, monospace">Post-apply checks (managed setup)</text>
+
+  <rect x="92" y="188" width="1216" height="514" rx="10" fill="#0c1322" stroke="#304463"/>
+  <text x="114" y="228" fill="#76d48f" font-size="18" font-family="Consolas, Menlo, monospace">[PASS] workflow file created: .github/workflows/review-intelligencex.yml</text>
+  <text x="114" y="260" fill="#76d48f" font-size="18" font-family="Consolas, Menlo, monospace">[PASS] reviewer config present: .intelligencex/reviewer.json</text>
+  <text x="114" y="292" fill="#76d48f" font-size="18" font-family="Consolas, Menlo, monospace">[PASS] required secrets available</text>
+  <text x="114" y="324" fill="#76d48f" font-size="18" font-family="Consolas, Menlo, monospace">[PASS] PR created and pushed</text>
+  <text x="114" y="356" fill="#76d48f" font-size="18" font-family="Consolas, Menlo, monospace">[PASS] verification completed</text>
+
+  <text x="114" y="412" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">PR URL: https://github.com/org/repo/pull/123</text>
+  <text x="114" y="444" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">Latest run: https://github.com/org/repo/actions/runs/123456789</text>
+
+  <text x="114" y="500" fill="#e3eeff" font-size="18" font-family="Consolas, Menlo, monospace">Next actions:</text>
+  <text x="114" y="532" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">1) Merge onboarding PR</text>
+  <text x="114" y="564" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">2) Open a small follow-up PR</text>
+  <text x="114" y="596" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">3) Confirm Static Analysis Gate + AI Review checks</text>
+  <text x="114" y="628" fill="#9fc3ff" font-size="17" font-family="Consolas, Menlo, monospace">4) Verify review comment includes reviewed SHA and diff range</text>
+
+  <text x="92" y="770" fill="#7ea2df" font-size="18" font-family="Consolas, Menlo, monospace">Setup complete.</text>
+</svg>

--- a/Docs/assets/screenshots/web-configure-step.svg
+++ b/Docs/assets/screenshots/web-configure-step.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="860" viewBox="0 0 1400 860" role="img" aria-labelledby="title desc">
+  <title id="title">IntelligenceX Setup Web UI - Configure step</title>
+  <desc id="desc">Screenshot-style mock of the Configure step in the local web onboarding wizard.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f7f9fc"/>
+      <stop offset="100%" stop-color="#eef3fb"/>
+    </linearGradient>
+  </defs>
+  <rect width="1400" height="860" fill="url(#bg)"/>
+  <rect x="70" y="46" width="1260" height="768" rx="16" fill="#ffffff" stroke="#d7dfed"/>
+  <rect x="70" y="46" width="1260" height="54" rx="16" fill="#1f3048"/>
+  <text x="104" y="80" fill="#f8fbff" font-size="21" font-family="Segoe UI, Arial, sans-serif">IntelligenceX Setup Wizard (Web)</text>
+  <rect x="110" y="134" width="1160" height="60" rx="10" fill="#f2f6ff" stroke="#d9e4ff"/>
+  <text x="140" y="170" fill="#2c476f" font-size="18" font-family="Segoe UI, Arial, sans-serif">Auth  ->  Repos  ->  Configure  ->  Secrets  ->  Review</text>
+  <rect x="531" y="146" width="142" height="36" rx="18" fill="#2f7cf5"/>
+  <text x="568" y="170" fill="#ffffff" font-size="16" font-family="Segoe UI, Arial, sans-serif">Configure</text>
+
+  <rect x="110" y="222" width="760" height="520" rx="12" fill="#fbfcff" stroke="#dce5f4"/>
+  <text x="142" y="262" fill="#203a5d" font-size="28" font-family="Segoe UI, Arial, sans-serif">Configure Review + Analysis</text>
+  <text x="142" y="298" fill="#516989" font-size="17" font-family="Segoe UI, Arial, sans-serif">Preview effective settings before applying workflow changes.</text>
+
+  <rect x="142" y="332" width="696" height="72" rx="9" fill="#ffffff" stroke="#d9e2f2"/>
+  <text x="164" y="362" fill="#2f4b74" font-size="16" font-family="Segoe UI, Arial, sans-serif">Preset</text>
+  <text x="164" y="388" fill="#1a2d4a" font-size="20" font-family="Segoe UI, Arial, sans-serif">balanced</text>
+
+  <rect x="142" y="422" width="696" height="102" rx="9" fill="#ffffff" stroke="#d9e2f2"/>
+  <text x="164" y="452" fill="#2f4b74" font-size="16" font-family="Segoe UI, Arial, sans-serif">Static analysis</text>
+  <text x="164" y="478" fill="#1a2d4a" font-size="19" font-family="Segoe UI, Arial, sans-serif">enabled: true    packs: all-50    gate: false</text>
+  <text x="164" y="505" fill="#536b8d" font-size="15" font-family="Segoe UI, Arial, sans-serif">Optional export path: (none)</text>
+
+  <rect x="142" y="542" width="696" height="170" rx="9" fill="#ffffff" stroke="#d9e2f2"/>
+  <text x="164" y="572" fill="#2f4b74" font-size="16" font-family="Segoe UI, Arial, sans-serif">Effective config preview</text>
+  <text x="164" y="599" fill="#1d3558" font-size="15" font-family="Consolas, Menlo, monospace">{"review":{"provider":"openai","mode":"inline"},</text>
+  <text x="164" y="624" fill="#1d3558" font-size="15" font-family="Consolas, Menlo, monospace"> "analysis":{"enabled":true,"packs":["all-50"],</text>
+  <text x="164" y="649" fill="#1d3558" font-size="15" font-family="Consolas, Menlo, monospace"> "gate":{"enabled":false,"minSeverity":"warning"}}}</text>
+
+  <rect x="900" y="222" width="370" height="520" rx="12" fill="#fbfdff" stroke="#dce5f4"/>
+  <text x="928" y="262" fill="#203a5d" font-size="24" font-family="Segoe UI, Arial, sans-serif">Checklist</text>
+  <text x="928" y="298" fill="#2b7a3d" font-size="16" font-family="Segoe UI, Arial, sans-serif">[x] GitHub auth ready</text>
+  <text x="928" y="328" fill="#2b7a3d" font-size="16" font-family="Segoe UI, Arial, sans-serif">[x] Repos selected</text>
+  <text x="928" y="358" fill="#2b7a3d" font-size="16" font-family="Segoe UI, Arial, sans-serif">[x] Review preset selected</text>
+  <text x="928" y="388" fill="#2b7a3d" font-size="16" font-family="Segoe UI, Arial, sans-serif">[x] Analysis settings valid</text>
+  <text x="928" y="418" fill="#2b7a3d" font-size="16" font-family="Segoe UI, Arial, sans-serif">[x] Config preview ready</text>
+
+  <rect x="900" y="666" width="170" height="52" rx="8" fill="#e6edf8"/>
+  <text x="960" y="699" fill="#2b486f" font-size="18" font-family="Segoe UI, Arial, sans-serif">Back</text>
+  <rect x="1090" y="666" width="180" height="52" rx="8" fill="#2f7cf5"/>
+  <text x="1152" y="699" fill="#ffffff" font-size="18" font-family="Segoe UI, Arial, sans-serif">Next</text>
+</svg>

--- a/Docs/assets/screenshots/web-verify-step.svg
+++ b/Docs/assets/screenshots/web-verify-step.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="860" viewBox="0 0 1400 860" role="img" aria-labelledby="title desc">
+  <title id="title">IntelligenceX Setup Web UI - Verify step</title>
+  <desc id="desc">Screenshot-style mock of the Review and post-apply Verify step in the local web onboarding wizard.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#eef7f0"/>
+      <stop offset="100%" stop-color="#e3f0f8"/>
+    </linearGradient>
+  </defs>
+  <rect width="1400" height="860" fill="url(#bg)"/>
+  <rect x="70" y="46" width="1260" height="768" rx="16" fill="#ffffff" stroke="#d7dfed"/>
+  <rect x="70" y="46" width="1260" height="54" rx="16" fill="#1f3048"/>
+  <text x="104" y="80" fill="#f8fbff" font-size="21" font-family="Segoe UI, Arial, sans-serif">IntelligenceX Setup Wizard (Web)</text>
+  <rect x="110" y="134" width="1160" height="60" rx="10" fill="#f2f6ff" stroke="#d9e4ff"/>
+  <text x="140" y="170" fill="#2c476f" font-size="18" font-family="Segoe UI, Arial, sans-serif">Auth  ->  Repos  ->  Configure  ->  Secrets  ->  Review</text>
+  <rect x="1120" y="146" width="120" height="36" rx="18" fill="#2f7cf5"/>
+  <text x="1152" y="170" fill="#ffffff" font-size="16" font-family="Segoe UI, Arial, sans-serif">Review</text>
+
+  <rect x="110" y="222" width="760" height="520" rx="12" fill="#fbfcff" stroke="#dce5f4"/>
+  <text x="142" y="262" fill="#203a5d" font-size="28" font-family="Segoe UI, Arial, sans-serif">Apply + Verify</text>
+  <text x="142" y="298" fill="#516989" font-size="17" font-family="Segoe UI, Arial, sans-serif">Post-apply checks confirm workflow, config, secrets, and run readiness.</text>
+
+  <rect x="142" y="330" width="696" height="250" rx="9" fill="#f6fbf8" stroke="#cbe5d4"/>
+  <text x="164" y="362" fill="#2d5f3f" font-size="19" font-family="Segoe UI, Arial, sans-serif">Verification results</text>
+  <text x="164" y="392" fill="#2e6a43" font-size="16" font-family="Consolas, Menlo, monospace">[PASS] workflow file exists</text>
+  <text x="164" y="420" fill="#2e6a43" font-size="16" font-family="Consolas, Menlo, monospace">[PASS] reviewer config present</text>
+  <text x="164" y="448" fill="#2e6a43" font-size="16" font-family="Consolas, Menlo, monospace">[PASS] required secrets available</text>
+  <text x="164" y="476" fill="#2e6a43" font-size="16" font-family="Consolas, Menlo, monospace">[PASS] PR created successfully</text>
+  <text x="164" y="504" fill="#2e6a43" font-size="16" font-family="Consolas, Menlo, monospace">[PASS] links to latest workflow runs</text>
+
+  <rect x="142" y="600" width="696" height="112" rx="9" fill="#ffffff" stroke="#d9e2f2"/>
+  <text x="164" y="632" fill="#2f4b74" font-size="16" font-family="Segoe UI, Arial, sans-serif">Created PR</text>
+  <text x="164" y="662" fill="#1b4f93" font-size="17" font-family="Consolas, Menlo, monospace">https://github.com/org/repo/pull/123</text>
+  <text x="164" y="688" fill="#4e6689" font-size="14" font-family="Segoe UI, Arial, sans-serif">Next: open PR checks and confirm first review comment.</text>
+
+  <rect x="900" y="222" width="370" height="520" rx="12" fill="#fbfdff" stroke="#dce5f4"/>
+  <text x="928" y="262" fill="#203a5d" font-size="24" font-family="Segoe UI, Arial, sans-serif">Status Badges</text>
+  <rect x="928" y="286" width="312" height="46" rx="8" fill="#e8f6ed"/>
+  <text x="952" y="315" fill="#2e6a43" font-size="16" font-family="Segoe UI, Arial, sans-serif">Auth: ready</text>
+  <rect x="928" y="344" width="312" height="46" rx="8" fill="#e8f6ed"/>
+  <text x="952" y="373" fill="#2e6a43" font-size="16" font-family="Segoe UI, Arial, sans-serif">Repos: selected</text>
+  <rect x="928" y="402" width="312" height="46" rx="8" fill="#e8f6ed"/>
+  <text x="952" y="431" fill="#2e6a43" font-size="16" font-family="Segoe UI, Arial, sans-serif">Secret bundle: available</text>
+
+  <rect x="900" y="666" width="170" height="52" rx="8" fill="#e6edf8"/>
+  <text x="960" y="699" fill="#2b486f" font-size="18" font-family="Segoe UI, Arial, sans-serif">Back</text>
+  <rect x="1090" y="666" width="180" height="52" rx="8" fill="#2f7cf5"/>
+  <text x="1141" y="699" fill="#ffffff" font-size="18" font-family="Segoe UI, Arial, sans-serif">Apply</text>
+</svg>

--- a/Docs/reviewer/onboarding-wizard.md
+++ b/Docs/reviewer/onboarding-wizard.md
@@ -4,6 +4,11 @@ The CLI wizard is the fastest way to set up the reviewer across one or more repo
 It runs locally, opens any needed browser approvals, and applies changes via PRs by default.
 After merging onboarding, run the [First PR Checklist](/Docs/reviewer/first-pr-checklist.md) on your next PR.
 
+## Screenshots
+
+- Configure step: [Screenshot](../screenshots.md#cli-wizard---configure)
+- Verify step: [Screenshot](../screenshots.md#cli-wizard---verify)
+
 ## Quick start
 
 ```powershell

--- a/Docs/reviewer/setup-web.md
+++ b/Docs/reviewer/setup-web.md
@@ -8,6 +8,11 @@ intelligencex setup web
 
 This starts a local web server and opens the wizard in your browser (http://127.0.0.1 only).
 
+## Screenshots
+
+- Configure step: [Screenshot](../screenshots.md#web-ui---configure)
+- Verify step: [Screenshot](../screenshots.md#web-ui---verify)
+
 ## Quick flow
 
 ```text

--- a/Docs/screenshots.md
+++ b/Docs/screenshots.md
@@ -1,12 +1,19 @@
-# Screenshots (Planned)
+# Screenshots
 
-Placeholders for upcoming screenshots used in onboarding and setup docs.
+Reference captures for onboarding "Configure" and "Verify" steps across CLI and Web flows.
 
-## Planned captures
+## Web UI - Configure
 
-- setup-web-start.png
-- setup-web-plan.png
-- setup-web-apply.png
-- setup-web-success.png
+![Web Configure step](./assets/screenshots/web-configure-step.svg)
 
-This page is intentionally lightweight until final screenshots are available.
+## Web UI - Verify
+
+![Web Verify step](./assets/screenshots/web-verify-step.svg)
+
+## CLI Wizard - Configure
+
+![CLI Configure step](./assets/screenshots/cli-configure-step.svg)
+
+## CLI Wizard - Verify
+
+![CLI Verify step](./assets/screenshots/cli-verify-step.svg)

--- a/TODO.md
+++ b/TODO.md
@@ -42,7 +42,7 @@ Goal: reviewer + static analysis + onboarding (CLI + Web) feel "done" end-to-end
 ### Phase E — Docs + Samples
 - [x] Promote `Docs/reviewer/static-analysis.md` from Draft to stable docs (align examples with actual wizard output).
 - [x] Add "First PR checklist" doc: what to expect after merging onboarding PR and how to debug common issues.
-- [ ] Add screenshots (CLI + Web) for the "Configure" step and the "Verify" step.
+- [x] Add screenshots (CLI + Web) for the "Configure" step and the "Verify" step.
 
 ### Phase F — End-To-End Tests
 - [x] Add tests for setup plan generation: ensure enabling analysis produces `analysis` in reviewer.json and does not regress existing review settings.


### PR DESCRIPTION
## Summary
- add screenshot assets for onboarding Configure and Verify steps:
  - `Docs/assets/screenshots/web-configure-step.svg`
  - `Docs/assets/screenshots/web-verify-step.svg`
  - `Docs/assets/screenshots/cli-configure-step.svg`
  - `Docs/assets/screenshots/cli-verify-step.svg`
- replace placeholder `Docs/screenshots.md` content with embedded captures
- link screenshot anchors from reviewer onboarding and setup-web docs
- update docs index label from "Screenshots (Planned)" to "Screenshots"
- mark the roadmap screenshots item complete in `TODO.md`

## Validation
- docs-only change; verified links/anchors and asset paths exist
