### PR TITLE
feat(todo): add vision project schema + label and issue-match automation

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -60,6 +60,8 @@ Notes:
 - Supports paginated fetches for larger backlogs (`--max-prs` / `--max-issues` up to 2000).
 - Uses token-based similarity for duplicate clusters (deterministic and explainable).
 - PR ranking uses mergeability/review/status-check/churn/recency signals as assistive scoring, not an automatic merge decision.
+- Emits assistive `category` + `tags` per item for reliable labeling workflows.
+- Emits PR `relatedIssues` candidates plus `matchedIssueUrl`/`matchedIssueConfidence` (explicit references like `closes #123` + similarity fallback).
 
 ## Vision check (assistive scope alignment)
 
@@ -106,7 +108,8 @@ intelligencex todo project-init \
 
 Notes:
 - Creates a project (or initializes an existing one with `--project <n>`).
-- Ensures required custom fields such as `Vision Fit`, `Triage Score`, and `Duplicate Cluster`.
+- Ensures required custom fields such as `Vision Fit`, `Category`, `Tags`, `Matched Issue`, `Triage Score`, and `Duplicate Cluster`.
+- Ensures IX label taxonomy in the repo by default (`--no-ensure-labels` to skip).
 - Writes a reusable config file containing owner/project/field metadata.
 - Requires GitHub token scopes: `project` (and typically `read:project` for follow-up sync).
 
@@ -126,6 +129,8 @@ intelligencex todo project-sync \
 Useful options:
 - `--config <path>` to resolve owner/project from `project-init` output.
 - `--ensure-fields` / `--no-ensure-fields`.
+- `--apply-labels` to apply IX labels (`ix/category:*`, `ix/vision:*`, `ix/match:*`) on PRs/issues.
+- `--ensure-labels` / `--no-ensure-labels` for label taxonomy management.
 - `--project-item-scan-limit <n>` for larger projects.
 - `--dry-run` for a no-write sync preview.
 

--- a/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
@@ -17,6 +17,19 @@ internal static class ProjectFieldCatalog {
             "likely-out-of-scope"
         }),
         new ProjectFieldDefinition("Vision Confidence", "NUMBER", Array.Empty<string>()),
+        new ProjectFieldDefinition("Category", "SINGLE_SELECT", new[] {
+            "bug",
+            "feature",
+            "documentation",
+            "maintenance",
+            "security",
+            "performance",
+            "testing",
+            "ci"
+        }),
+        new ProjectFieldDefinition("Tags", "TEXT", Array.Empty<string>()),
+        new ProjectFieldDefinition("Matched Issue", "TEXT", Array.Empty<string>()),
+        new ProjectFieldDefinition("Matched Issue Confidence", "NUMBER", Array.Empty<string>()),
         new ProjectFieldDefinition("Triage Score", "NUMBER", Array.Empty<string>()),
         new ProjectFieldDefinition("Duplicate Cluster", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Canonical Item", "TEXT", Array.Empty<string>()),

--- a/IntelligenceX.Cli/Todo/ProjectInitRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectInitRunner.cs
@@ -24,6 +24,7 @@ internal static class ProjectInitRunner {
         public bool IsPublic { get; set; }
         public bool VisibilitySpecified { get; set; }
         public bool LinkRepo { get; set; } = true;
+        public bool EnsureLabels { get; set; } = true;
         public string OutputPath { get; set; } = Path.Combine("artifacts", "triage", "ix-project-config.json");
         public bool ShowHelp { get; set; }
     }
@@ -105,7 +106,16 @@ internal static class ProjectInitRunner {
             }
         }
 
-        var report = BuildConfigReport(owner, options.Repo, project, fields);
+        if (options.EnsureLabels) {
+            try {
+                await RepositoryLabelManager.EnsureLabelsAsync(options.Repo, ProjectLabelCatalog.DefaultLabels).ConfigureAwait(false);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"Failed to ensure labels: {ex.Message}");
+                return 1;
+            }
+        }
+
+        var report = BuildConfigReport(owner, options.Repo, project, fields, options.EnsureLabels);
         WriteText(options.OutputPath, JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
 
         Console.WriteLine($"Project ready: #{project.Number} ({project.Url})");
@@ -165,6 +175,12 @@ internal static class ProjectInitRunner {
                 case "--no-link-repo":
                     options.LinkRepo = false;
                     break;
+                case "--ensure-labels":
+                    options.EnsureLabels = true;
+                    break;
+                case "--no-ensure-labels":
+                    options.EnsureLabels = false;
+                    break;
                 case "--out":
                     if (i + 1 < args.Length) {
                         options.OutputPath = args[++i];
@@ -197,6 +213,8 @@ internal static class ProjectInitRunner {
         Console.WriteLine("  --private                Set project visibility to private (default)");
         Console.WriteLine("  --link-repo              Link project to --repo (default)");
         Console.WriteLine("  --no-link-repo           Do not link project to repo");
+        Console.WriteLine("  --ensure-labels          Ensure IX labels exist in --repo (default)");
+        Console.WriteLine("  --no-ensure-labels       Skip repo label setup");
         Console.WriteLine("  --out <path>             Write project config JSON (default: artifacts/triage/ix-project-config.json)");
         Console.WriteLine();
         Console.WriteLine("Required token scopes for project setup: `project`.");
@@ -249,7 +267,8 @@ internal static class ProjectInitRunner {
         string owner,
         string repo,
         ProjectV2Client.ProjectRef project,
-        IReadOnlyDictionary<string, ProjectV2Client.ProjectField> fields) {
+        IReadOnlyDictionary<string, ProjectV2Client.ProjectField> fields,
+        bool labelsEnsured) {
         var fieldsJson = fields.Values
             .OrderBy(field => field.Name, StringComparer.OrdinalIgnoreCase)
             .Select(field => new {
@@ -277,7 +296,21 @@ internal static class ProjectInitRunner {
                 title = project.Title,
                 url = project.Url
             },
-            fields = fieldsJson
+            fields = fieldsJson,
+            labels = new {
+                ensured = labelsEnsured,
+                items = labelsEnsured
+                    ? ProjectLabelCatalog.DefaultLabels
+                        .OrderBy(label => label.Name, StringComparer.OrdinalIgnoreCase)
+                        .Select(label => new {
+                            name = label.Name,
+                            color = label.Color,
+                            description = label.Description
+                        })
+                        .Cast<object>()
+                        .ToList()
+                    : new List<object>()
+            }
         };
     }
 

--- a/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace IntelligenceX.Cli.Todo;
+
+internal sealed record ProjectLabelDefinition(
+    string Name,
+    string Color,
+    string Description
+);
+
+internal static class ProjectLabelCatalog {
+    public static readonly IReadOnlyList<ProjectLabelDefinition> DefaultLabels = new[] {
+        new ProjectLabelDefinition("ix/vision:aligned", "0e8a16", "Vision fit is aligned."),
+        new ProjectLabelDefinition("ix/vision:needs-review", "fbca04", "Vision fit needs human maintainer review."),
+        new ProjectLabelDefinition("ix/vision:out-of-scope", "d73a4a", "Vision fit appears out of scope."),
+
+        new ProjectLabelDefinition("ix/category:bug", "d73a4a", "Likely bug-fix work."),
+        new ProjectLabelDefinition("ix/category:feature", "1d76db", "Likely feature/enhancement work."),
+        new ProjectLabelDefinition("ix/category:documentation", "5319e7", "Likely documentation work."),
+        new ProjectLabelDefinition("ix/category:maintenance", "6f42c1", "Likely maintenance/chore/refactor work."),
+        new ProjectLabelDefinition("ix/category:security", "b60205", "Likely security work."),
+        new ProjectLabelDefinition("ix/category:performance", "0052cc", "Likely performance work."),
+        new ProjectLabelDefinition("ix/category:testing", "0e8a16", "Likely testing work."),
+        new ProjectLabelDefinition("ix/category:ci", "c5def5", "Likely CI/workflow automation work."),
+
+        new ProjectLabelDefinition("ix/match:linked-issue", "0366d6", "PR has a high-confidence related issue."),
+        new ProjectLabelDefinition("ix/duplicate:clustered", "f9d0c4", "Item is part of a duplicate cluster.")
+    };
+}

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -11,11 +11,16 @@ namespace IntelligenceX.Cli.Todo;
 
 internal static class ProjectSyncRunner {
     internal sealed record ProjectSyncEntry(
+        int Number,
         string Url,
         string Kind,
         double? TriageScore,
         string? DuplicateCluster,
         string? CanonicalItem,
+        string? Category,
+        IReadOnlyList<string> Tags,
+        string? MatchedIssueUrl,
+        double? MatchedIssueConfidence,
         string? VisionFit,
         double? VisionConfidence
     );
@@ -30,6 +35,8 @@ internal static class ProjectSyncRunner {
         public int MaxItems { get; set; } = 500;
         public int ProjectItemScanLimit { get; set; } = 5000;
         public bool EnsureFields { get; set; } = true;
+        public bool ApplyLabels { get; set; }
+        public bool EnsureLabels { get; set; } = true;
         public bool DryRun { get; set; }
         public bool ShowHelp { get; set; }
     }
@@ -102,11 +109,21 @@ internal static class ProjectSyncRunner {
             return 1;
         }
 
+        if (options.ApplyLabels && options.EnsureLabels && !options.DryRun) {
+            try {
+                await RepositoryLabelManager.EnsureLabelsAsync(options.Repo, ProjectLabelCatalog.DefaultLabels).ConfigureAwait(false);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"Failed to ensure labels before apply-labels: {ex.Message}");
+                return 1;
+            }
+        }
+
         var itemsByUrl = new Dictionary<string, ProjectV2Client.ProjectItem>(existingItems, StringComparer.OrdinalIgnoreCase);
         var processed = 0;
         var added = 0;
         var updatedFieldValues = 0;
         var skippedMissing = 0;
+        var labeled = 0;
 
         foreach (var entry in entries) {
             processed++;
@@ -140,12 +157,28 @@ internal static class ProjectSyncRunner {
             if (!options.DryRun) {
                 updatedFieldValues += await ApplyUpdatesAsync(client, project.Id, item.Id, fields, entry).ConfigureAwait(false);
             }
+
+            if (options.ApplyLabels) {
+                var labels = BuildLabelsForEntry(entry);
+                if (labels.Count > 0 && entry.Number > 0) {
+                    if (options.DryRun) {
+                        labeled++;
+                    } else {
+                        if (await RepositoryLabelManager.AddLabelsAsync(options.Repo, entry.Kind, entry.Number, labels).ConfigureAwait(false)) {
+                            labeled++;
+                        }
+                    }
+                }
+            }
         }
 
         Console.WriteLine($"Project sync target: {owner}#{projectNumber} ({project.Url})");
         Console.WriteLine($"Entries processed: {processed}");
         Console.WriteLine($"Items added: {added}");
         Console.WriteLine($"Field values updated: {(options.DryRun ? 0 : updatedFieldValues)}");
+        if (options.ApplyLabels) {
+            Console.WriteLine($"Items labeled: {labeled}");
+        }
         Console.WriteLine($"Skipped unresolved items: {skippedMissing}");
         Console.WriteLine(options.DryRun ? "Dry run complete (no project updates were written)." : "Project sync complete.");
         return 0;
@@ -210,6 +243,15 @@ internal static class ProjectSyncRunner {
                 case "--no-ensure-fields":
                     options.EnsureFields = false;
                     break;
+                case "--apply-labels":
+                    options.ApplyLabels = true;
+                    break;
+                case "--ensure-labels":
+                    options.EnsureLabels = true;
+                    break;
+                case "--no-ensure-labels":
+                    options.EnsureLabels = false;
+                    break;
                 case "--dry-run":
                     options.DryRun = true;
                     break;
@@ -241,6 +283,9 @@ internal static class ProjectSyncRunner {
         Console.WriteLine("  --project-item-scan-limit <n>  Existing project item scan limit (100-10000, default: 5000)");
         Console.WriteLine("  --ensure-fields          Ensure IX fields exist before sync (default)");
         Console.WriteLine("  --no-ensure-fields       Skip field creation");
+        Console.WriteLine("  --apply-labels           Apply IX labels to PRs/issues from synced signals");
+        Console.WriteLine("  --ensure-labels          Ensure IX labels exist before applying labels (default)");
+        Console.WriteLine("  --no-ensure-labels       Skip label ensure step");
         Console.WriteLine("  --dry-run                Compute sync plan without writing project changes");
         Console.WriteLine();
         Console.WriteLine("Required token scopes for sync: `read:project` and `project`.");
@@ -324,12 +369,17 @@ internal static class ProjectSyncRunner {
                 if (string.IsNullOrWhiteSpace(url)) {
                     continue;
                 }
+                var number = ReadInt(item, "number");
                 var kind = ReadString(item, "kind");
                 if (string.IsNullOrWhiteSpace(kind)) {
                     kind = "pull_request";
                 }
                 var triageScore = ReadNullableDouble(item, "score");
                 var duplicateClusterId = ReadNullableString(item, "duplicateClusterId");
+                var category = ReadNullableString(item, "category");
+                var tags = ReadStringArray(item, "tags");
+                var matchedIssueUrl = ReadNullableString(item, "matchedIssueUrl");
+                var matchedIssueConfidence = ReadNullableDouble(item, "matchedIssueConfidence");
 
                 string? canonicalUrl = null;
                 if (!string.IsNullOrWhiteSpace(duplicateClusterId) &&
@@ -339,11 +389,16 @@ internal static class ProjectSyncRunner {
                 }
 
                 entriesByUrl[url] = new ProjectSyncEntry(
+                    Number: number,
                     Url: url,
                     Kind: kind,
                     TriageScore: triageScore,
                     DuplicateCluster: duplicateClusterId,
                     CanonicalItem: canonicalUrl,
+                    Category: category,
+                    Tags: tags,
+                    MatchedIssueUrl: matchedIssueUrl,
+                    MatchedIssueConfidence: matchedIssueConfidence,
                     VisionFit: null,
                     VisionConfidence: null
                 );
@@ -369,12 +424,18 @@ internal static class ProjectSyncRunner {
                         TriageScore = existing.TriageScore ?? score
                     };
                 } else {
+                    var (kind, number) = ParseKindAndNumberFromUrl(url);
                     entriesByUrl[url] = new ProjectSyncEntry(
+                        Number: number,
                         Url: url,
-                        Kind: "pull_request",
+                        Kind: kind,
                         TriageScore: score,
                         DuplicateCluster: null,
                         CanonicalItem: null,
+                        Category: null,
+                        Tags: Array.Empty<string>(),
+                        MatchedIssueUrl: null,
+                        MatchedIssueConfidence: null,
                         VisionFit: classification,
                         VisionConfidence: confidence
                     );
@@ -446,6 +507,30 @@ internal static class ProjectSyncRunner {
             updated++;
         }
 
+        if (fields.TryGetValue("Category", out var categoryField) && !string.IsNullOrWhiteSpace(entry.Category)) {
+            if (TryResolveOptionId(categoryField, entry.Category, out var categoryOptionId)) {
+                await client.SetSingleSelectFieldAsync(projectId, itemId, categoryField.Id, categoryOptionId).ConfigureAwait(false);
+                updated++;
+            } else {
+                Console.Error.WriteLine($"Warning: option '{entry.Category}' not found in field '{categoryField.Name}'.");
+            }
+        }
+
+        if (fields.TryGetValue("Tags", out var tagsField) && entry.Tags.Count > 0) {
+            await client.SetTextFieldAsync(projectId, itemId, tagsField.Id, string.Join(", ", entry.Tags)).ConfigureAwait(false);
+            updated++;
+        }
+
+        if (fields.TryGetValue("Matched Issue", out var matchedIssueField) && !string.IsNullOrWhiteSpace(entry.MatchedIssueUrl)) {
+            await client.SetTextFieldAsync(projectId, itemId, matchedIssueField.Id, entry.MatchedIssueUrl).ConfigureAwait(false);
+            updated++;
+        }
+
+        if (fields.TryGetValue("Matched Issue Confidence", out var matchedIssueConfidenceField) && entry.MatchedIssueConfidence.HasValue) {
+            await client.SetNumberFieldAsync(projectId, itemId, matchedIssueConfidenceField.Id, entry.MatchedIssueConfidence.Value).ConfigureAwait(false);
+            updated++;
+        }
+
         if (fields.TryGetValue("Duplicate Cluster", out var duplicateField) && !string.IsNullOrWhiteSpace(entry.DuplicateCluster)) {
             await client.SetTextFieldAsync(projectId, itemId, duplicateField.Id, entry.DuplicateCluster).ConfigureAwait(false);
             updated++;
@@ -480,6 +565,41 @@ internal static class ProjectSyncRunner {
         }
 
         return updated;
+    }
+
+    private static IReadOnlyList<string> BuildLabelsForEntry(ProjectSyncEntry entry) {
+        var labels = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(entry.Category)) {
+            labels.Add($"ix/category:{entry.Category}");
+        }
+
+        var visionLabel = MapVisionLabel(entry.VisionFit);
+        if (!string.IsNullOrWhiteSpace(visionLabel) && entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
+            labels.Add(visionLabel);
+        }
+
+        if (!string.IsNullOrWhiteSpace(entry.MatchedIssueUrl) && entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
+            labels.Add("ix/match:linked-issue");
+        }
+
+        if (!string.IsNullOrWhiteSpace(entry.DuplicateCluster)) {
+            labels.Add("ix/duplicate:clustered");
+        }
+
+        return labels
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(label => label, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string? MapVisionLabel(string? visionFit) {
+        return visionFit?.ToLowerInvariant() switch {
+            "aligned" => "ix/vision:aligned",
+            "needs-human-review" => "ix/vision:needs-review",
+            "likely-out-of-scope" => "ix/vision:out-of-scope",
+            _ => null
+        };
     }
 
     private static bool TryResolveOptionId(ProjectV2Client.ProjectField field, string optionName, out string optionId) {
@@ -521,6 +641,29 @@ internal static class ProjectSyncRunner {
         return prop.GetString();
     }
 
+    private static IReadOnlyList<string> ReadStringArray(JsonElement obj, string name) {
+        if (!TryGetProperty(obj, name, out var prop) || prop.ValueKind != JsonValueKind.Array) {
+            return Array.Empty<string>();
+        }
+
+        var values = new List<string>();
+        foreach (var element in prop.EnumerateArray()) {
+            if (element.ValueKind != JsonValueKind.String) {
+                continue;
+            }
+
+            var value = element.GetString();
+            if (!string.IsNullOrWhiteSpace(value)) {
+                values.Add(value);
+            }
+        }
+
+        return values
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     private static int ReadInt(JsonElement obj, string name) {
         if (!TryGetProperty(obj, name, out var prop) || prop.ValueKind != JsonValueKind.Number || !prop.TryGetInt32(out var value)) {
             return 0;
@@ -539,5 +682,29 @@ internal static class ProjectSyncRunner {
             return null;
         }
         return value;
+    }
+
+    private static (string Kind, int Number) ParseKindAndNumberFromUrl(string url) {
+        if (string.IsNullOrWhiteSpace(url)) {
+            return ("pull_request", 0);
+        }
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri)) {
+            var segments = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length >= 4 &&
+                int.TryParse(segments[^1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var number) &&
+                number > 0) {
+                var kindSegment = segments[^2];
+                if (kindSegment.Equals("issues", StringComparison.OrdinalIgnoreCase)) {
+                    return ("issue", number);
+                }
+                if (kindSegment.Equals("pull", StringComparison.OrdinalIgnoreCase) ||
+                    kindSegment.Equals("pulls", StringComparison.OrdinalIgnoreCase)) {
+                    return ("pull_request", number);
+                }
+            }
+        }
+
+        return ("pull_request", 0);
     }
 }

--- a/IntelligenceX.Cli/Todo/RepositoryLabelManager.cs
+++ b/IntelligenceX.Cli/Todo/RepositoryLabelManager.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using IntelligenceX.Cli.GitHub;
+
+namespace IntelligenceX.Cli.Todo;
+
+internal static class RepositoryLabelManager {
+    public static async Task EnsureLabelsAsync(string repo, IReadOnlyList<ProjectLabelDefinition> labels) {
+        if (labels.Count == 0) {
+            return;
+        }
+
+        var existing = await GetExistingLabelNamesAsync(repo).ConfigureAwait(false);
+        foreach (var label in labels) {
+            if (existing.Contains(label.Name)) {
+                continue;
+            }
+
+            var (code, _, stderr) = await GhCli.RunAsync(
+                "label", "create", label.Name,
+                "--repo", repo,
+                "--color", label.Color,
+                "--description", label.Description
+            ).ConfigureAwait(false);
+
+            if (code != 0) {
+                throw new InvalidOperationException(
+                    $"Failed to create label '{label.Name}' in repo '{repo}': {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
+            }
+        }
+    }
+
+    public static async Task<bool> AddLabelsAsync(string repo, string kind, int number, IReadOnlyList<string> labels) {
+        if (number <= 0 || labels.Count == 0) {
+            return true;
+        }
+
+        var normalized = labels
+            .Where(label => !string.IsNullOrWhiteSpace(label))
+            .Select(label => label.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (normalized.Count == 0) {
+            return true;
+        }
+
+        var command = kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase) ? "pr" : "issue";
+        var (code, _, stderr) = await GhCli.RunAsync(
+            command, "edit",
+            number.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "--repo", repo,
+            "--add-label", string.Join(",", normalized)
+        ).ConfigureAwait(false);
+
+        if (code != 0) {
+            Console.Error.WriteLine(
+                $"Warning: failed to apply labels to {kind} #{number}: {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static async Task<HashSet<string>> GetExistingLabelNamesAsync(string repo) {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var (code, stdout, stderr) = await GhCli.RunAsync(
+            "label", "list",
+            "--repo", repo,
+            "--limit", "1000",
+            "--json", "name"
+        ).ConfigureAwait(false);
+        if (code != 0) {
+            throw new InvalidOperationException(
+                $"Failed to list labels for repo '{repo}': {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
+        }
+
+        try {
+            using var doc = JsonDocument.Parse(stdout);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) {
+                return names;
+            }
+
+            foreach (var item in doc.RootElement.EnumerateArray()) {
+                if (!item.TryGetProperty("name", out var nameProp) || nameProp.ValueKind != JsonValueKind.String) {
+                    continue;
+                }
+                var name = nameProp.GetString();
+                if (!string.IsNullOrWhiteSpace(name)) {
+                    names.Add(name.Trim());
+                }
+            }
+        } catch (Exception ex) {
+            throw new InvalidOperationException($"Failed to parse label list JSON: {ex.Message}");
+        }
+
+        return names;
+    }
+}

--- a/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
+++ b/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using IntelligenceX.Cli.GitHub;
 
@@ -18,6 +19,18 @@ internal static class TriageIndexRunner {
         "was", "were", "will", "with", "this", "these", "those", "into", "over",
         "under", "fix", "update", "add", "remove", "improve", "refactor", "cleanup"
     };
+    private static readonly Regex ExplicitIssueRef = new(
+        @"(?i)\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?|ref(?:s|erences?)|related to)\s+#(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly Regex ExplicitRepoIssueRef = new(
+        @"(?i)\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?|ref(?:s|erences?)|related to)\s+(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)#(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly Regex ExplicitIssueUrlRef = new(
+        @"(?i)\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?|ref(?:s|erences?)|related to)\s+https?://github\.com/(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)/issues/(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
 
     internal sealed record PullRequestSignals(
         bool IsDraft,
@@ -107,6 +120,21 @@ internal static class TriageIndexRunner {
         string? DuplicateClusterId
     );
 
+    internal sealed record RelatedIssueCandidate(
+        int Number,
+        string Url,
+        double Confidence,
+        string Reason
+    );
+
+    internal sealed record ItemEnrichment(
+        string Category,
+        IReadOnlyList<string> Tags,
+        string? MatchedIssueUrl,
+        double? MatchedIssueConfidence,
+        IReadOnlyList<RelatedIssueCandidate> RelatedIssues
+    );
+
     private sealed class Options {
         public string Repo { get; set; } = "EvotecIT/IntelligenceX";
         public int MaxPrs { get; set; } = 100;
@@ -147,6 +175,7 @@ internal static class TriageIndexRunner {
         var items = BuildItems(pullRequests, issues);
         var clusters = BuildDuplicateClusters(items, options.DuplicateThreshold);
         var clusterByItem = BuildClusterLookup(clusters);
+        var enrichments = BuildItemEnrichments(options.Repo, items, pullRequests, issues);
 
         var scoredItems = new List<ItemWithScore>(items.Count);
         foreach (var item in items) {
@@ -163,8 +192,8 @@ internal static class TriageIndexRunner {
         }
 
         var bestPullRequests = BuildBestPullRequests(scoredItems, clusters, options.BestLimit);
-        var report = BuildReport(options, nowUtc, scoredItems, clusters, bestPullRequests);
-        var summary = BuildMarkdownSummary(options, nowUtc, scoredItems, clusters, bestPullRequests);
+        var report = BuildReport(options, nowUtc, scoredItems, clusters, bestPullRequests, enrichments);
+        var summary = BuildMarkdownSummary(options, nowUtc, scoredItems, clusters, bestPullRequests, enrichments);
 
         WriteText(options.OutputPath, JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
         WriteText(options.SummaryPath, summary);
@@ -508,6 +537,237 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         }
 
         return items;
+    }
+
+    private static Dictionary<string, ItemEnrichment> BuildItemEnrichments(
+        string repo,
+        IReadOnlyList<TriageIndexItem> items,
+        IReadOnlyList<RawPullRequest> pullRequests,
+        IReadOnlyList<RawIssue> issues) {
+        var enrichments = new Dictionary<string, ItemEnrichment>(StringComparer.OrdinalIgnoreCase);
+        var issueItems = items
+            .Where(item => item.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var rawPrByNumber = pullRequests.ToDictionary(pr => pr.Number);
+
+        foreach (var item in items) {
+            var (category, tags) = InferCategoryAndTags(item);
+
+            IReadOnlyList<RelatedIssueCandidate> related = Array.Empty<RelatedIssueCandidate>();
+            string? matchedIssueUrl = null;
+            double? matchedIssueConfidence = null;
+
+            if (item.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
+                if (rawPrByNumber.TryGetValue(item.Number, out var rawPr)) {
+                    related = MatchPullRequestToIssues(repo, rawPr.Title, rawPr.Body, issueItems);
+                } else {
+                    related = MatchPullRequestToIssues(repo, item.Title, string.Join(' ', item.ContextTokens), issueItems);
+                }
+
+                if (related.Count > 0) {
+                    matchedIssueUrl = related[0].Url;
+                    matchedIssueConfidence = related[0].Confidence;
+                }
+            }
+
+            enrichments[item.Id] = new ItemEnrichment(
+                Category: category,
+                Tags: tags,
+                MatchedIssueUrl: matchedIssueUrl,
+                MatchedIssueConfidence: matchedIssueConfidence,
+                RelatedIssues: related
+            );
+        }
+
+        return enrichments;
+    }
+
+    internal static (string Category, IReadOnlyList<string> Tags) InferCategoryAndTags(TriageIndexItem item) {
+        var tokens = new HashSet<string>(item.ContextTokens, StringComparer.OrdinalIgnoreCase);
+        foreach (var token in item.TitleTokens) {
+            tokens.Add(token);
+        }
+
+        foreach (var label in item.Labels) {
+            foreach (var token in Tokenize(label)) {
+                tokens.Add(token);
+            }
+        }
+
+        bool HasAny(params string[] candidates) {
+            foreach (var candidate in candidates) {
+                if (tokens.Contains(candidate)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        var isSecurity = HasAny("security", "vulnerability", "vulnerabilities", "auth", "authorization", "xss", "injection", "cve", "secret", "secrets");
+        var isBug = HasAny("bug", "bugs", "error", "errors", "failure", "failures", "exception", "exceptions", "crash", "regression", "defect", "defects");
+        var isPerformance = HasAny("performance", "perf", "latency", "throughput", "memory", "cpu");
+        var isDocs = HasAny("docs", "doc", "documentation", "readme", "wiki", "changelog");
+        var isTesting = HasAny("test", "tests", "testing", "unittest", "integration", "e2e");
+        var isCi = HasAny("ci", "pipeline", "workflows", "workflow", "actions", "github", "build");
+        var isMaintenance = HasAny("refactor", "cleanup", "chore", "maintenance", "bump", "upgrade", "dependency", "dependencies", "deps");
+
+        var category = isSecurity ? "security"
+            : isBug ? "bug"
+            : isPerformance ? "performance"
+            : isDocs ? "documentation"
+            : isTesting ? "testing"
+            : isCi ? "ci"
+            : isMaintenance ? "maintenance"
+            : "feature";
+
+        var tags = new List<string>();
+        if (isSecurity) {
+            tags.Add("security");
+        }
+        if (isBug) {
+            tags.Add("bugfix");
+        }
+        if (isPerformance) {
+            tags.Add("performance");
+        }
+        if (isDocs) {
+            tags.Add("docs");
+        }
+        if (isTesting) {
+            tags.Add("testing");
+        }
+        if (isCi) {
+            tags.Add("ci");
+        }
+        if (isMaintenance) {
+            tags.Add("maintenance");
+        }
+        if (HasAny("api", "apis")) {
+            tags.Add("api");
+        }
+        if (HasAny("ui", "ux", "frontend", "website")) {
+            tags.Add("ux");
+        }
+        if (HasAny("dependency", "dependencies", "deps", "nuget", "package", "packages")) {
+            tags.Add("dependencies");
+        }
+        if (tags.Count == 0) {
+            tags.Add(category);
+        }
+
+        return (
+            Category: category,
+            Tags: tags
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase)
+                .Take(8)
+                .ToList()
+        );
+    }
+
+    internal static IReadOnlyList<RelatedIssueCandidate> MatchPullRequestToIssues(
+        string repo,
+        string prTitle,
+        string prBody,
+        IReadOnlyList<TriageIndexItem> issueItems) {
+        if (issueItems.Count == 0) {
+            return Array.Empty<RelatedIssueCandidate>();
+        }
+
+        var (owner, name) = SplitRepo(repo);
+        var issueByNumber = issueItems.ToDictionary(item => item.Number);
+        var matchesByNumber = new Dictionary<int, RelatedIssueCandidate>();
+
+        foreach (var issueNumber in ParseExplicitIssueReferences(prTitle, prBody, owner, name)) {
+            if (!issueByNumber.TryGetValue(issueNumber, out var issue)) {
+                continue;
+            }
+
+            matchesByNumber[issue.Number] = new RelatedIssueCandidate(
+                Number: issue.Number,
+                Url: issue.Url,
+                Confidence: 0.98,
+                Reason: "explicit issue reference in PR title/body"
+            );
+        }
+
+        var prTitleTokens = Tokenize(prTitle);
+        var prContextTokens = Tokenize($"{prTitle}\n{prBody}");
+
+        foreach (var issue in issueItems) {
+            if (matchesByNumber.ContainsKey(issue.Number)) {
+                continue;
+            }
+
+            var titleScore = Jaccard(prTitleTokens, issue.TitleTokens);
+            var contextScore = Jaccard(prContextTokens, issue.ContextTokens);
+            var blended = Math.Round((titleScore * 0.55) + (contextScore * 0.45), 4, MidpointRounding.AwayFromZero);
+            if (blended < 0.34) {
+                continue;
+            }
+
+            var reason = $"token similarity title={titleScore.ToString("0.00", CultureInfo.InvariantCulture)}, context={contextScore.ToString("0.00", CultureInfo.InvariantCulture)}";
+            matchesByNumber[issue.Number] = new RelatedIssueCandidate(
+                Number: issue.Number,
+                Url: issue.Url,
+                Confidence: blended,
+                Reason: reason
+            );
+        }
+
+        return matchesByNumber.Values
+            .OrderByDescending(match => match.Confidence)
+            .ThenBy(match => match.Number)
+            .Take(3)
+            .ToList();
+    }
+
+    private static IReadOnlyList<int> ParseExplicitIssueReferences(
+        string prTitle,
+        string prBody,
+        string owner,
+        string repoName) {
+        var text = $"{prTitle}\n{prBody}";
+        var results = new HashSet<int>();
+
+        foreach (Match match in ExplicitIssueRef.Matches(text)) {
+            if (TryReadIssueNumber(match, out var number)) {
+                results.Add(number);
+            }
+        }
+
+        foreach (Match match in ExplicitRepoIssueRef.Matches(text)) {
+            var refOwner = match.Groups["owner"].Value;
+            var refRepo = match.Groups["repo"].Value;
+            if (!refOwner.Equals(owner, StringComparison.OrdinalIgnoreCase) ||
+                !refRepo.Equals(repoName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (TryReadIssueNumber(match, out var number)) {
+                results.Add(number);
+            }
+        }
+
+        foreach (Match match in ExplicitIssueUrlRef.Matches(text)) {
+            var refOwner = match.Groups["owner"].Value;
+            var refRepo = match.Groups["repo"].Value;
+            if (!refOwner.Equals(owner, StringComparison.OrdinalIgnoreCase) ||
+                !refRepo.Equals(repoName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (TryReadIssueNumber(match, out var number)) {
+                results.Add(number);
+            }
+        }
+
+        return results.OrderBy(value => value).ToList();
+    }
+
+    private static bool TryReadIssueNumber(Match match, out int number) {
+        number = 0;
+        return match.Groups["num"].Success &&
+               int.TryParse(match.Groups["num"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out number) &&
+               number > 0;
     }
 
     internal static string NormalizeText(string? value) {
@@ -886,7 +1146,8 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         DateTimeOffset nowUtc,
         IReadOnlyList<ItemWithScore> scoredItems,
         IReadOnlyList<DuplicateCluster> clusters,
-        IReadOnlyList<BestPullRequest> bestPullRequests) {
+        IReadOnlyList<BestPullRequest> bestPullRequests,
+        IReadOnlyDictionary<string, ItemEnrichment> enrichments) {
         var duplicateIds = new HashSet<string>(
             clusters.SelectMany(cluster => cluster.ItemIds),
             StringComparer.OrdinalIgnoreCase
@@ -896,22 +1157,38 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
             .OrderByDescending(item => item.Item.UpdatedAtUtc)
             .ThenBy(item => item.Item.Kind, StringComparer.OrdinalIgnoreCase)
             .ThenBy(item => item.Item.Number)
-            .Select(item => new {
-                id = item.Item.Id,
-                kind = item.Item.Kind,
-                number = item.Item.Number,
-                title = item.Item.Title,
-                url = item.Item.Url,
-                updatedAtUtc = item.Item.UpdatedAtUtc.UtcDateTime.ToString("o", CultureInfo.InvariantCulture),
-                labels = item.Item.Labels,
-                dedupeKey = string.Join("-", item.Item.TitleTokens.Take(8)),
-                duplicateClusterId = item.DuplicateClusterId,
-                score = item.Score,
-                scoreReasons = item.ScoreReasons,
-                signals = new {
-                    pullRequest = item.Item.PullRequest,
-                    issue = item.Item.Issue
-                }
+            .Select(item => {
+                enrichments.TryGetValue(item.Item.Id, out var enrichment);
+                return new {
+                    id = item.Item.Id,
+                    kind = item.Item.Kind,
+                    number = item.Item.Number,
+                    title = item.Item.Title,
+                    url = item.Item.Url,
+                    updatedAtUtc = item.Item.UpdatedAtUtc.UtcDateTime.ToString("o", CultureInfo.InvariantCulture),
+                    labels = item.Item.Labels,
+                    dedupeKey = string.Join("-", item.Item.TitleTokens.Take(8)),
+                    duplicateClusterId = item.DuplicateClusterId,
+                    category = enrichment?.Category,
+                    tags = enrichment?.Tags ?? Array.Empty<string>(),
+                    matchedIssueUrl = enrichment?.MatchedIssueUrl,
+                    matchedIssueConfidence = enrichment?.MatchedIssueConfidence,
+                    relatedIssues = enrichment?.RelatedIssues
+                        .Select(related => new {
+                            number = related.Number,
+                            url = related.Url,
+                            confidence = related.Confidence,
+                            reason = related.Reason
+                        })
+                        .Cast<object>()
+                        .ToList() ?? new List<object>(),
+                    score = item.Score,
+                    scoreReasons = item.ScoreReasons,
+                    signals = new {
+                        pullRequest = item.Item.PullRequest,
+                        issue = item.Item.Issue
+                    }
+                };
             })
             .ToList();
 
@@ -949,7 +1226,8 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                 issues = scoredItems.Count(item => item.Item.Kind == "issue"),
                 duplicateClusters = clusters.Count,
                 duplicateItems = duplicateIds.Count,
-                bestPullRequestCandidates = bestPullRequests.Count
+                bestPullRequestCandidates = bestPullRequests.Count,
+                pullRequestsWithMatchedIssue = enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedIssueUrl))
             },
             bestPullRequests = best,
             duplicateClusters = duplicates,
@@ -962,7 +1240,8 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         DateTimeOffset nowUtc,
         IReadOnlyList<ItemWithScore> scoredItems,
         IReadOnlyList<DuplicateCluster> clusters,
-        IReadOnlyList<BestPullRequest> bestPullRequests) {
+        IReadOnlyList<BestPullRequest> bestPullRequests,
+        IReadOnlyDictionary<string, ItemEnrichment> enrichments) {
         var duplicateIds = new HashSet<string>(
             clusters.SelectMany(cluster => cluster.ItemIds),
             StringComparer.OrdinalIgnoreCase
@@ -983,6 +1262,7 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         sb.AppendLine($"- Issues: {scoredItems.Count(item => item.Item.Kind == "issue")}");
         sb.AppendLine($"- Duplicate clusters: {clusters.Count}");
         sb.AppendLine($"- Duplicate items: {duplicateIds.Count}");
+        sb.AppendLine($"- PRs with matched issue: {enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedIssueUrl))}");
         sb.AppendLine();
         sb.AppendLine("## Best PR Candidates");
         sb.AppendLine();

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -11,6 +11,10 @@ internal static partial class Program {
 
         AssertEqual(true, names.Contains("Vision Fit", StringComparer.OrdinalIgnoreCase), "has Vision Fit");
         AssertEqual(true, names.Contains("Vision Confidence", StringComparer.OrdinalIgnoreCase), "has Vision Confidence");
+        AssertEqual(true, names.Contains("Category", StringComparer.OrdinalIgnoreCase), "has Category");
+        AssertEqual(true, names.Contains("Tags", StringComparer.OrdinalIgnoreCase), "has Tags");
+        AssertEqual(true, names.Contains("Matched Issue", StringComparer.OrdinalIgnoreCase), "has Matched Issue");
+        AssertEqual(true, names.Contains("Matched Issue Confidence", StringComparer.OrdinalIgnoreCase), "has Matched Issue Confidence");
         AssertEqual(true, names.Contains("Triage Score", StringComparer.OrdinalIgnoreCase), "has Triage Score");
         AssertEqual(true, names.Contains("Maintainer Decision", StringComparer.OrdinalIgnoreCase), "has Maintainer Decision");
     }
@@ -24,7 +28,11 @@ internal static partial class Program {
       "kind": "pull_request",
       "url": "https://github.com/EvotecIT/IntelligenceX/pull/10",
       "score": 91.2,
-      "duplicateClusterId": "cluster-1"
+      "duplicateClusterId": "cluster-1",
+      "category": "feature",
+      "tags": [ "api", "automation" ],
+      "matchedIssueUrl": "https://github.com/EvotecIT/IntelligenceX/issues/11",
+      "matchedIssueConfidence": 0.93
     },
     {
       "id": "issue#11",
@@ -67,6 +75,10 @@ internal static partial class Program {
         AssertEqual(true, pr.VisionConfidence.HasValue && pr.VisionConfidence.Value > 0.8, "vision confidence merged");
         AssertEqual(true, pr.TriageScore.HasValue && pr.TriageScore.Value > 90, "triage score preserved");
         AssertEqual("https://github.com/EvotecIT/IntelligenceX/pull/10", pr.CanonicalItem, "canonical url resolved");
+        AssertEqual("feature", pr.Category, "category merged");
+        AssertEqual(true, pr.Tags.Contains("api", StringComparer.OrdinalIgnoreCase), "tags merged");
+        AssertEqual("https://github.com/EvotecIT/IntelligenceX/issues/11", pr.MatchedIssueUrl, "matched issue url merged");
+        AssertEqual(true, pr.MatchedIssueConfidence.HasValue && pr.MatchedIssueConfidence.Value > 0.9, "matched issue confidence merged");
 
         var issue = entries.First(item => item.Url.EndsWith("/issues/11", StringComparison.OrdinalIgnoreCase));
         AssertEqual("issue", issue.Kind, "issue kind preserved");

--- a/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
+++ b/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
@@ -97,5 +97,70 @@ internal static partial class Program {
         var weakScore = IntelligenceX.Cli.Todo.TriageIndexRunner.ScorePullRequest(weak, now, out _);
         AssertEqual(true, strongScore > weakScore, "strong score should be higher");
     }
+
+    private static void TestTriageIndexMatchPullRequestToIssuesSupportsExplicitReference() {
+        var now = DateTimeOffset.UtcNow;
+        var issue42 = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "issue#42",
+            "issue",
+            42,
+            "Parser crashes on null input",
+            "https://github.com/EvotecIT/IntelligenceX/issues/42",
+            now,
+            Array.Empty<string>(),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Parser crashes on null input"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Parser crashes on null input"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Parser crashes on null input with stack trace"),
+            null,
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.IssueSignals(4, "dev1")
+        );
+        var issue77 = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "issue#77",
+            "issue",
+            77,
+            "Website color tweaks",
+            "https://github.com/EvotecIT/IntelligenceX/issues/77",
+            now,
+            Array.Empty<string>(),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Website color tweaks"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Website color tweaks"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Website color tweaks"),
+            null,
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.IssueSignals(1, "dev2")
+        );
+
+        var matches = IntelligenceX.Cli.Todo.TriageIndexRunner.MatchPullRequestToIssues(
+            "EvotecIT/IntelligenceX",
+            "Fix parser null handling",
+            "This closes #42 and adds regression coverage.",
+            new[] { issue42, issue77 }
+        );
+
+        AssertEqual(true, matches.Count >= 1, "match exists");
+        AssertEqual(42, matches[0].Number, "explicit issue number wins");
+        AssertEqual(true, matches[0].Confidence >= 0.95, "explicit confidence");
+    }
+
+    private static void TestTriageIndexInferCategoryAndTagsDetectsSecurity() {
+        var now = DateTimeOffset.UtcNow;
+        var item = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "pr#88",
+            "pull_request",
+            88,
+            "Harden auth token validation",
+            "https://example/pr/88",
+            now,
+            new[] { "security" },
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Harden auth token validation"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Harden auth token validation"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Security fix for auth token validation and API checks"),
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.PullRequestSignals(false, "MERGEABLE", "APPROVED", "SUCCESS", 6, 40, 8, 1, 2, "dev"),
+            null
+        );
+
+        var (category, tags) = IntelligenceX.Cli.Todo.TriageIndexRunner.InferCategoryAndTags(item);
+        AssertEqual("security", category, "security category");
+        AssertEqual(true, tags.Contains("security", StringComparer.OrdinalIgnoreCase), "security tag");
+    }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -440,6 +440,8 @@ internal static partial class Program {
         failed += Run("Todo triage index tokenization", TestTriageIndexTokenizeNormalizesAndDropsStopWords);
         failed += Run("Todo triage index duplicate clusters", TestTriageIndexDuplicateClustersGroupNearMatches);
         failed += Run("Todo triage index PR scoring", TestTriageIndexScoreRewardsMergeableApprovedPrs);
+        failed += Run("Todo triage index PR-issue explicit match", TestTriageIndexMatchPullRequestToIssuesSupportsExplicitReference);
+        failed += Run("Todo triage index category/tag inference", TestTriageIndexInferCategoryAndTagsDetectsSecurity);
         failed += Run("Todo vision check out-of-scope classification", TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate);
         failed += Run("Todo vision check aligned classification", TestVisionCheckClassifiesAlignedWhenInTokensMatch);
         failed += Run("Todo project fields defaults", TestProjectFieldCatalogDefaultsIncludeVisionAndDecisionFields);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -56,6 +56,7 @@ Important:
 - This is a first-slice ranking/dedupe helper, not a hard merge gate.
 - Duplicate detection is deterministic and explainable; semantic/embedding clustering can be layered later.
 - PR ranking includes status-check signals (when available) in addition to mergeability/review/churn/recency.
+- Item output includes assistive `category` + `tags` and PR `relatedIssues`/`matchedIssueUrl` fields for downstream automation.
 
 ## Vision Check (Assistive)
 
@@ -91,11 +92,16 @@ Options:
 - `--title <text>` and `--description <text>` when creating
 - `--public` / `--private`
 - `--link-repo` / `--no-link-repo`
+- `--ensure-labels` / `--no-ensure-labels`
 - `--out <path>` (default `artifacts/triage/ix-project-config.json`)
 
 Expected fields:
 - `Vision Fit` (single-select)
 - `Vision Confidence` (number)
+- `Category` (single-select)
+- `Tags` (text)
+- `Matched Issue` (text)
+- `Matched Issue Confidence` (number)
 - `Triage Score` (number)
 - `Duplicate Cluster` (text)
 - `Canonical Item` (text)
@@ -116,6 +122,8 @@ Options:
 - `--max-items <n>` (default `500`)
 - `--project-item-scan-limit <n>` (default `5000`)
 - `--ensure-fields` / `--no-ensure-fields`
+- `--apply-labels`
+- `--ensure-labels` / `--no-ensure-labels`
 - `--dry-run`
 
 ## Workflow Template


### PR DESCRIPTION
## Summary
- expand triage artifacts with maintainer automation signals: `category`, `tags`, and PR→Issue `relatedIssues`/`matchedIssueUrl` confidence
- add deterministic PR→Issue matching engine (explicit `closes #123` refs + similarity fallback)
- extend project schema defaults to include `Category`, `Tags`, `Matched Issue`, and `Matched Issue Confidence`
- make `todo project-init` ensure IX label taxonomy by default
- add opt-in `todo project-sync --apply-labels` for reliable repo tagging of PRs/issues (`ix/category:*`, `ix/vision:*`, `ix/match:*`, `ix/duplicate:*`)
- update docs and tests to cover new schema, matching, and category/tag inference

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`

## Maintainer Notes
- label application is opt-in (`--apply-labels`) to avoid surprising repos
- project setup now ensures labels by default; disable with `--no-ensure-labels` if needed
