### PR TITLE
Chat.Host: add /compare benchmark mode with per-turn metrics

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Compare.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Compare.cs
@@ -1,0 +1,336 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Chat.Profiles;
+using IntelligenceX.Chat.Tooling;
+using IntelligenceX.OpenAI;
+using IntelligenceX.OpenAI.Auth;
+using IntelligenceX.Tools;
+
+namespace IntelligenceX.Chat.Host;
+
+internal static partial class Program {
+
+    private static async Task HandleCompareCommandAsync(string? arg, ReplOptions baseOptions, CancellationToken cancellationToken) {
+        if (!TryParseCompareArguments(arg, out var profileNames, out var prompt, out var error)) {
+            Console.WriteLine(error ?? "Invalid compare command. Try /help.");
+            return;
+        }
+
+        var dbPath = string.IsNullOrWhiteSpace(baseOptions.StateDbPath) ? ReplOptions.GetDefaultStateDbPath() : baseOptions.StateDbPath!.Trim();
+        using var store = new SqliteServiceProfileStore(dbPath);
+
+        var profiles = new List<(string Name, ServiceProfile Profile)>(profileNames.Count);
+        foreach (var profileName in profileNames) {
+            var profile = await store.GetAsync(profileName, cancellationToken).ConfigureAwait(false);
+            if (profile is null) {
+                Console.WriteLine($"Profile not found: {profileName}");
+                return;
+            }
+            profiles.Add((profileName, profile));
+        }
+
+        Console.WriteLine($"Running compare across {profiles.Count} profiles with shared tool catalog from current session...");
+
+        var runs = new List<CompareProfileRun>(profiles.Count);
+        foreach (var (name, profile) in profiles) {
+            cancellationToken.ThrowIfCancellationRequested();
+            Console.WriteLine($"> compare: {name}");
+            var run = await RunCompareProfileAsync(baseOptions, name, profile, prompt, cancellationToken).ConfigureAwait(false);
+            runs.Add(run);
+        }
+
+        Console.WriteLine();
+        WriteCompareTable(runs);
+
+        try {
+            var artifactPath = WriteCompareArtifact(prompt, runs, baseOptions);
+            Console.WriteLine();
+            Console.WriteLine($"Benchmark artifact: {artifactPath}");
+        } catch (Exception ex) {
+            Console.WriteLine();
+            Console.WriteLine($"Failed to write benchmark artifact: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static async Task<CompareProfileRun> RunCompareProfileAsync(ReplOptions baseOptions, string profileName, ServiceProfile profile,
+        string prompt, CancellationToken cancellationToken) {
+        var compareOptions = baseOptions.Clone();
+        ApplyCompareProfile(compareOptions, profileName, profile);
+        // Keep compare output compact and deterministic.
+        compareOptions.LiveProgress = false;
+        compareOptions.EchoToolOutputs = false;
+
+        IntelligenceXClient? client = null;
+        var startedAtUtc = DateTime.UtcNow;
+        try {
+            var packs = BuildPacks(compareOptions);
+            var clientOptions = new IntelligenceXClientOptions {
+                TransportKind = compareOptions.OpenAITransport,
+                DefaultModel = compareOptions.Model
+            };
+
+            var instructions = LoadInstructions(compareOptions);
+            var shaped = ApplyRuntimeShaping(instructions, compareOptions);
+            if (clientOptions.TransportKind == OpenAITransportKind.Native && !string.IsNullOrWhiteSpace(shaped)) {
+                clientOptions.NativeOptions.Instructions = shaped;
+            }
+
+            if (clientOptions.TransportKind == OpenAITransportKind.CompatibleHttp) {
+                clientOptions.CompatibleHttpOptions.BaseUrl = compareOptions.OpenAIBaseUrl;
+                clientOptions.CompatibleHttpOptions.ApiKey = compareOptions.OpenAIApiKey;
+                clientOptions.CompatibleHttpOptions.Streaming = compareOptions.OpenAIStreaming;
+                clientOptions.CompatibleHttpOptions.AllowInsecureHttp = compareOptions.OpenAIAllowInsecureHttp;
+                clientOptions.CompatibleHttpOptions.AllowInsecureHttpNonLoopback = compareOptions.OpenAIAllowInsecureHttpNonLoopback;
+            }
+
+            var authPath = ResolveAuthPath(compareOptions);
+            if (!string.IsNullOrWhiteSpace(authPath)) {
+                clientOptions.NativeOptions.AuthStore = new FileAuthBundleStore(authPath);
+            }
+
+            client = await IntelligenceXClient.ConnectAsync(clientOptions).ConfigureAwait(false);
+            if (client.TransportKind == OpenAITransportKind.Native) {
+                if (!compareOptions.ForceLogin && await TryUseCachedChatGptLoginAsync(client, cancellationToken).ConfigureAwait(false)) {
+                    // Cached login is available.
+                } else {
+                    await client.LoginChatGptAndWaitAsync(
+                        onUrl: url => {
+                            Console.WriteLine("ChatGPT login required. Open this URL in a browser:");
+                            Console.WriteLine(url);
+                            Console.WriteLine();
+                        },
+                        onPrompt: promptText => PromptForAuthAsync(promptText, cancellationToken),
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            var registry = new ToolRegistry();
+            ToolPackBootstrap.RegisterAll(registry, packs);
+            var session = new ReplSession(client, registry, compareOptions, shaped, status: null);
+            var turn = await session.AskWithMetricsAsync(prompt, cancellationToken).ConfigureAwait(false);
+
+            return new CompareProfileRun {
+                Profile = profileName,
+                Model = compareOptions.Model,
+                Outcome = "ok",
+                StartedAtUtc = turn.Metrics.StartedAtUtc,
+                FirstDeltaAtUtc = turn.Metrics.FirstDeltaAtUtc,
+                CompletedAtUtc = turn.Metrics.CompletedAtUtc,
+                DurationMs = turn.Metrics.DurationMs,
+                TtftMs = turn.Metrics.TtftMs,
+                PromptTokens = turn.Metrics.Usage?.InputTokens,
+                CompletionTokens = turn.Metrics.Usage?.OutputTokens,
+                TotalTokens = turn.Metrics.Usage?.TotalTokens,
+                CachedPromptTokens = turn.Metrics.Usage?.CachedInputTokens,
+                ReasoningTokens = turn.Metrics.Usage?.ReasoningTokens,
+                ToolCallsCount = turn.Metrics.ToolCallsCount,
+                ToolRounds = turn.Metrics.ToolRounds
+            };
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception ex) {
+            var completedAtUtc = DateTime.UtcNow;
+            return new CompareProfileRun {
+                Profile = profileName,
+                Model = compareOptions.Model,
+                Outcome = "error",
+                Error = $"{ex.GetType().Name}: {ex.Message}",
+                StartedAtUtc = startedAtUtc,
+                CompletedAtUtc = completedAtUtc,
+                DurationMs = (long)Math.Max(0, (completedAtUtc - startedAtUtc).TotalMilliseconds)
+            };
+        } finally {
+            if (client is not null) {
+                try {
+                    await client.DisposeAsync().ConfigureAwait(false);
+                } catch {
+                    // Ignore.
+                }
+            }
+        }
+    }
+
+    private static void ApplyCompareProfile(ReplOptions options, string profileName, ServiceProfile profile) {
+        options.ProfileName = profileName;
+
+        if (!string.IsNullOrWhiteSpace(profile.Model)) {
+            options.Model = profile.Model.Trim();
+        }
+        options.OpenAITransport = profile.OpenAITransport;
+        options.OpenAIBaseUrl = profile.OpenAIBaseUrl;
+        options.OpenAIApiKey = profile.OpenAIApiKey;
+        options.OpenAIStreaming = profile.OpenAIStreaming;
+        options.OpenAIAllowInsecureHttp = profile.OpenAIAllowInsecureHttp;
+        options.OpenAIAllowInsecureHttpNonLoopback = profile.OpenAIAllowInsecureHttpNonLoopback;
+        options.ReasoningEffort = profile.ReasoningEffort;
+        options.ReasoningSummary = profile.ReasoningSummary;
+        options.TextVerbosity = profile.TextVerbosity;
+        options.Temperature = profile.Temperature;
+    }
+
+    private static bool TryParseCompareArguments(string? arg, out IReadOnlyList<string> profileNames, out string prompt, out string? error) {
+        profileNames = Array.Empty<string>();
+        prompt = string.Empty;
+        error = null;
+
+        var raw = (arg ?? string.Empty).Trim();
+        if (raw.Length == 0) {
+            error = "Usage: /compare <profile1,profile2,...> -- <prompt>";
+            return false;
+        }
+
+        var marker = raw.IndexOf("--", StringComparison.Ordinal);
+        if (marker < 0) {
+            error = "Usage: /compare <profile1,profile2,...> -- <prompt>";
+            return false;
+        }
+
+        var namesPart = raw.Substring(0, marker).Trim();
+        prompt = raw.Substring(marker + 2).Trim();
+        if (namesPart.Length == 0 || prompt.Length == 0) {
+            error = "Usage: /compare <profile1,profile2,...> -- <prompt>";
+            return false;
+        }
+
+        var names = namesPart
+            .Split(new[] { ',', ';', '|' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(static n => !string.IsNullOrWhiteSpace(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (names.Length < 2) {
+            error = "Compare mode requires at least 2 profiles.";
+            return false;
+        }
+
+        profileNames = names;
+        return true;
+    }
+
+    private static void WriteCompareTable(IReadOnlyList<CompareProfileRun> runs) {
+        if (runs is null || runs.Count == 0) {
+            Console.WriteLine("(no compare results)");
+            return;
+        }
+
+        var rows = new List<string[]>(runs.Count);
+        foreach (var run in runs) {
+            rows.Add(new[] {
+                run.Profile ?? string.Empty,
+                run.Model ?? string.Empty,
+                FormatDuration(run.TtftMs),
+                FormatDuration(run.DurationMs),
+                FormatUsage(run.PromptTokens, run.CompletionTokens, run.TotalTokens),
+                $"{run.ToolCallsCount}/{run.ToolRounds}",
+                string.Equals(run.Outcome, "ok", StringComparison.OrdinalIgnoreCase) ? "ok" : (run.Error ?? "error")
+            });
+        }
+
+        var headers = new[] { "Profile", "Model", "TTFT", "Total", "Tokens(P/C/T)", "Tools(C/R)", "Outcome" };
+        var widths = new int[headers.Length];
+        for (var i = 0; i < headers.Length; i++) {
+            widths[i] = headers[i].Length;
+        }
+        foreach (var row in rows) {
+            for (var i = 0; i < row.Length; i++) {
+                var len = row[i]?.Length ?? 0;
+                if (len > widths[i]) {
+                    widths[i] = len;
+                }
+            }
+        }
+
+        WriteRow(headers, widths);
+        WriteRow(widths.Select(static w => new string('-', w)).ToArray(), widths);
+        foreach (var row in rows) {
+            WriteRow(row, widths);
+        }
+    }
+
+    private static void WriteRow(IReadOnlyList<string> cells, IReadOnlyList<int> widths) {
+        for (var i = 0; i < cells.Count; i++) {
+            if (i > 0) {
+                Console.Write("  ");
+            }
+            Console.Write((cells[i] ?? string.Empty).PadRight(widths[i]));
+        }
+        Console.WriteLine();
+    }
+
+    private static string FormatDuration(long? valueMs) {
+        if (!valueMs.HasValue) {
+            return "n/a";
+        }
+        var value = Math.Max(0, valueMs.Value);
+        if (value >= 1000) {
+            return (value / 1000d).ToString("0.00") + "s";
+        }
+        return value + "ms";
+    }
+
+    private static string FormatUsage(long? promptTokens, long? completionTokens, long? totalTokens) {
+        return $"{FormatToken(promptTokens)}/{FormatToken(completionTokens)}/{FormatToken(totalTokens)}";
+    }
+
+    private static string FormatToken(long? value) {
+        return value.HasValue ? Math.Max(0, value.Value).ToString() : "-";
+    }
+
+    private static string WriteCompareArtifact(string prompt, IReadOnlyList<CompareProfileRun> runs, ReplOptions options) {
+        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(root)) {
+            root = ".";
+        }
+
+        var folder = Path.Combine(root, "IntelligenceX.Chat", "benchmarks");
+        Directory.CreateDirectory(folder);
+
+        var timestamp = DateTime.UtcNow;
+        var path = Path.Combine(folder, $"compare-{timestamp:yyyyMMdd-HHmmss}.json");
+        var artifact = new CompareArtifact {
+            CreatedAtUtc = timestamp,
+            Prompt = prompt,
+            ActiveProfile = options.ProfileName,
+            ActiveModel = options.Model,
+            Runs = runs
+        };
+        var json = JsonSerializer.Serialize(artifact, new JsonSerializerOptions {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        });
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    private sealed class CompareArtifact {
+        public required DateTime CreatedAtUtc { get; init; }
+        public required string Prompt { get; init; }
+        public string? ActiveProfile { get; init; }
+        public string? ActiveModel { get; init; }
+        public required IReadOnlyList<CompareProfileRun> Runs { get; init; }
+    }
+
+    private sealed class CompareProfileRun {
+        public string? Profile { get; init; }
+        public string? Model { get; init; }
+        public required string Outcome { get; init; }
+        public string? Error { get; init; }
+        public required DateTime StartedAtUtc { get; init; }
+        public DateTime? FirstDeltaAtUtc { get; init; }
+        public required DateTime CompletedAtUtc { get; init; }
+        public long DurationMs { get; init; }
+        public long? TtftMs { get; init; }
+        public long? PromptTokens { get; init; }
+        public long? CompletionTokens { get; init; }
+        public long? TotalTokens { get; init; }
+        public long? CachedPromptTokens { get; init; }
+        public long? ReasoningTokens { get; init; }
+        public int ToolCallsCount { get; init; }
+        public int ToolRounds { get; init; }
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
@@ -426,6 +426,50 @@ internal static partial class Program {
             Redact = profile.Redact;
         }
 
+        internal ReplOptions Clone() {
+            var clone = new ReplOptions {
+                Model = Model,
+                OpenAITransport = OpenAITransport,
+                OpenAIBaseUrl = OpenAIBaseUrl,
+                OpenAIApiKey = OpenAIApiKey,
+                OpenAIStreaming = OpenAIStreaming,
+                OpenAIAllowInsecureHttp = OpenAIAllowInsecureHttp,
+                OpenAIAllowInsecureHttpNonLoopback = OpenAIAllowInsecureHttpNonLoopback,
+                ReasoningEffort = ReasoningEffort,
+                ReasoningSummary = ReasoningSummary,
+                TextVerbosity = TextVerbosity,
+                Temperature = Temperature,
+                ProfileName = ProfileName,
+                StateDbPath = StateDbPath,
+                ShowHelp = ShowHelp,
+                ForceLogin = ForceLogin,
+                ParallelToolCalls = ParallelToolCalls,
+                MaxToolRounds = MaxToolRounds,
+                TurnTimeoutSeconds = TurnTimeoutSeconds,
+                ToolTimeoutSeconds = ToolTimeoutSeconds,
+                EchoToolOutputs = EchoToolOutputs,
+                MaxConsoleToolOutputChars = MaxConsoleToolOutputChars,
+                ShowToolIds = ShowToolIds,
+                LiveProgress = LiveProgress,
+                MaxTableRows = MaxTableRows,
+                MaxSample = MaxSample,
+                Redact = Redact,
+                AuthPath = AuthPath,
+                InstructionsFile = InstructionsFile,
+                AdDomainController = AdDomainController,
+                AdDefaultSearchBaseDn = AdDefaultSearchBaseDn,
+                AdMaxResults = AdMaxResults,
+                EnablePowerShellPack = EnablePowerShellPack,
+                EnableTestimoXPack = EnableTestimoXPack
+            };
+
+            if (AllowedRoots.Count > 0) {
+                clone.AllowedRoots.AddRange(AllowedRoots);
+            }
+
+            return clone;
+        }
+
         private static bool TryGetValue(string[] args, ref int i, out string value, out string? error) {
             error = null;
             value = string.Empty;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
@@ -41,6 +41,48 @@ internal static partial class Program {
         }
 
         public async Task<ReplTurnResult> AskAsync(string text, CancellationToken cancellationToken) {
+            var withMetrics = await AskWithMetricsAsync(text, cancellationToken).ConfigureAwait(false);
+            return withMetrics.Result;
+        }
+
+        public async Task<ReplTurnMetricsResult> AskWithMetricsAsync(string text, CancellationToken cancellationToken) {
+            var startedAtUtc = DateTime.UtcNow;
+            var firstDeltaUtcTicks = 0L;
+
+            void OnDelta(object? _, string __) {
+                if (firstDeltaUtcTicks != 0) {
+                    return;
+                }
+                _ = Interlocked.CompareExchange(ref firstDeltaUtcTicks, DateTime.UtcNow.Ticks, 0);
+            }
+
+            _client.DeltaReceived += OnDelta;
+            try {
+                var result = await AskCoreAsync(text, cancellationToken).ConfigureAwait(false);
+                var completedAtUtc = DateTime.UtcNow;
+                DateTime? firstDeltaAtUtc = null;
+                long? ttftMs = null;
+                if (firstDeltaUtcTicks != 0) {
+                    firstDeltaAtUtc = new DateTime(firstDeltaUtcTicks, DateTimeKind.Utc);
+                    ttftMs = (long)Math.Max(0, TimeSpan.FromTicks(firstDeltaUtcTicks - startedAtUtc.Ticks).TotalMilliseconds);
+                }
+
+                var metrics = new ReplTurnMetrics(
+                    startedAtUtc,
+                    firstDeltaAtUtc,
+                    completedAtUtc,
+                    durationMs: (long)Math.Max(0, (completedAtUtc - startedAtUtc).TotalMilliseconds),
+                    ttftMs: ttftMs,
+                    usage: result.Usage,
+                    toolCallsCount: result.ToolCalls.Count,
+                    toolRounds: result.ToolRounds);
+                return new ReplTurnMetricsResult(result, metrics);
+            } finally {
+                _client.DeltaReceived -= OnDelta;
+            }
+        }
+
+        private async Task<ReplTurnResult> AskCoreAsync(string text, CancellationToken cancellationToken) {
             if (string.IsNullOrWhiteSpace(text)) {
                 return new ReplTurnResult(string.Empty, Array.Empty<ToolCall>(), Array.Empty<ToolOutput>());
             }
@@ -50,6 +92,7 @@ internal static partial class Program {
 
             var calls = new List<ToolCall>();
             var outputs = new List<ToolOutput>();
+            var toolRounds = 0;
 
             var input = ChatInput.FromText(text);
             var toolDefs = _registry.GetDefinitions();
@@ -77,9 +120,10 @@ internal static partial class Program {
                 if (extracted.Count == 0) {
                     var finalText = EasyChatResult.FromTurn(turn).Text ?? string.Empty;
                     _previousResponseId = TryGetResponseId(turn) ?? _previousResponseId;
-                    return new ReplTurnResult(finalText, calls, outputs);
+                    return new ReplTurnResult(finalText, calls, outputs, turn.Usage, toolRounds);
                 }
 
+                toolRounds++;
                 calls.AddRange(extracted);
                 if (_options.LiveProgress) {
                     foreach (var call in extracted) {
@@ -172,15 +216,53 @@ internal static partial class Program {
     }
 
     private sealed class ReplTurnResult {
-        public ReplTurnResult(string text, IReadOnlyList<ToolCall> toolCalls, IReadOnlyList<ToolOutput> toolOutputs) {
+        public ReplTurnResult(string text, IReadOnlyList<ToolCall> toolCalls, IReadOnlyList<ToolOutput> toolOutputs,
+            TurnUsage? usage = null, int toolRounds = 0) {
             Text = text ?? string.Empty;
             ToolCalls = toolCalls ?? Array.Empty<ToolCall>();
             ToolOutputs = toolOutputs ?? Array.Empty<ToolOutput>();
+            Usage = usage;
+            ToolRounds = Math.Max(0, toolRounds);
         }
 
         public string Text { get; }
         public IReadOnlyList<ToolCall> ToolCalls { get; }
         public IReadOnlyList<ToolOutput> ToolOutputs { get; }
+        public TurnUsage? Usage { get; }
+        public int ToolRounds { get; }
+    }
+
+    private sealed class ReplTurnMetrics {
+        public ReplTurnMetrics(DateTime startedAtUtc, DateTime? firstDeltaAtUtc, DateTime completedAtUtc, long durationMs, long? ttftMs,
+            TurnUsage? usage, int toolCallsCount, int toolRounds) {
+            StartedAtUtc = startedAtUtc;
+            FirstDeltaAtUtc = firstDeltaAtUtc;
+            CompletedAtUtc = completedAtUtc;
+            DurationMs = Math.Max(0, durationMs);
+            TtftMs = ttftMs.HasValue ? Math.Max(0, ttftMs.Value) : null;
+            Usage = usage;
+            ToolCallsCount = Math.Max(0, toolCallsCount);
+            ToolRounds = Math.Max(0, toolRounds);
+        }
+
+        public DateTime StartedAtUtc { get; }
+        public DateTime? FirstDeltaAtUtc { get; }
+        public DateTime CompletedAtUtc { get; }
+        public long DurationMs { get; }
+        public long? TtftMs { get; }
+        public TurnUsage? Usage { get; }
+        public int ToolCallsCount { get; }
+        public int ToolRounds { get; }
+    }
+
+    private sealed class ReplTurnMetricsResult {
+        public ReplTurnMetricsResult(ReplTurnResult result, ReplTurnMetrics metrics) {
+            Result = result ?? throw new ArgumentNullException(nameof(result));
+            Metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
+        }
+
+        public ReplTurnResult Result { get; }
+        public ReplTurnMetrics Metrics { get; }
     }
 
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.cs
@@ -176,7 +176,7 @@ internal static partial class Program {
             session = nextSession;
 
             Console.WriteLine($"Registered tools: {registry.GetDefinitions().Count}");
-            Console.WriteLine("Commands: /help, /tools, /roots, /profiles, /profile <name>, /models, /model <name>, /exit");
+            Console.WriteLine("Commands: /help, /tools, /roots, /profiles, /profile <name>, /models, /model <name>, /compare <p1,p2,...> -- <prompt>, /exit");
             Console.WriteLine();
         }
 
@@ -288,6 +288,9 @@ internal static partial class Program {
                                 Console.WriteLine($"Model set to: {options.Model} (new thread)");
                                 continue;
                             }
+                        case "/compare":
+                            await HandleCompareCommandAsync(arg, options, cancellationToken).ConfigureAwait(false);
+                            continue;
                         default:
                             Console.WriteLine("Unknown command. Try /help.");
                             continue;
@@ -477,7 +480,7 @@ internal static partial class Program {
         Console.WriteLine("  -h, --help              Show help.");
         Console.WriteLine();
         Console.WriteLine("REPL commands:");
-        Console.WriteLine("  /help, /tools, /roots, /profiles, /profile <name>, /models, /model <name>, /exit");
+        Console.WriteLine("  /help, /tools, /roots, /profiles, /profile <name>, /models, /model <name>, /compare <p1,p2,...> -- <prompt>, /exit");
     }
 
     private static string? LoadInstructions(ReplOptions options) {


### PR DESCRIPTION
## Summary
- add a new `/compare <p1,p2,...> -- <prompt>` REPL command in Chat.Host
- run the same prompt across multiple saved profiles using isolated per-profile sessions
- capture per-turn metrics for each run (TTFT, duration, usage, tool calls, tool rounds)
- print a compact comparison table to the console
- persist a benchmark JSON artifact under `%LOCALAPPDATA%/IntelligenceX.Chat/benchmarks`

## Design Notes
- compare runs keep the current session tool catalog/settings and only apply profile model/provider/reasoning shaping settings
- active interactive REPL state/thread is not mutated by compare runs

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.sln -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.sln -c Release --no-build`
- `dotnet run --project IntelligenceX.Chat/IntelligenceX.Chat.Host/IntelligenceX.Chat.Host.csproj --framework net10.0-windows -- --help`
