### PR TITLE
Website/docs: refine CTA labels and image hint coverage

### DIFF
--- a/Docs/library/overview.md
+++ b/Docs/library/overview.md
@@ -5,7 +5,7 @@ The core library provides a Codex app-server client, ChatGPT auth helpers, and a
 Quickstart: [Library Quickstart](/docs/library/quickstart/)  
 Providers: [Provider Setup](/docs/library/providers/)  
 Tools: [Tool Calling](/docs/library/tools/)
-Tool packs: [Tool Packs](/docs/library/tool-packs/)
+Tool packs: [Library Tool Packs](/docs/library/tool-packs/)
 Plugin rollout draft: [Plugin Rollout Draft](/docs/library/plugin-rollout-draft/)
 
 ## Quick start (app-server)

--- a/Docs/screenshots.md
+++ b/Docs/screenshots.md
@@ -4,16 +4,28 @@ Reference captures for onboarding "Configure" and "Verify" steps across CLI and 
 
 ## Web UI - Configure
 
-![Web Configure step](/assets/screenshots/web-configure-step.svg)
+<img src="/assets/screenshots/web-configure-step.svg"
+     alt="Web Configure step"
+     loading="lazy"
+     decoding="async" />
 
 ## Web UI - Verify
 
-![Web Verify step](/assets/screenshots/web-verify-step.svg)
+<img src="/assets/screenshots/web-verify-step.svg"
+     alt="Web Verify step"
+     loading="lazy"
+     decoding="async" />
 
 ## CLI Wizard - Configure
 
-![CLI Configure step](/assets/screenshots/cli-configure-step.svg)
+<img src="/assets/screenshots/cli-configure-step.svg"
+     alt="CLI Configure step"
+     loading="lazy"
+     decoding="async" />
 
 ## CLI Wizard - Verify
 
-![CLI Verify step](/assets/screenshots/cli-verify-step.svg)
+<img src="/assets/screenshots/cli-verify-step.svg"
+     alt="CLI Verify step"
+     loading="lazy"
+     decoding="async" />

--- a/Website/site.json
+++ b/Website/site.json
@@ -138,7 +138,7 @@
         "Items": [
           { "Title": "Reviewer", "Url": "/docs/reviewer/overview/" },
           { "Title": "IX Chat", "Url": "/docs/chat/overview/" },
-          { "Title": "Tool Packs", "Url": "/docs/tools/overview/" },
+          { "Title": "IX Tools", "Url": "/docs/tools/overview/" },
           { "Title": "CLI Tools", "Url": "/docs/cli/overview/" },
           { "Title": ".NET Library", "Url": "/docs/library/overview/" },
           { "Title": "API Reference", "Url": "/api/" },

--- a/Website/themes/intelligencex/layouts/showcase.html
+++ b/Website/themes/intelligencex/layouts/showcase.html
@@ -30,7 +30,7 @@
       {{ for item in data.showcase.cards }}
       <div class="showcase-card">
         <div class="showcase-image">
-          <img src="{{ item.screenshot }}" alt="{{ item.title }}" loading="lazy" />
+          <img src="{{ item.screenshot }}" alt="{{ item.title }}" loading="lazy" decoding="async" />
         </div>
         <div class="showcase-card-body">
           <h3>{{ item.title }}</h3>

--- a/Website/themes/intelligencex/partials/sections/products.html
+++ b/Website/themes/intelligencex/partials/sections/products.html
@@ -24,11 +24,11 @@
                     <code>{{ item.install }}</code>
                 </div>
                 {{ end }}
-                <a href="{{ item.link }}" class="feature-link">Learn more &rarr;</a>
+                <a href="{{ item.link }}" class="feature-link">Learn about {{ item.title }} &rarr;</a>
             </div>
             {{ if item.screenshot }}
             <div class="product-card-image">
-                <img src="{{ item.screenshot }}" alt="{{ item.title }}" loading="lazy" />
+                <img src="{{ item.screenshot }}" alt="{{ item.title }}" loading="lazy" decoding="async" />
             </div>
             {{ end }}
         </div>

--- a/Website/themes/intelligencex/partials/sections/showcase-preview.html
+++ b/Website/themes/intelligencex/partials/sections/showcase-preview.html
@@ -11,7 +11,7 @@
         {{ if for.index < 3 }}
         <div class="showcase-card">
             <div class="showcase-image">
-                <img src="{{ item.screenshot }}" alt="{{ item.title }}" loading="lazy" />
+                <img src="{{ item.screenshot }}" alt="{{ item.title }}" loading="lazy" decoding="async" />
             </div>
             <div class="showcase-card-body">
                 <h3>{{ item.title }}</h3>


### PR DESCRIPTION
Follow-up polish after docs/tool-pack truth updates.

## Improvements

- Disambiguated repetitive home CTA labels:
  - `Learn more ->` changed to `Learn about {Product} ->`
  - Improves link-purpose clarity and accessibility context.
- Added `decoding="async"` to key screenshot images in:
  - home product cards
  - showcase preview cards
  - showcase page cards
- Added explicit loading/decoding hints for screenshots docs page by switching to HTML `<img>` tags with attributes.
- Reduced docs library ambiguity by renaming inline link text:
  - `Tool Packs` -> `Library Tool Packs`
- Renamed footer docs entry `Tool Packs` -> `IX Tools` to avoid label collision.

## Validation

- Local CI pipeline: `Website/build.ps1 -CI` passed.
- Audit summary improved significantly (from 7 warnings to 1 warning in local run).

## Scope

Only docs/theme content updates; no engine behavior change.
