### PR TITLE
feat(todo): add bidirectional PR-issue suggestion comments

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -135,6 +135,7 @@ Useful options:
 - `--ensure-fields` / `--no-ensure-fields`.
 - `--apply-labels` to apply IX labels (`ix/category:*`, `ix/vision:*`, `ix/match:*`) on PRs/issues.
 - `--ensure-labels` / `--no-ensure-labels` for label taxonomy management.
+- `--apply-link-comments` to upsert assistive link comments on PRs (related issues) and issues (related PRs).
 - `--project-item-scan-limit <n>` for larger projects.
 - `--dry-run` for a no-write sync preview.
 

--- a/IntelligenceX.Cli/Todo/IssueSuggestionCommentManager.cs
+++ b/IntelligenceX.Cli/Todo/IssueSuggestionCommentManager.cs
@@ -10,13 +10,14 @@ namespace IntelligenceX.Cli.Todo;
 
 internal static class IssueSuggestionCommentManager {
     internal const string CommentMarker = "<!-- intelligencex:pr-issue-suggestions -->";
+    internal const string IssueBacklinkCommentMarker = "<!-- intelligencex:issue-pr-suggestions -->";
 
-    public static async Task<bool> UpsertAsync(string repo, int pullRequestNumber, string commentBody) {
-        if (string.IsNullOrWhiteSpace(repo) || pullRequestNumber <= 0 || string.IsNullOrWhiteSpace(commentBody)) {
+    public static async Task<bool> UpsertAsync(string repo, int issueNumber, string commentBody, string marker = CommentMarker) {
+        if (string.IsNullOrWhiteSpace(repo) || issueNumber <= 0 || string.IsNullOrWhiteSpace(commentBody) || string.IsNullOrWhiteSpace(marker)) {
             return false;
         }
 
-        var existingCommentId = await TryFindManagedCommentIdAsync(repo, pullRequestNumber).ConfigureAwait(false);
+        var existingCommentId = await TryFindManagedCommentIdAsync(repo, issueNumber, marker).ConfigureAwait(false);
         if (existingCommentId.HasValue) {
             var (updateCode, _, updateErr) = await GhCli.RunAsync(
                 "api",
@@ -30,14 +31,14 @@ internal static class IssueSuggestionCommentManager {
             }
 
             Console.Error.WriteLine(
-                $"Warning: failed to update PR suggestion comment for {repo}#{pullRequestNumber}: {(string.IsNullOrWhiteSpace(updateErr) ? "unknown error" : updateErr.Trim())}");
+                $"Warning: failed to update managed suggestion comment for {repo}#{issueNumber}: {(string.IsNullOrWhiteSpace(updateErr) ? "unknown error" : updateErr.Trim())}");
             return false;
         }
 
         var (createCode, _, createErr) = await GhCli.RunAsync(
             "api",
             "--method", "POST",
-            $"repos/{repo}/issues/{pullRequestNumber.ToString(CultureInfo.InvariantCulture)}/comments",
+            $"repos/{repo}/issues/{issueNumber.ToString(CultureInfo.InvariantCulture)}/comments",
             "-f", $"body={commentBody}"
         ).ConfigureAwait(false);
         if (createCode == 0) {
@@ -45,18 +46,18 @@ internal static class IssueSuggestionCommentManager {
         }
 
         Console.Error.WriteLine(
-            $"Warning: failed to create PR suggestion comment for {repo}#{pullRequestNumber}: {(string.IsNullOrWhiteSpace(createErr) ? "unknown error" : createErr.Trim())}");
+            $"Warning: failed to create managed suggestion comment for {repo}#{issueNumber}: {(string.IsNullOrWhiteSpace(createErr) ? "unknown error" : createErr.Trim())}");
         return false;
     }
 
-    private static async Task<long?> TryFindManagedCommentIdAsync(string repo, int pullRequestNumber) {
+    private static async Task<long?> TryFindManagedCommentIdAsync(string repo, int issueNumber, string marker) {
         var (code, stdout, stderr) = await GhCli.RunAsync(
             "api",
-            $"repos/{repo}/issues/{pullRequestNumber.ToString(CultureInfo.InvariantCulture)}/comments?per_page=100"
+            $"repos/{repo}/issues/{issueNumber.ToString(CultureInfo.InvariantCulture)}/comments?per_page=100"
         ).ConfigureAwait(false);
         if (code != 0) {
             Console.Error.WriteLine(
-                $"Warning: failed to list PR comments for {repo}#{pullRequestNumber}: {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
+                $"Warning: failed to list issue comments for {repo}#{issueNumber}: {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
             return null;
         }
 
@@ -72,7 +73,7 @@ internal static class IssueSuggestionCommentManager {
                     continue;
                 }
                 var body = bodyProp.GetString() ?? string.Empty;
-                if (body.IndexOf(CommentMarker, StringComparison.OrdinalIgnoreCase) < 0) {
+                if (body.IndexOf(marker, StringComparison.OrdinalIgnoreCase) < 0) {
                     continue;
                 }
 
@@ -92,7 +93,7 @@ internal static class IssueSuggestionCommentManager {
 
             return matches.Max();
         } catch (Exception ex) {
-            Console.Error.WriteLine($"Warning: failed to parse PR comments JSON for {repo}#{pullRequestNumber}: {ex.Message}");
+            Console.Error.WriteLine($"Warning: failed to parse issue comments JSON for {repo}#{issueNumber}: {ex.Message}");
             return null;
         }
     }

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -23,6 +23,13 @@ internal static class ProjectSyncRunner {
         string Reason
     );
 
+    internal sealed record RelatedPullRequestCandidate(
+        int Number,
+        string Url,
+        double Confidence,
+        string Reason
+    );
+
     internal sealed record PullRequestDecisionSignals(
         bool? IsDraft,
         string? Mergeable,
@@ -149,7 +156,8 @@ internal static class ProjectSyncRunner {
         var updatedFieldValues = 0;
         var skippedMissing = 0;
         var labeled = 0;
-        var commentUpserts = 0;
+        var prCommentUpserts = 0;
+        var issueCommentUpserts = 0;
 
         foreach (var entry in entries) {
             processed++;
@@ -205,11 +213,33 @@ internal static class ProjectSyncRunner {
                     options.LinkCommentMaxIssues);
                 if (!string.IsNullOrWhiteSpace(comment)) {
                     if (options.DryRun) {
-                        commentUpserts++;
+                        prCommentUpserts++;
                     } else if (await IssueSuggestionCommentManager.UpsertAsync(options.Repo, entry.Number, comment)
                                    .ConfigureAwait(false)) {
-                        commentUpserts++;
+                        prCommentUpserts++;
                     }
+                }
+            }
+        }
+
+        if (options.ApplyLinkComments) {
+            var issueBacklinkComments = BuildIssueBacklinkSuggestionComments(
+                entries,
+                options.LinkCommentMinConfidence,
+                options.LinkCommentMaxIssues);
+
+            foreach (var suggestion in issueBacklinkComments) {
+                if (options.DryRun) {
+                    issueCommentUpserts++;
+                    continue;
+                }
+
+                if (await IssueSuggestionCommentManager.UpsertAsync(
+                        options.Repo,
+                        suggestion.Key,
+                        suggestion.Value,
+                        IssueSuggestionCommentManager.IssueBacklinkCommentMarker).ConfigureAwait(false)) {
+                    issueCommentUpserts++;
                 }
             }
         }
@@ -222,7 +252,8 @@ internal static class ProjectSyncRunner {
             Console.WriteLine($"Items labeled: {labeled}");
         }
         if (options.ApplyLinkComments) {
-            Console.WriteLine($"PR suggestion comments upserted: {commentUpserts}");
+            Console.WriteLine($"PR suggestion comments upserted: {prCommentUpserts}");
+            Console.WriteLine($"Issue backlink comments upserted: {issueCommentUpserts}");
         }
         Console.WriteLine($"Skipped unresolved items: {skippedMissing}");
         Console.WriteLine(options.DryRun ? "Dry run complete (no project updates were written)." : "Project sync complete.");
@@ -346,7 +377,7 @@ internal static class ProjectSyncRunner {
         Console.WriteLine("  --apply-labels           Apply IX labels to PRs/issues from synced signals");
         Console.WriteLine("  --ensure-labels          Ensure IX labels exist before applying labels (default)");
         Console.WriteLine("  --no-ensure-labels       Skip label ensure step");
-        Console.WriteLine("  --apply-link-comments    Upsert one marker comment on PRs with related issue suggestions");
+        Console.WriteLine("  --apply-link-comments    Upsert marker comments on PRs (related issues) and issues (related PRs)");
         Console.WriteLine("  --link-comment-min-confidence <0-1>  Min confidence for suggestion comments (default: 0.55)");
         Console.WriteLine("  --link-comment-max-issues <n>  Max related issues to include per PR comment (1-10, default: 3)");
         Console.WriteLine("  --dry-run                Compute sync plan without writing project changes");
@@ -862,6 +893,101 @@ internal static class ProjectSyncRunner {
         foreach (var candidate in related) {
             var reason = NormalizeCommentReason(candidate.Reason);
             lines.Add($"- #{candidate.Number} ({candidate.Url}) - confidence {candidate.Confidence.ToString("0.00", CultureInfo.InvariantCulture)} - {reason}");
+        }
+
+        return string.Join(Environment.NewLine, lines).TrimEnd() + Environment.NewLine;
+    }
+
+    internal static IReadOnlyDictionary<int, string> BuildIssueBacklinkSuggestionComments(
+        IReadOnlyList<ProjectSyncEntry> entries,
+        double minConfidence,
+        int maxPullRequestsPerIssue) {
+        var threshold = Math.Clamp(minConfidence, 0.0, 1.0);
+        var issueToCandidates = new Dictionary<int, Dictionary<int, RelatedPullRequestCandidate>>();
+
+        foreach (var entry in entries) {
+            if (!entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase) || entry.Number <= 0) {
+                continue;
+            }
+
+            var related = (entry.RelatedIssues ?? Array.Empty<RelatedIssueCandidate>())
+                .Where(candidate => candidate.Number > 0 &&
+                                    candidate.Confidence >= threshold &&
+                                    !string.IsNullOrWhiteSpace(candidate.Url))
+                .ToList();
+            if (related.Count == 0) {
+                continue;
+            }
+
+            foreach (var candidate in related) {
+                if (!issueToCandidates.TryGetValue(candidate.Number, out var prMap)) {
+                    prMap = new Dictionary<int, RelatedPullRequestCandidate>();
+                    issueToCandidates[candidate.Number] = prMap;
+                }
+
+                if (prMap.TryGetValue(entry.Number, out var existing) &&
+                    existing.Confidence >= candidate.Confidence) {
+                    continue;
+                }
+
+                prMap[entry.Number] = new RelatedPullRequestCandidate(
+                    Number: entry.Number,
+                    Url: entry.Url,
+                    Confidence: candidate.Confidence,
+                    Reason: candidate.Reason
+                );
+            }
+        }
+
+        var comments = new Dictionary<int, string>();
+        foreach (var issueCandidates in issueToCandidates) {
+            var candidates = issueCandidates.Value.Values.ToList();
+            var comment = BuildIssueBacklinkSuggestionComment(
+                issueCandidates.Key,
+                candidates,
+                threshold,
+                maxPullRequestsPerIssue);
+            if (!string.IsNullOrWhiteSpace(comment)) {
+                comments[issueCandidates.Key] = comment;
+            }
+        }
+
+        return comments;
+    }
+
+    internal static string? BuildIssueBacklinkSuggestionComment(
+        int issueNumber,
+        IReadOnlyList<RelatedPullRequestCandidate> candidates,
+        double minConfidence,
+        int maxPullRequests) {
+        if (issueNumber <= 0 || candidates.Count == 0) {
+            return null;
+        }
+
+        var limit = Math.Max(1, Math.Min(maxPullRequests, 10));
+        var filtered = candidates
+            .Where(candidate => candidate.Number > 0 &&
+                                candidate.Confidence >= minConfidence &&
+                                !string.IsNullOrWhiteSpace(candidate.Url))
+            .OrderByDescending(candidate => candidate.Confidence)
+            .ThenBy(candidate => candidate.Number)
+            .Take(limit)
+            .ToList();
+        if (filtered.Count == 0) {
+            return null;
+        }
+
+        var lines = new List<string> {
+            IssueSuggestionCommentManager.IssueBacklinkCommentMarker,
+            $"### IntelligenceX Related Pull Request Suggestions for #{issueNumber.ToString(CultureInfo.InvariantCulture)}",
+            string.Empty,
+            $"Automated PR candidates (confidence >= {minConfidence.ToString("0.00", CultureInfo.InvariantCulture)}). Please verify before linking/closing.",
+            string.Empty
+        };
+
+        foreach (var candidate in filtered) {
+            var reason = NormalizeCommentReason(candidate.Reason);
+            lines.Add($"- PR #{candidate.Number} ({candidate.Url}) - confidence {candidate.Confidence.ToString("0.00", CultureInfo.InvariantCulture)} - {reason}");
         }
 
         return string.Join(Environment.NewLine, lines).TrimEnd() + Environment.NewLine;

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -300,6 +300,76 @@ internal static partial class Program {
         AssertEqual(true, string.IsNullOrWhiteSpace(comment), "no comment for weak matches");
     }
 
+    private static void TestProjectSyncBuildIssueBacklinkSuggestionCommentsAggregatesPullRequests() {
+        var entries = new[] {
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 70,
+                Url: "https://github.com/EvotecIT/IntelligenceX/pull/70",
+                Kind: "pull_request",
+                TriageScore: 71.5,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "feature",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: "https://github.com/EvotecIT/IntelligenceX/issues/15",
+                MatchedIssueConfidence: 0.93,
+                VisionFit: "aligned",
+                VisionConfidence: 0.78,
+                RelatedIssues: new[] {
+                    new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(15, "https://github.com/EvotecIT/IntelligenceX/issues/15", 0.93, "explicit issue reference"),
+                    new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(22, "https://github.com/EvotecIT/IntelligenceX/issues/22", 0.57, "token overlap")
+                }
+            ),
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 71,
+                Url: "https://github.com/EvotecIT/IntelligenceX/pull/71",
+                Kind: "pull_request",
+                TriageScore: 66.0,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "feature",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: "https://github.com/EvotecIT/IntelligenceX/issues/15",
+                MatchedIssueConfidence: 0.62,
+                VisionFit: "needs-human-review",
+                VisionConfidence: 0.55,
+                RelatedIssues: new[] {
+                    new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(15, "https://github.com/EvotecIT/IntelligenceX/issues/15", 0.62, "token overlap")
+                }
+            )
+        };
+
+        var comments = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildIssueBacklinkSuggestionComments(
+            entries,
+            minConfidence: 0.55,
+            maxPullRequestsPerIssue: 3);
+
+        AssertEqual(true, comments.ContainsKey(15), "issue 15 has backlink comment");
+        var issue15 = comments[15];
+        AssertContainsText(issue15, "<!-- intelligencex:issue-pr-suggestions -->", "issue marker present");
+        AssertContainsText(issue15, "PR #70", "top PR included");
+        AssertContainsText(issue15, "PR #71", "second PR included");
+    }
+
+    private static void TestProjectSyncBuildIssueBacklinkSuggestionCommentRespectsThresholdAndLimit() {
+        var candidates = new[] {
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedPullRequestCandidate(81, "https://github.com/EvotecIT/IntelligenceX/pull/81", 0.91, "explicit"),
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedPullRequestCandidate(82, "https://github.com/EvotecIT/IntelligenceX/pull/82", 0.74, "token overlap"),
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedPullRequestCandidate(83, "https://github.com/EvotecIT/IntelligenceX/pull/83", 0.44, "weak overlap")
+        };
+
+        var comment = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildIssueBacklinkSuggestionComment(
+            issueNumber: 30,
+            candidates: candidates,
+            minConfidence: 0.55,
+            maxPullRequests: 1);
+
+        AssertEqual(true, !string.IsNullOrWhiteSpace(comment), "issue backlink comment generated");
+        AssertContainsText(comment ?? string.Empty, "PR #81", "top confidence PR kept");
+        AssertEqual(false, (comment ?? string.Empty).Contains("PR #82", StringComparison.OrdinalIgnoreCase), "limited to maxPullRequests");
+        AssertEqual(false, (comment ?? string.Empty).Contains("PR #83", StringComparison.OrdinalIgnoreCase), "below threshold excluded");
+    }
+
     private static void TestProjectSyncBuildRelatedIssuesFieldValueOrdersAndLimitsCandidates() {
         var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
             Number: 57,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -456,6 +456,8 @@ internal static partial class Program {
         failed += Run("Todo project sync decision suggests defer for blocked PR", TestProjectSyncBuildEntriesSuggestsDeferForBlockedPr);
         failed += Run("Todo project sync comment filters by confidence", TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence);
         failed += Run("Todo project sync comment omitted for weak candidates", TestProjectSyncBuildIssueMatchSuggestionCommentReturnsNullWithoutQualifiedCandidates);
+        failed += Run("Todo project sync issue backlink comments aggregate PRs", TestProjectSyncBuildIssueBacklinkSuggestionCommentsAggregatesPullRequests);
+        failed += Run("Todo project sync issue backlink comment threshold and limit", TestProjectSyncBuildIssueBacklinkSuggestionCommentRespectsThresholdAndLimit);
         failed += Run("Todo project sync related issues field value", TestProjectSyncBuildRelatedIssuesFieldValueOrdersAndLimitsCandidates);
         failed += Run("Todo project bootstrap renders project target", TestProjectBootstrapRenderWorkflowTemplateInjectsProjectTarget);
         failed += Run("Todo project bootstrap clamps max items", TestProjectBootstrapRenderWorkflowTemplateClampsMaxItems);


### PR DESCRIPTION
## Summary
- extend `todo project-sync --apply-link-comments` from PR-only comments to bidirectional link suggestions
- keep existing PR comment behavior (`PR -> related issues`) and add issue-side backlink comments (`Issue -> related PRs`)
- aggregate issue backlink comments across matching PRs to avoid comment spam and keep one managed marker comment per issue
- make comment manager marker-aware so PR and issue comment streams are independently managed

## Behavior
- PR comments continue to use marker: `<!-- intelligencex:pr-issue-suggestions -->`
- Issue backlink comments use marker: `<!-- intelligencex:issue-pr-suggestions -->`
- Both honor `--link-comment-min-confidence` and `--link-comment-max-issues`
- CLI output now reports both counters:
  - `PR suggestion comments upserted`
  - `Issue backlink comments upserted`

## Tests
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`

Added tests:
- issue backlink aggregation across multiple PRs
- issue backlink threshold/limit behavior

## Docs
- update `Docs/cli/todo.md` option docs for `--apply-link-comments` to describe bidirectional comments
