### PR TITLE
Add shared onboarding contract verification API

### DIFF
--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -384,6 +384,60 @@ internal static partial class Program {
         AssertEqual(true, IsLowerHex(fingerprintWithoutMaintenance), "setup contract fingerprint without maintenance is lowercase hex");
     }
 
+    private static void TestSetupOnboardingContractVerificationMatchesCanonicalValues() {
+        var result = IntelligenceX.Setup.Onboarding.SetupOnboardingContractVerification.Verify(
+            autodetectContractVersion: IntelligenceX.Setup.Onboarding.SetupOnboardingContract.ContractVersion,
+            autodetectContractFingerprint: IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true),
+            packContractVersion: IntelligenceX.Setup.Onboarding.SetupOnboardingContract.ContractVersion,
+            packContractFingerprint: IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true),
+            includeMaintenancePath: true);
+
+        AssertEqual(true, result.IsMatch, "setup contract verification is match");
+        AssertEqual(0, result.MismatchCount, "setup contract verification mismatch count");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.ContractVersion, result.ExpectedContractVersion,
+            "setup contract verification expected version");
+    }
+
+    private static void TestSetupOnboardingContractVerificationDetectsMismatches() {
+        var result = IntelligenceX.Setup.Onboarding.SetupOnboardingContractVerification.Verify(
+            autodetectContractVersion: "1900-01-01.0",
+            autodetectContractFingerprint: IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true),
+            packContractVersion: IntelligenceX.Setup.Onboarding.SetupOnboardingContract.ContractVersion,
+            packContractFingerprint: "not-the-right-fingerprint",
+            includeMaintenancePath: true);
+
+        AssertEqual(false, result.IsMatch, "setup contract verification mismatch state");
+        AssertEqual(true, result.MismatchCount >= 2, "setup contract verification mismatch count");
+
+        var hasVersionMismatch = false;
+        var hasFingerprintMismatch = false;
+        for (var i = 0; i < result.Mismatches.Count; i++) {
+            var mismatch = result.Mismatches[i];
+            if (string.Equals(mismatch.Field, "contract_version", StringComparison.Ordinal)) {
+                hasVersionMismatch = true;
+            }
+            if (string.Equals(mismatch.Field, "contract_fingerprint", StringComparison.Ordinal)) {
+                hasFingerprintMismatch = true;
+            }
+        }
+
+        AssertEqual(true, hasVersionMismatch, "setup contract verification version mismatch captured");
+        AssertEqual(true, hasFingerprintMismatch, "setup contract verification fingerprint mismatch captured");
+    }
+
+    private static void TestSetupOnboardingContractVerificationRejectsMissingAutodetectMetadata() {
+        AssertThrows<ArgumentException>(() =>
+            IntelligenceX.Setup.Onboarding.SetupOnboardingContractVerification.Verify(
+                autodetectContractVersion: "",
+                autodetectContractFingerprint: "abc"),
+            "setup contract verification missing autodetect version");
+        AssertThrows<ArgumentException>(() =>
+            IntelligenceX.Setup.Onboarding.SetupOnboardingContractVerification.Verify(
+                autodetectContractVersion: IntelligenceX.Setup.Onboarding.SetupOnboardingContract.ContractVersion,
+                autodetectContractFingerprint: ""),
+            "setup contract verification missing autodetect fingerprint");
+    }
+
     private static bool IsLowerHex(string value) {
         if (string.IsNullOrWhiteSpace(value)) {
             return false;

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -67,6 +67,12 @@ internal static partial class Program {
         failed += Run("Setup autodetect unknown option fails", TestSetupAutodetectUnknownOptionFails);
         failed += Run("Setup onboarding contract canonical paths", TestSetupOnboardingContractCanonicalPaths);
         failed += Run("Setup onboarding contract command templates", TestSetupOnboardingContractCommandTemplates);
+        failed += Run("Setup onboarding contract verification matches canonical values",
+            TestSetupOnboardingContractVerificationMatchesCanonicalValues);
+        failed += Run("Setup onboarding contract verification detects mismatches",
+            TestSetupOnboardingContractVerificationDetectsMismatches);
+        failed += Run("Setup onboarding contract verification rejects missing autodetect metadata",
+            TestSetupOnboardingContractVerificationRejectsMissingAutodetectMetadata);
         failed += Run("Setup workflow upgrade preserves custom sections outside managed block",
             TestSetupWorkflowUpgradePreservesCustomSectionsOutsideManagedBlock);
         failed += Run("Setup workflow upgrade preserves outside managed block verbatim",

--- a/IntelligenceX/Setup/Onboarding/SetupOnboardingContractVerification.cs
+++ b/IntelligenceX/Setup/Onboarding/SetupOnboardingContractVerification.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+
+namespace IntelligenceX.Setup.Onboarding;
+
+/// <summary>
+/// Single mismatch entry for onboarding contract verification.
+/// </summary>
+public sealed class SetupOnboardingContractMismatch {
+    /// <summary>
+    /// Initializes a mismatch entry.
+    /// </summary>
+    public SetupOnboardingContractMismatch(string source, string field, string expected, string actual) {
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+        Field = field ?? throw new ArgumentNullException(nameof(field));
+        Expected = expected ?? throw new ArgumentNullException(nameof(expected));
+        Actual = actual ?? throw new ArgumentNullException(nameof(actual));
+    }
+
+    /// <summary>
+    /// Source of compared metadata (<c>autodetect</c> or <c>pack_info</c>).
+    /// </summary>
+    public string Source { get; }
+
+    /// <summary>
+    /// Name of the compared field.
+    /// </summary>
+    public string Field { get; }
+
+    /// <summary>
+    /// Canonical expected value.
+    /// </summary>
+    public string Expected { get; }
+
+    /// <summary>
+    /// Actual value received from caller metadata.
+    /// </summary>
+    public string Actual { get; }
+}
+
+/// <summary>
+/// Result payload for onboarding contract metadata verification.
+/// </summary>
+public sealed class SetupOnboardingContractVerificationResult {
+    /// <summary>
+    /// Initializes a verification result.
+    /// </summary>
+    public SetupOnboardingContractVerificationResult(
+        bool includeMaintenancePath,
+        string expectedContractVersion,
+        string expectedContractFingerprint,
+        string autodetectContractVersion,
+        string autodetectContractFingerprint,
+        string? packContractVersion,
+        string? packContractFingerprint,
+        IReadOnlyList<SetupOnboardingContractMismatch> mismatches) {
+        IncludeMaintenancePath = includeMaintenancePath;
+        ExpectedContractVersion = expectedContractVersion ?? throw new ArgumentNullException(nameof(expectedContractVersion));
+        ExpectedContractFingerprint = expectedContractFingerprint ?? throw new ArgumentNullException(nameof(expectedContractFingerprint));
+        AutodetectContractVersion = autodetectContractVersion ?? throw new ArgumentNullException(nameof(autodetectContractVersion));
+        AutodetectContractFingerprint = autodetectContractFingerprint ?? throw new ArgumentNullException(nameof(autodetectContractFingerprint));
+        PackContractVersion = packContractVersion;
+        PackContractFingerprint = packContractFingerprint;
+        Mismatches = mismatches ?? throw new ArgumentNullException(nameof(mismatches));
+    }
+
+    /// <summary>
+    /// Whether maintenance path was included when computing expected fingerprint.
+    /// </summary>
+    public bool IncludeMaintenancePath { get; }
+
+    /// <summary>
+    /// Canonical expected contract version.
+    /// </summary>
+    public string ExpectedContractVersion { get; }
+
+    /// <summary>
+    /// Canonical expected contract fingerprint.
+    /// </summary>
+    public string ExpectedContractFingerprint { get; }
+
+    /// <summary>
+    /// Autodetect contract version provided by caller.
+    /// </summary>
+    public string AutodetectContractVersion { get; }
+
+    /// <summary>
+    /// Autodetect contract fingerprint provided by caller.
+    /// </summary>
+    public string AutodetectContractFingerprint { get; }
+
+    /// <summary>
+    /// Optional pack contract version provided by caller.
+    /// </summary>
+    public string? PackContractVersion { get; }
+
+    /// <summary>
+    /// Optional pack contract fingerprint provided by caller.
+    /// </summary>
+    public string? PackContractFingerprint { get; }
+
+    /// <summary>
+    /// Detected mismatch list.
+    /// </summary>
+    public IReadOnlyList<SetupOnboardingContractMismatch> Mismatches { get; }
+
+    /// <summary>
+    /// Number of detected mismatches.
+    /// </summary>
+    public int MismatchCount => Mismatches.Count;
+
+    /// <summary>
+    /// True when no mismatches were detected.
+    /// </summary>
+    public bool IsMatch => Mismatches.Count == 0;
+}
+
+/// <summary>
+/// Verification helper for onboarding contract metadata parity checks.
+/// </summary>
+public static class SetupOnboardingContractVerification {
+    /// <summary>
+    /// Verifies autodetect/pack contract metadata against canonical onboarding contract values.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when required autodetect metadata is missing.</exception>
+    public static SetupOnboardingContractVerificationResult Verify(
+        string autodetectContractVersion,
+        string autodetectContractFingerprint,
+        string? packContractVersion = null,
+        string? packContractFingerprint = null,
+        bool includeMaintenancePath = true) {
+        if (string.IsNullOrWhiteSpace(autodetectContractVersion)) {
+            throw new ArgumentException("autodetectContractVersion is required.", nameof(autodetectContractVersion));
+        }
+        if (string.IsNullOrWhiteSpace(autodetectContractFingerprint)) {
+            throw new ArgumentException("autodetectContractFingerprint is required.", nameof(autodetectContractFingerprint));
+        }
+
+        var normalizedAutodetectVersion = autodetectContractVersion.Trim();
+        var normalizedAutodetectFingerprint = autodetectContractFingerprint.Trim();
+        var normalizedPackVersion = string.IsNullOrWhiteSpace(packContractVersion) ? null : packContractVersion.Trim();
+        var normalizedPackFingerprint = string.IsNullOrWhiteSpace(packContractFingerprint) ? null : packContractFingerprint.Trim();
+
+        var expectedContractVersion = SetupOnboardingContract.ContractVersion;
+        var expectedContractFingerprint = SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath);
+        var mismatches = new List<SetupOnboardingContractMismatch>();
+
+        AddMismatchIfDifferent(
+            mismatches: mismatches,
+            source: "autodetect",
+            field: "contract_version",
+            expected: expectedContractVersion,
+            actual: normalizedAutodetectVersion,
+            comparer: StringComparer.Ordinal);
+        AddMismatchIfDifferent(
+            mismatches: mismatches,
+            source: "autodetect",
+            field: "contract_fingerprint",
+            expected: expectedContractFingerprint,
+            actual: normalizedAutodetectFingerprint,
+            comparer: StringComparer.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(normalizedPackVersion)) {
+            AddMismatchIfDifferent(
+                mismatches: mismatches,
+                source: "pack_info",
+                field: "contract_version",
+                expected: expectedContractVersion,
+                actual: normalizedPackVersion!,
+                comparer: StringComparer.Ordinal);
+        }
+
+        if (!string.IsNullOrWhiteSpace(normalizedPackFingerprint)) {
+            AddMismatchIfDifferent(
+                mismatches: mismatches,
+                source: "pack_info",
+                field: "contract_fingerprint",
+                expected: expectedContractFingerprint,
+                actual: normalizedPackFingerprint!,
+                comparer: StringComparer.OrdinalIgnoreCase);
+        }
+
+        return new SetupOnboardingContractVerificationResult(
+            includeMaintenancePath: includeMaintenancePath,
+            expectedContractVersion: expectedContractVersion,
+            expectedContractFingerprint: expectedContractFingerprint,
+            autodetectContractVersion: normalizedAutodetectVersion,
+            autodetectContractFingerprint: normalizedAutodetectFingerprint,
+            packContractVersion: normalizedPackVersion,
+            packContractFingerprint: normalizedPackFingerprint,
+            mismatches: mismatches.ToArray());
+    }
+
+    private static void AddMismatchIfDifferent(
+        List<SetupOnboardingContractMismatch> mismatches,
+        string source,
+        string field,
+        string expected,
+        string actual,
+        StringComparer comparer) {
+        if (comparer.Equals(expected, actual)) {
+            return;
+        }
+
+        mismatches.Add(new SetupOnboardingContractMismatch(
+            source: source,
+            field: field,
+            expected: expected,
+            actual: actual));
+    }
+}


### PR DESCRIPTION
## Summary
- add `SetupOnboardingContractVerification` in core onboarding namespace to verify autodetect/pack metadata against canonical contract values
- add typed verification models (`SetupOnboardingContractVerificationResult`, `SetupOnboardingContractMismatch`) for reuse across CLI/Web/Bot tooling surfaces
- extend setup test harness coverage for canonical match, mismatch detection, and required metadata validation

## Validation
- `ALLOW_DIRTY=1 .agents/skills/intelligencex-onboarding-setup/scripts/preflight.sh`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh fast`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh full`
