### PR TITLE
feat(todo): improve triage labeling reliability

### DIFF
--- a/IntelligenceX.Cli/Templates/triage-project-sync.yml
+++ b/IntelligenceX.Cli/Templates/triage-project-sync.yml
@@ -81,7 +81,8 @@ jobs:
             --project "$PROJECT_NUMBER" \
             --triage artifacts/triage/ix-triage-index.json \
             --vision artifacts/triage/ix-vision-check.json \
-            --max-items "$MAX_ITEMS"
+            --max-items "$MAX_ITEMS" \
+            --apply-labels
 
       - name: Upload triage artifacts
         uses: actions/upload-artifact@v4

--- a/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace IntelligenceX.Cli.Todo;
@@ -9,6 +10,19 @@ internal sealed record ProjectLabelDefinition(
 );
 
 internal static class ProjectLabelCatalog {
+    private static readonly IReadOnlyDictionary<string, string> TagToLabel = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+        ["security"] = "ix/tag:security",
+        ["bugfix"] = "ix/tag:bugfix",
+        ["performance"] = "ix/tag:performance",
+        ["docs"] = "ix/tag:docs",
+        ["testing"] = "ix/tag:testing",
+        ["ci"] = "ix/tag:ci",
+        ["maintenance"] = "ix/tag:maintenance",
+        ["api"] = "ix/tag:api",
+        ["ux"] = "ix/tag:ux",
+        ["dependencies"] = "ix/tag:dependencies"
+    };
+
     public static readonly IReadOnlyList<ProjectLabelDefinition> DefaultLabels = new[] {
         new ProjectLabelDefinition("ix/vision:aligned", "0e8a16", "Vision fit is aligned."),
         new ProjectLabelDefinition("ix/vision:needs-review", "fbca04", "Vision fit needs human maintainer review."),
@@ -23,7 +37,28 @@ internal static class ProjectLabelCatalog {
         new ProjectLabelDefinition("ix/category:testing", "0e8a16", "Likely testing work."),
         new ProjectLabelDefinition("ix/category:ci", "c5def5", "Likely CI/workflow automation work."),
 
+        new ProjectLabelDefinition("ix/tag:security", "b60205", "Triage tag: security"),
+        new ProjectLabelDefinition("ix/tag:bugfix", "d73a4a", "Triage tag: bugfix"),
+        new ProjectLabelDefinition("ix/tag:performance", "0052cc", "Triage tag: performance"),
+        new ProjectLabelDefinition("ix/tag:docs", "5319e7", "Triage tag: docs"),
+        new ProjectLabelDefinition("ix/tag:testing", "0e8a16", "Triage tag: testing"),
+        new ProjectLabelDefinition("ix/tag:ci", "c5def5", "Triage tag: ci"),
+        new ProjectLabelDefinition("ix/tag:maintenance", "6f42c1", "Triage tag: maintenance"),
+        new ProjectLabelDefinition("ix/tag:api", "1d76db", "Triage tag: api"),
+        new ProjectLabelDefinition("ix/tag:ux", "fbca04", "Triage tag: ux"),
+        new ProjectLabelDefinition("ix/tag:dependencies", "6f42c1", "Triage tag: dependencies"),
+
         new ProjectLabelDefinition("ix/match:linked-issue", "0366d6", "PR has a high-confidence related issue."),
+        new ProjectLabelDefinition("ix/match:needs-review", "fbca04", "PR has a low-confidence issue match that needs maintainer review."),
         new ProjectLabelDefinition("ix/duplicate:clustered", "f9d0c4", "Item is part of a duplicate cluster.")
     };
+
+    public static bool TryMapTagLabel(string tag, out string label) {
+        if (string.IsNullOrWhiteSpace(tag)) {
+            label = string.Empty;
+            return false;
+        }
+
+        return TagToLabel.TryGetValue(tag.Trim(), out label!);
+    }
 }

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -10,6 +10,8 @@ using IntelligenceX.Cli.GitHub;
 namespace IntelligenceX.Cli.Todo;
 
 internal static class ProjectSyncRunner {
+    private const double HighConfidenceIssueMatchLabelThreshold = 0.80;
+
     internal sealed record ProjectSyncEntry(
         int Number,
         string Url,
@@ -567,11 +569,17 @@ internal static class ProjectSyncRunner {
         return updated;
     }
 
-    private static IReadOnlyList<string> BuildLabelsForEntry(ProjectSyncEntry entry) {
+    internal static IReadOnlyList<string> BuildLabelsForEntry(ProjectSyncEntry entry) {
         var labels = new List<string>();
 
         if (!string.IsNullOrWhiteSpace(entry.Category)) {
             labels.Add($"ix/category:{entry.Category}");
+        }
+
+        foreach (var tag in entry.Tags) {
+            if (ProjectLabelCatalog.TryMapTagLabel(tag, out var tagLabel)) {
+                labels.Add(tagLabel);
+            }
         }
 
         var visionLabel = MapVisionLabel(entry.VisionFit);
@@ -580,7 +588,12 @@ internal static class ProjectSyncRunner {
         }
 
         if (!string.IsNullOrWhiteSpace(entry.MatchedIssueUrl) && entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
-            labels.Add("ix/match:linked-issue");
+            if (entry.MatchedIssueConfidence.HasValue &&
+                entry.MatchedIssueConfidence.Value >= HighConfidenceIssueMatchLabelThreshold) {
+                labels.Add("ix/match:linked-issue");
+            } else {
+                labels.Add("ix/match:needs-review");
+            }
         }
 
         if (!string.IsNullOrWhiteSpace(entry.DuplicateCluster)) {

--- a/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
@@ -55,5 +55,17 @@ project={{ProjectNumber}}
         AssertEqual(false, rendered.Contains("{{Owner}}", StringComparison.Ordinal), "owner placeholder removed");
         AssertEqual(false, rendered.Contains("{{ProjectNumber}}", StringComparison.Ordinal), "project placeholder removed");
     }
+
+    private static void TestProjectBootstrapWorkflowTemplateEnablesApplyLabels() {
+        var template = IntelligenceX.Cli.Todo.ProjectBootstrapRunner.LoadWorkflowTemplate();
+        var rendered = IntelligenceX.Cli.Todo.ProjectBootstrapRunner.RenderWorkflowTemplate(
+            template,
+            "EvotecIT",
+            654,
+            300);
+
+        AssertContainsText(rendered, "todo project-sync", "workflow contains project sync step");
+        AssertContainsText(rendered, "--apply-labels", "workflow enables label application");
+    }
 #endif
 }

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -85,5 +85,52 @@ internal static partial class Program {
         AssertEqual("cluster-1", issue.DuplicateCluster, "duplicate cluster preserved");
         AssertEqual("https://github.com/EvotecIT/IntelligenceX/pull/10", issue.CanonicalItem, "issue canonical resolved");
     }
+
+    private static void TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch() {
+        var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+            Number: 42,
+            Url: "https://github.com/EvotecIT/IntelligenceX/pull/42",
+            Kind: "pull_request",
+            TriageScore: 88.5,
+            DuplicateCluster: "cluster-9",
+            CanonicalItem: "https://github.com/EvotecIT/IntelligenceX/pull/42",
+            Category: "security",
+            Tags: new[] { "security", "api", "unknown-tag" },
+            MatchedIssueUrl: "https://github.com/EvotecIT/IntelligenceX/issues/10",
+            MatchedIssueConfidence: 0.95,
+            VisionFit: "aligned",
+            VisionConfidence: 0.9
+        );
+
+        var labels = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildLabelsForEntry(entry);
+        AssertEqual(true, labels.Contains("ix/category:security", StringComparer.OrdinalIgnoreCase), "category label");
+        AssertEqual(true, labels.Contains("ix/tag:security", StringComparer.OrdinalIgnoreCase), "security tag label");
+        AssertEqual(true, labels.Contains("ix/tag:api", StringComparer.OrdinalIgnoreCase), "api tag label");
+        AssertEqual(false, labels.Any(label => label.Contains("unknown-tag", StringComparison.OrdinalIgnoreCase)), "unsupported tag skipped");
+        AssertEqual(true, labels.Contains("ix/match:linked-issue", StringComparer.OrdinalIgnoreCase), "high confidence match label");
+        AssertEqual(false, labels.Contains("ix/match:needs-review", StringComparer.OrdinalIgnoreCase), "no review label for high confidence");
+        AssertEqual(true, labels.Contains("ix/duplicate:clustered", StringComparer.OrdinalIgnoreCase), "duplicate label");
+    }
+
+    private static void TestProjectSyncBuildLabelsUsesNeedsReviewForLowConfidenceIssueMatch() {
+        var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+            Number: 77,
+            Url: "https://github.com/EvotecIT/IntelligenceX/pull/77",
+            Kind: "pull_request",
+            TriageScore: 60.0,
+            DuplicateCluster: null,
+            CanonicalItem: null,
+            Category: "feature",
+            Tags: Array.Empty<string>(),
+            MatchedIssueUrl: "https://github.com/EvotecIT/IntelligenceX/issues/99",
+            MatchedIssueConfidence: 0.62,
+            VisionFit: null,
+            VisionConfidence: null
+        );
+
+        var labels = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildLabelsForEntry(entry);
+        AssertEqual(true, labels.Contains("ix/match:needs-review", StringComparer.OrdinalIgnoreCase), "low confidence match review label");
+        AssertEqual(false, labels.Contains("ix/match:linked-issue", StringComparer.OrdinalIgnoreCase), "low confidence should not be linked-issue");
+    }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -450,9 +450,12 @@ internal static partial class Program {
         failed += Run("Todo vision check explicit policy prefix parsing", TestVisionCheckParseSignalsSupportsExplicitPolicyPrefixes);
         failed += Run("Todo project fields defaults", TestProjectFieldCatalogDefaultsIncludeVisionAndDecisionFields);
         failed += Run("Todo project sync merges vision and canonical", TestProjectSyncBuildEntriesMergesVisionAndCanonical);
+        failed += Run("Todo project sync labels include tags and high-confidence match", TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch);
+        failed += Run("Todo project sync labels mark low-confidence match for review", TestProjectSyncBuildLabelsUsesNeedsReviewForLowConfidenceIssueMatch);
         failed += Run("Todo project bootstrap renders project target", TestProjectBootstrapRenderWorkflowTemplateInjectsProjectTarget);
         failed += Run("Todo project bootstrap clamps max items", TestProjectBootstrapRenderWorkflowTemplateClampsMaxItems);
         failed += Run("Todo project bootstrap renders vision template", TestProjectBootstrapRenderVisionTemplateInjectsContext);
+        failed += Run("Todo project bootstrap workflow enables label apply", TestProjectBootstrapWorkflowTemplateEnablesApplyLabels);
         failed += Run("Analyze run PowerShell script captures engine errors", TestAnalyzeRunPowerShellScriptCapturesEngineErrors);
         failed += Run("Analyze run PowerShell strict args include fail switch", TestAnalyzeRunPowerShellStrictArgsIncludeFailSwitch);
         failed += Run("Analyze run disabled writes empty findings", TestAnalyzeRunDisabledWritesEmptyFindings);


### PR DESCRIPTION
## Summary
- enable automatic label application in generated triage sync workflow (`--apply-labels`)
- expand IX managed label catalog with tag labels (`ix/tag:*`) and a low-confidence match label (`ix/match:needs-review`)
- improve `project-sync` label reliability:
  - map inferred tags to managed tag labels
  - apply `ix/match:linked-issue` only for high-confidence PR-issue matches
  - apply `ix/match:needs-review` for lower-confidence matches
- add tests for label behavior and workflow template coverage

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release --no-build`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`