### PR TITLE
CI: ensure rendered audit dependencies

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -153,7 +153,7 @@
       "requiredRoutes": "/,/docs/,/404.html,/api/,/search/,/sitemap/,/showcase/",
       "failOnCategories": "budget,nav,link,asset,rendered-console-error,rendered-request-failure",
       "rendered": true,
-      "renderedEnsureInstalled": false,
+      "renderedEnsureInstalled": true,
       "renderedMaxPages": 8,
       "renderedInclude": "index.html,docs/**,faq/**,changelog/**,api/index.html,showcase/**",
       "renderedExclude": "docs/api/**,api-docs/**",


### PR DESCRIPTION
Deploy Website workflow on Linux reported a new 'rendered' warning during the doctor step (fail-on-new enabled).

Set enderedEnsureInstalled: true in Website/pipeline.json so CI installs required rendered-audit dependencies and stays deterministic.