### PR TITLE
Chat app: clarify LM Studio model-source vs runtime detection

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -249,6 +249,9 @@ public sealed partial class MainWindow : Window {
             localModel = new {
                 transport = _localProviderTransport,
                 baseUrl = _localProviderBaseUrl ?? string.Empty,
+                modelsEndpoint = string.Equals(_localProviderTransport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase)
+                    ? BuildModelsProbeUrl(_localProviderBaseUrl ?? string.Empty)
+                    : string.Empty,
                 model = _localProviderModel,
                 models = _availableModels,
                 favoriteModels = _favoriteModels,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
@@ -78,6 +78,7 @@
       localModel: {
         transport: "native",
         baseUrl: "",
+        modelsEndpoint: "",
         model: "gpt-5.3-codex",
         models: [],
         favoriteModels: [],

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -443,11 +443,42 @@
     return normalized.indexOf("127.0.0.1:1234") >= 0 || normalized.indexOf("localhost:1234") >= 0;
   }
 
+  function looksCloudHostedModelName(value) {
+    var normalized = normalizeModelText(value).toLowerCase();
+    if (!normalized) {
+      return false;
+    }
+
+    return normalized.indexOf("gpt-") === 0
+      || normalized === "gpt5"
+      || normalized.indexOf("chatgpt") === 0
+      || normalized.indexOf("o1") === 0
+      || normalized.indexOf("o3") === 0
+      || normalized.indexOf("o4") === 0;
+  }
+
+  function countCloudHostedModelNames(models) {
+    if (!Array.isArray(models) || models.length === 0) {
+      return 0;
+    }
+
+    var count = 0;
+    for (var i = 0; i < models.length; i++) {
+      var item = models[i] || {};
+      var modelName = normalizeModelText(item.model || item.Model || item.id || item.Id);
+      if (looksCloudHostedModelName(modelName)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
   function renderLocalModelOptions() {
     var local = state.options.localModel || {};
     var transport = normalizeLocalTransport(local.transport);
     var isCompatible = transport === "compatible-http";
     var baseUrl = String(local.baseUrl || "");
+    var modelsEndpoint = normalizeModelText(local.modelsEndpoint || "");
     var model = normalizeModelText(local.model || "");
     var models = Array.isArray(local.models) ? local.models : [];
     var favorites = toStringArray(local.favoriteModels);
@@ -455,6 +486,7 @@
     var warning = normalizeModelText(local.warning || "");
     var isStale = local.isStale === true;
     var profileSaved = local.profileSaved === true;
+    var profileApplyMode = normalizeProfileApplyMode(state.options.profileApplyMode || "session");
     var runtimeDetection = local.runtimeDetection || {};
     var runtimeDetectionHasRun = runtimeDetection.hasRun === true;
     var lmStudioAvailable = runtimeDetection.lmStudioAvailable === true;
@@ -653,18 +685,32 @@
           parts.push(String(models.length) + " local models cached");
         }
       } else {
+        if (modelsEndpoint) {
+          parts.push("model source: " + modelsEndpoint);
+        }
         if (runtimeDetectedName) {
-          parts.push("detected runtime: " + runtimeDetectedName);
+          parts.push("runtime probe: " + runtimeDetectedName + " reachable");
         } else if (runtimeDetectionHasRun && runtimeDetectionWarning) {
           parts.push(runtimeDetectionWarning);
         }
         if (models.length > 0) {
-          parts.push(String(models.length) + " models discovered");
+          parts.push(String(models.length) + " models returned");
+          var cloudHostedCount = countCloudHostedModelNames(models);
+          if (cloudHostedCount > 0 && cloudHostedCount >= Math.ceil(models.length * 0.6)) {
+            parts.push("catalog looks cloud-hosted; load a local model in LM Studio to see local IDs");
+          }
         } else {
           parts.push("No discovered models yet");
+          if (lmStudioConnected) {
+            parts.push("Load a model in LM Studio, then click Refresh Models");
+          }
         }
       }
-      parts.push(profileSaved ? "service profile saved" : "service profile not saved yet");
+      if (profileApplyMode === "session" || !profileSaved) {
+        parts.push("scope: current session only");
+      } else {
+        parts.push("scope: saved as default profile");
+      }
       if (isStale) {
         parts.push("showing cached results");
       }


### PR DESCRIPTION
## Summary
- clarify that runtime detection means endpoint reachability, not necessarily local model loading
- include the exact model source endpoint in Runtime -> Local Model Selection status text
- improve status wording to "models returned" and "runtime probe" for less ambiguity
- add a lightweight warning when the returned catalog looks cloud-hosted (for example mostly `gpt-*`/`o*` names)
- replace "service profile not saved yet" with explicit scope wording (session-only vs saved default)

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
