### PR TITLE
docs(tools): unify pack naming and clarify OSS availability

### DIFF
--- a/Docs/tools/catalog.md
+++ b/Docs/tools/catalog.md
@@ -14,11 +14,11 @@ This catalog is generated from what the codebase currently registers in tool-pac
 | Event Log | `eventlog` | `builtin` | SensitiveRead | OSS + internal |
 | File System | `fs` | `builtin` | ReadOnly | OSS + internal |
 | Reviewer Setup | `reviewer_setup` | `builtin` | ReadOnly | OSS + internal |
-| Email | `email` | `builtin` | SensitiveRead | Optional (assembly-dependent) |
-| IX.PowerShell | `powershell` | `builtin` | DangerousWrite | Optional (disabled by default) |
+| Email | `email` | `builtin` | SensitiveRead | OSS + internal (dependency-gated at runtime) |
+| PowerShell | `powershell` | `builtin` | DangerousWrite | OSS + internal (opt-in by policy) |
 | System | `system` | `closed_source` | ReadOnly | Internal/private builds |
 | Active Directory | `ad` | `closed_source` | SensitiveRead | Internal/private builds |
-| IX.TestimoX | `testimox` | `closed_source` | SensitiveRead | Internal/private builds |
+| TestimoX | `testimox` | `closed_source` | SensitiveRead | Internal/private builds |
 
 ## Builtin / OSS-Oriented Packs
 
@@ -58,7 +58,7 @@ Representative tools:
 - `email_imap_get`
 - `email_smtp_send`
 
-### IX.PowerShell (`powershell`)
+### PowerShell (`powershell`)
 
 Representative tools:
 
@@ -91,7 +91,7 @@ Representative tools:
 - `system_service_list` (Windows)
 - `system_firewall_rules` (Windows)
 
-### IX.TestimoX (`testimox`)
+### TestimoX (`testimox`)
 
 Representative tools:
 
@@ -102,6 +102,7 @@ Representative tools:
 ## Notes
 
 - Tool availability depends on host/runtime composition and platform.
+- `builtin` packs are OSS-oriented by source model; "optional" indicates runtime policy/dependency gating, not closed-source licensing.
 - `sourceKind` classification comes from `ToolPackBootstrap` normalization rules.
 - Closed-source packs may be enabled by default in config but still absent in OSS environments.
 

--- a/Docs/tools/overview.md
+++ b/Docs/tools/overview.md
@@ -46,11 +46,11 @@ The table below reflects the actual bootstrap in `IntelligenceX.Chat.Tooling/Too
 | Event Log | `eventlog` | `builtin` | Yes | SensitiveRead | Windows |
 | File System | `fs` | `builtin` | Yes | ReadOnly | Cross-platform |
 | Reviewer Setup | `reviewer_setup` | `builtin` | Yes | ReadOnly | Cross-platform |
-| Email | `email` | `builtin` | Yes (when assembly is available) | SensitiveRead | Cross-platform |
-| IX.PowerShell | `powershell` | `builtin` | No (opt-in) | DangerousWrite | Windows/PowerShell hosts |
+| Email | `email` | `builtin` | Yes (OSS pack; runtime dependency-gated) | SensitiveRead | Cross-platform |
+| PowerShell | `powershell` | `builtin` | No (OSS pack; opt-in by policy) | DangerousWrite | Windows/PowerShell hosts |
 | System | `system` | `closed_source` | Yes (when available) | ReadOnly | Windows |
 | Active Directory | `ad` | `closed_source` | Yes (when available) | SensitiveRead | Windows (domain environments) |
-| IX.TestimoX | `testimox` | `closed_source` | Yes (when available) | SensitiveRead | Windows |
+| TestimoX | `testimox` | `closed_source` | Yes (when available) | SensitiveRead | Windows |
 
 ## IX Chat vs .NET Integration
 
@@ -58,7 +58,7 @@ The table below reflects the actual bootstrap in `IntelligenceX.Chat.Tooling/Too
 
 - Tool packs are loaded by the host bootstrap.
 - Some packs are always available in OSS (`eventlog`, `fs`, `reviewer_setup`).
-- Some are optional/conditional (`email` if assembly is present, `powershell` if enabled).
+- Some are optional/conditional for runtime reasons (`email` dependency gating, `powershell` safety opt-in), while still being OSS-oriented packs.
 - Some are enabled by default but may not exist in OSS environments (`system`, `ad`, `testimox`).
 
 ### .NET library (custom apps)


### PR DESCRIPTION
Unify pack names (PowerShell/TestimoX) and clarify that builtin packs are OSS-oriented even when runtime gated by policy or dependencies.