### PR TITLE
feat(setup): add optional triage project bootstrap

### DIFF
--- a/IntelligenceX.Cli/Setup/Host/SetupArgsBuilder.cs
+++ b/IntelligenceX.Cli/Setup/Host/SetupArgsBuilder.cs
@@ -50,6 +50,10 @@ internal static class SetupArgsBuilder {
             args.Add("--with-config");
         }
 
+        if (plan.TriageBootstrap) {
+            args.Add("--triage-bootstrap");
+        }
+
         if (!string.IsNullOrWhiteSpace(plan.ConfigPath)) {
             args.Add("--config-path");
             args.Add(plan.ConfigPath);

--- a/IntelligenceX.Cli/Setup/Host/SetupPlan.cs
+++ b/IntelligenceX.Cli/Setup/Host/SetupPlan.cs
@@ -14,6 +14,7 @@ internal sealed class SetupPlan {
     public string? GitHubClientId { get; init; }
     public string? GitHubToken { get; init; }
     public bool WithConfig { get; init; }
+    public bool TriageBootstrap { get; init; }
     public string? ConfigPath { get; init; }
     public string? ConfigJson { get; init; }
     public string? AuthB64 { get; init; }

--- a/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
@@ -55,6 +55,7 @@ internal static partial class SetupRunner {
         Console.WriteLine("  --cleanup-allowed-edits <comma-list>");
         Console.WriteLine("  --cleanup-post-edit-comment <true|false>");
         Console.WriteLine("  --with-config (also write .intelligencex/reviewer.json)");
+        Console.WriteLine("  --triage-bootstrap (also bootstrap IX triage project schema + workflow + VISION.md)");
         Console.WriteLine("  --upgrade (update managed sections instead of skipping)");
         Console.WriteLine("  --update-secret (refresh INTELLIGENCEX_AUTH_B64 only)");
         Console.WriteLine("  --skip-secret (skip secret update during setup)");

--- a/IntelligenceX.Cli/Setup/SetupRunner.TriageBootstrap.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.TriageBootstrap.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Cli.Todo;
+
+namespace IntelligenceX.Cli.Setup;
+
+internal static partial class SetupRunner {
+    private const string DefaultTriageProjectConfigPath = "artifacts/triage/ix-project-config.json";
+    private const string DefaultTriageWorkflowPath = ".github/workflows/ix-triage-project-sync.yml";
+    private const string DefaultVisionPath = "VISION.md";
+    private static readonly SemaphoreSlim ProjectInitLock = new(1, 1);
+
+    private static async Task<List<FilePlan>> PlanTriageBootstrapFilesAsync(
+        GitHubApi github,
+        SetupOptions options,
+        string owner,
+        string repo,
+        string defaultBranch,
+        string? gitHubToken) {
+        var repoFullName = $"{owner}/{repo}";
+        var existingConfig = await github.TryGetFileAsync(owner, repo, DefaultTriageProjectConfigPath, defaultBranch)
+            .ConfigureAwait(false);
+
+        string projectOwner;
+        int projectNumber;
+        string projectConfigContent;
+
+        if (existingConfig is not null &&
+            ProjectBootstrapRunner.TryReadProjectTargetFromConfigJson(
+                existingConfig.Content,
+                out projectOwner,
+                out projectNumber,
+                out _)) {
+            projectConfigContent = existingConfig.Content;
+        } else {
+            if (string.IsNullOrWhiteSpace(gitHubToken)) {
+                throw new InvalidOperationException(
+                    "--triage-bootstrap requires a GitHub token. Re-run with --github-token or GH_TOKEN.");
+            }
+
+            projectConfigContent = await CreateTriageProjectConfigAsync(repoFullName, gitHubToken).ConfigureAwait(false);
+            if (!ProjectBootstrapRunner.TryReadProjectTargetFromConfigJson(
+                    projectConfigContent,
+                    out projectOwner,
+                    out projectNumber,
+                    out var parseError)) {
+                throw new InvalidOperationException(parseError);
+            }
+        }
+
+        var workflowTemplate = ProjectBootstrapRunner.LoadWorkflowTemplate();
+        var workflowContent = ProjectBootstrapRunner.RenderWorkflowTemplate(
+            workflowTemplate,
+            projectOwner,
+            projectNumber,
+            maxItems: 500);
+
+        var visionTemplate = ProjectBootstrapRunner.LoadVisionTemplate();
+        var visionContent = ProjectBootstrapRunner.RenderVisionTemplate(
+            visionTemplate,
+            repoFullName,
+            projectOwner,
+            projectNumber);
+
+        var existingWorkflow = await github.TryGetFileAsync(owner, repo, DefaultTriageWorkflowPath, defaultBranch)
+            .ConfigureAwait(false);
+        var existingVision = await github.TryGetFileAsync(owner, repo, DefaultVisionPath, defaultBranch)
+            .ConfigureAwait(false);
+
+        var plans = new List<FilePlan> {
+            PlanWrite(DefaultTriageProjectConfigPath, existingConfig?.Content, projectConfigContent, options.Force),
+            PlanWrite(DefaultTriageWorkflowPath, existingWorkflow?.Content, workflowContent, options.Force),
+            PlanWrite(DefaultVisionPath, existingVision?.Content, visionContent, options.Force)
+        };
+
+        return plans;
+    }
+
+    private static async Task<string> CreateTriageProjectConfigAsync(string repoFullName, string gitHubToken) {
+        await ProjectInitLock.WaitAsync().ConfigureAwait(false);
+        try {
+            var tempDirectory = Path.Combine(Path.GetTempPath(), "ix-setup-triage-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDirectory);
+            var tempConfigPath = Path.Combine(tempDirectory, "ix-project-config.json");
+
+            var previousGhToken = Environment.GetEnvironmentVariable("GH_TOKEN");
+            var previousGitHubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+            try {
+                Environment.SetEnvironmentVariable("GH_TOKEN", gitHubToken);
+                Environment.SetEnvironmentVariable("GITHUB_TOKEN", gitHubToken);
+
+                var exitCode = await ProjectInitRunner.RunAsync(new[] {
+                    "--repo", repoFullName,
+                    "--title", "IX Triage Control",
+                    "--out", tempConfigPath,
+                    "--link-repo"
+                }).ConfigureAwait(false);
+
+                if (exitCode != 0) {
+                    throw new InvalidOperationException(
+                        "--triage-bootstrap could not initialize GitHub Project schema automatically. " +
+                        "Ensure token scopes include `project` and `read:project`.");
+                }
+
+                if (!File.Exists(tempConfigPath)) {
+                    throw new InvalidOperationException("Project config was not produced by project-init.");
+                }
+
+                return File.ReadAllText(tempConfigPath);
+            } finally {
+                Environment.SetEnvironmentVariable("GH_TOKEN", previousGhToken);
+                Environment.SetEnvironmentVariable("GITHUB_TOKEN", previousGitHubToken);
+                TryDeleteDirectory(tempDirectory);
+            }
+        } finally {
+            ProjectInitLock.Release();
+        }
+    }
+}

--- a/IntelligenceX.Cli/Setup/SetupRunner.Types.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.Types.cs
@@ -65,6 +65,7 @@ internal static partial class SetupRunner {
         public bool CleanupPostEditComment { get; set; } = true;
         public string? BranchName { get; set; }
         public bool WithConfig { get; set; }
+        public bool TriageBootstrap { get; set; }
         public bool Upgrade { get; set; }
         public bool Cleanup { get; set; }
         public bool UpdateSecret { get; set; }
@@ -299,6 +300,9 @@ internal static partial class SetupRunner {
                         break;
                     case "with-config":
                         options.WithConfig = ParseBool(value, true);
+                        break;
+                    case "triage-bootstrap":
+                        options.TriageBootstrap = ParseBool(value, true);
                         break;
                     case "upgrade":
                         options.Upgrade = ParseBool(value, true);

--- a/IntelligenceX.Cli/Setup/SetupRunner.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.cs
@@ -37,6 +37,10 @@ internal static partial class SetupRunner {
                 Console.Error.WriteLine("Choose only one of --manual-secret or --update-secret.");
                 return 1;
             }
+            if (options.TriageBootstrap && (options.Cleanup || options.UpdateSecret)) {
+                Console.Error.WriteLine("--triage-bootstrap is only supported for setup operation.");
+                return 1;
+            }
             if (!string.IsNullOrWhiteSpace(options.ConfigJson) && !string.IsNullOrWhiteSpace(options.ConfigPath)) {
                 Console.Error.WriteLine("Choose only one of --config-json or --config-path.");
                 return 1;
@@ -131,9 +135,12 @@ internal static partial class SetupRunner {
             var exportPlans = await PlanAnalysisExportFilesAsync(
                 github, options, owner, repo, defaultBranch, configPlan, existingConfig?.Content ?? seedConfigContent)
                 .ConfigureAwait(false);
+            var triagePlans = options.TriageBootstrap
+                ? await PlanTriageBootstrapFilesAsync(github, options, owner, repo, defaultBranch, state.GitHub.Token).ConfigureAwait(false)
+                : new List<FilePlan>();
 
             if (options.DryRun) {
-                PrintDryRun(state, workflowPlan, configPlan, exportPlans);
+                PrintDryRun(state, workflowPlan, configPlan, exportPlans, triagePlans);
                 return 0;
             }
 
@@ -155,7 +162,8 @@ internal static partial class SetupRunner {
                 }
             }
 
-            var hasFileChanges = workflowPlan.IsWrite || configPlan.IsWrite || exportPlans.Any(plan => plan.IsWrite);
+            var hasFileChanges = workflowPlan.IsWrite || configPlan.IsWrite || exportPlans.Any(plan => plan.IsWrite) ||
+                                 triagePlans.Any(plan => plan.IsWrite);
             if (!hasFileChanges) {
                 Console.WriteLine("No files changed. Skipping PR creation.");
                 return 0;
@@ -181,6 +189,13 @@ internal static partial class SetupRunner {
                 changed |= await github.CreateOrUpdateFileAsync(owner, repo, exportPlan.Path, exportPlan.Content,
                     "Export analyzer configs for IDE support", branchName, overwrite: true).ConfigureAwait(false);
             }
+            foreach (var triagePlan in triagePlans) {
+                if (!triagePlan.IsWrite || triagePlan.Content is null) {
+                    continue;
+                }
+                changed |= await github.CreateOrUpdateFileAsync(owner, repo, triagePlan.Path, triagePlan.Content,
+                    DescribeTriageBootstrapCommitMessage(triagePlan.Path), branchName, overwrite: true).ConfigureAwait(false);
+            }
             if (legacyConfigLooksLikeReviewer && legacyConfig is not null && configPlan.IsWrite) {
                 // Migrate legacy reviewer config location to the correct file name.
                 changed |= await github.DeleteFileAsync(owner, repo, ".intelligencex/config.json",
@@ -193,9 +208,10 @@ internal static partial class SetupRunner {
             }
 
             var prTitle = "Add IntelligenceX review automation";
-            var prBody = options.WithConfig
-                ? BuildSetupPrBody(includeAnalysisExport: exportPlans.Any(plan => plan.IsWrite))
-                : "This adds the IntelligenceX review workflow.";
+            var prBody = BuildSetupPrBody(
+                includeConfig: options.WithConfig,
+                includeAnalysisExport: exportPlans.Any(plan => plan.IsWrite),
+                includeTriageBootstrap: triagePlans.Any(plan => plan.IsWrite));
             var prUrl = await github.CreatePullRequestAsync(owner, repo, prTitle, branchName, defaultBranch, prBody)
                 .ConfigureAwait(false);
 
@@ -594,7 +610,12 @@ internal static partial class SetupRunner {
         }
     }
 
-    private static void PrintDryRun(SetupState state, FilePlan workflowPlan, FilePlan configPlan, IReadOnlyList<FilePlan> exportPlans) {
+    private static void PrintDryRun(
+        SetupState state,
+        FilePlan workflowPlan,
+        FilePlan configPlan,
+        IReadOnlyList<FilePlan> exportPlans,
+        IReadOnlyList<FilePlan> triagePlans) {
         Console.WriteLine("Dry run summary:");
         Console.WriteLine($"- Repo: {state.GitHub.RepositoryFullName}");
         Console.WriteLine($"- Secret: INTELLIGENCEX_AUTH_B64 ({DescribeSecretAction(state.Options)})");
@@ -602,6 +623,9 @@ internal static partial class SetupRunner {
         Console.WriteLine($"- File: {configPlan.Path} ({DescribePlan(configPlan)})");
         foreach (var exportPlan in exportPlans) {
             Console.WriteLine($"- File: {exportPlan.Path} ({DescribePlan(exportPlan)})");
+        }
+        foreach (var triagePlan in triagePlans) {
+            Console.WriteLine($"- File: {triagePlan.Path} ({DescribePlan(triagePlan)})");
         }
         Console.WriteLine("- PR: would be created on a new branch for file changes");
         Console.WriteLine();
@@ -621,13 +645,45 @@ internal static partial class SetupRunner {
             Console.WriteLine($"--- {exportPlan.Path} ---");
             Console.WriteLine(exportPlan.Content);
         }
+        foreach (var triagePlan in triagePlans) {
+            if (triagePlan.Content is null) {
+                continue;
+            }
+            Console.WriteLine($"--- {triagePlan.Path} ---");
+            Console.WriteLine(triagePlan.Content);
+        }
     }
 
-    private static string BuildSetupPrBody(bool includeAnalysisExport) {
-        if (!includeAnalysisExport) {
-            return "This adds the IntelligenceX review workflow and config.";
+    private static string BuildSetupPrBody(bool includeConfig, bool includeAnalysisExport, bool includeTriageBootstrap) {
+        var baseText = includeConfig
+            ? "This adds the IntelligenceX review workflow and config"
+            : "This adds the IntelligenceX review workflow";
+
+        var extras = new List<string>();
+        if (includeAnalysisExport) {
+            extras.Add("exports analyzer configs for IDE support");
         }
-        return "This adds the IntelligenceX review workflow and config, and exports analyzer configs for IDE support.";
+        if (includeTriageBootstrap) {
+            extras.Add("bootstraps IX triage project automation (VISION.md + project sync workflow)");
+        }
+
+        if (extras.Count == 0) {
+            return baseText + ".";
+        }
+        if (extras.Count == 1) {
+            return baseText + ", and " + extras[0] + ".";
+        }
+
+        return baseText + ", " + extras[0] + ", and " + extras[1] + ".";
+    }
+
+    private static string DescribeTriageBootstrapCommitMessage(string path) {
+        return path.Replace('\\', '/').ToLowerInvariant() switch {
+            "artifacts/triage/ix-project-config.json" => "Bootstrap IX triage project configuration",
+            ".github/workflows/ix-triage-project-sync.yml" => "Add IX triage project sync workflow",
+            "vision.md" => "Add IX vision document scaffold",
+            _ => "Bootstrap IX triage project automation"
+        };
     }
 
     private static string DescribePlan(FilePlan plan) {

--- a/IntelligenceX.Cli/Setup/Web/WebApi.Models.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebApi.Models.cs
@@ -87,6 +87,7 @@ internal sealed partial class WebApi {
         public string? GitHubToken { get; set; }
         public string? GitHubClientId { get; set; }
         public bool WithConfig { get; set; }
+        public bool TriageBootstrap { get; set; }
         public string? AuthB64 { get; set; }
         public string? AuthB64Path { get; set; }
         public string? Provider { get; set; }

--- a/IntelligenceX.Cli/Setup/Web/WebApi.Setup.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebApi.Setup.cs
@@ -59,6 +59,15 @@ internal sealed partial class WebApi {
         return BuildSetupArgsForRepo(request, routeDryRun: false, "owner/repo");
     }
 
+    internal static string[] BuildSetupArgsForTriageBootstrapTests(bool triageBootstrap) {
+        var request = new SetupRequest {
+            Repo = "owner/repo",
+            GitHubToken = "token",
+            TriageBootstrap = triageBootstrap
+        };
+        return BuildSetupArgsForRepo(request, routeDryRun: false, "owner/repo");
+    }
+
     internal static bool ResolveWithConfigFromArgsForTests(params string[] args) {
         return ResolveWithConfigFromArgs(args);
     }

--- a/IntelligenceX.Cli/Setup/Web/WebApi.SetupRunner.cs
+++ b/IntelligenceX.Cli/Setup/Web/WebApi.SetupRunner.cs
@@ -20,6 +20,7 @@ internal sealed partial class WebApi {
             GitHubToken = request.GitHubToken,
             GitHubClientId = request.GitHubClientId,
             WithConfig = withConfig,
+            TriageBootstrap = request.TriageBootstrap,
             AuthB64 = request.AuthB64,
             AuthB64Path = request.AuthB64Path,
             ConfigJson = request.ConfigJson,

--- a/IntelligenceX.Cli/Todo/ProjectBootstrapRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectBootstrapRunner.cs
@@ -137,6 +137,14 @@ internal static class ProjectBootstrapRunner {
         return result;
     }
 
+    internal static string LoadWorkflowTemplate() {
+        return ReadEmbeddedResource(WorkflowTemplateResourceName);
+    }
+
+    internal static string LoadVisionTemplate() {
+        return ReadEmbeddedResource(VisionTemplateResourceName);
+    }
+
     private static string[] BuildProjectInitArgs(Options options) {
         var result = new List<string> {
             "--repo", options.Repo,
@@ -323,17 +331,35 @@ internal static class ProjectBootstrapRunner {
     }
 
     private static bool TryReadProjectTarget(string configPath, out string owner, out int projectNumber, out string error) {
-        owner = string.Empty;
-        projectNumber = 0;
-        error = string.Empty;
-
         if (!File.Exists(configPath)) {
+            owner = string.Empty;
+            projectNumber = 0;
             error = $"Project config file not found: {configPath}";
             return false;
         }
 
         try {
-            using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
+            return TryReadProjectTargetFromConfigJson(File.ReadAllText(configPath), out owner, out projectNumber, out error);
+        } catch (Exception ex) {
+            owner = string.Empty;
+            projectNumber = 0;
+            error = $"Failed to parse project config at {configPath}: {ex.Message}";
+            return false;
+        }
+    }
+
+    internal static bool TryReadProjectTargetFromConfigJson(string json, out string owner, out int projectNumber, out string error) {
+        owner = string.Empty;
+        projectNumber = 0;
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(json)) {
+            error = "Project config JSON is empty.";
+            return false;
+        }
+
+        try {
+            using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
 
             if (TryGetProperty(root, "owner", out var ownerProp) && ownerProp.ValueKind == JsonValueKind.String) {
@@ -348,9 +374,14 @@ internal static class ProjectBootstrapRunner {
                 projectNumber = numberValue;
             }
 
+            if (string.IsNullOrWhiteSpace(owner) || projectNumber <= 0) {
+                error = "Project config JSON is missing owner/project number.";
+                return false;
+            }
+
             return true;
         } catch (Exception ex) {
-            error = $"Failed to parse project config at {configPath}: {ex.Message}";
+            error = $"Failed to parse project config JSON: {ex.Message}";
             return false;
         }
     }

--- a/IntelligenceX.Tests/Program.Setup.Web.cs
+++ b/IntelligenceX.Tests/Program.Setup.Web.cs
@@ -189,6 +189,16 @@ internal static partial class Program {
             "web setup args analysis run strict omitted for config override");
     }
 
+    private static void TestWebSetupBuildSetupArgsPropagatesTriageBootstrap() {
+        var enabled = IntelligenceX.Cli.Setup.Web.WebApi.BuildSetupArgsForTriageBootstrapTests(triageBootstrap: true);
+        AssertEqual(true, Array.IndexOf(enabled, "--triage-bootstrap") >= 0,
+            "web setup args triage bootstrap enabled");
+
+        var disabled = IntelligenceX.Cli.Setup.Web.WebApi.BuildSetupArgsForTriageBootstrapTests(triageBootstrap: false);
+        AssertEqual(false, Array.IndexOf(disabled, "--triage-bootstrap") >= 0,
+            "web setup args triage bootstrap disabled");
+    }
+
     private static void TestWebSetupResolveWithConfigFromArgs() {
         AssertEqual(true, IntelligenceX.Cli.Setup.Web.WebApi.ResolveWithConfigFromArgsForTests(
             "--repo", "owner/repo", "--with-config"), "web setup resolve with-config flag");

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -25,6 +25,17 @@ internal static partial class Program {
         }, args, "setup args analysis");
     }
 
+    private static void TestSetupArgsIncludeTriageBootstrap() {
+        var plan = new SetupPlan("owner/repo") {
+            TriageBootstrap = true
+        };
+        var args = SetupArgsBuilder.FromPlan(plan);
+        AssertSequenceEqual(new[] {
+            "--repo", "owner/repo",
+            "--triage-bootstrap"
+        }, args, "setup args triage bootstrap");
+    }
+
     private static void TestSetupArgsIncludeAnalysisRunStrictOption() {
         var plan = new SetupPlan("owner/repo") {
             AnalysisEnabled = true,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -79,6 +79,7 @@ internal static partial class Program {
         failed += Run("Setup args include analysis run strict option", TestSetupArgsIncludeAnalysisRunStrictOption);
         failed += Run("Setup args include analysis export path", TestSetupArgsIncludeAnalysisExportPath);
         failed += Run("Setup args disable analysis omits gate and packs", TestSetupArgsDisableAnalysisOmitsGateAndPacks);
+        failed += Run("Setup args include triage bootstrap", TestSetupArgsIncludeTriageBootstrap);
         failed += Run("Setup args include OpenAI account routing", TestSetupArgsIncludeOpenAiAccountRouting);
         failed += Run("Setup args include OpenAI account routing with primary only",
             TestSetupArgsIncludeOpenAiAccountRoutingWithPrimaryOnly);
@@ -184,6 +185,7 @@ internal static partial class Program {
         failed += Run("Web setup args propagate OpenAI account routing with primary only",
             TestWebSetupBuildSetupArgsPropagatesOpenAiAccountRoutingWithPrimaryOnly);
         failed += Run("Web setup args propagate analysis run strict", TestWebSetupBuildSetupArgsPropagatesAnalysisRunStrict);
+        failed += Run("Web setup args propagate triage bootstrap", TestWebSetupBuildSetupArgsPropagatesTriageBootstrap);
         failed += Run("Web setup resolves with-config from args", TestWebSetupResolveWithConfigFromArgs);
         failed += Run("Web setup OpenAI routing validation rejects config override",
             TestWebSetupOpenAiRoutingValidationRejectsConfigOverride);


### PR DESCRIPTION
## Summary
- add `--triage-bootstrap` setup option (CLI + web setup API path)
- bootstrap triage artifacts during setup PR creation: project schema config, workflow, and `VISION.md`
- reuse existing triage config when present; otherwise auto-init via `ProjectInitRunner`
- include triage bootstrap files in setup dry-run/apply planning and generated PR text
- add tests covering CLI args and web setup propagation for the new option

## Validation
- `dotnet test IntelligenceX.sln -c Release --no-build`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`