### PR TITLE
Add onboarding contract version and fingerprint metadata

### DIFF
--- a/Docs/reviewer/onboarding-unification-tracker.md
+++ b/Docs/reviewer/onboarding-unification-tracker.md
@@ -25,6 +25,7 @@ This file tracks onboarding/cleanup/maintenance unification across CLI, Web, and
 | .Chat: register reviewer setup pack by default | Completed | IX Chat + IX Tools | Chat now registers the reviewer setup tool pack by default through `ToolRegistryReviewerSetupExtensions`. |
 | Shared canonical onboarding contract | Completed | IX Core | Added `IntelligenceX/Setup/Onboarding/SetupOnboardingContract.cs` as the source of truth for path ids and command templates. |
 | Drift guard contract tests | Completed | IX + IX.Tools + IX.Chat | Added tests for CLI contract parity and bot/tool contract payload parity (`IntelligenceX.Tests`, `IntelligenceX.Tools.Tests`, `IntelligenceX.Chat.Tests`). |
+| Contract version/fingerprint surfaced by autodetect | Completed | IX Core + IX CLI Web | Added `ContractVersion` + deterministic contract fingerprint in `SetupOnboardingContract`, emitted by `setup autodetect` JSON and Web autodetect API/summary panel. |
 | .Chat: autodetect-first onboarding playbook | Completed | IX Chat | Updated `Docs/HostSystemPrompt.md` to require `reviewer_setup_pack_info` + preflight autodetect before path execution. |
 | Docs: diagrams and flow updates | Completed | Docs | Added path-first flow docs and Mermaid diagrams in onboarding pages. |
 | Website FAQ/data updates | Completed | Website | Updated FAQ/features/how-it-works for path-first + auto-detect positioning. |
@@ -40,6 +41,7 @@ None for this unification scope. As of February 12, 2026:
 - `IntelligenceX` PR `#248` is merged.
 - `IntelligenceX` PR `#249` is merged.
 - `IntelligenceX` PR `#250` is merged.
+- `IntelligenceX` PR `#251` is merged.
 
 ## Next Actions
 

--- a/IntelligenceX.Cli/Setup/Onboarding/SetupOnboardingAutoDetect.cs
+++ b/IntelligenceX.Cli/Setup/Onboarding/SetupOnboardingAutoDetect.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Cli;
 using IntelligenceX.Cli.Doctor;
+using IntelligenceX.Setup.Onboarding;
 
 namespace IntelligenceX.Cli.Setup.Onboarding;
 
@@ -31,6 +32,8 @@ internal sealed class SetupOnboardingAutoDetectResult {
     public string? Repo { get; set; }
     public bool LocalWorkflowExists { get; set; }
     public bool LocalConfigExists { get; set; }
+    public string ContractVersion { get; set; } = SetupOnboardingContract.ContractVersion;
+    public string ContractFingerprint { get; set; } = SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true);
     public string RecommendedPath { get; set; } = SetupOnboardingPaths.NewSetup;
     public string RecommendedReason { get; set; } = string.Empty;
     public IReadOnlyList<SetupOnboardingCheck> Checks { get; set; } = Array.Empty<SetupOnboardingCheck>();
@@ -69,6 +72,8 @@ internal static class SetupOnboardingAutoDetectRunner {
             Repo = repo,
             LocalWorkflowExists = localWorkflowExists,
             LocalConfigExists = localConfigExists,
+            ContractVersion = SetupOnboardingContract.ContractVersion,
+            ContractFingerprint = SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true),
             RecommendedPath = recommendedPath,
             RecommendedReason = reason,
             Checks = checks,

--- a/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
+++ b/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
@@ -449,6 +449,8 @@ function formatAutoDetectOutput(data) {
   lines.push(`status: ${data.status || 'unknown'}`);
   lines.push(`workspace: ${data.workspace || '-'}`);
   lines.push(`repo: ${data.repo || '(not detected)'}`);
+  if (data.contractVersion) lines.push(`contract version: ${data.contractVersion}`);
+  if (data.contractFingerprint) lines.push(`contract fingerprint: ${data.contractFingerprint}`);
   lines.push(`local workflow: ${data.localWorkflowExists ? 'yes' : 'no'}`);
   lines.push(`local config: ${data.localConfigExists ? 'yes' : 'no'}`);
   lines.push(`recommended path: ${data.recommendedPath || '-'}`);
@@ -475,7 +477,8 @@ function renderAutoDetect(data) {
     : status === 'warn'
       ? 'Warning'
       : 'OK';
-  summaryEl.textContent = `${statusText} | checks: ${counts.ok} ok, ${counts.warn} warn, ${counts.fail} fail | Suggested path: ${recommendedPath}. ${data.recommendedReason || ''}`;
+  const contractText = data.contractVersion ? ` | contract: ${data.contractVersion}` : '';
+  summaryEl.textContent = `${statusText} | checks: ${counts.ok} ok, ${counts.warn} warn, ${counts.fail} fail | Suggested path: ${recommendedPath}${contractText}. ${data.recommendedReason || ''}`;
   outputEl.textContent = formatAutoDetectOutput(data);
 
   if (applyBtn) {

--- a/IntelligenceX.Cli/Setup/Web/WebApi.Autodetect.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebApi.Autodetect.cs
@@ -51,6 +51,8 @@ internal sealed partial class WebApi {
         }).ToArray();
 
         await WriteJsonOkAsync(context, new {
+            contractVersion = result.ContractVersion,
+            contractFingerprint = result.ContractFingerprint,
             status = result.Status,
             workspace = result.Workspace,
             repo = result.Repo,

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -262,6 +262,11 @@ internal static partial class Program {
         using var document = System.Text.Json.JsonDocument.Parse(json);
         AssertEqual(false, document.RootElement.TryGetProperty("Checks", out _),
             "setup autodetect json root does not use PascalCase");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.ContractVersion,
+            document.RootElement.GetProperty("contractVersion").GetString(),
+            "setup autodetect json contract version");
+        var contractFingerprint = document.RootElement.GetProperty("contractFingerprint").GetString() ?? string.Empty;
+        AssertEqual(64, contractFingerprint.Length, "setup autodetect json contract fingerprint length");
         var checks = document.RootElement.GetProperty("checks");
 
         AssertEqual(System.Text.Json.JsonValueKind.String, checks[0].GetProperty("status").ValueKind,
@@ -328,8 +333,27 @@ internal static partial class Program {
             AssertEqual(contractPaths[i].Id, cliPaths[i].Id, $"setup cli path[{i}] id matches contract");
             AssertEqual(contractPaths[i].DisplayName, cliPaths[i].DisplayName, $"setup cli path[{i}] display name matches contract");
             AssertEqual(contractPaths[i].Description, cliPaths[i].Description, $"setup cli path[{i}] description matches contract");
+            AssertEqual(contractPaths[i].RequiresGitHubAuth, cliPaths[i].RequiresGitHubAuth,
+                $"setup cli path[{i}] requires github auth matches contract");
+            AssertEqual(contractPaths[i].RequiresRepoSelection, cliPaths[i].RequiresRepoSelection,
+                $"setup cli path[{i}] requires repo selection matches contract");
+            AssertEqual(contractPaths[i].RequiresAiAuth, cliPaths[i].RequiresAiAuth,
+                $"setup cli path[{i}] requires ai auth matches contract");
+            var expectedOperation = contractPaths[i].Operation switch {
+                "update-secret" => SetupApplyOperation.UpdateSecret,
+                "cleanup" => SetupApplyOperation.Cleanup,
+                _ => SetupApplyOperation.Setup
+            };
+            AssertEqual(expectedOperation, cliPaths[i].DefaultOperation, $"setup cli path[{i}] operation matches contract");
             AssertSequenceEqual(contractPaths[i].Flow, cliPaths[i].Flow, $"setup cli path[{i}] flow matches contract");
         }
+
+        var mutableFlow = contractPaths[0].Flow as string[];
+        AssertNotNull(mutableFlow, "setup contract flow returns concrete array for defensive copy check");
+        var originalFlowStep = mutableFlow![0];
+        mutableFlow[0] = "Mutated step";
+        var freshPaths = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetPaths(includeMaintenancePath: true);
+        AssertEqual(originalFlowStep, freshPaths[0].Flow[0], "setup contract returns defensive path copies");
     }
 
     private static void TestSetupOnboardingContractCommandTemplates() {
@@ -348,6 +372,31 @@ internal static partial class Program {
         AssertEqual("intelligencex setup --repo owner/name --cleanup", templates.CleanupApply,
             "setup contract cleanup apply template");
         AssertEqual("intelligencex setup web", templates.MaintenanceWizard, "setup contract maintenance wizard template");
+
+        var fingerprintWithMaintenance = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true);
+        var fingerprintWithoutMaintenance = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: false);
+        AssertEqual(64, fingerprintWithMaintenance.Length, "setup contract fingerprint with maintenance length");
+        AssertEqual(64, fingerprintWithoutMaintenance.Length, "setup contract fingerprint without maintenance length");
+        AssertEqual(false, string.Equals(fingerprintWithMaintenance, fingerprintWithoutMaintenance, StringComparison.Ordinal),
+            "setup contract fingerprint differs by maintenance mode");
+
+        AssertEqual(true, IsLowerHex(fingerprintWithMaintenance), "setup contract fingerprint with maintenance is lowercase hex");
+        AssertEqual(true, IsLowerHex(fingerprintWithoutMaintenance), "setup contract fingerprint without maintenance is lowercase hex");
+    }
+
+    private static bool IsLowerHex(string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+        for (var i = 0; i < value.Length; i++) {
+            var c = value[i];
+            var isDigit = c >= '0' && c <= '9';
+            var isLowerHexLetter = c >= 'a' && c <= 'f';
+            if (!isDigit && !isLowerHexLetter) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static void TestSetupWorkflowUpgradePreservesCustomSectionsOutsideManagedBlock() {

--- a/IntelligenceX/Setup/Onboarding/SetupOnboardingContract.cs
+++ b/IntelligenceX/Setup/Onboarding/SetupOnboardingContract.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace IntelligenceX.Setup.Onboarding;
 
@@ -181,6 +183,11 @@ public static class SetupOnboardingContract {
     /// </summary>
     public const string MaintenancePathId = "maintenance";
 
+    /// <summary>
+    /// Semantic onboarding contract version.
+    /// </summary>
+    public const string ContractVersion = "2026-02-12.3";
+
     private static readonly IReadOnlyList<SetupOnboardingPathContract> PathsWithMaintenance = new[] {
         new SetupOnboardingPathContract(
             id: NewSetupPathId,
@@ -259,11 +266,14 @@ public static class SetupOnboardingContract {
         cleanupApply: "intelligencex setup --repo owner/name --cleanup",
         maintenanceWizard: "intelligencex setup web");
 
+    private static readonly string FingerprintWithMaintenance = ComputeFingerprint(includeMaintenancePath: true);
+    private static readonly string FingerprintWithoutMaintenance = ComputeFingerprint(includeMaintenancePath: false);
+
     /// <summary>
     /// Returns onboarding paths.
     /// </summary>
     public static IReadOnlyList<SetupOnboardingPathContract> GetPaths(bool includeMaintenancePath = true) {
-        return includeMaintenancePath ? PathsWithMaintenance : PathsWithoutMaintenance;
+        return ClonePaths(includeMaintenancePath ? PathsWithMaintenance : PathsWithoutMaintenance);
     }
 
     /// <summary>
@@ -299,6 +309,93 @@ public static class SetupOnboardingContract {
     /// Returns canonical command templates.
     /// </summary>
     public static SetupOnboardingCommandTemplates GetCommandTemplates() {
-        return CommandTemplates;
+        return new SetupOnboardingCommandTemplates(
+            autoDetect: CommandTemplates.AutoDetect,
+            newSetupDryRun: CommandTemplates.NewSetupDryRun,
+            newSetupApply: CommandTemplates.NewSetupApply,
+            refreshAuthDryRun: CommandTemplates.RefreshAuthDryRun,
+            refreshAuthApply: CommandTemplates.RefreshAuthApply,
+            cleanupDryRun: CommandTemplates.CleanupDryRun,
+            cleanupApply: CommandTemplates.CleanupApply,
+            maintenanceWizard: CommandTemplates.MaintenanceWizard);
+    }
+
+    /// <summary>
+    /// Returns deterministic contract fingerprint for drift checks.
+    /// </summary>
+    public static string GetContractFingerprint(bool includeMaintenancePath = true) {
+        return includeMaintenancePath ? FingerprintWithMaintenance : FingerprintWithoutMaintenance;
+    }
+
+    private static IReadOnlyList<SetupOnboardingPathContract> ClonePaths(IReadOnlyList<SetupOnboardingPathContract> source) {
+        var copy = new SetupOnboardingPathContract[source.Count];
+        for (var i = 0; i < source.Count; i++) {
+            var path = source[i];
+            var flowCopy = new string[path.Flow.Count];
+            for (var j = 0; j < path.Flow.Count; j++) {
+                flowCopy[j] = path.Flow[j];
+            }
+
+            copy[i] = new SetupOnboardingPathContract(
+                id: path.Id,
+                displayName: path.DisplayName,
+                description: path.Description,
+                operation: path.Operation,
+                requiresGitHubAuth: path.RequiresGitHubAuth,
+                requiresRepoSelection: path.RequiresRepoSelection,
+                requiresAiAuth: path.RequiresAiAuth,
+                flow: flowCopy);
+        }
+
+        return copy;
+    }
+
+    private static string ComputeFingerprint(bool includeMaintenancePath) {
+        var data = includeMaintenancePath ? PathsWithMaintenance : PathsWithoutMaintenance;
+        var builder = new StringBuilder();
+        builder.Append("version=").Append(ContractVersion).Append('\n');
+        for (var i = 0; i < data.Count; i++) {
+            var path = data[i];
+            builder.Append(path.Id).Append('|')
+                .Append(path.DisplayName).Append('|')
+                .Append(path.Description).Append('|')
+                .Append(path.Operation).Append('|')
+                .Append(path.RequiresGitHubAuth ? '1' : '0').Append('|')
+                .Append(path.RequiresRepoSelection ? '1' : '0').Append('|')
+                .Append(path.RequiresAiAuth ? '1' : '0').Append('\n');
+            for (var j = 0; j < path.Flow.Count; j++) {
+                builder.Append('>').Append(path.Flow[j]).Append('\n');
+            }
+        }
+
+        builder.Append("autoDetect=").Append(CommandTemplates.AutoDetect).Append('\n');
+        builder.Append("newSetupDryRun=").Append(CommandTemplates.NewSetupDryRun).Append('\n');
+        builder.Append("newSetupApply=").Append(CommandTemplates.NewSetupApply).Append('\n');
+        builder.Append("refreshAuthDryRun=").Append(CommandTemplates.RefreshAuthDryRun).Append('\n');
+        builder.Append("refreshAuthApply=").Append(CommandTemplates.RefreshAuthApply).Append('\n');
+        builder.Append("cleanupDryRun=").Append(CommandTemplates.CleanupDryRun).Append('\n');
+        builder.Append("cleanupApply=").Append(CommandTemplates.CleanupApply).Append('\n');
+        builder.Append("maintenanceWizard=").Append(CommandTemplates.MaintenanceWizard).Append('\n');
+
+        using var hash = SHA256.Create();
+        var digest = hash.ComputeHash(Encoding.UTF8.GetBytes(builder.ToString()));
+        return ToHexLower(digest);
+    }
+
+    private static string ToHexLower(byte[] bytes) {
+        var chars = new char[bytes.Length * 2];
+        var index = 0;
+        for (var i = 0; i < bytes.Length; i++) {
+            var b = bytes[i];
+            chars[index++] = ToHexNibbleLower((b >> 4) & 0xF);
+            chars[index++] = ToHexNibbleLower(b & 0xF);
+        }
+        return new string(chars);
+    }
+
+    private static char ToHexNibbleLower(int value) {
+        return value < 10
+            ? (char)('0' + value)
+            : (char)('a' + (value - 10));
     }
 }


### PR DESCRIPTION
## Summary
- add semantic onboarding contract version and deterministic SHA-256 fingerprint to `SetupOnboardingContract`
- expose `contractVersion` and `contractFingerprint` in `setup autodetect --json` and the web autodetect API/panel summary
- harden contract data access with defensive copies for paths/command templates and extend setup tests for parity + fingerprint shape checks
- update onboarding unification tracker with this completed hardening step

## Validation
- `ALLOW_DIRTY=1 .agents/skills/intelligencex-onboarding-setup/scripts/preflight.sh`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh fast`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh full`
