### PR TITLE
Chat app: split Runtime settings tab and fix model picker overflow

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.base.css
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.base.css
@@ -31,7 +31,7 @@
   --ix-radius-sm: 7px;
   --ix-radius-md: 10px;
   --ix-radius-lg: 14px;
-  --ix-options-width: min(380px, 88vw);
+  --ix-options-width: min(560px, 94vw);
   --ix-scrollbar-thumb: rgba(76, 195, 255, 0.36);
   --ix-scrollbar-thumb-hover: rgba(76, 195, 255, 0.56);
   --ix-user-avatar-bg: #3b82f6;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
@@ -398,6 +398,7 @@
   }
 
   function switchOptionsTab(tabId) {
+    closeOpenCustomSelect();
     var tabs = optionsPanel.querySelectorAll(".options-tab");
     var contents = optionsPanel.querySelectorAll(".options-tab-content");
     for (var i = 0; i < tabs.length; i++) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.12.core.helpers.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.12.core.helpers.js
@@ -191,11 +191,30 @@
     }
 
     var rect = button.getBoundingClientRect();
+    var viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    var edgePadding = 8;
+    var preferredMaxHeight = 260;
+    var availableBelow = Math.max(0, viewportHeight - rect.bottom - edgePadding);
+    var availableAbove = Math.max(0, rect.top - edgePadding);
+    var openUpwards = availableBelow < 150 && availableAbove > availableBelow;
+    var availableHeight = openUpwards ? availableAbove : availableBelow;
+    var maxHeight = Math.max(64, Math.min(preferredMaxHeight, availableHeight));
+    if (availableHeight < 64) {
+      maxHeight = Math.max(32, availableHeight);
+    }
+
     menu.style.position = "fixed";
     menu.style.left = rect.left + "px";
-    menu.style.top = (rect.bottom + 4) + "px";
+    if (openUpwards) {
+      menu.classList.add("ix-select-menu-up");
+      menu.style.top = Math.max(edgePadding, rect.top - maxHeight - 4) + "px";
+    } else {
+      menu.classList.remove("ix-select-menu-up");
+      menu.style.top = (rect.bottom + 4) + "px";
+    }
     menu.style.width = rect.width + "px";
     menu.style.right = "auto";
+    menu.style.maxHeight = Math.max(32, maxHeight) + "px";
   }
 
   function clearSelectMenuPosition(wrap) {
@@ -208,6 +227,8 @@
     menu.style.top = "";
     menu.style.width = "";
     menu.style.right = "";
+    menu.style.maxHeight = "";
+    menu.classList.remove("ix-select-menu-up");
   }
 
   function closeOpenCustomSelect() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -462,20 +462,57 @@
     var runtimeDetectedName = normalizeModelText(runtimeDetection.detectedName || "");
     var runtimeDetectionWarning = normalizeModelText(runtimeDetection.warning || "");
     var lmStudioConnected = isCompatible && isLmStudioBaseUrl(baseUrl);
+    var runtimeSummary = byId("optRuntimeSummary");
+    if (runtimeSummary) {
+      if (isCompatible) {
+        var endpoint = baseUrl ? baseUrl : "(base URL not set)";
+        runtimeSummary.textContent = "Current: Local runtime (Compatible HTTP) via " + endpoint + ".";
+      } else {
+        runtimeSummary.textContent = "Current: ChatGPT runtime (OpenAI native).";
+      }
+    }
+
+    var runtimeAuthHint = byId("optRuntimeAuthHint");
+    if (runtimeAuthHint) {
+      if (isCompatible) {
+        runtimeAuthHint.textContent = "You can stay signed in to ChatGPT while running local models.";
+      } else {
+        runtimeAuthHint.textContent = "ChatGPT sign-in and runtime provider are separate. You can switch to LM Studio any time.";
+      }
+    }
+
     var simpleHint = byId("optLocalSimpleHint");
     if (simpleHint) {
-      if (lmStudioConnected) {
+      if (!isCompatible) {
+        simpleHint.textContent = "ChatGPT runtime is active. Switch to LM Studio runtime to use local models.";
+      } else if (lmStudioConnected) {
         simpleHint.textContent = "LM Studio runtime is active for this profile.";
       } else if (runtimeDetectionHasRun && !lmStudioAvailable) {
-        simpleHint.textContent = "LM Studio not detected on http://127.0.0.1:1234/v1. Start LM Studio or open Advanced Runtime.";
+        simpleHint.textContent = "LM Studio not detected on http://127.0.0.1:1234/v1. Start LM Studio and reconnect, or configure Advanced Runtime.";
       } else {
-        simpleHint.textContent = "ChatGPT native is default. Connect LM Studio for local models.";
+        simpleHint.textContent = "Local runtime is active. Use LM Studio Runtime for the default LM Studio endpoint.";
       }
+    }
+
+    var useOpenAiRuntimeButton = byId("btnUseOpenAiRuntime");
+    if (useOpenAiRuntimeButton) {
+      useOpenAiRuntimeButton.textContent = isCompatible ? "Use ChatGPT Runtime" : "ChatGPT Runtime Active";
+      useOpenAiRuntimeButton.classList.toggle("options-btn-active", !isCompatible);
     }
 
     var connectLmStudioButton = byId("btnConnectLmStudio");
     if (connectLmStudioButton) {
-      connectLmStudioButton.textContent = lmStudioConnected ? "Reconnect LM Studio" : "Connect LM Studio";
+      connectLmStudioButton.textContent = lmStudioConnected ? "LM Studio Runtime Active" : "Use LM Studio Runtime";
+      connectLmStudioButton.classList.toggle("options-btn-active", lmStudioConnected);
+      connectLmStudioButton.title = runtimeDetectionHasRun && !lmStudioAvailable && !lmStudioConnected
+        ? "LM Studio was not detected. Start LM Studio and click Auto Detect Runtime in Advanced Runtime."
+        : "";
+    }
+
+    var refreshModelsButton = byId("btnRefreshModels");
+    if (refreshModelsButton) {
+      refreshModelsButton.disabled = !isCompatible;
+      refreshModelsButton.title = isCompatible ? "" : "Switch to local runtime to refresh local models.";
     }
 
     var advancedShouldBeOpen = isRuntimeAdvancedOpen();
@@ -611,16 +648,21 @@
     if (stateNote) {
       var parts = [];
       if (!isCompatible) {
-        parts.push("ChatGPT native runtime active");
-      } else if (runtimeDetectedName) {
-        parts.push("detected runtime: " + runtimeDetectedName);
-      } else if (runtimeDetectionHasRun && runtimeDetectionWarning) {
-        parts.push(runtimeDetectionWarning);
-      }
-      if (models.length > 0) {
-        parts.push(String(models.length) + " models discovered");
+        parts.push("ChatGPT runtime active");
+        if (models.length > 0) {
+          parts.push(String(models.length) + " local models cached");
+        }
       } else {
-        parts.push("No discovered models yet");
+        if (runtimeDetectedName) {
+          parts.push("detected runtime: " + runtimeDetectedName);
+        } else if (runtimeDetectionHasRun && runtimeDetectionWarning) {
+          parts.push(runtimeDetectionWarning);
+        }
+        if (models.length > 0) {
+          parts.push(String(models.length) + " models discovered");
+        } else {
+          parts.push("No discovered models yet");
+        }
       }
       parts.push(profileSaved ? "service profile saved" : "service profile not saved yet");
       if (isStale) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -671,6 +671,13 @@
     setRuntimeAdvancedOpen(!isRuntimeAdvancedOpen());
   });
 
+  byId("btnUseOpenAiRuntime").addEventListener("click", function() {
+    var transport = byId("optLocalTransport");
+    transport.value = "native";
+    syncCustomSelect(transport);
+    applyLocalProviderSettings(true);
+  });
+
   byId("btnConnectLmStudio").addEventListener("click", function() {
     var transport = byId("optLocalTransport");
     var baseUrl = byId("optLocalBaseUrl");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.30.options.css
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.30.options.css
@@ -69,8 +69,9 @@ body.options-open .options-panel {
 
 .options-tabs {
   display: flex;
-  gap: 4px;
-  padding: 8px 12px 0;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 12px 6px;
   border-bottom: 1px solid var(--ix-border-subtle);
   background: rgba(0, 0, 0, 0.1);
   flex-shrink: 0;
@@ -81,9 +82,9 @@ body.options-open .options-panel {
   background: transparent;
   color: var(--ix-text-muted);
   font-family: inherit;
-  font-size: 11.5px;
+  font-size: 11px;
   font-weight: 600;
-  padding: 7px 12px;
+  padding: 7px 11px;
   border-radius: 8px 8px 0 0;
   cursor: pointer;
   border-bottom: 2px solid transparent;
@@ -253,6 +254,10 @@ body.options-open .options-panel {
   scrollbar-color: var(--ix-scrollbar-thumb) transparent;
 }
 
+.ix-select-menu.ix-select-menu-up {
+  box-shadow: 0 -8px 22px rgba(0, 0, 0, 0.45);
+}
+
 .ix-select.open .ix-select-menu {
   display: block;
 }
@@ -348,6 +353,12 @@ body.options-open .options-panel {
   color: var(--ix-text-muted);
 }
 
+.options-note-strong {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ix-text-secondary);
+}
+
 .options-policy-list-wrap {
   margin-top: 8px;
   border: 1px solid rgba(58, 96, 144, 0.45);
@@ -409,6 +420,11 @@ body.options-open .options-panel {
 
 .options-btn:hover {
   background: rgba(76, 195, 255, 0.32);
+}
+
+.options-btn-active {
+  border-color: rgba(76, 195, 255, 0.85);
+  background: rgba(76, 195, 255, 0.34);
 }
 
 .options-btn-ghost {
@@ -791,6 +807,10 @@ body.options-open .options-panel {
 }
 
 @media (max-width: 680px) {
+  .options-panel {
+    width: min(100vw, 560px);
+  }
+
   .chat-sidebar {
     width: 160px;
     min-width: 160px;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -97,6 +97,7 @@
     </header>
     <nav class="options-tabs" id="optionsTabs">
       <button class="options-tab active" data-tab="profile">Profile</button>
+      <button class="options-tab" data-tab="runtime">Runtime</button>
       <button class="options-tab" data-tab="display">Display</button>
       <button class="options-tab" data-tab="export">Export</button>
       <button class="options-tab" data-tab="tools">Tools</button>
@@ -143,14 +144,30 @@
             </select>
             <div id="optProfileScopeHint" class="options-note"></div>
           </div>
-          <div class="options-label">Model Runtime</div>
-          <div class="options-note" id="optLocalSimpleHint">ChatGPT native is default. Connect LM Studio for local models.</div>
+          <div class="options-actions">
+            <button id="btnSaveProfile" class="options-btn">Save As Default</button>
+            <button id="btnRestartOnboarding" class="options-btn options-btn-ghost">Restart Onboarding</button>
+          </div>
+        </section>
+      </div>
+
+      <div class="options-tab-content" data-tab="runtime">
+        <section class="options-group">
+          <div class="options-label">Runtime Mode</div>
+          <div id="optRuntimeSummary" class="options-note options-note-strong"></div>
+          <div class="options-note" id="optRuntimeAuthHint">ChatGPT sign-in and runtime provider are separate. You can stay signed in while using local models.</div>
           <div class="options-actions options-actions-wrap">
-            <button id="btnConnectLmStudio" class="options-btn options-btn-sm">Connect LM Studio</button>
+            <button id="btnUseOpenAiRuntime" class="options-btn options-btn-sm">Use ChatGPT Runtime</button>
+            <button id="btnConnectLmStudio" class="options-btn options-btn-sm options-btn-ghost">Use LM Studio Runtime</button>
             <button id="btnRefreshModels" class="options-btn options-btn-sm options-btn-ghost">Refresh Models</button>
             <button id="btnApplyLocalProvider" class="options-btn options-btn-sm options-btn-ghost">Apply Runtime</button>
             <button id="btnToggleLocalAdvancedRuntime" class="options-btn options-btn-sm options-btn-ghost">Show Advanced Runtime</button>
           </div>
+        </section>
+
+        <section class="options-group">
+          <div class="options-label">Local Model Selection</div>
+          <div class="options-note" id="optLocalSimpleHint">ChatGPT runtime is active. Switch to LM Studio to use local models.</div>
           <div id="optLocalAdvancedArea" hidden>
             <div class="options-row" id="optLocalTransportRow">
               <label class="options-label-inline" for="optLocalTransport">Provider transport</label>
@@ -161,7 +178,7 @@
             </div>
             <div class="options-row" id="optLocalBaseUrlRow">
               <label class="options-label-inline" for="optLocalBaseUrl">Base URL</label>
-              <input id="optLocalBaseUrl" class="options-input options-input-sm" placeholder="http://127.0.0.1:11434" />
+              <input id="optLocalBaseUrl" class="options-input options-input-sm" placeholder="http://127.0.0.1:1234/v1" />
             </div>
             <div class="options-row" id="optLocalApiKeyRow">
               <label class="options-label-inline" for="optLocalApiKey">API key (optional)</label>
@@ -185,10 +202,6 @@
             <select id="optLocalModelSelect" class="options-select"></select>
           </div>
           <div class="options-note" id="optLocalModelsState"></div>
-          <div class="options-actions">
-            <button id="btnSaveProfile" class="options-btn">Save As Default</button>
-            <button id="btnRestartOnboarding" class="options-btn options-btn-ghost">Restart Onboarding</button>
-          </div>
         </section>
       </div>
 


### PR DESCRIPTION
## Summary
- move provider/model runtime controls out of the Profile tab into a dedicated Runtime tab
- make ChatGPT vs LM Studio mode explicit with quick actions and a runtime status summary
- enlarge the Options panel and make tab headers wrap cleanly with the extra tab
- fix custom select positioning so model dropdowns stay in-bounds (flip upward + viewport-clamped height)

## UX outcomes
- profile settings and runtime settings are now clearly separated
- users can switch runtime mode without mixing that flow with identity/theme settings
- model picker no longer spills out awkwardly near panel bounds

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
