### PR TITLE
feat(docs): improve Mermaid rendering and add architecture diagrams

### DIFF
--- a/Docs/chat/architecture.md
+++ b/Docs/chat/architecture.md
@@ -11,9 +11,14 @@ IX Chat uses a dual-process architecture to separate UI concerns from AI provide
 
 ```mermaid
 flowchart LR
+    classDef ui fill:#BAE6FD,stroke:#0369A1,color:#082F49,stroke-width:2px;
+    classDef host fill:#DDD6FE,stroke:#5B21B6,color:#2E1065,stroke-width:2px;
     UI["UI Process<br/>(WinUI 3)<br/><br/>- Window management<br/>- Tray icon<br/>- WebView2 chat"]
     HOST["Host Process<br/>(Console App)<br/><br/>- AI providers<br/>- Tool execution<br/>- Thread storage"]
     UI <-->|"Named pipe (JSON-RPC)"| HOST
+
+    class UI ui;
+    class HOST host;
 ```
 
 ## UI Process

--- a/Docs/library/overview.md
+++ b/Docs/library/overview.md
@@ -8,6 +8,34 @@ Tools: [Tool Calling](/docs/library/tools/)
 Tool packs: [Library Tool Packs](/docs/library/tool-packs/)
 Plugin rollout draft: [Plugin Rollout Draft](/docs/library/plugin-rollout-draft/)
 
+## Conceptual Package Map
+
+```mermaid
+flowchart TD
+  classDef app fill:#BAE6FD,stroke:#0369A1,color:#082F49,stroke-width:2px;
+  classDef core fill:#DDD6FE,stroke:#5B21B6,color:#2E1065,stroke-width:2px;
+  classDef provider fill:#FDE68A,stroke:#B45309,color:#451A03,stroke-width:2px;
+  classDef tools fill:#A7F3D0,stroke:#047857,color:#052E2B,stroke-width:2px;
+  classDef optional fill:#FBCFE8,stroke:#BE185D,color:#500724,stroke-width:2px;
+
+  APP["Your .NET app"] --> CORE["IntelligenceX.OpenAI"]
+  APP --> COPI["IntelligenceX.Copilot"]
+  CORE --> NATIVE["Native transport"]
+  CORE --> APPSERVER["AppServer transport"]
+  CORE --> HTTP["Compatible HTTP transport"]
+  CORE --> TOOLCALL["Tool-calling orchestration"]
+  TOOLCALL --> TOOLS["IntelligenceX.Tools contract"]
+  TOOLS --> PACKS["IntelligenceX.Tools.* packs"]
+  COPI --> COPCLI["Copilot CLI transport"]
+  COPI --> COPDIR["Copilot Direct transport (experimental)"]
+
+  class APP app;
+  class CORE core;
+  class NATIVE,APPSERVER,HTTP provider;
+  class TOOLCALL,TOOLS,PACKS tools;
+  class COPI,COPCLI,COPDIR optional;
+```
+
 ## Quick start (app-server)
 
 ```csharp

--- a/Docs/reviewer/onboarding-wizard.md
+++ b/Docs/reviewer/onboarding-wizard.md
@@ -24,6 +24,12 @@ intelligencex setup autodetect --json
 
 ```mermaid
 flowchart TD
+  classDef start fill:#38BDF8,stroke:#0369A1,color:#082F49,stroke-width:2px;
+  classDef decision fill:#FDE68A,stroke:#B45309,color:#451A03,stroke-width:2px;
+  classDef path fill:#A7F3D0,stroke:#047857,color:#052E2B,stroke-width:2px;
+  classDef converge fill:#C7D2FE,stroke:#4338CA,color:#1E1B4B,stroke-width:2px;
+  classDef finish fill:#E9D5FF,stroke:#7C3AED,color:#2E1065,stroke-width:2px;
+
   A["Run wizard"] --> B["Doctor auto-detect"]
   B --> C{"Choose path"}
   C --> D["new-setup"]
@@ -36,6 +42,12 @@ flowchart TD
   G --> H
   H --> I["Path-specific configure and auth requirements"]
   I --> J["Plan apply verify"]
+
+  class A,B start;
+  class C decision;
+  class D,E,F,G path;
+  class H converge;
+  class I,J finish;
 ```
 
 Path requirements and Bot parity flow are documented in [Web Onboarding Flow](/docs/reviewer/web-onboarding/).

--- a/Docs/reviewer/overview.md
+++ b/Docs/reviewer/overview.md
@@ -17,6 +17,30 @@ Related docs:
 - [Configuration](/docs/reviewer/configuration/)
 - [Security and Trust](/docs/reviewer/security-trust/)
 
+## Runtime Flow
+
+```mermaid
+flowchart LR
+  classDef trigger fill:#BAE6FD,stroke:#0369A1,color:#082F49,stroke-width:2px;
+  classDef engine fill:#DDD6FE,stroke:#5B21B6,color:#2E1065,stroke-width:2px;
+  classDef provider fill:#FDE68A,stroke:#B45309,color:#451A03,stroke-width:2px;
+  classDef output fill:#A7F3D0,stroke:#047857,color:#052E2B,stroke-width:2px;
+
+  A["Pull request event"] --> B["GitHub Actions job"]
+  B --> C["IntelligenceX review pipeline"]
+  C --> D["Context builder<br/>diff selection, chunking, redaction"]
+  D --> E["Provider call<br/>OpenAI or Copilot"]
+  E --> F["Findings parser and formatter"]
+  F --> G["PR summary comment"]
+  F --> H["Inline comments (if enabled)"]
+  C --> I["Thread triage and optional auto-resolve"]
+
+  class A,B trigger;
+  class C,D,F,I engine;
+  class E provider;
+  class G,H output;
+```
+
 ## Trust model (short version)
 - BYO GitHub App is supported for branded bot identity.
 - Secrets are stored in GitHub Actions (you control access).

--- a/Docs/reviewer/review-output.md
+++ b/Docs/reviewer/review-output.md
@@ -4,6 +4,27 @@ The IntelligenceX reviewer posts a structured Markdown comment on each PR. The s
 
 The reviewer uses H2 headings (`## ...`) for each required section to keep the output easy to scan and tooling-friendly.
 
+## Output Contract Map
+
+```mermaid
+flowchart TD
+  classDef required fill:#FDE68A,stroke:#B45309,color:#451A03,stroke-width:2px;
+  classDef optional fill:#DDD6FE,stroke:#5B21B6,color:#2E1065,stroke-width:2px;
+  classDef inline fill:#A7F3D0,stroke:#047857,color:#052E2B,stroke-width:2px;
+
+  A["Reviewer markdown comment"] --> B["Todo List"]
+  A --> C["Critical Issues"]
+  A --> D["Other Issues"]
+  A --> E["Next Steps"]
+  A --> F["Other Reviews (triage context)"]
+  C --> G["Inline comments for actionable findings"]
+  B --> G
+
+  class B,C,D required;
+  class E,F optional;
+  class G inline;
+```
+
 ## Merge blockers vs suggestions
 
 Merge blockers:

--- a/Docs/reviewer/setup-web.md
+++ b/Docs/reviewer/setup-web.md
@@ -26,12 +26,20 @@ This starts a local web server and opens the wizard in your browser (http://127.
 
 ```mermaid
 flowchart LR
+  classDef step fill:#BAE6FD,stroke:#0369A1,color:#082F49,stroke-width:2px;
+  classDef auth fill:#FDE68A,stroke:#B45309,color:#451A03,stroke-width:2px;
+  classDef apply fill:#A7F3D0,stroke:#047857,color:#052E2B,stroke-width:2px;
+
   A["Path"] --> B["Auto-Detect"]
   B --> C["GitHub Auth"]
   C --> D["Repos"]
   D --> E["Configure/Auth"]
   E --> F["Plan"]
   F --> G["Apply + Verify"]
+
+  class A,B,D,E,F step;
+  class C auth;
+  class G apply;
 ```
 
 Path requirements (GitHub/repo/AI auth) and Bot contract checks are defined in [Web Onboarding Flow](/docs/reviewer/web-onboarding/).

--- a/Docs/reviewer/web-onboarding.md
+++ b/Docs/reviewer/web-onboarding.md
@@ -17,6 +17,12 @@ CLI, Web, and Bot all use the same path contract in `SetupOnboardingContract`.
 
 ```mermaid
 flowchart TD
+  classDef trigger fill:#38BDF8,stroke:#0369A1,color:#082F49,stroke-width:2px;
+  classDef path fill:#A7F3D0,stroke:#047857,color:#052E2B,stroke-width:2px;
+  classDef auth fill:#FDE68A,stroke:#B45309,color:#451A03,stroke-width:2px;
+  classDef apply fill:#E9D5FF,stroke:#7C3AED,color:#2E1065,stroke-width:2px;
+  classDef decision fill:#FBCFE8,stroke:#BE185D,color:#500724,stroke-width:2px;
+
   A["Start intelligencex setup web"] --> B["Run doctor auto-detect"]
   B --> C{"Choose path"}
 
@@ -47,6 +53,13 @@ flowchart TD
   G4 --> D5
   G4 --> E4
   G4 --> F4
+
+  class A,B trigger;
+  class C decision;
+  class D,E,F,G path;
+  class D1,D2,D4,E1,E2,E3,F1,F2,G1,G2 auth;
+  class D3,E4,F3,G3,G4 apply;
+  class D5,F4 apply;
 ```
 
 ## Bot Contract-Check Flow
@@ -55,11 +68,22 @@ flowchart TD
 
 ```mermaid
 flowchart LR
+  classDef bot fill:#BAE6FD,stroke:#0369A1,color:#082F49,stroke-width:2px;
+  classDef verify fill:#FDE68A,stroke:#B45309,color:#451A03,stroke-width:2px;
+  classDef ok fill:#A7F3D0,stroke:#047857,color:#052E2B,stroke-width:2px;
+  classDef stop fill:#FECACA,stroke:#B91C1C,color:#450A0A,stroke-width:2px;
+  classDef decision fill:#DDD6FE,stroke:#5B21B6,color:#2E1065,stroke-width:2px;
+
   A["reviewer_setup_pack_info"] --> B["setup autodetect --json"]
   B --> C["reviewer_setup_contract_verify"]
   C --> D{"Metadata matches"}
   D -->|yes| E["Run setup update-secret or cleanup command"]
   D -->|no| F["Stop and request contract/tool update"]
+
+  class A,B,C bot;
+  class D decision;
+  class E ok;
+  class F stop;
 ```
 
 ## Steps

--- a/Docs/tools/overview.md
+++ b/Docs/tools/overview.md
@@ -17,6 +17,26 @@ IntelligenceX.Chat classifies packs with a runtime `sourceKind`:
 | `open_source` | Pack is loaded from external open-source plugin assemblies. |
 | `closed_source` | Pack exists but may come from private/internal assemblies not present in OSS checkouts. |
 
+## Tool Pack Loading Flow
+
+```mermaid
+flowchart LR
+  classDef host fill:#BAE6FD,stroke:#0369A1,color:#082F49,stroke-width:2px;
+  classDef pack fill:#DDD6FE,stroke:#5B21B6,color:#2E1065,stroke-width:2px;
+  classDef runtime fill:#A7F3D0,stroke:#047857,color:#052E2B,stroke-width:2px;
+
+  A["IX Chat host startup"] --> B["ToolPackBootstrap"]
+  B --> C["Discover assemblies"]
+  C --> D["Register descriptors and tools"]
+  D --> E["Normalize sourceKind and tier"]
+  E --> F["Expose tool registry to model runtime"]
+  F --> G["Tool call -> local execution -> result"]
+
+  class A,B host;
+  class C,D,E pack;
+  class F,G runtime;
+```
+
 ## Pack Inventory (Current Runtime Truth)
 
 The table below reflects the actual bootstrap in `IntelligenceX.Chat.Tooling/ToolPackBootstrap.cs`.

--- a/Website/static/css/main.css
+++ b/Website/static/css/main.css
@@ -97,15 +97,37 @@ code { font-family: var(--pf-font-mono); font-size: 0.875em; }
 
 /* Mermaid diagrams (rendered from ```mermaid code fences). */
 .mermaid-diagram {
-  background: var(--pf-code-bg);
+  background:
+    radial-gradient(160% 120% at 0% 0%, var(--pf-glow-primary), transparent 55%),
+    radial-gradient(140% 140% at 100% 0%, var(--pf-glow-secondary), transparent 60%),
+    var(--pf-code-bg);
   border: 1px solid var(--pf-code-border);
   border-radius: var(--pf-radius-sm);
-  padding: 1rem;
+  padding: 1rem 1.1rem;
   margin-bottom: 1.5rem;
   overflow-x: auto;
 }
 .mermaid-diagram .mermaid {
-  min-width: 280px;
+  min-width: 320px;
+}
+.mermaid-diagram .mermaid svg {
+  display: block;
+  margin: 0 auto;
+  max-width: 100%;
+  height: auto;
+}
+.mermaid-diagram .mermaid text,
+.mermaid-diagram .mermaid tspan {
+  font-family: var(--pf-font-body) !important;
+}
+[data-theme="light"] .mermaid-diagram {
+  background:
+    radial-gradient(160% 120% at 0% 0%, rgba(8, 145, 178, 0.08), transparent 55%),
+    radial-gradient(140% 140% at 100% 0%, rgba(124, 58, 237, 0.08), transparent 60%),
+    var(--pf-code-bg);
+}
+.mermaid-diagram-failed {
+  border-color: rgba(239, 68, 68, 0.55);
 }
 
 /* ===== Buttons ===== */

--- a/Website/static/js/main.js
+++ b/Website/static/js/main.js
@@ -7,6 +7,10 @@
 
 // Mobile nav toggle
 document.addEventListener('DOMContentLoaded', function () {
+  var mermaidScriptUrl = 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js';
+  var mermaidLoadPromise = null;
+  var mermaidThemeObserver = null;
+
   function loadScript(src) {
     return new Promise(function (resolve) {
       var existing = document.querySelector('script[data-dynamic-src="' + src + '"]');
@@ -36,44 +40,113 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
-  async function renderMermaidDiagrams() {
-    var blocks = Array.from(document.querySelectorAll('pre code.language-mermaid'));
-    if (!blocks.length) {
-      return;
-    }
+  function getThemeName() {
+    var theme = document.documentElement.getAttribute('data-theme');
+    return theme === 'light' ? 'light' : 'dark';
+  }
 
-    var loaded = await loadScript('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js');
-    if (!loaded || !window.mermaid) {
-      return;
-    }
+  function getCssVar(name, fallback) {
+    var value = getComputedStyle(document.documentElement).getPropertyValue(name);
+    if (!value) return fallback;
+    var trimmed = value.trim();
+    return trimmed || fallback;
+  }
 
-    var isLight = document.documentElement.getAttribute('data-theme') === 'light';
-    window.mermaid.initialize({
+  function getMermaidConfig() {
+    var isLight = getThemeName() === 'light';
+    return {
       startOnLoad: false,
       securityLevel: 'strict',
-      theme: isLight ? 'default' : 'dark'
-    });
+      theme: 'base',
+      flowchart: { curve: 'basis' },
+      themeVariables: {
+        background: getCssVar('--pf-code-bg', isLight ? '#F1F5F9' : '#0B1220'),
+        primaryColor: getCssVar('--pf-card-bg', isLight ? '#E2E8F0' : '#1E293B'),
+        primaryTextColor: getCssVar('--pf-ink-strong', isLight ? '#0F172A' : '#F8FAFC'),
+        primaryBorderColor: getCssVar('--pf-accent', isLight ? '#0891B2' : '#06B6D4'),
+        lineColor: getCssVar('--pf-muted', isLight ? '#64748B' : '#94A3B8'),
+        secondaryColor: getCssVar('--pf-bg-alt', isLight ? '#E2E8F0' : '#111827'),
+        tertiaryColor: getCssVar('--pf-glow-primary', isLight ? '#DBEAFE' : '#1F2937'),
+        clusterBkg: getCssVar('--pf-bg-alt', isLight ? '#E2E8F0' : '#111827'),
+        clusterBorder: getCssVar('--pf-border', isLight ? '#94A3B8' : '#334155'),
+        fontFamily: getCssVar('--pf-font-body', 'Segoe UI, sans-serif'),
+        fontSize: '15px'
+      }
+    };
+  }
 
+  function ensureMermaidLoaded() {
+    if (window.mermaid) {
+      return Promise.resolve(true);
+    }
+    if (!mermaidLoadPromise) {
+      mermaidLoadPromise = loadScript(mermaidScriptUrl);
+    }
+    return mermaidLoadPromise;
+  }
+
+  function normalizeMermaidBlocks() {
+    var blocks = Array.from(document.querySelectorAll('pre code.language-mermaid'));
     blocks.forEach(function (code) {
       var pre = code.closest('pre');
-      if (!pre) return;
+      if (!pre || pre.parentElement && pre.parentElement.classList.contains('mermaid-diagram')) {
+        return;
+      }
 
       var source = (code.textContent || '').trim();
       if (!source) return;
 
       var host = document.createElement('div');
       host.className = 'mermaid-diagram';
+      host.setAttribute('data-mermaid-source', source);
+      pre.replaceWith(host);
+    });
+  }
+
+  async function renderMermaidDiagrams() {
+    normalizeMermaidBlocks();
+    var hosts = Array.from(document.querySelectorAll('.mermaid-diagram[data-mermaid-source]'));
+    if (!hosts.length) {
+      return;
+    }
+
+    var loaded = await ensureMermaidLoaded();
+    if (!loaded || !window.mermaid) {
+      return;
+    }
+
+    window.mermaid.initialize(getMermaidConfig());
+
+    var nodes = [];
+    hosts.forEach(function (host) {
+      var source = host.getAttribute('data-mermaid-source') || '';
+      host.classList.remove('mermaid-diagram-failed');
+      host.innerHTML = '';
+
       var diagram = document.createElement('div');
       diagram.className = 'mermaid';
       diagram.textContent = source;
       host.appendChild(diagram);
-      pre.replaceWith(host);
+      nodes.push(diagram);
     });
 
     try {
-      await window.mermaid.run({ querySelector: '.mermaid-diagram .mermaid' });
+      await window.mermaid.run({ nodes: nodes });
     } catch (err) {
       console.warn('Mermaid render failed', err);
+      hosts.forEach(function (host) {
+        if (host.querySelector('svg')) {
+          return;
+        }
+        host.classList.add('mermaid-diagram-failed');
+        var fallback = document.createElement('pre');
+        var code = document.createElement('code');
+        code.className = 'language-mermaid';
+        code.textContent = host.getAttribute('data-mermaid-source') || '';
+        fallback.appendChild(code);
+        host.innerHTML = '';
+        host.appendChild(fallback);
+      });
     }
   }
 
@@ -91,8 +164,23 @@ document.addEventListener('DOMContentLoaded', function () {
       var next = current === 'dark' ? 'light' : 'dark';
       document.documentElement.setAttribute('data-theme', next);
       localStorage.setItem('theme', next);
+      renderMermaidDiagrams();
     });
   });
+
+  if (!mermaidThemeObserver) {
+    mermaidThemeObserver = new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'data-theme') {
+          renderMermaidDiagrams();
+        }
+      });
+    });
+    mermaidThemeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme']
+    });
+  }
 
   // Code tabs
   document.querySelectorAll('.code-tabs').forEach(function (tabBar) {


### PR DESCRIPTION
## Summary\n- make Mermaid rendering theme-aware and re-render on theme toggle\n- add colorful, readable Mermaid diagrams to core docs flows (reviewer, tools, library, chat)\n- add safe Mermaid fallback rendering when parse/render fails\n\n## Why\n- fixes diagram theme mismatch where diagrams could remain dark after switching to light theme\n- improves docs clarity with visual flow maps for onboarding, reviewer runtime, tool loading, and package architecture\n\n## Validation\n- ran ./build.ps1 -CI -PowerForgeRoot C:\\Support\\GitHub\\PSPublishModule in Website\n- pipeline passed with doctor/audit 0 errors, 0 warnings