### PR TITLE
Harden autodetect payload immutability and web parity tests

### DIFF
--- a/Docs/reviewer/onboarding-unification-tracker.md
+++ b/Docs/reviewer/onboarding-unification-tracker.md
@@ -37,6 +37,8 @@ This file tracks onboarding/cleanup/maintenance unification across CLI, Web, and
 | .Chat: autodetect-first onboarding playbook | Completed | IX Chat | Updated `Docs/HostSystemPrompt.md` to require `reviewer_setup_pack_info` + preflight autodetect before path execution. |
 | Web UI: path hints from shared contract metadata | Completed | IX CLI Web | Step-1 path cards/hints/requirements now hydrate from autodetect `paths` + `contractVersion`/`contractFingerprint` instead of hardcoded path text. |
 | Web API: include command templates in autodetect payload | Completed | IX CLI Web | `/api/setup/autodetect` now returns `commandTemplates` sourced from `SetupOnboardingContract` for CLI/Web/Bot parity. |
+| Web API: autodetect response parity regression coverage | Completed | IX Tests + IX CLI Web | Added web-response contract parity tests (`BuildSetupAutodetectResponseJsonForTests`) and null-safe fallbacks for `paths`/`commandTemplates` projection. |
+| Autodetect contract payload immutability hardening | Completed | IX CLI | Switched `SetupOnboardingAutoDetectResult` and `SetupOnboardingCheck` to `init`-based properties to reduce post-construction mutation risk. |
 | Docs: canonical path matrix + Bot contract-check diagram | Completed | Docs | `Docs/reviewer/web-onboarding.md` now includes per-path auth/operation matrix and Mermaid flow for tool-driven parity verification. |
 | Docs: diagrams and flow updates | Completed | Docs | Added path-first flow docs and Mermaid diagrams in onboarding pages. |
 | Website FAQ/data updates | Completed | Website | Updated FAQ/features/how-it-works for path-first + auto-detect positioning. |

--- a/IntelligenceX.Cli/Setup/Onboarding/SetupOnboardingAutoDetect.cs
+++ b/IntelligenceX.Cli/Setup/Onboarding/SetupOnboardingAutoDetect.cs
@@ -21,25 +21,25 @@ internal enum SetupOnboardingCheckStatus {
 }
 
 internal sealed class SetupOnboardingCheck {
-    public string Name { get; set; } = string.Empty;
-    public SetupOnboardingCheckStatus Status { get; set; }
-    public string Message { get; set; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public SetupOnboardingCheckStatus Status { get; init; }
+    public string Message { get; init; } = string.Empty;
 }
 
 internal sealed class SetupOnboardingAutoDetectResult {
-    public string Status { get; set; } = "ok";
-    public string Workspace { get; set; } = string.Empty;
-    public string? Repo { get; set; }
-    public bool LocalWorkflowExists { get; set; }
-    public bool LocalConfigExists { get; set; }
-    public string ContractVersion { get; set; } = SetupOnboardingContract.ContractVersion;
-    public string ContractFingerprint { get; set; } = SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true);
-    public SetupOnboardingCommandTemplates CommandTemplates { get; set; } = SetupOnboardingContract.GetCommandTemplates();
-    public string RecommendedPath { get; set; } = SetupOnboardingPaths.NewSetup;
-    public string RecommendedReason { get; set; } = string.Empty;
-    public IReadOnlyList<SetupOnboardingPathContract> Paths { get; set; } = SetupOnboardingContract.GetPaths(includeMaintenancePath: true);
-    public IReadOnlyList<SetupOnboardingCheck> Checks { get; set; } = Array.Empty<SetupOnboardingCheck>();
-    public string RawDoctorOutput { get; set; } = string.Empty;
+    public string Status { get; init; } = "ok";
+    public string Workspace { get; init; } = string.Empty;
+    public string? Repo { get; init; }
+    public bool LocalWorkflowExists { get; init; }
+    public bool LocalConfigExists { get; init; }
+    public string ContractVersion { get; init; } = SetupOnboardingContract.ContractVersion;
+    public string ContractFingerprint { get; init; } = SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true);
+    public SetupOnboardingCommandTemplates CommandTemplates { get; init; } = SetupOnboardingContract.GetCommandTemplates();
+    public string RecommendedPath { get; init; } = SetupOnboardingPaths.NewSetup;
+    public string RecommendedReason { get; init; } = string.Empty;
+    public IReadOnlyList<SetupOnboardingPathContract> Paths { get; init; } = SetupOnboardingContract.GetPaths(includeMaintenancePath: true);
+    public IReadOnlyList<SetupOnboardingCheck> Checks { get; init; } = Array.Empty<SetupOnboardingCheck>();
+    public string RawDoctorOutput { get; init; } = string.Empty;
 }
 
 internal static class SetupOnboardingAutoDetectRunner {

--- a/IntelligenceX.Cli/Setup/Web/WebApi.Autodetect.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebApi.Autodetect.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using IntelligenceX.Cli.Setup.Onboarding;
+using IntelligenceX.Setup.Onboarding;
 
 namespace IntelligenceX.Cli.Setup.Web;
 
@@ -39,7 +40,22 @@ internal sealed partial class WebApi {
             ConsoleLock.Release();
         }
 
-        var paths = result.Paths.Select(path => new {
+        await WriteJsonOkAsync(context, BuildSetupAutodetectResponsePayload(result)).ConfigureAwait(false);
+    }
+
+    internal static string BuildSetupAutodetectResponseJsonForTests(SetupOnboardingAutoDetectResult result) {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        return JsonSerializer.Serialize(BuildSetupAutodetectResponsePayload(result), options);
+    }
+
+    private static object BuildSetupAutodetectResponsePayload(SetupOnboardingAutoDetectResult result) {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var pathContracts = result.Paths ?? SetupOnboardingContract.GetPaths(includeMaintenancePath: true);
+        var commands = result.CommandTemplates ?? SetupOnboardingContract.GetCommandTemplates();
+        var checks = result.Checks ?? Array.Empty<SetupOnboardingCheck>();
+
+        var paths = pathContracts.Select(path => new {
             id = path.Id,
             displayName = path.DisplayName,
             description = path.Description,
@@ -49,9 +65,7 @@ internal sealed partial class WebApi {
             requiresAiAuth = path.RequiresAiAuth,
             flow = path.Flow
         }).ToArray();
-        var commands = result.CommandTemplates;
-
-        await WriteJsonOkAsync(context, new {
+        return new {
             contractVersion = result.ContractVersion,
             contractFingerprint = result.ContractFingerprint,
             commandTemplates = new {
@@ -71,12 +85,12 @@ internal sealed partial class WebApi {
             localConfigExists = result.LocalConfigExists,
             recommendedPath = result.RecommendedPath,
             recommendedReason = result.RecommendedReason,
-            checks = result.Checks.Select(check => new {
+            checks = checks.Select(check => new {
                 name = check.Name,
                 status = check.Status.ToString().ToLowerInvariant(),
                 message = check.Message
             }).ToArray(),
             paths
-        }).ConfigureAwait(false);
+        };
     }
 }

--- a/IntelligenceX.Tests/Program.Setup.Web.cs
+++ b/IntelligenceX.Tests/Program.Setup.Web.cs
@@ -2,6 +2,78 @@ namespace IntelligenceX.Tests;
 
 internal static partial class Program {
 #if !NET472
+    private static void TestWebSetupAutodetectResponseJsonMatchesSharedContractPayload() {
+        var contractCommands = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetCommandTemplates();
+        var contractPaths = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetPaths(includeMaintenancePath: true);
+        var result = new IntelligenceX.Cli.Setup.Onboarding.SetupOnboardingAutoDetectResult {
+            Status = "warn",
+            Workspace = "/tmp/workspace",
+            Repo = "owner/repo",
+            ContractVersion = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.ContractVersion,
+            ContractFingerprint = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true),
+            CommandTemplates = contractCommands,
+            RecommendedPath = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.RefreshAuthPathId,
+            RecommendedReason = "Auth refresh required.",
+            Paths = contractPaths,
+            Checks = new[] {
+                new IntelligenceX.Cli.Setup.Onboarding.SetupOnboardingCheck {
+                    Name = "doctor",
+                    Status = IntelligenceX.Cli.Setup.Onboarding.SetupOnboardingCheckStatus.Warn,
+                    Message = "warn"
+                }
+            }
+        };
+
+        var json = IntelligenceX.Cli.Setup.Web.WebApi.BuildSetupAutodetectResponseJsonForTests(result);
+        using var document = System.Text.Json.JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.ContractVersion,
+            root.GetProperty("contractVersion").GetString(),
+            "web setup autodetect response contract version");
+        AssertEqual(contractCommands.AutoDetect,
+            root.GetProperty("commandTemplates").GetProperty("autoDetect").GetString(),
+            "web setup autodetect response auto-detect template");
+        AssertEqual(contractCommands.NewSetupApply,
+            root.GetProperty("commandTemplates").GetProperty("newSetupApply").GetString(),
+            "web setup autodetect response setup apply template");
+        AssertEqual(contractPaths.Count, root.GetProperty("paths").GetArrayLength(),
+            "web setup autodetect response path count");
+        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.NewSetupPathId,
+            root.GetProperty("paths")[0].GetProperty("id").GetString(),
+            "web setup autodetect response first path id");
+        AssertEqual("setup",
+            root.GetProperty("paths")[0].GetProperty("defaultOperation").GetString(),
+            "web setup autodetect response first path default operation");
+        AssertEqual(System.Text.Json.JsonValueKind.String, root.GetProperty("checks")[0].GetProperty("status").ValueKind,
+            "web setup autodetect response check status type");
+        AssertEqual("warn", root.GetProperty("checks")[0].GetProperty("status").GetString(),
+            "web setup autodetect response check status lowercase");
+    }
+
+    private static void TestWebSetupAutodetectResponseJsonFallbacksForNullPayloads() {
+        var result = new IntelligenceX.Cli.Setup.Onboarding.SetupOnboardingAutoDetectResult {
+            Status = "ok",
+            Workspace = "/tmp/workspace",
+            Paths = null!,
+            CommandTemplates = null!,
+            Checks = null!
+        };
+
+        var json = IntelligenceX.Cli.Setup.Web.WebApi.BuildSetupAutodetectResponseJsonForTests(result);
+        using var document = System.Text.Json.JsonDocument.Parse(json);
+        var root = document.RootElement;
+        var contractCommands = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetCommandTemplates();
+
+        AssertEqual(contractCommands.AutoDetect,
+            root.GetProperty("commandTemplates").GetProperty("autoDetect").GetString(),
+            "web setup autodetect response fallback command template");
+        AssertEqual(4, root.GetProperty("paths").GetArrayLength(),
+            "web setup autodetect response fallback path count");
+        AssertEqual(0, root.GetProperty("checks").GetArrayLength(),
+            "web setup autodetect response fallback check count");
+    }
+
     private static void TestWebSetupBuildSetupArgsPropagatesRequestDryRun() {
         var fromRequest = IntelligenceX.Cli.Setup.Web.WebApi.BuildSetupArgsForDryRunPropagationTests(
             routeDryRun: false,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -112,6 +112,10 @@ internal static partial class Program {
         failed += Run("Manage external command captures help tail line", TestManageRunExternalCommandCapturesHelpTailLine);
         failed += Run("Manage external command start failure returns promptly", TestManageRunExternalCommandStartFailureReturnsPromptly);
         failed += Run("Manage external command non-timeout failure is not timeout", TestManageRunExternalCommandNonTimeoutFailureIsNotTimeout);
+        failed += Run("Web setup autodetect response matches shared contract payload",
+            TestWebSetupAutodetectResponseJsonMatchesSharedContractPayload);
+        failed += Run("Web setup autodetect response fallbacks for null payloads",
+            TestWebSetupAutodetectResponseJsonFallbacksForNullPayloads);
         failed += Run("Web setup args propagate request dry-run", TestWebSetupBuildSetupArgsPropagatesRequestDryRun);
         failed += Run("Web setup resolves with-config from args", TestWebSetupResolveWithConfigFromArgs);
         failed += Run("Web setup post-apply verify skips callback on failed apply",


### PR DESCRIPTION
## Summary
- make onboarding autodetect payloads immutable via `init` properties (`SetupOnboardingAutoDetectResult`, `SetupOnboardingCheck`)
- refactor web autodetect response projection into a shared payload builder with null-safe fallback for `paths` and `commandTemplates`
- add web-surface regression tests to verify response parity with shared onboarding contract metadata
- update onboarding unification tracker with this hardening/testing milestone

## Validation
- `ALLOW_DIRTY=1 .agents/skills/intelligencex-onboarding-setup/scripts/preflight.sh`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh fast`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh full`
