### PR TITLE
fix(chat): fallback without tools on low-context LM Studio errors

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
@@ -113,7 +113,7 @@ internal static partial class Program {
             if (_options.LiveProgress) {
                 _status?.Invoke("thinking...");
             }
-            TurnInfo turn = await _client.ChatAsync(input, chatOptions, turnToken).ConfigureAwait(false);
+            TurnInfo turn = await ChatWithToolSchemaRecoveryAsync(input, chatOptions, turnToken).ConfigureAwait(false);
 
             for (var round = 0; round < Math.Max(1, _options.MaxToolRounds); round++) {
                 var extracted = ToolCallParser.Extract(turn);
@@ -145,7 +145,7 @@ internal static partial class Program {
                 if (_options.LiveProgress) {
                     _status?.Invoke("thinking...");
                 }
-                turn = await _client.ChatAsync(next, chatOptions, turnToken).ConfigureAwait(false);
+                turn = await ChatWithToolSchemaRecoveryAsync(next, chatOptions, turnToken).ConfigureAwait(false);
             }
 
             throw new InvalidOperationException($"Tool runner exceeded max rounds ({_options.MaxToolRounds}).");
@@ -212,6 +212,41 @@ internal static partial class Program {
             }
             var response = turn.Raw.GetObject("response");
             return response?.GetString("id");
+        }
+
+        private async Task<TurnInfo> ChatWithToolSchemaRecoveryAsync(ChatInput input, ChatOptions options, CancellationToken cancellationToken) {
+            try {
+                return await _client.ChatAsync(input, options, cancellationToken).ConfigureAwait(false);
+            } catch (Exception ex) when (ShouldRetryWithoutTools(ex, options)) {
+                options.Tools = null;
+                options.ToolChoice = null;
+                return await _client.ChatAsync(input, options, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private static bool ShouldRetryWithoutTools(Exception ex, ChatOptions options) {
+            if (options.Tools is not { Count: > 0 }) {
+                return false;
+            }
+
+            var message = ex.Message ?? string.Empty;
+            if (message.Length == 0) {
+                return false;
+            }
+
+            var missingToolName = message.IndexOf("missing required parameter", StringComparison.OrdinalIgnoreCase) >= 0
+                                  && message.IndexOf("tools", StringComparison.OrdinalIgnoreCase) >= 0
+                                  && message.IndexOf(".name", StringComparison.OrdinalIgnoreCase) >= 0;
+            if (missingToolName) {
+                return true;
+            }
+
+            return message.IndexOf("cannot truncate prompt with n_keep", StringComparison.OrdinalIgnoreCase) >= 0
+                   || message.IndexOf("n_ctx", StringComparison.OrdinalIgnoreCase) >= 0
+                   || message.IndexOf("context length", StringComparison.OrdinalIgnoreCase) >= 0
+                   || message.IndexOf("context window", StringComparison.OrdinalIgnoreCase) >= 0
+                   || message.IndexOf("maximum context length", StringComparison.OrdinalIgnoreCase) >= 0
+                   || message.IndexOf("prompt too long", StringComparison.OrdinalIgnoreCase) >= 0;
         }
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolExecution.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolExecution.cs
@@ -46,9 +46,21 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        return message.IndexOf("missing required parameter", StringComparison.OrdinalIgnoreCase) >= 0
-               && message.IndexOf("tools", StringComparison.OrdinalIgnoreCase) >= 0
-               && message.IndexOf(".name", StringComparison.OrdinalIgnoreCase) >= 0;
+        var missingToolName = message.IndexOf("missing required parameter", StringComparison.OrdinalIgnoreCase) >= 0
+                              && message.IndexOf("tools", StringComparison.OrdinalIgnoreCase) >= 0
+                              && message.IndexOf(".name", StringComparison.OrdinalIgnoreCase) >= 0;
+        if (missingToolName) {
+            return true;
+        }
+
+        // Compatible local providers (for example LM Studio with low n_ctx) can reject requests
+        // once tool schemas push prompt size over context limits.
+        return message.IndexOf("cannot truncate prompt with n_keep", StringComparison.OrdinalIgnoreCase) >= 0
+               || message.IndexOf("n_ctx", StringComparison.OrdinalIgnoreCase) >= 0
+               || message.IndexOf("context length", StringComparison.OrdinalIgnoreCase) >= 0
+               || message.IndexOf("context window", StringComparison.OrdinalIgnoreCase) >= 0
+               || message.IndexOf("maximum context length", StringComparison.OrdinalIgnoreCase) >= 0
+               || message.IndexOf("prompt too long", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private async Task<IReadOnlyList<ToolOutputDto>> ExecuteToolsAsync(StreamWriter writer, string requestId, string threadId, IReadOnlyList<ToolCall> calls,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatSchemaRecoveryFallbackTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatSchemaRecoveryFallbackTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Reflection;
+using IntelligenceX.OpenAI.Chat;
+using IntelligenceX.OpenAI.ToolCalling;
+using IntelligenceX.Tools;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class ChatSchemaRecoveryFallbackTests {
+    private static readonly Type ChatServiceSessionType =
+        Type.GetType("IntelligenceX.Chat.Service.ChatServiceSession, IntelligenceX.Chat.Service")
+        ?? throw new InvalidOperationException("ChatServiceSession type not found.");
+
+    private static readonly MethodInfo ServiceShouldRetryWithoutToolsMethod = ChatServiceSessionType.GetMethod(
+        "ShouldRetryWithoutTools",
+        BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("ChatServiceSession.ShouldRetryWithoutTools not found.");
+
+    [Fact]
+    public void ServiceShouldRetryWithoutTools_RetriesOnContextWindowFailure() {
+        var options = BuildOptionsWithTools();
+        var ex = new InvalidOperationException("Chat request failed (400): {\"error\":\"Cannot truncate prompt with n_keep (12378) >= n_ctx (4096)\"}");
+
+        var shouldRetry = InvokeShouldRetry(ServiceShouldRetryWithoutToolsMethod, ex, options);
+
+        Assert.True(shouldRetry);
+    }
+
+    [Fact]
+    public void ServiceShouldRetryWithoutTools_DoesNotRetryWhenNoTools() {
+        var options = new ChatOptions {
+            Tools = null,
+            ToolChoice = null
+        };
+        var ex = new InvalidOperationException("maximum context length exceeded");
+
+        var shouldRetry = InvokeShouldRetry(ServiceShouldRetryWithoutToolsMethod, ex, options);
+
+        Assert.False(shouldRetry);
+    }
+
+    private static ChatOptions BuildOptionsWithTools() {
+        return new ChatOptions {
+            Tools = new[] { new ToolDefinition("fs_list", "List files") },
+            ToolChoice = ToolChoice.Auto
+        };
+    }
+
+    private static bool InvokeShouldRetry(MethodInfo method, Exception ex, ChatOptions options) {
+        var result = method.Invoke(null, new object?[] { ex, options });
+        return Assert.IsType<bool>(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add context-window aware fallback for tool-schema retries in chat service
- add matching fallback in chat host session flow
- when compatible providers (like LM Studio with small `n_ctx`) reject tool-heavy prompts, retry once without tool schema
- add regression tests for service-side retry predicate

## Why
LM Studio can return 400 errors such as `Cannot truncate prompt with n_keep >= n_ctx` when tool schema + instructions exceed context. Previously this could block turns even for simple prompts. This change keeps turns usable by degrading to text-only when needed.

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.sln -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release`
- Manual: `Build/Run-Chat.ps1` against LM Studio with `openai/gpt-oss-20b` now returns `LM_STUDIO_OK` (tool schema fallback path).
