### PR TITLE
Centralize onboarding contract for CLI, web, and bot

### DIFF
--- a/IntelligenceX.Cli/Setup/Onboarding/SetupOnboardingPaths.cs
+++ b/IntelligenceX.Cli/Setup/Onboarding/SetupOnboardingPaths.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using IntelligenceX.Setup.Onboarding;
 
 namespace IntelligenceX.Cli.Setup.Onboarding;
 
@@ -15,76 +17,24 @@ internal sealed class SetupOnboardingPathDefinition {
 }
 
 internal static class SetupOnboardingPaths {
-    public const string NewSetup = "new-setup";
-    public const string RefreshAuth = "refresh-auth";
-    public const string Cleanup = "cleanup";
-    public const string Maintenance = "maintenance";
+    public const string NewSetup = SetupOnboardingContract.NewSetupPathId;
+    public const string RefreshAuth = SetupOnboardingContract.RefreshAuthPathId;
+    public const string Cleanup = SetupOnboardingContract.CleanupPathId;
+    public const string Maintenance = SetupOnboardingContract.MaintenancePathId;
 
-    private static readonly IReadOnlyList<SetupOnboardingPathDefinition> Paths = new[] {
-        new SetupOnboardingPathDefinition {
-            Id = NewSetup,
-            DisplayName = "New Setup",
-            Description = "Configure workflow and reviewer config for first-time onboarding.",
-            DefaultOperation = SetupApplyOperation.Setup,
-            RequiresGitHubAuth = true,
-            RequiresRepoSelection = true,
-            RequiresAiAuth = true,
-            Flow = new[] {
-                "Authenticate with GitHub",
-                "Select repositories",
-                "Configure workflow and reviewer profile",
-                "Authenticate with AI provider",
-                "Plan, apply, verify"
-            }
-        },
-        new SetupOnboardingPathDefinition {
-            Id = RefreshAuth,
-            DisplayName = "Fix Expired Auth",
-            Description = "Refresh OpenAI/ChatGPT auth and update INTELLIGENCEX_AUTH_B64 secret.",
-            DefaultOperation = SetupApplyOperation.UpdateSecret,
-            RequiresGitHubAuth = true,
-            RequiresRepoSelection = true,
-            RequiresAiAuth = true,
-            Flow = new[] {
-                "Authenticate with GitHub",
-                "Select repositories",
-                "Refresh AI auth bundle",
-                "Apply update-secret",
-                "Verify secret presence"
-            }
-        },
-        new SetupOnboardingPathDefinition {
-            Id = Cleanup,
-            DisplayName = "Cleanup",
-            Description = "Remove workflow/config and optionally remove secrets from repositories.",
-            DefaultOperation = SetupApplyOperation.Cleanup,
-            RequiresGitHubAuth = true,
-            RequiresRepoSelection = true,
-            RequiresAiAuth = false,
-            Flow = new[] {
-                "Authenticate with GitHub",
-                "Select repositories",
-                "Choose cleanup options",
-                "Plan, apply cleanup",
-                "Verify removal"
-            }
-        },
-        new SetupOnboardingPathDefinition {
-            Id = Maintenance,
-            DisplayName = "Maintenance",
-            Description = "Run preflight checks, inspect existing setup, then choose setup/update-secret/cleanup.",
-            DefaultOperation = SetupApplyOperation.Setup,
-            RequiresGitHubAuth = true,
-            RequiresRepoSelection = true,
-            RequiresAiAuth = false,
-            Flow = new[] {
-                "Run auto-detect preflight",
-                "Inspect current workflow/config status",
-                "Select operation based on findings",
-                "Plan, apply, verify"
-            }
-        }
-    };
+    private static readonly IReadOnlyList<SetupOnboardingPathDefinition> Paths = SetupOnboardingContract
+        .GetPaths(includeMaintenancePath: true)
+        .Select(static path => new SetupOnboardingPathDefinition {
+            Id = path.Id,
+            DisplayName = path.DisplayName,
+            Description = path.Description,
+            DefaultOperation = MapOperation(path.Operation),
+            RequiresGitHubAuth = path.RequiresGitHubAuth,
+            RequiresRepoSelection = path.RequiresRepoSelection,
+            RequiresAiAuth = path.RequiresAiAuth,
+            Flow = path.Flow.ToArray()
+        })
+        .ToArray();
 
     public static IReadOnlyList<SetupOnboardingPathDefinition> GetAll() {
         return Paths;
@@ -104,9 +54,19 @@ internal static class SetupOnboardingPaths {
 
     public static string FromOperation(SetupApplyOperation operation) {
         return operation switch {
-            SetupApplyOperation.UpdateSecret => RefreshAuth,
-            SetupApplyOperation.Cleanup => Cleanup,
-            _ => NewSetup
+            SetupApplyOperation.UpdateSecret => SetupOnboardingContract.PathIdFromOperation(SetupOnboardingOperationIds.UpdateSecret),
+            SetupApplyOperation.Cleanup => SetupOnboardingContract.PathIdFromOperation(SetupOnboardingOperationIds.Cleanup),
+            _ => SetupOnboardingContract.PathIdFromOperation(SetupOnboardingOperationIds.Setup)
         };
+    }
+
+    private static SetupApplyOperation MapOperation(string operationId) {
+        if (string.Equals(operationId, SetupOnboardingOperationIds.UpdateSecret, StringComparison.OrdinalIgnoreCase)) {
+            return SetupApplyOperation.UpdateSecret;
+        }
+        if (string.Equals(operationId, SetupOnboardingOperationIds.Cleanup, StringComparison.OrdinalIgnoreCase)) {
+            return SetupApplyOperation.Cleanup;
+        }
+        return SetupApplyOperation.Setup;
     }
 }

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -292,6 +292,64 @@ internal static partial class Program {
         AssertContainsText(output, "Unknown option: --badflag", "setup autodetect unknown option message");
     }
 
+    private static void TestSetupOnboardingContractCanonicalPaths() {
+        var contractPaths = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetPaths(includeMaintenancePath: true);
+        AssertEqual(4, contractPaths.Count, "setup contract path count with maintenance");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.NewSetupPathId, contractPaths[0].Id, "setup contract path[0] id");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.RefreshAuthPathId, contractPaths[1].Id, "setup contract path[1] id");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.CleanupPathId, contractPaths[2].Id, "setup contract path[2] id");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.MaintenancePathId, contractPaths[3].Id, "setup contract path[3] id");
+
+        var contractPathsNoMaintenance = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetPaths(includeMaintenancePath: false);
+        AssertEqual(3, contractPathsNoMaintenance.Count, "setup contract path count without maintenance");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.NewSetupPathId, contractPathsNoMaintenance[0].Id,
+            "setup contract path[0] id without maintenance");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.RefreshAuthPathId, contractPathsNoMaintenance[1].Id,
+            "setup contract path[1] id without maintenance");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.CleanupPathId, contractPathsNoMaintenance[2].Id,
+            "setup contract path[2] id without maintenance");
+
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.NewSetupPathId,
+            IntelligenceX.Setup.Onboarding.SetupOnboardingContract.PathIdFromOperation(IntelligenceX.Setup.Onboarding.SetupOnboardingOperationIds.Setup),
+            "setup contract map setup operation");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.RefreshAuthPathId,
+            IntelligenceX.Setup.Onboarding.SetupOnboardingContract.PathIdFromOperation(IntelligenceX.Setup.Onboarding.SetupOnboardingOperationIds.UpdateSecret),
+            "setup contract map update-secret operation");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.CleanupPathId,
+            IntelligenceX.Setup.Onboarding.SetupOnboardingContract.PathIdFromOperation(IntelligenceX.Setup.Onboarding.SetupOnboardingOperationIds.Cleanup),
+            "setup contract map cleanup operation");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.NewSetupPathId,
+            IntelligenceX.Setup.Onboarding.SetupOnboardingContract.PathIdFromOperation("unknown"),
+            "setup contract map unknown operation");
+
+        var cliPaths = IntelligenceX.Cli.Setup.Onboarding.SetupOnboardingPaths.GetAll();
+        AssertEqual(contractPaths.Count, cliPaths.Count, "setup cli path count matches contract");
+        for (var i = 0; i < contractPaths.Count; i++) {
+            AssertEqual(contractPaths[i].Id, cliPaths[i].Id, $"setup cli path[{i}] id matches contract");
+            AssertEqual(contractPaths[i].DisplayName, cliPaths[i].DisplayName, $"setup cli path[{i}] display name matches contract");
+            AssertEqual(contractPaths[i].Description, cliPaths[i].Description, $"setup cli path[{i}] description matches contract");
+            AssertSequenceEqual(contractPaths[i].Flow, cliPaths[i].Flow, $"setup cli path[{i}] flow matches contract");
+        }
+    }
+
+    private static void TestSetupOnboardingContractCommandTemplates() {
+        var templates = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetCommandTemplates();
+        AssertEqual("intelligencex setup autodetect --json", templates.AutoDetect, "setup contract auto-detect template");
+        AssertEqual("intelligencex setup --repo owner/name --with-config --dry-run", templates.NewSetupDryRun,
+            "setup contract new-setup dry-run template");
+        AssertEqual("intelligencex setup --repo owner/name --with-config", templates.NewSetupApply,
+            "setup contract new-setup apply template");
+        AssertEqual("intelligencex setup --repo owner/name --update-secret --auth-b64 <base64> --dry-run", templates.RefreshAuthDryRun,
+            "setup contract refresh-auth dry-run template");
+        AssertEqual("intelligencex setup --repo owner/name --update-secret --auth-b64 <base64>", templates.RefreshAuthApply,
+            "setup contract refresh-auth apply template");
+        AssertEqual("intelligencex setup --repo owner/name --cleanup --dry-run", templates.CleanupDryRun,
+            "setup contract cleanup dry-run template");
+        AssertEqual("intelligencex setup --repo owner/name --cleanup", templates.CleanupApply,
+            "setup contract cleanup apply template");
+        AssertEqual("intelligencex setup web", templates.MaintenanceWizard, "setup contract maintenance wizard template");
+    }
+
     private static void TestSetupWorkflowUpgradePreservesCustomSectionsOutsideManagedBlock() {
         var seed = """
 name: IntelligenceX Review

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -65,6 +65,8 @@ internal static partial class Program {
         failed += Run("Setup autodetect missing workspace value fails", TestSetupAutodetectMissingWorkspaceValueFails);
         failed += Run("Setup autodetect missing repo value fails", TestSetupAutodetectMissingRepoValueFails);
         failed += Run("Setup autodetect unknown option fails", TestSetupAutodetectUnknownOptionFails);
+        failed += Run("Setup onboarding contract canonical paths", TestSetupOnboardingContractCanonicalPaths);
+        failed += Run("Setup onboarding contract command templates", TestSetupOnboardingContractCommandTemplates);
         failed += Run("Setup workflow upgrade preserves custom sections outside managed block",
             TestSetupWorkflowUpgradePreservesCustomSectionsOutsideManagedBlock);
         failed += Run("Setup workflow upgrade preserves outside managed block verbatim",

--- a/IntelligenceX/Setup/Onboarding/SetupOnboardingContract.cs
+++ b/IntelligenceX/Setup/Onboarding/SetupOnboardingContract.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+
+namespace IntelligenceX.Setup.Onboarding;
+
+/// <summary>
+/// Canonical operation ids used by onboarding contracts.
+/// </summary>
+public static class SetupOnboardingOperationIds {
+    /// <summary>
+    /// Setup operation id.
+    /// </summary>
+    public const string Setup = "setup";
+
+    /// <summary>
+    /// Update secret operation id.
+    /// </summary>
+    public const string UpdateSecret = "update-secret";
+
+    /// <summary>
+    /// Cleanup operation id.
+    /// </summary>
+    public const string Cleanup = "cleanup";
+}
+
+/// <summary>
+/// Immutable onboarding path contract.
+/// </summary>
+public sealed class SetupOnboardingPathContract {
+    /// <summary>
+    /// Initializes a new path contract.
+    /// </summary>
+    public SetupOnboardingPathContract(
+        string id,
+        string displayName,
+        string description,
+        string operation,
+        bool requiresGitHubAuth,
+        bool requiresRepoSelection,
+        bool requiresAiAuth,
+        IReadOnlyList<string> flow) {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+        Description = description ?? throw new ArgumentNullException(nameof(description));
+        Operation = operation ?? throw new ArgumentNullException(nameof(operation));
+        RequiresGitHubAuth = requiresGitHubAuth;
+        RequiresRepoSelection = requiresRepoSelection;
+        RequiresAiAuth = requiresAiAuth;
+        Flow = flow ?? throw new ArgumentNullException(nameof(flow));
+    }
+
+    /// <summary>
+    /// Stable path id (for example, <c>new-setup</c>).
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Human-readable path label.
+    /// </summary>
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// Path description.
+    /// </summary>
+    public string Description { get; }
+
+    /// <summary>
+    /// Default operation id.
+    /// </summary>
+    public string Operation { get; }
+
+    /// <summary>
+    /// Whether GitHub auth is required.
+    /// </summary>
+    public bool RequiresGitHubAuth { get; }
+
+    /// <summary>
+    /// Whether repository selection is required.
+    /// </summary>
+    public bool RequiresRepoSelection { get; }
+
+    /// <summary>
+    /// Whether AI auth is required.
+    /// </summary>
+    public bool RequiresAiAuth { get; }
+
+    /// <summary>
+    /// Ordered flow steps for this path.
+    /// </summary>
+    public IReadOnlyList<string> Flow { get; }
+}
+
+/// <summary>
+/// Canonical command templates for onboarding flows.
+/// </summary>
+public sealed class SetupOnboardingCommandTemplates {
+    /// <summary>
+    /// Initializes command templates.
+    /// </summary>
+    public SetupOnboardingCommandTemplates(
+        string autoDetect,
+        string newSetupDryRun,
+        string newSetupApply,
+        string refreshAuthDryRun,
+        string refreshAuthApply,
+        string cleanupDryRun,
+        string cleanupApply,
+        string maintenanceWizard) {
+        AutoDetect = autoDetect ?? throw new ArgumentNullException(nameof(autoDetect));
+        NewSetupDryRun = newSetupDryRun ?? throw new ArgumentNullException(nameof(newSetupDryRun));
+        NewSetupApply = newSetupApply ?? throw new ArgumentNullException(nameof(newSetupApply));
+        RefreshAuthDryRun = refreshAuthDryRun ?? throw new ArgumentNullException(nameof(refreshAuthDryRun));
+        RefreshAuthApply = refreshAuthApply ?? throw new ArgumentNullException(nameof(refreshAuthApply));
+        CleanupDryRun = cleanupDryRun ?? throw new ArgumentNullException(nameof(cleanupDryRun));
+        CleanupApply = cleanupApply ?? throw new ArgumentNullException(nameof(cleanupApply));
+        MaintenanceWizard = maintenanceWizard ?? throw new ArgumentNullException(nameof(maintenanceWizard));
+    }
+
+    /// <summary>
+    /// Auto-detect command.
+    /// </summary>
+    public string AutoDetect { get; }
+
+    /// <summary>
+    /// New setup dry-run command.
+    /// </summary>
+    public string NewSetupDryRun { get; }
+
+    /// <summary>
+    /// New setup apply command.
+    /// </summary>
+    public string NewSetupApply { get; }
+
+    /// <summary>
+    /// Refresh auth dry-run command.
+    /// </summary>
+    public string RefreshAuthDryRun { get; }
+
+    /// <summary>
+    /// Refresh auth apply command.
+    /// </summary>
+    public string RefreshAuthApply { get; }
+
+    /// <summary>
+    /// Cleanup dry-run command.
+    /// </summary>
+    public string CleanupDryRun { get; }
+
+    /// <summary>
+    /// Cleanup apply command.
+    /// </summary>
+    public string CleanupApply { get; }
+
+    /// <summary>
+    /// Maintenance wizard command.
+    /// </summary>
+    public string MaintenanceWizard { get; }
+}
+
+/// <summary>
+/// Canonical onboarding contract consumed by CLI, Web, and Bot surfaces.
+/// </summary>
+public static class SetupOnboardingContract {
+    /// <summary>
+    /// New setup path id.
+    /// </summary>
+    public const string NewSetupPathId = "new-setup";
+
+    /// <summary>
+    /// Refresh auth path id.
+    /// </summary>
+    public const string RefreshAuthPathId = "refresh-auth";
+
+    /// <summary>
+    /// Cleanup path id.
+    /// </summary>
+    public const string CleanupPathId = "cleanup";
+
+    /// <summary>
+    /// Maintenance path id.
+    /// </summary>
+    public const string MaintenancePathId = "maintenance";
+
+    private static readonly IReadOnlyList<SetupOnboardingPathContract> PathsWithMaintenance = new[] {
+        new SetupOnboardingPathContract(
+            id: NewSetupPathId,
+            displayName: "New Setup",
+            description: "Configure workflow and reviewer config for first-time onboarding.",
+            operation: SetupOnboardingOperationIds.Setup,
+            requiresGitHubAuth: true,
+            requiresRepoSelection: true,
+            requiresAiAuth: true,
+            flow: new[] {
+                "Authenticate with GitHub",
+                "Select repositories",
+                "Configure workflow and reviewer profile",
+                "Authenticate with AI provider",
+                "Plan, apply, verify"
+            }),
+        new SetupOnboardingPathContract(
+            id: RefreshAuthPathId,
+            displayName: "Fix Expired Auth",
+            description: "Refresh OpenAI/ChatGPT auth and update INTELLIGENCEX_AUTH_B64 secret.",
+            operation: SetupOnboardingOperationIds.UpdateSecret,
+            requiresGitHubAuth: true,
+            requiresRepoSelection: true,
+            requiresAiAuth: true,
+            flow: new[] {
+                "Authenticate with GitHub",
+                "Select repositories",
+                "Refresh AI auth bundle",
+                "Apply update-secret",
+                "Verify secret presence"
+            }),
+        new SetupOnboardingPathContract(
+            id: CleanupPathId,
+            displayName: "Cleanup",
+            description: "Remove workflow/config and optionally remove secrets from repositories.",
+            operation: SetupOnboardingOperationIds.Cleanup,
+            requiresGitHubAuth: true,
+            requiresRepoSelection: true,
+            requiresAiAuth: false,
+            flow: new[] {
+                "Authenticate with GitHub",
+                "Select repositories",
+                "Choose cleanup options",
+                "Plan, apply cleanup",
+                "Verify removal"
+            }),
+        new SetupOnboardingPathContract(
+            id: MaintenancePathId,
+            displayName: "Maintenance",
+            description: "Run preflight checks, inspect existing setup, then choose setup/update-secret/cleanup.",
+            operation: SetupOnboardingOperationIds.Setup,
+            requiresGitHubAuth: true,
+            requiresRepoSelection: true,
+            requiresAiAuth: false,
+            flow: new[] {
+                "Run auto-detect preflight",
+                "Inspect current workflow/config status",
+                "Select operation based on findings",
+                "Plan, apply, verify"
+            })
+    };
+
+    private static readonly IReadOnlyList<SetupOnboardingPathContract> PathsWithoutMaintenance = new[] {
+        PathsWithMaintenance[0],
+        PathsWithMaintenance[1],
+        PathsWithMaintenance[2]
+    };
+
+    private static readonly SetupOnboardingCommandTemplates CommandTemplates = new(
+        autoDetect: "intelligencex setup autodetect --json",
+        newSetupDryRun: "intelligencex setup --repo owner/name --with-config --dry-run",
+        newSetupApply: "intelligencex setup --repo owner/name --with-config",
+        refreshAuthDryRun: "intelligencex setup --repo owner/name --update-secret --auth-b64 <base64> --dry-run",
+        refreshAuthApply: "intelligencex setup --repo owner/name --update-secret --auth-b64 <base64>",
+        cleanupDryRun: "intelligencex setup --repo owner/name --cleanup --dry-run",
+        cleanupApply: "intelligencex setup --repo owner/name --cleanup",
+        maintenanceWizard: "intelligencex setup web");
+
+    /// <summary>
+    /// Returns onboarding paths.
+    /// </summary>
+    public static IReadOnlyList<SetupOnboardingPathContract> GetPaths(bool includeMaintenancePath = true) {
+        return includeMaintenancePath ? PathsWithMaintenance : PathsWithoutMaintenance;
+    }
+
+    /// <summary>
+    /// Returns a path by id, or the default path when not found.
+    /// </summary>
+    public static SetupOnboardingPathContract GetPathOrDefault(string? id, bool includeMaintenancePath = true) {
+        var paths = GetPaths(includeMaintenancePath);
+        if (!string.IsNullOrWhiteSpace(id)) {
+            foreach (var path in paths) {
+                if (string.Equals(path.Id, id, StringComparison.OrdinalIgnoreCase)) {
+                    return path;
+                }
+            }
+        }
+
+        return paths[0];
+    }
+
+    /// <summary>
+    /// Returns canonical path id for the given operation id.
+    /// </summary>
+    public static string PathIdFromOperation(string? operationId) {
+        if (string.Equals(operationId, SetupOnboardingOperationIds.UpdateSecret, StringComparison.OrdinalIgnoreCase)) {
+            return RefreshAuthPathId;
+        }
+        if (string.Equals(operationId, SetupOnboardingOperationIds.Cleanup, StringComparison.OrdinalIgnoreCase)) {
+            return CleanupPathId;
+        }
+        return NewSetupPathId;
+    }
+
+    /// <summary>
+    /// Returns canonical command templates.
+    /// </summary>
+    public static SetupOnboardingCommandTemplates GetCommandTemplates() {
+        return CommandTemplates;
+    }
+}


### PR DESCRIPTION
## Summary
- add canonical onboarding contract types to `IntelligenceX` core (`paths`, `operation ids`, `command templates`)
- update CLI `SetupOnboardingPaths` to map from the shared contract instead of hardcoded duplicated path data
- add drift-guard tests that lock canonical path IDs/operations/templates and verify CLI mapping stays aligned

## Validation
- `.agents/skills/intelligencex-onboarding-setup/scripts/preflight.sh`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh fast`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh full`
