### PR TITLE
Harden web autodetect metadata fallbacks and contract tests

### DIFF
--- a/Docs/reviewer/onboarding-unification-tracker.md
+++ b/Docs/reviewer/onboarding-unification-tracker.md
@@ -39,6 +39,7 @@ This file tracks onboarding/cleanup/maintenance unification across CLI, Web, and
 | Web API: include command templates in autodetect payload | Completed | IX CLI Web | `/api/setup/autodetect` now returns `commandTemplates` sourced from `SetupOnboardingContract` for CLI/Web/Bot parity. |
 | Web API: autodetect response parity regression coverage | Completed | IX Tests + IX CLI Web | Added web-response contract parity tests (`BuildSetupAutodetectResponseJsonForTests`) and null-safe fallbacks for `paths`/`commandTemplates` projection. |
 | Autodetect contract payload immutability hardening | Completed | IX CLI | Switched `SetupOnboardingAutoDetectResult` and `SetupOnboardingCheck` to `init`-based properties to reduce post-construction mutation risk. |
+| Web autodetect metadata fallback + stable status wire mapping | Completed | IX CLI Web + IX Tests | Web autodetect payload now falls back `contractVersion`/`contractFingerprint` when missing, uses explicit check-status mapping (`ok`/`warn`/`fail`), and tests now derive expected path counts from shared contract metadata. |
 | Docs: canonical path matrix + Bot contract-check diagram | Completed | Docs | `Docs/reviewer/web-onboarding.md` now includes per-path auth/operation matrix and Mermaid flow for tool-driven parity verification. |
 | Docs: diagrams and flow updates | Completed | Docs | Added path-first flow docs and Mermaid diagrams in onboarding pages. |
 | Website FAQ/data updates | Completed | Website | Updated FAQ/features/how-it-works for path-first + auto-detect positioning. |

--- a/IntelligenceX.Cli/Setup/Web/WebApi.Autodetect.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebApi.Autodetect.cs
@@ -52,8 +52,16 @@ internal sealed partial class WebApi {
         ArgumentNullException.ThrowIfNull(result);
 
         var pathContracts = result.Paths ?? SetupOnboardingContract.GetPaths(includeMaintenancePath: true);
+        var includeMaintenancePath = pathContracts.Any(path =>
+            string.Equals(path.Id, SetupOnboardingContract.MaintenancePathId, StringComparison.Ordinal));
         var commands = result.CommandTemplates ?? SetupOnboardingContract.GetCommandTemplates();
         var checks = result.Checks ?? Array.Empty<SetupOnboardingCheck>();
+        var contractVersion = string.IsNullOrWhiteSpace(result.ContractVersion)
+            ? SetupOnboardingContract.ContractVersion
+            : result.ContractVersion;
+        var contractFingerprint = string.IsNullOrWhiteSpace(result.ContractFingerprint)
+            ? SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath)
+            : result.ContractFingerprint;
 
         var paths = pathContracts.Select(path => new {
             id = path.Id,
@@ -66,8 +74,8 @@ internal sealed partial class WebApi {
             flow = path.Flow
         }).ToArray();
         return new {
-            contractVersion = result.ContractVersion,
-            contractFingerprint = result.ContractFingerprint,
+            contractVersion,
+            contractFingerprint,
             commandTemplates = new {
                 autoDetect = commands.AutoDetect,
                 newSetupDryRun = commands.NewSetupDryRun,
@@ -87,10 +95,19 @@ internal sealed partial class WebApi {
             recommendedReason = result.RecommendedReason,
             checks = checks.Select(check => new {
                 name = check.Name,
-                status = check.Status.ToString().ToLowerInvariant(),
+                status = ToWireCheckStatus(check.Status),
                 message = check.Message
             }).ToArray(),
             paths
+        };
+    }
+
+    private static string ToWireCheckStatus(SetupOnboardingCheckStatus status) {
+        return status switch {
+            SetupOnboardingCheckStatus.Ok => "ok",
+            SetupOnboardingCheckStatus.Warn => "warn",
+            SetupOnboardingCheckStatus.Fail => "fail",
+            _ => status.ToString().ToLowerInvariant()
         };
     }
 }

--- a/IntelligenceX.Tests/Program.Setup.Web.cs
+++ b/IntelligenceX.Tests/Program.Setup.Web.cs
@@ -52,9 +52,14 @@ internal static partial class Program {
     }
 
     private static void TestWebSetupAutodetectResponseJsonFallbacksForNullPayloads() {
+        var contractPaths = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetPaths(includeMaintenancePath: true);
+        var expectedContractVersion = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.ContractVersion;
+        var expectedContractFingerprint = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetContractFingerprint(includeMaintenancePath: true);
         var result = new IntelligenceX.Cli.Setup.Onboarding.SetupOnboardingAutoDetectResult {
             Status = "ok",
             Workspace = "/tmp/workspace",
+            ContractVersion = string.Empty,
+            ContractFingerprint = string.Empty,
             Paths = null!,
             CommandTemplates = null!,
             Checks = null!
@@ -68,7 +73,11 @@ internal static partial class Program {
         AssertEqual(contractCommands.AutoDetect,
             root.GetProperty("commandTemplates").GetProperty("autoDetect").GetString(),
             "web setup autodetect response fallback command template");
-        AssertEqual(4, root.GetProperty("paths").GetArrayLength(),
+        AssertEqual(expectedContractVersion, root.GetProperty("contractVersion").GetString(),
+            "web setup autodetect response fallback contract version");
+        AssertEqual(expectedContractFingerprint, root.GetProperty("contractFingerprint").GetString(),
+            "web setup autodetect response fallback contract fingerprint");
+        AssertEqual(contractPaths.Count, root.GetProperty("paths").GetArrayLength(),
             "web setup autodetect response fallback path count");
         AssertEqual(0, root.GetProperty("checks").GetArrayLength(),
             "web setup autodetect response fallback check count");

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -280,23 +280,17 @@ internal static partial class Program {
         AssertEqual("intelligencex setup --repo owner/name --cleanup",
             commandTemplates.GetProperty("cleanupApply").GetString(),
             "setup autodetect json command template cleanup apply");
+        var expectedPaths = IntelligenceX.Setup.Onboarding.SetupOnboardingContract.GetPaths(includeMaintenancePath: true);
         var paths = document.RootElement.GetProperty("paths");
-        AssertEqual(4, paths.GetArrayLength(), "setup autodetect json path count");
-        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.NewSetupPathId,
-            paths[0].GetProperty("id").GetString(),
-            "setup autodetect json path[0] id");
-        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.RefreshAuthPathId,
-            paths[1].GetProperty("id").GetString(),
-            "setup autodetect json path[1] id");
-        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.CleanupPathId,
-            paths[2].GetProperty("id").GetString(),
-            "setup autodetect json path[2] id");
-        AssertEqual(IntelligenceX.Setup.Onboarding.SetupOnboardingContract.MaintenancePathId,
-            paths[3].GetProperty("id").GetString(),
-            "setup autodetect json path[3] id");
-        AssertEqual("setup", paths[0].GetProperty("operation").GetString(), "setup autodetect json path[0] operation");
-        AssertEqual("update-secret", paths[1].GetProperty("operation").GetString(), "setup autodetect json path[1] operation");
-        AssertEqual("cleanup", paths[2].GetProperty("operation").GetString(), "setup autodetect json path[2] operation");
+        AssertEqual(expectedPaths.Count, paths.GetArrayLength(), "setup autodetect json path count");
+        for (var i = 0; i < expectedPaths.Count; i++) {
+            AssertEqual(expectedPaths[i].Id,
+                paths[i].GetProperty("id").GetString(),
+                $"setup autodetect json path[{i}] id");
+            AssertEqual(expectedPaths[i].Operation,
+                paths[i].GetProperty("operation").GetString(),
+                $"setup autodetect json path[{i}] operation");
+        }
         var checks = document.RootElement.GetProperty("checks");
 
         AssertEqual(System.Text.Json.JsonValueKind.String, checks[0].GetProperty("status").ValueKind,


### PR DESCRIPTION
## Summary
- add fallback defaults for web autodetect `contractVersion` and `contractFingerprint` when payload metadata is missing
- switch web autodetect check-status serialization to explicit stable wire mapping (`ok`/`warn`/`fail`)
- remove brittle hardcoded autodetect path-count assertions in setup/web contract tests by deriving expected paths from `SetupOnboardingContract`
- update onboarding unification tracker with this hardening batch

## Validation
- `ALLOW_DIRTY=1 .agents/skills/intelligencex-onboarding-setup/scripts/preflight.sh`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh fast`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh full`
