### PR TITLE
Chat.App: local model runtime setup + service profile/model sync

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ServiceLaunchArgumentsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ServiceLaunchArgumentsTests.cs
@@ -44,4 +44,56 @@ public sealed class ServiceLaunchArgumentsTests {
     public void Build_Throws_WhenPipeNameMissing() {
         Assert.Throws<ArgumentException>(() => ServiceLaunchArguments.Build("  ", detachedServiceMode: false, parentProcessId: 42));
     }
+
+    /// <summary>
+    /// Ensures profile/runtime overrides are emitted when provided.
+    /// </summary>
+    [Fact]
+    public void Build_IncludesProfileAndTransportOverrides_WhenConfigured() {
+        var args = ServiceLaunchArguments.Build(
+            "intelligencex.chat",
+            detachedServiceMode: true,
+            parentProcessId: 12345,
+            new ServiceLaunchArguments.ProfileOptions {
+                LoadProfileName = "default",
+                SaveProfileName = "default",
+                Model = "gpt-4.1-mini",
+                OpenAITransport = "compatible-http",
+                OpenAIBaseUrl = "http://127.0.0.1:11434",
+                OpenAIApiKey = "token",
+                OpenAIStreaming = true,
+                OpenAIAllowInsecureHttp = true
+            });
+
+        Assert.Equal(new[] {
+            "--pipe",
+            "intelligencex.chat",
+            "--profile",
+            "default",
+            "--save-profile",
+            "default",
+            "--model",
+            "gpt-4.1-mini",
+            "--openai-transport",
+            "compatible-http",
+            "--openai-base-url",
+            "http://127.0.0.1:11434",
+            "--openai-api-key",
+            "token",
+            "--openai-stream",
+            "--openai-allow-insecure-http"
+        }, args);
+    }
+
+    /// <summary>
+    /// Ensures unknown transport values are rejected.
+    /// </summary>
+    [Fact]
+    public void Build_Throws_WhenTransportUnknown() {
+        Assert.Throws<ArgumentException>(() => ServiceLaunchArguments.Build(
+            "intelligencex.chat",
+            detachedServiceMode: true,
+            parentProcessId: 12345,
+            new ServiceLaunchArguments.ProfileOptions { OpenAITransport = "invalid" }));
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
@@ -161,6 +161,9 @@ internal sealed class ChatAppState {
     public string? UserName { get; set; }
     public string? AssistantPersona { get; set; }
     public string ThemePreset { get; set; } = "default";
+    public string LocalProviderTransport { get; set; } = "native";
+    public string? LocalProviderBaseUrl { get; set; }
+    public string LocalProviderModel { get; set; } = "gpt-5.3-codex";
     public string TimestampMode { get; set; } = "seconds";
     public int? AutonomyMaxToolRounds { get; set; }
     public bool? AutonomyParallelTools { get; set; }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Launch/ServiceLaunchArguments.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Launch/ServiceLaunchArguments.cs
@@ -7,14 +7,26 @@ namespace IntelligenceX.Chat.App.Launch;
 /// Provides typed construction of local runtime service launch arguments.
 /// </summary>
 internal static class ServiceLaunchArguments {
+    internal sealed class ProfileOptions {
+        public string? LoadProfileName { get; init; }
+        public string? SaveProfileName { get; init; }
+        public string? Model { get; init; }
+        public string? OpenAITransport { get; init; }
+        public string? OpenAIBaseUrl { get; init; }
+        public string? OpenAIApiKey { get; init; }
+        public bool? OpenAIStreaming { get; init; }
+        public bool? OpenAIAllowInsecureHttp { get; init; }
+    }
+
     /// <summary>
     /// Builds runtime service arguments for the configured pipe and lifecycle mode.
     /// </summary>
     /// <param name="pipeName">Named-pipe identifier.</param>
     /// <param name="detachedServiceMode">Whether service is detached from app lifetime.</param>
     /// <param name="parentProcessId">Parent process id used for exit-on-disconnect mode.</param>
+    /// <param name="profileOptions">Optional profile/runtime overrides passed to the service process.</param>
     /// <returns>Ordered argument vector.</returns>
-    public static IReadOnlyList<string> Build(string pipeName, bool detachedServiceMode, int parentProcessId) {
+    public static IReadOnlyList<string> Build(string pipeName, bool detachedServiceMode, int parentProcessId, ProfileOptions? profileOptions = null) {
         var normalizedPipe = (pipeName ?? string.Empty).Trim();
         if (normalizedPipe.Length == 0) {
             throw new ArgumentException("Pipe name cannot be empty.", nameof(pipeName));
@@ -31,6 +43,56 @@ internal static class ServiceLaunchArguments {
             args.Add(parentProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
         }
 
+        if (profileOptions is null) {
+            return args;
+        }
+
+        AddKeyValueArg(args, "--profile", profileOptions.LoadProfileName);
+        AddKeyValueArg(args, "--save-profile", profileOptions.SaveProfileName);
+        AddKeyValueArg(args, "--model", profileOptions.Model);
+
+        var transport = NormalizeTransport(profileOptions.OpenAITransport);
+        if (transport is not null) {
+            args.Add("--openai-transport");
+            args.Add(transport);
+        }
+
+        AddKeyValueArg(args, "--openai-base-url", profileOptions.OpenAIBaseUrl);
+        AddKeyValueArg(args, "--openai-api-key", profileOptions.OpenAIApiKey);
+
+        if (profileOptions.OpenAIStreaming.HasValue) {
+            args.Add(profileOptions.OpenAIStreaming.Value ? "--openai-stream" : "--openai-no-stream");
+        }
+
+        if (profileOptions.OpenAIAllowInsecureHttp == true) {
+            args.Add("--openai-allow-insecure-http");
+        }
+
         return args;
+    }
+
+    private static void AddKeyValueArg(List<string> args, string key, string? value) {
+        var normalized = (value ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return;
+        }
+
+        args.Add(key);
+        args.Add(normalized);
+    }
+
+    private static string? NormalizeTransport(string? value) {
+        var normalized = (value ?? string.Empty).Trim().ToLowerInvariant();
+        if (normalized.Length == 0) {
+            return null;
+        }
+
+        return normalized switch {
+            "native" => "native",
+            "appserver" => "appserver",
+            "compatible-http" => "compatible-http",
+            "compatiblehttp" => "compatible-http",
+            _ => throw new ArgumentException($"Unsupported OpenAI transport '{value}'.", nameof(value))
+        };
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Conversations.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Conversations.cs
@@ -339,6 +339,25 @@ public sealed partial class MainWindow : Window {
 
         await PersistAppStateAsync().ConfigureAwait(false);
         await LoadProfileStateAsync(normalized, render: true).ConfigureAwait(false);
+        ClearConversationThreadIds();
+        await PersistAppStateAsync().ConfigureAwait(false);
+
+        if (_client is not null) {
+            try {
+                var profileApplied = await SyncConnectedServiceProfileAndModelsAsync(
+                    forceModelRefresh: false,
+                    setProfileNewThread: true,
+                    appendWarnings: false).ConfigureAwait(false);
+                if (!profileApplied) {
+                    await ReconnectServiceSessionAsync().ConfigureAwait(false);
+                }
+            } catch (Exception ex) {
+                if (VerboseServiceLogs || _debugMode) {
+                    AppendSystem("Profile switch runtime sync failed: " + ex.Message);
+                }
+            }
+        }
+
         await EnsureFirstRunAuthenticatedAsync().ConfigureAwait(false);
         await EnsureOnboardingStartedAsync().ConfigureAwait(false);
         await PersistAppStateAsync().ConfigureAwait(false);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Chat.Abstractions.Policy;
+using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.App.Conversation;
+using IntelligenceX.Chat.Client;
+using Microsoft.UI;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using OfficeIMO.MarkdownRenderer;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Graphics;
+
+namespace IntelligenceX.Chat.App;
+
+public sealed partial class MainWindow : Window {
+    private async Task RefreshModelsFromUiAsync(bool forceRefresh) {
+        if (!await EnsureConnectedAsync().ConfigureAwait(false)) {
+            return;
+        }
+
+        await SyncConnectedServiceProfileAndModelsAsync(
+            forceModelRefresh: forceRefresh,
+            setProfileNewThread: false,
+            appendWarnings: true).ConfigureAwait(false);
+    }
+
+    private async Task<bool> SyncConnectedServiceProfileAndModelsAsync(bool forceModelRefresh, bool setProfileNewThread, bool appendWarnings) {
+        var client = _client;
+        if (client is null) {
+            return false;
+        }
+
+        await RefreshServiceProfilesAsync(client, publishOptions: false, appendWarnings).ConfigureAwait(false);
+        var profileApplied = await TryApplyServiceProfileAsync(client, setProfileNewThread, appendWarnings).ConfigureAwait(false);
+        await RefreshModelsAsync(client, forceModelRefresh, publishOptions: false, appendWarnings).ConfigureAwait(false);
+        await PublishOptionsStateAsync().ConfigureAwait(false);
+        return profileApplied;
+    }
+
+    private async Task RefreshServiceProfilesAsync(ChatServiceClient client, bool publishOptions, bool appendWarnings) {
+        try {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+            var profiles = await client.ListProfilesAsync(cts.Token).ConfigureAwait(false);
+            _serviceProfileNames = NormalizeProfileNames(profiles.Profiles);
+        } catch (Exception ex) {
+            _serviceProfileNames = Array.Empty<string>();
+            if (appendWarnings && (VerboseServiceLogs || _debugMode)) {
+                AppendSystem("Couldn't load service profiles: " + ex.Message);
+            }
+        }
+
+        if (publishOptions) {
+            await PublishOptionsStateAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task<bool> TryApplyServiceProfileAsync(ChatServiceClient client, bool newThread, bool appendWarnings) {
+        if (!ContainsProfileName(_serviceProfileNames, _appProfileName)) {
+            return false;
+        }
+
+        try {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+            _ = await client.SetProfileAsync(_appProfileName, newThread, cts.Token).ConfigureAwait(false);
+            return true;
+        } catch (Exception ex) {
+            if (appendWarnings && (VerboseServiceLogs || _debugMode)) {
+                AppendSystem("Couldn't apply service profile '" + _appProfileName + "': " + ex.Message);
+            }
+            return false;
+        }
+    }
+
+    private async Task RefreshModelsAsync(ChatServiceClient client, bool forceRefresh, bool publishOptions, bool appendWarnings) {
+        try {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            var modelList = await client.ListModelsAsync(forceRefresh, cts.Token).ConfigureAwait(false);
+            _availableModels = NormalizeModelList(modelList.Models);
+            _favoriteModels = NormalizeModelNames(modelList.FavoriteModels);
+            _recentModels = NormalizeModelNames(modelList.RecentModels);
+            _modelListIsStale = modelList.IsStale;
+            _modelListWarning = string.IsNullOrWhiteSpace(modelList.Warning) ? null : modelList.Warning.Trim();
+
+            if (string.IsNullOrWhiteSpace(_localProviderModel) && _availableModels.Length > 0) {
+                _localProviderModel = _availableModels[0].Model;
+            }
+        } catch (Exception ex) {
+            _modelListIsStale = true;
+            _modelListWarning = "Model discovery failed: " + ex.Message;
+            if (appendWarnings && (VerboseServiceLogs || _debugMode)) {
+                AppendSystem(_modelListWarning);
+            }
+        }
+
+        if (publishOptions) {
+            await PublishOptionsStateAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task ApplyLocalProviderAsync(string? transportValue, string? baseUrlValue, string? modelValue, bool forceModelRefresh) {
+        if (_isSending) {
+            await SetStatusAsync("Finish the active response before changing local runtime settings.").ConfigureAwait(false);
+            return;
+        }
+
+        var rawTransport = (transportValue ?? string.Empty).Trim();
+        var normalizedTransport = NormalizeLocalProviderTransport(rawTransport);
+        var normalizedBaseUrl = NormalizeLocalProviderBaseUrl(baseUrlValue, normalizedTransport, rawTransport);
+        var normalizedModel = NormalizeLocalProviderModel(modelValue);
+
+        var changed = !string.Equals(_localProviderTransport, normalizedTransport, StringComparison.OrdinalIgnoreCase)
+                      || !string.Equals(_localProviderBaseUrl ?? string.Empty, normalizedBaseUrl ?? string.Empty, StringComparison.OrdinalIgnoreCase)
+                      || !string.Equals(_localProviderModel, normalizedModel, StringComparison.Ordinal);
+
+        _localProviderTransport = normalizedTransport;
+        _localProviderBaseUrl = normalizedBaseUrl;
+        _localProviderModel = normalizedModel;
+        _appState.LocalProviderTransport = _localProviderTransport;
+        _appState.LocalProviderBaseUrl = _localProviderBaseUrl;
+        _appState.LocalProviderModel = _localProviderModel;
+
+        var profileSaved = ContainsProfileName(_serviceProfileNames, _appProfileName);
+        await PersistAppStateAsync().ConfigureAwait(false);
+
+        if (!changed && profileSaved) {
+            await RefreshModelsFromUiAsync(forceModelRefresh).ConfigureAwait(false);
+            return;
+        }
+
+        ClearConversationThreadIds();
+        await PersistAppStateAsync().ConfigureAwait(false);
+
+        _pendingServiceLaunchProfileOptions = new ServiceLaunchProfileOptions {
+            LoadProfileName = _appProfileName,
+            SaveProfileName = _appProfileName,
+            Model = _localProviderModel,
+            OpenAITransport = _localProviderTransport,
+            OpenAIBaseUrl = _localProviderBaseUrl,
+            OpenAIApiKey = null,
+            OpenAIStreaming = true,
+            OpenAIAllowInsecureHttp = ShouldAllowInsecureHttp(_localProviderTransport, _localProviderBaseUrl)
+        };
+
+        await RestartSidecarAsync().ConfigureAwait(false);
+        await SyncConnectedServiceProfileAndModelsAsync(
+            forceModelRefresh: true,
+            setProfileNewThread: false,
+            appendWarnings: true).ConfigureAwait(false);
+    }
+
+    private async Task ReconnectServiceSessionAsync() {
+        StopAutoReconnectLoop();
+        await DisposeClientAsync().ConfigureAwait(false);
+        await ConnectAsync(fromUserAction: false).ConfigureAwait(false);
+    }
+
+    private void ClearConversationThreadIds() {
+        for (var i = 0; i < _conversations.Count; i++) {
+            _conversations[i].ThreadId = null;
+        }
+
+        _threadId = null;
+        _appState.ThreadId = null;
+    }
+
+    private static string[] NormalizeProfileNames(string[]? names) {
+        if (names is null || names.Length == 0) {
+            return Array.Empty<string>();
+        }
+
+        var list = new List<string>(names.Length);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < names.Length; i++) {
+            var normalized = (names[i] ?? string.Empty).Trim();
+            if (normalized.Length == 0 || !seen.Add(normalized)) {
+                continue;
+            }
+
+            list.Add(normalized);
+        }
+
+        if (list.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        list.Sort(StringComparer.OrdinalIgnoreCase);
+        return list.ToArray();
+    }
+
+    private static string[] NormalizeModelNames(string[]? names) {
+        if (names is null || names.Length == 0) {
+            return Array.Empty<string>();
+        }
+
+        var list = new List<string>(names.Length);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < names.Length; i++) {
+            var normalized = (names[i] ?? string.Empty).Trim();
+            if (normalized.Length == 0 || !seen.Add(normalized)) {
+                continue;
+            }
+
+            list.Add(normalized);
+        }
+
+        return list.Count == 0 ? Array.Empty<string>() : list.ToArray();
+    }
+
+    private static ModelInfoDto[] NormalizeModelList(ModelInfoDto[]? models) {
+        if (models is null || models.Length == 0) {
+            return Array.Empty<ModelInfoDto>();
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var list = new List<ModelInfoDto>(models.Length);
+        for (var i = 0; i < models.Length; i++) {
+            var entry = models[i];
+            if (entry is null) {
+                continue;
+            }
+
+            var model = (entry.Model ?? string.Empty).Trim();
+            if (model.Length == 0 || !seen.Add(model)) {
+                continue;
+            }
+
+            var id = (entry.Id ?? string.Empty).Trim();
+            if (id.Length == 0) {
+                id = model;
+            }
+
+            list.Add(new ModelInfoDto {
+                Id = id,
+                Model = model,
+                DisplayName = string.IsNullOrWhiteSpace(entry.DisplayName) ? null : entry.DisplayName.Trim(),
+                Description = string.IsNullOrWhiteSpace(entry.Description) ? null : entry.Description.Trim(),
+                IsDefault = entry.IsDefault,
+                DefaultReasoningEffort = string.IsNullOrWhiteSpace(entry.DefaultReasoningEffort) ? null : entry.DefaultReasoningEffort.Trim(),
+                SupportedReasoningEfforts = entry.SupportedReasoningEfforts ?? Array.Empty<ReasoningEffortOptionDto>()
+            });
+        }
+
+        return list.Count == 0 ? Array.Empty<ModelInfoDto>() : list.ToArray();
+    }
+
+    private static bool ContainsProfileName(string[] names, string profileName) {
+        if (names.Length == 0 || string.IsNullOrWhiteSpace(profileName)) {
+            return false;
+        }
+
+        for (var i = 0; i < names.Length; i++) {
+            if (string.Equals(names[i], profileName, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ShouldAllowInsecureHttp(string transport, string? baseUrl) {
+        if (!string.Equals(transport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        var value = (baseUrl ?? string.Empty).Trim();
+        if (value.Length == 0) {
+            return true;
+        }
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri)) {
+            return false;
+        }
+
+        return string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
@@ -113,6 +113,16 @@ public sealed partial class MainWindow : Window {
             }
 
             _ = await RefreshAuthenticationStateAsync(updateStatus: true).ConfigureAwait(false);
+            try {
+                await SyncConnectedServiceProfileAndModelsAsync(
+                    forceModelRefresh: false,
+                    setProfileNewThread: false,
+                    appendWarnings: false).ConfigureAwait(false);
+            } catch (Exception ex) {
+                if (VerboseServiceLogs || _debugMode) {
+                    AppendSystem("Model/profile sync failed: " + ex.Message);
+                }
+            }
         } finally {
             _connectGate.Release();
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
@@ -107,6 +107,12 @@ public sealed partial class MainWindow : Window {
                 case "options_refresh":
                     await PublishOptionsStateAsync().ConfigureAwait(true);
                     break;
+                case "refresh_models":
+                    {
+                        var forceRefresh = TryGetBoolean(root, "forceRefresh");
+                        await RefreshModelsFromUiAsync(forceRefresh ?? true).ConfigureAwait(true);
+                        break;
+                    }
                 case "debug_copy_startup_log":
                     CopyStartupLogToClipboard();
                     break;
@@ -264,6 +270,15 @@ public sealed partial class MainWindow : Window {
                         if (!string.IsNullOrWhiteSpace(profileName)) {
                             await SwitchProfileAsync(profileName).ConfigureAwait(true);
                         }
+                        break;
+                    }
+                case "apply_local_provider":
+                    {
+                        var transport = TryGetString(root, "transport");
+                        var baseUrl = TryGetString(root, "baseUrl");
+                        var model = TryGetString(root, "model");
+                        var forceRefresh = TryGetBoolean(root, "forceRefresh");
+                        await ApplyLocalProviderAsync(transport, baseUrl, model, forceRefresh ?? true).ConfigureAwait(true);
                         break;
                     }
                 case "restart_onboarding":

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
@@ -50,6 +50,9 @@ public sealed partial class MainWindow : Window {
             _appState.ExportDefaultFormat = _exportDefaultFormat;
             _appState.ExportLastDirectory = _lastExportDirectory;
             _appState.PersistentMemoryEnabled = _persistentMemoryEnabled;
+            _appState.LocalProviderTransport = _localProviderTransport;
+            _appState.LocalProviderBaseUrl = _localProviderBaseUrl;
+            _appState.LocalProviderModel = _localProviderModel;
             _appState.MemoryFacts = NormalizeMemoryFacts(_appState.MemoryFacts);
             _appState.ActiveConversationId = _activeConversationId;
             _appState.ThreadId = activeConversation.ThreadId;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
@@ -277,6 +277,7 @@ public sealed partial class MainWindow : Window {
             ?? SafeDefaultToolTimeoutSeconds;
 
         return new ChatRequestOptions {
+            Model = string.IsNullOrWhiteSpace(_localProviderModel) ? null : _localProviderModel,
             DisabledTools = disabled.Count == 0 ? null : disabled.ToArray(),
             MaxToolRounds = effectiveMaxToolRounds,
             ParallelTools = effectiveParallelTools,
@@ -341,6 +342,43 @@ public sealed partial class MainWindow : Window {
         }
 
         return parsed;
+    }
+
+    private static string NormalizeLocalProviderTransport(string? value) {
+        var normalized = (value ?? string.Empty).Trim().ToLowerInvariant();
+        return normalized switch {
+            "native" => TransportNative,
+            "compatible-http" => TransportCompatibleHttp,
+            "compatiblehttp" => TransportCompatibleHttp,
+            "http" => TransportCompatibleHttp,
+            "local" => TransportCompatibleHttp,
+            "ollama" => TransportCompatibleHttp,
+            "lmstudio" => TransportCompatibleHttp,
+            "lm-studio" => TransportCompatibleHttp,
+            _ => TransportNative
+        };
+    }
+
+    private static string? NormalizeLocalProviderBaseUrl(string? value, string transport, string? transportHint = null) {
+        var normalized = (value ?? string.Empty).Trim();
+        if (!string.Equals(transport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase)) {
+            return null;
+        }
+
+        if (normalized.Length == 0) {
+            var hint = (transportHint ?? string.Empty).Trim().ToLowerInvariant();
+            if (hint is "lmstudio" or "lm-studio") {
+                return DefaultLmStudioBaseUrl;
+            }
+            return DefaultOllamaBaseUrl;
+        }
+
+        return normalized;
+    }
+
+    private static string NormalizeLocalProviderModel(string? value) {
+        var normalized = (value ?? string.Empty).Trim();
+        return normalized.Length == 0 ? DefaultLocalModel : normalized;
     }
 
     private static bool? ParseAutonomyParallelMode(string? raw) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
@@ -333,7 +333,21 @@ public sealed partial class MainWindow : Window {
         }
 
         try {
-            var launchArgs = ServiceLaunchArguments.Build(pipeName, DetachedServiceMode, Environment.ProcessId);
+            var pending = _pendingServiceLaunchProfileOptions;
+            var launchArgs = ServiceLaunchArguments.Build(
+                pipeName,
+                DetachedServiceMode,
+                Environment.ProcessId,
+                pending is null ? null : new ServiceLaunchArguments.ProfileOptions {
+                    LoadProfileName = pending.LoadProfileName,
+                    SaveProfileName = pending.SaveProfileName,
+                    Model = pending.Model,
+                    OpenAITransport = pending.OpenAITransport,
+                    OpenAIBaseUrl = pending.OpenAIBaseUrl,
+                    OpenAIApiKey = pending.OpenAIApiKey,
+                    OpenAIStreaming = pending.OpenAIStreaming,
+                    OpenAIAllowInsecureHttp = pending.OpenAIAllowInsecureHttp
+                });
             var hasExe = File.Exists(exe);
             var psi = new ProcessStartInfo {
                 FileName = hasExe ? exe : "dotnet",
@@ -397,6 +411,7 @@ public sealed partial class MainWindow : Window {
 
             _serviceProcess = p;
             _servicePipeName = pipeName;
+            _pendingServiceLaunchProfileOptions = null;
 
             await Task.Delay(250).ConfigureAwait(true);
             return true;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -246,6 +246,17 @@ public sealed partial class MainWindow : Window {
                     theme = !string.IsNullOrWhiteSpace(_sessionThemeOverride)
                 }
             },
+            localModel = new {
+                transport = _localProviderTransport,
+                baseUrl = _localProviderBaseUrl ?? string.Empty,
+                model = _localProviderModel,
+                models = _availableModels,
+                favoriteModels = _favoriteModels,
+                recentModels = _recentModels,
+                isStale = _modelListIsStale,
+                warning = _modelListWarning,
+                profileSaved = Array.Exists(_serviceProfileNames, name => string.Equals(name, _appProfileName, StringComparison.OrdinalIgnoreCase))
+            },
             packs,
             tools,
             policy = _sessionPolicy is null ? null : new {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -42,6 +42,11 @@ public sealed partial class MainWindow : Window {
     private const int MaxConversations = 40;
     private const int MaxMessagesPerConversation = 250;
     private const string DefaultConversationTitle = "New Chat";
+    private const string DefaultLocalModel = "gpt-5.3-codex";
+    private const string TransportNative = "native";
+    private const string TransportCompatibleHttp = "compatible-http";
+    private const string DefaultOllamaBaseUrl = "http://127.0.0.1:11434";
+    private const string DefaultLmStudioBaseUrl = "http://127.0.0.1:1234/v1";
     private static readonly TimeSpan StreamingTranscriptRenderCadence = TimeSpan.FromMilliseconds(80);
     private static readonly Regex UserNameIntentRegex = new(@"\b(?:you can call me|call me|my name is|name is|set my name to|change my name to)\s+(?<value>[^,\.\!\?\r\n]{1,64})", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex PersonaIntentRegex = new(@"\b(?:assistant\s+persona|persona|style|tone|mode)\s*(?:is|to|=|:)\s*(?<value>[^,\.\!\?\r\n]{2,180})", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
@@ -145,6 +150,15 @@ public sealed partial class MainWindow : Window {
     private string _exportDefaultFormat = ExportPreferencesContract.DefaultFormat;
     private string? _lastExportDirectory;
     private bool _persistentMemoryEnabled = true;
+    private string _localProviderTransport = TransportNative;
+    private string? _localProviderBaseUrl;
+    private string _localProviderModel = DefaultLocalModel;
+    private ModelInfoDto[] _availableModels = Array.Empty<ModelInfoDto>();
+    private string[] _favoriteModels = Array.Empty<string>();
+    private string[] _recentModels = Array.Empty<string>();
+    private bool _modelListIsStale;
+    private string? _modelListWarning;
+    private string[] _serviceProfileNames = Array.Empty<string>();
     private SessionPolicyDto? _sessionPolicy;
     private readonly Dictionary<string, bool> _toolStates = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _toolDisplayNames = new(StringComparer.OrdinalIgnoreCase);
@@ -194,6 +208,7 @@ public sealed partial class MainWindow : Window {
     private Process? _serviceProcess;
     private string? _servicePipeName;
     private string? _stagedServiceDir;
+    private ServiceLaunchProfileOptions? _pendingServiceLaunchProfileOptions;
     private readonly object _aliveProbeSync = new();
     private ChatServiceClient? _aliveProbeClient;
     private long _aliveProbeTicksUtc;
@@ -222,6 +237,17 @@ public sealed partial class MainWindow : Window {
     private sealed class MemorySemanticVectorCacheEntry {
         public required string Signature { get; init; }
         public required Dictionary<int, double> Vector { get; init; }
+    }
+
+    private sealed class ServiceLaunchProfileOptions {
+        public string? LoadProfileName { get; init; }
+        public string? SaveProfileName { get; init; }
+        public string? Model { get; init; }
+        public string? OpenAITransport { get; init; }
+        public string? OpenAIBaseUrl { get; init; }
+        public string? OpenAIApiKey { get; init; }
+        public bool? OpenAIStreaming { get; init; }
+        public bool? OpenAIAllowInsecureHttp { get; init; }
     }
 
     private sealed class MemoryDebugSnapshot {
@@ -699,6 +725,18 @@ public sealed partial class MainWindow : Window {
 
         _themePreset = NormalizeTheme(_appState.ThemePreset) ?? "default";
         _appState.ThemePreset = _themePreset;
+        _localProviderTransport = NormalizeLocalProviderTransport(_appState.LocalProviderTransport);
+        _localProviderBaseUrl = NormalizeLocalProviderBaseUrl(_appState.LocalProviderBaseUrl, _localProviderTransport);
+        _localProviderModel = NormalizeLocalProviderModel(_appState.LocalProviderModel);
+        _appState.LocalProviderTransport = _localProviderTransport;
+        _appState.LocalProviderBaseUrl = _localProviderBaseUrl;
+        _appState.LocalProviderModel = _localProviderModel;
+        _availableModels = Array.Empty<ModelInfoDto>();
+        _favoriteModels = Array.Empty<string>();
+        _recentModels = Array.Empty<string>();
+        _modelListIsStale = false;
+        _modelListWarning = null;
+        _serviceProfileNames = Array.Empty<string>();
 
         if (!string.IsNullOrWhiteSpace(_appState.TimestampMode)) {
             _timestampMode = ResolveTimestampMode(_appState.TimestampMode);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
@@ -75,6 +75,17 @@
         theme: "default",
         onboardingCompleted: false
       },
+      localModel: {
+        transport: "native",
+        baseUrl: "",
+        model: "gpt-5.3-codex",
+        models: [],
+        favoriteModels: [],
+        recentModels: [],
+        isStale: false,
+        warning: "",
+        profileSaved: false
+      },
       debugToolsEnabled: false,
       toolFilter: "",
       policy: null,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -404,6 +404,118 @@
     hint.textContent = baseText;
   }
 
+  function normalizeLocalTransport(value) {
+    return String(value || "").toLowerCase() === "compatible-http" ? "compatible-http" : "native";
+  }
+
+  function normalizeModelText(value) {
+    return String(value == null ? "" : value).trim();
+  }
+
+  function renderLocalModelOptions() {
+    var local = state.options.localModel || {};
+    var transport = normalizeLocalTransport(local.transport);
+    var baseUrl = String(local.baseUrl || "");
+    var model = normalizeModelText(local.model || "");
+    var models = Array.isArray(local.models) ? local.models : [];
+    var favorites = toStringArray(local.favoriteModels);
+    var recents = toStringArray(local.recentModels);
+    var warning = normalizeModelText(local.warning || "");
+    var isStale = local.isStale === true;
+    var profileSaved = local.profileSaved === true;
+
+    var transportSelect = byId("optLocalTransport");
+    if (transportSelect) {
+      transportSelect.value = transport;
+      syncCustomSelect(transportSelect);
+    }
+
+    var baseUrlRow = byId("optLocalBaseUrlRow");
+    if (baseUrlRow) {
+      baseUrlRow.hidden = transport !== "compatible-http";
+    }
+
+    var baseUrlInput = byId("optLocalBaseUrl");
+    if (baseUrlInput) {
+      baseUrlInput.value = baseUrl;
+      baseUrlInput.disabled = transport !== "compatible-http";
+    }
+
+    var modelInput = byId("optLocalModelInput");
+    if (modelInput) {
+      modelInput.value = model;
+    }
+
+    var modelSelect = byId("optLocalModelSelect");
+    if (modelSelect) {
+      modelSelect.innerHTML = "";
+
+      var manualOption = document.createElement("option");
+      manualOption.value = "";
+      manualOption.textContent = "Manual model input";
+      modelSelect.appendChild(manualOption);
+
+      var seen = {};
+      function pushModelOption(modelName, labelPrefix) {
+        var normalized = normalizeModelText(modelName);
+        if (!normalized) {
+          return;
+        }
+        var key = normalized.toLowerCase();
+        if (seen[key]) {
+          return;
+        }
+        seen[key] = true;
+        var option = document.createElement("option");
+        option.value = normalized;
+        option.textContent = labelPrefix ? (labelPrefix + " " + normalized) : normalized;
+        modelSelect.appendChild(option);
+      }
+
+      for (var r = 0; r < recents.length; r++) {
+        pushModelOption(recents[r], "Recent:");
+      }
+      for (var f = 0; f < favorites.length; f++) {
+        pushModelOption(favorites[f], "Favorite:");
+      }
+      for (var i = 0; i < models.length; i++) {
+        var item = models[i] || {};
+        var modelName = normalizeModelText(item.model || item.Model || item.id || item.Id);
+        if (!modelName) {
+          continue;
+        }
+        var displayName = normalizeModelText(item.displayName || item.DisplayName);
+        pushModelOption(modelName, displayName ? (displayName + " ->") : "");
+      }
+
+      modelSelect.value = model;
+      if (modelSelect.value !== model) {
+        modelSelect.value = "";
+      }
+      syncCustomSelect(modelSelect);
+    }
+
+    var stateNote = byId("optLocalModelsState");
+    if (stateNote) {
+      var parts = [];
+      if (models.length > 0) {
+        parts.push(String(models.length) + " models discovered");
+      } else {
+        parts.push("No discovered models yet");
+      }
+      parts.push(profileSaved ? "service profile saved" : "service profile not saved yet");
+      if (isStale) {
+        parts.push("showing cached results");
+      }
+      if (warning) {
+        parts.push(warning);
+      } else if (transport === "compatible-http" && !baseUrl) {
+        parts.push("Set a base URL, then refresh models.");
+      }
+      stateNote.textContent = parts.join(" | ");
+    }
+  }
+
   function normalizeExportSaveMode(value) {
     var normalized = String(value || "").toLowerCase();
     return normalized === "remember" ? "remember" : "ask";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
@@ -31,12 +31,15 @@
     ensureCustomSelect("optExportDefaultFormat");
     ensureCustomSelect("optSidebarMode");
     ensureCustomSelect("optProfileApplyMode");
+    ensureCustomSelect("optLocalTransport");
+    ensureCustomSelect("optLocalModelSelect");
     ensureCustomSelect("optAutonomyParallel");
     ensureCustomSelect("optAutonomyWeightedRouting");
 
     renderPolicy();
     renderAutonomy();
     renderMemory();
+    renderLocalModelOptions();
     renderTools();
     renderSidebarConversations();
     renderProfileScopeHint();
@@ -227,6 +230,7 @@
     state.options.activeConversationId = nextOptions.activeConversationId || state.options.activeConversationId;
     state.options.conversations = nextOptions.conversations || [];
     state.options.profile = nextOptions.profile || state.options.profile;
+    state.options.localModel = nextOptions.localModel || state.options.localModel;
     state.options.policy = nextOptions.policy || null;
     state.options.packs = nextOptions.packs || [];
     state.options.tools = nextOptions.tools || [];

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -551,6 +551,76 @@
     input.value = "";
   });
 
+  function normalizeLocalTransportValue(value) {
+    return String(value || "").toLowerCase() === "compatible-http" ? "compatible-http" : "native";
+  }
+
+  function applyLocalProviderSettings(forceRefresh) {
+    var transport = normalizeLocalTransportValue(byId("optLocalTransport").value || "native");
+    var baseUrl = (byId("optLocalBaseUrl").value || "").trim();
+    var model = (byId("optLocalModelInput").value || "").trim();
+    post("apply_local_provider", {
+      transport: transport,
+      baseUrl: baseUrl,
+      model: model,
+      forceRefresh: forceRefresh !== false
+    });
+  }
+
+  byId("optLocalTransport").addEventListener("change", function(e) {
+    var next = normalizeLocalTransportValue(e.target.value || "native");
+    e.target.value = next;
+    syncCustomSelect(e.target);
+
+    var baseRow = byId("optLocalBaseUrlRow");
+    var baseInput = byId("optLocalBaseUrl");
+    if (baseRow) {
+      baseRow.hidden = next !== "compatible-http";
+    }
+    if (baseInput) {
+      baseInput.disabled = next !== "compatible-http";
+      if (next !== "compatible-http") {
+        baseInput.value = "";
+      }
+    }
+  });
+
+  byId("optLocalModelSelect").addEventListener("change", function(e) {
+    var selected = (e.target.value || "").trim();
+    if (!selected) {
+      return;
+    }
+    byId("optLocalModelInput").value = selected;
+  });
+
+  byId("btnLocalPresetOllama").addEventListener("click", function() {
+    var transport = byId("optLocalTransport");
+    var baseUrl = byId("optLocalBaseUrl");
+    transport.value = "compatible-http";
+    syncCustomSelect(transport);
+    baseUrl.value = "http://127.0.0.1:11434";
+    byId("optLocalBaseUrlRow").hidden = false;
+    baseUrl.disabled = false;
+  });
+
+  byId("btnLocalPresetLmStudio").addEventListener("click", function() {
+    var transport = byId("optLocalTransport");
+    var baseUrl = byId("optLocalBaseUrl");
+    transport.value = "compatible-http";
+    syncCustomSelect(transport);
+    baseUrl.value = "http://127.0.0.1:1234/v1";
+    byId("optLocalBaseUrlRow").hidden = false;
+    baseUrl.disabled = false;
+  });
+
+  byId("btnRefreshModels").addEventListener("click", function() {
+    post("refresh_models", { forceRefresh: true });
+  });
+
+  byId("btnApplyLocalProvider").addEventListener("click", function() {
+    applyLocalProviderSettings(true);
+  });
+
   var btnNewConversation = byId("btnNewConversation");
   if (btnNewConversation) {
     btnNewConversation.addEventListener("click", function() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -143,6 +143,34 @@
             </select>
             <div id="optProfileScopeHint" class="options-note"></div>
           </div>
+          <div class="options-label">Model Runtime</div>
+          <div class="options-note">Configure runtime provider + model and persist it to the active service profile.</div>
+          <div class="options-row">
+            <label class="options-label-inline" for="optLocalTransport">Provider transport</label>
+            <select id="optLocalTransport" class="options-select">
+              <option value="native">OpenAI Native</option>
+              <option value="compatible-http">Compatible HTTP (Ollama / LM Studio)</option>
+            </select>
+          </div>
+          <div class="options-row" id="optLocalBaseUrlRow">
+            <label class="options-label-inline" for="optLocalBaseUrl">Base URL</label>
+            <input id="optLocalBaseUrl" class="options-input options-input-sm" placeholder="http://127.0.0.1:11434" />
+          </div>
+          <div class="options-row">
+            <label class="options-label-inline" for="optLocalModelInput">Model</label>
+            <input id="optLocalModelInput" class="options-input options-input-sm" placeholder="e.g. gpt-5.3-codex or llama3.2" />
+          </div>
+          <div class="options-row">
+            <label class="options-label-inline" for="optLocalModelSelect">Discovered models</label>
+            <select id="optLocalModelSelect" class="options-select"></select>
+          </div>
+          <div class="options-note" id="optLocalModelsState"></div>
+          <div class="options-actions options-actions-wrap">
+            <button id="btnLocalPresetOllama" class="options-btn options-btn-sm options-btn-ghost">Use Ollama URL</button>
+            <button id="btnLocalPresetLmStudio" class="options-btn options-btn-sm options-btn-ghost">Use LM Studio URL</button>
+            <button id="btnRefreshModels" class="options-btn options-btn-sm options-btn-ghost">Refresh Models</button>
+            <button id="btnApplyLocalProvider" class="options-btn options-btn-sm">Apply Runtime</button>
+          </div>
           <div class="options-actions">
             <button id="btnSaveProfile" class="options-btn">Save As Default</button>
             <button id="btnRestartOnboarding" class="options-btn options-btn-ghost">Restart Onboarding</button>


### PR DESCRIPTION
## Summary
- add end-to-end local model runtime setup in Chat.App options (transport, base URL, model picker, presets, refresh/apply actions)
- wire profile/model synchronization on connect and profile switch so app profiles align with service profiles and model discovery state
- support passing profile/runtime launch overrides to the sidecar (`--profile`, `--save-profile`, `--model`, `--openai-*`) and cover with unit tests

## UX Behavior
- users can configure `native` vs `compatible-http` transport from the UI
- users can set Ollama / LM Studio URLs quickly via presets
- users can refresh discovered models, select from discovered/favorite/recent entries, and apply runtime changes
- applying runtime settings persists app state, restarts the sidecar with save-profile args, and refreshes model discovery

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.sln -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release`
