### PR TITLE
Allow single bullet fallback choices with explicit inline /act ids

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
@@ -919,7 +919,10 @@ internal sealed partial class ChatServiceSession {
         // Single-option fallback is intentionally conservative:
         // only allow it for explicitly numbered option lines (e.g., "1. ..."),
         // which usually represent an actionable "pick this" list.
-        return choices.Count == 1 && choices[0].IsNumbered;
+        // If a single bullet carries an explicit inline action id (/act <id>),
+        // it's also safe to route as an actionable follow-up.
+        return choices.Count == 1
+               && (choices[0].IsNumbered || !string.IsNullOrWhiteSpace(choices[0].ActionId));
     }
 
     private static bool TryExtractFallbackChoiceTitle(string trimmedLine, out string title, out bool isNumbered, out string actionId) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
@@ -382,6 +382,24 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ExpandContinuationUserRequest_ResolvesSingleBulletFallbackChoiceWithInlineActIdWithPromptContext() {
+        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var assistantDraft = """
+            Pulling failed logons from ADO now would be the next step, but I need your go-ahead in this flow:
+            - Run failed logon report (4625) on ADO Security (/act act_failed4625)
+            """;
+
+        RememberPendingActionsMethod.Invoke(session, new object?[] { "thread-001", assistantDraft });
+        var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", "go ahead and run it" });
+        var expanded = Assert.IsType<string>(result);
+
+        using var doc = JsonDocument.Parse(expanded);
+        var selection = doc.RootElement.GetProperty("ix_action_selection");
+        Assert.Equal("act_failed4625", selection.GetProperty("id").GetString());
+        Assert.Equal("Run failed logon report (4625) on ADO Security", selection.GetProperty("request").GetString());
+    }
+
+    [Fact]
     public void ExpandContinuationUserRequest_ResolvesSingleNumberedFallbackChoiceWithInlineActIdInParentheses() {
         var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
         var assistantDraft = """


### PR DESCRIPTION
## What
This follow-up reliability pass allows single fallback bullet choices to be actionable when they include an explicit inline `/act <id>` token.

## Why
We already parse inline action ids from fallback choices. But single-bullet fallback was still blocked unless the choice was numbered, which could still produce "I should run it" loops in compact bullet responses.

## Changes
- In single-choice fallback mode, keep the existing numbered-list allowance.
- Also allow single-bullet fallback if that bullet includes a parsed explicit action id.
- Keep all existing prompt-context and parsing guardrails.

## Tests
- Added regression: single bullet + inline `/act` + natural confirmation resolves to the explicit action id.
- Ran local preflight:
  - `dotnet build IntelligenceX.sln -c Release`
  - `dotnet test IntelligenceX.sln -c Release`
  - `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
  - `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
