### PR TITLE
Chat App: runtime/model badge + discovered-model filter

### DIFF
--- a/Docs/apps/chat-local-providers.md
+++ b/Docs/apps/chat-local-providers.md
@@ -15,7 +15,7 @@ For the WinUI desktop app (`Build/Run-ChatApp.ps1`):
 1. Open **Options -> Profile -> Model Runtime**.
 2. Click **Connect LM Studio** (primary flow).
 3. The app switches to compatible HTTP using LM Studio defaults and refreshes model discovery.
-4. Choose a model from **Discovered models** and click **Apply Runtime** when needed.
+4. Choose a model from **Discovered models** (use **Filter models** for long lists) and click **Apply Runtime** when needed.
 5. Open **Show Advanced Runtime** only for transport/base URL/API key/manual model overrides.
 
 Notes:
@@ -23,6 +23,7 @@ Notes:
 - For `compatible-http`, if the current model is empty or invalid, the app auto-selects the first discovered model.
 - Leaving API key empty keeps the currently saved key unchanged.
 - Use **Clear Saved API Key** to remove the saved key from the active profile.
+- The panel shows an explicit active runtime/model badge so you can confirm what is currently used.
 
 ## Security Model
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -416,6 +416,10 @@
     return "ixchat.runtime.advanced";
   }
 
+  function runtimeModelFilterStorageKey() {
+    return "ixchat.runtime.model.filter";
+  }
+
   function isRuntimeAdvancedOpen() {
     return readStorage(runtimeAdvancedStorageKey()) === "1";
   }
@@ -473,6 +477,18 @@
     return count;
   }
 
+  function isOllamaBaseUrl(value) {
+    var normalized = String(value || "").trim().toLowerCase();
+    if (!normalized) {
+      return false;
+    }
+    return normalized.indexOf("127.0.0.1:11434") >= 0 || normalized.indexOf("localhost:11434") >= 0;
+  }
+
+  function normalizeModelFilter(value) {
+    return String(value || "").trim().toLowerCase();
+  }
+
   function renderLocalModelOptions() {
     var local = state.options.localModel || {};
     var transport = normalizeLocalTransport(local.transport);
@@ -511,6 +527,21 @@
       } else {
         runtimeAuthHint.textContent = "ChatGPT sign-in and runtime provider are separate. You can switch to LM Studio any time.";
       }
+    }
+
+    var ollamaConnected = isCompatible && isOllamaBaseUrl(baseUrl);
+    var runtimeBadge = byId("optLocalRuntimeBadge");
+    if (runtimeBadge) {
+      var runtimeName = "ChatGPT Native";
+      if (lmStudioConnected) {
+        runtimeName = "LM Studio";
+      } else if (ollamaConnected) {
+        runtimeName = "Ollama";
+      } else if (isCompatible) {
+        runtimeName = "Compatible HTTP";
+      }
+      var activeModel = model ? model : "(auto)";
+      runtimeBadge.textContent = "Active runtime: " + runtimeName + " | Active model: " + activeModel;
     }
 
     var simpleHint = byId("optLocalSimpleHint");
@@ -609,7 +640,15 @@
       modelInput.value = model;
     }
 
+    var modelFilterInput = byId("optLocalModelFilter");
+    var storedModelFilter = String(readStorage(runtimeModelFilterStorageKey()) || "");
+    if (modelFilterInput && modelFilterInput.value.length === 0 && storedModelFilter.length > 0) {
+      modelFilterInput.value = storedModelFilter;
+    }
+    var modelFilterQuery = normalizeModelFilter(modelFilterInput ? modelFilterInput.value : storedModelFilter);
+
     var modelSelect = byId("optLocalModelSelect");
+    var selectableOptionCount = 0;
     if (modelSelect) {
       modelSelect.innerHTML = "";
 
@@ -619,9 +658,15 @@
       modelSelect.appendChild(manualOption);
 
       var seen = {};
-      function pushModelOption(modelName, labelPrefix) {
+      function pushModelOption(modelName, labelPrefix, matchLabel) {
         var normalized = normalizeModelText(modelName);
         if (!normalized) {
+          return;
+        }
+        var normalizedMatchLabel = normalizeModelText(matchLabel || labelPrefix || "");
+        if (modelFilterQuery.length > 0
+            && normalized.toLowerCase().indexOf(modelFilterQuery) < 0
+            && normalizedMatchLabel.toLowerCase().indexOf(modelFilterQuery) < 0) {
           return;
         }
         var key = normalized.toLowerCase();
@@ -633,13 +678,14 @@
         option.value = normalized;
         option.textContent = labelPrefix ? (labelPrefix + " " + normalized) : normalized;
         modelSelect.appendChild(option);
+        selectableOptionCount++;
       }
 
       for (var r = 0; r < recents.length; r++) {
-        pushModelOption(recents[r], "Recent:");
+        pushModelOption(recents[r], "Recent:", recents[r]);
       }
       for (var f = 0; f < favorites.length; f++) {
-        pushModelOption(favorites[f], "Favorite:");
+        pushModelOption(favorites[f], "Favorite:", favorites[f]);
       }
       for (var i = 0; i < models.length; i++) {
         var item = models[i] || {};
@@ -649,9 +695,9 @@
         }
         var displayName = normalizeModelText(item.displayName || item.DisplayName);
         if (displayName && displayName.toLowerCase() !== modelName.toLowerCase()) {
-          pushModelOption(modelName, displayName + ":");
+          pushModelOption(modelName, displayName + ":", displayName);
         } else {
-          pushModelOption(modelName, "");
+          pushModelOption(modelName, "", modelName);
         }
       }
 
@@ -664,16 +710,21 @@
 
     var modelInputRow = byId("optLocalModelInputRow");
     var modelSelectRow = byId("optLocalModelSelectRow");
-    var hasSelectableModels = recents.length > 0 || favorites.length > 0 || models.length > 0;
+    var modelFilterRow = byId("optLocalModelFilterRow");
+    var hasSelectableModels = selectableOptionCount > 0;
     var usingManualInput = !modelSelect || !hasSelectableModels || modelSelect.value === "";
+    var showModelSelect = isCompatible && (hasSelectableModels || modelFilterQuery.length > 0);
     if (modelSelectRow) {
-      modelSelectRow.hidden = !isCompatible || !hasSelectableModels;
+      modelSelectRow.hidden = !showModelSelect;
+    }
+    if (modelFilterRow) {
+      modelFilterRow.hidden = !showModelSelect;
     }
     if (modelInputRow) {
-      modelInputRow.hidden = !isCompatible || (hasSelectableModels && !usingManualInput);
+      modelInputRow.hidden = !isCompatible || (showModelSelect && !usingManualInput);
     }
     if (modelInput) {
-      modelInput.disabled = !isCompatible || (hasSelectableModels && !usingManualInput);
+      modelInput.disabled = !isCompatible || (showModelSelect && !usingManualInput);
     }
 
     var stateNote = byId("optLocalModelsState");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -667,6 +667,11 @@
     }
   });
 
+  byId("optLocalModelFilter").addEventListener("input", function(e) {
+    writeStorage(runtimeModelFilterStorageKey(), (e.target.value || "").trim());
+    renderLocalModelOptions();
+  });
+
   byId("btnToggleLocalAdvancedRuntime").addEventListener("click", function() {
     setRuntimeAdvancedOpen(!isRuntimeAdvancedOpen());
   });

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -155,6 +155,7 @@
         <section class="options-group">
           <div class="options-label">Runtime Mode</div>
           <div id="optRuntimeSummary" class="options-note options-note-strong"></div>
+          <div class="options-note" id="optLocalRuntimeBadge"></div>
           <div class="options-note" id="optRuntimeAuthHint">ChatGPT sign-in and runtime provider are separate. You can stay signed in while using local models.</div>
           <div class="options-actions options-actions-wrap">
             <button id="btnUseOpenAiRuntime" class="options-btn options-btn-sm">Use ChatGPT Runtime</button>
@@ -200,6 +201,10 @@
           <div class="options-row" id="optLocalModelSelectRow">
             <label class="options-label-inline" for="optLocalModelSelect">Discovered models</label>
             <select id="optLocalModelSelect" class="options-select"></select>
+          </div>
+          <div class="options-row" id="optLocalModelFilterRow">
+            <label class="options-label-inline" for="optLocalModelFilter">Filter models</label>
+            <input id="optLocalModelFilter" class="options-input options-input-sm" placeholder="Type to filter discovered models" />
           </div>
           <div class="options-note" id="optLocalModelsState"></div>
         </section>


### PR DESCRIPTION
## Summary
- add a clear **Active runtime / Active model** badge in Model Runtime
- add **Filter models** input for discovered model lists (persists per profile in localStorage)
- make filtering live (as you type) and keep manual-input flow intact
- update local provider docs with filter + runtime badge behavior

## Why
After LM Studio-first simplification, large discovered-model lists were still hard to scan. This keeps setup simple while making model selection faster and more obvious.

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release` (123 passed)
