### PR TITLE
chore(website): extract CI toggle and resilient local build step

### DIFF
--- a/Website/build.ps1
+++ b/Website/build.ps1
@@ -36,8 +36,12 @@
 .PARAMETER PowerForgeRoot
     Root folder of PSPublishModule (overrides $env:POWERFORGE_ROOT).
 
+.PARAMETER CI
+    Force pipeline CI mode locally (equivalent to setting CI=true).
+
 .EXAMPLE
     ./build.ps1
+    ./build.ps1 -CI
     ./build.ps1 -Serve
     ./build.ps1 -Serve -Port 3000
 #>
@@ -52,6 +56,7 @@ param(
     [int]$Port = 8081,
     [string[]]$Only = @(),
     [string[]]$Skip = @(),
+    [switch]$CI,
     [switch]$SkipBuildTool,
     [string]$PowerForgeRoot = $env:POWERFORGE_ROOT
 )
@@ -136,7 +141,8 @@ function Assert-SiteOutput {
 try {
     $UseDev = ($Dev -or ($Serve -and -not $NoDev))
     $UseFast = ($Fast -or ($Serve -and -not $NoFast))
-    $IsCI = ($env:CI -and $env:CI.ToString().ToLowerInvariant() -eq 'true') -or
+    $IsCI = $CI -or
+            ($env:CI -and $env:CI.ToString().ToLowerInvariant() -eq 'true') -or
             ($env:GITHUB_ACTIONS -and $env:GITHUB_ACTIONS.ToString().ToLowerInvariant() -eq 'true') -or
             ($env:TF_BUILD -and $env:TF_BUILD.ToString().ToLowerInvariant() -eq 'true')
 
@@ -161,6 +167,9 @@ try {
     if ($Watch) {
         $pipelineArgs += '--watch'
     }
+
+    $modeLabel = $UseDev ? 'dev' : ($UseFast ? 'fast' : ($IsCI ? 'ci' : 'default'))
+    Write-Host "Pipeline mode: $modeLabel" -ForegroundColor DarkGray
 
     if ($Serve) {
         Write-Host 'Building website...' -ForegroundColor Cyan

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -10,7 +10,8 @@
       "id": "build-library",
       "project": "../IntelligenceX/IntelligenceX.csproj",
       "configuration": "Release",
-      "framework": "net8.0"
+      "framework": "net8.0",
+      "skipIfProjectMissing": true
     },
     {
       "task": "build",


### PR DESCRIPTION
## Summary\n- extract two useful Website-only tweaks from #277 into an isolated PR\n- add -CI switch to Website/build.ps1 to force pipeline CI mode locally\n- add skipIfProjectMissing: true for uild-library in Website/pipeline.json\n\n## Why\n- keeps website workflow improvements without pulling in unrelated monorepo/chat/tools changes\n- reduces conflicts and keeps PR review focused\n\n## Validation\n- pwsh -NoProfile -File Website/build.ps1 -CI -Only build -SkipBuildTool -PowerForgeRoot C:/Support/GitHub/_worktrees/PSPublishModule-main-ci\n