### PR TITLE
Strengthen workflow upgrade stability regression coverage

### DIFF
--- a/IntelligenceX.Tests/Program.Setup.WorkflowUpgrade.cs
+++ b/IntelligenceX.Tests/Program.Setup.WorkflowUpgrade.cs
@@ -1,0 +1,94 @@
+namespace IntelligenceX.Tests;
+
+#if !NET472
+internal static partial class Program {
+    private static void TestSetupWorkflowUpgradePreservesOutsideManagedBlockVerbatim() {
+        var seed = """
+name: IntelligenceX Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Optional override"
+        required: false
+        default: ""
+
+concurrency:
+  group: custom-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  custom_pre:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo pre
+  # INTELLIGENCEX:BEGIN
+  review:
+    uses: evotecit/github-actions/.github/workflows/review-intelligencex.yml@master
+    with:
+      provider: openai
+      model: gpt-5.3-codex
+      preflight_timeout_seconds: 15
+  # INTELLIGENCEX:END
+  custom_post:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo post
+""";
+
+        var upgraded = SetupRunner.BuildWorkflowYamlFromSeedForTests(
+            new[] { "--provider", "copilot" },
+            seed);
+
+        AssertContainsText(upgraded, "provider: copilot", "workflow upgrade updates provider");
+        AssertEqual(1, CountOccurrencesInText(upgraded, "# INTELLIGENCEX:BEGIN"),
+            "workflow upgrade has one begin marker");
+        AssertEqual(1, CountOccurrencesInText(upgraded, "# INTELLIGENCEX:END"),
+            "workflow upgrade has one end marker");
+
+        var seedOutside = NormalizeLineEndingsForWorkflowAssert(StripManagedBlockForWorkflowAssert(seed)).Trim();
+        var upgradedOutside = NormalizeLineEndingsForWorkflowAssert(StripManagedBlockForWorkflowAssert(upgraded)).Trim();
+        AssertEqual(seedOutside, upgradedOutside,
+            "workflow upgrade preserves content outside managed block");
+
+        var secondPass = SetupRunner.BuildWorkflowYamlFromSeedForTests(
+            new[] { "--provider", "copilot" },
+            upgraded);
+        AssertEqual(upgraded, secondPass, "workflow upgrade remains idempotent after outside-block preserve");
+    }
+
+    private static int CountOccurrencesInText(string value, string marker) {
+        if (string.IsNullOrEmpty(value) || string.IsNullOrEmpty(marker)) {
+            return 0;
+        }
+        var count = 0;
+        var start = 0;
+        while (true) {
+            var index = value.IndexOf(marker, start, StringComparison.Ordinal);
+            if (index < 0) {
+                break;
+            }
+            count++;
+            start = index + marker.Length;
+        }
+        return count;
+    }
+
+    private static string StripManagedBlockForWorkflowAssert(string content) {
+        var pattern = @"^[ \t]*# INTELLIGENCEX:BEGIN[\s\S]*?^[ \t]*# INTELLIGENCEX:END[ \t]*\r?$";
+        return System.Text.RegularExpressions.Regex.Replace(content, pattern, string.Empty,
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+    }
+
+    private static string NormalizeLineEndingsForWorkflowAssert(string content) {
+        return (content ?? string.Empty).Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}
+#endif

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -62,6 +62,8 @@ internal static partial class Program {
         failed += Run("Setup config merge preserves review settings when enabling analysis", TestSetupBuildConfigJsonMergePreservesReviewSettingsWhenEnablingAnalysis);
         failed += Run("Setup workflow upgrade preserves custom sections outside managed block",
             TestSetupWorkflowUpgradePreservesCustomSectionsOutsideManagedBlock);
+        failed += Run("Setup workflow upgrade preserves outside managed block verbatim",
+            TestSetupWorkflowUpgradePreservesOutsideManagedBlockVerbatim);
         failed += Run("Setup post-apply verify passes for managed setup", TestSetupPostApplyVerifySetupPassesWithManagedWorkflowAndSecret);
         failed += Run("Setup post-apply verify detects residual cleanup config", TestSetupPostApplyVerifyCleanupDetectsResidualConfig);
         failed += Run("Setup post-apply verify allows unknown branch state when PR exists",

--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,7 @@ Goal: reviewer + static analysis + onboarding (CLI + Web) feel "done" end-to-end
 ### Phase B — Setup Output (Workflow + reviewer.json)
 - [x] Setup config writer: include `analysis` section in `.intelligencex/reviewer.json` when static analysis is enabled (create + merge paths).
 - [x] Setup presets: define recommended tiers for analysis packs (`all-50`, `all-100`, `all-500`) and a "no analysis" option.
-- [ ] Ensure workflow/config generation stays stable across upgrades (managed block upgrades do not delete user customization outside managed block).
+- [x] Ensure workflow/config generation stays stable across upgrades (managed block upgrades do not delete user customization outside managed block).
 
 ### Phase C — Review Reliability (Reduce Churn, Increase Continuity)
 - [ ] Add a diff range option for incremental review (for example `reviewDiffRange: last-reviewed` uses the last reviewed commit from the sticky summary as base).


### PR DESCRIPTION
## Summary
- add a new regression test (`TestSetupWorkflowUpgradePreservesOutsideManagedBlockVerbatim`) in a dedicated setup test file
- verify workflow upgrade updates managed settings while preserving all content outside `# INTELLIGENCEX:BEGIN/END` verbatim
- verify idempotency on second upgrade pass
- register the new test in `IntelligenceX.Tests/Program.cs`
- mark the roadmap item for workflow/config upgrade stability complete in `TODO.md`

## Validation
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
