### PR TITLE
Improve usage-limit account switch guidance in Chat menu

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -105,9 +105,10 @@ public sealed partial class MainWindow : Window {
         }
     }
 
-    private async Task SetStatusAsync(string text, SessionStatusTone? tone = null) {
+    private async Task SetStatusAsync(string text, SessionStatusTone? tone = null, bool? usageLimitSwitchRecommended = null) {
         _statusText = text ?? string.Empty;
         _statusTone = tone ?? InferStatusTone(_statusText);
+        _usageLimitSwitchRecommended = usageLimitSwitchRecommended ?? InferUsageLimitSwitchRecommendation(_statusText);
         if (!_webViewReady) {
             return;
         }
@@ -123,7 +124,8 @@ public sealed partial class MainWindow : Window {
     private Task SetStatusAsync(SessionStatus status) {
         return SetStatusAsync(
             SessionStatusFormatter.Format(status),
-            SessionStatusToneResolver.Resolve(status));
+            SessionStatusToneResolver.Resolve(status),
+            status.Kind == SessionStatusKind.UsageLimitReached);
     }
 
     private async Task PublishSessionStateAsync() {
@@ -134,6 +136,8 @@ public sealed partial class MainWindow : Window {
         var json = JsonSerializer.Serialize(new {
             status = _statusText,
             statusTone = MapStatusTone(_statusTone),
+            usageLimitSwitchRecommended = _usageLimitSwitchRecommended,
+            queuedPromptPending = !string.IsNullOrWhiteSpace(_queuedPromptAfterLogin),
             connected = _isConnected,
             authenticated = _isAuthenticated,
             loginInProgress = _loginInProgress,
@@ -183,6 +187,16 @@ public sealed partial class MainWindow : Window {
         }
 
         return SessionStatusTone.Neutral;
+    }
+
+    private static bool InferUsageLimitSwitchRecommendation(string text) {
+        var normalized = (text ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return false;
+        }
+
+        return normalized.Contains("usage limit", StringComparison.OrdinalIgnoreCase)
+               || normalized.Contains("switch account", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task PublishOptionsStateAsync() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -130,6 +130,7 @@ public sealed partial class MainWindow : Window {
     private bool _isConnected;
     private string _statusText = SessionStatusFormatter.Format(SessionStatus.Disconnected());
     private SessionStatusTone _statusTone = SessionStatusToneResolver.Resolve(SessionStatus.Disconnected());
+    private bool _usageLimitSwitchRecommended;
     private string _timestampMode = ResolveTimestampMode(Environment.GetEnvironmentVariable("IXCHAT_TIME_FORMAT"));
     private string _timestampFormat = ResolveTimestampFormat(Environment.GetEnvironmentVariable("IXCHAT_TIME_FORMAT"));
     private int? _autonomyMaxToolRounds;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
@@ -31,6 +31,8 @@
   var state = {
     status: "Starting runtime...",
     statusTone: "warn",
+    usageLimitSwitchRecommended: false,
+    queuedPromptPending: false,
     connected: false,
     authenticated: false,
     loginInProgress: false,
@@ -431,6 +433,7 @@
     var debugDivider = byId("menuDebugDivider");
     var authenticated = normalizeBool(state.authenticated);
     var loginInProgress = normalizeBool(state.loginInProgress);
+    var switchRecommended = normalizeBool(state.usageLimitSwitchRecommended) || normalizeBool(state.queuedPromptPending);
     var debugToolsEnabled = normalizeBool(state.options.debugToolsEnabled);
 
     signIn.hidden = false;
@@ -439,14 +442,16 @@
       signIn.textContent = loginInProgress ? "Signing In..." : "Sign In Again";
       signIn.setAttribute("data-cmd", "relogin");
     } else {
-      signIn.textContent = loginInProgress ? "Signing In..." : "Sign In";
+      signIn.textContent = loginInProgress
+        ? "Signing In..."
+        : (switchRecommended ? "Sign In (retry queued prompt)" : "Sign In");
       signIn.setAttribute("data-cmd", "login");
     }
 
     if (switchAccount) {
       switchAccount.hidden = false;
       switchAccount.disabled = loginInProgress;
-      switchAccount.textContent = authenticated ? "Switch Account" : "Switch Account";
+      switchAccount.textContent = switchRecommended ? "Switch Account (Recommended)" : "Switch Account";
     }
 
     reconnect.textContent = normalizeBool(state.connected) ? "Reconnect runtime" : "Start runtime";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -599,6 +599,12 @@
     if (typeof nextState.statusTone === "string") {
       state.statusTone = nextState.statusTone;
     }
+    if (typeof nextState.usageLimitSwitchRecommended === "boolean") {
+      state.usageLimitSwitchRecommended = nextState.usageLimitSwitchRecommended;
+    }
+    if (typeof nextState.queuedPromptPending === "boolean") {
+      state.queuedPromptPending = nextState.queuedPromptPending;
+    }
     if (typeof nextState.connected === "boolean") {
       state.connected = nextState.connected;
     }


### PR DESCRIPTION
## Summary
Improve the menu UX when usage limits are hit so account switching is obvious and immediate.

### What changed
- Added explicit session-state flags from app runtime to UI:
  - `usageLimitSwitchRecommended`
  - `queuedPromptPending`
- `SetStatusAsync(SessionStatus)` now marks `usageLimitSwitchRecommended=true` only for `UsageLimitReached`, and clears it for other typed statuses.
- `PublishSessionStateAsync` now emits both flags.
- Updated menu behavior:
  - `Switch Account` becomes `Switch Account (Recommended)` when usage-limit or queued-prompt conditions are active.
  - For unauthenticated state with queued prompt, `Sign In` becomes `Sign In (retry queued prompt)`.

### Why
Users who hit quota limits should get a clear, immediate CTA in the existing menu without guessing the next step.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`

Passed locally.
