### PR TITLE
Chat App: simplify runtime setup with auto-detect + clear-key flow

### DIFF
--- a/Docs/apps/chat-local-providers.md
+++ b/Docs/apps/chat-local-providers.md
@@ -13,15 +13,17 @@ Examples: Ollama, LM Studio, llama.cpp server, and similar OpenAI-compat endpoin
 For the WinUI desktop app (`Build/Run-ChatApp.ps1`):
 
 1. Open **Options -> Profile -> Model Runtime**.
-2. Click **Use Ollama Runtime** or **Use LM Studio Runtime**.
-3. If your provider needs auth, enter **API key (optional)**.
-4. The app applies runtime settings immediately and refreshes model discovery.
-5. If needed, choose a model from **Discovered models** and click **Apply Runtime**.
+2. Click **Auto Detect Runtime** (recommended). The app probes common local endpoints and picks an available runtime.
+3. If auto-detect is not available, use **Use LM Studio Runtime** or **Use Ollama Runtime** when shown.
+4. If your provider needs auth, enter **API key (optional)**.
+5. The app applies runtime settings immediately and refreshes model discovery.
+6. If needed, choose a model from **Discovered models** (or switch to manual input) and click **Apply Runtime**.
 
 Notes:
 - `Refresh Models` applies pending runtime field changes first, then refreshes discovery.
 - For `compatible-http`, if the current model is empty or invalid, the app auto-selects the first discovered model.
 - Leaving API key empty keeps the currently saved key unchanged.
+- Use **Clear Saved API Key** to remove the saved key from the active profile.
 
 ## Security Model
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ServiceLaunchArgumentsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ServiceLaunchArgumentsTests.cs
@@ -86,6 +86,27 @@ public sealed class ServiceLaunchArgumentsTests {
     }
 
     /// <summary>
+    /// Ensures explicit API-key clearing emits a dedicated clear flag.
+    /// </summary>
+    [Fact]
+    public void Build_IncludesClearApiKeyFlag_WhenRequested() {
+        var args = ServiceLaunchArguments.Build(
+            "intelligencex.chat",
+            detachedServiceMode: true,
+            parentProcessId: 12345,
+            new ServiceLaunchArguments.ProfileOptions {
+                LoadProfileName = "default",
+                SaveProfileName = "default",
+                OpenAITransport = "compatible-http",
+                OpenAIBaseUrl = "http://127.0.0.1:1234/v1",
+                ClearOpenAIApiKey = true
+            });
+
+        Assert.DoesNotContain("--openai-api-key", args);
+        Assert.Contains("--openai-clear-api-key", args);
+    }
+
+    /// <summary>
     /// Ensures unknown transport values are rejected.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Launch/ServiceLaunchArguments.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Launch/ServiceLaunchArguments.cs
@@ -14,6 +14,7 @@ internal static class ServiceLaunchArguments {
         public string? OpenAITransport { get; init; }
         public string? OpenAIBaseUrl { get; init; }
         public string? OpenAIApiKey { get; init; }
+        public bool ClearOpenAIApiKey { get; init; }
         public bool? OpenAIStreaming { get; init; }
         public bool? OpenAIAllowInsecureHttp { get; init; }
     }
@@ -58,7 +59,11 @@ internal static class ServiceLaunchArguments {
         }
 
         AddKeyValueArg(args, "--openai-base-url", profileOptions.OpenAIBaseUrl);
-        AddKeyValueArg(args, "--openai-api-key", profileOptions.OpenAIApiKey);
+        if (profileOptions.ClearOpenAIApiKey) {
+            args.Add("--openai-clear-api-key");
+        } else {
+            AddKeyValueArg(args, "--openai-api-key", profileOptions.OpenAIApiKey);
+        }
 
         if (profileOptions.OpenAIStreaming.HasValue) {
             args.Add(profileOptions.OpenAIStreaming.Value ? "--openai-stream" : "--openai-no-stream");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -27,6 +28,13 @@ using Windows.Graphics;
 namespace IntelligenceX.Chat.App;
 
 public sealed partial class MainWindow : Window {
+    private sealed record LocalRuntimeDetectionSnapshot(
+        bool LmStudioAvailable,
+        bool OllamaAvailable,
+        string? DetectedName,
+        string? DetectedBaseUrl,
+        string? Warning);
+
     private async Task RefreshModelsFromUiAsync(bool forceRefresh) {
         if (!await EnsureConnectedAsync().ConfigureAwait(false)) {
             return;
@@ -49,6 +57,32 @@ public sealed partial class MainWindow : Window {
         await RefreshModelsAsync(client, forceModelRefresh, publishOptions: false, appendWarnings).ConfigureAwait(false);
         await PublishOptionsStateAsync().ConfigureAwait(false);
         return profileApplied;
+    }
+
+    private async Task RefreshLocalRuntimeDetectionAsync(bool publishOptions) {
+        var snapshot = await ProbeLocalRuntimeAvailabilityAsync().ConfigureAwait(false);
+        ApplyLocalRuntimeDetectionSnapshot(snapshot);
+        if (publishOptions) {
+            await PublishOptionsStateAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task AutoDetectAndApplyLocalRuntimeAsync(bool forceModelRefresh) {
+        var snapshot = await ProbeLocalRuntimeAvailabilityAsync().ConfigureAwait(false);
+        ApplyLocalRuntimeDetectionSnapshot(snapshot);
+        if (string.IsNullOrWhiteSpace(snapshot.DetectedBaseUrl)) {
+            await SetStatusAsync("No local runtime detected. Start LM Studio or Ollama, then try again.").ConfigureAwait(false);
+            await PublishOptionsStateAsync().ConfigureAwait(false);
+            return;
+        }
+
+        await ApplyLocalProviderAsync(
+            TransportCompatibleHttp,
+            snapshot.DetectedBaseUrl,
+            string.Empty,
+            apiKeyValue: null,
+            clearApiKey: false,
+            forceModelRefresh: forceModelRefresh).ConfigureAwait(false);
     }
 
     private async Task RefreshServiceProfilesAsync(ChatServiceClient client, bool publishOptions, bool appendWarnings) {
@@ -118,7 +152,7 @@ public sealed partial class MainWindow : Window {
         }
     }
 
-    private async Task ApplyLocalProviderAsync(string? transportValue, string? baseUrlValue, string? modelValue, string? apiKeyValue, bool forceModelRefresh) {
+    private async Task ApplyLocalProviderAsync(string? transportValue, string? baseUrlValue, string? modelValue, string? apiKeyValue, bool clearApiKey, bool forceModelRefresh) {
         if (_isSending) {
             await SetStatusAsync("Finish the active response before changing local runtime settings.").ConfigureAwait(false);
             return;
@@ -128,8 +162,9 @@ public sealed partial class MainWindow : Window {
         var normalizedTransport = NormalizeLocalProviderTransport(rawTransport);
         var normalizedBaseUrl = NormalizeLocalProviderBaseUrl(baseUrlValue, normalizedTransport, rawTransport);
         var normalizedModel = NormalizeLocalProviderModel(modelValue, normalizedTransport);
+        var clearApiKeyRequested = clearApiKey && string.Equals(normalizedTransport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase);
         var normalizedApiKey = NormalizeLocalProviderApiKey(apiKeyValue, normalizedTransport);
-        var hasApiKeyUpdate = normalizedApiKey is not null;
+        var hasApiKeyUpdate = clearApiKeyRequested || normalizedApiKey is not null;
 
         var changed = !string.Equals(_localProviderTransport, normalizedTransport, StringComparison.OrdinalIgnoreCase)
                       || !string.Equals(_localProviderBaseUrl ?? string.Empty, normalizedBaseUrl ?? string.Empty, StringComparison.OrdinalIgnoreCase)
@@ -161,11 +196,13 @@ public sealed partial class MainWindow : Window {
             OpenAITransport = _localProviderTransport,
             OpenAIBaseUrl = _localProviderBaseUrl,
             OpenAIApiKey = normalizedApiKey,
+            ClearOpenAIApiKey = clearApiKeyRequested,
             OpenAIStreaming = true,
             OpenAIAllowInsecureHttp = ShouldAllowInsecureHttp(_localProviderTransport, _localProviderBaseUrl)
         };
 
         await RestartSidecarAsync().ConfigureAwait(false);
+        await RefreshLocalRuntimeDetectionAsync(publishOptions: false).ConfigureAwait(false);
         await SyncConnectedServiceProfileAndModelsAsync(
             forceModelRefresh: true,
             setProfileNewThread: false,
@@ -310,5 +347,90 @@ public sealed partial class MainWindow : Window {
         }
 
         return string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<LocalRuntimeDetectionSnapshot> ProbeLocalRuntimeAvailabilityAsync() {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var lmStudio = await ProbeModelsEndpointAsync(DefaultLmStudioBaseUrl, cts.Token).ConfigureAwait(false);
+        var ollama = await ProbeModelsEndpointAsync(DefaultOllamaBaseUrl, cts.Token).ConfigureAwait(false);
+
+        if (lmStudio) {
+            return new LocalRuntimeDetectionSnapshot(
+                LmStudioAvailable: true,
+                OllamaAvailable: ollama,
+                DetectedName: "LM Studio",
+                DetectedBaseUrl: DefaultLmStudioBaseUrl,
+                Warning: null);
+        }
+
+        if (ollama) {
+            return new LocalRuntimeDetectionSnapshot(
+                LmStudioAvailable: false,
+                OllamaAvailable: true,
+                DetectedName: "Ollama",
+                DetectedBaseUrl: DefaultOllamaBaseUrl,
+                Warning: null);
+        }
+
+        return new LocalRuntimeDetectionSnapshot(
+            LmStudioAvailable: false,
+            OllamaAvailable: false,
+            DetectedName: null,
+            DetectedBaseUrl: null,
+            Warning: "No local runtime detected on localhost ports 1234 or 11434.");
+    }
+
+    private void ApplyLocalRuntimeDetectionSnapshot(LocalRuntimeDetectionSnapshot snapshot) {
+        _localRuntimeDetectionRan = true;
+        _localRuntimeLmStudioAvailable = snapshot.LmStudioAvailable;
+        _localRuntimeOllamaAvailable = snapshot.OllamaAvailable;
+        _localRuntimeDetectedName = snapshot.DetectedName;
+        _localRuntimeDetectedBaseUrl = snapshot.DetectedBaseUrl;
+        _localRuntimeDetectionWarning = snapshot.Warning;
+    }
+
+    private static async Task<bool> ProbeModelsEndpointAsync(string baseUrl, CancellationToken cancellationToken) {
+        var probeUrl = BuildModelsProbeUrl(baseUrl);
+        using var handler = new HttpClientHandler {
+            UseProxy = false
+        };
+        using var client = new HttpClient(handler) {
+            Timeout = TimeSpan.FromSeconds(2)
+        };
+
+        try {
+            using var request = new HttpRequestMessage(HttpMethod.Get, probeUrl);
+            using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            return response.IsSuccessStatusCode;
+        } catch {
+            return false;
+        }
+    }
+
+    private static string BuildModelsProbeUrl(string baseUrl) {
+        var normalized = (baseUrl ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return "http://127.0.0.1:11434/v1/models";
+        }
+
+        if (!Uri.TryCreate(normalized, UriKind.Absolute, out var uri)) {
+            return normalized;
+        }
+
+        var path = uri.AbsolutePath ?? string.Empty;
+        if (!path.EndsWith("/", StringComparison.Ordinal)) {
+            path += "/";
+        }
+
+        if (!path.Contains("/v1/", StringComparison.OrdinalIgnoreCase)) {
+            path += "v1/";
+        }
+
+        var builder = new UriBuilder(uri) {
+            Path = path + "models",
+            Query = string.Empty
+        };
+
+        return builder.Uri.ToString();
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
@@ -105,8 +105,15 @@ public sealed partial class MainWindow : Window {
                     await PublishOptionsStateAsync().ConfigureAwait(true);
                     break;
                 case "options_refresh":
+                    await RefreshLocalRuntimeDetectionAsync(publishOptions: false).ConfigureAwait(true);
                     await PublishOptionsStateAsync().ConfigureAwait(true);
                     break;
+                case "auto_detect_local_runtime":
+                    {
+                        var forceRefresh = TryGetBoolean(root, "forceRefresh");
+                        await AutoDetectAndApplyLocalRuntimeAsync(forceRefresh ?? true).ConfigureAwait(true);
+                        break;
+                    }
                 case "refresh_models":
                     {
                         var forceRefresh = TryGetBoolean(root, "forceRefresh");
@@ -278,8 +285,9 @@ public sealed partial class MainWindow : Window {
                         var baseUrl = TryGetString(root, "baseUrl");
                         var model = TryGetString(root, "model");
                         var apiKey = TryGetString(root, "apiKey");
+                        var clearApiKey = TryGetBoolean(root, "clearApiKey");
                         var forceRefresh = TryGetBoolean(root, "forceRefresh");
-                        await ApplyLocalProviderAsync(transport, baseUrl, model, apiKey, forceRefresh ?? true).ConfigureAwait(true);
+                        await ApplyLocalProviderAsync(transport, baseUrl, model, apiKey, clearApiKey ?? false, forceRefresh ?? true).ConfigureAwait(true);
                         break;
                     }
                 case "restart_onboarding":

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
@@ -345,6 +345,7 @@ public sealed partial class MainWindow : Window {
                     OpenAITransport = pending.OpenAITransport,
                     OpenAIBaseUrl = pending.OpenAIBaseUrl,
                     OpenAIApiKey = pending.OpenAIApiKey,
+                    ClearOpenAIApiKey = pending.ClearOpenAIApiKey,
                     OpenAIStreaming = pending.OpenAIStreaming,
                     OpenAIAllowInsecureHttp = pending.OpenAIAllowInsecureHttp
                 });

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -255,7 +255,15 @@ public sealed partial class MainWindow : Window {
                 recentModels = _recentModels,
                 isStale = _modelListIsStale,
                 warning = _modelListWarning,
-                profileSaved = Array.Exists(_serviceProfileNames, name => string.Equals(name, _appProfileName, StringComparison.OrdinalIgnoreCase))
+                profileSaved = Array.Exists(_serviceProfileNames, name => string.Equals(name, _appProfileName, StringComparison.OrdinalIgnoreCase)),
+                runtimeDetection = new {
+                    hasRun = _localRuntimeDetectionRan,
+                    lmStudioAvailable = _localRuntimeLmStudioAvailable,
+                    ollamaAvailable = _localRuntimeOllamaAvailable,
+                    detectedName = _localRuntimeDetectedName ?? string.Empty,
+                    detectedBaseUrl = _localRuntimeDetectedBaseUrl ?? string.Empty,
+                    warning = _localRuntimeDetectionWarning ?? string.Empty
+                }
             },
             packs,
             tools,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -153,6 +153,12 @@ public sealed partial class MainWindow : Window {
     private string _localProviderTransport = TransportNative;
     private string? _localProviderBaseUrl;
     private string _localProviderModel = DefaultLocalModel;
+    private bool _localRuntimeDetectionRan;
+    private bool _localRuntimeLmStudioAvailable;
+    private bool _localRuntimeOllamaAvailable;
+    private string? _localRuntimeDetectedName;
+    private string? _localRuntimeDetectedBaseUrl;
+    private string? _localRuntimeDetectionWarning;
     private ModelInfoDto[] _availableModels = Array.Empty<ModelInfoDto>();
     private string[] _favoriteModels = Array.Empty<string>();
     private string[] _recentModels = Array.Empty<string>();
@@ -246,6 +252,7 @@ public sealed partial class MainWindow : Window {
         public string? OpenAITransport { get; init; }
         public string? OpenAIBaseUrl { get; init; }
         public string? OpenAIApiKey { get; init; }
+        public bool ClearOpenAIApiKey { get; init; }
         public bool? OpenAIStreaming { get; init; }
         public bool? OpenAIAllowInsecureHttp { get; init; }
     }
@@ -731,6 +738,12 @@ public sealed partial class MainWindow : Window {
         _appState.LocalProviderTransport = _localProviderTransport;
         _appState.LocalProviderBaseUrl = _localProviderBaseUrl;
         _appState.LocalProviderModel = _localProviderModel;
+        _localRuntimeDetectionRan = false;
+        _localRuntimeLmStudioAvailable = false;
+        _localRuntimeOllamaAvailable = false;
+        _localRuntimeDetectedName = null;
+        _localRuntimeDetectedBaseUrl = null;
+        _localRuntimeDetectionWarning = null;
         _availableModels = Array.Empty<ModelInfoDto>();
         _favoriteModels = Array.Empty<string>();
         _recentModels = Array.Empty<string>();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
@@ -84,7 +84,15 @@
         recentModels: [],
         isStale: false,
         warning: "",
-        profileSaved: false
+        profileSaved: false,
+        runtimeDetection: {
+          hasRun: false,
+          lmStudioAvailable: false,
+          ollamaAvailable: false,
+          detectedName: "",
+          detectedBaseUrl: "",
+          warning: ""
+        }
       },
       debugToolsEnabled: false,
       toolFilter: "",

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -423,11 +423,32 @@
     var warning = normalizeModelText(local.warning || "");
     var isStale = local.isStale === true;
     var profileSaved = local.profileSaved === true;
+    var runtimeDetection = local.runtimeDetection || {};
+    var runtimeDetectionHasRun = runtimeDetection.hasRun === true;
+    var lmStudioAvailable = runtimeDetection.lmStudioAvailable === true;
+    var ollamaAvailable = runtimeDetection.ollamaAvailable === true;
+    var runtimeDetectedName = normalizeModelText(runtimeDetection.detectedName || "");
+    var runtimeDetectionWarning = normalizeModelText(runtimeDetection.warning || "");
 
     var transportSelect = byId("optLocalTransport");
     if (transportSelect) {
       transportSelect.value = transport;
       syncCustomSelect(transportSelect);
+    }
+
+    var btnAutoDetect = byId("btnAutoDetectLocalRuntime");
+    if (btnAutoDetect) {
+      btnAutoDetect.hidden = transport !== "compatible-http";
+    }
+
+    var btnPresetLmStudio = byId("btnLocalPresetLmStudio");
+    if (btnPresetLmStudio) {
+      btnPresetLmStudio.hidden = runtimeDetectionHasRun && !lmStudioAvailable;
+    }
+
+    var btnPresetOllama = byId("btnLocalPresetOllama");
+    if (btnPresetOllama) {
+      btnPresetOllama.hidden = runtimeDetectionHasRun && !ollamaAvailable;
     }
 
     var baseUrlRow = byId("optLocalBaseUrlRow");
@@ -444,6 +465,11 @@
     var apiKeyRow = byId("optLocalApiKeyRow");
     if (apiKeyRow) {
       apiKeyRow.hidden = transport !== "compatible-http";
+    }
+
+    var apiKeyHint = byId("optLocalApiKeyHint");
+    if (apiKeyHint) {
+      apiKeyHint.hidden = transport !== "compatible-http";
     }
 
     var apiKeyInput = byId("optLocalApiKey");
@@ -498,7 +524,11 @@
           continue;
         }
         var displayName = normalizeModelText(item.displayName || item.DisplayName);
-        pushModelOption(modelName, displayName ? (displayName + " ->") : "");
+        if (displayName && displayName.toLowerCase() !== modelName.toLowerCase()) {
+          pushModelOption(modelName, displayName + ":");
+        } else {
+          pushModelOption(modelName, "");
+        }
       }
 
       modelSelect.value = model;
@@ -508,9 +538,28 @@
       syncCustomSelect(modelSelect);
     }
 
+    var modelInputRow = byId("optLocalModelInputRow");
+    var modelSelectRow = byId("optLocalModelSelectRow");
+    var hasSelectableModels = recents.length > 0 || favorites.length > 0 || models.length > 0;
+    var usingManualInput = !modelSelect || !hasSelectableModels || modelSelect.value === "";
+    if (modelSelectRow) {
+      modelSelectRow.hidden = !hasSelectableModels;
+    }
+    if (modelInputRow) {
+      modelInputRow.hidden = hasSelectableModels && !usingManualInput;
+    }
+    if (modelInput) {
+      modelInput.disabled = hasSelectableModels && !usingManualInput;
+    }
+
     var stateNote = byId("optLocalModelsState");
     if (stateNote) {
       var parts = [];
+      if (transport === "compatible-http" && runtimeDetectedName) {
+        parts.push("detected runtime: " + runtimeDetectedName);
+      } else if (transport === "compatible-http" && runtimeDetectionHasRun && runtimeDetectionWarning) {
+        parts.push(runtimeDetectionWarning);
+      }
       if (models.length > 0) {
         parts.push(String(models.length) + " models discovered");
       } else {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -555,18 +555,23 @@
     return String(value || "").toLowerCase() === "compatible-http" ? "compatible-http" : "native";
   }
 
-  function applyLocalProviderSettings(forceRefresh) {
+  function applyLocalProviderSettings(forceRefresh, clearApiKey) {
     var transport = normalizeLocalTransportValue(byId("optLocalTransport").value || "native");
     var baseUrl = (byId("optLocalBaseUrl").value || "").trim();
     var model = (byId("optLocalModelInput").value || "").trim();
+    var shouldClearApiKey = clearApiKey === true;
     var apiKey = transport === "compatible-http"
       ? (byId("optLocalApiKey").value || "").trim()
       : "";
+    if (shouldClearApiKey) {
+      apiKey = "";
+    }
     post("apply_local_provider", {
       transport: transport,
       baseUrl: baseUrl,
       model: model,
       apiKey: apiKey,
+      clearApiKey: shouldClearApiKey,
       forceRefresh: forceRefresh !== false
     });
   }
@@ -602,7 +607,9 @@
     var baseRow = byId("optLocalBaseUrlRow");
     var baseInput = byId("optLocalBaseUrl");
     var apiKeyRow = byId("optLocalApiKeyRow");
+    var apiKeyHint = byId("optLocalApiKeyHint");
     var apiKeyInput = byId("optLocalApiKey");
+    var autoDetectButton = byId("btnAutoDetectLocalRuntime");
     if (baseRow) {
       baseRow.hidden = next !== "compatible-http";
     }
@@ -610,10 +617,22 @@
       baseInput.disabled = next !== "compatible-http";
       if (next !== "compatible-http") {
         baseInput.value = "";
+      } else if (!(baseInput.value || "").trim()) {
+        var runtimeDetection = (((state.options || {}).localModel || {}).runtimeDetection || {});
+        var lmStudioAvailable = runtimeDetection.lmStudioAvailable === true;
+        var ollamaAvailable = runtimeDetection.ollamaAvailable === true;
+        if (lmStudioAvailable && !ollamaAvailable) {
+          baseInput.value = "http://127.0.0.1:1234/v1";
+        } else if (ollamaAvailable && !lmStudioAvailable) {
+          baseInput.value = "http://127.0.0.1:11434";
+        }
       }
     }
     if (apiKeyRow) {
       apiKeyRow.hidden = next !== "compatible-http";
+    }
+    if (apiKeyHint) {
+      apiKeyHint.hidden = next !== "compatible-http";
     }
     if (apiKeyInput) {
       apiKeyInput.disabled = next !== "compatible-http";
@@ -621,14 +640,35 @@
         apiKeyInput.value = "";
       }
     }
+    if (autoDetectButton) {
+      autoDetectButton.hidden = next !== "compatible-http";
+    }
   });
 
   byId("optLocalModelSelect").addEventListener("change", function(e) {
     var selected = (e.target.value || "").trim();
+    var modelInput = byId("optLocalModelInput");
+    var modelInputRow = byId("optLocalModelInputRow");
     if (!selected) {
+      if (modelInput) {
+        modelInput.disabled = false;
+      }
+      if (modelInputRow) {
+        modelInputRow.hidden = false;
+      }
       return;
     }
-    byId("optLocalModelInput").value = selected;
+    if (modelInput) {
+      modelInput.value = selected;
+      modelInput.disabled = true;
+    }
+    if (modelInputRow) {
+      modelInputRow.hidden = true;
+    }
+  });
+
+  byId("btnAutoDetectLocalRuntime").addEventListener("click", function() {
+    post("auto_detect_local_runtime", { forceRefresh: true });
   });
 
   byId("btnLocalPresetOllama").addEventListener("click", function() {
@@ -640,6 +680,7 @@
     byId("optLocalBaseUrlRow").hidden = false;
     baseUrl.disabled = false;
     byId("optLocalApiKeyRow").hidden = false;
+    byId("optLocalApiKeyHint").hidden = false;
     byId("optLocalApiKey").disabled = false;
     applyLocalProviderSettings(true);
   });
@@ -653,6 +694,7 @@
     byId("optLocalBaseUrlRow").hidden = false;
     baseUrl.disabled = false;
     byId("optLocalApiKeyRow").hidden = false;
+    byId("optLocalApiKeyHint").hidden = false;
     byId("optLocalApiKey").disabled = false;
     applyLocalProviderSettings(true);
   });
@@ -667,6 +709,14 @@
 
   byId("btnApplyLocalProvider").addEventListener("click", function() {
     applyLocalProviderSettings(true);
+  });
+
+  byId("btnClearLocalApiKey").addEventListener("click", function() {
+    if (normalizeLocalTransportValue(byId("optLocalTransport").value || "native") !== "compatible-http") {
+      return;
+    }
+    byId("optLocalApiKey").value = "";
+    applyLocalProviderSettings(true, true);
   });
 
   var btnNewConversation = byId("btnNewConversation");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -145,7 +145,7 @@
           </div>
           <div class="options-label">Model Runtime</div>
           <div class="options-note">Configure runtime provider + model and persist it to the active service profile.</div>
-          <div class="options-row">
+          <div class="options-row" id="optLocalTransportRow">
             <label class="options-label-inline" for="optLocalTransport">Provider transport</label>
             <select id="optLocalTransport" class="options-select">
               <option value="native">OpenAI Native</option>
@@ -160,20 +160,23 @@
             <label class="options-label-inline" for="optLocalApiKey">API key (optional)</label>
             <input id="optLocalApiKey" type="password" class="options-input options-input-sm" placeholder="Leave blank to keep existing key" autocomplete="off" />
           </div>
-          <div class="options-row">
+          <div class="options-note" id="optLocalApiKeyHint">Use Clear Saved API Key to remove the currently stored key.</div>
+          <div class="options-row" id="optLocalModelInputRow">
             <label class="options-label-inline" for="optLocalModelInput">Model</label>
             <input id="optLocalModelInput" class="options-input options-input-sm" placeholder="e.g. gpt-5.3-codex or llama3.2" />
           </div>
-          <div class="options-row">
+          <div class="options-row" id="optLocalModelSelectRow">
             <label class="options-label-inline" for="optLocalModelSelect">Discovered models</label>
             <select id="optLocalModelSelect" class="options-select"></select>
           </div>
           <div class="options-note" id="optLocalModelsState"></div>
-          <div class="options-note">Preset buttons apply runtime settings immediately and refresh model discovery.</div>
+          <div class="options-note">Auto-detect picks an available local runtime and refreshes models.</div>
           <div class="options-actions options-actions-wrap">
+            <button id="btnAutoDetectLocalRuntime" class="options-btn options-btn-sm">Auto Detect Runtime</button>
             <button id="btnLocalPresetOllama" class="options-btn options-btn-sm options-btn-ghost">Use Ollama Runtime</button>
             <button id="btnLocalPresetLmStudio" class="options-btn options-btn-sm options-btn-ghost">Use LM Studio Runtime</button>
             <button id="btnRefreshModels" class="options-btn options-btn-sm options-btn-ghost">Refresh Models</button>
+            <button id="btnClearLocalApiKey" class="options-btn options-btn-sm options-btn-ghost">Clear Saved API Key</button>
             <button id="btnApplyLocalProvider" class="options-btn options-btn-sm">Apply Runtime</button>
           </div>
           <div class="options-actions">

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -167,6 +167,10 @@ internal sealed class ServiceOptions {
                 options.OpenAIApiKey = value;
                 continue;
             }
+            if (arg is "--openai-clear-api-key") {
+                options.OpenAIApiKey = null;
+                continue;
+            }
             if (arg is "--openai-stream") {
                 options.OpenAIStreaming = true;
                 continue;
@@ -395,6 +399,7 @@ internal sealed class ServiceOptions {
         Console.WriteLine("  --openai-transport <KIND>  Underlying provider transport: native|appserver|compatible-http (default: native).");
         Console.WriteLine("  --openai-base-url <URL> Base URL for compatible-http (example: http://127.0.0.1:11434 or http://127.0.0.1:11434/v1).");
         Console.WriteLine("  --openai-api-key <KEY>  Optional Bearer token for compatible-http.");
+        Console.WriteLine("  --openai-clear-api-key Clear any saved compatible-http API key when profile overrides are saved.");
         Console.WriteLine("  --openai-stream         Request streaming responses (default: on).");
         Console.WriteLine("  --openai-no-stream      Disable streaming responses.");
         Console.WriteLine("  --openai-allow-insecure-http  Allow http:// base URLs for loopback hosts (default: off).");

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -41,10 +41,10 @@ Markdown renderer dependency resolution is automatic:
 Inside the app:
 
 1. Open **Options -> Profile -> Model Runtime**.
-2. Click **Use Ollama Runtime** or **Use LM Studio Runtime**.
+2. Click **Auto Detect Runtime** (recommended) or pick LM Studio/Ollama if shown.
 3. Wait for model discovery to populate.
 4. If your provider needs auth, enter **API key (optional)**.
-5. Optionally choose a model and click **Apply Runtime**.
+5. Optionally choose a discovered model (or switch to manual model input), then click **Apply Runtime**.
 
 Reference: `Docs/apps/chat-local-providers.md`
 


### PR DESCRIPTION
## Summary
- simplify **Model Runtime** UX with context-aware controls:
  - add **Auto Detect Runtime** action for LM Studio/Ollama local endpoints
  - hide LM Studio/Ollama preset buttons when runtime detection says unavailable
  - auto-fill base URL when exactly one local runtime is detected
  - reduce model-selection clutter by showing either discovered model picker or manual input at a time
- add explicit **Clear Saved API Key** flow end-to-end:
  - UI sends `clearApiKey`
  - app launch plumbing emits `--openai-clear-api-key`
  - service parses `--openai-clear-api-key` and persists cleared key in profile save path
- include runtime detection state in options payload so UI can adapt what it shows
- update local-provider docs/README for auto-detect and clear-key behavior

## Why
Users were seeing too many controls at once and stale/irrelevant choices, which made runtime setup confusing. This change makes setup more guided and self-adapting while keeping ChatGPT native as the default.

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release` (123 passed)
