### PR TITLE
feat(todo): add PR issue suggestion comments

### DIFF
--- a/IntelligenceX.Cli/Templates/triage-project-sync.yml
+++ b/IntelligenceX.Cli/Templates/triage-project-sync.yml
@@ -82,7 +82,8 @@ jobs:
             --triage artifacts/triage/ix-triage-index.json \
             --vision artifacts/triage/ix-vision-check.json \
             --max-items "$MAX_ITEMS" \
-            --apply-labels
+            --apply-labels \
+            --apply-link-comments
 
       - name: Upload triage artifacts
         uses: actions/upload-artifact@v4

--- a/IntelligenceX.Cli/Todo/IssueSuggestionCommentManager.cs
+++ b/IntelligenceX.Cli/Todo/IssueSuggestionCommentManager.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using IntelligenceX.Cli.GitHub;
+
+namespace IntelligenceX.Cli.Todo;
+
+internal static class IssueSuggestionCommentManager {
+    internal const string CommentMarker = "<!-- intelligencex:pr-issue-suggestions -->";
+
+    public static async Task<bool> UpsertAsync(string repo, int pullRequestNumber, string commentBody) {
+        if (string.IsNullOrWhiteSpace(repo) || pullRequestNumber <= 0 || string.IsNullOrWhiteSpace(commentBody)) {
+            return false;
+        }
+
+        var existingCommentId = await TryFindManagedCommentIdAsync(repo, pullRequestNumber).ConfigureAwait(false);
+        if (existingCommentId.HasValue) {
+            var (updateCode, _, updateErr) = await GhCli.RunAsync(
+                "api",
+                "--method", "PATCH",
+                $"repos/{repo}/issues/comments/{existingCommentId.Value.ToString(CultureInfo.InvariantCulture)}",
+                "-f", $"body={commentBody}"
+            ).ConfigureAwait(false);
+
+            if (updateCode == 0) {
+                return true;
+            }
+
+            Console.Error.WriteLine(
+                $"Warning: failed to update PR suggestion comment for {repo}#{pullRequestNumber}: {(string.IsNullOrWhiteSpace(updateErr) ? "unknown error" : updateErr.Trim())}");
+            return false;
+        }
+
+        var (createCode, _, createErr) = await GhCli.RunAsync(
+            "api",
+            "--method", "POST",
+            $"repos/{repo}/issues/{pullRequestNumber.ToString(CultureInfo.InvariantCulture)}/comments",
+            "-f", $"body={commentBody}"
+        ).ConfigureAwait(false);
+        if (createCode == 0) {
+            return true;
+        }
+
+        Console.Error.WriteLine(
+            $"Warning: failed to create PR suggestion comment for {repo}#{pullRequestNumber}: {(string.IsNullOrWhiteSpace(createErr) ? "unknown error" : createErr.Trim())}");
+        return false;
+    }
+
+    private static async Task<long?> TryFindManagedCommentIdAsync(string repo, int pullRequestNumber) {
+        var (code, stdout, stderr) = await GhCli.RunAsync(
+            "api",
+            $"repos/{repo}/issues/{pullRequestNumber.ToString(CultureInfo.InvariantCulture)}/comments?per_page=100"
+        ).ConfigureAwait(false);
+        if (code != 0) {
+            Console.Error.WriteLine(
+                $"Warning: failed to list PR comments for {repo}#{pullRequestNumber}: {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
+            return null;
+        }
+
+        try {
+            using var doc = JsonDocument.Parse(stdout);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) {
+                return null;
+            }
+
+            var matches = new List<long>();
+            foreach (var item in doc.RootElement.EnumerateArray()) {
+                if (!item.TryGetProperty("body", out var bodyProp) || bodyProp.ValueKind != JsonValueKind.String) {
+                    continue;
+                }
+                var body = bodyProp.GetString() ?? string.Empty;
+                if (body.IndexOf(CommentMarker, StringComparison.OrdinalIgnoreCase) < 0) {
+                    continue;
+                }
+
+                if (!item.TryGetProperty("id", out var idProp) || idProp.ValueKind != JsonValueKind.Number) {
+                    continue;
+                }
+                if (!idProp.TryGetInt64(out var id) || id <= 0) {
+                    continue;
+                }
+
+                matches.Add(id);
+            }
+
+            if (matches.Count == 0) {
+                return null;
+            }
+
+            return matches.Max();
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Warning: failed to parse PR comments JSON for {repo}#{pullRequestNumber}: {ex.Message}");
+            return null;
+        }
+    }
+}

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -11,6 +11,14 @@ namespace IntelligenceX.Cli.Todo;
 
 internal static class ProjectSyncRunner {
     private const double HighConfidenceIssueMatchLabelThreshold = 0.80;
+    private const double DefaultIssueCommentMinConfidence = 0.55;
+
+    internal sealed record RelatedIssueCandidate(
+        int Number,
+        string Url,
+        double Confidence,
+        string Reason
+    );
 
     internal sealed record ProjectSyncEntry(
         int Number,
@@ -24,7 +32,8 @@ internal static class ProjectSyncRunner {
         string? MatchedIssueUrl,
         double? MatchedIssueConfidence,
         string? VisionFit,
-        double? VisionConfidence
+        double? VisionConfidence,
+        IReadOnlyList<RelatedIssueCandidate>? RelatedIssues = null
     );
 
     private sealed class Options {
@@ -39,6 +48,9 @@ internal static class ProjectSyncRunner {
         public bool EnsureFields { get; set; } = true;
         public bool ApplyLabels { get; set; }
         public bool EnsureLabels { get; set; } = true;
+        public bool ApplyLinkComments { get; set; }
+        public double LinkCommentMinConfidence { get; set; } = DefaultIssueCommentMinConfidence;
+        public int LinkCommentMaxIssues { get; set; } = 3;
         public bool DryRun { get; set; }
         public bool ShowHelp { get; set; }
     }
@@ -126,6 +138,7 @@ internal static class ProjectSyncRunner {
         var updatedFieldValues = 0;
         var skippedMissing = 0;
         var labeled = 0;
+        var commentUpserts = 0;
 
         foreach (var entry in entries) {
             processed++;
@@ -172,6 +185,22 @@ internal static class ProjectSyncRunner {
                     }
                 }
             }
+
+            if (options.ApplyLinkComments && entry.Number > 0 &&
+                entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
+                var comment = BuildIssueMatchSuggestionComment(
+                    entry,
+                    options.LinkCommentMinConfidence,
+                    options.LinkCommentMaxIssues);
+                if (!string.IsNullOrWhiteSpace(comment)) {
+                    if (options.DryRun) {
+                        commentUpserts++;
+                    } else if (await IssueSuggestionCommentManager.UpsertAsync(options.Repo, entry.Number, comment)
+                                   .ConfigureAwait(false)) {
+                        commentUpserts++;
+                    }
+                }
+            }
         }
 
         Console.WriteLine($"Project sync target: {owner}#{projectNumber} ({project.Url})");
@@ -180,6 +209,9 @@ internal static class ProjectSyncRunner {
         Console.WriteLine($"Field values updated: {(options.DryRun ? 0 : updatedFieldValues)}");
         if (options.ApplyLabels) {
             Console.WriteLine($"Items labeled: {labeled}");
+        }
+        if (options.ApplyLinkComments) {
+            Console.WriteLine($"PR suggestion comments upserted: {commentUpserts}");
         }
         Console.WriteLine($"Skipped unresolved items: {skippedMissing}");
         Console.WriteLine(options.DryRun ? "Dry run complete (no project updates were written)." : "Project sync complete.");
@@ -254,6 +286,21 @@ internal static class ProjectSyncRunner {
                 case "--no-ensure-labels":
                     options.EnsureLabels = false;
                     break;
+                case "--apply-link-comments":
+                    options.ApplyLinkComments = true;
+                    break;
+                case "--link-comment-min-confidence":
+                    if (i + 1 < args.Length &&
+                        double.TryParse(args[++i], NumberStyles.Float, CultureInfo.InvariantCulture, out var minConfidence)) {
+                        options.LinkCommentMinConfidence = Math.Clamp(minConfidence, 0.0, 1.0);
+                    }
+                    break;
+                case "--link-comment-max-issues":
+                    if (i + 1 < args.Length &&
+                        int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var maxIssues)) {
+                        options.LinkCommentMaxIssues = Math.Max(1, Math.Min(maxIssues, 10));
+                    }
+                    break;
                 case "--dry-run":
                     options.DryRun = true;
                     break;
@@ -288,6 +335,9 @@ internal static class ProjectSyncRunner {
         Console.WriteLine("  --apply-labels           Apply IX labels to PRs/issues from synced signals");
         Console.WriteLine("  --ensure-labels          Ensure IX labels exist before applying labels (default)");
         Console.WriteLine("  --no-ensure-labels       Skip label ensure step");
+        Console.WriteLine("  --apply-link-comments    Upsert one marker comment on PRs with related issue suggestions");
+        Console.WriteLine("  --link-comment-min-confidence <0-1>  Min confidence for suggestion comments (default: 0.55)");
+        Console.WriteLine("  --link-comment-max-issues <n>  Max related issues to include per PR comment (1-10, default: 3)");
         Console.WriteLine("  --dry-run                Compute sync plan without writing project changes");
         Console.WriteLine();
         Console.WriteLine("Required token scopes for sync: `read:project` and `project`.");
@@ -382,6 +432,7 @@ internal static class ProjectSyncRunner {
                 var tags = ReadStringArray(item, "tags");
                 var matchedIssueUrl = ReadNullableString(item, "matchedIssueUrl");
                 var matchedIssueConfidence = ReadNullableDouble(item, "matchedIssueConfidence");
+                var relatedIssues = ParseRelatedIssueCandidates(item);
 
                 string? canonicalUrl = null;
                 if (!string.IsNullOrWhiteSpace(duplicateClusterId) &&
@@ -402,7 +453,8 @@ internal static class ProjectSyncRunner {
                     MatchedIssueUrl: matchedIssueUrl,
                     MatchedIssueConfidence: matchedIssueConfidence,
                     VisionFit: null,
-                    VisionConfidence: null
+                    VisionConfidence: null,
+                    RelatedIssues: relatedIssues
                 );
             }
         }
@@ -439,7 +491,8 @@ internal static class ProjectSyncRunner {
                         MatchedIssueUrl: null,
                         MatchedIssueConfidence: null,
                         VisionFit: classification,
-                        VisionConfidence: confidence
+                        VisionConfidence: confidence,
+                        RelatedIssues: Array.Empty<RelatedIssueCandidate>()
                     );
                 }
             }
@@ -606,6 +659,39 @@ internal static class ProjectSyncRunner {
             .ToList();
     }
 
+    internal static string? BuildIssueMatchSuggestionComment(ProjectSyncEntry entry, double minConfidence, int maxIssues) {
+        if (!entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase) || entry.Number <= 0) {
+            return null;
+        }
+
+        var threshold = Math.Clamp(minConfidence, 0.0, 1.0);
+        var limit = Math.Max(1, Math.Min(maxIssues, 10));
+        var related = (entry.RelatedIssues ?? Array.Empty<RelatedIssueCandidate>())
+            .Where(candidate => candidate.Confidence >= threshold && !string.IsNullOrWhiteSpace(candidate.Url))
+            .OrderByDescending(candidate => candidate.Confidence)
+            .ThenBy(candidate => candidate.Number)
+            .Take(limit)
+            .ToList();
+        if (related.Count == 0) {
+            return null;
+        }
+
+        var lines = new List<string> {
+            IssueSuggestionCommentManager.CommentMarker,
+            "### IntelligenceX Related Issue Suggestions",
+            string.Empty,
+            $"Automated match candidates (confidence >= {threshold.ToString("0.00", CultureInfo.InvariantCulture)}). Please verify before linking/closing.",
+            string.Empty
+        };
+
+        foreach (var candidate in related) {
+            var reason = NormalizeCommentReason(candidate.Reason);
+            lines.Add($"- #{candidate.Number} ({candidate.Url}) - confidence {candidate.Confidence.ToString("0.00", CultureInfo.InvariantCulture)} - {reason}");
+        }
+
+        return string.Join(Environment.NewLine, lines).TrimEnd() + Environment.NewLine;
+    }
+
     private static string? MapVisionLabel(string? visionFit) {
         return visionFit?.ToLowerInvariant() switch {
             "aligned" => "ix/vision:aligned",
@@ -624,6 +710,50 @@ internal static class ProjectSyncRunner {
             }
         }
         return false;
+    }
+
+    private static IReadOnlyList<RelatedIssueCandidate> ParseRelatedIssueCandidates(JsonElement item) {
+        if (!TryGetProperty(item, "relatedIssues", out var relatedProp) || relatedProp.ValueKind != JsonValueKind.Array) {
+            return Array.Empty<RelatedIssueCandidate>();
+        }
+
+        var results = new List<RelatedIssueCandidate>();
+        foreach (var related in relatedProp.EnumerateArray()) {
+            var number = ReadInt(related, "number");
+            var url = ReadString(related, "url");
+            var confidence = ReadNullableDouble(related, "confidence");
+            var reason = ReadNullableString(related, "reason") ?? string.Empty;
+            if (number <= 0 || string.IsNullOrWhiteSpace(url) || !confidence.HasValue) {
+                continue;
+            }
+
+            results.Add(new RelatedIssueCandidate(
+                Number: number,
+                Url: url,
+                Confidence: Math.Round(Math.Clamp(confidence.Value, 0.0, 1.0), 4, MidpointRounding.AwayFromZero),
+                Reason: reason
+            ));
+        }
+
+        return results
+            .OrderByDescending(candidate => candidate.Confidence)
+            .ThenBy(candidate => candidate.Number)
+            .Take(10)
+            .ToList();
+    }
+
+    private static string NormalizeCommentReason(string reason) {
+        if (string.IsNullOrWhiteSpace(reason)) {
+            return "token similarity";
+        }
+
+        var compact = string.Join(" ", reason
+            .Split(new[] { '\r', '\n', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+            .Trim();
+        if (compact.Length <= 140) {
+            return compact;
+        }
+        return compact[..137] + "...";
     }
 
     private static bool TryGetProperty(JsonElement obj, string name, out JsonElement value) {

--- a/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
@@ -66,6 +66,7 @@ project={{ProjectNumber}}
 
         AssertContainsText(rendered, "todo project-sync", "workflow contains project sync step");
         AssertContainsText(rendered, "--apply-labels", "workflow enables label application");
+        AssertContainsText(rendered, "--apply-link-comments", "workflow enables PR issue suggestion comments");
     }
 #endif
 }

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -32,7 +32,21 @@ internal static partial class Program {
       "category": "feature",
       "tags": [ "api", "automation" ],
       "matchedIssueUrl": "https://github.com/EvotecIT/IntelligenceX/issues/11",
-      "matchedIssueConfidence": 0.93
+      "matchedIssueConfidence": 0.93,
+      "relatedIssues": [
+        {
+          "number": 11,
+          "url": "https://github.com/EvotecIT/IntelligenceX/issues/11",
+          "confidence": 0.93,
+          "reason": "explicit issue reference in PR title/body"
+        },
+        {
+          "number": 19,
+          "url": "https://github.com/EvotecIT/IntelligenceX/issues/19",
+          "confidence": 0.61,
+          "reason": "token similarity title=0.72, context=0.51"
+        }
+      ]
     },
     {
       "id": "issue#11",
@@ -79,6 +93,8 @@ internal static partial class Program {
         AssertEqual(true, pr.Tags.Contains("api", StringComparer.OrdinalIgnoreCase), "tags merged");
         AssertEqual("https://github.com/EvotecIT/IntelligenceX/issues/11", pr.MatchedIssueUrl, "matched issue url merged");
         AssertEqual(true, pr.MatchedIssueConfidence.HasValue && pr.MatchedIssueConfidence.Value > 0.9, "matched issue confidence merged");
+        AssertEqual(true, (pr.RelatedIssues?.Count ?? 0) == 2, "related issues merged");
+        AssertEqual(11, pr.RelatedIssues![0].Number, "related issue ordering");
 
         var issue = entries.First(item => item.Url.EndsWith("/issues/11", StringComparison.OrdinalIgnoreCase));
         AssertEqual("issue", issue.Kind, "issue kind preserved");
@@ -131,6 +147,56 @@ internal static partial class Program {
         var labels = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildLabelsForEntry(entry);
         AssertEqual(true, labels.Contains("ix/match:needs-review", StringComparer.OrdinalIgnoreCase), "low confidence match review label");
         AssertEqual(false, labels.Contains("ix/match:linked-issue", StringComparer.OrdinalIgnoreCase), "low confidence should not be linked-issue");
+    }
+
+    private static void TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence() {
+        var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+            Number: 55,
+            Url: "https://github.com/EvotecIT/IntelligenceX/pull/55",
+            Kind: "pull_request",
+            TriageScore: 71.1,
+            DuplicateCluster: null,
+            CanonicalItem: null,
+            Category: "feature",
+            Tags: Array.Empty<string>(),
+            MatchedIssueUrl: "https://github.com/EvotecIT/IntelligenceX/issues/10",
+            MatchedIssueConfidence: 0.88,
+            VisionFit: "aligned",
+            VisionConfidence: 0.73,
+            RelatedIssues: new[] {
+                new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(10, "https://github.com/EvotecIT/IntelligenceX/issues/10", 0.88, "explicit issue reference in PR title/body"),
+                new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(12, "https://github.com/EvotecIT/IntelligenceX/issues/12", 0.49, "token similarity title=0.62, context=0.31")
+            }
+        );
+
+        var comment = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildIssueMatchSuggestionComment(entry, minConfidence: 0.50, maxIssues: 3);
+        AssertEqual(true, !string.IsNullOrWhiteSpace(comment), "comment generated");
+        AssertContainsText(comment ?? string.Empty, "<!-- intelligencex:pr-issue-suggestions -->", "marker present");
+        AssertContainsText(comment ?? string.Empty, "https://github.com/EvotecIT/IntelligenceX/issues/10", "high confidence issue included");
+        AssertEqual(false, (comment ?? string.Empty).Contains("issues/12", StringComparison.OrdinalIgnoreCase), "low confidence issue excluded");
+    }
+
+    private static void TestProjectSyncBuildIssueMatchSuggestionCommentReturnsNullWithoutQualifiedCandidates() {
+        var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+            Number: 56,
+            Url: "https://github.com/EvotecIT/IntelligenceX/pull/56",
+            Kind: "pull_request",
+            TriageScore: 48.2,
+            DuplicateCluster: null,
+            CanonicalItem: null,
+            Category: "feature",
+            Tags: Array.Empty<string>(),
+            MatchedIssueUrl: null,
+            MatchedIssueConfidence: null,
+            VisionFit: null,
+            VisionConfidence: null,
+            RelatedIssues: new[] {
+                new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(15, "https://github.com/EvotecIT/IntelligenceX/issues/15", 0.22, "weak token overlap")
+            }
+        );
+
+        var comment = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildIssueMatchSuggestionComment(entry, minConfidence: 0.55, maxIssues: 3);
+        AssertEqual(true, string.IsNullOrWhiteSpace(comment), "no comment for weak matches");
     }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -452,6 +452,8 @@ internal static partial class Program {
         failed += Run("Todo project sync merges vision and canonical", TestProjectSyncBuildEntriesMergesVisionAndCanonical);
         failed += Run("Todo project sync labels include tags and high-confidence match", TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch);
         failed += Run("Todo project sync labels mark low-confidence match for review", TestProjectSyncBuildLabelsUsesNeedsReviewForLowConfidenceIssueMatch);
+        failed += Run("Todo project sync comment filters by confidence", TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence);
+        failed += Run("Todo project sync comment omitted for weak candidates", TestProjectSyncBuildIssueMatchSuggestionCommentReturnsNullWithoutQualifiedCandidates);
         failed += Run("Todo project bootstrap renders project target", TestProjectBootstrapRenderWorkflowTemplateInjectsProjectTarget);
         failed += Run("Todo project bootstrap clamps max items", TestProjectBootstrapRenderWorkflowTemplateClampsMaxItems);
         failed += Run("Todo project bootstrap renders vision template", TestProjectBootstrapRenderVisionTemplateInjectsContext);


### PR DESCRIPTION
## Summary
- add `--apply-link-comments` support to `todo project-sync` to upsert one marker-based PR comment with related issue suggestions
- parse and carry `relatedIssues` candidates from triage index into project-sync entries
- add confidence filtering controls:
  - `--link-comment-min-confidence` (default `0.55`)
  - `--link-comment-max-issues` (default `3`)
- keep comments idempotent by updating an existing managed marker comment instead of posting duplicates
- enable this behavior in generated triage workflow (`triage-project-sync.yml`)

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release --no-build`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`