### PR TITLE
feat(todo): add IX suggested decision signal for project triage

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -112,7 +112,7 @@ intelligencex todo project-init \
 
 Notes:
 - Creates a project (or initializes an existing one with `--project <n>`).
-- Ensures required custom fields such as `Vision Fit`, `Category`, `Tags`, `Matched Issue`, `Triage Score`, and `Duplicate Cluster`.
+- Ensures required custom fields such as `Vision Fit`, `Category`, `Tags`, `Matched Issue`, `Triage Score`, `Duplicate Cluster`, and `IX Suggested Decision`.
 - Ensures IX label taxonomy in the repo by default (`--no-ensure-labels` to skip).
 - Writes a reusable config file containing owner/project/field metadata.
 - Requires GitHub token scopes: `project` (and typically `read:project` for follow-up sync).
@@ -137,6 +137,10 @@ Useful options:
 - `--ensure-labels` / `--no-ensure-labels` for label taxonomy management.
 - `--project-item-scan-limit <n>` for larger projects.
 - `--dry-run` for a no-write sync preview.
+
+Behavior:
+- `IX Suggested Decision` is populated automatically (`accept`, `defer`, `reject`, `merge-candidate`) from combined triage + vision signals.
+- `Maintainer Decision` remains human-owned for final triage decisions.
 
 ## Bootstrap project + workflow (recommended first run)
 

--- a/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
@@ -38,6 +38,12 @@ internal static class ProjectFieldCatalog {
             "pull_request",
             "issue"
         }),
+        new ProjectFieldDefinition("IX Suggested Decision", "SINGLE_SELECT", new[] {
+            "accept",
+            "defer",
+            "reject",
+            "merge-candidate"
+        }),
         new ProjectFieldDefinition("Maintainer Decision", "SINGLE_SELECT", new[] {
             "accept",
             "defer",

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -12,12 +12,22 @@ namespace IntelligenceX.Cli.Todo;
 internal static class ProjectSyncRunner {
     private const double HighConfidenceIssueMatchLabelThreshold = 0.80;
     private const double DefaultIssueCommentMinConfidence = 0.55;
+    private const double RejectVisionConfidenceThreshold = 0.70;
+    private const double AcceptVisionConfidenceThreshold = 0.68;
+    private const double MergeCandidateScoreThreshold = 82.0;
 
     internal sealed record RelatedIssueCandidate(
         int Number,
         string Url,
         double Confidence,
         string Reason
+    );
+
+    internal sealed record PullRequestDecisionSignals(
+        bool? IsDraft,
+        string? Mergeable,
+        string? ReviewDecision,
+        string? StatusCheckState
     );
 
     internal sealed record ProjectSyncEntry(
@@ -33,7 +43,8 @@ internal static class ProjectSyncRunner {
         double? MatchedIssueConfidence,
         string? VisionFit,
         double? VisionConfidence,
-        IReadOnlyList<RelatedIssueCandidate>? RelatedIssues = null
+        IReadOnlyList<RelatedIssueCandidate>? RelatedIssues = null,
+        string? SuggestedDecision = null
     );
 
     private sealed class Options {
@@ -396,6 +407,8 @@ internal static class ProjectSyncRunner {
         var entriesByUrl = new Dictionary<string, ProjectSyncEntry>(StringComparer.OrdinalIgnoreCase);
         var idToUrl = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var clusterToCanonicalId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var decisionSignalsByUrl = new Dictionary<string, PullRequestDecisionSignals>(StringComparer.OrdinalIgnoreCase);
+        var bestPullRequestUrls = ParseBestPullRequestUrls(triageRoot);
 
         if (TryGetProperty(triageRoot, "items", out var items) && items.ValueKind == JsonValueKind.Array) {
             foreach (var item in items.EnumerateArray()) {
@@ -433,6 +446,10 @@ internal static class ProjectSyncRunner {
                 var matchedIssueUrl = ReadNullableString(item, "matchedIssueUrl");
                 var matchedIssueConfidence = ReadNullableDouble(item, "matchedIssueConfidence");
                 var relatedIssues = ParseRelatedIssueCandidates(item);
+                var decisionSignals = ParsePullRequestSignals(item);
+                if (decisionSignals is not null) {
+                    decisionSignalsByUrl[url] = decisionSignals;
+                }
 
                 string? canonicalUrl = null;
                 if (!string.IsNullOrWhiteSpace(duplicateClusterId) &&
@@ -454,7 +471,8 @@ internal static class ProjectSyncRunner {
                     MatchedIssueConfidence: matchedIssueConfidence,
                     VisionFit: null,
                     VisionConfidence: null,
-                    RelatedIssues: relatedIssues
+                    RelatedIssues: relatedIssues,
+                    SuggestedDecision: null
                 );
             }
         }
@@ -492,9 +510,21 @@ internal static class ProjectSyncRunner {
                         MatchedIssueConfidence: null,
                         VisionFit: classification,
                         VisionConfidence: confidence,
-                        RelatedIssues: Array.Empty<RelatedIssueCandidate>()
+                        RelatedIssues: Array.Empty<RelatedIssueCandidate>(),
+                        SuggestedDecision: null
                     );
                 }
+            }
+        }
+
+        foreach (var pair in entriesByUrl.ToList()) {
+            decisionSignalsByUrl.TryGetValue(pair.Key, out var decisionSignals);
+            var suggestion = SuggestMaintainerDecision(
+                pair.Value,
+                bestPullRequestUrls.Contains(pair.Key),
+                decisionSignals);
+            if (!string.IsNullOrWhiteSpace(suggestion)) {
+                entriesByUrl[pair.Key] = pair.Value with { SuggestedDecision = suggestion };
             }
         }
 
@@ -513,6 +543,117 @@ internal static class ProjectSyncRunner {
             "aligned" => 2,
             _ => 3
         };
+    }
+
+    private static string? SuggestMaintainerDecision(
+        ProjectSyncEntry entry,
+        bool isBestPullRequest,
+        PullRequestDecisionSignals? prSignals) {
+        if (!entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
+            return null;
+        }
+
+        var visionFit = entry.VisionFit?.Trim().ToLowerInvariant();
+        var visionConfidence = entry.VisionConfidence ?? 0;
+        var triageScore = entry.TriageScore ?? 0;
+
+        if (visionFit == "likely-out-of-scope" && visionConfidence >= RejectVisionConfidenceThreshold) {
+            return "reject";
+        }
+
+        var blockedBySignals = prSignals is not null && IsBlockedByReviewOrChecks(prSignals);
+        if (blockedBySignals && visionFit != "likely-out-of-scope") {
+            return "defer";
+        }
+
+        if (prSignals is not null &&
+            IsStronglyReadyForMerge(prSignals) &&
+            visionFit != "likely-out-of-scope" &&
+            (isBestPullRequest || triageScore >= MergeCandidateScoreThreshold)) {
+            return "merge-candidate";
+        }
+
+        if (visionFit == "aligned" &&
+            visionConfidence >= AcceptVisionConfidenceThreshold &&
+            triageScore >= 60 &&
+            !blockedBySignals) {
+            return "accept";
+        }
+
+        return "defer";
+    }
+
+    private static bool IsStronglyReadyForMerge(PullRequestDecisionSignals signals) {
+        return signals.IsDraft == false &&
+               string.Equals(signals.Mergeable, "MERGEABLE", StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(signals.ReviewDecision, "APPROVED", StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(signals.StatusCheckState, "SUCCESS", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsBlockedByReviewOrChecks(PullRequestDecisionSignals signals) {
+        if (signals.IsDraft == true) {
+            return true;
+        }
+
+        if (string.Equals(signals.Mergeable, "CONFLICTING", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(signals.Mergeable, "UNKNOWN", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        if (string.Equals(signals.ReviewDecision, "CHANGES_REQUESTED", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        return string.Equals(signals.StatusCheckState, "FAILURE", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(signals.StatusCheckState, "ERROR", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(signals.StatusCheckState, "PENDING", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IReadOnlySet<string> ParseBestPullRequestUrls(JsonElement triageRoot) {
+        var urls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!TryGetProperty(triageRoot, "bestPullRequests", out var best) || best.ValueKind != JsonValueKind.Array) {
+            return urls;
+        }
+
+        foreach (var candidate in best.EnumerateArray()) {
+            var url = ReadString(candidate, "url");
+            if (!string.IsNullOrWhiteSpace(url)) {
+                urls.Add(url);
+            }
+        }
+        return urls;
+    }
+
+    private static PullRequestDecisionSignals? ParsePullRequestSignals(JsonElement item) {
+        var kind = ReadString(item, "kind");
+        if (!kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
+            return null;
+        }
+
+        if (!TryGetPropertyCaseInsensitive(item, "signals", out var signalsObj) ||
+            signalsObj.ValueKind != JsonValueKind.Object ||
+            !TryGetPropertyCaseInsensitive(signalsObj, "pullRequest", out var prSignalsObj) ||
+            prSignalsObj.ValueKind != JsonValueKind.Object) {
+            return null;
+        }
+
+        var isDraft = ReadNullableBoolCaseInsensitive(prSignalsObj, "isDraft");
+        var mergeable = ReadNullableStringCaseInsensitive(prSignalsObj, "mergeable");
+        var reviewDecision = ReadNullableStringCaseInsensitive(prSignalsObj, "reviewDecision");
+        var statusCheckState = ReadNullableStringCaseInsensitive(prSignalsObj, "statusCheckState");
+        if (!isDraft.HasValue &&
+            string.IsNullOrWhiteSpace(mergeable) &&
+            string.IsNullOrWhiteSpace(reviewDecision) &&
+            string.IsNullOrWhiteSpace(statusCheckState)) {
+            return null;
+        }
+
+        return new PullRequestDecisionSignals(
+            isDraft,
+            mergeable,
+            reviewDecision,
+            statusCheckState
+        );
     }
 
     private static async Task<IReadOnlyDictionary<string, ProjectV2Client.ProjectField>> EnsureFieldsAsync(
@@ -616,6 +757,16 @@ internal static class ProjectSyncRunner {
         if (fields.TryGetValue("Vision Confidence", out var confidenceField) && entry.VisionConfidence.HasValue) {
             await client.SetNumberFieldAsync(projectId, itemId, confidenceField.Id, entry.VisionConfidence.Value).ConfigureAwait(false);
             updated++;
+        }
+
+        if (fields.TryGetValue("IX Suggested Decision", out var suggestedDecisionField) &&
+            !string.IsNullOrWhiteSpace(entry.SuggestedDecision)) {
+            if (TryResolveOptionId(suggestedDecisionField, entry.SuggestedDecision, out var optionId)) {
+                await client.SetSingleSelectFieldAsync(projectId, itemId, suggestedDecisionField.Id, optionId).ConfigureAwait(false);
+                updated++;
+            } else {
+                Console.Error.WriteLine($"Warning: option '{entry.SuggestedDecision}' not found in field '{suggestedDecisionField.Name}'.");
+            }
         }
 
         if (fields.TryGetValue("Triage Kind", out var kindField) && !string.IsNullOrWhiteSpace(entry.Kind)) {
@@ -788,11 +939,57 @@ internal static class ProjectSyncRunner {
         return obj.TryGetProperty(name, out value);
     }
 
+    private static bool TryGetPropertyCaseInsensitive(JsonElement obj, string name, out JsonElement value) {
+        value = default;
+        if (obj.ValueKind != JsonValueKind.Object) {
+            return false;
+        }
+
+        if (obj.TryGetProperty(name, out value)) {
+            return true;
+        }
+
+        foreach (var property in obj.EnumerateObject()) {
+            if (property.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static string ReadString(JsonElement obj, string name) {
         if (!TryGetProperty(obj, name, out var prop) || prop.ValueKind != JsonValueKind.String) {
             return string.Empty;
         }
         return prop.GetString() ?? string.Empty;
+    }
+
+    private static string? ReadNullableStringCaseInsensitive(JsonElement obj, string name) {
+        if (!TryGetPropertyCaseInsensitive(obj, name, out var prop)) {
+            return null;
+        }
+        if (prop.ValueKind == JsonValueKind.Null) {
+            return null;
+        }
+        if (prop.ValueKind != JsonValueKind.String) {
+            return null;
+        }
+        return prop.GetString();
+    }
+
+    private static bool? ReadNullableBoolCaseInsensitive(JsonElement obj, string name) {
+        if (!TryGetPropertyCaseInsensitive(obj, name, out var prop)) {
+            return null;
+        }
+        if (prop.ValueKind == JsonValueKind.Null) {
+            return null;
+        }
+        if (prop.ValueKind != JsonValueKind.True && prop.ValueKind != JsonValueKind.False) {
+            return null;
+        }
+        return prop.GetBoolean();
     }
 
     private static string? ReadNullableString(JsonElement obj, string name) {

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -17,6 +17,7 @@ internal static partial class Program {
         AssertEqual(true, names.Contains("Matched Issue Confidence", StringComparer.OrdinalIgnoreCase), "has Matched Issue Confidence");
         AssertEqual(true, names.Contains("Related Issues", StringComparer.OrdinalIgnoreCase), "has Related Issues");
         AssertEqual(true, names.Contains("Triage Score", StringComparer.OrdinalIgnoreCase), "has Triage Score");
+        AssertEqual(true, names.Contains("IX Suggested Decision", StringComparer.OrdinalIgnoreCase), "has IX Suggested Decision");
         AssertEqual(true, names.Contains("Maintainer Decision", StringComparer.OrdinalIgnoreCase), "has Maintainer Decision");
     }
 
@@ -96,11 +97,110 @@ internal static partial class Program {
         AssertEqual(true, pr.MatchedIssueConfidence.HasValue && pr.MatchedIssueConfidence.Value > 0.9, "matched issue confidence merged");
         AssertEqual(true, (pr.RelatedIssues?.Count ?? 0) == 2, "related issues merged");
         AssertEqual(11, pr.RelatedIssues![0].Number, "related issue ordering");
+        AssertEqual("reject", pr.SuggestedDecision, "vision reject suggestion");
 
         var issue = entries.First(item => item.Url.EndsWith("/issues/11", StringComparison.OrdinalIgnoreCase));
         AssertEqual("issue", issue.Kind, "issue kind preserved");
         AssertEqual("cluster-1", issue.DuplicateCluster, "duplicate cluster preserved");
         AssertEqual("https://github.com/EvotecIT/IntelligenceX/pull/10", issue.CanonicalItem, "issue canonical resolved");
+        AssertEqual(true, string.IsNullOrWhiteSpace(issue.SuggestedDecision), "issues do not get automated decision");
+    }
+
+    private static void TestProjectSyncBuildEntriesSuggestsMergeCandidateForBestReadyPr() {
+        const string triageJson = """
+{
+  "items": [
+    {
+      "id": "pr#21",
+      "kind": "pull_request",
+      "number": 21,
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/21",
+      "score": 92.3,
+      "signals": {
+        "pullRequest": {
+          "IsDraft": false,
+          "Mergeable": "MERGEABLE",
+          "ReviewDecision": "APPROVED",
+          "StatusCheckState": "SUCCESS"
+        }
+      }
+    }
+  ],
+  "bestPullRequests": [
+    {
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/21"
+    }
+  ]
+}
+""";
+
+        const string visionJson = """
+{
+  "assessments": [
+    {
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/21",
+      "classification": "aligned",
+      "confidence": 0.84
+    }
+  ]
+}
+""";
+
+        using var triageDoc = System.Text.Json.JsonDocument.Parse(triageJson);
+        using var visionDoc = System.Text.Json.JsonDocument.Parse(visionJson);
+        var entries = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildEntriesFromDocuments(
+            triageDoc.RootElement,
+            visionDoc.RootElement,
+            100);
+
+        var pr = entries.Single(item => item.Url.EndsWith("/pull/21", StringComparison.OrdinalIgnoreCase));
+        AssertEqual("merge-candidate", pr.SuggestedDecision, "best ready PR suggestion");
+    }
+
+    private static void TestProjectSyncBuildEntriesSuggestsDeferForBlockedPr() {
+        const string triageJson = """
+{
+  "items": [
+    {
+      "id": "pr#33",
+      "kind": "pull_request",
+      "number": 33,
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/33",
+      "score": 88.1,
+      "signals": {
+        "pullRequest": {
+          "isDraft": false,
+          "mergeable": "MERGEABLE",
+          "reviewDecision": "CHANGES_REQUESTED",
+          "statusCheckState": "SUCCESS"
+        }
+      }
+    }
+  ]
+}
+""";
+
+        const string visionJson = """
+{
+  "assessments": [
+    {
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/33",
+      "classification": "aligned",
+      "confidence": 0.91
+    }
+  ]
+}
+""";
+
+        using var triageDoc = System.Text.Json.JsonDocument.Parse(triageJson);
+        using var visionDoc = System.Text.Json.JsonDocument.Parse(visionJson);
+        var entries = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildEntriesFromDocuments(
+            triageDoc.RootElement,
+            visionDoc.RootElement,
+            100);
+
+        var pr = entries.Single(item => item.Url.EndsWith("/pull/33", StringComparison.OrdinalIgnoreCase));
+        AssertEqual("defer", pr.SuggestedDecision, "blocked PR suggestion");
     }
 
     private static void TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch() {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -452,6 +452,8 @@ internal static partial class Program {
         failed += Run("Todo project sync merges vision and canonical", TestProjectSyncBuildEntriesMergesVisionAndCanonical);
         failed += Run("Todo project sync labels include tags and high-confidence match", TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch);
         failed += Run("Todo project sync labels mark low-confidence match for review", TestProjectSyncBuildLabelsUsesNeedsReviewForLowConfidenceIssueMatch);
+        failed += Run("Todo project sync decision suggests merge-candidate", TestProjectSyncBuildEntriesSuggestsMergeCandidateForBestReadyPr);
+        failed += Run("Todo project sync decision suggests defer for blocked PR", TestProjectSyncBuildEntriesSuggestsDeferForBlockedPr);
         failed += Run("Todo project sync comment filters by confidence", TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence);
         failed += Run("Todo project sync comment omitted for weak candidates", TestProjectSyncBuildIssueMatchSuggestionCommentReturnsNullWithoutQualifiedCandidates);
         failed += Run("Todo project sync related issues field value", TestProjectSyncBuildRelatedIssuesFieldValueOrdersAndLimitsCandidates);


### PR DESCRIPTION
## Summary
- add an automation-owned project field: `IX Suggested Decision` (`accept`, `defer`, `reject`, `merge-candidate`)
- compute a suggested decision in `todo project-sync` from combined signals:
  - vision fit + vision confidence
  - triage score
  - PR readiness signals (`isDraft`, `mergeable`, `reviewDecision`, `statusCheckState`)
  - `bestPullRequests` membership from triage index
- write this value during sync without touching the human-owned `Maintainer Decision` field
- document the behavior in `Docs/cli/todo.md`

## Why
This gives maintainers a reliable assistive signal directly in GitHub Projects for large PR/issue backlogs while preserving manual final decisions.

## Tests
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`

Added test coverage for:
- out-of-scope vision confidence -> `reject`
- best+ready PR -> `merge-candidate`
- blocked PR (changes requested) -> `defer`

## Notes
- I also attempted the analysis-gate skill script: `bash .agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.sh fast`.
- It failed only due missing local module dependency: `PSScriptAnalyzer module not found`.
