### PR TITLE
Fix local runtime startup loop when service profile is missing

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -190,7 +190,7 @@ public sealed partial class MainWindow : Window {
         await PersistAppStateAsync().ConfigureAwait(false);
 
         _pendingServiceLaunchProfileOptions = new ServiceLaunchProfileOptions {
-            LoadProfileName = _appProfileName,
+            LoadProfileName = profileSaved ? _appProfileName : null,
             SaveProfileName = _appProfileName,
             Model = _localProviderModel,
             OpenAITransport = _localProviderTransport,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -593,6 +593,13 @@ internal sealed class ServiceOptions {
                 options.ProfileName = value;
                 continue;
             }
+            if (arg is "--save-profile") {
+                if (!TryConsume(args, ref i, out var value, out error)) {
+                    return;
+                }
+                options.SaveProfileName = value;
+                continue;
+            }
         }
     }
 
@@ -612,11 +619,27 @@ internal sealed class ServiceOptions {
         using var store = new SqliteServiceProfileStore(dbPath);
         var profile = store.GetAsync(name, CancellationToken.None).GetAwaiter().GetResult();
         if (profile == null) {
+            if (ShouldBootstrapMissingProfile(options, name)) {
+                return true;
+            }
             error = $"Profile not found: {name}";
             return false;
         }
         options.ApplyProfile(profile);
         return true;
+    }
+
+    private static bool ShouldBootstrapMissingProfile(ServiceOptions options, string profileName) {
+        if (options == null || string.IsNullOrWhiteSpace(profileName) || options.NoStateDb) {
+            return false;
+        }
+
+        var saveName = (options.SaveProfileName ?? string.Empty).Trim();
+        if (saveName.Length == 0) {
+            return false;
+        }
+
+        return string.Equals(saveName, profileName, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool TrySaveProfile(ServiceOptions options, out string? error) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ServiceOptionsProfileBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ServiceOptionsProfileBootstrapTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using IntelligenceX.Chat.Service;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+/// <summary>
+/// Covers profile bootstrap semantics for service startup argument parsing.
+/// </summary>
+public sealed class ServiceOptionsProfileBootstrapTests {
+    [Fact]
+    public void Parse_AllowsMissingProfile_WhenSaveProfileMatches() {
+        var dbPath = Path.Combine(Path.GetTempPath(), "ix-chat-service-" + Guid.NewGuid().ToString("N") + ".db");
+        try {
+            var options = ServiceOptions.Parse(new[] {
+                "--pipe", "test.pipe",
+                "--state-db", dbPath,
+                "--profile", "default",
+                "--save-profile", "default"
+            }, out var error);
+
+            Assert.NotNull(options);
+            Assert.True(string.IsNullOrWhiteSpace(error));
+            Assert.Equal("default", options.ProfileName);
+            Assert.Equal("default", options.SaveProfileName);
+        } finally {
+            TryDelete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_RejectsMissingProfile_WhenNoMatchingSaveProfile() {
+        var dbPath = Path.Combine(Path.GetTempPath(), "ix-chat-service-" + Guid.NewGuid().ToString("N") + ".db");
+        try {
+            _ = ServiceOptions.Parse(new[] {
+                "--pipe", "test.pipe",
+                "--state-db", dbPath,
+                "--profile", "default"
+            }, out var error);
+
+            Assert.Equal("Profile not found: default", error);
+        } finally {
+            TryDelete(dbPath);
+        }
+    }
+
+    private static void TryDelete(string path) {
+        try {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        } catch {
+            // Best-effort cleanup only.
+        }
+    }
+}


### PR DESCRIPTION
## Why
Some local-runtime restarts failed with `Timed out waiting for service pipe.` while startup log showed `Profile not found: default` from the service process.

## What
- Service parser now pre-scans `--save-profile` before profile load.
- Service startup no longer fails when `--profile <name>` is missing and `--save-profile <same-name>` is provided (bootstrap path).
- App launch now only passes `LoadProfileName` when profile already exists in discovered profile list; it still saves profile every time.
- Added regression tests for both bootstrap and true-missing-profile paths.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ServiceOptionsProfileBootstrapTests"`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Debug --filter "FullyQualifiedName~ServiceLaunchArgumentsTests"`

## Result
First-run / missing-profile local runtime startup no longer drops into pipe-timeout loops during profile bootstrap.
