### PR TITLE
Fix project-sync GraphQL coercion for numeric single-select option IDs

### DIFF
--- a/IntelligenceX.Cli/Todo/ProjectV2Client.cs
+++ b/IntelligenceX.Cli/Todo/ProjectV2Client.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using IntelligenceX.Cli.GitHub;
 
@@ -552,12 +553,18 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
   }
 }
 """;
-        await QueryGraphQlAsync(
-            mutation,
-            ("projectId", projectId),
-            ("itemId", itemId),
-            ("fieldId", fieldId),
-            ("optionId", optionId)).ConfigureAwait(false);
+        try {
+            await QueryGraphQlAsync(
+                mutation,
+                ("projectId", projectId),
+                ("itemId", itemId),
+                ("fieldId", fieldId),
+                ("optionId", optionId)).ConfigureAwait(false);
+        } catch (Exception ex) {
+            throw new InvalidOperationException(
+                $"Failed to set single-select field '{fieldId}' with option '{optionId}' for item '{itemId}'. {ex.Message}",
+                ex);
+        }
     }
 
     public async Task ClearFieldAsync(string projectId, string itemId, string fieldId) {
@@ -630,23 +637,44 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!) {
             "-f",
             $"query={query}"
         };
+        var variableTypes = ParseVariableTypes(query);
         foreach (var (key, value) in variables) {
             if (value is null) {
                 continue;
             }
-            args.Add("-F");
+            args.Add(UseTypedFormValue(variableTypes, key) ? "-F" : "-f");
             args.Add($"{key}={value}");
         }
 
         var (code, stdout, stderr) = await GhCli.RunAsync(TimeSpan.FromSeconds(90), args.ToArray()).ConfigureAwait(false);
+        JsonElement root;
+        try {
+            using var doc = JsonDocument.Parse(stdout);
+            root = doc.RootElement.Clone();
+        } catch (Exception) {
+            if (code != 0) {
+                throw new InvalidOperationException(stderr.Trim().Length > 0 ? stderr.Trim() : "Failed to query GitHub GraphQL API.");
+            }
+            throw;
+        }
+
         if (code != 0) {
+            if (root.TryGetProperty("errors", out var nonZeroErrors) &&
+                nonZeroErrors.ValueKind == JsonValueKind.Array &&
+                nonZeroErrors.GetArrayLength() > 0 &&
+                ShouldIgnoreErrors(root, nonZeroErrors)) {
+                return root;
+            }
+
             throw new InvalidOperationException(stderr.Trim().Length > 0 ? stderr.Trim() : "Failed to query GitHub GraphQL API.");
         }
-        using var doc = JsonDocument.Parse(stdout);
-        var root = doc.RootElement.Clone();
+
         if (root.TryGetProperty("errors", out var errors) &&
             errors.ValueKind == JsonValueKind.Array &&
             errors.GetArrayLength() > 0) {
+            if (ShouldIgnoreErrors(root, errors)) {
+                return root;
+            }
             var first = errors[0];
             var message = first.TryGetProperty("message", out var msg)
                 ? (msg.GetString() ?? "GraphQL error")
@@ -654,6 +682,56 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!) {
             throw new InvalidOperationException($"GitHub GraphQL returned errors: {message}");
         }
         return root;
+    }
+
+    private static bool ShouldIgnoreErrors(JsonElement root, JsonElement errors) {
+        if (!TryGetProperty(root, "data", out var data) || data.ValueKind != JsonValueKind.Object) {
+            return false;
+        }
+
+        foreach (var error in errors.EnumerateArray()) {
+            var message = ReadString(error, "message");
+            if (string.IsNullOrWhiteSpace(message)) {
+                return false;
+            }
+
+            if (message.Contains("Could not resolve to a User with the login of", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (message.Contains("Could not resolve to an Organization with the login of", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private static IReadOnlyDictionary<string, string> ParseVariableTypes(string query) {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (Match match in Regex.Matches(query, @"\$(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?<type>[A-Za-z0-9_!\[\]]+)")) {
+            var name = match.Groups["name"].Value;
+            var type = match.Groups["type"].Value;
+            if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(type)) {
+                map[name] = type;
+            }
+        }
+        return map;
+    }
+
+    private static bool UseTypedFormValue(IReadOnlyDictionary<string, string> variableTypes, string key) {
+        if (!variableTypes.TryGetValue(key, out var graphType) || string.IsNullOrWhiteSpace(graphType)) {
+            return true;
+        }
+
+        var normalized = graphType.Replace("!", string.Empty, StringComparison.Ordinal)
+            .Replace("[", string.Empty, StringComparison.Ordinal)
+            .Replace("]", string.Empty, StringComparison.Ordinal);
+
+        return normalized.Equals("Int", StringComparison.Ordinal) ||
+               normalized.Equals("Float", StringComparison.Ordinal) ||
+               normalized.Equals("Boolean", StringComparison.Ordinal);
     }
 
     private static bool TryGetProperty(JsonElement obj, string name, out JsonElement value) {


### PR DESCRIPTION
## Summary
- keep GraphQL query results when owner lookups return ignorable user/org resolution errors but still include valid data
- preserve string semantics for GraphQL variables typed as String/ID/URI by sending them with -f instead of -F
- retain typed -F behavior for numeric and boolean variables (Int/Float/Boolean)
- add context-rich error details for single-select field writes to aid triage

## Why
gh api graphql -F coerces all-digit values to numbers. Project single-select option IDs like 71209585 were being sent as numeric variables, causing:

Variable  of type String! was provided invalid value

This made 	odo project-sync fail while updating fields.

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
- live smoke in disposable project: 	odo project-sync now completes with Skipped unresolved items: 0 and field updates applied