### PR TITLE
chore: lock LF for shell and git metadata files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,16 @@ insert_final_newline = false
 [*.ps1]
 end_of_line = crlf
 
+# Bash scripts and Git attributes/config metadata
+[*.sh]
+end_of_line = lf
+
+[.gitattributes]
+end_of_line = lf
+
+[.editorconfig]
+end_of_line = lf
+
 #### .NET Code Actions ####
 
 # Type members

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,7 +20,10 @@
 *.cs    text eol=lf
 *.csproj text eol=lf
 *.sln   text eol=lf
+*.sh    text eol=lf
 *.ps1   text eol=crlf
+.gitattributes text eol=lf
+.editorconfig text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.


### PR DESCRIPTION
## Summary
- enforce `LF` line endings for `*.sh` in `.gitattributes`
- enforce `LF` for `.gitattributes` and `.editorconfig` themselves
- mirror these expectations in `.editorconfig` to keep editors aligned

## Why
- prevents Windows CRLF checkouts from breaking bash scripts (`set -euo pipefail` issues)
- reduces recurring local EOL drift/noise without changing runtime logic

## Scope
- policy/config only (`.gitattributes`, `.editorconfig`)
- no code/runtime behavior changes
