### PR TITLE
CLI wizard: recommendation-first path UX and verbose autodetect diagnostics

### DIFF
--- a/Docs/reviewer/onboarding-unification-tracker.md
+++ b/Docs/reviewer/onboarding-unification-tracker.md
@@ -18,6 +18,7 @@ This file tracks onboarding/cleanup/maintenance unification across CLI, Web, and
 | Add auto-detect preflight (doctor-based) | Completed | IX CLI | Added `setup autodetect` + Web API endpoint `/api/setup/autodetect` + Manage menu entry. |
 | Web: path-first + maintenance + auto-detect panel | Completed | IX CLI Web | Added maintenance path card and auto-detect panel before repo selection. |
 | CLI wizard: path-first + auto-detect first step | Completed | IX CLI | Wizard now runs doctor-based auto-detect summary and path selection before auth/repo steps, with `--path` support for non-interactive path preselection. |
+| CLI wizard: recommendation-first UX + verbose preflight diagnostics | Completed | IX CLI | Wizard now prints path recommendation before path selection and supports `--verbose` to include full auto-detect exception details when preflight fails. |
 | Web/CLI: centralize setup arg building | Completed | IX CLI | Web now builds args via `SetupPlan` + `SetupArgsBuilder`. |
 | CLI wizard: honor preselected operation | Completed | IX CLI | `--operation` now skips re-prompt. |
 | Manage hub: include cleanup and auto-detect | Completed | IX CLI | Setup menu now includes both flows. |

--- a/Docs/reviewer/onboarding-wizard.md
+++ b/Docs/reviewer/onboarding-wizard.md
@@ -65,6 +65,12 @@ intelligencex setup wizard --path refresh-auth --repo owner/name
 intelligencex setup wizard --path cleanup --repo owner/name --dry-run
 ```
 
+If auto-detect preflight fails and you need richer diagnostics:
+
+```powershell
+intelligencex setup wizard --verbose
+```
+
 ## GitHub auth modes
 
 1) GitHub App (installation token)

--- a/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
@@ -73,6 +73,11 @@ internal static class WizardPrompts {
         var recommended = SetupOnboardingPaths.GetOrDefault(recommendedPathId);
         var recommendedId = recommended?.Id ?? string.Empty;
         var recommendedDisplayName = recommended?.DisplayName ?? "New Setup";
+        if (!string.IsNullOrWhiteSpace(recommendedReason)) {
+            AnsiConsole.MarkupLine($"[grey]Recommendation: {recommendedDisplayName}. {recommendedReason}[/]");
+            AnsiConsole.WriteLine();
+        }
+
         var orderedPaths = paths
             .OrderBy(path => string.Equals(path.Id, recommendedId, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
             .ThenBy(path => path.DisplayName, StringComparer.Ordinal)
@@ -88,10 +93,6 @@ internal static class WizardPrompts {
                 return $"{path.DisplayName}{recommendedSuffix} - {path.Description}";
             });
         var selected = AnsiConsole.Prompt(prompt);
-        if (!string.IsNullOrWhiteSpace(recommendedReason)) {
-            AnsiConsole.MarkupLine($"[grey]Recommendation: {recommendedDisplayName}. {recommendedReason}[/]");
-        }
-
         return selected.Id;
     }
 

--- a/IntelligenceX.Cli/Setup/Wizard/WizardRunner.Options.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/WizardRunner.Options.cs
@@ -24,6 +24,7 @@ internal static partial class WizardRunner {
         Console.WriteLine("  --force");
         Console.WriteLine("  --dry-run");
         Console.WriteLine("  --branch <name>");
+        Console.WriteLine("  --verbose");
         Console.WriteLine("  --plain (disable wizard UI)");
         Console.WriteLine("  --help");
         Console.WriteLine();
@@ -73,6 +74,7 @@ internal static partial class WizardRunner {
         public bool OperationSpecified { get; set; }
         public bool DryRun { get; set; }
         public string? BranchName { get; set; }
+        public bool Verbose { get; set; }
         public bool ForcePlain { get; set; }
         public bool ShowHelp { get; set; }
         public string? ParseError { get; set; }
@@ -132,6 +134,9 @@ internal static partial class WizardRunner {
                         break;
                     case "plain":
                         options.ForcePlain = ParseBool(value, true);
+                        break;
+                    case "verbose":
+                        options.Verbose = ParseBool(value, true);
                         break;
                     case "help":
                         options.ShowHelp = true;

--- a/IntelligenceX.Cli/Setup/Wizard/WizardRunner.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/WizardRunner.cs
@@ -66,7 +66,7 @@ internal static partial class WizardRunner {
                             .ConfigureAwait(false);
                     }).ConfigureAwait(false);
             } catch (Exception ex) {
-                AnsiConsole.MarkupLine($"[yellow]Auto-detect unavailable: {Markup.Escape(ex.Message)}[/]");
+                AnsiConsole.MarkupLine($"[yellow]{Markup.Escape(FormatAutoDetectUnavailableMessage(ex, options.Verbose))}[/]");
             }
 
             if (autoDetect is not null) {
@@ -250,6 +250,9 @@ internal static partial class WizardRunner {
             $"Recommended path: [cyan]{Markup.Escape(path.DisplayName)}[/]",
             $"Reason: {Markup.Escape(recommendedReason)}"
         };
+        if (string.Equals(result.Status, "fail", StringComparison.OrdinalIgnoreCase)) {
+            lines.Add("Run `intelligencex setup autodetect --json` for full preflight diagnostics.");
+        }
 
         if (checks.Count > 0) {
             lines.Add(string.Empty);
@@ -279,6 +282,10 @@ internal static partial class WizardRunner {
         return NormalizeAutoDetectRecommendedReason(recommendedReason);
     }
 
+    internal static string FormatAutoDetectUnavailableMessageForTests(Exception? exception, bool verbose) {
+        return FormatAutoDetectUnavailableMessage(exception, verbose);
+    }
+
     internal static (string RecommendedPathId, string RecommendedReason) ResolveAutoDetectPromptRecommendationForTests(
         SetupOnboardingAutoDetectResult? autoDetect) {
         return ResolveAutoDetectPromptRecommendation(autoDetect);
@@ -288,6 +295,18 @@ internal static partial class WizardRunner {
         return string.IsNullOrWhiteSpace(recommendedReason)
             ? "No recommendation details provided."
             : recommendedReason.Trim();
+    }
+
+    private static string FormatAutoDetectUnavailableMessage(Exception? exception, bool verbose) {
+        if (exception is null) {
+            return "Auto-detect unavailable. Continuing with manual path selection.";
+        }
+
+        if (verbose) {
+            return $"Auto-detect unavailable ({exception.GetType().Name}): {exception}";
+        }
+
+        return $"Auto-detect unavailable: {exception.Message}. Re-run with --verbose for full exception details.";
     }
 
     private static (string RecommendedPathId, string RecommendedReason) ResolveAutoDetectPromptRecommendation(

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -419,6 +419,20 @@ internal static partial class Program {
             "setup wizard auto-detect prompt detected reason normalized");
     }
 
+    private static void TestSetupWizardAutoDetectUnavailableMessageFormatting() {
+        var exception = new InvalidOperationException("doctor failed");
+        var compact = IntelligenceX.Cli.Setup.Wizard.WizardRunner.FormatAutoDetectUnavailableMessageForTests(exception, verbose: false);
+        AssertContainsText(compact, "Auto-detect unavailable: doctor failed.", "setup wizard auto-detect unavailable compact prefix");
+        AssertContainsText(compact, "--verbose", "setup wizard auto-detect unavailable compact hint");
+
+        var verbose = IntelligenceX.Cli.Setup.Wizard.WizardRunner.FormatAutoDetectUnavailableMessageForTests(exception, verbose: true);
+        AssertContainsText(verbose, "InvalidOperationException", "setup wizard auto-detect unavailable verbose type");
+        AssertContainsText(verbose, "doctor failed", "setup wizard auto-detect unavailable verbose message");
+
+        var nullException = IntelligenceX.Cli.Setup.Wizard.WizardRunner.FormatAutoDetectUnavailableMessageForTests(null, verbose: false);
+        AssertContainsText(nullException, "manual path selection", "setup wizard auto-detect unavailable null exception fallback");
+    }
+
     private static void TestSetupOnboardingContractCommandTemplates() {
         var templates = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetCommandTemplates();
         AssertEqual("intelligencex setup autodetect --json", templates.AutoDetect, "setup contract auto-detect template");

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -70,6 +70,7 @@ internal static partial class Program {
         failed += Run("Setup wizard operation maps to path id", TestSetupWizardOperationMapsToPathId);
         failed += Run("Setup wizard auto-detect reason normalization", TestSetupWizardAutoDetectReasonNormalization);
         failed += Run("Setup wizard auto-detect prompt fallback recommendation", TestSetupWizardAutoDetectPromptRecommendationFallback);
+        failed += Run("Setup wizard auto-detect unavailable message formatting", TestSetupWizardAutoDetectUnavailableMessageFormatting);
         failed += Run("Setup onboarding contract command templates", TestSetupOnboardingContractCommandTemplates);
         failed += Run("Setup onboarding contract verification matches canonical values",
             TestSetupOnboardingContractVerificationMatchesCanonicalValues);


### PR DESCRIPTION
## Summary
- show auto-detect recommendation context *before* path selection so guidance influences the decision
- add `--verbose` to `setup wizard` and surface richer auto-detect exception details when preflight fails
- add focused tests for auto-detect unavailable message formatting and update onboarding docs/tracker

## Validation
- `ALLOW_DIRTY=1 .agents/skills/intelligencex-onboarding-setup/scripts/preflight.sh`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh fast`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh full`
