### PR TITLE
Fail fast on unknown web autodetect check status

### DIFF
--- a/Docs/reviewer/onboarding-unification-tracker.md
+++ b/Docs/reviewer/onboarding-unification-tracker.md
@@ -40,6 +40,7 @@ This file tracks onboarding/cleanup/maintenance unification across CLI, Web, and
 | Web API: autodetect response parity regression coverage | Completed | IX Tests + IX CLI Web | Added web-response contract parity tests (`BuildSetupAutodetectResponseJsonForTests`) and null-safe fallbacks for `paths`/`commandTemplates` projection. |
 | Autodetect contract payload immutability hardening | Completed | IX CLI | Switched `SetupOnboardingAutoDetectResult` and `SetupOnboardingCheck` to `init`-based properties to reduce post-construction mutation risk. |
 | Web autodetect metadata fallback + stable status wire mapping | Completed | IX CLI Web + IX Tests | Web autodetect payload now falls back `contractVersion`/`contractFingerprint` when missing, uses explicit check-status mapping (`ok`/`warn`/`fail`), and tests now derive expected path counts from shared contract metadata. |
+| Web autodetect fail-fast enum wire guard | Completed | IX CLI Web + IX Tests | Unknown `SetupOnboardingCheckStatus` values now throw during web payload projection and regression tests assert fail-fast behavior. |
 | Docs: canonical path matrix + Bot contract-check diagram | Completed | Docs | `Docs/reviewer/web-onboarding.md` now includes per-path auth/operation matrix and Mermaid flow for tool-driven parity verification. |
 | Docs: diagrams and flow updates | Completed | Docs | Added path-first flow docs and Mermaid diagrams in onboarding pages. |
 | Website FAQ/data updates | Completed | Website | Updated FAQ/features/how-it-works for path-first + auto-detect positioning. |

--- a/IntelligenceX.Cli/Setup/Web/WebApi.Autodetect.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebApi.Autodetect.cs
@@ -52,6 +52,7 @@ internal sealed partial class WebApi {
         ArgumentNullException.ThrowIfNull(result);
 
         var pathContracts = result.Paths ?? SetupOnboardingContract.GetPaths(includeMaintenancePath: true);
+        // Fingerprint selection must reflect the effective path set projected to clients.
         var includeMaintenancePath = pathContracts.Any(path =>
             string.Equals(path.Id, SetupOnboardingContract.MaintenancePathId, StringComparison.Ordinal));
         var commands = result.CommandTemplates ?? SetupOnboardingContract.GetCommandTemplates();
@@ -107,7 +108,8 @@ internal sealed partial class WebApi {
             SetupOnboardingCheckStatus.Ok => "ok",
             SetupOnboardingCheckStatus.Warn => "warn",
             SetupOnboardingCheckStatus.Fail => "fail",
-            _ => status.ToString().ToLowerInvariant()
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status,
+                "Unknown setup onboarding check status.")
         };
     }
 }

--- a/IntelligenceX.Tests/Program.Setup.Web.cs
+++ b/IntelligenceX.Tests/Program.Setup.Web.cs
@@ -83,6 +83,24 @@ internal static partial class Program {
             "web setup autodetect response fallback check count");
     }
 
+    private static void TestWebSetupAutodetectResponseJsonRejectsUnknownCheckStatus() {
+        var result = new IntelligenceX.Cli.Setup.Onboarding.SetupOnboardingAutoDetectResult {
+            Status = "warn",
+            Workspace = "/tmp/workspace",
+            Checks = new[] {
+                new IntelligenceX.Cli.Setup.Onboarding.SetupOnboardingCheck {
+                    Name = "doctor",
+                    Status = (IntelligenceX.Cli.Setup.Onboarding.SetupOnboardingCheckStatus)999,
+                    Message = "unexpected"
+                }
+            }
+        };
+
+        AssertThrows<ArgumentOutOfRangeException>(() =>
+                IntelligenceX.Cli.Setup.Web.WebApi.BuildSetupAutodetectResponseJsonForTests(result),
+            "web setup autodetect response unknown check status");
+    }
+
     private static void TestWebSetupBuildSetupArgsPropagatesRequestDryRun() {
         var fromRequest = IntelligenceX.Cli.Setup.Web.WebApi.BuildSetupArgsForDryRunPropagationTests(
             routeDryRun: false,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -116,6 +116,8 @@ internal static partial class Program {
             TestWebSetupAutodetectResponseJsonMatchesSharedContractPayload);
         failed += Run("Web setup autodetect response fallbacks for null payloads",
             TestWebSetupAutodetectResponseJsonFallbacksForNullPayloads);
+        failed += Run("Web setup autodetect response rejects unknown check status",
+            TestWebSetupAutodetectResponseJsonRejectsUnknownCheckStatus);
         failed += Run("Web setup args propagate request dry-run", TestWebSetupBuildSetupArgsPropagatesRequestDryRun);
         failed += Run("Web setup resolves with-config from args", TestWebSetupResolveWithConfigFromArgs);
         failed += Run("Web setup post-apply verify skips callback on failed apply",


### PR DESCRIPTION
## Summary
- enforce fail-fast behavior in web autodetect status wire mapping by throwing on unknown `SetupOnboardingCheckStatus`
- document fingerprint coupling with effective projected paths in `BuildSetupAutodetectResponsePayload`
- add regression test proving unknown check-status values are rejected
- register the new test in the harness and update onboarding unification tracker

## Validation
- `ALLOW_DIRTY=1 .agents/skills/intelligencex-onboarding-setup/scripts/preflight.sh`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh fast`
- `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh full`
