### PR TITLE
fix(chat-app): auto-select discovered model for compatible-http

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -95,8 +95,15 @@ public sealed partial class MainWindow : Window {
             _modelListIsStale = modelList.IsStale;
             _modelListWarning = string.IsNullOrWhiteSpace(modelList.Warning) ? null : modelList.Warning.Trim();
 
-            if (string.IsNullOrWhiteSpace(_localProviderModel) && _availableModels.Length > 0) {
+            var normalizedCurrentModel = (_localProviderModel ?? string.Empty).Trim();
+            var shouldAutoSelectModel = _availableModels.Length > 0
+                                        && (normalizedCurrentModel.Length == 0
+                                            || (string.Equals(_localProviderTransport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase)
+                                                && !ContainsModel(_availableModels, normalizedCurrentModel)));
+            if (shouldAutoSelectModel) {
                 _localProviderModel = _availableModels[0].Model;
+                _appState.LocalProviderModel = _localProviderModel;
+                await PersistAppStateAsync().ConfigureAwait(false);
             }
         } catch (Exception ex) {
             _modelListIsStale = true;
@@ -120,7 +127,7 @@ public sealed partial class MainWindow : Window {
         var rawTransport = (transportValue ?? string.Empty).Trim();
         var normalizedTransport = NormalizeLocalProviderTransport(rawTransport);
         var normalizedBaseUrl = NormalizeLocalProviderBaseUrl(baseUrlValue, normalizedTransport, rawTransport);
-        var normalizedModel = NormalizeLocalProviderModel(modelValue);
+        var normalizedModel = NormalizeLocalProviderModel(modelValue, normalizedTransport);
 
         var changed = !string.Equals(_localProviderTransport, normalizedTransport, StringComparison.OrdinalIgnoreCase)
                       || !string.Equals(_localProviderBaseUrl ?? string.Empty, normalizedBaseUrl ?? string.Empty, StringComparison.OrdinalIgnoreCase)
@@ -264,6 +271,20 @@ public sealed partial class MainWindow : Window {
 
         for (var i = 0; i < names.Length; i++) {
             if (string.Equals(names[i], profileName, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsModel(ModelInfoDto[] models, string modelName) {
+        if (models is null || models.Length == 0 || string.IsNullOrWhiteSpace(modelName)) {
+            return false;
+        }
+
+        for (var i = 0; i < models.Length; i++) {
+            if (string.Equals(models[i].Model, modelName, StringComparison.OrdinalIgnoreCase)) {
                 return true;
             }
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
@@ -376,9 +376,17 @@ public sealed partial class MainWindow : Window {
         return normalized;
     }
 
-    private static string NormalizeLocalProviderModel(string? value) {
+    private static string NormalizeLocalProviderModel(string? value, string transport) {
         var normalized = (value ?? string.Empty).Trim();
-        return normalized.Length == 0 ? DefaultLocalModel : normalized;
+        if (normalized.Length > 0) {
+            return normalized;
+        }
+
+        if (string.Equals(transport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase)) {
+            return string.Empty;
+        }
+
+        return DefaultLocalModel;
     }
 
     private static bool? ParseAutonomyParallelMode(string? raw) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -727,7 +727,7 @@ public sealed partial class MainWindow : Window {
         _appState.ThemePreset = _themePreset;
         _localProviderTransport = NormalizeLocalProviderTransport(_appState.LocalProviderTransport);
         _localProviderBaseUrl = NormalizeLocalProviderBaseUrl(_appState.LocalProviderBaseUrl, _localProviderTransport);
-        _localProviderModel = NormalizeLocalProviderModel(_appState.LocalProviderModel);
+        _localProviderModel = NormalizeLocalProviderModel(_appState.LocalProviderModel, _localProviderTransport);
         _appState.LocalProviderTransport = _localProviderTransport;
         _appState.LocalProviderBaseUrl = _localProviderBaseUrl;
         _appState.LocalProviderModel = _localProviderModel;


### PR DESCRIPTION
## Summary
- stop forcing `gpt-5.3-codex` as the local model when transport is `compatible-http`
- auto-select and persist the first discovered model when the current compatible-http model is empty or invalid for the discovered model list
- keep native transport behavior unchanged (still falls back to default model)

## Why
Local-model first runs could fail because the app would launch compatible-http with an OpenAI default model that does not exist on Ollama/LM Studio. This update makes the first local setup path resilient by snapping to a discovered model automatically.

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.sln -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release`
