### PR TITLE
Chat: add runtime traces for pending-action and tool-nudge decisions

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
@@ -20,30 +20,65 @@ internal sealed partial class ChatServiceSession {
 
     private static bool ShouldAttemptToolExecutionNudge(string userRequest, string assistantDraft, bool toolsAvailable, int priorToolCalls,
         int assistantDraftToolCalls, bool usedContinuationSubset) {
+        return EvaluateToolExecutionNudgeDecision(
+            userRequest,
+            assistantDraft,
+            toolsAvailable,
+            priorToolCalls,
+            assistantDraftToolCalls,
+            usedContinuationSubset,
+            out _);
+    }
+
+    private static bool EvaluateToolExecutionNudgeDecision(
+        string userRequest,
+        string assistantDraft,
+        bool toolsAvailable,
+        int priorToolCalls,
+        int assistantDraftToolCalls,
+        bool usedContinuationSubset,
+        out string reason) {
+        reason = "not_eligible";
+
         // Keep the eligibility checks inside this method (not only at the call site) so future callers can't
         // accidentally force a retry when tools can't run or when tool execution is already happening.
-        if (!toolsAvailable || priorToolCalls > 0 || assistantDraftToolCalls > 0) {
+        if (!toolsAvailable) {
+            reason = "tools_unavailable";
+            return false;
+        }
+
+        if (priorToolCalls > 0) {
+            reason = "prior_tool_calls_present";
+            return false;
+        }
+
+        if (assistantDraftToolCalls > 0) {
+            reason = "assistant_draft_has_tool_calls";
             return false;
         }
 
         var request = (userRequest ?? string.Empty).Trim();
         if (request.Length == 0) {
+            reason = "empty_user_request";
             return false;
         }
 
         var draft = (assistantDraft ?? string.Empty).Trim();
         if (draft.Length == 0 || draft.Length > 2400) {
+            reason = draft.Length == 0 ? "empty_assistant_draft" : "assistant_draft_too_long";
             return false;
         }
 
         // Guard against accidental feedback loops where the assistant echoes the correction prompt itself.
         if (draft.Contains(ExecutionCorrectionMarker, StringComparison.OrdinalIgnoreCase)) {
+            reason = "already_contains_execution_correction_marker";
             return false;
         }
 
         // If the user selected an explicit pending action (/act or ordinal selection), we should strongly prefer
         // tool execution over a "talky" draft. This is language-agnostic and works after app restarts.
         if (LooksLikeActionSelectionPayload(request)) {
+            reason = "explicit_action_selection_payload";
             return true;
         }
 
@@ -51,16 +86,24 @@ internal sealed partial class ChatServiceSession {
         // weighted continuation routing wasn't used (for example after a restart or when tool routing kept full tool lists).
         var echoedCallToAction = UserMatchesAssistantCallToAction(request, draft);
         if (!usedContinuationSubset && !echoedCallToAction) {
+            reason = "no_continuation_subset_and_no_cta_echo";
             return false;
         }
 
         if (!echoedCallToAction && !LooksLikeCompactFollowUp(request)) {
+            reason = "request_not_compact_follow_up";
             return false;
         }
 
         var asksAnotherQuestion = draft.Contains('?', StringComparison.Ordinal);
         if (asksAnotherQuestion) {
-            return echoedCallToAction || AssistantDraftReferencesUserRequest(request, draft);
+            if (echoedCallToAction || AssistantDraftReferencesUserRequest(request, draft)) {
+                reason = "assistant_question_linked_to_follow_up";
+                return true;
+            }
+
+            reason = "assistant_question_not_linked";
+            return false;
         }
 
         // Language-agnostic "acknowledgement-like" draft: short, no structured output, no numeric evidence.
@@ -73,7 +116,13 @@ internal sealed partial class ChatServiceSession {
             // Multi-line drafts are usually results/explanations; avoid retrying tools based on incidental quoted text
             // inside structured output (for example JSON like `"run now",`). Only allow the nudge when the CTA quote
             // is formatted as an explicit option/bullet on its own line.
-            return echoedCallToAction && UserMatchesAssistantCallToAction(request, draft, onlyBulletContext: true);
+            if (echoedCallToAction && UserMatchesAssistantCallToAction(request, draft, onlyBulletContext: true)) {
+                reason = "structured_draft_with_explicit_bullet_cta";
+                return true;
+            }
+
+            reason = "structured_draft_not_eligible";
+            return false;
         }
 
         var hasNumericSignal = false;
@@ -85,12 +134,19 @@ internal sealed partial class ChatServiceSession {
         }
 
         if (hasNumericSignal || draft.Length > 220) {
+            reason = hasNumericSignal ? "assistant_draft_has_numeric_signal" : "assistant_draft_too_long_for_nudge";
             return false;
         }
 
         // Avoid overriding already-good short completions (for example "You're welcome.").
         // Only retry tool execution when the assistant draft still appears tied to the user's follow-up.
-        return echoedCallToAction || AssistantDraftReferencesUserRequest(request, draft);
+        if (echoedCallToAction || AssistantDraftReferencesUserRequest(request, draft)) {
+            reason = echoedCallToAction ? "cta_echo_linked_to_follow_up" : "assistant_draft_references_follow_up";
+            return true;
+        }
+
+        reason = "assistant_draft_not_linked_to_follow_up";
+        return false;
     }
 
     private static bool LooksLikeActionSelectionPayload(string text) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -138,14 +138,31 @@ internal sealed partial class ChatServiceSession {
             var extracted = ToolCallParser.Extract(turn);
             if (extracted.Count == 0) {
                 var text = EasyChatResult.FromTurn(turn).Text ?? string.Empty;
-                if (!executionNudgeUsed
-                    && ShouldAttemptToolExecutionNudge(
+                var shouldAttemptExecutionNudge = false;
+                var executionNudgeReason = executionNudgeUsed
+                    ? "execution_nudge_already_used"
+                    : "execution_nudge_not_evaluated";
+                if (!executionNudgeUsed) {
+                    shouldAttemptExecutionNudge = EvaluateToolExecutionNudgeDecision(
                         userRequest: routedUserRequest,
                         assistantDraft: text,
                         toolsAvailable: toolDefs.Count > 0,
                         priorToolCalls: toolCalls.Count,
                         assistantDraftToolCalls: extracted.Count,
-                        usedContinuationSubset: usedContinuationSubset)) {
+                        usedContinuationSubset: usedContinuationSubset,
+                        out executionNudgeReason);
+                }
+
+                if (shouldAttemptExecutionNudge) {
+                    TraceToolExecutionNudgeDecision(
+                        userRequest: routedUserRequest,
+                        usedContinuationSubset: usedContinuationSubset,
+                        toolsAvailable: toolDefs.Count > 0,
+                        priorToolCalls: toolCalls.Count,
+                        assistantDraftToolCalls: extracted.Count,
+                        executionNudgeAlreadyUsed: executionNudgeUsed,
+                        shouldAttemptNudge: shouldAttemptExecutionNudge,
+                        reason: executionNudgeReason);
                     executionNudgeUsed = true;
                     var nudgePrompt = BuildToolExecutionNudgePrompt(routedUserRequest, text);
                     await TryWriteStatusAsync(
@@ -163,6 +180,16 @@ internal sealed partial class ChatServiceSession {
                         .ConfigureAwait(false);
                     continue;
                 }
+
+                TraceToolExecutionNudgeDecision(
+                    userRequest: routedUserRequest,
+                    usedContinuationSubset: usedContinuationSubset,
+                    toolsAvailable: toolDefs.Count > 0,
+                    priorToolCalls: toolCalls.Count,
+                    assistantDraftToolCalls: extracted.Count,
+                    executionNudgeAlreadyUsed: executionNudgeUsed,
+                    shouldAttemptNudge: false,
+                    reason: executionNudgeReason);
 
                 if (!toolReceiptCorrectionUsed
                     && ShouldAttemptToolReceiptCorrection(
@@ -260,6 +287,32 @@ internal sealed partial class ChatServiceSession {
         }
 
         throw new InvalidOperationException($"Tool runner exceeded max rounds ({maxRounds}).");
+    }
+
+    private static void TraceToolExecutionNudgeDecision(
+        string userRequest,
+        bool usedContinuationSubset,
+        bool toolsAvailable,
+        int priorToolCalls,
+        int assistantDraftToolCalls,
+        bool executionNudgeAlreadyUsed,
+        bool shouldAttemptNudge,
+        string reason) {
+        var normalized = (userRequest ?? string.Empty).Trim();
+        var isFollowUp = LooksLikeContinuationFollowUp(normalized);
+        var isActionPayload = LooksLikeActionSelectionPayload(normalized);
+        if (!isFollowUp && !isActionPayload) {
+            return;
+        }
+
+        var tokenCount = CountLetterDigitTokens(normalized, maxTokens: 16);
+        var kind = isActionPayload ? "action_payload" : "follow_up";
+        var routing = usedContinuationSubset ? "subset" : "full";
+        var outcome = shouldAttemptNudge ? "retry" : "skip";
+        var nudgeState = executionNudgeAlreadyUsed ? "used" : "unused";
+
+        Console.Error.WriteLine(
+            $"[tool-nudge] outcome={outcome} reason={reason} kind={kind} routing={routing} nudge={nudgeState} tools={toolsAvailable} prior_calls={Math.Max(0, priorToolCalls)} draft_calls={Math.Max(0, assistantDraftToolCalls)} tokens={tokenCount}");
     }
 
     private static IReadOnlyList<ToolErrorMetricDto> BuildToolErrorMetrics(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
@@ -125,6 +125,7 @@ internal sealed partial class ChatServiceSession {
         PendingAction[]? actions;
         long ticks;
         string[]? callToActionTokens;
+        var usedSnapshot = false;
         lock (_toolRoutingContextLock) {
             _pendingActionsByThreadId.TryGetValue(normalizedThreadId, out actions);
             ticks = _pendingActionsSeenUtcTicks.TryGetValue(normalizedThreadId, out var seen) ? seen : 0;
@@ -133,9 +134,17 @@ internal sealed partial class ChatServiceSession {
 
         if (actions is null || actions.Length == 0) {
             if (!TryLoadPendingActionsSnapshot(normalizedThreadId, out var persistedTicks, out var persistedActions, out var persistedCallToActionTokens)) {
+                TracePendingActionDecision(
+                    userText: normalized,
+                    isExplicitAct: isExplicitAct,
+                    actionsCount: 0,
+                    usedSnapshot: false,
+                    outcome: "skip",
+                    reason: "no_pending_action_context");
                 return false;
             }
 
+            usedSnapshot = true;
             actions = persistedActions;
             ticks = persistedTicks;
             callToActionTokens = persistedCallToActionTokens;
@@ -161,6 +170,13 @@ internal sealed partial class ChatServiceSession {
                     TrimWeightedRoutingContextsNoLock();
                 }
                 RemovePendingActionsSnapshot(normalizedThreadId);
+                TracePendingActionDecision(
+                    userText: normalized,
+                    isExplicitAct: isExplicitAct,
+                    actionsCount: actions?.Length ?? 0,
+                    usedSnapshot: usedSnapshot,
+                    outcome: "skip",
+                    reason: "pending_action_ticks_invalid");
                 return false;
             }
 
@@ -173,6 +189,13 @@ internal sealed partial class ChatServiceSession {
                     TrimWeightedRoutingContextsNoLock();
                 }
                 RemovePendingActionsSnapshot(normalizedThreadId);
+                TracePendingActionDecision(
+                    userText: normalized,
+                    isExplicitAct: isExplicitAct,
+                    actionsCount: actions?.Length ?? 0,
+                    usedSnapshot: usedSnapshot,
+                    outcome: "skip",
+                    reason: "pending_action_context_in_future");
                 return false;
             }
 
@@ -185,14 +208,33 @@ internal sealed partial class ChatServiceSession {
                     TrimWeightedRoutingContextsNoLock();
                 }
                 RemovePendingActionsSnapshot(normalizedThreadId);
+                TracePendingActionDecision(
+                    userText: normalized,
+                    isExplicitAct: isExplicitAct,
+                    actionsCount: actions?.Length ?? 0,
+                    usedSnapshot: usedSnapshot,
+                    outcome: "skip",
+                    reason: "pending_action_context_expired");
                 return false;
             }
         }
 
-        var selected = TryMatchPendingAction(normalized, actions, callToActionTokens ?? Array.Empty<string>(), out var match)
+        var selected = TryMatchPendingActionWithReason(
+                normalized,
+                actions,
+                callToActionTokens ?? Array.Empty<string>(),
+                out var match,
+                out var matchReason)
             ? match
             : (PendingAction?)null;
         if (selected is null) {
+            TracePendingActionDecision(
+                userText: normalized,
+                isExplicitAct: isExplicitAct,
+                actionsCount: actions?.Length ?? 0,
+                usedSnapshot: usedSnapshot,
+                outcome: "skip",
+                reason: matchReason);
             return false;
         }
 
@@ -207,6 +249,14 @@ internal sealed partial class ChatServiceSession {
 
         var request = string.IsNullOrWhiteSpace(selected.Value.Request) ? selected.Value.Title : selected.Value.Request;
         if (string.IsNullOrWhiteSpace(request)) {
+            TracePendingActionDecision(
+                userText: normalized,
+                isExplicitAct: isExplicitAct,
+                actionsCount: actions?.Length ?? 0,
+                usedSnapshot: usedSnapshot,
+                outcome: "skip",
+                reason: "matched_action_missing_request",
+                selectedActionId: selected.Value.Id);
             return false;
         }
 
@@ -218,18 +268,37 @@ internal sealed partial class ChatServiceSession {
                 request = CollapseWhitespace(request).Trim()
             }
         });
+        TracePendingActionDecision(
+            userText: normalized,
+            isExplicitAct: isExplicitAct,
+            actionsCount: actions?.Length ?? 0,
+            usedSnapshot: usedSnapshot,
+            outcome: "match",
+            reason: matchReason,
+            selectedActionId: selected.Value.Id);
         return true;
     }
 
     private static bool TryMatchPendingAction(string userText, IReadOnlyList<PendingAction> actions, IReadOnlyList<string> callToActionTokens, out PendingAction match) {
+        return TryMatchPendingActionWithReason(userText, actions, callToActionTokens, out match, out _);
+    }
+
+    private static bool TryMatchPendingActionWithReason(string userText, IReadOnlyList<PendingAction> actions, IReadOnlyList<string> callToActionTokens, out PendingAction match, out string reason) {
         match = default;
+        reason = "no_match";
 
         // Be careful with normalization: explicit selections like `/act <id>` should treat `<id>` as an opaque token.
         // Applying FormKC to the whole input can change codepoints and prevent matching an otherwise valid ID copied
         // from the assistant output.
         var trimmed = (userText ?? string.Empty).Trim();
 
-        if (trimmed.Length == 0 || actions.Count == 0) {
+        if (trimmed.Length == 0) {
+            reason = "empty_follow_up";
+            return false;
+        }
+
+        if (actions.Count == 0) {
+            reason = "no_actions_available";
             return false;
         }
 
@@ -237,29 +306,35 @@ internal sealed partial class ChatServiceSession {
         if (trimmed.StartsWith("/act", StringComparison.OrdinalIgnoreCase)) {
             // Require `/act` as a standalone token; avoid accidentally treating `/actuator` etc. as an action selection.
             if (trimmed.Length > 4 && !char.IsWhiteSpace(trimmed[4])) {
+                reason = "invalid_act_command_token";
                 return false;
             }
 
             var rest = trimmed[4..].Trim();
             if (rest.Length == 0) {
+                reason = "act_id_missing";
                 return false;
             }
             var id = ReadFirstToken(rest);
             if (id.Length == 0) {
+                reason = "act_id_missing";
                 return false;
             }
             var trailing = rest[id.Length..].Trim();
             if (trailing.Length != 0) {
+                reason = "act_command_has_trailing_tokens";
                 return false;
             }
 
             for (var i = 0; i < actions.Count; i++) {
                 if (string.Equals(actions[i].Id, id, StringComparison.OrdinalIgnoreCase)) {
                     match = actions[i];
+                    reason = "explicit_act_id";
                     return true;
                 }
             }
 
+            reason = "act_id_not_found";
             return false;
         }
 
@@ -274,12 +349,14 @@ internal sealed partial class ChatServiceSession {
         // "1" / "2" selects by ordinal.
         if (TryParseOrdinalSelection(normalized, out var idx) && idx > 0 && idx <= actions.Count) {
             match = actions[idx - 1];
+            reason = "ordinal_selection";
             return true;
         }
 
         if (trimmed.IndexOfAny(PendingActionConfirmationQuestionPunctuation) >= 0
             || trimmed.IndexOfAny(PendingActionConfirmationDisqualifierPunctuation) >= 0
             || LooksLikeStructuredPendingActionConfirmationInput(trimmed)) {
+            reason = "follow_up_disqualified_shape";
             return false;
         }
 
@@ -291,25 +368,35 @@ internal sealed partial class ChatServiceSession {
             && callToActionTokens is { Count: > 0 }
             && UserMatchesPendingActionCallToActionTokens(trimmed, callToActionTokens)) {
             match = actions[0];
+            reason = "cta_echo_selection";
             return true;
         }
 
-        if (TryMatchPendingActionByIntentOverlap(trimmed, actions, out var overlapMatch)) {
+        if (TryMatchPendingActionByIntentOverlapWithReason(trimmed, actions, out var overlapMatch, out var overlapReason)) {
             match = overlapMatch;
+            reason = overlapReason;
             return true;
         }
 
+        reason = overlapReason;
         return false;
     }
 
     private static bool TryMatchPendingActionByIntentOverlap(string userText, IReadOnlyList<PendingAction> actions, out PendingAction match) {
+        return TryMatchPendingActionByIntentOverlapWithReason(userText, actions, out match, out _);
+    }
+
+    private static bool TryMatchPendingActionByIntentOverlapWithReason(string userText, IReadOnlyList<PendingAction> actions, out PendingAction match, out string reason) {
         match = default;
+        reason = "intent_overlap_no_match";
         if (actions is null || actions.Count == 0) {
+            reason = "intent_overlap_no_actions";
             return false;
         }
 
         var userTokens = ExtractPendingActionIntentTokens(userText, maxTokens: 12);
         if (userTokens.Count == 0) {
+            reason = "intent_overlap_no_user_tokens";
             return false;
         }
 
@@ -369,15 +456,18 @@ internal sealed partial class ChatServiceSession {
         }
 
         if (bestIndex < 0 || tieOnBest) {
+            reason = tieOnBest ? "intent_overlap_ambiguous" : "intent_overlap_no_hits";
             return false;
         }
 
         if (actions.Count > 1) {
             if (bestHits < 2) {
+                reason = "intent_overlap_multi_too_weak";
                 return false;
             }
 
             match = actions[bestIndex];
+            reason = "intent_overlap_multi";
             return true;
         }
 
@@ -386,11 +476,31 @@ internal sealed partial class ChatServiceSession {
                 hitCount: bestHits,
                 lastHitIndex: bestLastHitIndex,
                 longestMatchedTokenLength: bestLongestMatchedTokenLength)) {
+            reason = "intent_overlap_single_too_weak";
             return false;
         }
 
         match = actions[bestIndex];
+        reason = "intent_overlap_single";
         return true;
+    }
+
+    private static void TracePendingActionDecision(
+        string userText,
+        bool isExplicitAct,
+        int actionsCount,
+        bool usedSnapshot,
+        string outcome,
+        string reason,
+        string? selectedActionId = null) {
+        var normalized = (userText ?? string.Empty).Trim();
+        var tokenCount = CountLetterDigitTokens(normalized, maxTokens: 16);
+        var selected = string.IsNullOrWhiteSpace(selectedActionId) ? "-" : selectedActionId.Trim();
+        var source = actionsCount <= 0 ? "none" : (usedSnapshot ? "snapshot" : "memory");
+        var kind = isExplicitAct ? "explicit_act" : "follow_up";
+
+        Console.Error.WriteLine(
+            $"[pending-action] outcome={outcome} reason={reason} kind={kind} source={source} actions={Math.Max(0, actionsCount)} tokens={tokenCount} selected={selected}");
     }
 
     private static bool SingleActionIntentOverlapIsStrongEnough(int userTokenCount, int hitCount, int lastHitIndex, int longestMatchedTokenLength) {


### PR DESCRIPTION
## What this adds
- Adds lightweight runtime tracing for pending-action selection outcomes.
- Adds reasoned tracing for execution-nudge decisions when assistant produced no tool calls.

## Why
This makes "agent said it would do it, then stopped" diagnosable from production startup/service logs without guesswork.

## New trace lines
- `[pending-action] ...`
  - includes: outcome, reason, kind (explicit_act/follow_up), context source (memory/snapshot/none), action count, token count, selected id.
- `[tool-nudge] ...`
  - includes: outcome (retry/skip), reason, kind (follow_up/action_payload), routing mode, nudge state, tool-call counts, token count.

## Notes
- No hardcoded confirmation phrase lists were introduced.
- Existing behavior remains intact; this change adds observability around decision points.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRoutingTrimTests"`