### PR TITLE
chat: surface plugin startup diagnostics in session policy

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Policy/SessionPolicyDto.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Policy/SessionPolicyDto.cs
@@ -53,4 +53,14 @@ public sealed record SessionPolicyDto {
     /// Whether outputs should be redacted (best-effort) for display/logging.
     /// </summary>
     public bool Redact { get; init; }
+
+    /// <summary>
+    /// Startup/bootstrap notices (for example plugin load warnings).
+    /// </summary>
+    public string[] StartupWarnings { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Effective plugin search roots used by the runtime.
+    /// </summary>
+    public string[] PluginSearchPaths { get; init; } = Array.Empty<string>();
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -247,7 +247,9 @@ public sealed partial class MainWindow : Window {
                 turnTimeoutSeconds = _sessionPolicy.TurnTimeoutSeconds,
                 toolTimeoutSeconds = _sessionPolicy.ToolTimeoutSeconds,
                 maxToolRounds = _sessionPolicy.MaxToolRounds,
-                parallelTools = _sessionPolicy.ParallelTools
+                parallelTools = _sessionPolicy.ParallelTools,
+                startupWarnings = _sessionPolicy.StartupWarnings,
+                pluginSearchPaths = _sessionPolicy.PluginSearchPaths
             }
         });
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
@@ -79,6 +79,27 @@
     return value === true;
   }
 
+  function toStringArray(value) {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    var list = [];
+    for (var i = 0; i < value.length; i++) {
+      if (typeof value[i] !== "string") {
+        continue;
+      }
+
+      var normalized = value[i].trim();
+      if (!normalized) {
+        continue;
+      }
+
+      list.push(normalized);
+    }
+    return list;
+  }
+
   function normalizeProfileApplyMode(value) {
     return value === "profile" ? "profile" : "session";
   }
@@ -494,20 +515,34 @@
 
   function renderPolicy() {
     var policyEl = byId("policyInfo");
+    var startupWarningsEl = byId("policyStartupWarnings");
+    var pluginRootsEl = byId("policyPluginRoots");
     policyEl.innerHTML = "";
 
     var p = state.options.policy;
     if (!p) {
       policyEl.innerHTML = "<span class='options-k'>Policy</span><span class='options-v'>Not available</span>";
+      if (startupWarningsEl) {
+        startupWarningsEl.hidden = true;
+        startupWarningsEl.innerHTML = "";
+      }
+      if (pluginRootsEl) {
+        pluginRootsEl.hidden = true;
+        pluginRootsEl.innerHTML = "";
+      }
       return;
     }
 
+    var startupWarnings = toStringArray(p.startupWarnings);
+    var pluginSearchPaths = toStringArray(p.pluginSearchPaths);
     var rows = [
       ["Read-only", p.readOnly ? "Yes" : "No"],
       ["Parallel tools", p.parallelTools ? "Yes" : "No"],
       ["Max tool rounds", p.maxToolRounds == null ? "Default" : String(p.maxToolRounds)],
       ["Turn timeout", p.turnTimeoutSeconds == null ? "Default" : (String(p.turnTimeoutSeconds) + "s")],
-      ["Tool timeout", p.toolTimeoutSeconds == null ? "Default" : (String(p.toolTimeoutSeconds) + "s")]
+      ["Tool timeout", p.toolTimeoutSeconds == null ? "Default" : (String(p.toolTimeoutSeconds) + "s")],
+      ["Plugin roots", pluginSearchPaths.length === 0 ? "None" : String(pluginSearchPaths.length)],
+      ["Runtime notices", startupWarnings.length === 0 ? "None" : String(startupWarnings.length)]
     ];
 
     for (var i = 0; i < rows.length; i++) {
@@ -520,6 +555,37 @@
       policyEl.appendChild(k);
       policyEl.appendChild(v);
     }
+
+    renderPolicyList(pluginRootsEl, pluginSearchPaths, "Plugin search roots");
+    renderPolicyList(startupWarningsEl, startupWarnings, startupWarnings.length === 1 ? "Runtime notice" : "Runtime notices");
+  }
+
+  function renderPolicyList(host, values, title) {
+    if (!host) {
+      return;
+    }
+
+    host.innerHTML = "";
+    if (!values || values.length === 0) {
+      host.hidden = true;
+      return;
+    }
+
+    host.hidden = false;
+
+    var heading = document.createElement("div");
+    heading.className = "options-policy-list-title";
+    heading.textContent = title;
+    host.appendChild(heading);
+
+    var list = document.createElement("ul");
+    list.className = "options-policy-list";
+    for (var i = 0; i < values.length; i++) {
+      var item = document.createElement("li");
+      item.textContent = values[i];
+      list.appendChild(item);
+    }
+    host.appendChild(list);
   }
 
   function conversationTitle(item) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.30.options.css
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.30.options.css
@@ -348,6 +348,39 @@ body.options-open .options-panel {
   color: var(--ix-text-muted);
 }
 
+.options-policy-list-wrap {
+  margin-top: 8px;
+  border: 1px solid rgba(58, 96, 144, 0.45);
+  border-radius: 8px;
+  background: rgba(9, 33, 60, 0.48);
+  padding: 8px;
+}
+
+.options-policy-list-warn {
+  border-color: rgba(255, 182, 92, 0.45);
+  background: rgba(110, 70, 14, 0.22);
+}
+
+.options-policy-list-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ix-text-secondary);
+}
+
+.options-policy-list {
+  margin: 6px 0 0;
+  padding-left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.options-policy-list li {
+  font-size: 10.8px;
+  color: var(--ix-text-secondary);
+  word-break: break-word;
+}
+
 .options-actions {
   display: flex;
   gap: 8px;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -241,6 +241,8 @@
         <section class="options-group">
           <div class="options-label">Session Policy</div>
           <div class="options-kv" id="policyInfo"></div>
+          <div class="options-note options-policy-list-wrap" id="policyPluginRoots" hidden></div>
+          <div class="options-note options-policy-list-wrap options-policy-list-warn" id="policyStartupWarnings" hidden></div>
         </section>
       </div>
 
@@ -262,7 +264,7 @@
             <button id="btnDebugToggleEngine" class="options-btn options-btn-sm">Enable Engine Debug</button>
             <button id="btnDebugCopyWheel" class="options-btn options-btn-sm options-btn-ghost">Copy Wheel Diagnostics</button>
             <button id="btnDebugCopyStartupLog" class="options-btn options-btn-sm options-btn-ghost">Copy Startup Log</button>
-            <button id="btnDebugRestartSidecar" class="options-btn options-btn-sm options-btn-ghost">Restart Sidecar</button>
+            <button id="btnDebugRestartSidecar" class="options-btn options-btn-sm options-btn-ghost">Restart Runtime</button>
           </div>
         </section>
       </div>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
@@ -26,6 +26,8 @@ internal sealed class ChatServiceSession {
     private readonly Stream _stream;
     private readonly ToolRegistry _registry;
     private readonly IReadOnlyList<IToolPack> _packs;
+    private readonly string[] _startupWarnings;
+    private readonly string[] _pluginSearchPaths;
 
     private readonly JsonSerializerOptions _json;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
@@ -38,7 +40,8 @@ internal sealed class ChatServiceSession {
     public ChatServiceSession(ServiceOptions options, Stream stream) {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
-        _packs = ToolPackBootstrap.CreateDefaultReadOnlyPacks(new ToolPackBootstrapOptions {
+        var startupWarnings = new List<string>();
+        var bootstrapOptions = new ToolPackBootstrapOptions {
             AllowedRoots = _options.AllowedRoots.ToArray(),
             AdDomainController = _options.AdDomainController,
             AdDefaultSearchBaseDn = _options.AdDefaultSearchBaseDn,
@@ -48,8 +51,12 @@ internal sealed class ChatServiceSession {
             EnableTestimoXPack = _options.EnableTestimoXPack,
             EnableDefaultPluginPaths = _options.EnableDefaultPluginPaths,
             PluginPaths = _options.PluginPaths.ToArray(),
-            OnBootstrapWarning = warning => Console.Error.WriteLine($"[pack warning] {warning}")
-        });
+            OnBootstrapWarning = warning => RecordBootstrapWarning(startupWarnings, warning)
+        };
+
+        _packs = ToolPackBootstrap.CreateDefaultReadOnlyPacks(bootstrapOptions);
+        _pluginSearchPaths = NormalizeDistinctStrings(ToolPackBootstrap.GetPluginSearchPaths(bootstrapOptions), maxItems: 32);
+        _startupWarnings = NormalizeDistinctStrings(startupWarnings, maxItems: 64);
         _registry = new ToolRegistry();
         ToolPackBootstrap.RegisterAll(_registry, _packs);
 
@@ -109,7 +116,7 @@ internal sealed class ChatServiceSession {
                             Name = "IntelligenceX.Chat.Service",
                             Version = typeof(ChatServiceSession).Assembly.GetName().Version?.ToString() ?? "0.0.0",
                             ProcessId = Environment.ProcessId.ToString(),
-                            Policy = BuildSessionPolicy(_options, _packs)
+                            Policy = BuildSessionPolicy(_options, _packs, _startupWarnings, _pluginSearchPaths)
                         }, cancellationToken).ConfigureAwait(false);
                         break;
 
@@ -1137,7 +1144,8 @@ internal sealed class ChatServiceSession {
     // Tool errors are returned as JSON strings to the model. Use the shared contract helper so
     // tool packs and hosts converge on the same envelope over time.
 
-    private static SessionPolicyDto BuildSessionPolicy(ServiceOptions options, IEnumerable<IToolPack> packs) {
+    private static SessionPolicyDto BuildSessionPolicy(ServiceOptions options, IEnumerable<IToolPack> packs, IReadOnlyList<string> startupWarnings,
+        IReadOnlyList<string> pluginSearchPaths) {
         var roots = options.AllowedRoots.Count == 0 ? Array.Empty<string>() : options.AllowedRoots.ToArray();
 
         var packList = new List<ToolPackInfoDto>();
@@ -1165,8 +1173,46 @@ internal sealed class ChatServiceSession {
             ParallelTools = options.ParallelTools,
             MaxTableRows = options.MaxTableRows <= 0 ? null : options.MaxTableRows,
             MaxSample = options.MaxSample <= 0 ? null : options.MaxSample,
-            Redact = options.Redact
+            Redact = options.Redact,
+            StartupWarnings = startupWarnings.Count == 0 ? Array.Empty<string>() : startupWarnings.ToArray(),
+            PluginSearchPaths = pluginSearchPaths.Count == 0 ? Array.Empty<string>() : pluginSearchPaths.ToArray()
         };
+    }
+
+    private static void RecordBootstrapWarning(ICollection<string> sink, string? warning) {
+        var normalized = (warning ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return;
+        }
+
+        sink.Add(normalized);
+        Console.Error.WriteLine($"[pack warning] {normalized}");
+    }
+
+    private static string[] NormalizeDistinctStrings(IEnumerable<string> values, int maxItems) {
+        if (values is null) {
+            return Array.Empty<string>();
+        }
+
+        var dedupe = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var list = new List<string>();
+        foreach (var value in values) {
+            var normalized = (value ?? string.Empty).Trim();
+            if (normalized.Length == 0) {
+                continue;
+            }
+
+            if (!dedupe.Add(normalized)) {
+                continue;
+            }
+
+            list.Add(normalized);
+            if (maxItems > 0 && list.Count >= maxItems) {
+                break;
+            }
+        }
+
+        return list.Count == 0 ? Array.Empty<string>() : list.ToArray();
     }
 
     private static CapabilityTier MapTier(ToolCapabilityTier tier) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\IntelligenceX.Chat.Abstractions\IntelligenceX.Chat.Abstractions.csproj" />
     <ProjectReference Include="..\IntelligenceX.Chat.Tooling\IntelligenceX.Chat.Tooling.csproj" />
   </ItemGroup>
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/SessionPolicyContractTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/SessionPolicyContractTests.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using IntelligenceX.Chat.Abstractions.Policy;
+using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Abstractions.Serialization;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class SessionPolicyContractTests {
+    [Fact]
+    public void HelloMessage_RoundTripsPolicyDiagnostics() {
+        var hello = new HelloMessage {
+            Kind = ChatServiceMessageKind.Response,
+            RequestId = "req_1",
+            Name = "IntelligenceX.Chat.Service",
+            Version = "1.0.0",
+            ProcessId = "1234",
+            Policy = new SessionPolicyDto {
+                ReadOnly = true,
+                DangerousToolsEnabled = false,
+                MaxToolRounds = 3,
+                ParallelTools = true,
+                StartupWarnings = new[] {
+                    "[plugin] path_not_found path='C:\\plugins\\missing'",
+                    "[plugin] init_failed plugin='ix.mail' error='dependency missing'"
+                },
+                PluginSearchPaths = new[] {
+                    "C:\\Users\\user\\AppData\\Local\\IntelligenceX.Chat\\plugins",
+                    "C:\\Support\\GitHub\\IntelligenceX\\plugins"
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize<ChatServiceMessage>(hello, ChatServiceJsonContext.Default.ChatServiceMessage);
+        var parsed = JsonSerializer.Deserialize(json, ChatServiceJsonContext.Default.ChatServiceMessage);
+        var roundTrip = Assert.IsType<HelloMessage>(parsed);
+        var policy = Assert.IsType<SessionPolicyDto>(roundTrip.Policy);
+
+        Assert.Equal(2, policy.StartupWarnings.Length);
+        Assert.Equal("[plugin] path_not_found path='C:\\plugins\\missing'", policy.StartupWarnings[0]);
+        Assert.Equal(2, policy.PluginSearchPaths.Length);
+        Assert.Equal("C:\\Support\\GitHub\\IntelligenceX\\plugins", policy.PluginSearchPaths[1]);
+    }
+}


### PR DESCRIPTION
## Summary
- add startup diagnostics to the service policy contract so the app can show plugin/bootstrap warnings directly in UI
- include effective plugin search roots in the same policy payload
- show both in the Session tab under Session Policy (counts + detailed lists)
- rename visible debug action label from "Restart Sidecar" to "Restart Runtime"
- add a policy contract roundtrip test in `IntelligenceX.Chat.Tests`

## Why
- plugin/autoload failures were visible mostly in stderr/startup logs, not in user-facing app flow
- users need quick answers on what plugin roots were searched and which startup notices occurred

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`