### PR TITLE
todo: support dynamic category and tag labels in project sync

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -133,7 +133,7 @@ intelligencex todo project-sync \
 Useful options:
 - `--config <path>` to resolve owner/project from `project-init` output.
 - `--ensure-fields` / `--no-ensure-fields`.
-- `--apply-labels` to apply IX labels (`ix/category:*`, `ix/vision:*`, `ix/match:*`, `ix/decision:*`) on PRs/issues.
+- `--apply-labels` to apply IX labels (`ix/category:*`, `ix/tag:*`, `ix/vision:*`, `ix/match:*`, `ix/decision:*`) on PRs/issues.
 - `--ensure-labels` / `--no-ensure-labels` for label taxonomy management.
 - `--apply-link-comments` to upsert assistive link comments on PRs (related issues) and issues (related PRs).
 - `--project-item-scan-limit <n>` for larger projects.
@@ -142,6 +142,7 @@ Useful options:
 Behavior:
 - `IX Suggested Decision` is populated automatically (`accept`, `defer`, `reject`, `merge-candidate`) from combined triage + vision signals.
 - `Maintainer Decision` remains human-owned for final triage decisions.
+- Unknown categories/tags are normalized into dynamic labels (for example `ML Ops` -> `ix/category:ml-ops`, `Release Candidate` -> `ix/tag:release-candidate`) and are auto-created when `--apply-labels --ensure-labels` is used.
 
 ## Bootstrap project + workflow (recommended first run)
 

--- a/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace IntelligenceX.Cli.Todo;
 
@@ -10,17 +11,47 @@ internal sealed record ProjectLabelDefinition(
 );
 
 internal static class ProjectLabelCatalog {
+    private const int MaxNormalizedTokenLength = 38;
+    private static readonly IReadOnlyDictionary<string, string> CategoryToLabel = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+        ["bug"] = "ix/category:bug",
+        ["feature"] = "ix/category:feature",
+        ["documentation"] = "ix/category:documentation",
+        ["docs"] = "ix/category:documentation",
+        ["maintenance"] = "ix/category:maintenance",
+        ["security"] = "ix/category:security",
+        ["performance"] = "ix/category:performance",
+        ["testing"] = "ix/category:testing",
+        ["ci"] = "ix/category:ci"
+    };
+
     private static readonly IReadOnlyDictionary<string, string> TagToLabel = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
         ["security"] = "ix/tag:security",
         ["bugfix"] = "ix/tag:bugfix",
+        ["bug-fix"] = "ix/tag:bugfix",
         ["performance"] = "ix/tag:performance",
         ["docs"] = "ix/tag:docs",
+        ["doc"] = "ix/tag:docs",
+        ["documentation"] = "ix/tag:docs",
         ["testing"] = "ix/tag:testing",
+        ["test"] = "ix/tag:testing",
+        ["tests"] = "ix/tag:testing",
         ["ci"] = "ix/tag:ci",
         ["maintenance"] = "ix/tag:maintenance",
         ["api"] = "ix/tag:api",
         ["ux"] = "ix/tag:ux",
-        ["dependencies"] = "ix/tag:dependencies"
+        ["dependencies"] = "ix/tag:dependencies",
+        ["dependency"] = "ix/tag:dependencies"
+    };
+
+    private static readonly string[] DynamicLabelPalette = {
+        "5319e7",
+        "1d76db",
+        "0052cc",
+        "0e8a16",
+        "fbca04",
+        "d73a4a",
+        "6f42c1",
+        "b60205"
     };
 
     public static readonly IReadOnlyList<ProjectLabelDefinition> DefaultLabels = new[] {
@@ -57,12 +88,133 @@ internal static class ProjectLabelCatalog {
         new ProjectLabelDefinition("ix/duplicate:clustered", "f9d0c4", "Item is part of a duplicate cluster.")
     };
 
-    public static bool TryMapTagLabel(string tag, out string label) {
-        if (string.IsNullOrWhiteSpace(tag)) {
-            label = string.Empty;
+    public static bool TryMapCategoryLabel(string category, out string label) {
+        label = string.Empty;
+        if (!TryNormalizeToken(category, out var normalized)) {
             return false;
         }
 
-        return TagToLabel.TryGetValue(tag.Trim(), out label!);
+        if (CategoryToLabel.TryGetValue(normalized, out var knownLabel)) {
+            label = knownLabel;
+            return true;
+        }
+
+        label = $"ix/category:{normalized}";
+        return true;
+    }
+
+    public static bool TryMapTagLabel(string tag, out string label) {
+        label = string.Empty;
+        if (!TryNormalizeToken(tag, out var normalized)) {
+            return false;
+        }
+
+        if (TagToLabel.TryGetValue(normalized, out var knownLabel)) {
+            label = knownLabel;
+            return true;
+        }
+
+        label = $"ix/tag:{normalized}";
+        return true;
+    }
+
+    public static IReadOnlyList<ProjectLabelDefinition> BuildEnsureLabelCatalog(
+        IEnumerable<string?> categories,
+        IEnumerable<string?> tags) {
+        var byName = DefaultLabels.ToDictionary(label => label.Name, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var category in categories) {
+            if (!TryBuildDynamicCategoryLabelDefinition(category, out var definition)) {
+                continue;
+            }
+            byName[definition.Name] = definition;
+        }
+
+        foreach (var tag in tags) {
+            if (!TryBuildDynamicTagLabelDefinition(tag, out var definition)) {
+                continue;
+            }
+            byName[definition.Name] = definition;
+        }
+
+        return byName.Values
+            .OrderBy(label => label.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static bool TryBuildDynamicCategoryLabelDefinition(string? category, out ProjectLabelDefinition definition) {
+        definition = default!;
+        if (!TryNormalizeToken(category, out var normalized) || CategoryToLabel.ContainsKey(normalized)) {
+            return false;
+        }
+
+        var labelName = $"ix/category:{normalized}";
+        definition = new ProjectLabelDefinition(
+            labelName,
+            ResolveDynamicColor(labelName),
+            $"Triage category: {normalized}");
+        return true;
+    }
+
+    private static bool TryBuildDynamicTagLabelDefinition(string? tag, out ProjectLabelDefinition definition) {
+        definition = default!;
+        if (!TryNormalizeToken(tag, out var normalized) || TagToLabel.ContainsKey(normalized)) {
+            return false;
+        }
+
+        var labelName = $"ix/tag:{normalized}";
+        definition = new ProjectLabelDefinition(
+            labelName,
+            ResolveDynamicColor(labelName),
+            $"Triage tag: {normalized}");
+        return true;
+    }
+
+    private static bool TryNormalizeToken(string? value, out string normalized) {
+        normalized = string.Empty;
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        var buffer = new char[Math.Min(MaxNormalizedTokenLength, value.Length * 2)];
+        var length = 0;
+        var previousDash = false;
+        foreach (var character in value.Trim().ToLowerInvariant()) {
+            if ((character >= 'a' && character <= 'z') || (character >= '0' && character <= '9')) {
+                if (length < buffer.Length) {
+                    buffer[length++] = character;
+                }
+                previousDash = false;
+                continue;
+            }
+
+            if (!previousDash && length > 0) {
+                if (length < buffer.Length) {
+                    buffer[length++] = '-';
+                }
+                previousDash = true;
+            }
+        }
+
+        while (length > 0 && buffer[length - 1] == '-') {
+            length--;
+        }
+        if (length <= 0) {
+            return false;
+        }
+
+        normalized = new string(buffer, 0, length);
+        return true;
+    }
+
+    private static string ResolveDynamicColor(string labelName) {
+        uint hash = 2166136261;
+        foreach (var character in labelName) {
+            hash ^= character;
+            hash *= 16777619;
+        }
+
+        var index = (int)(hash % (uint)DynamicLabelPalette.Length);
+        return DynamicLabelPalette[index];
     }
 }

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -143,7 +143,10 @@ internal static class ProjectSyncRunner {
 
         if (options.ApplyLabels && options.EnsureLabels && !options.DryRun) {
             try {
-                await RepositoryLabelManager.EnsureLabelsAsync(options.Repo, ProjectLabelCatalog.DefaultLabels).ConfigureAwait(false);
+                var labelsToEnsure = ProjectLabelCatalog.BuildEnsureLabelCatalog(
+                    entries.Select(entry => entry.Category),
+                    entries.SelectMany(entry => entry.Tags));
+                await RepositoryLabelManager.EnsureLabelsAsync(options.Repo, labelsToEnsure).ConfigureAwait(false);
             } catch (Exception ex) {
                 Console.Error.WriteLine($"Failed to ensure labels before apply-labels: {ex.Message}");
                 return 1;
@@ -815,8 +818,8 @@ internal static class ProjectSyncRunner {
     internal static IReadOnlyList<string> BuildLabelsForEntry(ProjectSyncEntry entry) {
         var labels = new List<string>();
 
-        if (!string.IsNullOrWhiteSpace(entry.Category)) {
-            labels.Add($"ix/category:{entry.Category}");
+        if (ProjectLabelCatalog.TryMapCategoryLabel(entry.Category ?? string.Empty, out var categoryLabel)) {
+            labels.Add(categoryLabel);
         }
 
         foreach (var tag in entry.Tags) {

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -31,6 +31,19 @@ internal static partial class Program {
         AssertEqual(true, labels.Contains("ix/decision:merge-candidate", StringComparer.OrdinalIgnoreCase), "decision merge-candidate label");
     }
 
+    private static void TestProjectLabelCatalogBuildEnsureCatalogIncludesDynamicCategoryAndTags() {
+        var labels = IntelligenceX.Cli.Todo.ProjectLabelCatalog.BuildEnsureLabelCatalog(
+            categories: new[] { "security", "ML Ops" },
+            tags: new[] { "docs", "Release Candidate", "unknown-tag" });
+
+        AssertEqual(true, labels.Any(label => label.Name.Equals("ix/category:security", StringComparison.OrdinalIgnoreCase)), "known category label present");
+        AssertEqual(true, labels.Any(label => label.Name.Equals("ix/category:ml-ops", StringComparison.OrdinalIgnoreCase)), "dynamic category label present");
+        AssertEqual(true, labels.Any(label => label.Name.Equals("ix/tag:docs", StringComparison.OrdinalIgnoreCase)), "known tag label present");
+        AssertEqual(true, labels.Any(label => label.Name.Equals("ix/tag:release-candidate", StringComparison.OrdinalIgnoreCase)), "dynamic normalized tag label present");
+        AssertEqual(true, labels.Any(label => label.Name.Equals("ix/tag:unknown-tag", StringComparison.OrdinalIgnoreCase)), "dynamic passthrough tag label present");
+        AssertEqual(1, labels.Count(label => label.Name.Equals("ix/tag:docs", StringComparison.OrdinalIgnoreCase)), "known tag label deduped");
+    }
+
     private static void TestProjectSyncBuildEntriesMergesVisionAndCanonical() {
         const string triageJson = """
 {
@@ -234,11 +247,33 @@ internal static partial class Program {
         AssertEqual(true, labels.Contains("ix/category:security", StringComparer.OrdinalIgnoreCase), "category label");
         AssertEqual(true, labels.Contains("ix/tag:security", StringComparer.OrdinalIgnoreCase), "security tag label");
         AssertEqual(true, labels.Contains("ix/tag:api", StringComparer.OrdinalIgnoreCase), "api tag label");
-        AssertEqual(false, labels.Any(label => label.Contains("unknown-tag", StringComparison.OrdinalIgnoreCase)), "unsupported tag skipped");
+        AssertEqual(true, labels.Contains("ix/tag:unknown-tag", StringComparer.OrdinalIgnoreCase), "dynamic tag label");
         AssertEqual(true, labels.Contains("ix/match:linked-issue", StringComparer.OrdinalIgnoreCase), "high confidence match label");
         AssertEqual(false, labels.Contains("ix/match:needs-review", StringComparer.OrdinalIgnoreCase), "no review label for high confidence");
         AssertEqual(true, labels.Contains("ix/decision:merge-candidate", StringComparer.OrdinalIgnoreCase), "decision label");
         AssertEqual(true, labels.Contains("ix/duplicate:clustered", StringComparer.OrdinalIgnoreCase), "duplicate label");
+    }
+
+    private static void TestProjectSyncBuildLabelsNormalizesDynamicCategoryAndTags() {
+        var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+            Number: 88,
+            Url: "https://github.com/EvotecIT/IntelligenceX/pull/88",
+            Kind: "pull_request",
+            TriageScore: 79.4,
+            DuplicateCluster: null,
+            CanonicalItem: null,
+            Category: "ML Ops",
+            Tags: new[] { "Release Candidate", "Docs" },
+            MatchedIssueUrl: null,
+            MatchedIssueConfidence: null,
+            VisionFit: null,
+            VisionConfidence: null
+        );
+
+        var labels = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildLabelsForEntry(entry);
+        AssertEqual(true, labels.Contains("ix/category:ml-ops", StringComparer.OrdinalIgnoreCase), "dynamic category label");
+        AssertEqual(true, labels.Contains("ix/tag:release-candidate", StringComparer.OrdinalIgnoreCase), "dynamic tag label");
+        AssertEqual(true, labels.Contains("ix/tag:docs", StringComparer.OrdinalIgnoreCase), "known normalized alias tag label");
     }
 
     private static void TestProjectSyncBuildLabelsUsesNeedsReviewForLowConfidenceIssueMatch() {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -450,8 +450,10 @@ internal static partial class Program {
         failed += Run("Todo vision check explicit policy prefix parsing", TestVisionCheckParseSignalsSupportsExplicitPolicyPrefixes);
         failed += Run("Todo project fields defaults", TestProjectFieldCatalogDefaultsIncludeVisionAndDecisionFields);
         failed += Run("Todo project labels include decision taxonomy", TestProjectLabelCatalogDefaultsIncludeDecisionLabels);
+        failed += Run("Todo project labels include dynamic category and tag taxonomy", TestProjectLabelCatalogBuildEnsureCatalogIncludesDynamicCategoryAndTags);
         failed += Run("Todo project sync merges vision and canonical", TestProjectSyncBuildEntriesMergesVisionAndCanonical);
         failed += Run("Todo project sync labels include tags and high-confidence match", TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch);
+        failed += Run("Todo project sync labels normalize dynamic category and tags", TestProjectSyncBuildLabelsNormalizesDynamicCategoryAndTags);
         failed += Run("Todo project sync labels mark low-confidence match for review", TestProjectSyncBuildLabelsUsesNeedsReviewForLowConfidenceIssueMatch);
         failed += Run("Todo project sync decision suggests merge-candidate", TestProjectSyncBuildEntriesSuggestsMergeCandidateForBestReadyPr);
         failed += Run("Todo project sync decision suggests defer for blocked PR", TestProjectSyncBuildEntriesSuggestsDeferForBlockedPr);


### PR DESCRIPTION
## Summary
- normalize unknown triage categories/tags into valid labels (for example `ML Ops` -> `ix/category:ml-ops`, `Release Candidate` -> `ix/tag:release-candidate`)
- keep known category/tag aliases mapped to canonical labels (`docs` -> `ix/tag:docs`, etc.)
- ensure dynamic labels are auto-created when running `todo project-sync --apply-labels --ensure-labels`
- update tests/docs to cover dynamic label mapping and ensure-catalog behavior

## Why
This makes label application reliable even when triage emits tags/categories outside the static taxonomy.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`