### PR TITLE
todo: bootstrap control issue automation for project sync summaries

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -169,6 +169,9 @@ Useful options:
 - `--force-workflow-write` to overwrite an existing workflow file.
 - `--skip-vision-scaffold` to keep the bootstrap workflow only.
 - `--force-vision-write` to overwrite an existing vision file.
+- `--control-issue <n>` to point summaries at an existing GitHub issue by setting `IX_TRIAGE_CONTROL_ISSUE`.
+- `--create-control-issue` to create a new control issue and auto-set `IX_TRIAGE_CONTROL_ISSUE`.
+- `--control-issue-title <text>` to customize the created control issue title.
 
 ## GitHub Actions template
 
@@ -180,6 +183,7 @@ A reusable scheduled workflow template is available at:
 It runs `build-triage-index`, uploads artifacts, and can optionally post the markdown summary to a control issue
 when repository variable `IX_TRIAGE_CONTROL_ISSUE` is set.
 For `triage-project-sync.yml`, the posted comment includes both triage and vision markdown summaries.
+`todo project-bootstrap --create-control-issue` can set this variable for you automatically.
 
 ## Options
 

--- a/IntelligenceX.Cli/Todo/ProjectBootstrapRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectBootstrapRunner.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using IntelligenceX.Cli.GitHub;
 
 namespace IntelligenceX.Cli.Todo;
 
@@ -18,6 +19,8 @@ internal static class ProjectBootstrapRunner {
     private const string DefaultConfigPath = "artifacts/triage/ix-project-config.json";
     private const string DefaultWorkflowPath = ".github/workflows/ix-triage-project-sync.yml";
     private const string DefaultVisionPath = "VISION.md";
+    private const string DefaultControlIssueTitle = "IX Triage Control";
+    private const string ControlIssueVariableName = "IX_TRIAGE_CONTROL_ISSUE";
 
     private sealed class Options {
         public string Repo { get; set; } = DefaultRepo;
@@ -37,6 +40,9 @@ internal static class ProjectBootstrapRunner {
         public bool ForceWorkflowWrite { get; set; }
         public bool SkipVisionScaffold { get; set; }
         public bool ForceVisionWrite { get; set; }
+        public int? ControlIssueNumber { get; set; }
+        public bool CreateControlIssue { get; set; }
+        public string ControlIssueTitle { get; set; } = DefaultControlIssueTitle;
         public bool ShowHelp { get; set; }
         public bool ParseFailed { get; set; }
     }
@@ -110,6 +116,28 @@ internal static class ProjectBootstrapRunner {
             }
         }
 
+        var controlIssueStatus = "Control issue variable unchanged.";
+        if (options.CreateControlIssue || options.ControlIssueNumber.HasValue) {
+            var controlIssueNumber = options.ControlIssueNumber ?? 0;
+            if (options.CreateControlIssue) {
+                var createResult = await CreateControlIssueAsync(options.Repo, options.ControlIssueTitle, owner, projectNumber)
+                    .ConfigureAwait(false);
+                if (!createResult.Success) {
+                    Console.Error.WriteLine(createResult.Error);
+                    return 1;
+                }
+                controlIssueNumber = createResult.IssueNumber;
+            }
+
+            var variableError = await SetControlIssueVariableAsync(options.Repo, controlIssueNumber).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(variableError)) {
+                Console.Error.WriteLine(variableError);
+                return 1;
+            }
+
+            controlIssueStatus = $"Control issue configured: #{controlIssueNumber} ({ControlIssueVariableName}).";
+        }
+
         Console.WriteLine(options.SkipProjectInit
             ? "Bootstrap workflow generated from existing project config."
             : "Project initialized and bootstrap workflow generated.");
@@ -117,6 +145,7 @@ internal static class ProjectBootstrapRunner {
         Console.WriteLine($"Project config: {options.ConfigPath}");
         Console.WriteLine($"Workflow file: {options.WorkflowPath}");
         Console.WriteLine(visionStatusMessage);
+        Console.WriteLine(controlIssueStatus);
         Console.WriteLine("Next step: commit generated files (workflow + vision) to enable scheduled GitHub-only triage sync.");
         return 0;
     }
@@ -143,6 +172,53 @@ internal static class ProjectBootstrapRunner {
 
     internal static string LoadVisionTemplate() {
         return ReadEmbeddedResource(VisionTemplateResourceName);
+    }
+
+    internal static string BuildControlIssueBody(string repo, string owner, int projectNumber) {
+        var builder = new StringBuilder();
+        builder.AppendLine("# IX Triage Control Plane");
+        builder.AppendLine();
+        builder.AppendLine("This issue is used by the scheduled IX triage workflow as a summary sink.");
+        builder.AppendLine();
+        builder.AppendLine($"- Repository: `{repo}`");
+        builder.AppendLine($"- Project target: `{owner}#{projectNumber}`");
+        builder.AppendLine($"- Variable: `{ControlIssueVariableName}`");
+        builder.AppendLine();
+        builder.AppendLine("## What appears here");
+        builder.AppendLine();
+        builder.AppendLine("- Triage index summary (duplicate clusters + best PR candidates)");
+        builder.AppendLine("- Vision check summary (aligned / needs-human-review / likely-out-of-scope)");
+        builder.AppendLine("- Links to each workflow run");
+        builder.AppendLine();
+        builder.AppendLine("## Maintainer flow");
+        builder.AppendLine();
+        builder.AppendLine("1. Review latest workflow comment.");
+        builder.AppendLine("2. Open project board and filter by `IX Suggested Decision`, `Vision Fit`, and `Category`.");
+        builder.AppendLine("3. Confirm human decision in `Maintainer Decision` and merge/close as needed.");
+        builder.AppendLine();
+        builder.AppendLine("_Managed by IntelligenceX project-bootstrap._");
+        return builder.ToString().TrimEnd();
+    }
+
+    internal static bool TryParseIssueNumberFromGhOutput(string stdout, out int issueNumber) {
+        issueNumber = 0;
+        if (string.IsNullOrWhiteSpace(stdout)) {
+            return false;
+        }
+
+        var lines = stdout.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var rawLine in lines) {
+            var line = rawLine.Trim();
+            if (TryParseIssueNumberFromUrl(line, out issueNumber)) {
+                return true;
+            }
+
+            if (TryParseTrailingInteger(line, out issueNumber)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string[] BuildProjectInitArgs(Options options) {
@@ -288,6 +364,27 @@ internal static class ProjectBootstrapRunner {
                 case "--force-vision-write":
                     options.ForceVisionWrite = true;
                     break;
+                case "--control-issue":
+                    if (i + 1 < args.Length &&
+                        int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var controlIssueNumber) &&
+                        controlIssueNumber > 0) {
+                        options.ControlIssueNumber = controlIssueNumber;
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--create-control-issue":
+                    options.CreateControlIssue = true;
+                    break;
+                case "--control-issue-title":
+                    if (i + 1 < args.Length) {
+                        options.ControlIssueTitle = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
                 default:
                     Console.Error.WriteLine($"Unknown option: {arg}");
                     options.ParseFailed = true;
@@ -299,6 +396,16 @@ internal static class ProjectBootstrapRunner {
         if (string.IsNullOrWhiteSpace(options.Repo) || !options.Repo.Contains('/')) {
             options.ParseFailed = true;
             options.ShowHelp = true;
+        }
+
+        if (options.CreateControlIssue && options.ControlIssueNumber.HasValue) {
+            Console.Error.WriteLine("Choose either --control-issue <n> or --create-control-issue, not both.");
+            options.ParseFailed = true;
+            options.ShowHelp = true;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.ControlIssueTitle)) {
+            options.ControlIssueTitle = DefaultControlIssueTitle;
         }
 
         return options;
@@ -326,8 +433,12 @@ internal static class ProjectBootstrapRunner {
         Console.WriteLine("  --force-workflow-write    Overwrite existing workflow output file");
         Console.WriteLine("  --skip-vision-scaffold    Do not create/update VISION.md template");
         Console.WriteLine("  --force-vision-write      Overwrite existing VISION.md output file");
+        Console.WriteLine("  --control-issue <n>       Set IX_TRIAGE_CONTROL_ISSUE to an existing issue number");
+        Console.WriteLine("  --create-control-issue    Create a new control issue and set IX_TRIAGE_CONTROL_ISSUE");
+        Console.WriteLine("  --control-issue-title     New control issue title (default: IX Triage Control)");
         Console.WriteLine();
         Console.WriteLine("Required token scopes: project (+ read:project for sync operations).");
+        Console.WriteLine("For control issue automation, repository issue + variable write permissions are also required.");
     }
 
     private static bool TryReadProjectTarget(string configPath, out string owner, out int projectNumber, out string error) {
@@ -411,5 +522,100 @@ internal static class ProjectBootstrapRunner {
             Directory.CreateDirectory(directory);
         }
         File.WriteAllText(path, content, Utf8NoBom);
+    }
+
+    private static async Task<(bool Success, int IssueNumber, string Error)> CreateControlIssueAsync(
+        string repo,
+        string title,
+        string owner,
+        int projectNumber) {
+        var body = BuildControlIssueBody(repo, owner, projectNumber);
+        var (code, stdout, stderr) = await GhCli.RunAsync(
+            TimeSpan.FromSeconds(90),
+            "issue", "create",
+            "--repo", repo,
+            "--title", title,
+            "--body", body
+        ).ConfigureAwait(false);
+
+        if (code != 0) {
+            return (
+                false,
+                0,
+                $"Failed to create control issue in '{repo}': {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
+        }
+
+        if (!TryParseIssueNumberFromGhOutput(stdout, out var issueNumber)) {
+            return (
+                false,
+                0,
+                "Control issue was created but issue number could not be parsed from `gh issue create` output.");
+        }
+
+        return (true, issueNumber, string.Empty);
+    }
+
+    private static async Task<string> SetControlIssueVariableAsync(string repo, int issueNumber) {
+        var (code, _, stderr) = await GhCli.RunAsync(
+            "variable", "set",
+            ControlIssueVariableName,
+            "--repo", repo,
+            "--body", issueNumber.ToString(CultureInfo.InvariantCulture)
+        ).ConfigureAwait(false);
+
+        if (code == 0) {
+            return string.Empty;
+        }
+
+        return $"Failed to set {ControlIssueVariableName} for '{repo}': {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}";
+    }
+
+    private static bool TryParseIssueNumberFromUrl(string value, out int issueNumber) {
+        issueNumber = 0;
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri)) {
+            return false;
+        }
+
+        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i + 1 < segments.Length; i++) {
+            if (!segments[i].Equals("issues", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            if (int.TryParse(segments[i + 1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var number) && number > 0) {
+                issueNumber = number;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryParseTrailingInteger(string value, out int number) {
+        number = 0;
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        var end = value.Length - 1;
+        while (end >= 0 && !char.IsDigit(value[end])) {
+            end--;
+        }
+        if (end < 0) {
+            return false;
+        }
+
+        var start = end;
+        while (start >= 0 && char.IsDigit(value[start])) {
+            start--;
+        }
+        start++;
+
+        if (start > end) {
+            return false;
+        }
+
+        return int.TryParse(value.AsSpan(start, end - start + 1), NumberStyles.Integer, CultureInfo.InvariantCulture, out number) &&
+               number > 0;
     }
 }

--- a/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
@@ -68,5 +68,44 @@ project={{ProjectNumber}}
         AssertContainsText(rendered, "--apply-labels", "workflow enables label application");
         AssertContainsText(rendered, "--apply-link-comments", "workflow enables PR issue suggestion comments");
     }
+
+    private static void TestProjectBootstrapBuildControlIssueBodyIncludesProjectContext() {
+        var body = IntelligenceX.Cli.Todo.ProjectBootstrapRunner.BuildControlIssueBody(
+            "EvotecIT/IntelligenceX",
+            "EvotecIT",
+            789);
+
+        AssertContainsText(body, "`EvotecIT/IntelligenceX`", "control issue body includes repo");
+        AssertContainsText(body, "`EvotecIT#789`", "control issue body includes project target");
+        AssertContainsText(body, "IX_TRIAGE_CONTROL_ISSUE", "control issue body includes variable name");
+    }
+
+    private static void TestProjectBootstrapParseIssueNumberFromGhOutputParsesIssueUrl() {
+        var parsed = IntelligenceX.Cli.Todo.ProjectBootstrapRunner.TryParseIssueNumberFromGhOutput(
+            "https://github.com/EvotecIT/IntelligenceX/issues/456\n",
+            out var issueNumber);
+
+        AssertEqual(true, parsed, "issue number parsed from gh output");
+        AssertEqual(456, issueNumber, "parsed issue number");
+    }
+
+    private static void TestProjectBootstrapParseIssueNumberFromGhOutputParsesTrailingInteger() {
+        var parsed = IntelligenceX.Cli.Todo.ProjectBootstrapRunner.TryParseIssueNumberFromGhOutput(
+            "created issue #912",
+            out var issueNumber);
+
+        AssertEqual(true, parsed, "issue number parsed from trailing integer");
+        AssertEqual(912, issueNumber, "parsed trailing issue number");
+    }
+
+    private static void TestProjectBootstrapRejectsConflictingControlIssueOptions() {
+        var exitCode = IntelligenceX.Cli.Todo.ProjectBootstrapRunner.RunAsync(new[] {
+            "--help",
+            "--create-control-issue",
+            "--control-issue", "42"
+        }).GetAwaiter().GetResult();
+
+        AssertEqual(1, exitCode, "conflicting control issue options should fail parse");
+    }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -466,6 +466,10 @@ internal static partial class Program {
         failed += Run("Todo project bootstrap clamps max items", TestProjectBootstrapRenderWorkflowTemplateClampsMaxItems);
         failed += Run("Todo project bootstrap renders vision template", TestProjectBootstrapRenderVisionTemplateInjectsContext);
         failed += Run("Todo project bootstrap workflow enables label apply", TestProjectBootstrapWorkflowTemplateEnablesApplyLabels);
+        failed += Run("Todo project bootstrap control issue body includes context", TestProjectBootstrapBuildControlIssueBodyIncludesProjectContext);
+        failed += Run("Todo project bootstrap parses issue url output", TestProjectBootstrapParseIssueNumberFromGhOutputParsesIssueUrl);
+        failed += Run("Todo project bootstrap parses trailing issue number", TestProjectBootstrapParseIssueNumberFromGhOutputParsesTrailingInteger);
+        failed += Run("Todo project bootstrap rejects conflicting control issue options", TestProjectBootstrapRejectsConflictingControlIssueOptions);
         failed += Run("Analyze run PowerShell script captures engine errors", TestAnalyzeRunPowerShellScriptCapturesEngineErrors);
         failed += Run("Analyze run PowerShell strict args include fail switch", TestAnalyzeRunPowerShellStrictArgsIncludeFailSwitch);
         failed += Run("Analyze run disabled writes empty findings", TestAnalyzeRunDisabledWritesEmptyFindings);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -154,6 +154,9 @@ Options:
 - `--force-workflow-write` overwrite existing workflow file
 - `--skip-vision-scaffold` do not create/update vision file
 - `--force-vision-write` overwrite existing vision file
+- `--control-issue <n>` set `IX_TRIAGE_CONTROL_ISSUE` to an existing issue number
+- `--create-control-issue` create a control issue and set `IX_TRIAGE_CONTROL_ISSUE`
+- `--control-issue-title <text>` customize the title when creating a control issue
 
 ## Workflow Template
 
@@ -166,6 +169,7 @@ Behavior:
 - Generates triage index artifacts.
 - Optional control-issue comment when repo variable `IX_TRIAGE_CONTROL_ISSUE` is configured.
 - `triage-project-sync.yml` posts a combined triage + vision markdown summary to the control issue.
+- `todo project-bootstrap --create-control-issue` can configure the control issue variable automatically.
 
 ## Legacy Script
 


### PR DESCRIPTION
## Summary
- add control-issue automation to `todo project-bootstrap` so GitHub-only summary workflows can be configured in one command
- support `--control-issue <n>` (reuse existing issue) and `--create-control-issue`/`--control-issue-title` (create new issue)
- add helper coverage for control issue body rendering, `gh issue create` output parsing, and conflicting option validation
- document new bootstrap options in CLI docs/internal docs

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll