### PR TITLE
Chat App: repair legacy transcript markdown rendering and auto-heal persisted history

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
@@ -91,4 +91,25 @@ public sealed class TranscriptHtmlFormatterTests {
         Assert.DoesNotContain("✅I", html);
         Assert.DoesNotContain("or2)", html);
     }
+
+    /// <summary>
+    /// Ensures malformed collapsed status metrics render as proper bullet rows rather than literal markdown markers.
+    /// </summary>
+    [Fact]
+    public void Format_RepairsCollapsedStatusMetricMarkdownBeforeRender() {
+        var options = MarkdownRendererPresets.CreateChatStrictMinimal();
+        var now = new DateTime(2026, 2, 13, 19, 25, 24, DateTimeKind.Local);
+        var html = TranscriptHtmlFormatter.Format(new[] {
+            ("Assistant", "**Status: HEALTHY** - **Servers checked:**5 -**Replication edges:**62 -*Failed edges:**0 -*Stale edges (>24h):**0 - **Servers with failures:**0", now)
+        }, "HH:mm:ss", options);
+
+        Assert.Contains("Status <strong>HEALTHY</strong>", html);
+        Assert.Contains("<li>Servers checked <strong>5</strong></li>", html);
+        Assert.Contains("<li>Replication edges <strong>62</strong></li>", html);
+        Assert.Contains("<li>Failed edges <strong>0</strong></li>", html);
+        Assert.Contains("<li>Stale edges (&gt;24h) <strong>0</strong></li>", html);
+        Assert.Contains("<li>Servers with failures <strong>0</strong></li>", html);
+        Assert.DoesNotContain("**Servers checked:**", html);
+        Assert.DoesNotContain("**Replication edges:**", html);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
@@ -31,7 +31,8 @@ public sealed class TranscriptMarkdownNormalizerTests {
 
         var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
 
-        Assert.Contains("**Status: HEALTHY**\n- **Servers checked:** 5 - **Replication edges:** 62", normalized);
+        Assert.Contains("Status **HEALTHY**\n- Servers checked **5**", normalized);
+        Assert.Contains("\n- Replication edges **62**", normalized);
     }
 
     /// <summary>
@@ -56,5 +57,43 @@ public sealed class TranscriptMarkdownNormalizerTests {
         var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
 
         Assert.Equal("\r\n  line  \r\n", normalized);
+    }
+
+    /// <summary>
+    /// Ensures malformed collapsed status chains are expanded into markdown list lines.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_ExpandsMalformedStatusMetricChains() {
+        var text = "**Status: HEALTHY** - **Servers checked:**5 -**Replication edges:**62 -*Failed edges:**0 -*Stale edges (>24h):**0 - **Servers with failures:**0";
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+
+        Assert.Contains("Status **HEALTHY**", normalized);
+        Assert.Contains("- Servers checked **5**", normalized);
+        Assert.Contains("- Replication edges **62**", normalized);
+        Assert.Contains("- Failed edges **0**", normalized);
+        Assert.Contains("- Stale edges (>24h) **0**", normalized);
+        Assert.Contains("- Servers with failures **0**", normalized);
+        Assert.DoesNotContain("-**", normalized);
+        Assert.DoesNotContain(":**0", normalized);
+        Assert.DoesNotContain(":**5", normalized);
+        Assert.DoesNotContain("**Servers checked:**", normalized);
+    }
+
+    /// <summary>
+    /// Ensures legacy repair only triggers for malformed transcript artifacts.
+    /// </summary>
+    [Fact]
+    public void TryRepairLegacyTranscript_RepairsOnlyWhenLegacyArtifactsDetected() {
+        var malformed = "**Status: HEALTHY** - **Servers checked:**5 -**Replication edges:**62";
+        var clean = "Quick AD replication check\n- Servers checked **5**";
+
+        var repaired = TranscriptMarkdownNormalizer.TryRepairLegacyTranscript(malformed, out var fixedText);
+        var cleanChanged = TranscriptMarkdownNormalizer.TryRepairLegacyTranscript(clean, out var cleanText);
+
+        Assert.True(repaired);
+        Assert.Contains("Status **HEALTHY**", fixedText);
+        Assert.False(cleanChanged);
+        Assert.Equal(clean, cleanText);
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Conversations.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Conversations.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using IntelligenceX.Chat.Abstractions.Policy;
 using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.App.Conversation;
+using IntelligenceX.Chat.App.Rendering;
 using IntelligenceX.Chat.Client;
 using Microsoft.UI;
 using Microsoft.UI.Dispatching;
@@ -27,7 +28,8 @@ using Windows.Graphics;
 namespace IntelligenceX.Chat.App;
 
 public sealed partial class MainWindow : Window {
-    private void LoadConversationsFromState(ChatAppState state) {
+    private bool LoadConversationsFromState(ChatAppState state) {
+        var repaired = false;
         _conversations.Clear();
         if (state.Conversations is { Count: > 0 }) {
             foreach (var stored in state.Conversations) {
@@ -48,8 +50,14 @@ public sealed partial class MainWindow : Window {
                             continue;
                         }
 
+                        var repairedText = RepairLegacyTranscriptText(message.Text, out var messageWasRepaired);
+                        if (messageWasRepaired) {
+                            message.Text = repairedText;
+                            repaired = true;
+                        }
+
                         var local = EnsureUtc(message.TimeUtc).ToLocalTime();
-                        conversation.Messages.Add((message.Role ?? "System", message.Text, local));
+                        conversation.Messages.Add((message.Role ?? "System", repairedText, local));
                     }
                 }
 
@@ -77,8 +85,14 @@ public sealed partial class MainWindow : Window {
                         continue;
                     }
 
+                    var repairedText = RepairLegacyTranscriptText(message.Text, out var messageWasRepaired);
+                    if (messageWasRepaired) {
+                        message.Text = repairedText;
+                        repaired = true;
+                    }
+
                     var local = EnsureUtc(message.TimeUtc).ToLocalTime();
-                    legacy.Messages.Add((message.Role ?? "System", message.Text, local));
+                    legacy.Messages.Add((message.Role ?? "System", repairedText, local));
                 }
             }
             legacy.Title = ComputeConversationTitle(legacy.Title, legacy.Messages);
@@ -96,6 +110,18 @@ public sealed partial class MainWindow : Window {
         if (_conversations.Count > MaxConversations) {
             _conversations.RemoveRange(MaxConversations, _conversations.Count - MaxConversations);
         }
+
+        return repaired;
+    }
+
+    private static string RepairLegacyTranscriptText(string text, out bool repaired) {
+        if (!TranscriptMarkdownNormalizer.TryRepairLegacyTranscript(text, out var normalized)) {
+            repaired = false;
+            return text;
+        }
+
+        repaired = true;
+        return normalized;
     }
 
     private string ResolveInitialConversationId(ChatAppState state) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -682,8 +682,11 @@ public sealed partial class MainWindow : Window {
         _lastExportDirectory = ExportPreferencesContract.NormalizeDirectory(_appState.ExportLastDirectory);
         _appState.ExportLastDirectory = _lastExportDirectory;
 
-        LoadConversationsFromState(_appState);
+        var repairedLegacyTranscriptState = LoadConversationsFromState(_appState);
         ActivateConversation(ResolveInitialConversationId(_appState));
+        if (repairedLegacyTranscriptState) {
+            await PersistAppStateAsync().ConfigureAwait(false);
+        }
 
         var knownToolNames = new List<string>(_toolDescriptions.Keys);
         _modelKickoffAttempted = _messages.Count > 0;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMarkdownNormalizer.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMarkdownNormalizer.cs
@@ -19,7 +19,39 @@ internal static class TranscriptMarkdownNormalizer {
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex CollapsedBulletRegex = new(
-        @"(?<=\*\*)\s-\s\*\*",
+        @"(?<=\*\*)[ \t]-[ \t]\*\*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex TightBoldValueRegex = new(
+        @"(?<=:\*\*)(?=\S)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex MissingSpaceBeforeBoldMetricRegex = new(
+        @"(?<=\s)-(?=\*\*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex SingleStarMetricRegex = new(
+        @"(?<=\s)-\*(?=[A-Za-z])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex StatusCollapsedLineRegex = new(
+        @"(?m)^(?<lead>\s*\*\*Status:[^\r\n]*?)[ \t]-[ \t](?<rest>\*\*.*)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex BulletCollapsedLineRegex = new(
+        @"(?m)^(?<lead>\s*-\s[^\r\n]*?)[ \t]-[ \t](?<rest>\*\*.*)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex LegacyStatusSummaryRegex = new(
+        @"(?m)^(?<indent>\s*)\*\*Status:\s*(?<value>[^*\r\n]+)\*\*\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex LegacyBoldMetricBulletRegex = new(
+        @"(?m)^(?<indent>\s*-\s)\*\*(?<label>[^*\r\n:]+):\*\*\s*(?<value>[^\r\n]*)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex LegacyRepairSignalRegex = new(
+        @"\*\*Status:\s|-\*\*|-\*[A-Za-z]|:\*\*\S",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     public static string NormalizeForRendering(string? text) {
@@ -31,7 +63,67 @@ internal static class TranscriptMarkdownNormalizer {
         normalized = EmojiWordJoinRegex.Replace(normalized, "$1 ");
         normalized = NumberedChoiceJoinRegex.Replace(normalized, "$1 ");
         normalized = LetterToNumberedChoiceJoinRegex.Replace(normalized, " ");
+        normalized = TightBoldValueRegex.Replace(normalized, " ");
+        normalized = MissingSpaceBeforeBoldMetricRegex.Replace(normalized, "- ");
+        normalized = SingleStarMetricRegex.Replace(normalized, "- **");
         normalized = CollapsedBulletRegex.Replace(normalized, "\n- **");
+        normalized = ExpandCollapsedMetricLines(normalized);
+        normalized = ConvertLegacyMetricMarkdown(normalized);
         return normalized;
+    }
+
+    public static bool TryRepairLegacyTranscript(string? text, out string normalized) {
+        normalized = text ?? string.Empty;
+        if (normalized.Length == 0 || !LegacyRepairSignalRegex.IsMatch(normalized)) {
+            return false;
+        }
+
+        var repaired = NormalizeForRendering(normalized);
+        if (repaired == normalized) {
+            return false;
+        }
+
+        normalized = repaired;
+        return true;
+    }
+
+    private static string ExpandCollapsedMetricLines(string text) {
+        var newline = text.Contains("\r\n", System.StringComparison.Ordinal) ? "\r\n" : "\n";
+        var current = text;
+
+        while (true) {
+            var afterStatus = StatusCollapsedLineRegex.Replace(
+                current,
+                match => match.Groups["lead"].Value + newline + "- " + match.Groups["rest"].Value);
+
+            var afterBullets = BulletCollapsedLineRegex.Replace(
+                afterStatus,
+                match => match.Groups["lead"].Value + newline + "- " + match.Groups["rest"].Value);
+
+            if (afterBullets == current) {
+                return afterBullets;
+            }
+
+            current = afterBullets;
+        }
+    }
+
+    private static string ConvertLegacyMetricMarkdown(string text) {
+        var statusNormalized = LegacyStatusSummaryRegex.Replace(
+            text,
+            match => {
+                var indent = match.Groups["indent"].Value;
+                var value = match.Groups["value"].Value.Trim();
+                return value.Length == 0 ? indent + "Status" : indent + "Status **" + value + "**";
+            });
+
+        return LegacyBoldMetricBulletRegex.Replace(
+            statusNormalized,
+            match => {
+                var indent = match.Groups["indent"].Value;
+                var label = match.Groups["label"].Value.Trim();
+                var value = match.Groups["value"].Value.Trim();
+                return value.Length == 0 ? indent + label : indent + label + " **" + value + "**";
+            });
     }
 }


### PR DESCRIPTION
## Summary
- harden transcript markdown normalization for legacy malformed status/metric blocks seen in persisted chat history
- add targeted legacy repair detection (`TryRepairLegacyTranscript`) so we only rewrite messages that match known broken patterns
- auto-heal stored conversation messages during state load and persist repaired state once loaded
- add regression tests for malformed AD replication/status output and formatter rendering

## Problem This Fixes
Some historical messages were stored as markdown variants like:
- `**Status: HEALTHY** - **Servers checked:**5 -**Replication edges:**62 ...`
- mixed `-**` / `-*` metric markers

Those exports looked fine in raw markdown, but in-app render could collapse/misparse segments. This patch normalizes legacy artifacts before rendering and repairs old persisted entries on load.

## Files
- `IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMarkdownNormalizer.cs`
- `IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Conversations.cs`
- `IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs`
- `IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs`
- `IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs`

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
- Result: Passed (`90/90`)
