### PR TITLE
Unify autodetect contract payload across CLI and Web

### DIFF
--- a/IntelligenceX.Cli/Setup/Onboarding/SetupOnboardingAutoDetect.cs
+++ b/IntelligenceX.Cli/Setup/Onboarding/SetupOnboardingAutoDetect.cs
@@ -34,8 +34,10 @@ internal sealed class SetupOnboardingAutoDetectResult {
     public bool LocalConfigExists { get; set; }
     public string ContractVersion { get; set; } = SetupOnboardingContract.ContractVersion;
     public string ContractFingerprint { get; set; } = SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true);
+    public SetupOnboardingCommandTemplates CommandTemplates { get; set; } = SetupOnboardingContract.GetCommandTemplates();
     public string RecommendedPath { get; set; } = SetupOnboardingPaths.NewSetup;
     public string RecommendedReason { get; set; } = string.Empty;
+    public IReadOnlyList<SetupOnboardingPathContract> Paths { get; set; } = SetupOnboardingContract.GetPaths(includeMaintenancePath: true);
     public IReadOnlyList<SetupOnboardingCheck> Checks { get; set; } = Array.Empty<SetupOnboardingCheck>();
     public string RawDoctorOutput { get; set; } = string.Empty;
 }
@@ -74,8 +76,10 @@ internal static class SetupOnboardingAutoDetectRunner {
             LocalConfigExists = localConfigExists,
             ContractVersion = SetupOnboardingContract.ContractVersion,
             ContractFingerprint = SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true),
+            CommandTemplates = SetupOnboardingContract.GetCommandTemplates(),
             RecommendedPath = recommendedPath,
             RecommendedReason = reason,
+            Paths = SetupOnboardingContract.GetPaths(includeMaintenancePath: true),
             Checks = checks,
             RawDoctorOutput = output
         };

--- a/IntelligenceX.Cli/Setup/Web/WebApi.Autodetect.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebApi.Autodetect.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using IntelligenceX.Cli.Setup.Onboarding;
-using IntelligenceX.Setup.Onboarding;
 
 namespace IntelligenceX.Cli.Setup.Web;
 
@@ -40,7 +39,7 @@ internal sealed partial class WebApi {
             ConsoleLock.Release();
         }
 
-        var paths = SetupOnboardingContract.GetPaths(includeMaintenancePath: true).Select(path => new {
+        var paths = result.Paths.Select(path => new {
             id = path.Id,
             displayName = path.DisplayName,
             description = path.Description,
@@ -50,7 +49,7 @@ internal sealed partial class WebApi {
             requiresAiAuth = path.RequiresAiAuth,
             flow = path.Flow
         }).ToArray();
-        var commands = SetupOnboardingContract.GetCommandTemplates();
+        var commands = result.CommandTemplates;
 
         await WriteJsonOkAsync(context, new {
             contractVersion = result.ContractVersion,

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -267,6 +267,36 @@ internal static partial class Program {
             "setup autodetect json contract version");
         var contractFingerprint = document.RootElement.GetProperty("contractFingerprint").GetString() ?? string.Empty;
         AssertEqual(64, contractFingerprint.Length, "setup autodetect json contract fingerprint length");
+        var commandTemplates = document.RootElement.GetProperty("commandTemplates");
+        AssertEqual("intelligencex setup autodetect --json",
+            commandTemplates.GetProperty("autoDetect").GetString(),
+            "setup autodetect json command template auto-detect");
+        AssertEqual("intelligencex setup --repo owner/name --with-config",
+            commandTemplates.GetProperty("newSetupApply").GetString(),
+            "setup autodetect json command template setup apply");
+        AssertEqual("intelligencex setup --repo owner/name --update-secret --auth-b64 <base64>",
+            commandTemplates.GetProperty("refreshAuthApply").GetString(),
+            "setup autodetect json command template update-secret apply");
+        AssertEqual("intelligencex setup --repo owner/name --cleanup",
+            commandTemplates.GetProperty("cleanupApply").GetString(),
+            "setup autodetect json command template cleanup apply");
+        var paths = document.RootElement.GetProperty("paths");
+        AssertEqual(4, paths.GetArrayLength(), "setup autodetect json path count");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.NewSetupPathId,
+            paths[0].GetProperty("id").GetString(),
+            "setup autodetect json path[0] id");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.RefreshAuthPathId,
+            paths[1].GetProperty("id").GetString(),
+            "setup autodetect json path[1] id");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.CleanupPathId,
+            paths[2].GetProperty("id").GetString(),
+            "setup autodetect json path[2] id");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.MaintenancePathId,
+            paths[3].GetProperty("id").GetString(),
+            "setup autodetect json path[3] id");
+        AssertEqual("setup", paths[0].GetProperty("operation").GetString(), "setup autodetect json path[0] operation");
+        AssertEqual("update-secret", paths[1].GetProperty("operation").GetString(), "setup autodetect json path[1] operation");
+        AssertEqual("cleanup", paths[2].GetProperty("operation").GetString(), "setup autodetect json path[2] operation");
         var checks = document.RootElement.GetProperty("checks");
 
         AssertEqual(System.Text.Json.JsonValueKind.String, checks[0].GetProperty("status").ValueKind,


### PR DESCRIPTION
## Summary
- move onboarding contract payload (`paths`, `commandTemplates`) into `SetupOnboardingAutoDetectResult`
- make Web autodetect API reuse the same model payload instead of rebuilding from contract separately
- extend regression coverage for `setup autodetect --json` to assert command templates and canonical path metadata

## Why
This keeps CLI/Web/Bot metadata parity grounded in one runtime result object and reduces drift risk between surfaces.

## Validation
- `ALLOW_DIRTY=1 .agents/skills/intelligencex-onboarding-setup/scripts/preflight.sh`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh fast`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh full`
