### PR TITLE
todo: add decision labels for project sync suggestions

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -133,7 +133,7 @@ intelligencex todo project-sync \
 Useful options:
 - `--config <path>` to resolve owner/project from `project-init` output.
 - `--ensure-fields` / `--no-ensure-fields`.
-- `--apply-labels` to apply IX labels (`ix/category:*`, `ix/vision:*`, `ix/match:*`) on PRs/issues.
+- `--apply-labels` to apply IX labels (`ix/category:*`, `ix/vision:*`, `ix/match:*`, `ix/decision:*`) on PRs/issues.
 - `--ensure-labels` / `--no-ensure-labels` for label taxonomy management.
 - `--apply-link-comments` to upsert assistive link comments on PRs (related issues) and issues (related PRs).
 - `--project-item-scan-limit <n>` for larger projects.

--- a/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
@@ -50,6 +50,10 @@ internal static class ProjectLabelCatalog {
 
         new ProjectLabelDefinition("ix/match:linked-issue", "0366d6", "PR has a high-confidence related issue."),
         new ProjectLabelDefinition("ix/match:needs-review", "fbca04", "PR has a low-confidence issue match that needs maintainer review."),
+        new ProjectLabelDefinition("ix/decision:accept", "0e8a16", "IX suggested decision is accept."),
+        new ProjectLabelDefinition("ix/decision:defer", "fbca04", "IX suggested decision is defer."),
+        new ProjectLabelDefinition("ix/decision:reject", "d73a4a", "IX suggested decision is reject."),
+        new ProjectLabelDefinition("ix/decision:merge-candidate", "1d76db", "IX suggested decision is merge-candidate."),
         new ProjectLabelDefinition("ix/duplicate:clustered", "f9d0c4", "Item is part of a duplicate cluster.")
     };
 

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -839,6 +839,11 @@ internal static class ProjectSyncRunner {
             }
         }
 
+        var decisionLabel = MapSuggestedDecisionLabel(entry.SuggestedDecision);
+        if (!string.IsNullOrWhiteSpace(decisionLabel) && entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
+            labels.Add(decisionLabel);
+        }
+
         if (!string.IsNullOrWhiteSpace(entry.DuplicateCluster)) {
             labels.Add("ix/duplicate:clustered");
         }
@@ -998,6 +1003,16 @@ internal static class ProjectSyncRunner {
             "aligned" => "ix/vision:aligned",
             "needs-human-review" => "ix/vision:needs-review",
             "likely-out-of-scope" => "ix/vision:out-of-scope",
+            _ => null
+        };
+    }
+
+    private static string? MapSuggestedDecisionLabel(string? suggestedDecision) {
+        return suggestedDecision?.ToLowerInvariant() switch {
+            "accept" => "ix/decision:accept",
+            "defer" => "ix/decision:defer",
+            "reject" => "ix/decision:reject",
+            "merge-candidate" => "ix/decision:merge-candidate",
             _ => null
         };
     }

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -21,6 +21,16 @@ internal static partial class Program {
         AssertEqual(true, names.Contains("Maintainer Decision", StringComparer.OrdinalIgnoreCase), "has Maintainer Decision");
     }
 
+    private static void TestProjectLabelCatalogDefaultsIncludeDecisionLabels() {
+        var labels = IntelligenceX.Cli.Todo.ProjectLabelCatalog.DefaultLabels
+            .Select(label => label.Name)
+            .ToList();
+        AssertEqual(true, labels.Contains("ix/decision:accept", StringComparer.OrdinalIgnoreCase), "decision accept label");
+        AssertEqual(true, labels.Contains("ix/decision:defer", StringComparer.OrdinalIgnoreCase), "decision defer label");
+        AssertEqual(true, labels.Contains("ix/decision:reject", StringComparer.OrdinalIgnoreCase), "decision reject label");
+        AssertEqual(true, labels.Contains("ix/decision:merge-candidate", StringComparer.OrdinalIgnoreCase), "decision merge-candidate label");
+    }
+
     private static void TestProjectSyncBuildEntriesMergesVisionAndCanonical() {
         const string triageJson = """
 {
@@ -216,7 +226,8 @@ internal static partial class Program {
             MatchedIssueUrl: "https://github.com/EvotecIT/IntelligenceX/issues/10",
             MatchedIssueConfidence: 0.95,
             VisionFit: "aligned",
-            VisionConfidence: 0.9
+            VisionConfidence: 0.9,
+            SuggestedDecision: "merge-candidate"
         );
 
         var labels = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildLabelsForEntry(entry);
@@ -226,6 +237,7 @@ internal static partial class Program {
         AssertEqual(false, labels.Any(label => label.Contains("unknown-tag", StringComparison.OrdinalIgnoreCase)), "unsupported tag skipped");
         AssertEqual(true, labels.Contains("ix/match:linked-issue", StringComparer.OrdinalIgnoreCase), "high confidence match label");
         AssertEqual(false, labels.Contains("ix/match:needs-review", StringComparer.OrdinalIgnoreCase), "no review label for high confidence");
+        AssertEqual(true, labels.Contains("ix/decision:merge-candidate", StringComparer.OrdinalIgnoreCase), "decision label");
         AssertEqual(true, labels.Contains("ix/duplicate:clustered", StringComparer.OrdinalIgnoreCase), "duplicate label");
     }
 
@@ -242,12 +254,14 @@ internal static partial class Program {
             MatchedIssueUrl: "https://github.com/EvotecIT/IntelligenceX/issues/99",
             MatchedIssueConfidence: 0.62,
             VisionFit: null,
-            VisionConfidence: null
+            VisionConfidence: null,
+            SuggestedDecision: "defer"
         );
 
         var labels = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildLabelsForEntry(entry);
         AssertEqual(true, labels.Contains("ix/match:needs-review", StringComparer.OrdinalIgnoreCase), "low confidence match review label");
         AssertEqual(false, labels.Contains("ix/match:linked-issue", StringComparer.OrdinalIgnoreCase), "low confidence should not be linked-issue");
+        AssertEqual(true, labels.Contains("ix/decision:defer", StringComparer.OrdinalIgnoreCase), "decision defer label");
     }
 
     private static void TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence() {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -449,6 +449,7 @@ internal static partial class Program {
         failed += Run("Todo vision check explicit reject policy precedence", TestVisionCheckExplicitRejectPolicyTakesPrecedence);
         failed += Run("Todo vision check explicit policy prefix parsing", TestVisionCheckParseSignalsSupportsExplicitPolicyPrefixes);
         failed += Run("Todo project fields defaults", TestProjectFieldCatalogDefaultsIncludeVisionAndDecisionFields);
+        failed += Run("Todo project labels include decision taxonomy", TestProjectLabelCatalogDefaultsIncludeDecisionLabels);
         failed += Run("Todo project sync merges vision and canonical", TestProjectSyncBuildEntriesMergesVisionAndCanonical);
         failed += Run("Todo project sync labels include tags and high-confidence match", TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch);
         failed += Run("Todo project sync labels mark low-confidence match for review", TestProjectSyncBuildLabelsUsesNeedsReviewForLowConfidenceIssueMatch);


### PR DESCRIPTION
## Summary
- add `ix/decision:*` labels to the default IX label taxonomy
- map `SuggestedDecision` values to decision labels during `todo project-sync` label application for PR items
- extend tests to verify taxonomy registration and decision label emission
- update CLI docs to include decision labels in `--apply-labels` behavior

## Why
This gives maintainers a direct label-based filter for AI decision signals (`accept`, `defer`, `reject`, `merge-candidate`) and keeps project views/automation easier to build on top of GitHub labels.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`