### PR TITLE
feat(todo): add explicit vision-policy parsing for vision-check

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -90,6 +90,10 @@ intelligencex todo vision-check \
 Notes:
 - Classification is assistive (`aligned`, `needs-human-review`, `likely-out-of-scope`), not an automatic reject gate.
 - Uses `VISION.md` section heuristics (`In Scope`, `Out of Scope`, `Goals`, `Non-Goals`) plus token overlap.
+- Supports explicit policy bullets for stronger guidance:
+  - `aligned: ...`
+  - `likely-out-of-scope: ...`
+  - `needs-human-review: ...`
 
 ## Initialize GitHub Project (assistive control plane)
 

--- a/IntelligenceX.Cli/Todo/VisionCheckRunner.cs
+++ b/IntelligenceX.Cli/Todo/VisionCheckRunner.cs
@@ -13,10 +13,17 @@ namespace IntelligenceX.Cli.Todo;
 internal static class VisionCheckRunner {
     private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
     private static readonly Regex NumberedBullet = new(@"^\d+\.\s+", RegexOptions.Compiled);
+    private static readonly Regex PolicyPrefix = new(
+        @"^(aligned|accept|approve|likely-out-of-scope|reject|deny|needs-human-review|human-review|review|required-review)\s*:\s*(.+)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase
+    );
 
     internal sealed record VisionSignals(
         IReadOnlySet<string> InScopeTokens,
-        IReadOnlySet<string> OutOfScopeTokens
+        IReadOnlySet<string> OutOfScopeTokens,
+        IReadOnlySet<string> ExplicitAcceptTokens,
+        IReadOnlySet<string> ExplicitRejectTokens,
+        IReadOnlySet<string> ExplicitReviewTokens
     );
 
     internal sealed record PullRequestCandidate(
@@ -38,6 +45,9 @@ internal static class VisionCheckRunner {
         double? Score,
         IReadOnlyList<string> InScopeMatches,
         IReadOnlyList<string> OutOfScopeMatches,
+        IReadOnlyList<string> ExplicitAcceptMatches,
+        IReadOnlyList<string> ExplicitRejectMatches,
+        IReadOnlyList<string> ExplicitReviewMatches,
         string Reason
     );
 
@@ -97,7 +107,10 @@ internal static class VisionCheckRunner {
             vision = new {
                 path = options.VisionPath,
                 inScopeTokens = signals.InScopeTokens.Count,
-                outOfScopeTokens = signals.OutOfScopeTokens.Count
+                outOfScopeTokens = signals.OutOfScopeTokens.Count,
+                explicitAcceptTokens = signals.ExplicitAcceptTokens.Count,
+                explicitRejectTokens = signals.ExplicitRejectTokens.Count,
+                explicitReviewTokens = signals.ExplicitReviewTokens.Count
             },
             summary = new {
                 pullRequestsEvaluated = assessments.Count,
@@ -207,6 +220,9 @@ internal static class VisionCheckRunner {
     internal static VisionSignals ParseVisionSignals(string visionPath) {
         var inScope = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var outOfScope = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var explicitAccept = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var explicitReject = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var explicitReview = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var allTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var section = string.Empty;
 
@@ -229,24 +245,61 @@ internal static class VisionCheckRunner {
                 section = "out";
                 continue;
             }
+            if (lowered.Contains("accept guidance", StringComparison.Ordinal) ||
+                lowered.Contains("accept signals", StringComparison.Ordinal) ||
+                lowered.Equals("## accept", StringComparison.Ordinal) ||
+                lowered.Equals("### accept", StringComparison.Ordinal)) {
+                section = "accept";
+                continue;
+            }
+            if (lowered.Contains("reject guidance", StringComparison.Ordinal) ||
+                lowered.Contains("reject signals", StringComparison.Ordinal) ||
+                lowered.Equals("## reject", StringComparison.Ordinal) ||
+                lowered.Equals("### reject", StringComparison.Ordinal)) {
+                section = "reject";
+                continue;
+            }
+            if (lowered.Contains("human review guidance", StringComparison.Ordinal) ||
+                lowered.Contains("needs human review", StringComparison.Ordinal) ||
+                lowered.Equals("## review", StringComparison.Ordinal) ||
+                lowered.Equals("### review", StringComparison.Ordinal)) {
+                section = "review";
+                continue;
+            }
 
             if (!IsBulletLine(line)) {
                 continue;
             }
 
             var content = StripBullet(line);
-            var tokens = TriageIndexRunner.Tokenize(content);
+            var policySection = TryParsePolicySection(content, out var policyBody)
+                ? policyBody.Item1
+                : section;
+            var policyContent = policyBody.Item2;
+            var tokens = TriageIndexRunner.Tokenize(policyContent);
             foreach (var token in tokens) {
                 allTokens.Add(token);
             }
 
-            if (section == "in") {
+            if (policySection == "in") {
                 foreach (var token in tokens) {
                     inScope.Add(token);
                 }
-            } else if (section == "out") {
+            } else if (policySection == "out") {
                 foreach (var token in tokens) {
                     outOfScope.Add(token);
+                }
+            } else if (policySection == "accept") {
+                foreach (var token in tokens) {
+                    explicitAccept.Add(token);
+                }
+            } else if (policySection == "reject") {
+                foreach (var token in tokens) {
+                    explicitReject.Add(token);
+                }
+            } else if (policySection == "review") {
+                foreach (var token in tokens) {
+                    explicitReview.Add(token);
                 }
             }
         }
@@ -257,7 +310,7 @@ internal static class VisionCheckRunner {
             }
         }
 
-        return new VisionSignals(inScope, outOfScope);
+        return new VisionSignals(inScope, outOfScope, explicitAccept, explicitReject, explicitReview);
     }
 
     private static bool IsBulletLine(string line) {
@@ -271,6 +324,41 @@ internal static class VisionCheckRunner {
             return line.Substring(2).Trim();
         }
         return NumberedBullet.Replace(line, string.Empty).Trim();
+    }
+
+    private static bool TryParsePolicySection(string content, out (string Item1, string Item2) policy) {
+        policy = (string.Empty, content);
+        var match = PolicyPrefix.Match(content);
+        if (!match.Success) {
+            return false;
+        }
+
+        var directive = match.Groups[1].Value.Trim().ToLowerInvariant();
+        var body = match.Groups[2].Value.Trim();
+        if (string.IsNullOrWhiteSpace(body)) {
+            return false;
+        }
+
+        var section = directive switch {
+            "aligned" => "accept",
+            "accept" => "accept",
+            "approve" => "accept",
+            "likely-out-of-scope" => "reject",
+            "reject" => "reject",
+            "deny" => "reject",
+            "needs-human-review" => "review",
+            "human-review" => "review",
+            "review" => "review",
+            "required-review" => "review",
+            _ => string.Empty
+        };
+
+        if (string.IsNullOrWhiteSpace(section)) {
+            return false;
+        }
+
+        policy = (section, body);
+        return true;
     }
 
     private static List<PullRequestCandidate> LoadCandidates(string indexPath) {
@@ -315,11 +403,42 @@ internal static class VisionCheckRunner {
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(token => token, StringComparer.OrdinalIgnoreCase)
             .ToList();
+        var explicitAcceptMatches = tokens
+            .Where(token => signals.ExplicitAcceptTokens.Contains(token))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(token => token, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var explicitRejectMatches = tokens
+            .Where(token => signals.ExplicitRejectTokens.Contains(token))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(token => token, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var explicitReviewMatches = tokens
+            .Where(token => signals.ExplicitReviewTokens.Contains(token))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(token => token, StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
         string classification;
         double confidence;
         string reason;
-        if (outMatches.Count >= 2 && inMatches.Count == 0) {
+        if (explicitRejectMatches.Count > 0 && explicitAcceptMatches.Count == 0) {
+            classification = "likely-out-of-scope";
+            confidence = Math.Min(0.99, 0.80 + (explicitRejectMatches.Count * 0.06));
+            reason = $"Explicit reject-policy matches: {string.Join(", ", explicitRejectMatches.Take(5))}.";
+        } else if (explicitAcceptMatches.Count > 0 && explicitRejectMatches.Count == 0 && explicitReviewMatches.Count == 0) {
+            classification = "aligned";
+            confidence = Math.Min(0.98, 0.78 + (explicitAcceptMatches.Count * 0.05));
+            reason = $"Explicit accept-policy matches: {string.Join(", ", explicitAcceptMatches.Take(5))}.";
+        } else if (explicitAcceptMatches.Count > 0 && explicitRejectMatches.Count > 0) {
+            classification = "needs-human-review";
+            confidence = 0.66;
+            reason = $"Conflicting explicit policy matches (accept: {string.Join(", ", explicitAcceptMatches.Take(3))}; reject: {string.Join(", ", explicitRejectMatches.Take(3))}).";
+        } else if (explicitReviewMatches.Count > 0) {
+            classification = "needs-human-review";
+            confidence = Math.Min(0.80, 0.60 + (explicitReviewMatches.Count * 0.05));
+            reason = $"Explicit human-review policy matches: {string.Join(", ", explicitReviewMatches.Take(5))}.";
+        } else if (outMatches.Count >= 2 && inMatches.Count == 0) {
             classification = "likely-out-of-scope";
             confidence = Math.Min(0.98, 0.65 + (outMatches.Count * 0.10));
             reason = $"Out-of-scope token matches: {string.Join(", ", outMatches.Take(5))}.";
@@ -347,6 +466,9 @@ internal static class VisionCheckRunner {
             candidate.Score,
             inMatches,
             outMatches,
+            explicitAcceptMatches,
+            explicitRejectMatches,
+            explicitReviewMatches,
             reason
         );
     }

--- a/IntelligenceX.Tests/Program.Todo.VisionCheck.cs
+++ b/IntelligenceX.Tests/Program.Todo.VisionCheck.cs
@@ -5,7 +5,10 @@ internal static partial class Program {
     private static void TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate() {
         var signals = new IntelligenceX.Cli.Todo.VisionCheckRunner.VisionSignals(
             new HashSet<string>(new[] { "api", "stability", "security" }, StringComparer.OrdinalIgnoreCase),
-            new HashSet<string>(new[] { "website", "marketing", "rebrand" }, StringComparer.OrdinalIgnoreCase)
+            new HashSet<string>(new[] { "website", "marketing", "rebrand" }, StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         );
         var candidate = new IntelligenceX.Cli.Todo.VisionCheckRunner.PullRequestCandidate(
             "pr#77",
@@ -23,7 +26,10 @@ internal static partial class Program {
     private static void TestVisionCheckClassifiesAlignedWhenInTokensMatch() {
         var signals = new IntelligenceX.Cli.Todo.VisionCheckRunner.VisionSignals(
             new HashSet<string>(new[] { "api", "stability", "security" }, StringComparer.OrdinalIgnoreCase),
-            new HashSet<string>(new[] { "website", "marketing", "rebrand" }, StringComparer.OrdinalIgnoreCase)
+            new HashSet<string>(new[] { "website", "marketing", "rebrand" }, StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         );
         var candidate = new IntelligenceX.Cli.Todo.VisionCheckRunner.PullRequestCandidate(
             "pr#78",
@@ -36,6 +42,62 @@ internal static partial class Program {
         var assessment = IntelligenceX.Cli.Todo.VisionCheckRunner.EvaluateAlignment(candidate, signals);
         AssertEqual("aligned", assessment.Classification, "vision classification");
         AssertEqual(true, assessment.InScopeMatches.Count >= 2, "in-scope token matches");
+    }
+
+    private static void TestVisionCheckExplicitRejectPolicyTakesPrecedence() {
+        var signals = new IntelligenceX.Cli.Todo.VisionCheckRunner.VisionSignals(
+            new HashSet<string>(new[] { "api", "stability", "security" }, StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(new[] { "website", "marketing", "rebrand" }, StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(new[] { "marketing" }, StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(new[] { "migration" }, StringComparer.OrdinalIgnoreCase)
+        );
+        var candidate = new IntelligenceX.Cli.Todo.VisionCheckRunner.PullRequestCandidate(
+            "pr#79",
+            79,
+            "Marketing redesign PR cleanup",
+            "https://example/pr/79",
+            Array.Empty<string>(),
+            22.4
+        );
+        var assessment = IntelligenceX.Cli.Todo.VisionCheckRunner.EvaluateAlignment(candidate, signals);
+        AssertEqual(true, assessment.ExplicitRejectMatches.Count >= 1, "explicit reject matches");
+        AssertEqual("likely-out-of-scope", assessment.Classification, "explicit reject policy classification");
+    }
+
+    private static void TestVisionCheckParseSignalsSupportsExplicitPolicyPrefixes() {
+        var tempDir = Path.Combine(Path.GetTempPath(), "ix-vision-policy-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try {
+            var visionPath = Path.Combine(tempDir, "VISION.md");
+            var visionContent = string.Join('\n', new[] {
+                "# Vision",
+                string.Empty,
+                "## In Scope",
+                "- API stability and security hardening",
+                string.Empty,
+                "## Out Of Scope",
+                "- Website redesign and marketing",
+                string.Empty,
+                "## Maintainer Guidance",
+                "- aligned: security hardening",
+                "- likely-out-of-scope: marketing redesign",
+                "- needs-human-review: migration rollout"
+            }) + "\n";
+            File.WriteAllText(visionPath, visionContent);
+
+            var signals = IntelligenceX.Cli.Todo.VisionCheckRunner.ParseVisionSignals(visionPath);
+            AssertEqual(true, signals.ExplicitAcceptTokens.Contains("security"), "accept policy token");
+            AssertEqual(true, signals.ExplicitRejectTokens.Contains("marketing"), "reject policy token");
+            AssertEqual(true, signals.ExplicitReviewTokens.Contains("migration"), "review policy token");
+        } finally {
+            try {
+                Directory.Delete(tempDir, recursive: true);
+            } catch {
+                // best effort
+            }
+        }
     }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -442,6 +442,8 @@ internal static partial class Program {
         failed += Run("Todo triage index PR scoring", TestTriageIndexScoreRewardsMergeableApprovedPrs);
         failed += Run("Todo vision check out-of-scope classification", TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate);
         failed += Run("Todo vision check aligned classification", TestVisionCheckClassifiesAlignedWhenInTokensMatch);
+        failed += Run("Todo vision check explicit reject policy precedence", TestVisionCheckExplicitRejectPolicyTakesPrecedence);
+        failed += Run("Todo vision check explicit policy prefix parsing", TestVisionCheckParseSignalsSupportsExplicitPolicyPrefixes);
         failed += Run("Todo project fields defaults", TestProjectFieldCatalogDefaultsIncludeVisionAndDecisionFields);
         failed += Run("Todo project sync merges vision and canonical", TestProjectSyncBuildEntriesMergesVisionAndCanonical);
         failed += Run("Analyze run PowerShell script captures engine errors", TestAnalyzeRunPowerShellScriptCapturesEngineErrors);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -78,6 +78,11 @@ Output classes:
 - `needs-human-review`
 - `likely-out-of-scope`
 
+Explicit policy prefixes supported in `VISION.md` bullets:
+- `aligned: ...`
+- `likely-out-of-scope: ...`
+- `needs-human-review: ...`
+
 ## Project Init (GitHub-native)
 
 Create or initialize a GitHub Project for triage/vision workflows:


### PR DESCRIPTION
## Summary
- extend `todo vision-check` to parse explicit vision policy directives from `VISION.md` bullets/sections
- add explicit accept/reject/review token sets and precedence in alignment classification
- include explicit policy token counts in vision-check JSON output and document supported prefixes
- add tests for explicit reject precedence and explicit prefix parsing

## Supported explicit policy prefixes
- `aligned:` / `accept:` / `approve:`
- `likely-out-of-scope:` / `reject:` / `deny:`
- `needs-human-review:` / `human-review:` / `review:` / `required-review:`

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`

## Notes
- Optional analysis skill suite command (`run-analysis-suite.sh fast`) started successfully but failed in strict mode due missing local `PSScriptAnalyzer` module (`Install-Module PSScriptAnalyzer -Scope CurrentUser`).
