### PR TITLE
OfficeIMO read: add document-mode indexing payloads

### DIFF
--- a/IntelligenceX.Tools/Docs/OfficeIMO.md
+++ b/IntelligenceX.Tools/Docs/OfficeIMO.md
@@ -7,7 +7,7 @@
 - `officeimo_pack_info`
   - Returns capabilities, limits, and recommended flow.
 - `officeimo_read`
-  - Reads a single file or a folder and emits normalized chunks for model reasoning.
+  - Reads a single file or a folder and emits normalized chunks and/or source-level documents for reasoning/indexing.
 
 ## Supported formats
 
@@ -43,19 +43,27 @@
 - `include_word_footnotes`: include Word footnotes.
 - `include_ppt_notes`: include PowerPoint speaker notes.
 - `markdown_chunk_by_headings`: chunk markdown by headings when possible.
+- `output_mode`: payload shape selector:
+  - `chunks` (default): return flat `chunks`.
+  - `documents`: return per-source `documents` payload.
+  - `both`: return both flat `chunks` and `documents`.
+- `include_document_chunks`: when `output_mode` includes `documents`, controls whether each document includes its `chunks` array (default: `true`).
 
 ## Output shape
 
 `officeimo_read` returns a standard tool envelope with:
 
 - `files`: ingested file list
-- `chunks`: normalized chunk list (`id`, `kind`, `text`, optional `markdown`, `location`, `tables`, `warnings`)
+- `chunks`: normalized chunk list (`id`, `kind`, `text`, optional `markdown`, `location`, `tables`, `warnings`, `source_id`, `source_hash`, `chunk_hash`, `source_last_write_utc`, `source_length_bytes`, `token_estimate`)
+- `documents`: source-level list (`path`, `source_id`, `source_hash`, `parsed`, `chunks_produced`, `chunks_returned`, token totals, warnings, optional source chunks)
 - `warnings`: per-file warnings (skipped/unsupported/error)
 - `truncated`: indicates cap-based truncation
-- `meta`: includes `count`, `files`, and cap values
+- counters: `files_scanned`, `files_parsed`, `files_skipped`, `bytes_read`, `chunks_produced`, `chunks_returned`, `token_estimate_returned`
+- `meta`: includes `count`, caps, and output-shape counters
 - `summary_markdown`: compact preview of extracted chunks
 
-Use raw `chunks` fields for reasoning; treat `summary_markdown` as preview only.
+For incremental indexing, prefer `output_mode=documents` and upsert by `source_id`/`source_hash` + per-chunk `chunk_hash`.
+Use `summary_markdown` as preview only.
 
 ## Build modes (`OFFICEIMO_ENABLED` vs `OFFICEIMO_DISABLED`)
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoPackInfoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoPackInfoTool.cs
@@ -33,7 +33,8 @@ public sealed class OfficeImoPackInfoTool : OfficeImoToolBase, ITool {
             tools: ToolRegistryOfficeImoExtensions.GetRegisteredToolNames(Options),
             recommendedFlow: new[] {
                 "Use officeimo_pack_info to confirm caps and supported formats.",
-                "Use officeimo_read on a file or folder to extract normalized chunks for reasoning.",
+                "Use officeimo_read on a file or folder to extract normalized chunks/documents.",
+                "For indexing pipelines, set output_mode='documents' (or 'both') and upsert by source_id/source_hash + chunk_hash.",
                 "Reason from raw payload fields (chunks/text/tables). Use summary markdown only as a preview."
             },
             flowSteps: new[] {
@@ -44,12 +45,16 @@ public sealed class OfficeImoPackInfoTool : OfficeImoToolBase, ITool {
                 ToolPackGuidance.FlowStep(
                     goal: "Extract evidence from Office documents",
                     suggestedTools: new[] { "officeimo_read" },
-                    notes: "Prefer passing a folder to ingest a document set; use max_files/max_total_bytes to bound work.")
+                    notes: "Prefer passing a folder to ingest a document set; use max_files/max_total_bytes to bound work."),
+                ToolPackGuidance.FlowStep(
+                    goal: "Build incremental document index",
+                    suggestedTools: new[] { "officeimo_read" },
+                    notes: "Use output_mode='documents' and include_document_chunks=true to get per-source hashes/chunks for direct DB upserts.")
             },
             capabilities: new[] {
                 ToolPackGuidance.Capability(
                     id: "office_ingestion",
-                    summary: "Extract text/markdown/tables from Word/Excel/PowerPoint/Markdown/PDF files into AI-friendly chunks.",
+                    summary: "Extract text/markdown/tables from Word/Excel/PowerPoint/Markdown/PDF files into AI-friendly chunks and source-level documents.",
                     primaryTools: new[] { "officeimo_read" }),
                 ToolPackGuidance.Capability(
                     id: "bounded_access",

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace IntelligenceX.Tools.OfficeIMO;
@@ -17,6 +18,11 @@ public sealed class OfficeImoReadResult {
     public List<OfficeImoChunk> Chunks { get; set; } = new();
 
     /// <summary>
+    /// Source-level document payloads optimized for indexing/database upserts.
+    /// </summary>
+    public List<OfficeImoDocument> Documents { get; set; } = new();
+
+    /// <summary>
     /// Warnings (for example: truncation or skipped files).
     /// </summary>
     public List<string> Warnings { get; set; } = new();
@@ -25,6 +31,111 @@ public sealed class OfficeImoReadResult {
     /// Whether ingestion was truncated by caps.
     /// </summary>
     public bool Truncated { get; set; }
+
+    /// <summary>
+    /// Output shape selected by caller: <c>chunks</c>, <c>documents</c>, or <c>both</c>.
+    /// </summary>
+    public string OutputMode { get; set; } = "chunks";
+
+    /// <summary>
+    /// Files considered for ingestion (allowed extension scope).
+    /// </summary>
+    public int FilesScanned { get; set; }
+
+    /// <summary>
+    /// Files parsed successfully.
+    /// </summary>
+    public int FilesParsed { get; set; }
+
+    /// <summary>
+    /// Files skipped during ingestion.
+    /// </summary>
+    public int FilesSkipped { get; set; }
+
+    /// <summary>
+    /// Total bytes accepted for parsed files.
+    /// </summary>
+    public long BytesRead { get; set; }
+
+    /// <summary>
+    /// Total chunks produced by extraction before output shaping caps.
+    /// </summary>
+    public int ChunksProduced { get; set; }
+
+    /// <summary>
+    /// Total chunks returned in this tool payload after output shaping caps.
+    /// </summary>
+    public int ChunksReturned { get; set; }
+
+    /// <summary>
+    /// Aggregated token estimate across returned chunks (best-effort).
+    /// </summary>
+    public int TokenEstimateReturned { get; set; }
+}
+
+/// <summary>
+/// Source-level ingestion payload.
+/// </summary>
+public sealed class OfficeImoDocument {
+    /// <summary>
+    /// Source file path.
+    /// </summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Stable source identifier when available.
+    /// </summary>
+    public string? SourceId { get; set; }
+
+    /// <summary>
+    /// Source content hash when available.
+    /// </summary>
+    public string? SourceHash { get; set; }
+
+    /// <summary>
+    /// Source last write timestamp (UTC) when available.
+    /// </summary>
+    public DateTime? SourceLastWriteUtc { get; set; }
+
+    /// <summary>
+    /// Source length in bytes when available.
+    /// </summary>
+    public long? SourceLengthBytes { get; set; }
+
+    /// <summary>
+    /// True when parsing succeeded for the source.
+    /// </summary>
+    public bool Parsed { get; set; }
+
+    /// <summary>
+    /// Chunks produced by extraction for this source.
+    /// </summary>
+    public int ChunksProduced { get; set; }
+
+    /// <summary>
+    /// Chunks returned for this source after output shaping caps.
+    /// </summary>
+    public int ChunksReturned { get; set; }
+
+    /// <summary>
+    /// Token estimate produced by extraction for this source.
+    /// </summary>
+    public int TokenEstimateTotal { get; set; }
+
+    /// <summary>
+    /// Token estimate returned for this source after output shaping caps.
+    /// </summary>
+    public int TokenEstimateReturned { get; set; }
+
+    /// <summary>
+    /// Source-level warnings.
+    /// </summary>
+    public List<string> Warnings { get; set; } = new();
+
+    /// <summary>
+    /// Source-level returned chunks (optional based on output mode and flags).
+    /// </summary>
+    public List<OfficeImoChunk> Chunks { get; set; } = new();
 }
 
 /// <summary>
@@ -65,5 +176,34 @@ public sealed class OfficeImoChunk {
     /// Optional per-chunk warnings.
     /// </summary>
     public IReadOnlyList<string>? Warnings { get; set; }
-}
 
+    /// <summary>
+    /// Stable source identifier when available.
+    /// </summary>
+    public string? SourceId { get; set; }
+
+    /// <summary>
+    /// Source content hash when available.
+    /// </summary>
+    public string? SourceHash { get; set; }
+
+    /// <summary>
+    /// Chunk content hash when available.
+    /// </summary>
+    public string? ChunkHash { get; set; }
+
+    /// <summary>
+    /// Source last write timestamp (UTC) when available.
+    /// </summary>
+    public DateTime? SourceLastWriteUtc { get; set; }
+
+    /// <summary>
+    /// Source length in bytes when available.
+    /// </summary>
+    public long? SourceLengthBytes { get; set; }
+
+    /// <summary>
+    /// Best-effort token estimate for prompt budgeting.
+    /// </summary>
+    public int? TokenEstimate { get; set; }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadTool.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Json;
@@ -15,7 +16,7 @@ using OfficeIMO.Reader;
 namespace IntelligenceX.Tools.OfficeIMO;
 
 /// <summary>
-/// Reads a supported Office document (or a folder of documents) and emits AI-friendly chunks (safe-by-default; requires AllowedRoots).
+/// Reads a supported Office document (or a folder of documents) and emits AI-friendly chunks/documents.
 /// </summary>
 public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
     private static readonly string[] DefaultOfficeExtensions = {
@@ -28,7 +29,7 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
 
     private static readonly ToolDefinition DefinitionValue = new(
         "officeimo_read",
-        "Read a Word/Excel/PowerPoint/Markdown/PDF file (or a folder containing those) and return normalized chunks for reasoning.",
+        "Read a Word/Excel/PowerPoint/Markdown/PDF file (or a folder containing those) and return normalized chunks/documents for reasoning and indexing.",
         ToolSchema.Object(
                 ("path", ToolSchema.String("Path to a file or folder (absolute or relative).")),
                 ("recurse", ToolSchema.Boolean("If path is a folder, recurse into subfolders (default: false).")),
@@ -44,7 +45,9 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
                 ("excel_headers_in_first_row", ToolSchema.Boolean("Whether to treat the first row as headers (default: true).")),
                 ("include_word_footnotes", ToolSchema.Boolean("Include Word footnotes (default: true).")),
                 ("include_ppt_notes", ToolSchema.Boolean("Include PowerPoint speaker notes (default: true).")),
-                ("markdown_chunk_by_headings", ToolSchema.Boolean("Chunk Markdown by headings when possible (default: true).")))
+                ("markdown_chunk_by_headings", ToolSchema.Boolean("Chunk Markdown by headings when possible (default: true).")),
+                ("output_mode", ToolSchema.String("Output shape: 'chunks' (default), 'documents', or 'both'.")),
+                ("include_document_chunks", ToolSchema.Boolean("When output_mode includes documents, include per-document chunk arrays (default: true).")))
             .Required("path")
             .NoAdditionalProperties());
 
@@ -60,7 +63,6 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         var inputPath = arguments?.GetString("path") ?? string.Empty;
 
-        // Resolve path + enforce AllowedRoots (without assuming file vs directory).
         if (!PathResolver.TryResolvePath(inputPath, Options.AllowedRoots, out var fullPath, out var resolveError)) {
             return Task.FromResult(ToolResponse.Error(
                 errorCode: "access_denied",
@@ -75,7 +77,6 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
         var maxInputBytes = ToolArgs.GetCappedInt64(arguments, "max_input_bytes", Options.MaxInputBytes, 1, Options.MaxInputBytes);
         var maxChunks = ToolArgs.GetCappedInt32(arguments, "max_chunks", defaultValue: 10_000, minInclusive: 1, maxInclusive: 100_000);
 
-        // Output shaping caps (avoid accidental multi-megabyte chunks in tool payloads).
         var maxChars = ToolArgs.GetCappedInt32(arguments, "max_chars", defaultValue: 8000, minInclusive: 256, maxInclusive: 250_000);
         var maxTableRows = ToolArgs.GetCappedInt32(arguments, "max_table_rows", defaultValue: 200, minInclusive: 1, maxInclusive: 10_000);
 
@@ -85,16 +86,27 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
         var includeWordFootnotes = ToolArgs.GetBoolean(arguments, "include_word_footnotes", defaultValue: true);
         var includePptNotes = ToolArgs.GetBoolean(arguments, "include_ppt_notes", defaultValue: true);
         var markdownChunkByHeadings = ToolArgs.GetBoolean(arguments, "markdown_chunk_by_headings", defaultValue: true);
+        var includeDocumentChunks = ToolArgs.GetBoolean(arguments, "include_document_chunks", defaultValue: true);
+
+        if (!TryParseOutputMode(ToolArgs.GetOptionalTrimmed(arguments, "output_mode"), out var outputMode)) {
+            return Task.FromResult(ToolResponse.Error(
+                errorCode: "invalid_argument",
+                error: "Invalid output_mode. Allowed values: chunks, documents, both.",
+                hints: new[] { "Use output_mode='chunks' (default), 'documents', or 'both'." },
+                isTransient: false));
+        }
 
         var extensions = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("extensions"));
         var normalizedExt = NormalizeExtensions(extensions);
 
-        var result = new OfficeImoReadResult();
+        var result = new OfficeImoReadResult {
+            OutputMode = ToOutputModeString(outputMode)
+        };
 
+#if !OFFICEIMO_ENABLED
         if (Directory.Exists(fullPath)) {
-            var folder = fullPath;
             var files = EnumerateFolderFilesSafe(
-                folderPath: folder,
+                folderPath: fullPath,
                 recurse: recurse,
                 allowedExt: normalizedExt,
                 maxFiles: maxFiles,
@@ -104,47 +116,101 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
                 truncated: out var folderTruncated);
 
             result.Truncated |= folderTruncated;
-            foreach (var f in files) {
-                cancellationToken.ThrowIfCancellationRequested();
-                if (result.Files.Count >= maxFiles) {
-                    result.Truncated = true;
-                    break;
-                }
-
-                // Enforce per-file cap early.
-                try {
-                    var len = new FileInfo(f).Length;
-                    if (len > maxInputBytes) {
-                        result.Warnings.Add($"Skipped (too large): {f}");
-                        continue;
-                    }
-                } catch {
-                    result.Warnings.Add($"Skipped (cannot stat): {f}");
-                    continue;
-                }
-
-                result.Files.Add(f);
-                var chunks = ReadChunks(f, maxInputBytes, maxChars, maxTableRows, excelSheetName, excelA1Range, excelHeadersInFirstRow, includeWordFootnotes, includePptNotes, markdownChunkByHeadings, cancellationToken, out var readWarning);
-                if (!string.IsNullOrWhiteSpace(readWarning)) {
-                    result.Warnings.Add(readWarning!);
-                }
-                if (AddChunksWithCap(result.Chunks, chunks, maxChunks)) {
-                    result.Truncated = true;
-                    result.Warnings.Add($"Stopped after reaching max_chunks={maxChunks}.");
-                    break;
-                }
-            }
+            result.Files.AddRange(files);
+            result.FilesScanned = result.Files.Count;
         } else if (File.Exists(fullPath)) {
-            // Single file.
             result.Files.Add(fullPath);
-            var chunks = ReadChunks(fullPath, maxInputBytes, maxChars, maxTableRows, excelSheetName, excelA1Range, excelHeadersInFirstRow, includeWordFootnotes, includePptNotes, markdownChunkByHeadings, cancellationToken, out var readWarning);
-            if (!string.IsNullOrWhiteSpace(readWarning)) {
-                result.Warnings.Add(readWarning!);
+            result.FilesScanned = 1;
+        } else {
+            return Task.FromResult(ToolResponse.Error(
+                errorCode: "not_found",
+                error: "File or directory not found.",
+                hints: new[] { "Verify the path exists and is inside AllowedRoots." },
+                isTransient: false));
+        }
+
+        result.Warnings.Add("OfficeIMO.Reader is not available in this build (missing reference).");
+        var disabledSummary = ToolMarkdown.SummaryText(
+            title: "OfficeIMO read",
+            "Reader dependency is unavailable in this build.",
+            $"Files listed: {result.Files.Count}");
+
+        var disabledMeta = ToolOutputHints.Meta(count: 0, truncated: result.Truncated)
+            .Add("files", result.Files.Count)
+            .Add("output_mode", result.OutputMode)
+            .Add("officeimo_enabled", false);
+
+        return Task.FromResult(ToolResponse.OkModel(model: result, meta: disabledMeta, summaryMarkdown: disabledSummary));
+#else
+        var readerOptions = CreateReaderOptions(
+            maxInputBytes: maxInputBytes,
+            maxChars: maxChars,
+            maxTableRows: maxTableRows,
+            excelSheetName: excelSheetName,
+            excelA1Range: excelA1Range,
+            excelHeadersInFirstRow: excelHeadersInFirstRow,
+            includeWordFootnotes: includeWordFootnotes,
+            includePptNotes: includePptNotes,
+            markdownChunkByHeadings: markdownChunkByHeadings);
+
+        var includeFlatChunks = outputMode is OfficeImoOutputMode.Chunks or OfficeImoOutputMode.Both;
+        var includeDocuments = outputMode is OfficeImoOutputMode.Documents or OfficeImoOutputMode.Both;
+        var includeDocChunksInPayload = includeDocuments && includeDocumentChunks;
+        var enforceChunkBudget = includeFlatChunks || includeDocChunksInPayload;
+        var remainingChunkBudget = enforceChunkBudget ? maxChunks : int.MaxValue;
+
+        if (Directory.Exists(fullPath)) {
+            var progress = new FolderProgressState();
+            var folderOptions = new ReaderFolderOptions {
+                Recurse = recurse,
+                MaxFiles = maxFiles,
+                MaxTotalBytes = maxTotalBytes,
+                Extensions = normalizedExt.OrderBy(static x => x, StringComparer.Ordinal).ToArray(),
+                SkipReparsePoints = true,
+                DeterministicOrder = true
+            };
+
+            foreach (var source in DocumentReader.ReadFolderDocuments(
+                         folderPath: fullPath,
+                         folderOptions: folderOptions,
+                         options: readerOptions,
+                         onProgress: p => UpdateProgress(progress, p),
+                         cancellationToken: cancellationToken)) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!string.IsNullOrWhiteSpace(source.Path)) {
+                    result.Files.Add(source.Path);
+                }
+                ProcessSourceDocument(
+                    source,
+                    includeFlatChunks,
+                    includeDocuments,
+                    includeDocChunksInPayload,
+                    ref remainingChunkBudget,
+                    result);
+
+                if (enforceChunkBudget && remainingChunkBudget <= 0) {
+                    result.Truncated = true;
+                    AddWarning(result.Warnings, $"Stopped after reaching max_chunks={maxChunks}.");
+                    break;
+                }
             }
-            if (AddChunksWithCap(result.Chunks, chunks, maxChunks)) {
-                result.Truncated = true;
-                result.Warnings.Add($"Stopped after reaching max_chunks={maxChunks}.");
-            }
+
+            result.FilesScanned = progress.FilesScanned;
+            result.FilesParsed = progress.FilesParsed;
+            result.FilesSkipped = progress.FilesSkipped;
+            result.BytesRead = progress.BytesRead;
+            result.ChunksProduced = progress.ChunksProduced;
+        } else if (File.Exists(fullPath)) {
+            ProcessSingleFile(
+                fullPath,
+                readerOptions,
+                includeFlatChunks,
+                includeDocuments,
+                includeDocChunksInPayload,
+                ref remainingChunkBudget,
+                maxChunks,
+                result,
+                cancellationToken);
         } else {
             return Task.FromResult(ToolResponse.Error(
                 errorCode: "not_found",
@@ -154,27 +220,42 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
         }
 
         var preview = BuildPreviewMarkdown(result.Chunks, maxChunks: 6, maxCharsPerChunk: 1800);
-        var meta = ToolOutputHints.Meta(count: result.Chunks.Count, truncated: result.Truncated)
+        var meta = ToolOutputHints.Meta(
+                count: includeFlatChunks ? result.Chunks.Count : result.Documents.Count,
+                truncated: result.Truncated)
             .Add("files", result.Files.Count)
+            .Add("documents", result.Documents.Count)
+            .Add("files_scanned", result.FilesScanned)
+            .Add("files_parsed", result.FilesParsed)
+            .Add("files_skipped", result.FilesSkipped)
+            .Add("bytes_read", result.BytesRead)
+            .Add("chunks_produced", result.ChunksProduced)
+            .Add("chunks_returned", result.ChunksReturned)
+            .Add("token_estimate_returned", result.TokenEstimateReturned)
+            .Add("output_mode", result.OutputMode)
             .Add("max_files", maxFiles)
             .Add("max_total_bytes", maxTotalBytes)
             .Add("max_input_bytes", maxInputBytes)
             .Add("max_chunks", maxChunks)
             .Add("max_chars", maxChars)
-            .Add("max_table_rows", maxTableRows);
+            .Add("max_table_rows", maxTableRows)
+            .Add("officeimo_enabled", true);
 
         var summary = ToolMarkdown.JoinBlocks(
             ToolMarkdown.SummaryFacts(
                 title: "OfficeIMO read",
                 facts: new (string Key, string Value)[] {
+                    ("Output mode", result.OutputMode),
                     ("Files", result.Files.Count.ToString()),
-                    ("Chunks", result.Chunks.Count.ToString()),
+                    ("Documents", result.Documents.Count.ToString()),
+                    ("Chunks returned", result.ChunksReturned.ToString()),
+                    ("Chunks produced", result.ChunksProduced.ToString()),
                     ("Truncated", result.Truncated ? "yes" : "no")
                 }),
             preview);
 
-        // Keep render hints minimal; consumer usually reasons from `chunks`.
         return Task.FromResult(ToolResponse.OkModel(model: result, meta: meta, summaryMarkdown: summary));
+#endif
     }
 
     private static string BuildPreviewMarkdown(IReadOnlyList<OfficeImoChunk> chunks, int maxChunks, int maxCharsPerChunk) {
@@ -183,7 +264,7 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
         }
 
         var take = Math.Clamp(maxChunks, 1, 25);
-        var sb = new System.Text.StringBuilder();
+        var sb = new StringBuilder();
         sb.AppendLine(ToolMarkdown.Heading(3, "Preview"));
         sb.AppendLine();
 
@@ -205,6 +286,32 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
         return sb.ToString().TrimEnd();
     }
 
+    private static bool TryParseOutputMode(string? raw, out OfficeImoOutputMode outputMode) {
+        var normalized = string.IsNullOrWhiteSpace(raw) ? "chunks" : raw.Trim().ToLowerInvariant();
+        switch (normalized) {
+            case "chunks":
+                outputMode = OfficeImoOutputMode.Chunks;
+                return true;
+            case "documents":
+                outputMode = OfficeImoOutputMode.Documents;
+                return true;
+            case "both":
+                outputMode = OfficeImoOutputMode.Both;
+                return true;
+            default:
+                outputMode = OfficeImoOutputMode.Chunks;
+                return false;
+        }
+    }
+
+    private static string ToOutputModeString(OfficeImoOutputMode outputMode) {
+        return outputMode switch {
+            OfficeImoOutputMode.Documents => "documents",
+            OfficeImoOutputMode.Both => "both",
+            _ => "chunks"
+        };
+    }
+
     private static HashSet<string> NormalizeExtensions(List<string> extensions) {
         var set = new HashSet<string>(OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
         IEnumerable<string> source = (extensions is null || extensions.Count == 0) ? DefaultOfficeExtensions : extensions;
@@ -215,6 +322,236 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
             set.Add(v);
         }
         return set;
+    }
+
+#if OFFICEIMO_ENABLED
+    private static ReaderOptions CreateReaderOptions(
+        long maxInputBytes,
+        int maxChars,
+        int maxTableRows,
+        string? excelSheetName,
+        string? excelA1Range,
+        bool excelHeadersInFirstRow,
+        bool includeWordFootnotes,
+        bool includePptNotes,
+        bool markdownChunkByHeadings) {
+        return new ReaderOptions {
+            MaxInputBytes = maxInputBytes,
+            MaxChars = maxChars,
+            MaxTableRows = maxTableRows,
+            ExcelSheetName = excelSheetName,
+            ExcelA1Range = excelA1Range,
+            ExcelHeadersInFirstRow = excelHeadersInFirstRow,
+            IncludeWordFootnotes = includeWordFootnotes,
+            IncludePowerPointNotes = includePptNotes,
+            MarkdownChunkByHeadings = markdownChunkByHeadings,
+            ComputeHashes = true
+            // Keep OpenXmlMaxCharactersInPart default from OfficeIMO.Reader for safety.
+        };
+    }
+
+    private static void UpdateProgress(FolderProgressState state, ReaderProgress progress) {
+        if (state == null || progress == null) return;
+        state.FilesScanned = progress.FilesScanned;
+        state.FilesParsed = progress.FilesParsed;
+        state.FilesSkipped = progress.FilesSkipped;
+        state.BytesRead = progress.BytesRead;
+        state.ChunksProduced = progress.ChunksProduced;
+    }
+
+    private static void ProcessSingleFile(
+        string path,
+        ReaderOptions readerOptions,
+        bool includeFlatChunks,
+        bool includeDocuments,
+        bool includeDocChunksInPayload,
+        ref int remainingChunkBudget,
+        int maxChunks,
+        OfficeImoReadResult result,
+        CancellationToken cancellationToken) {
+        result.Files.Add(path);
+        result.FilesScanned = 1;
+
+        List<ReaderChunk>? sourceChunks = null;
+        string? warning = null;
+        try {
+            sourceChunks = DocumentReader.Read(path, options: readerOptions, cancellationToken: cancellationToken).ToList();
+        } catch (NotSupportedException ex) {
+            warning = $"Skipped (unsupported): {path} ({ex.Message})";
+        } catch (IOException ex) {
+            warning = $"Skipped (I/O): {path} ({ex.Message})";
+        } catch (Exception ex) {
+            warning = $"Skipped (error): {path} ({ex.Message})";
+        }
+
+        if (sourceChunks == null) {
+            result.FilesSkipped = 1;
+            AddWarning(result.Warnings, warning ?? $"Skipped (error): {path}");
+            if (includeDocuments) {
+                var failedDoc = new OfficeImoDocument {
+                    Path = path,
+                    Parsed = false
+                };
+                if (!string.IsNullOrWhiteSpace(warning)) {
+                    failedDoc.Warnings.Add(warning!);
+                }
+                result.Documents.Add(failedDoc);
+            }
+            return;
+        }
+
+        result.FilesParsed = 1;
+        result.ChunksProduced = sourceChunks.Count;
+
+        var sourceDoc = BuildSourceDocumentFromChunks(path, sourceChunks);
+        ProcessSourceDocument(
+            sourceDoc,
+            includeFlatChunks,
+            includeDocuments,
+            includeDocChunksInPayload,
+            ref remainingChunkBudget,
+            result);
+
+        if ((includeFlatChunks || includeDocChunksInPayload) && remainingChunkBudget <= 0) {
+            result.Truncated = true;
+            AddWarning(result.Warnings, $"Stopped after reaching max_chunks={maxChunks}.");
+        }
+    }
+
+    private static ReaderSourceDocument BuildSourceDocumentFromChunks(string path, IReadOnlyList<ReaderChunk> chunks) {
+        if (chunks is null || chunks.Count == 0) {
+            return new ReaderSourceDocument {
+                Path = path,
+                Parsed = true,
+                ChunksProduced = 0,
+                TokenEstimateTotal = 0,
+                Chunks = Array.Empty<ReaderChunk>()
+            };
+        }
+
+        var first = chunks[0];
+        var tokenEstimateTotal = 0;
+        var warnings = new List<string>();
+        for (var i = 0; i < chunks.Count; i++) {
+            var c = chunks[i];
+            tokenEstimateTotal += c.TokenEstimate ?? 0;
+            if (c.Warnings is null) continue;
+            for (var j = 0; j < c.Warnings.Count; j++) {
+                var w = c.Warnings[j];
+                if (!string.IsNullOrWhiteSpace(w)) warnings.Add(w!);
+            }
+        }
+
+        return new ReaderSourceDocument {
+            Path = first.Location?.Path ?? path,
+            SourceId = first.SourceId,
+            SourceHash = first.SourceHash,
+            SourceLastWriteUtc = first.SourceLastWriteUtc,
+            SourceLengthBytes = first.SourceLengthBytes,
+            Parsed = true,
+            ChunksProduced = chunks.Count,
+            TokenEstimateTotal = tokenEstimateTotal,
+            Warnings = warnings.Count > 0 ? warnings : null,
+            Chunks = chunks
+        };
+    }
+
+    private static void ProcessSourceDocument(
+        ReaderSourceDocument source,
+        bool includeFlatChunks,
+        bool includeDocuments,
+        bool includeDocChunksInPayload,
+        ref int remainingChunkBudget,
+        OfficeImoReadResult result) {
+        if (source == null) return;
+
+        var officeDocument = new OfficeImoDocument {
+            Path = source.Path ?? string.Empty,
+            SourceId = source.SourceId,
+            SourceHash = source.SourceHash,
+            SourceLastWriteUtc = source.SourceLastWriteUtc,
+            SourceLengthBytes = source.SourceLengthBytes,
+            Parsed = source.Parsed,
+            ChunksProduced = source.ChunksProduced,
+            TokenEstimateTotal = source.TokenEstimateTotal
+        };
+
+        if (source.Warnings != null) {
+            for (var i = 0; i < source.Warnings.Count; i++) {
+                var warning = source.Warnings[i];
+                if (string.IsNullOrWhiteSpace(warning)) continue;
+                officeDocument.Warnings.Add(warning!);
+                AddWarning(result.Warnings, warning!);
+            }
+        }
+
+        var returnedChunks = 0;
+        var returnedTokens = 0;
+        if (source.Chunks != null && (includeFlatChunks || includeDocChunksInPayload)) {
+            for (var i = 0; i < source.Chunks.Count; i++) {
+                if (remainingChunkBudget <= 0) break;
+
+                var mapped = ToOfficeChunk(source.Chunks[i]);
+                if (includeFlatChunks) {
+                    result.Chunks.Add(mapped);
+                }
+                if (includeDocChunksInPayload) {
+                    officeDocument.Chunks.Add(mapped);
+                }
+
+                returnedChunks++;
+                returnedTokens += mapped.TokenEstimate ?? 0;
+                remainingChunkBudget--;
+            }
+        }
+
+        officeDocument.ChunksReturned = returnedChunks;
+        officeDocument.TokenEstimateReturned = returnedTokens;
+        result.ChunksReturned += returnedChunks;
+        result.TokenEstimateReturned += returnedTokens;
+
+        if (includeDocuments) {
+            result.Documents.Add(officeDocument);
+        }
+
+        if (source.Parsed && source.SourceLengthBytes.HasValue) {
+            result.BytesRead += source.SourceLengthBytes.Value;
+        }
+    }
+
+    private static OfficeImoChunk ToOfficeChunk(ReaderChunk chunk) {
+        if (chunk == null) return new OfficeImoChunk();
+
+        return new OfficeImoChunk {
+            Id = chunk.Id ?? string.Empty,
+            Kind = chunk.Kind.ToString().ToLowerInvariant(),
+            Text = chunk.Text ?? string.Empty,
+            Markdown = chunk.Markdown,
+            Location = chunk.Location,
+            Tables = chunk.Tables,
+            Warnings = chunk.Warnings,
+            SourceId = chunk.SourceId,
+            SourceHash = chunk.SourceHash,
+            ChunkHash = chunk.ChunkHash,
+            SourceLastWriteUtc = chunk.SourceLastWriteUtc,
+            SourceLengthBytes = chunk.SourceLengthBytes,
+            TokenEstimate = chunk.TokenEstimate
+        };
+    }
+
+    private sealed class FolderProgressState {
+        public int FilesScanned { get; set; }
+        public int FilesParsed { get; set; }
+        public int FilesSkipped { get; set; }
+        public long BytesRead { get; set; }
+        public int ChunksProduced { get; set; }
+    }
+#endif
+
+    private static void AddWarning(List<string> warnings, string warning) {
+        if (warnings is null || string.IsNullOrWhiteSpace(warning)) return;
+        if (warnings.Any(x => string.Equals(x, warning, StringComparison.OrdinalIgnoreCase))) return;
+        warnings.Add(warning);
     }
 
     private static IEnumerable<string> EnumerateFolderFilesSafe(
@@ -230,7 +567,6 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
         truncated = false;
         var files = new List<string>(capacity: Math.Min(maxFiles, 512));
 
-        // Stable traversal: per-directory sort; also skip reparse points (symlinks/junctions) to avoid escaping AllowedRoots.
         var dirs = new Stack<string>();
         dirs.Push(folderPath);
 
@@ -262,7 +598,6 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
                             continue;
                         }
 
-                        // Skip reparse points (junctions/symlinks) for safety.
                         try {
                             var attrs = File.GetAttributes(entry);
                             if ((attrs & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint) {
@@ -311,84 +646,9 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
         return files;
     }
 
-    private static bool AddChunksWithCap(List<OfficeImoChunk> destination, List<OfficeImoChunk> source, int maxChunks) {
-        if (destination.Count >= maxChunks) {
-            return true;
-        }
-
-        var remaining = maxChunks - destination.Count;
-        if (source.Count <= remaining) {
-            destination.AddRange(source);
-            return false;
-        }
-
-        destination.AddRange(source.GetRange(0, remaining));
-        return true;
-    }
-
-    private static List<OfficeImoChunk> ReadChunks(
-        string path,
-        long maxInputBytes,
-        int maxChars,
-        int maxTableRows,
-        string? excelSheetName,
-        string? excelA1Range,
-        bool excelHeadersInFirstRow,
-        bool includeWordFootnotes,
-        bool includePptNotes,
-        bool markdownChunkByHeadings,
-        CancellationToken cancellationToken,
-        out string? warning) {
-
-        warning = null;
-
-#if !OFFICEIMO_ENABLED
-        warning = "OfficeIMO.Reader is not available in this build (missing reference).";
-        return new List<OfficeImoChunk>();
-#else
-        ReaderOptions opt = new() {
-            MaxInputBytes = maxInputBytes,
-            MaxChars = maxChars,
-            MaxTableRows = maxTableRows,
-            ExcelSheetName = excelSheetName,
-            ExcelA1Range = excelA1Range,
-            ExcelHeadersInFirstRow = excelHeadersInFirstRow,
-            IncludeWordFootnotes = includeWordFootnotes,
-            IncludePowerPointNotes = includePptNotes,
-            MarkdownChunkByHeadings = markdownChunkByHeadings
-            // Keep OpenXmlMaxCharactersInPart default from OfficeIMO.Reader for safety.
-        };
-
-        IEnumerable<ReaderChunk> chunks;
-        try {
-            chunks = DocumentReader.Read(path, options: opt, cancellationToken: cancellationToken);
-        } catch (NotSupportedException ex) {
-            warning = $"Skipped (unsupported): {path} ({ex.Message})";
-            return new List<OfficeImoChunk>();
-        } catch (IOException ex) {
-            warning = $"Skipped (I/O): {path} ({ex.Message})";
-            return new List<OfficeImoChunk>();
-        } catch (Exception ex) {
-            warning = $"Skipped (error): {path} ({ex.Message})";
-            return new List<OfficeImoChunk>();
-        }
-
-        var list = new List<OfficeImoChunk>();
-        foreach (var c in chunks) {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (c == null) continue;
-
-            list.Add(new OfficeImoChunk {
-                Id = c.Id ?? string.Empty,
-                Kind = c.Kind.ToString().ToLowerInvariant(),
-                Text = c.Text ?? string.Empty,
-                Markdown = c.Markdown,
-                Location = c.Location,
-                Tables = c.Tables,
-                Warnings = c.Warnings
-            });
-        }
-        return list;
-#endif
+    private enum OfficeImoOutputMode {
+        Chunks = 0,
+        Documents = 1,
+        Both = 2
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoToolPack.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoToolPack.cs
@@ -24,7 +24,7 @@ public sealed class OfficeImoToolPack : IToolPack {
         Name = "OfficeIMO",
         Tier = ToolCapabilityTier.ReadOnly,
         IsDangerous = false,
-        Description = "Read-only Office document ingestion (Word/Excel/PowerPoint/Markdown) backed by OfficeIMO.Reader."
+        Description = "Read-only Office document ingestion (Word/Excel/PowerPoint/Markdown/PDF) backed by OfficeIMO.Reader."
     };
 
     /// <inheritdoc />
@@ -32,4 +32,3 @@ public sealed class OfficeImoToolPack : IToolPack {
         registry.RegisterOfficeImoPack(_options);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -52,4 +52,88 @@ public class OfficeImoReadToolTests {
             }
         }
     }
+
+    [Fact]
+    public async Task OfficeImoRead_WhenOutputModeDocuments_ReturnsDocumentContractShape() {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "ix-officeimo-read-" + Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(tempRoot);
+
+        try {
+            var markdownPath = Path.Combine(tempRoot, "knowledge.md");
+            File.WriteAllText(markdownPath, "# SOP\n\nLine 1");
+
+            var options = new OfficeImoToolOptions();
+            options.AllowedRoots.Add(tempRoot);
+            var tool = new OfficeImoReadTool(options);
+
+            var json = await tool.InvokeAsync(
+                arguments: new JsonObject()
+                    .Add("path", markdownPath)
+                    .Add("output_mode", "documents")
+                    .Add("include_document_chunks", false),
+                cancellationToken: CancellationToken.None);
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            Assert.True(root.GetProperty("ok").GetBoolean());
+            Assert.Equal("documents", root.GetProperty("output_mode").GetString());
+            Assert.True(root.TryGetProperty("documents", out var documents));
+            Assert.True(root.TryGetProperty("chunks", out var chunks));
+            Assert.Equal(0, chunks.GetArrayLength());
+
+            var files = root.GetProperty("files").EnumerateArray()
+                .Select(static x => x.GetString())
+                .Where(static x => !string.IsNullOrWhiteSpace(x))
+                .Select(static x => Path.GetFileName(x!))
+                .ToArray();
+
+            Assert.Contains("knowledge.md", files, StringComparer.OrdinalIgnoreCase);
+
+            if (documents.GetArrayLength() > 0) {
+                var first = documents[0];
+                Assert.Equal("knowledge.md", Path.GetFileName(first.GetProperty("path").GetString() ?? string.Empty));
+                Assert.Equal(0, first.GetProperty("chunks_returned").GetInt32());
+            }
+        } finally {
+            try {
+                Directory.Delete(tempRoot, recursive: true);
+            } catch {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task OfficeImoRead_WhenOutputModeInvalid_ReturnsInvalidArgument() {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "ix-officeimo-read-" + Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(tempRoot);
+
+        try {
+            var markdownPath = Path.Combine(tempRoot, "knowledge.md");
+            File.WriteAllText(markdownPath, "# SOP");
+
+            var options = new OfficeImoToolOptions();
+            options.AllowedRoots.Add(tempRoot);
+            var tool = new OfficeImoReadTool(options);
+
+            var json = await tool.InvokeAsync(
+                arguments: new JsonObject()
+                    .Add("path", markdownPath)
+                    .Add("output_mode", "nope"),
+                cancellationToken: CancellationToken.None);
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            Assert.False(root.GetProperty("ok").GetBoolean());
+            Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        } finally {
+            try {
+                Directory.Delete(tempRoot, recursive: true);
+            } catch {
+                // Best-effort cleanup.
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- upgrades `officeimo_read` to support indexing-friendly output shapes via `output_mode` (`chunks`, `documents`, `both`)
- adds per-source `documents` payload with hashes, token totals, parse status, warnings, and optional per-document chunks
- enriches flat `chunks` with source/chunk hashes, token estimate, and source metadata
- surfaces ingestion counters (`files_scanned/parsed/skipped`, `bytes_read`, `chunks_produced/returned`, token totals)
- updates OfficeIMO pack guidance/docs and expands OfficeIMO tool tests

## Why
This makes IX ingestion much simpler for large knowledge bases: callers can upsert by `source_id/source_hash` and `chunk_hash` directly, without custom grouping logic.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~OfficeImo|FullyQualifiedName~ToolPackInfoContractTests"`
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/IntelligenceX.Tools.OfficeIMO.csproj -c Release /p:OfficeImoReaderProject=C:\_none\OfficeIMO.Reader.csproj /p:OfficeImoReaderNuGetVersion=""`

## Notes
- backward compatibility preserved for existing consumers (`files/chunks/warnings/truncated` still present)
- when `OFFICEIMO_ENABLED` is false, the tool still returns contract shape + a clear dependency warning
- pairs with OfficeIMO.Reader ingestion improvements in EvotecIT/OfficeIMO PR #1432