### PR TITLE
docs(chat): document WinUI local-model quick start

### DIFF
--- a/Docs/apps/chat-local-providers.md
+++ b/Docs/apps/chat-local-providers.md
@@ -8,6 +8,19 @@ This is intended for providers that support (at minimum):
 
 Examples: Ollama, LM Studio, llama.cpp server, and similar OpenAI-compat endpoints.
 
+## Chat App (Easiest Local Setup)
+
+For the WinUI desktop app (`Build/Run-ChatApp.ps1`):
+
+1. Open **Options -> Profile -> Model Runtime**.
+2. Click **Use Ollama Runtime** or **Use LM Studio Runtime**.
+3. The app applies runtime settings immediately and refreshes model discovery.
+4. If needed, choose a model from **Discovered models** and click **Apply Runtime**.
+
+Notes:
+- `Refresh Models` applies pending runtime field changes first, then refreshes discovery.
+- For `compatible-http`, if the current model is empty or invalid, the app auto-selects the first discovered model.
+
 ## Security Model
 
 - `http://` is rejected by default.
@@ -72,4 +85,3 @@ When tool calling is not supported by the provider, the chat still works but too
 ## Current Limitations
 
 - Image inputs are not supported for `compatible-http` yet (text + tools only).
-

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -36,6 +36,17 @@ Markdown renderer dependency resolution is automatic:
 
 `Run-ChatApp.ps1` launches only the app. The local runtime service is auto-started and auto-restarted by the app.
 
+### WinUI Local Model Quick Setup
+
+Inside the app:
+
+1. Open **Options -> Profile -> Model Runtime**.
+2. Click **Use Ollama Runtime** or **Use LM Studio Runtime**.
+3. Wait for model discovery to populate.
+4. Optionally choose a model and click **Apply Runtime**.
+
+Reference: `Docs/apps/chat-local-providers.md`
+
 Service-only mode (advanced):
 
 ```powershell


### PR DESCRIPTION
## Summary
- document the WinUI in-app local-model quick-start flow in `IntelligenceX.Chat/README.md`
- add an explicit Chat App section to `Docs/apps/chat-local-providers.md` aligned with the new one-click runtime preset UX

## Why
We improved local runtime setup ergonomics in the app, so docs should reflect the easiest path first for single-user local installs.
