### PR TITLE
Chat App: LM Studio-first runtime setup with advanced options hidden

### DIFF
--- a/Docs/apps/chat-local-providers.md
+++ b/Docs/apps/chat-local-providers.md
@@ -13,11 +13,10 @@ Examples: Ollama, LM Studio, llama.cpp server, and similar OpenAI-compat endpoin
 For the WinUI desktop app (`Build/Run-ChatApp.ps1`):
 
 1. Open **Options -> Profile -> Model Runtime**.
-2. Click **Auto Detect Runtime** (recommended). The app probes common local endpoints and picks an available runtime.
-3. If auto-detect is not available, use **Use LM Studio Runtime** or **Use Ollama Runtime** when shown.
-4. If your provider needs auth, enter **API key (optional)**.
-5. The app applies runtime settings immediately and refreshes model discovery.
-6. If needed, choose a model from **Discovered models** (or switch to manual input) and click **Apply Runtime**.
+2. Click **Connect LM Studio** (primary flow).
+3. The app switches to compatible HTTP using LM Studio defaults and refreshes model discovery.
+4. Choose a model from **Discovered models** and click **Apply Runtime** when needed.
+5. Open **Show Advanced Runtime** only for transport/base URL/API key/manual model overrides.
 
 Notes:
 - `Refresh Models` applies pending runtime field changes first, then refreshes discovery.

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -412,9 +412,41 @@
     return String(value == null ? "" : value).trim();
   }
 
+  function runtimeAdvancedStorageKey() {
+    return "ixchat.runtime.advanced";
+  }
+
+  function isRuntimeAdvancedOpen() {
+    return readStorage(runtimeAdvancedStorageKey()) === "1";
+  }
+
+  function setRuntimeAdvancedOpen(open) {
+    var next = open === true;
+    var advancedArea = byId("optLocalAdvancedArea");
+    if (advancedArea) {
+      advancedArea.hidden = !next;
+    }
+
+    var toggle = byId("btnToggleLocalAdvancedRuntime");
+    if (toggle) {
+      toggle.textContent = next ? "Hide Advanced Runtime" : "Show Advanced Runtime";
+    }
+
+    writeStorage(runtimeAdvancedStorageKey(), next ? "1" : "0");
+  }
+
+  function isLmStudioBaseUrl(value) {
+    var normalized = String(value || "").trim().toLowerCase();
+    if (!normalized) {
+      return false;
+    }
+    return normalized.indexOf("127.0.0.1:1234") >= 0 || normalized.indexOf("localhost:1234") >= 0;
+  }
+
   function renderLocalModelOptions() {
     var local = state.options.localModel || {};
     var transport = normalizeLocalTransport(local.transport);
+    var isCompatible = transport === "compatible-http";
     var baseUrl = String(local.baseUrl || "");
     var model = normalizeModelText(local.model || "");
     var models = Array.isArray(local.models) ? local.models : [];
@@ -429,6 +461,29 @@
     var ollamaAvailable = runtimeDetection.ollamaAvailable === true;
     var runtimeDetectedName = normalizeModelText(runtimeDetection.detectedName || "");
     var runtimeDetectionWarning = normalizeModelText(runtimeDetection.warning || "");
+    var lmStudioConnected = isCompatible && isLmStudioBaseUrl(baseUrl);
+    var simpleHint = byId("optLocalSimpleHint");
+    if (simpleHint) {
+      if (lmStudioConnected) {
+        simpleHint.textContent = "LM Studio runtime is active for this profile.";
+      } else if (runtimeDetectionHasRun && !lmStudioAvailable) {
+        simpleHint.textContent = "LM Studio not detected on http://127.0.0.1:1234/v1. Start LM Studio or open Advanced Runtime.";
+      } else {
+        simpleHint.textContent = "ChatGPT native is default. Connect LM Studio for local models.";
+      }
+    }
+
+    var connectLmStudioButton = byId("btnConnectLmStudio");
+    if (connectLmStudioButton) {
+      connectLmStudioButton.textContent = lmStudioConnected ? "Reconnect LM Studio" : "Connect LM Studio";
+    }
+
+    var advancedShouldBeOpen = isRuntimeAdvancedOpen();
+    if (!isCompatible && !advancedShouldBeOpen) {
+      setRuntimeAdvancedOpen(false);
+    } else {
+      setRuntimeAdvancedOpen(advancedShouldBeOpen);
+    }
 
     var transportSelect = byId("optLocalTransport");
     if (transportSelect) {
@@ -438,7 +493,7 @@
 
     var btnAutoDetect = byId("btnAutoDetectLocalRuntime");
     if (btnAutoDetect) {
-      btnAutoDetect.hidden = transport !== "compatible-http";
+      btnAutoDetect.hidden = !isCompatible;
     }
 
     var btnPresetLmStudio = byId("btnLocalPresetLmStudio");
@@ -453,29 +508,29 @@
 
     var baseUrlRow = byId("optLocalBaseUrlRow");
     if (baseUrlRow) {
-      baseUrlRow.hidden = transport !== "compatible-http";
+      baseUrlRow.hidden = !isCompatible;
     }
 
     var baseUrlInput = byId("optLocalBaseUrl");
     if (baseUrlInput) {
       baseUrlInput.value = baseUrl;
-      baseUrlInput.disabled = transport !== "compatible-http";
+      baseUrlInput.disabled = !isCompatible;
     }
 
     var apiKeyRow = byId("optLocalApiKeyRow");
     if (apiKeyRow) {
-      apiKeyRow.hidden = transport !== "compatible-http";
+      apiKeyRow.hidden = !isCompatible;
     }
 
     var apiKeyHint = byId("optLocalApiKeyHint");
     if (apiKeyHint) {
-      apiKeyHint.hidden = transport !== "compatible-http";
+      apiKeyHint.hidden = !isCompatible;
     }
 
     var apiKeyInput = byId("optLocalApiKey");
     if (apiKeyInput) {
-      apiKeyInput.disabled = transport !== "compatible-http";
-      if (transport !== "compatible-http") {
+      apiKeyInput.disabled = !isCompatible;
+      if (!isCompatible) {
         apiKeyInput.value = "";
       }
     }
@@ -543,21 +598,23 @@
     var hasSelectableModels = recents.length > 0 || favorites.length > 0 || models.length > 0;
     var usingManualInput = !modelSelect || !hasSelectableModels || modelSelect.value === "";
     if (modelSelectRow) {
-      modelSelectRow.hidden = !hasSelectableModels;
+      modelSelectRow.hidden = !isCompatible || !hasSelectableModels;
     }
     if (modelInputRow) {
-      modelInputRow.hidden = hasSelectableModels && !usingManualInput;
+      modelInputRow.hidden = !isCompatible || (hasSelectableModels && !usingManualInput);
     }
     if (modelInput) {
-      modelInput.disabled = hasSelectableModels && !usingManualInput;
+      modelInput.disabled = !isCompatible || (hasSelectableModels && !usingManualInput);
     }
 
     var stateNote = byId("optLocalModelsState");
     if (stateNote) {
       var parts = [];
-      if (transport === "compatible-http" && runtimeDetectedName) {
+      if (!isCompatible) {
+        parts.push("ChatGPT native runtime active");
+      } else if (runtimeDetectedName) {
         parts.push("detected runtime: " + runtimeDetectedName);
-      } else if (transport === "compatible-http" && runtimeDetectionHasRun && runtimeDetectionWarning) {
+      } else if (runtimeDetectionHasRun && runtimeDetectionWarning) {
         parts.push(runtimeDetectionWarning);
       }
       if (models.length > 0) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -667,6 +667,23 @@
     }
   });
 
+  byId("btnToggleLocalAdvancedRuntime").addEventListener("click", function() {
+    setRuntimeAdvancedOpen(!isRuntimeAdvancedOpen());
+  });
+
+  byId("btnConnectLmStudio").addEventListener("click", function() {
+    var transport = byId("optLocalTransport");
+    var baseUrl = byId("optLocalBaseUrl");
+    var modelInput = byId("optLocalModelInput");
+    transport.value = "compatible-http";
+    syncCustomSelect(transport);
+    baseUrl.value = "http://127.0.0.1:1234/v1";
+    if (modelInput) {
+      modelInput.value = "";
+    }
+    applyLocalProviderSettings(true);
+  });
+
   byId("btnAutoDetectLocalRuntime").addEventListener("click", function() {
     post("auto_detect_local_runtime", { forceRefresh: true });
   });

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -144,41 +144,47 @@
             <div id="optProfileScopeHint" class="options-note"></div>
           </div>
           <div class="options-label">Model Runtime</div>
-          <div class="options-note">Configure runtime provider + model and persist it to the active service profile.</div>
-          <div class="options-row" id="optLocalTransportRow">
-            <label class="options-label-inline" for="optLocalTransport">Provider transport</label>
-            <select id="optLocalTransport" class="options-select">
-              <option value="native">OpenAI Native</option>
-              <option value="compatible-http">Compatible HTTP (Ollama / LM Studio)</option>
-            </select>
+          <div class="options-note" id="optLocalSimpleHint">ChatGPT native is default. Connect LM Studio for local models.</div>
+          <div class="options-actions options-actions-wrap">
+            <button id="btnConnectLmStudio" class="options-btn options-btn-sm">Connect LM Studio</button>
+            <button id="btnRefreshModels" class="options-btn options-btn-sm options-btn-ghost">Refresh Models</button>
+            <button id="btnApplyLocalProvider" class="options-btn options-btn-sm options-btn-ghost">Apply Runtime</button>
+            <button id="btnToggleLocalAdvancedRuntime" class="options-btn options-btn-sm options-btn-ghost">Show Advanced Runtime</button>
           </div>
-          <div class="options-row" id="optLocalBaseUrlRow">
-            <label class="options-label-inline" for="optLocalBaseUrl">Base URL</label>
-            <input id="optLocalBaseUrl" class="options-input options-input-sm" placeholder="http://127.0.0.1:11434" />
-          </div>
-          <div class="options-row" id="optLocalApiKeyRow">
-            <label class="options-label-inline" for="optLocalApiKey">API key (optional)</label>
-            <input id="optLocalApiKey" type="password" class="options-input options-input-sm" placeholder="Leave blank to keep existing key" autocomplete="off" />
-          </div>
-          <div class="options-note" id="optLocalApiKeyHint">Use Clear Saved API Key to remove the currently stored key.</div>
-          <div class="options-row" id="optLocalModelInputRow">
-            <label class="options-label-inline" for="optLocalModelInput">Model</label>
-            <input id="optLocalModelInput" class="options-input options-input-sm" placeholder="e.g. gpt-5.3-codex or llama3.2" />
+          <div id="optLocalAdvancedArea" hidden>
+            <div class="options-row" id="optLocalTransportRow">
+              <label class="options-label-inline" for="optLocalTransport">Provider transport</label>
+              <select id="optLocalTransport" class="options-select">
+                <option value="native">OpenAI Native</option>
+                <option value="compatible-http">Compatible HTTP (Ollama / LM Studio)</option>
+              </select>
+            </div>
+            <div class="options-row" id="optLocalBaseUrlRow">
+              <label class="options-label-inline" for="optLocalBaseUrl">Base URL</label>
+              <input id="optLocalBaseUrl" class="options-input options-input-sm" placeholder="http://127.0.0.1:11434" />
+            </div>
+            <div class="options-row" id="optLocalApiKeyRow">
+              <label class="options-label-inline" for="optLocalApiKey">API key (optional)</label>
+              <input id="optLocalApiKey" type="password" class="options-input options-input-sm" placeholder="Leave blank to keep existing key" autocomplete="off" />
+            </div>
+            <div class="options-note" id="optLocalApiKeyHint">Use Clear Saved API Key to remove the currently stored key.</div>
+            <div class="options-row" id="optLocalModelInputRow">
+              <label class="options-label-inline" for="optLocalModelInput">Model</label>
+              <input id="optLocalModelInput" class="options-input options-input-sm" placeholder="e.g. gpt-5.3-codex or llama3.2" />
+            </div>
+            <div class="options-note">Auto-detect picks an available local runtime and refreshes models.</div>
+            <div class="options-actions options-actions-wrap">
+              <button id="btnAutoDetectLocalRuntime" class="options-btn options-btn-sm">Auto Detect Runtime</button>
+              <button id="btnLocalPresetLmStudio" class="options-btn options-btn-sm options-btn-ghost">Use LM Studio Runtime</button>
+              <button id="btnLocalPresetOllama" class="options-btn options-btn-sm options-btn-ghost">Use Ollama Runtime</button>
+              <button id="btnClearLocalApiKey" class="options-btn options-btn-sm options-btn-ghost">Clear Saved API Key</button>
+            </div>
           </div>
           <div class="options-row" id="optLocalModelSelectRow">
             <label class="options-label-inline" for="optLocalModelSelect">Discovered models</label>
             <select id="optLocalModelSelect" class="options-select"></select>
           </div>
           <div class="options-note" id="optLocalModelsState"></div>
-          <div class="options-note">Auto-detect picks an available local runtime and refreshes models.</div>
-          <div class="options-actions options-actions-wrap">
-            <button id="btnAutoDetectLocalRuntime" class="options-btn options-btn-sm">Auto Detect Runtime</button>
-            <button id="btnLocalPresetOllama" class="options-btn options-btn-sm options-btn-ghost">Use Ollama Runtime</button>
-            <button id="btnLocalPresetLmStudio" class="options-btn options-btn-sm options-btn-ghost">Use LM Studio Runtime</button>
-            <button id="btnRefreshModels" class="options-btn options-btn-sm options-btn-ghost">Refresh Models</button>
-            <button id="btnClearLocalApiKey" class="options-btn options-btn-sm options-btn-ghost">Clear Saved API Key</button>
-            <button id="btnApplyLocalProvider" class="options-btn options-btn-sm">Apply Runtime</button>
-          </div>
           <div class="options-actions">
             <button id="btnSaveProfile" class="options-btn">Save As Default</button>
             <button id="btnRestartOnboarding" class="options-btn options-btn-ghost">Restart Onboarding</button>

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -41,10 +41,10 @@ Markdown renderer dependency resolution is automatic:
 Inside the app:
 
 1. Open **Options -> Profile -> Model Runtime**.
-2. Click **Auto Detect Runtime** (recommended) or pick LM Studio/Ollama if shown.
-3. Wait for model discovery to populate.
-4. If your provider needs auth, enter **API key (optional)**.
-5. Optionally choose a discovered model (or switch to manual model input), then click **Apply Runtime**.
+2. Click **Connect LM Studio**.
+3. Wait for model discovery to populate and choose a discovered model if needed.
+4. Use **Advanced Runtime** only when you need custom transport/base URL/API key/manual model options.
+5. Click **Apply Runtime** after changing model/runtime options.
 
 Reference: `Docs/apps/chat-local-providers.md`
 


### PR DESCRIPTION
## Summary
- make **LM Studio** the primary runtime setup path in Chat App options
- add a single primary CTA: **Connect LM Studio**
- move provider-level controls behind a hidden-by-default **Advanced Runtime** section
- keep the existing runtime auto-detection logic, but avoid showing all choices at once
- keep model discovery visible for compatible-http and simplify default guidance text
- update Chat docs to reflect the new LM Studio-first flow

## UX impact
- less cognitive load in `Options -> Profile -> Model Runtime`
- default flow is one click for local LM Studio users
- advanced transport/base URL/API key/manual model controls remain available when needed

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release` (123 passed)
