### PR TITLE
Chat: bump OfficeIMO.MarkdownRenderer to 0.1.1

### DIFF
--- a/IntelligenceX.Chat/Directory.Build.props
+++ b/IntelligenceX.Chat/Directory.Build.props
@@ -29,6 +29,6 @@
     <DbaClientXRepoRoot Condition="'$(DbaClientXRepoRoot)' == '' and Exists('$(DbaClientXRepoRootCandidate2)DbaClientX.SQLite\\DbaClientX.SQLite.csproj')">$(DbaClientXRepoRootCandidate2)</DbaClientXRepoRoot>
     <DbaClientXRepoRoot Condition="'$(DbaClientXRepoRoot)' == ''">$(DbaClientXRepoRootCandidate1)</DbaClientXRepoRoot>
 
-    <OfficeImoMarkdownRendererNuGetVersion Condition="'$(OfficeImoMarkdownRendererNuGetVersion)' == ''">0.1.0</OfficeImoMarkdownRendererNuGetVersion>
+    <OfficeImoMarkdownRendererNuGetVersion Condition="'$(OfficeImoMarkdownRendererNuGetVersion)' == ''">0.1.1</OfficeImoMarkdownRendererNuGetVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Bumps the fallback NuGet version used by IntelligenceX.Chat when a local OfficeIMO checkout is not present.

- Updated: OfficeIMO.MarkdownRenderer 0.1.0 -> 0.1.1
- Local dev behavior unchanged: still prefers sibling source checkout when present.

Local preflight:
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll