### PR TITLE
feat(chat-app): streamline local runtime setup actions

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -567,6 +567,25 @@
     });
   }
 
+  function hasPendingLocalProviderChanges() {
+    var local = state.options.localModel || {};
+    var currentTransport = normalizeLocalTransportValue(local.transport || "native");
+    var currentBaseUrl = currentTransport === "compatible-http"
+      ? String(local.baseUrl || "").trim().toLowerCase()
+      : "";
+    var currentModel = String(local.model || "").trim();
+
+    var draftTransport = normalizeLocalTransportValue(byId("optLocalTransport").value || "native");
+    var draftBaseUrl = draftTransport === "compatible-http"
+      ? (byId("optLocalBaseUrl").value || "").trim().toLowerCase()
+      : "";
+    var draftModel = (byId("optLocalModelInput").value || "").trim();
+
+    return draftTransport !== currentTransport
+      || draftBaseUrl !== currentBaseUrl
+      || draftModel !== currentModel;
+  }
+
   byId("optLocalTransport").addEventListener("change", function(e) {
     var next = normalizeLocalTransportValue(e.target.value || "native");
     e.target.value = next;
@@ -601,6 +620,7 @@
     baseUrl.value = "http://127.0.0.1:11434";
     byId("optLocalBaseUrlRow").hidden = false;
     baseUrl.disabled = false;
+    applyLocalProviderSettings(true);
   });
 
   byId("btnLocalPresetLmStudio").addEventListener("click", function() {
@@ -611,9 +631,14 @@
     baseUrl.value = "http://127.0.0.1:1234/v1";
     byId("optLocalBaseUrlRow").hidden = false;
     baseUrl.disabled = false;
+    applyLocalProviderSettings(true);
   });
 
   byId("btnRefreshModels").addEventListener("click", function() {
+    if (hasPendingLocalProviderChanges()) {
+      applyLocalProviderSettings(true);
+      return;
+    }
     post("refresh_models", { forceRefresh: true });
   });
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -165,9 +165,10 @@
             <select id="optLocalModelSelect" class="options-select"></select>
           </div>
           <div class="options-note" id="optLocalModelsState"></div>
+          <div class="options-note">Preset buttons apply runtime settings immediately and refresh model discovery.</div>
           <div class="options-actions options-actions-wrap">
-            <button id="btnLocalPresetOllama" class="options-btn options-btn-sm options-btn-ghost">Use Ollama URL</button>
-            <button id="btnLocalPresetLmStudio" class="options-btn options-btn-sm options-btn-ghost">Use LM Studio URL</button>
+            <button id="btnLocalPresetOllama" class="options-btn options-btn-sm options-btn-ghost">Use Ollama Runtime</button>
+            <button id="btnLocalPresetLmStudio" class="options-btn options-btn-sm options-btn-ghost">Use LM Studio Runtime</button>
             <button id="btnRefreshModels" class="options-btn options-btn-sm options-btn-ghost">Refresh Models</button>
             <button id="btnApplyLocalProvider" class="options-btn options-btn-sm">Apply Runtime</button>
           </div>


### PR DESCRIPTION
## Summary
- make `Use Ollama Runtime` and `Use LM Studio Runtime` true one-click actions by applying settings immediately
- make `Refresh Models` smart: if local runtime form values differ from active runtime state, apply first, then refresh
- clarify the UI hint text so behavior is explicit

## Why
Users had to manually click multiple controls in sequence and could easily refresh against stale runtime settings. This smooths the local-model setup path and prevents confusion between draft form values vs active runtime values.

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.sln -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release`
