### PR TITLE
Chat App: add compatible-http API key support in Model Runtime

### DIFF
--- a/Docs/apps/chat-local-providers.md
+++ b/Docs/apps/chat-local-providers.md
@@ -14,12 +14,14 @@ For the WinUI desktop app (`Build/Run-ChatApp.ps1`):
 
 1. Open **Options -> Profile -> Model Runtime**.
 2. Click **Use Ollama Runtime** or **Use LM Studio Runtime**.
-3. The app applies runtime settings immediately and refreshes model discovery.
-4. If needed, choose a model from **Discovered models** and click **Apply Runtime**.
+3. If your provider needs auth, enter **API key (optional)**.
+4. The app applies runtime settings immediately and refreshes model discovery.
+5. If needed, choose a model from **Discovered models** and click **Apply Runtime**.
 
 Notes:
 - `Refresh Models` applies pending runtime field changes first, then refreshes discovery.
 - For `compatible-http`, if the current model is empty or invalid, the app auto-selects the first discovered model.
+- Leaving API key empty keeps the currently saved key unchanged.
 
 ## Security Model
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -118,7 +118,7 @@ public sealed partial class MainWindow : Window {
         }
     }
 
-    private async Task ApplyLocalProviderAsync(string? transportValue, string? baseUrlValue, string? modelValue, bool forceModelRefresh) {
+    private async Task ApplyLocalProviderAsync(string? transportValue, string? baseUrlValue, string? modelValue, string? apiKeyValue, bool forceModelRefresh) {
         if (_isSending) {
             await SetStatusAsync("Finish the active response before changing local runtime settings.").ConfigureAwait(false);
             return;
@@ -128,10 +128,13 @@ public sealed partial class MainWindow : Window {
         var normalizedTransport = NormalizeLocalProviderTransport(rawTransport);
         var normalizedBaseUrl = NormalizeLocalProviderBaseUrl(baseUrlValue, normalizedTransport, rawTransport);
         var normalizedModel = NormalizeLocalProviderModel(modelValue, normalizedTransport);
+        var normalizedApiKey = NormalizeLocalProviderApiKey(apiKeyValue, normalizedTransport);
+        var hasApiKeyUpdate = normalizedApiKey is not null;
 
         var changed = !string.Equals(_localProviderTransport, normalizedTransport, StringComparison.OrdinalIgnoreCase)
                       || !string.Equals(_localProviderBaseUrl ?? string.Empty, normalizedBaseUrl ?? string.Empty, StringComparison.OrdinalIgnoreCase)
-                      || !string.Equals(_localProviderModel, normalizedModel, StringComparison.Ordinal);
+                      || !string.Equals(_localProviderModel, normalizedModel, StringComparison.Ordinal)
+                      || hasApiKeyUpdate;
 
         _localProviderTransport = normalizedTransport;
         _localProviderBaseUrl = normalizedBaseUrl;
@@ -157,7 +160,7 @@ public sealed partial class MainWindow : Window {
             Model = _localProviderModel,
             OpenAITransport = _localProviderTransport,
             OpenAIBaseUrl = _localProviderBaseUrl,
-            OpenAIApiKey = null,
+            OpenAIApiKey = normalizedApiKey,
             OpenAIStreaming = true,
             OpenAIAllowInsecureHttp = ShouldAllowInsecureHttp(_localProviderTransport, _localProviderBaseUrl)
         };

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
@@ -277,8 +277,9 @@ public sealed partial class MainWindow : Window {
                         var transport = TryGetString(root, "transport");
                         var baseUrl = TryGetString(root, "baseUrl");
                         var model = TryGetString(root, "model");
+                        var apiKey = TryGetString(root, "apiKey");
                         var forceRefresh = TryGetBoolean(root, "forceRefresh");
-                        await ApplyLocalProviderAsync(transport, baseUrl, model, forceRefresh ?? true).ConfigureAwait(true);
+                        await ApplyLocalProviderAsync(transport, baseUrl, model, apiKey, forceRefresh ?? true).ConfigureAwait(true);
                         break;
                     }
                 case "restart_onboarding":

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
@@ -389,6 +389,15 @@ public sealed partial class MainWindow : Window {
         return DefaultLocalModel;
     }
 
+    private static string? NormalizeLocalProviderApiKey(string? value, string transport) {
+        if (!string.Equals(transport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase)) {
+            return null;
+        }
+
+        var normalized = (value ?? string.Empty).Trim();
+        return normalized.Length == 0 ? null : normalized;
+    }
+
     private static bool? ParseAutonomyParallelMode(string? raw) {
         var text = (raw ?? string.Empty).Trim();
         if (text.Equals("on", StringComparison.OrdinalIgnoreCase)) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -441,6 +441,19 @@
       baseUrlInput.disabled = transport !== "compatible-http";
     }
 
+    var apiKeyRow = byId("optLocalApiKeyRow");
+    if (apiKeyRow) {
+      apiKeyRow.hidden = transport !== "compatible-http";
+    }
+
+    var apiKeyInput = byId("optLocalApiKey");
+    if (apiKeyInput) {
+      apiKeyInput.disabled = transport !== "compatible-http";
+      if (transport !== "compatible-http") {
+        apiKeyInput.value = "";
+      }
+    }
+
     var modelInput = byId("optLocalModelInput");
     if (modelInput) {
       modelInput.value = model;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -559,10 +559,14 @@
     var transport = normalizeLocalTransportValue(byId("optLocalTransport").value || "native");
     var baseUrl = (byId("optLocalBaseUrl").value || "").trim();
     var model = (byId("optLocalModelInput").value || "").trim();
+    var apiKey = transport === "compatible-http"
+      ? (byId("optLocalApiKey").value || "").trim()
+      : "";
     post("apply_local_provider", {
       transport: transport,
       baseUrl: baseUrl,
       model: model,
+      apiKey: apiKey,
       forceRefresh: forceRefresh !== false
     });
   }
@@ -580,10 +584,14 @@
       ? (byId("optLocalBaseUrl").value || "").trim().toLowerCase()
       : "";
     var draftModel = (byId("optLocalModelInput").value || "").trim();
+    var draftApiKey = draftTransport === "compatible-http"
+      ? (byId("optLocalApiKey").value || "").trim()
+      : "";
 
     return draftTransport !== currentTransport
       || draftBaseUrl !== currentBaseUrl
-      || draftModel !== currentModel;
+      || draftModel !== currentModel
+      || draftApiKey.length > 0;
   }
 
   byId("optLocalTransport").addEventListener("change", function(e) {
@@ -593,6 +601,8 @@
 
     var baseRow = byId("optLocalBaseUrlRow");
     var baseInput = byId("optLocalBaseUrl");
+    var apiKeyRow = byId("optLocalApiKeyRow");
+    var apiKeyInput = byId("optLocalApiKey");
     if (baseRow) {
       baseRow.hidden = next !== "compatible-http";
     }
@@ -600,6 +610,15 @@
       baseInput.disabled = next !== "compatible-http";
       if (next !== "compatible-http") {
         baseInput.value = "";
+      }
+    }
+    if (apiKeyRow) {
+      apiKeyRow.hidden = next !== "compatible-http";
+    }
+    if (apiKeyInput) {
+      apiKeyInput.disabled = next !== "compatible-http";
+      if (next !== "compatible-http") {
+        apiKeyInput.value = "";
       }
     }
   });
@@ -620,6 +639,8 @@
     baseUrl.value = "http://127.0.0.1:11434";
     byId("optLocalBaseUrlRow").hidden = false;
     baseUrl.disabled = false;
+    byId("optLocalApiKeyRow").hidden = false;
+    byId("optLocalApiKey").disabled = false;
     applyLocalProviderSettings(true);
   });
 
@@ -631,6 +652,8 @@
     baseUrl.value = "http://127.0.0.1:1234/v1";
     byId("optLocalBaseUrlRow").hidden = false;
     baseUrl.disabled = false;
+    byId("optLocalApiKeyRow").hidden = false;
+    byId("optLocalApiKey").disabled = false;
     applyLocalProviderSettings(true);
   });
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -156,6 +156,10 @@
             <label class="options-label-inline" for="optLocalBaseUrl">Base URL</label>
             <input id="optLocalBaseUrl" class="options-input options-input-sm" placeholder="http://127.0.0.1:11434" />
           </div>
+          <div class="options-row" id="optLocalApiKeyRow">
+            <label class="options-label-inline" for="optLocalApiKey">API key (optional)</label>
+            <input id="optLocalApiKey" type="password" class="options-input options-input-sm" placeholder="Leave blank to keep existing key" autocomplete="off" />
+          </div>
           <div class="options-row">
             <label class="options-label-inline" for="optLocalModelInput">Model</label>
             <input id="optLocalModelInput" class="options-input options-input-sm" placeholder="e.g. gpt-5.3-codex or llama3.2" />

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -43,7 +43,8 @@ Inside the app:
 1. Open **Options -> Profile -> Model Runtime**.
 2. Click **Use Ollama Runtime** or **Use LM Studio Runtime**.
 3. Wait for model discovery to populate.
-4. Optionally choose a model and click **Apply Runtime**.
+4. If your provider needs auth, enter **API key (optional)**.
+5. Optionally choose a model and click **Apply Runtime**.
 
 Reference: `Docs/apps/chat-local-providers.md`
 


### PR DESCRIPTION
## Summary
- add an optional masked **API key** field to `Options -> Profile -> Model Runtime` in the WinUI chat app
- wire `apiKey` through `apply_local_provider` from WebView bindings into the app message handler
- persist key updates for `compatible-http` by passing `--openai-api-key` on sidecar restart when the user explicitly provides a key
- keep ChatGPT (`native`) as the default transport and preserve existing profile keys when API key input is left blank
- update local provider docs/quick-start to cover GUI API key usage

## Why
This keeps ChatGPT as the primary default path while enabling easy switching/login to other OpenAI-compatible providers (for example LM Studio) directly from the GUI, aligned with existing CLI support.

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
