### PR TITLE
Improve tool resilience, projection fallback, and action UX

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Protocol/MetricsDtos.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Protocol/MetricsDtos.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace IntelligenceX.Chat.Abstractions.Protocol;
 
@@ -44,6 +45,14 @@ public sealed record ChatMetricsMessage : ChatServiceMessage {
     /// Number of tool-call rounds executed in the turn.
     /// </summary>
     public int ToolRounds { get; init; }
+    /// <summary>
+    /// Number of tool calls where view-projection arguments were auto-reset and retried.
+    /// </summary>
+    public int ProjectionFallbackCount { get; init; }
+    /// <summary>
+    /// Optional per-tool error-code counts for this turn.
+    /// </summary>
+    public IReadOnlyList<ToolErrorMetricDto>? ToolErrors { get; init; }
 
     /// <summary>
     /// Outcome identifier (ok, canceled, error).
@@ -79,4 +88,22 @@ public sealed record TokenUsageDto {
     /// Reasoning tokens when the provider exposes them.
     /// </summary>
     public long? ReasoningTokens { get; init; }
+}
+
+/// <summary>
+/// Per-tool error taxonomy entry for a single turn.
+/// </summary>
+public sealed record ToolErrorMetricDto {
+    /// <summary>
+    /// Tool name.
+    /// </summary>
+    public required string ToolName { get; init; }
+    /// <summary>
+    /// Stable error code observed for the tool output.
+    /// </summary>
+    public required string ErrorCode { get; init; }
+    /// <summary>
+    /// Number of occurrences for this tool/error-code pair in the turn.
+    /// </summary>
+    public int Count { get; init; }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Serialization/ChatServiceJsonContext.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Serialization/ChatServiceJsonContext.cs
@@ -52,6 +52,7 @@ namespace IntelligenceX.Chat.Abstractions.Serialization;
 [JsonSerializable(typeof(ModelInfoDto))]
 [JsonSerializable(typeof(ReasoningEffortOptionDto))]
 [JsonSerializable(typeof(TokenUsageDto))]
+[JsonSerializable(typeof(ToolErrorMetricDto))]
 [JsonSerializable(typeof(SessionPolicyDto))]
 [JsonSerializable(typeof(ToolPackInfoDto))]
 [JsonSerializable(typeof(ToolPackSourceKind))]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ActionModelProtocolTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ActionModelProtocolTests.cs
@@ -1,0 +1,65 @@
+using IntelligenceX.Chat.App;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Tests for assistant action protocol extraction and visible-text normalization.
+/// </summary>
+public sealed class ActionModelProtocolTests {
+    /// <summary>
+    /// Ensures pending action protocol blocks are removed from visible text and converted to a concise action summary.
+    /// </summary>
+    [Fact]
+    public void TryStripAndExtractPendingActions_StripsProtocolAndBuildsVisibleSummary() {
+        const string text = """
+                            I can retry this with safer defaults.
+
+                            [Action]
+                            ix:action:v1
+                            id: act_ad0_sys_top5_bare
+                            title: Retry AD0 System top 5 with bare defaults
+                            request: Query AD0 System log for top 5 events using default output schema, then summarize key fields.
+                            reply: /act act_ad0_sys_top5_bare
+                            """;
+
+        var normalized = ActionModelProtocol.TryStripAndExtractPendingActions(text, out var actions, out var cleaned);
+
+        Assert.True(normalized);
+        Assert.Single(actions);
+        Assert.DoesNotContain("ix:action:v1", cleaned);
+        Assert.DoesNotContain("[Action]", cleaned);
+        Assert.Equal("act_ad0_sys_top5_bare", actions[0].Id);
+
+        var visible = ActionModelProtocol.MergeVisibleTextWithPendingActions(cleaned, actions);
+        Assert.Contains("follow-up actions", visible, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("`/act act_ad0_sys_top5_bare`", visible);
+    }
+
+    /// <summary>
+    /// Ensures malformed action blocks are still stripped from visible text without exposing invalid follow-up actions.
+    /// </summary>
+    [Fact]
+    public void TryStripAndExtractPendingActions_StripsMalformedBlocksWithoutCreatingActions() {
+        const string text = """
+                            We can try a recovery step.
+
+                            [Action]
+                            ix:action:v1
+                            id: act_missing_reply
+                            title: Retry with defaults
+                            request: Retry now.
+
+                            Done.
+                            """;
+
+        var normalized = ActionModelProtocol.TryStripAndExtractPendingActions(text, out var actions, out var cleaned);
+
+        Assert.True(normalized);
+        Assert.Empty(actions);
+        Assert.DoesNotContain("ix:action:v1", cleaned);
+        Assert.DoesNotContain("[Action]", cleaned);
+        Assert.Contains("We can try a recovery step.", cleaned);
+        Assert.Contains("Done.", cleaned);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/ActionModelProtocol.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/ActionModelProtocol.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace IntelligenceX.Chat.App;
+
+internal sealed record AssistantPendingAction(string Id, string Title, string Request, string Reply);
+
+internal static class ActionModelProtocol {
+    private const string ActionHeader = "[Action]";
+    private const string ActionMarker = "ix:action:v1";
+
+    public static bool TryStripAndExtractPendingActions(
+        string? assistantText,
+        out IReadOnlyList<AssistantPendingAction> actions,
+        out string cleanedText) {
+        actions = Array.Empty<AssistantPendingAction>();
+        var input = (assistantText ?? string.Empty).Trim();
+        cleanedText = input;
+        if (input.Length == 0) {
+            return false;
+        }
+
+        var normalized = input.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        var lines = normalized.Split('\n');
+        if (lines.Length == 0) {
+            return false;
+        }
+
+        var removed = new bool[lines.Length];
+        var extracted = new List<AssistantPendingAction>();
+        var markerSeen = false;
+
+        for (var i = 0; i < lines.Length; i++) {
+            var line = (lines[i] ?? string.Empty).Trim();
+            var isHeader = string.Equals(line, ActionHeader, StringComparison.OrdinalIgnoreCase);
+            var isMarker = string.Equals(line, ActionMarker, StringComparison.OrdinalIgnoreCase);
+            if (!isHeader && !isMarker) {
+                continue;
+            }
+
+            var markerIndex = i;
+            if (isHeader) {
+                markerIndex = i + 1;
+                while (markerIndex < lines.Length && string.IsNullOrWhiteSpace(lines[markerIndex])) {
+                    markerIndex++;
+                }
+                if (markerIndex >= lines.Length
+                    || !string.Equals((lines[markerIndex] ?? string.Empty).Trim(), ActionMarker, StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+            }
+
+            markerSeen = true;
+            var id = string.Empty;
+            var title = string.Empty;
+            var reply = string.Empty;
+            var requestBuilder = new StringBuilder();
+            var sawRequest = false;
+            var endExclusive = markerIndex + 1;
+
+            for (var j = markerIndex + 1; j < lines.Length; j++) {
+                var current = lines[j] ?? string.Empty;
+                var trimmedCurrent = current.Trim();
+                if (trimmedCurrent.Length == 0) {
+                    endExclusive = j + 1;
+                    break;
+                }
+                if (string.Equals(trimmedCurrent, ActionHeader, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(trimmedCurrent, ActionMarker, StringComparison.OrdinalIgnoreCase)
+                    || trimmedCurrent.StartsWith("ix:", StringComparison.OrdinalIgnoreCase)) {
+                    endExclusive = j;
+                    break;
+                }
+
+                if (TryReadField(trimmedCurrent, "id", out var field)) {
+                    id = field;
+                    continue;
+                }
+                if (TryReadField(trimmedCurrent, "title", out field)) {
+                    title = field;
+                    continue;
+                }
+                if (TryReadField(trimmedCurrent, "request", out field)) {
+                    sawRequest = true;
+                    if (!string.IsNullOrWhiteSpace(field)) {
+                        if (requestBuilder.Length > 0) {
+                            requestBuilder.Append(' ');
+                        }
+                        requestBuilder.Append(field.Trim());
+                    }
+                    continue;
+                }
+                if (TryReadField(trimmedCurrent, "reply", out field)) {
+                    reply = field;
+                    continue;
+                }
+
+                if (sawRequest) {
+                    if (requestBuilder.Length > 0) {
+                        requestBuilder.Append(' ');
+                    }
+                    requestBuilder.Append(trimmedCurrent);
+                }
+
+                endExclusive = j + 1;
+            }
+
+            var start = isHeader ? i : markerIndex;
+            for (var j = start; j < Math.Min(lines.Length, endExclusive); j++) {
+                removed[j] = true;
+            }
+
+            id = id.Trim();
+            title = title.Trim();
+            reply = reply.Trim();
+            var request = requestBuilder.ToString().Trim();
+            if (id.Length > 0 && LooksLikeValidActionReply(reply, id)) {
+                extracted.Add(new AssistantPendingAction(
+                    Id: id,
+                    Title: title,
+                    Request: request,
+                    Reply: reply));
+            }
+
+            i = Math.Max(i, endExclusive - 1);
+        }
+
+        if (!markerSeen) {
+            return false;
+        }
+
+        var kept = new List<string>(lines.Length);
+        for (var i = 0; i < lines.Length; i++) {
+            if (removed[i]) {
+                continue;
+            }
+
+            var trimmed = (lines[i] ?? string.Empty).Trim();
+            if (string.Equals(trimmed, ActionHeader, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(trimmed, ActionMarker, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            kept.Add(lines[i]);
+        }
+
+        cleanedText = Regex.Replace(string.Join('\n', kept).Trim(), @"\n{3,}", "\n\n");
+
+        actions = extracted
+            .GroupBy(x => x.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToArray();
+        return true;
+    }
+
+    public static string MergeVisibleTextWithPendingActions(string cleanedText, IReadOnlyList<AssistantPendingAction> actions) {
+        var text = (cleanedText ?? string.Empty).Trim();
+        if (actions is null || actions.Count == 0) {
+            return text;
+        }
+
+        var summary = BuildPendingActionSummary(actions);
+        if (summary.Length == 0) {
+            return text;
+        }
+
+        return text.Length == 0 ? summary : text + "\n\n" + summary;
+    }
+
+    private static string BuildPendingActionSummary(IReadOnlyList<AssistantPendingAction> actions) {
+        if (actions.Count == 0) {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("You can run one of these follow-up actions:");
+        for (var i = 0; i < actions.Count; i++) {
+            var action = actions[i];
+            var label = (action.Title ?? string.Empty).Trim();
+            if (label.Length == 0) {
+                label = (action.Request ?? string.Empty).Trim();
+            }
+            if (label.Length == 0) {
+                label = action.Id.Trim();
+            }
+            if (label.Length > 180) {
+                label = label[..180].TrimEnd();
+            }
+
+            sb.Append(i + 1)
+                .Append(". ")
+                .Append(label)
+                .Append(" (`/act ")
+                .Append(action.Id.Trim())
+                .AppendLine("`)");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static bool TryReadField(string line, string name, out string value) {
+        value = string.Empty;
+        if (string.IsNullOrWhiteSpace(line)) {
+            return false;
+        }
+
+        var idx = line.IndexOf(':', StringComparison.Ordinal);
+        if (idx < 0) {
+            return false;
+        }
+
+        var key = line[..idx].Trim();
+        if (!string.Equals(key, name, StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        value = line[(idx + 1)..].Trim();
+        return true;
+    }
+
+    private static bool LooksLikeValidActionReply(string reply, string id) {
+        var normalizedReply = (reply ?? string.Empty).Trim();
+        var normalizedId = (id ?? string.Empty).Trim();
+        if (normalizedReply.Length == 0 || normalizedId.Length == 0) {
+            return false;
+        }
+
+        if (!normalizedReply.StartsWith("/act", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        var rest = normalizedReply[4..].Trim();
+        var token = ReadFirstToken(rest);
+        if (token.Length == 0 || !string.Equals(token, normalizedId, StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        var trailing = rest[token.Length..].Trim();
+        return trailing.Length == 0;
+    }
+
+    private static string ReadFirstToken(string text) {
+        var value = (text ?? string.Empty).Trim();
+        if (value.Length == 0) {
+            return string.Empty;
+        }
+
+        var i = 0;
+        while (i < value.Length && !char.IsWhiteSpace(value[i])) {
+            i++;
+        }
+
+        return value[..i];
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileNormalization.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileNormalization.cs
@@ -42,6 +42,10 @@ public sealed partial class MainWindow : Window {
             cleanedText = memoryCleanedText;
         }
 
+        if (ActionModelProtocol.TryStripAndExtractPendingActions(cleanedText, out var pendingActions, out var actionCleanedText)) {
+            cleanedText = ActionModelProtocol.MergeVisibleTextWithPendingActions(actionCleanedText, pendingActions);
+        }
+
         if (!string.IsNullOrWhiteSpace(cleanedText)) {
             return cleanedText;
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -26,7 +26,13 @@ namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
 
-    private sealed record ChatTurnRunResult(ChatResultMessage Result, TurnUsage? Usage, int ToolCallsCount, int ToolRounds);
+    private sealed record ChatTurnRunResult(
+        ChatResultMessage Result,
+        TurnUsage? Usage,
+        int ToolCallsCount,
+        int ToolRounds,
+        int ProjectionFallbackCount,
+        IReadOnlyList<ToolErrorMetricDto> ToolErrors);
 
     private static ChatOptions CopyChatOptions(ChatOptions options, bool? newThreadOverride = null) {
         if (options is null) {
@@ -45,6 +51,7 @@ internal sealed partial class ChatServiceSession {
         var toolCalls = new List<ToolCallDto>();
         var toolOutputs = new List<ToolOutputDto>();
         var toolRounds = 0;
+        var projectionFallbackCount = 0;
 
         IReadOnlyList<ToolDefinition> toolDefs = _registry.GetDefinitions();
         if (request.Options?.DisabledTools is { Length: > 0 } disabledTools && toolDefs.Count > 0) {
@@ -204,7 +211,9 @@ internal sealed partial class ChatServiceSession {
                     Result: result,
                     Usage: turn.Usage,
                     ToolCallsCount: toolCalls.Count,
-                    ToolRounds: toolRounds);
+                    ToolRounds: toolRounds,
+                    ProjectionFallbackCount: projectionFallbackCount,
+                    ToolErrors: BuildToolErrorMetrics(toolCalls, toolOutputs));
             }
 
             toolRounds++;
@@ -223,6 +232,10 @@ internal sealed partial class ChatServiceSession {
                 .ConfigureAwait(false);
             UpdateToolRoutingStats(extracted, executed);
             foreach (var output in executed) {
+                if (WasProjectionFallbackApplied(output)) {
+                    projectionFallbackCount++;
+                }
+
                 toolOutputs.Add(new ToolOutputDto {
                     CallId = output.CallId,
                     Output = output.Output,
@@ -247,6 +260,76 @@ internal sealed partial class ChatServiceSession {
         }
 
         throw new InvalidOperationException($"Tool runner exceeded max rounds ({maxRounds}).");
+    }
+
+    private static IReadOnlyList<ToolErrorMetricDto> BuildToolErrorMetrics(
+        IReadOnlyList<ToolCallDto> calls,
+        IReadOnlyList<ToolOutputDto> outputs) {
+        if (calls.Count == 0 || outputs.Count == 0) {
+            return Array.Empty<ToolErrorMetricDto>();
+        }
+
+        var nameByCallId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < calls.Count; i++) {
+            var call = calls[i];
+            var callId = (call.CallId ?? string.Empty).Trim();
+            var toolName = (call.Name ?? string.Empty).Trim();
+            if (callId.Length == 0 || toolName.Length == 0) {
+                continue;
+            }
+
+            nameByCallId[callId] = toolName;
+        }
+
+        if (nameByCallId.Count == 0) {
+            return Array.Empty<ToolErrorMetricDto>();
+        }
+
+        var counts = new Dictionary<(string ToolName, string ErrorCode), int>();
+        for (var i = 0; i < outputs.Count; i++) {
+            var output = outputs[i];
+            var callId = (output.CallId ?? string.Empty).Trim();
+            if (callId.Length == 0 || !nameByCallId.TryGetValue(callId, out var toolName)) {
+                continue;
+            }
+
+            var errorCode = NormalizeToolErrorCode(output);
+            if (errorCode.Length == 0) {
+                continue;
+            }
+
+            var key = (toolName, errorCode);
+            counts.TryGetValue(key, out var count);
+            counts[key] = count + 1;
+        }
+
+        if (counts.Count == 0) {
+            return Array.Empty<ToolErrorMetricDto>();
+        }
+
+        return counts
+            .Select(pair => new ToolErrorMetricDto {
+                ToolName = pair.Key.ToolName,
+                ErrorCode = pair.Key.ErrorCode,
+                Count = pair.Value
+            })
+            .OrderByDescending(metric => metric.Count)
+            .ThenBy(metric => metric.ToolName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(metric => metric.ErrorCode, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string NormalizeToolErrorCode(ToolOutputDto output) {
+        var errorCode = (output.ErrorCode ?? string.Empty).Trim();
+        if (errorCode.Length > 0) {
+            return errorCode;
+        }
+
+        if (output.Ok is false || !string.IsNullOrWhiteSpace(output.Error)) {
+            return "tool_error";
+        }
+
+        return string.Empty;
     }
 
     private static IReadOnlyList<ToolDefinition> SanitizeToolDefinitions(IReadOnlyList<ToolDefinition> definitions) {
@@ -589,7 +672,104 @@ internal sealed partial class ChatServiceSession {
             }
         }
 
+        var schemaArguments = ExtractToolSchemaPropertyNames(definition, maxCount: 12, out var hasTableViewProjection);
+        for (var i = 0; i < schemaArguments.Length; i++) {
+            sb.Append(' ').Append(schemaArguments[i]);
+        }
+
+        var requiredArguments = ExtractToolSchemaRequiredNames(definition, maxCount: 8);
+        if (requiredArguments.Length > 0) {
+            sb.Append(" required");
+            for (var i = 0; i < requiredArguments.Length; i++) {
+                sb.Append(' ').Append(requiredArguments[i]);
+            }
+        }
+
+        if (hasTableViewProjection) {
+            sb.Append(" table view projection columns sort_by sort_direction top");
+        }
+
         return sb.ToString();
+    }
+
+    private static string[] ExtractToolSchemaPropertyNames(ToolDefinition definition, int maxCount, out bool hasTableViewProjection) {
+        hasTableViewProjection = false;
+        if (definition?.Parameters is null || maxCount <= 0) {
+            return Array.Empty<string>();
+        }
+
+        var properties = definition.Parameters.GetObject("properties");
+        if (properties is null || properties.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        hasTableViewProjection = HasTableViewProjectionArguments(properties);
+
+        var names = new List<string>(Math.Min(maxCount, properties.Count));
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kv in properties) {
+            var name = NormalizeToolSchemaToken(kv.Key);
+            if (name.Length == 0 || !seen.Add(name)) {
+                continue;
+            }
+
+            names.Add(name);
+            if (names.Count >= maxCount) {
+                break;
+            }
+        }
+
+        return names.Count == 0 ? Array.Empty<string>() : names.ToArray();
+    }
+
+    private static string[] ExtractToolSchemaRequiredNames(ToolDefinition definition, int maxCount) {
+        if (definition?.Parameters is null || maxCount <= 0) {
+            return Array.Empty<string>();
+        }
+
+        var required = definition.Parameters.GetArray("required");
+        if (required is null || required.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        var names = new List<string>(Math.Min(maxCount, required.Count));
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < required.Count && names.Count < maxCount; i++) {
+            var value = NormalizeToolSchemaToken(required[i]?.AsString());
+            if (value.Length == 0 || !seen.Add(value)) {
+                continue;
+            }
+
+            names.Add(value);
+        }
+
+        return names.Count == 0 ? Array.Empty<string>() : names.ToArray();
+    }
+
+    private static bool HasTableViewProjectionArguments(JsonObject properties) {
+        return properties.TryGetValue("columns", out _)
+               || properties.TryGetValue("sort_by", out _)
+               || properties.TryGetValue("sort_direction", out _)
+               || properties.TryGetValue("top", out _);
+    }
+
+    private static string NormalizeToolSchemaToken(string? token) {
+        var value = (token ?? string.Empty).Trim();
+        if (value.Length == 0) {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(value.Length);
+        for (var i = 0; i < value.Length; i++) {
+            var c = value[i];
+            if (char.IsLetterOrDigit(c) || c is '_' or '-') {
+                sb.Append(c);
+            } else if (char.IsWhiteSpace(c)) {
+                sb.Append('_');
+            }
+        }
+
+        return sb.ToString().Trim('_');
     }
 
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
@@ -444,6 +444,8 @@ internal sealed partial class ChatServiceSession {
             TokenUsageDto? usageDto = null;
             var toolCallsCount = 0;
             var toolRounds = 0;
+            var projectionFallbackCount = 0;
+            IReadOnlyList<ToolErrorMetricDto>? toolErrors = null;
             var outcome = "ok";
             string? outcomeCode = null;
             var threadIdForDelta = run.ThreadId ?? string.Empty;
@@ -461,6 +463,8 @@ internal sealed partial class ChatServiceSession {
                 usageDto = MapUsage(result.Usage);
                 toolCallsCount = result.ToolCallsCount;
                 toolRounds = result.ToolRounds;
+                projectionFallbackCount = result.ProjectionFallbackCount;
+                toolErrors = result.ToolErrors;
                 await WriteAsync(writer, result.Result, CancellationToken.None).ConfigureAwait(false);
 
                 await TryRecordRecentModelAsync(usedModel, CancellationToken.None).ConfigureAwait(false);
@@ -518,6 +522,8 @@ internal sealed partial class ChatServiceSession {
                         Usage = usageDto,
                         ToolCallsCount = toolCallsCount,
                         ToolRounds = toolRounds,
+                        ProjectionFallbackCount = projectionFallbackCount,
+                        ToolErrors = toolErrors is { Count: > 0 } ? toolErrors : null,
                         Outcome = outcome,
                         ErrorCode = outcomeCode
                     }, CancellationToken.None).ConfigureAwait(false);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolExecution.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolExecution.cs
@@ -24,6 +24,7 @@ using IntelligenceX.Tools.Common;
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
+    private static readonly string[] ProjectionViewArgumentNames = { "columns", "sort_by", "sort_direction", "top" };
 
     private static async Task<TurnInfo> ChatWithToolSchemaRecoveryAsync(IntelligenceXClient client, ChatInput input, ChatOptions options,
         CancellationToken cancellationToken) {
@@ -115,9 +116,24 @@ internal sealed partial class ChatServiceSession {
 
         // Retry profile wiring is enforced in this execution loop.
         var profile = ResolveRetryProfile(call.Name);
+        var currentCall = call;
+        var projectionFallbackAttempted = false;
         ToolOutputDto? lastFailure = null;
         for (var attemptIndex = 0; attemptIndex < profile.MaxAttempts; attemptIndex++) {
-            var output = await ExecuteToolAttemptAsync(tool, call, toolTimeoutSeconds, cancellationToken).ConfigureAwait(false);
+            var output = await ExecuteToolAttemptAsync(tool, currentCall, toolTimeoutSeconds, cancellationToken).ConfigureAwait(false);
+            if (!projectionFallbackAttempted
+                && TryBuildProjectionArgsFallbackCall(currentCall, output, out var fallbackCall, out var fallbackInfo)) {
+                projectionFallbackAttempted = true;
+                currentCall = fallbackCall;
+
+                // One deterministic self-heal pass for view-projection failures: retry with bare/default view args.
+                var fallbackOutput = await ExecuteToolAttemptAsync(tool, currentCall, toolTimeoutSeconds, cancellationToken).ConfigureAwait(false);
+                output = AttachProjectionFallbackMetadata(fallbackOutput, fallbackInfo);
+                if (output.Ok is true) {
+                    return output;
+                }
+            }
+
             if (!ShouldRetryToolCall(output, profile, attemptIndex)) {
                 return output;
             }
@@ -134,6 +150,225 @@ internal sealed partial class ChatServiceSession {
         }
 
         return lastFailure ?? await ExecuteToolAttemptAsync(tool, call, toolTimeoutSeconds, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool TryBuildProjectionArgsFallbackCall(ToolCall call, ToolOutputDto output, out ToolCall fallbackCall,
+        out ProjectionFallbackInfo fallbackInfo) {
+        fallbackCall = call;
+        fallbackInfo = default;
+
+        if (!IsProjectionViewArgumentFailure(output)) {
+            return false;
+        }
+
+        var fallbackArguments = CloneWithoutProjectionViewArguments(call.Arguments, out var removedArguments);
+        if (removedArguments.Length == 0) {
+            return false;
+        }
+
+        var fallbackInput = fallbackArguments is null ? null : JsonLite.Serialize(fallbackArguments);
+        fallbackCall = new ToolCall(call.CallId, call.Name, fallbackInput, fallbackArguments, call.Raw);
+        fallbackInfo = new ProjectionFallbackInfo(
+            RemovedArguments: removedArguments,
+            OriginalErrorCode: (output.ErrorCode ?? string.Empty).Trim(),
+            OriginalError: CompactProjectionFallbackReason(output.Error));
+        return true;
+    }
+
+    private static bool IsProjectionViewArgumentFailure(ToolOutputDto output) {
+        if (output.Ok is true) {
+            return false;
+        }
+
+        var text = BuildToolFailureSearchText(output);
+        if (text.Length == 0) {
+            return false;
+        }
+
+        var hasProjectionSignal = text.Contains("columns", StringComparison.OrdinalIgnoreCase)
+                                  || text.Contains("sort_by", StringComparison.OrdinalIgnoreCase)
+                                  || text.Contains("sort direction", StringComparison.OrdinalIgnoreCase)
+                                  || text.Contains("sort_direction", StringComparison.OrdinalIgnoreCase)
+                                  || text.Contains("tabular view", StringComparison.OrdinalIgnoreCase)
+                                  || text.Contains("projection", StringComparison.OrdinalIgnoreCase)
+                                  || text.Contains("table view response envelope", StringComparison.OrdinalIgnoreCase);
+        if (!hasProjectionSignal) {
+            return false;
+        }
+
+        if (string.Equals(output.ErrorCode, "invalid_argument", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(output.ErrorCode, "tool_error", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        return text.Contains("unsupported value", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("must be one of", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("invalid", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static JsonObject? CloneWithoutProjectionViewArguments(JsonObject? arguments, out string[] removedArguments) {
+        removedArguments = Array.Empty<string>();
+        if (arguments is null || arguments.Count == 0) {
+            return arguments;
+        }
+
+        var clone = new JsonObject(StringComparer.Ordinal);
+        var removed = new List<string>(ProjectionViewArgumentNames.Length);
+        var seenRemoved = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kv in arguments) {
+            var key = (kv.Key ?? string.Empty).Trim();
+            if (key.Length == 0) {
+                continue;
+            }
+
+            if (IsProjectionViewArgumentName(key)) {
+                if (seenRemoved.Add(key)) {
+                    removed.Add(key);
+                }
+                continue;
+            }
+
+            clone.Add(key, kv.Value);
+        }
+
+        removedArguments = removed.Count == 0 ? Array.Empty<string>() : removed.ToArray();
+        return clone;
+    }
+
+    private static bool IsProjectionViewArgumentName(string argumentName) {
+        for (var i = 0; i < ProjectionViewArgumentNames.Length; i++) {
+            if (string.Equals(argumentName, ProjectionViewArgumentNames[i], StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static ToolOutputDto AttachProjectionFallbackMetadata(ToolOutputDto output, ProjectionFallbackInfo info) {
+        if (string.IsNullOrWhiteSpace(output.Output)) {
+            return output;
+        }
+
+        JsonObject? envelope = null;
+        try {
+            envelope = JsonLite.Parse(output.Output)?.AsObject();
+        } catch {
+            envelope = null;
+        }
+
+        if (envelope is null) {
+            return output;
+        }
+
+        var meta = envelope.GetObject("meta") ?? new JsonObject(StringComparer.Ordinal);
+        meta.Add("projection_fallback_applied", true);
+
+        var removed = new JsonArray();
+        for (var i = 0; i < info.RemovedArguments.Length; i++) {
+            if (!string.IsNullOrWhiteSpace(info.RemovedArguments[i])) {
+                removed.Add(info.RemovedArguments[i].Trim());
+            }
+        }
+        meta.Add("projection_fallback_removed_args", removed);
+        if (!string.IsNullOrWhiteSpace(info.OriginalErrorCode)) {
+            meta.Add("projection_fallback_reason_code", info.OriginalErrorCode);
+        }
+        if (!string.IsNullOrWhiteSpace(info.OriginalError)) {
+            meta.Add("projection_fallback_reason", info.OriginalError);
+        }
+        envelope.Add("meta", meta);
+
+        const string fallbackHint = "Projection arguments were reset to defaults after a view-argument failure.";
+        if (envelope.GetArray("hints") is JsonArray rootHints) {
+            AddDistinctJsonString(rootHints, fallbackHint);
+        } else {
+            envelope.Add("hints", new JsonArray().Add(fallbackHint));
+        }
+
+        if (envelope.GetObject("failure") is JsonObject failure) {
+            if (failure.GetArray("hints") is JsonArray failureHints) {
+                AddDistinctJsonString(failureHints, fallbackHint);
+            } else {
+                failure.Add("hints", new JsonArray().Add(fallbackHint));
+            }
+            envelope.Add("failure", failure);
+        }
+
+        return BuildToolOutputDto(output.CallId, JsonLite.Serialize(envelope));
+    }
+
+    private static void AddDistinctJsonString(JsonArray target, string value) {
+        if (target is null || string.IsNullOrWhiteSpace(value)) {
+            return;
+        }
+
+        var normalized = value.Trim();
+        for (var i = 0; i < target.Count; i++) {
+            var existing = target[i]?.AsString();
+            if (string.Equals(existing, normalized, StringComparison.OrdinalIgnoreCase)) {
+                return;
+            }
+        }
+
+        target.Add(normalized);
+    }
+
+    private static string CompactProjectionFallbackReason(string? errorText) {
+        var compact = CompactFailureText(errorText);
+        const int maxReasonLength = 320;
+        if (compact.Length <= maxReasonLength) {
+            return compact;
+        }
+        return compact[..maxReasonLength].TrimEnd();
+    }
+
+    private static bool WasProjectionFallbackApplied(ToolOutputDto output) {
+        if (output is null) {
+            return false;
+        }
+
+        return TryReadProjectionFallbackApplied(output.MetaJson, out var appliedFromMeta) && appliedFromMeta
+               || TryReadProjectionFallbackApplied(output.Output, out var appliedFromOutput) && appliedFromOutput;
+    }
+
+    private static bool TryReadProjectionFallbackApplied(string? rawJson, out bool applied) {
+        applied = false;
+        if (string.IsNullOrWhiteSpace(rawJson)) {
+            return false;
+        }
+
+        JsonObject? obj;
+        try {
+            obj = JsonLite.Parse(rawJson)?.AsObject();
+        } catch {
+            return false;
+        }
+
+        if (obj is null) {
+            return false;
+        }
+
+        if (TryReadProjectionFallbackFlag(obj, out applied)) {
+            return true;
+        }
+
+        if (obj.GetObject("meta") is JsonObject meta && TryReadProjectionFallbackFlag(meta, out applied)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadProjectionFallbackFlag(JsonObject obj, out bool applied) {
+        applied = false;
+        if (!obj.TryGetValue("projection_fallback_applied", out var raw)
+            || raw is null
+            || raw.Kind != IntelligenceX.Json.JsonValueKind.Boolean) {
+            return false;
+        }
+
+        applied = raw.AsBoolean();
+        return true;
     }
 
     private async Task<ToolOutputDto> ExecuteToolAttemptAsync(ITool tool, ToolCall call, int toolTimeoutSeconds, CancellationToken cancellationToken) {
@@ -442,5 +677,7 @@ internal sealed partial class ChatServiceSession {
 
         return new ToolRetryProfile(MaxAttempts: 1, DelayBaseMs: 0, RetryOnTimeout: false, RetryOnTransport: false);
     }
+
+    private readonly record struct ProjectionFallbackInfo(string[] RemovedArguments, string OriginalErrorCode, string OriginalError);
 
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
@@ -201,9 +201,20 @@ internal sealed partial class ChatServiceSession {
             if (description.Length > 220) {
                 description = description[..220].TrimEnd();
             }
+            var schemaArguments = ExtractToolSchemaPropertyNames(definition, maxCount: 8, out var hasTableViewProjection);
+            var requiredArguments = ExtractToolSchemaRequiredNames(definition, maxCount: 4);
             sb.Append(i + 1).Append(". ").Append(name);
             if (description.Length > 0) {
                 sb.Append(" :: ").Append(description);
+            }
+            if (requiredArguments.Length > 0) {
+                sb.Append(" | required: ").Append(string.Join(", ", requiredArguments));
+            }
+            if (schemaArguments.Length > 0) {
+                sb.Append(" | args: ").Append(string.Join(", ", schemaArguments));
+            }
+            if (hasTableViewProjection) {
+                sb.Append(" | traits: table_view_projection");
             }
             sb.AppendLine();
         }
@@ -459,4 +470,3 @@ internal sealed partial class ChatServiceSession {
         bool RetryOnTransport);
 
 }
-

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using IntelligenceX.Chat.Service;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+/// <summary>
+/// Validates planner and lexical-routing prompts include schema hints.
+/// </summary>
+public sealed class ChatServicePlannerPromptTests {
+    private static readonly MethodInfo BuildModelPlannerPromptMethod =
+        typeof(ChatServiceSession).GetMethod("BuildModelPlannerPrompt", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildModelPlannerPrompt not found.");
+
+    private static readonly MethodInfo BuildToolRoutingSearchTextMethod =
+        typeof(ChatServiceSession).GetMethod("BuildToolRoutingSearchText", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildToolRoutingSearchText not found.");
+
+    [Fact]
+    public void BuildModelPlannerPrompt_IncludesSchemaArgumentsRequiredAndTableViewTrait() {
+        var definitions = new List<ToolDefinition> {
+            new(
+                "eventlog_top_events",
+                "Return top events from a log.",
+                ToolSchema.Object(
+                        ("log_name", ToolSchema.String("Log name.")),
+                        ("machine_name", ToolSchema.String("Remote host.")))
+                    .WithTableViewOptions()
+                    .Required("log_name")
+                    .NoAdditionalProperties())
+        };
+
+        var prompt = Assert.IsType<string>(BuildModelPlannerPromptMethod.Invoke(null, new object?[] {
+            "top 5 system events from AD0",
+            definitions,
+            6
+        }));
+
+        Assert.Contains("required: log_name", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("args: ", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("traits: table_view_projection", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildToolRoutingSearchText_IncludesSchemaTokens() {
+        var definition = new ToolDefinition(
+            "eventlog_top_events",
+            "Return top events from a log.",
+            ToolSchema.Object(
+                    ("log_name", ToolSchema.String("Log name.")),
+                    ("machine_name", ToolSchema.String("Remote host.")))
+                .WithTableViewOptions()
+                .Required("log_name")
+                .NoAdditionalProperties());
+
+        var searchText = Assert.IsType<string>(BuildToolRoutingSearchTextMethod.Invoke(null, new object?[] { definition }));
+
+        Assert.Contains("log_name", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("required", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("table view projection", searchText, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRetryPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRetryPolicyTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Reflection;
 using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
 using Xunit;
 
 namespace IntelligenceX.Chat.Tests;
@@ -22,6 +24,14 @@ public sealed class ChatServiceRetryPolicyTests {
         "ShouldRetryToolCall",
         BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("ShouldRetryToolCall not found.");
+    private static readonly MethodInfo IsProjectionViewArgumentFailureMethod = ChatServiceSessionType.GetMethod(
+        "IsProjectionViewArgumentFailure",
+        BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("IsProjectionViewArgumentFailure not found.");
+    private static readonly MethodInfo TryBuildProjectionArgsFallbackCallMethod = ChatServiceSessionType.GetMethod(
+        "TryBuildProjectionArgsFallbackCall",
+        BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("TryBuildProjectionArgsFallbackCall not found.");
 
     [Fact]
     public void ShouldRetryToolCall_DoesNotRetryPermanentAccessDeniedFailure() {
@@ -74,6 +84,71 @@ public sealed class ChatServiceRetryPolicyTests {
         Assert.False(shouldRetry);
     }
 
+    [Fact]
+    public void IsProjectionViewArgumentFailure_DetectsUnsupportedProjectionColumns() {
+        var output = new ToolOutputDto {
+            CallId = "call-4",
+            Output = "{\"ok\":false,\"error_code\":\"invalid_argument\",\"error\":\"columns contains unsupported value 'bad_column'.\"}",
+            Ok = false,
+            ErrorCode = "invalid_argument",
+            Error = "columns contains unsupported value 'bad_column'."
+        };
+
+        var detected = InvokeIsProjectionViewArgumentFailure(output);
+
+        Assert.True(detected);
+    }
+
+    [Fact]
+    public void IsProjectionViewArgumentFailure_DoesNotMatchUnrelatedPermanentErrors() {
+        var output = new ToolOutputDto {
+            CallId = "call-5",
+            Output = "{\"ok\":false,\"error_code\":\"tool_exception\",\"error\":\"Access denied.\"}",
+            Ok = false,
+            ErrorCode = "tool_exception",
+            Error = "Access denied."
+        };
+
+        var detected = InvokeIsProjectionViewArgumentFailure(output);
+
+        Assert.False(detected);
+    }
+
+    [Fact]
+    public void TryBuildProjectionArgsFallbackCall_StripsProjectionArgumentsAndKeepsToolArguments() {
+        var call = new ToolCall(
+            callId: "call-6",
+            name: "eventlog_top_events",
+            input: null,
+            arguments: new JsonObject()
+                .Add("log_name", "System")
+                .Add("columns", new JsonArray().Add("event_id"))
+                .Add("sort_by", "event_id")
+                .Add("sort_direction", "desc")
+                .Add("top", 5),
+            raw: new JsonObject());
+        var output = new ToolOutputDto {
+            CallId = call.CallId,
+            Output = "{\"ok\":false,\"error_code\":\"invalid_argument\",\"error\":\"sort_by must be one of: event_id, level.\"}",
+            Ok = false,
+            ErrorCode = "invalid_argument",
+            Error = "sort_by must be one of: event_id, level."
+        };
+
+        var args = new object?[] { call, output, null, null };
+        var built = TryBuildProjectionArgsFallbackCallMethod.Invoke(null, args);
+        var fallbackCall = Assert.IsType<ToolCall>(args[2]);
+
+        Assert.True(Assert.IsType<bool>(built));
+        Assert.NotNull(args[3]);
+        Assert.NotNull(fallbackCall.Arguments);
+        Assert.Equal("System", fallbackCall.Arguments!.GetString("log_name"));
+        Assert.False(fallbackCall.Arguments.TryGetValue("columns", out _));
+        Assert.False(fallbackCall.Arguments.TryGetValue("sort_by", out _));
+        Assert.False(fallbackCall.Arguments.TryGetValue("sort_direction", out _));
+        Assert.False(fallbackCall.Arguments.TryGetValue("top", out _));
+    }
+
     private static object InvokeResolveRetryProfile(string toolName) {
         var profile = ResolveRetryProfileMethod.Invoke(null, new object?[] { toolName });
         return profile ?? throw new InvalidOperationException("ResolveRetryProfile returned null.");
@@ -81,6 +156,11 @@ public sealed class ChatServiceRetryPolicyTests {
 
     private static bool InvokeShouldRetryToolCall(ToolOutputDto output, object profile, int attemptIndex) {
         var result = ShouldRetryToolCallMethod.Invoke(null, new object?[] { output, profile, attemptIndex });
+        return Assert.IsType<bool>(result);
+    }
+
+    private static bool InvokeIsProjectionViewArgumentFailure(ToolOutputDto output) {
+        var result = IsProjectionViewArgumentFailureMethod.Invoke(null, new object?[] { output });
         return Assert.IsType<bool>(result);
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolTableViewEnvelope.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolTableViewEnvelope.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using IntelligenceX.Json;
+using IntelligenceX.Tools;
 
 namespace IntelligenceX.Tools.Common;
 
@@ -70,7 +71,21 @@ public static class ToolTableViewEnvelope {
         int? scanned = null,
         Action<JsonObject>? metaMutate = null) {
         if (!ToolTableView.TryParse(arguments, columnKeys, maxTop: maxTop, out var view, out var viewError)) {
-            response = ToolResponse.Error("invalid_argument", viewError ?? "Invalid tabular view arguments.");
+            var error = string.IsNullOrWhiteSpace(viewError) ? "Invalid tabular view arguments." : viewError!;
+            var hints = new List<string> {
+                "Use only listed columns for projection.",
+                "Use sort_direction as 'asc' or 'desc'.",
+                "If projection keeps failing, retry without columns/sort_by/sort_direction/top."
+            };
+            var meta = new JsonObject()
+                .Add("available_columns", new JsonArray().AddRange(columnKeys))
+                .Add("projection_arguments", new JsonArray().Add("columns").Add("sort_by").Add("sort_direction").Add("top"));
+            response = ToolOutputEnvelope.Error(
+                errorCode: "invalid_argument",
+                error: error,
+                hints: hints,
+                isTransient: false,
+                meta: meta);
             return false;
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogTopEventsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogTopEventsTool.cs
@@ -198,7 +198,7 @@ public sealed class EventLogTopEventsTool : EventLogToolBase, ITool {
             maxTop: MaxViewTop,
             baseTruncated: root!.Truncated,
             response: out var response)) {
-            return ToolResponse.Error("tool_error", "Failed to build table view response envelope.");
+            return response;
         }
         return response;
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolTableViewTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolTableViewTests.cs
@@ -106,6 +106,31 @@ public class ToolTableViewTests {
     }
 
     [Fact]
+    public void EnvelopeAutoColumns_ShouldReturnProjectionMetadataOnInvalidViewArguments() {
+        var ok = ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+            arguments: new JsonObject().Add("columns", new JsonArray().Add("missing_column")),
+            model: new AutoModel {
+                Items = new[] {
+                    new AutoRow(1, "alpha", DateTime.UnixEpoch, new[] { "a" })
+                }
+            },
+            sourceRows: new[] {
+                new AutoRow(1, "alpha", DateTime.UnixEpoch, new[] { "a" })
+            },
+            viewRowsPath: "items_view",
+            title: "Items",
+            maxTop: 100,
+            baseTruncated: false,
+            response: out var response);
+
+        Assert.False(ok);
+        Assert.Contains("\"ok\":false", response);
+        Assert.Contains("\"error_code\":\"invalid_argument\"", response);
+        Assert.Contains("\"available_columns\":[", response);
+        Assert.Contains("\"projection_arguments\":[\"columns\",\"sort_by\",\"sort_direction\",\"top\"]", response);
+    }
+
+    [Fact]
     public void DynamicEnvelope_ShouldProjectDictionaryRows() {
         IReadOnlyList<IReadOnlyDictionary<string, object?>> rows = new[] {
             new Dictionary<string, object?>(StringComparer.Ordinal) {


### PR DESCRIPTION
## Summary
- fix `eventlog_top_events` to preserve structured invalid-argument envelopes from table-view parsing
- add deterministic runtime projection fallback (strip `columns/sort_by/sort_direction/top` and retry once)
- enrich turn metrics with `projectionFallbackCount` and per-tool error taxonomy (`toolErrors`)
- improve planner/routing prompts with schema-derived required args and table-view trait hints
- normalize assistant action protocol blocks in the app (`ix:action:v1`) into clean visible follow-up actions
- add targeted tests for table-view envelope metadata, projection fallback behavior, planner prompt hints, and action protocol normalization

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
