### PR TITLE
Backport OfficeIMO counter contract hardening from post-#350 follow-up

### DIFF
--- a/IntelligenceX.Tools/Docs/OfficeIMO.md
+++ b/IntelligenceX.Tools/Docs/OfficeIMO.md
@@ -59,6 +59,7 @@
 - `warnings`: per-file warnings (skipped/unsupported/error)
 - `truncated`: indicates cap-based truncation
 - counters: `files_scanned`, `files_parsed`, `files_skipped`, `bytes_read`, `chunks_produced`, `chunks_returned`, `token_estimate_returned`
+  - `chunks_returned`/`token_estimate_returned` reflect chunk objects present in the payload shape; in `both` mode this includes flat chunks plus per-document chunks.
 - `meta`: includes `count`, caps, and output-shape counters
 - `summary_markdown`: compact preview of extracted chunks
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
@@ -63,12 +63,13 @@ public sealed class OfficeImoReadResult {
     public int ChunksProduced { get; set; }
 
     /// <summary>
-    /// Total chunks returned in this tool payload after output shaping caps.
+    /// Total chunk objects returned in this tool payload after output shaping caps.
+    /// In <c>both</c> mode this includes flat chunks plus per-document chunks.
     /// </summary>
     public int ChunksReturned { get; set; }
 
     /// <summary>
-    /// Aggregated token estimate across returned chunks (best-effort).
+    /// Aggregated token estimate across returned chunk objects (best-effort).
     /// </summary>
     public int TokenEstimateReturned { get; set; }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadTool.cs
@@ -130,6 +130,14 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
         }
 
         result.Warnings.Add("OfficeIMO.Reader is not available in this build (missing reference).");
+        result.FilesParsed = 0;
+        result.FilesSkipped = result.FilesScanned;
+        result.BytesRead = 0;
+        result.ChunksProduced = 0;
+        result.ChunksReturned = 0;
+        result.TokenEstimateReturned = 0;
+        result.Chunks.Clear();
+        result.Documents.Clear();
         var disabledSummary = ToolMarkdown.SummaryText(
             title: "OfficeIMO read",
             "Reader dependency is unavailable in this build.",
@@ -219,7 +227,13 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
                 isTransient: false));
         }
 
-        var preview = BuildPreviewMarkdown(result.Chunks, maxChunks: 6, maxCharsPerChunk: 1800);
+        FinalizeResultCounters(result, includeFlatChunks, includeDocChunksInPayload);
+        var preview = BuildPreviewMarkdown(
+            chunks: result.Chunks,
+            documents: result.Documents,
+            includeDocumentChunks: includeDocChunksInPayload,
+            maxChunks: 6,
+            maxCharsPerChunk: 1800);
         var meta = ToolOutputHints.Meta(
                 count: includeFlatChunks ? result.Chunks.Count : result.Documents.Count,
                 truncated: result.Truncated)
@@ -258,9 +272,35 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
 #endif
     }
 
-    private static string BuildPreviewMarkdown(IReadOnlyList<OfficeImoChunk> chunks, int maxChunks, int maxCharsPerChunk) {
+    private static string BuildPreviewMarkdown(
+        IReadOnlyList<OfficeImoChunk> chunks,
+        IReadOnlyList<OfficeImoDocument> documents,
+        bool includeDocumentChunks,
+        int maxChunks,
+        int maxCharsPerChunk) {
         if (chunks is null || chunks.Count == 0) {
-            return ToolMarkdown.SummaryText("Preview", "No chunks returned.");
+            if (includeDocumentChunks && documents != null) {
+                var projected = new List<OfficeImoChunk>();
+                for (var i = 0; i < documents.Count; i++) {
+                    var doc = documents[i];
+                    if (doc?.Chunks is null || doc.Chunks.Count == 0) continue;
+                    projected.AddRange(doc.Chunks);
+                    if (projected.Count >= maxChunks) break;
+                }
+                if (projected.Count > 0) {
+                    chunks = projected;
+                }
+            }
+
+            if (chunks is null || chunks.Count == 0) {
+                if (documents != null && documents.Count > 0) {
+                    return ToolMarkdown.SummaryText(
+                        "Preview",
+                        $"Returned {documents.Count} document record(s).",
+                        includeDocumentChunks ? "No chunk text available in preview." : "Per-document chunks were excluded (include_document_chunks=false).");
+                }
+                return ToolMarkdown.SummaryText("Preview", "No chunks returned.");
+            }
         }
 
         var take = Math.Clamp(maxChunks, 1, 25);
@@ -507,8 +547,6 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
 
         officeDocument.ChunksReturned = returnedChunks;
         officeDocument.TokenEstimateReturned = returnedTokens;
-        result.ChunksReturned += returnedChunks;
-        result.TokenEstimateReturned += returnedTokens;
 
         if (includeDocuments) {
             result.Documents.Add(officeDocument);
@@ -537,6 +575,52 @@ public sealed class OfficeImoReadTool : OfficeImoToolBase, ITool {
             SourceLengthBytes = chunk.SourceLengthBytes,
             TokenEstimate = chunk.TokenEstimate
         };
+    }
+
+    private static int SumTokenEstimate(IReadOnlyList<OfficeImoChunk> chunks) {
+        if (chunks is null || chunks.Count == 0) return 0;
+        var total = 0;
+        for (var i = 0; i < chunks.Count; i++) {
+            total += chunks[i]?.TokenEstimate ?? 0;
+        }
+        return total;
+    }
+
+    private static void FinalizeResultCounters(
+        OfficeImoReadResult result,
+        bool includeFlatChunks,
+        bool includeDocumentChunks) {
+        if (result == null) return;
+
+        if (!includeFlatChunks && result.Chunks.Count > 0) {
+            result.Chunks.Clear();
+        }
+
+        var flatCount = result.Chunks.Count;
+        var flatTokens = SumTokenEstimate(result.Chunks);
+
+        var documentCount = 0;
+        var documentTokens = 0;
+        for (var i = 0; i < result.Documents.Count; i++) {
+            var doc = result.Documents[i];
+            if (doc == null) continue;
+
+            if (!includeDocumentChunks && doc.Chunks.Count > 0) {
+                doc.Chunks.Clear();
+            }
+
+            doc.ChunksReturned = doc.Chunks.Count;
+            doc.TokenEstimateReturned = SumTokenEstimate(doc.Chunks);
+
+            if (includeDocumentChunks) {
+                documentCount += doc.ChunksReturned;
+                documentTokens += doc.TokenEstimateReturned;
+            }
+        }
+
+        // Count actual chunk objects present in the payload shape.
+        result.ChunksReturned = flatCount + documentCount;
+        result.TokenEstimateReturned = flatTokens + documentTokens;
     }
 
     private sealed class FolderProgressState {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -81,6 +81,8 @@ public class OfficeImoReadToolTests {
             Assert.True(root.TryGetProperty("documents", out var documents));
             Assert.True(root.TryGetProperty("chunks", out var chunks));
             Assert.Equal(0, chunks.GetArrayLength());
+            Assert.Equal(0, root.GetProperty("chunks_returned").GetInt32());
+            Assert.Equal(0, root.GetProperty("token_estimate_returned").GetInt32());
 
             var files = root.GetProperty("files").EnumerateArray()
                 .Select(static x => x.GetString())
@@ -94,6 +96,8 @@ public class OfficeImoReadToolTests {
                 var first = documents[0];
                 Assert.Equal("knowledge.md", Path.GetFileName(first.GetProperty("path").GetString() ?? string.Empty));
                 Assert.Equal(0, first.GetProperty("chunks_returned").GetInt32());
+                Assert.Equal(0, first.GetProperty("token_estimate_returned").GetInt32());
+                Assert.True(first.GetProperty("chunks_produced").GetInt32() >= 1);
             }
         } finally {
             try {
@@ -128,6 +132,82 @@ public class OfficeImoReadToolTests {
 
             Assert.False(root.GetProperty("ok").GetBoolean());
             Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        } finally {
+            try {
+                Directory.Delete(tempRoot, recursive: true);
+            } catch {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task OfficeImoRead_WhenOutputModeBoth_IncludesBothArraysAndCoherentCounters() {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "ix-officeimo-read-" + Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(tempRoot);
+
+        try {
+            var markdownPath = Path.Combine(tempRoot, "knowledge.md");
+            File.WriteAllText(markdownPath, "# Top\n\nParagraph 1.\n\n## Child\n\nParagraph 2.");
+
+            var options = new OfficeImoToolOptions();
+            options.AllowedRoots.Add(tempRoot);
+            var tool = new OfficeImoReadTool(options);
+
+            var json = await tool.InvokeAsync(
+                arguments: new JsonObject()
+                    .Add("path", markdownPath)
+                    .Add("output_mode", "both")
+                    .Add("include_document_chunks", true),
+                cancellationToken: CancellationToken.None);
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            Assert.True(root.GetProperty("ok").GetBoolean());
+            Assert.Equal("both", root.GetProperty("output_mode").GetString());
+
+            var flatChunks = root.GetProperty("chunks");
+            var documents = root.GetProperty("documents");
+            Assert.True(flatChunks.GetArrayLength() > 0);
+            Assert.True(documents.GetArrayLength() > 0);
+
+            var documentChunkCount = 0;
+            var documentTokenTotal = 0;
+            foreach (var source in documents.EnumerateArray()) {
+                var sourceChunks = source.GetProperty("chunks");
+                var sourceChunkCount = sourceChunks.GetArrayLength();
+                documentChunkCount += sourceChunkCount;
+                Assert.Equal(sourceChunkCount, source.GetProperty("chunks_returned").GetInt32());
+
+                var sourceTokenTotal = 0;
+                foreach (var c in sourceChunks.EnumerateArray()) {
+                    if (c.TryGetProperty("token_estimate", out var token) && token.ValueKind == global::System.Text.Json.JsonValueKind.Number) {
+                        sourceTokenTotal += token.GetInt32();
+                    }
+                }
+                Assert.Equal(sourceTokenTotal, source.GetProperty("token_estimate_returned").GetInt32());
+                documentTokenTotal += sourceTokenTotal;
+            }
+
+            var flatTokenTotal = 0;
+            foreach (var c in flatChunks.EnumerateArray()) {
+                Assert.True(c.TryGetProperty("source_id", out _));
+                Assert.True(c.TryGetProperty("source_hash", out _));
+                Assert.True(c.TryGetProperty("chunk_hash", out _));
+                if (c.TryGetProperty("token_estimate", out var token) && token.ValueKind == global::System.Text.Json.JsonValueKind.Number) {
+                    flatTokenTotal += token.GetInt32();
+                }
+            }
+
+            var expectedChunkObjectsInPayload = flatChunks.GetArrayLength() + documentChunkCount;
+            var expectedTokenEstimateInPayload = flatTokenTotal + documentTokenTotal;
+
+            Assert.Equal(expectedChunkObjectsInPayload, root.GetProperty("chunks_returned").GetInt32());
+            Assert.Equal(expectedTokenEstimateInPayload, root.GetProperty("token_estimate_returned").GetInt32());
+            Assert.True(root.GetProperty("chunks_produced").GetInt32() >= flatChunks.GetArrayLength());
+            Assert.True(root.GetProperty("files_scanned").GetInt32() >= 1);
+            Assert.True(root.GetProperty("files_parsed").GetInt32() >= 1);
         } finally {
             try {
                 Directory.Delete(tempRoot, recursive: true);


### PR DESCRIPTION
Follow-up PR to land the post-#350 OfficeIMO counter-contract fixes (chunks/token counters, disabled-path defaults, documents-mode preview, and tests/docs updates).