### PR TITLE
chat: align user-facing wording on local runtime service

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Launch/ServiceLaunchArguments.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Launch/ServiceLaunchArguments.cs
@@ -4,11 +4,11 @@ using System.Collections.Generic;
 namespace IntelligenceX.Chat.App.Launch;
 
 /// <summary>
-/// Provides typed construction of service sidecar launch arguments.
+/// Provides typed construction of local runtime service launch arguments.
 /// </summary>
 internal static class ServiceLaunchArguments {
     /// <summary>
-    /// Builds service-sidecar arguments for the configured pipe and lifecycle mode.
+    /// Builds runtime service arguments for the configured pipe and lifecycle mode.
     /// </summary>
     /// <param name="pipeName">Named-pipe identifier.</param>
     /// <param name="detachedServiceMode">Whether service is detached from app lifetime.</param>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -299,7 +299,7 @@ internal sealed class ServiceOptions {
         Console.WriteLine("  --max-table-rows <N>    Max rows to show in table-like output (0 = no limit; default: 20).");
         Console.WriteLine("  --max-sample <N>        Max sample items to show from long lists (0 = no limit; default: 10).");
         Console.WriteLine("  --redact                Best-effort redact output for display/logging (default: off).");
-        Console.WriteLine("  --exit-on-disconnect    Exit when parent app disconnects (sidecar mode).");
+        Console.WriteLine("  --exit-on-disconnect    Exit when parent app disconnects (runtime-managed mode).");
         Console.WriteLine("  --parent-pid <PID>      Parent process id used with --exit-on-disconnect.");
         Console.WriteLine("  -h, --help              Show help.");
     }

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -34,7 +34,7 @@ Markdown renderer dependency resolution is automatic:
 - Dev: if sibling local source exists (`..\OfficeIMO`), Chat builds against that local project.
 - Fallback: if local source is not present (CI/clean OSS checkout), Chat uses the NuGet package.
 
-`Run-ChatApp.ps1` launches only the app. The local chat service sidecar is auto-started and auto-restarted by the app.
+`Run-ChatApp.ps1` launches only the app. The local runtime service is auto-started and auto-restarted by the app.
 
 Service-only mode (advanced):
 
@@ -54,7 +54,7 @@ By default, Host + Service + WinUI app share auth and use separate local state s
   - Override: `INTELLIGENCEX_AUTH_PATH`
 - WinUI app state (profiles, chats, UI options): `%LOCALAPPDATA%\\IntelligenceX.Chat\\app-state.db`
 - Service profile state (service CLI profiles): `%LOCALAPPDATA%\\IntelligenceX.Chat\\state.db`
-- Sidecar staging (temporary service runtime copy): `%TEMP%\\IntelligenceX.Chat\\service-runtime\\<guid>`
+- Runtime staging (temporary service runtime copy): `%TEMP%\\IntelligenceX.Chat\\service-runtime\\<guid>`
 - IPC channel: named pipe `intelligencex.chat`
 
 Status-chip behavior is connection/auth based:


### PR DESCRIPTION
## Summary
- replace remaining user-facing `sidecar` wording with `runtime service` wording in chat docs/help
- keep behavior and compatibility unchanged (argument names and internal mechanics untouched)

## Files
- `IntelligenceX.Chat/README.md`
- `IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs`
- `IntelligenceX.Chat/IntelligenceX.Chat.App/Launch/ServiceLaunchArguments.cs`

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`