### PR TITLE
Improve pending action recovery for single numbered choices

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
@@ -863,7 +863,7 @@ internal sealed partial class ChatServiceSession {
 
         var lines = SplitLines(text);
         var inFence = false;
-        var candidateTitles = new List<string>();
+        var candidateChoices = new List<(string Title, bool IsNumbered)>();
         var candidateStartLine = -1;
         for (var i = 0; i < lines.Count; i++) {
             var trimmedLine = (lines[i] ?? string.Empty).Trim();
@@ -876,31 +876,54 @@ internal sealed partial class ChatServiceSession {
                 continue;
             }
 
-            if (TryExtractFallbackChoiceTitle(trimmedLine, out var title)) {
+            if (TryExtractFallbackChoiceTitle(trimmedLine, out var title, out var isNumbered)) {
                 if (candidateStartLine < 0) {
                     candidateStartLine = i;
                 }
-                candidateTitles.Add(title);
+                candidateChoices.Add((title, isNumbered));
                 continue;
             }
 
-            if (candidateTitles.Count >= 2 && LooksLikeFallbackChoicePromptContext(lines, candidateStartLine)) {
-                return BuildFallbackChoicePendingActions(candidateTitles);
+            if (ShouldBuildFallbackChoiceActions(candidateChoices, lines, candidateStartLine)) {
+                return BuildFallbackChoicePendingActions(candidateChoices.Select(static c => c.Title).ToArray());
             }
 
-            candidateTitles.Clear();
+            candidateChoices.Clear();
             candidateStartLine = -1;
         }
 
-        if (candidateTitles.Count >= 2 && LooksLikeFallbackChoicePromptContext(lines, candidateStartLine)) {
-            return BuildFallbackChoicePendingActions(candidateTitles);
+        if (ShouldBuildFallbackChoiceActions(candidateChoices, lines, candidateStartLine)) {
+            return BuildFallbackChoicePendingActions(candidateChoices.Select(static c => c.Title).ToArray());
         }
 
         return new List<PendingAction>();
     }
 
-    private static bool TryExtractFallbackChoiceTitle(string trimmedLine, out string title) {
+    private static bool ShouldBuildFallbackChoiceActions(
+        IReadOnlyList<(string Title, bool IsNumbered)> choices,
+        IReadOnlyList<string> lines,
+        int firstChoiceLine) {
+        if (!LooksLikeFallbackChoicePromptContext(lines, firstChoiceLine)) {
+            return false;
+        }
+
+        if (choices is null || choices.Count == 0) {
+            return false;
+        }
+
+        if (choices.Count >= 2) {
+            return true;
+        }
+
+        // Single-option fallback is intentionally conservative:
+        // only allow it for explicitly numbered option lines (e.g., "1. ..."),
+        // which usually represent an actionable "pick this" list.
+        return choices.Count == 1 && choices[0].IsNumbered;
+    }
+
+    private static bool TryExtractFallbackChoiceTitle(string trimmedLine, out string title, out bool isNumbered) {
         title = string.Empty;
+        isNumbered = false;
         if (string.IsNullOrWhiteSpace(trimmedLine)) {
             return false;
         }
@@ -931,6 +954,7 @@ internal sealed partial class ChatServiceSession {
                     && char.IsWhiteSpace(value[idx + 1])) {
                     value = value[(idx + 2)..].Trim();
                     startsWithBullet = true;
+                    isNumbered = true;
                 }
             }
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
@@ -349,6 +349,39 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ExpandContinuationUserRequest_ResolvesSingleNumberedFallbackChoiceWithPromptContext() {
+        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var assistantDraft = """
+            Pulling failed logons from ADO now would be the next step, but I need your go-ahead in this flow:
+            1. Run failed logon report (4625) on ADO Security
+            """;
+
+        RememberPendingActionsMethod.Invoke(session, new object?[] { "thread-001", assistantDraft });
+        var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", "go ahead and run it" });
+        var expanded = Assert.IsType<string>(result);
+
+        using var doc = JsonDocument.Parse(expanded);
+        var selection = doc.RootElement.GetProperty("ix_action_selection");
+        Assert.Equal("choice_001", selection.GetProperty("id").GetString());
+        Assert.Equal("Run failed logon report (4625) on ADO Security", selection.GetProperty("request").GetString());
+    }
+
+    [Fact]
+    public void ExpandContinuationUserRequest_DoesNotResolveSingleBulletFallbackChoiceWithPromptContext() {
+        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var assistantDraft = """
+            Pulling failed logons from ADO now would be the next step, but I need your go-ahead in this flow:
+            - Run failed logon report (4625) on ADO Security
+            """;
+
+        RememberPendingActionsMethod.Invoke(session, new object?[] { "thread-001", assistantDraft });
+        var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", "go ahead and run it" });
+        var expanded = Assert.IsType<string>(result);
+
+        Assert.Equal("go ahead and run it", expanded);
+    }
+
+    [Fact]
     public void RememberPendingActions_NoMarkerOrFallbackChoices_DoesNotClearExistingActionContext() {
         var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
         var actionDraft = """


### PR DESCRIPTION
## Summary
- extend fallback pending-action extraction to accept a single numbered option when prompt context indicates an action-choice list
- keep single bullet-only fallback disabled to avoid over-eager matches
- add routing tests for both the positive (single numbered option) and negative (single bullet option) paths

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRoutingTrimTests"
