### PR TITLE
feat(todo): sync related issue matches into project field

### DIFF
--- a/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
@@ -30,6 +30,7 @@ internal static class ProjectFieldCatalog {
         new ProjectFieldDefinition("Tags", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Matched Issue", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Matched Issue Confidence", "NUMBER", Array.Empty<string>()),
+        new ProjectFieldDefinition("Related Issues", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Triage Score", "NUMBER", Array.Empty<string>()),
         new ProjectFieldDefinition("Duplicate Cluster", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Canonical Item", "TEXT", Array.Empty<string>()),

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -586,6 +586,14 @@ internal static class ProjectSyncRunner {
             updated++;
         }
 
+        if (fields.TryGetValue("Related Issues", out var relatedIssuesField)) {
+            var relatedIssuesValue = BuildRelatedIssuesFieldValue(entry, maxIssues: 3);
+            if (!string.IsNullOrWhiteSpace(relatedIssuesValue)) {
+                await client.SetTextFieldAsync(projectId, itemId, relatedIssuesField.Id, relatedIssuesValue).ConfigureAwait(false);
+                updated++;
+            }
+        }
+
         if (fields.TryGetValue("Duplicate Cluster", out var duplicateField) && !string.IsNullOrWhiteSpace(entry.DuplicateCluster)) {
             await client.SetTextFieldAsync(projectId, itemId, duplicateField.Id, entry.DuplicateCluster).ConfigureAwait(false);
             updated++;
@@ -657,6 +665,22 @@ internal static class ProjectSyncRunner {
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(label => label, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    internal static string BuildRelatedIssuesFieldValue(ProjectSyncEntry entry, int maxIssues) {
+        var limit = Math.Max(1, Math.Min(maxIssues, 10));
+        var related = (entry.RelatedIssues ?? Array.Empty<RelatedIssueCandidate>())
+            .Where(candidate => candidate.Number > 0 && !string.IsNullOrWhiteSpace(candidate.Url))
+            .OrderByDescending(candidate => candidate.Confidence)
+            .ThenBy(candidate => candidate.Number)
+            .Take(limit)
+            .ToList();
+        if (related.Count == 0) {
+            return string.Empty;
+        }
+
+        return string.Join(Environment.NewLine, related.Select(candidate =>
+            $"#{candidate.Number.ToString(CultureInfo.InvariantCulture)} | {candidate.Confidence.ToString("0.00", CultureInfo.InvariantCulture)} | {candidate.Url}"));
     }
 
     internal static string? BuildIssueMatchSuggestionComment(ProjectSyncEntry entry, double minConfidence, int maxIssues) {

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -15,6 +15,7 @@ internal static partial class Program {
         AssertEqual(true, names.Contains("Tags", StringComparer.OrdinalIgnoreCase), "has Tags");
         AssertEqual(true, names.Contains("Matched Issue", StringComparer.OrdinalIgnoreCase), "has Matched Issue");
         AssertEqual(true, names.Contains("Matched Issue Confidence", StringComparer.OrdinalIgnoreCase), "has Matched Issue Confidence");
+        AssertEqual(true, names.Contains("Related Issues", StringComparer.OrdinalIgnoreCase), "has Related Issues");
         AssertEqual(true, names.Contains("Triage Score", StringComparer.OrdinalIgnoreCase), "has Triage Score");
         AssertEqual(true, names.Contains("Maintainer Decision", StringComparer.OrdinalIgnoreCase), "has Maintainer Decision");
     }
@@ -197,6 +198,35 @@ internal static partial class Program {
 
         var comment = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildIssueMatchSuggestionComment(entry, minConfidence: 0.55, maxIssues: 3);
         AssertEqual(true, string.IsNullOrWhiteSpace(comment), "no comment for weak matches");
+    }
+
+    private static void TestProjectSyncBuildRelatedIssuesFieldValueOrdersAndLimitsCandidates() {
+        var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+            Number: 57,
+            Url: "https://github.com/EvotecIT/IntelligenceX/pull/57",
+            Kind: "pull_request",
+            TriageScore: 70.0,
+            DuplicateCluster: null,
+            CanonicalItem: null,
+            Category: "feature",
+            Tags: Array.Empty<string>(),
+            MatchedIssueUrl: null,
+            MatchedIssueConfidence: null,
+            VisionFit: null,
+            VisionConfidence: null,
+            RelatedIssues: new[] {
+                new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(20, "https://github.com/EvotecIT/IntelligenceX/issues/20", 0.52, "token overlap"),
+                new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(11, "https://github.com/EvotecIT/IntelligenceX/issues/11", 0.93, "explicit"),
+                new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(19, "https://github.com/EvotecIT/IntelligenceX/issues/19", 0.61, "token overlap"),
+                new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(18, "https://github.com/EvotecIT/IntelligenceX/issues/18", 0.58, "token overlap")
+            }
+        );
+
+        var value = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildRelatedIssuesFieldValue(entry, maxIssues: 3);
+        AssertContainsText(value, "#11 | 0.93", "top candidate first");
+        AssertContainsText(value, "#19 | 0.61", "second candidate");
+        AssertContainsText(value, "#18 | 0.58", "third candidate");
+        AssertEqual(false, value.Contains("#20", StringComparison.OrdinalIgnoreCase), "limited to top three");
     }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -454,6 +454,7 @@ internal static partial class Program {
         failed += Run("Todo project sync labels mark low-confidence match for review", TestProjectSyncBuildLabelsUsesNeedsReviewForLowConfidenceIssueMatch);
         failed += Run("Todo project sync comment filters by confidence", TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence);
         failed += Run("Todo project sync comment omitted for weak candidates", TestProjectSyncBuildIssueMatchSuggestionCommentReturnsNullWithoutQualifiedCandidates);
+        failed += Run("Todo project sync related issues field value", TestProjectSyncBuildRelatedIssuesFieldValueOrdersAndLimitsCandidates);
         failed += Run("Todo project bootstrap renders project target", TestProjectBootstrapRenderWorkflowTemplateInjectsProjectTarget);
         failed += Run("Todo project bootstrap clamps max items", TestProjectBootstrapRenderWorkflowTemplateClampsMaxItems);
         failed += Run("Todo project bootstrap renders vision template", TestProjectBootstrapRenderVisionTemplateInjectsContext);


### PR DESCRIPTION
## Summary
- add new default project field: `Related Issues` (TEXT)
- populate that field during `todo project-sync` from top related issue candidates detected by triage index
- format related issue entries as ranked lines with issue number, confidence, and URL
- keep value deterministic (confidence-ordered, capped list)
- add tests for field catalog coverage and related-issues value formatting

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release --no-build`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`