### PR TITLE
Make workflow-run lookup results immutable

### DIFF
--- a/IntelligenceX.Cli/Setup/Wizard/GitHubRepoClient.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/GitHubRepoClient.cs
@@ -493,24 +493,25 @@ internal sealed class GitHubRepoClient : IDisposable {
     }
 
     public sealed class WorkflowRunLookupResult {
-        private WorkflowRunLookupResult(string status, bool success, string? note, List<WorkflowRunInfo>? runs = null) {
+        private WorkflowRunLookupResult(string status, string? note, IReadOnlyList<WorkflowRunInfo>? runs = null) {
             Status = status;
-            Success = success;
             Note = note;
-            Runs = runs ?? new List<WorkflowRunInfo>();
+            Runs = runs is null || runs.Count == 0
+                ? Array.Empty<WorkflowRunInfo>()
+                : runs.ToArray();
         }
 
         public string Status { get; }
-        public bool Success { get; }
+        public bool Success => string.Equals(Status, "ok", StringComparison.Ordinal);
         public string? Note { get; }
-        public List<WorkflowRunInfo> Runs { get; }
+        public IReadOnlyList<WorkflowRunInfo> Runs { get; }
 
-        public static WorkflowRunLookupResult Ok(List<WorkflowRunInfo> runs) => new("ok", true, null, runs);
-        public static WorkflowRunLookupResult InvalidArguments(string note) => new("invalid_arguments", false, note);
-        public static WorkflowRunLookupResult Unauthorized(string note) => new("unauthorized", false, note);
-        public static WorkflowRunLookupResult Forbidden(string note) => new("forbidden", false, note);
-        public static WorkflowRunLookupResult RateLimited(string note) => new("rate_limited", false, note);
-        public static WorkflowRunLookupResult HttpError(string note) => new("http_error", false, note);
-        public static WorkflowRunLookupResult ParseError(string note) => new("parse_error", false, note);
+        public static WorkflowRunLookupResult Ok(IReadOnlyList<WorkflowRunInfo> runs) => new("ok", null, runs);
+        public static WorkflowRunLookupResult InvalidArguments(string note) => new("invalid_arguments", note);
+        public static WorkflowRunLookupResult Unauthorized(string note) => new("unauthorized", note);
+        public static WorkflowRunLookupResult Forbidden(string note) => new("forbidden", note);
+        public static WorkflowRunLookupResult RateLimited(string note) => new("rate_limited", note);
+        public static WorkflowRunLookupResult HttpError(string note) => new("http_error", note);
+        public static WorkflowRunLookupResult ParseError(string note) => new("parse_error", note);
     }
 }

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -630,6 +630,27 @@ jobs:
         AssertContainsText(lookup.Runs[0].Url ?? string.Empty, "actions/runs/42", "repo client workflow run url");
     }
 
+    private static void TestGitHubRepoClientWorkflowRunLookupResultUsesDefensiveCopy() {
+        var sourceRuns = new List<IntelligenceX.Cli.Setup.Wizard.GitHubRepoClient.WorkflowRunInfo> {
+            new(
+                id: 7,
+                url: "https://github.com/owner/repo/actions/runs/7",
+                status: "completed",
+                conclusion: "success",
+                headBranch: "main",
+                @event: "pull_request",
+                createdAt: DateTimeOffset.Parse("2026-02-11T20:00:00Z", System.Globalization.CultureInfo.InvariantCulture))
+        };
+        var lookup = IntelligenceX.Cli.Setup.Wizard.GitHubRepoClient.WorkflowRunLookupResult.Ok(sourceRuns);
+        sourceRuns.Clear();
+
+        AssertEqual("ok", lookup.Status, "repo client workflow runs defensive copy status");
+        AssertEqual(true, lookup.Success, "repo client workflow runs defensive copy success");
+        AssertEqual(1, lookup.Runs.Count, "repo client workflow runs defensive copy count");
+        AssertEqual(false, lookup.Runs is List<IntelligenceX.Cli.Setup.Wizard.GitHubRepoClient.WorkflowRunInfo>,
+            "repo client workflow runs defensive copy list exposure");
+    }
+
     private static void TestGitHubRepoClientListWorkflowRunsInvalidPayloadReturnsEmpty() {
         using var client = CreateGitHubRepoClientForTests((_, _) => {
             var payload = """

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -108,6 +108,8 @@ internal static partial class Program {
         failed += Run("GitHub repo client secret lookup cancellation propagates", TestGitHubRepoClientSecretLookupCancellationPropagates);
         failed += Run("GitHub repo client list workflow runs parses latest run",
             TestGitHubRepoClientListWorkflowRunsParsesLatestRun);
+        failed += Run("GitHub repo client workflow run lookup result uses defensive copy",
+            TestGitHubRepoClientWorkflowRunLookupResultUsesDefensiveCopy);
         failed += Run("GitHub repo client list workflow runs invalid payload returns empty",
             TestGitHubRepoClientListWorkflowRunsInvalidPayloadReturnsEmpty);
         failed += Run("GitHub repo client list workflow runs encodes path segments",


### PR DESCRIPTION
## Summary
- expose workflow-run lookup runs as an immutable `IReadOnlyList`
- derive `Success` from `Status` to remove duplicated mutable state
- add regression coverage proving lookup result uses a defensive copy

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
