### PR TITLE
todo: add template-based view bootstrap for GitHub Projects

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -112,10 +112,15 @@ intelligencex todo project-init \
 
 Notes:
 - Creates a project (or initializes an existing one with `--project <n>`).
+- Can copy from a prepared template project with `--view-template-project <n>` to preserve saved GitHub views.
 - Ensures required custom fields such as `Vision Fit`, `Category`, `Tags`, `Matched Issue`, `Triage Score`, `Duplicate Cluster`, and `IX Suggested Decision`.
 - Ensures IX label taxonomy in the repo by default (`--no-ensure-labels` to skip).
+- Validates default IX view coverage by default (`--no-ensure-default-views` to skip).
 - Writes a reusable config file containing owner/project/field metadata.
 - Requires GitHub token scopes: `project` (and typically `read:project` for follow-up sync).
+
+Important:
+- GitHub API currently does not provide a `createProjectV2View` mutation, so IX can validate/report default view coverage but cannot create views from scratch without a template copy.
 
 ## Sync triage + vision into GitHub Project
 
@@ -169,6 +174,9 @@ Useful options:
 - `--force-workflow-write` to overwrite an existing workflow file.
 - `--skip-vision-scaffold` to keep the bootstrap workflow only.
 - `--force-vision-write` to overwrite an existing vision file.
+- `--view-template-project <n>` to copy from an existing template project (preserves saved views).
+- `--view-template-owner <login>` to resolve template project from a different owner.
+- `--ensure-default-views` / `--no-ensure-default-views` to control default view coverage checks.
 - `--control-issue <n>` to point summaries at an existing GitHub issue by setting `IX_TRIAGE_CONTROL_ISSUE`.
 - `--create-control-issue` to create a new control issue and auto-set `IX_TRIAGE_CONTROL_ISSUE`.
 - `--control-issue-title <text>` to customize the created control issue title.

--- a/IntelligenceX.Cli/Todo/ProjectBootstrapRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectBootstrapRunner.cs
@@ -32,6 +32,9 @@ internal static class ProjectBootstrapRunner {
         public bool IsPublic { get; set; }
         public bool VisibilitySpecified { get; set; }
         public bool LinkRepo { get; set; } = true;
+        public bool EnsureDefaultViews { get; set; } = true;
+        public int? ViewTemplateProjectNumber { get; set; }
+        public string? ViewTemplateOwner { get; set; }
         public string ConfigPath { get; set; } = DefaultConfigPath;
         public string WorkflowPath { get; set; } = DefaultWorkflowPath;
         public string VisionPath { get; set; } = DefaultVisionPath;
@@ -248,6 +251,18 @@ internal static class ProjectBootstrapRunner {
         }
 
         result.Add(options.LinkRepo ? "--link-repo" : "--no-link-repo");
+        result.Add(options.EnsureDefaultViews ? "--ensure-default-views" : "--no-ensure-default-views");
+
+        if (options.ViewTemplateProjectNumber.HasValue && options.ViewTemplateProjectNumber.Value > 0) {
+            result.Add("--view-template-project");
+            result.Add(options.ViewTemplateProjectNumber.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.ViewTemplateOwner)) {
+            result.Add("--view-template-owner");
+            result.Add(options.ViewTemplateOwner.Trim());
+        }
+
         return result.ToArray();
     }
 
@@ -317,6 +332,30 @@ internal static class ProjectBootstrapRunner {
                     break;
                 case "--no-link-repo":
                     options.LinkRepo = false;
+                    break;
+                case "--ensure-default-views":
+                    options.EnsureDefaultViews = true;
+                    break;
+                case "--no-ensure-default-views":
+                    options.EnsureDefaultViews = false;
+                    break;
+                case "--view-template-project":
+                    if (i + 1 < args.Length &&
+                        int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var viewTemplateProjectNumber) &&
+                        viewTemplateProjectNumber > 0) {
+                        options.ViewTemplateProjectNumber = viewTemplateProjectNumber;
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--view-template-owner":
+                    if (i + 1 < args.Length) {
+                        options.ViewTemplateOwner = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
                     break;
                 case "--config-out":
                     if (i + 1 < args.Length) {
@@ -425,6 +464,10 @@ internal static class ProjectBootstrapRunner {
         Console.WriteLine("  --private                 Set project visibility to private (default)");
         Console.WriteLine("  --link-repo               Link project to --repo (default)");
         Console.WriteLine("  --no-link-repo            Do not link project to repo");
+        Console.WriteLine("  --ensure-default-views    Validate default IX view set presence (default)");
+        Console.WriteLine("  --no-ensure-default-views Skip default view coverage checks");
+        Console.WriteLine("  --view-template-project <n> Copy from a template project to preserve saved views");
+        Console.WriteLine("  --view-template-owner <login> Owner of --view-template-project");
         Console.WriteLine("  --config-out <path>       Project config path (default: artifacts/triage/ix-project-config.json)");
         Console.WriteLine("  --workflow-out <path>     Workflow output path (default: .github/workflows/ix-triage-project-sync.yml)");
         Console.WriteLine("  --vision-out <path>       Vision file output path (default: VISION.md)");

--- a/IntelligenceX.Cli/Todo/ProjectInitRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectInitRunner.cs
@@ -25,6 +25,9 @@ internal static class ProjectInitRunner {
         public bool VisibilitySpecified { get; set; }
         public bool LinkRepo { get; set; } = true;
         public bool EnsureLabels { get; set; } = true;
+        public bool EnsureDefaultViews { get; set; } = true;
+        public int? ViewTemplateProjectNumber { get; set; }
+        public string? ViewTemplateOwner { get; set; }
         public string OutputPath { get; set; } = Path.Combine("artifacts", "triage", "ix-project-config.json");
         public bool ShowHelp { get; set; }
     }
@@ -46,10 +49,17 @@ internal static class ProjectInitRunner {
         }
 
         var owner = ResolveOwner(options);
+        if (options.ProjectNumber.HasValue && options.ViewTemplateProjectNumber.HasValue) {
+            Console.Error.WriteLine("Choose either --project <n> or --view-template-project <n>, not both.");
+            return 1;
+        }
+
         var client = new ProjectV2Client();
+        ProjectV2Client.OwnerRef? ownerRef = null;
 
         ProjectV2Client.ProjectRef project;
         var createdProject = false;
+        var copiedFromTemplate = false;
         try {
             if (options.ProjectNumber.HasValue) {
                 var existing = await client.TryGetProjectAsync(owner, options.ProjectNumber.Value).ConfigureAwait(false);
@@ -58,8 +68,28 @@ internal static class ProjectInitRunner {
                     return 1;
                 }
                 project = existing;
+            } else if (options.ViewTemplateProjectNumber.HasValue) {
+                ownerRef = await client.GetOwnerAsync(owner).ConfigureAwait(false);
+                var templateOwner = string.IsNullOrWhiteSpace(options.ViewTemplateOwner)
+                    ? owner
+                    : options.ViewTemplateOwner.Trim();
+                var templateProject = await client.TryGetProjectAsync(templateOwner, options.ViewTemplateProjectNumber.Value)
+                    .ConfigureAwait(false);
+                if (templateProject is null) {
+                    Console.Error.WriteLine(
+                        $"Template project {options.ViewTemplateProjectNumber.Value} was not found for owner '{templateOwner}'.");
+                    return 1;
+                }
+
+                project = await client.CopyProjectAsync(
+                    templateProject.Id,
+                    ownerRef.NodeId,
+                    options.Title,
+                    includeDraftIssues: false).ConfigureAwait(false);
+                createdProject = true;
+                copiedFromTemplate = true;
             } else {
-                var ownerRef = await client.GetOwnerAsync(owner).ConfigureAwait(false);
+                ownerRef = await client.GetOwnerAsync(owner).ConfigureAwait(false);
                 project = await client.CreateProjectAsync(ownerRef.NodeId, options.Title).ConfigureAwait(false);
                 createdProject = true;
             }
@@ -115,11 +145,45 @@ internal static class ProjectInitRunner {
             }
         }
 
-        var report = BuildConfigReport(owner, options.Repo, project, fields, options.EnsureLabels);
+        IReadOnlyDictionary<string, ProjectV2Client.ProjectView> views;
+        try {
+            views = await client.GetProjectViewsByNameAsync(owner, project.Number).ConfigureAwait(false);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Failed to read project views: {ex.Message}");
+            return 1;
+        }
+
+        var missingDefaultViews = options.EnsureDefaultViews
+            ? ProjectViewCatalog.FindMissingDefaultViews(views)
+            : Array.Empty<ProjectViewDefinition>();
+        var defaultViewCoverage = ProjectViewCatalog.DefaultViews.Count - missingDefaultViews.Count;
+
+        if (options.EnsureDefaultViews && missingDefaultViews.Count > 0) {
+            Console.Error.WriteLine(
+                $"Warning: missing recommended default views ({missingDefaultViews.Count}/{ProjectViewCatalog.DefaultViews.Count}): " +
+                string.Join(", ", missingDefaultViews.Select(view => view.Name)));
+            if (!options.ViewTemplateProjectNumber.HasValue) {
+                Console.Error.WriteLine(
+                    "Tip: use --view-template-project <n> to copy a prepared GitHub Project template with standard views.");
+            }
+        }
+
+        var report = BuildConfigReport(
+            owner,
+            options.Repo,
+            project,
+            fields,
+            views,
+            options.EnsureLabels,
+            options.EnsureDefaultViews,
+            options.ViewTemplateProjectNumber,
+            options.ViewTemplateOwner,
+            copiedFromTemplate);
         WriteText(options.OutputPath, JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
 
         Console.WriteLine($"Project ready: #{project.Number} ({project.Url})");
         Console.WriteLine($"Fields ensured: {fields.Count}");
+        Console.WriteLine($"Views discovered: {views.Count} (default coverage: {defaultViewCoverage}/{ProjectViewCatalog.DefaultViews.Count})");
         Console.WriteLine($"Project config written: {options.OutputPath}");
         return 0;
     }
@@ -181,6 +245,24 @@ internal static class ProjectInitRunner {
                 case "--no-ensure-labels":
                     options.EnsureLabels = false;
                     break;
+                case "--ensure-default-views":
+                    options.EnsureDefaultViews = true;
+                    break;
+                case "--no-ensure-default-views":
+                    options.EnsureDefaultViews = false;
+                    break;
+                case "--view-template-project":
+                    if (i + 1 < args.Length &&
+                        int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var templateNumber) &&
+                        templateNumber > 0) {
+                        options.ViewTemplateProjectNumber = templateNumber;
+                    }
+                    break;
+                case "--view-template-owner":
+                    if (i + 1 < args.Length) {
+                        options.ViewTemplateOwner = args[++i];
+                    }
+                    break;
                 case "--out":
                     if (i + 1 < args.Length) {
                         options.OutputPath = args[++i];
@@ -215,6 +297,10 @@ internal static class ProjectInitRunner {
         Console.WriteLine("  --no-link-repo           Do not link project to repo");
         Console.WriteLine("  --ensure-labels          Ensure IX labels exist in --repo (default)");
         Console.WriteLine("  --no-ensure-labels       Skip repo label setup");
+        Console.WriteLine("  --ensure-default-views   Validate default IX view set presence (default)");
+        Console.WriteLine("  --no-ensure-default-views Skip default view coverage checks");
+        Console.WriteLine("  --view-template-project <n> Copy from an existing template project to preserve saved views");
+        Console.WriteLine("  --view-template-owner <login> Owner of --view-template-project (defaults to --owner/repo owner)");
         Console.WriteLine("  --out <path>             Write project config JSON (default: artifacts/triage/ix-project-config.json)");
         Console.WriteLine();
         Console.WriteLine("Required token scopes for project setup: `project`.");
@@ -268,7 +354,12 @@ internal static class ProjectInitRunner {
         string repo,
         ProjectV2Client.ProjectRef project,
         IReadOnlyDictionary<string, ProjectV2Client.ProjectField> fields,
-        bool labelsEnsured) {
+        IReadOnlyDictionary<string, ProjectV2Client.ProjectView> views,
+        bool labelsEnsured,
+        bool defaultViewsEnsured,
+        int? viewTemplateProjectNumber,
+        string? viewTemplateOwner,
+        bool copiedFromTemplate) {
         var fieldsJson = fields.Values
             .OrderBy(field => field.Name, StringComparer.OrdinalIgnoreCase)
             .Select(field => new {
@@ -282,6 +373,19 @@ internal static class ProjectInitRunner {
                         id = option.Value
                     })
                     .ToList()
+            })
+            .ToList();
+
+        var defaultMissingViews = defaultViewsEnsured
+            ? ProjectViewCatalog.FindMissingDefaultViews(views).Select(view => view.Name).ToList()
+            : new List<string>();
+        var viewsJson = views.Values
+            .OrderBy(view => view.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(view => new {
+                id = view.Id,
+                name = view.Name,
+                layout = view.Layout,
+                url = view.Url
             })
             .ToList();
 
@@ -310,6 +414,29 @@ internal static class ProjectInitRunner {
                         .Cast<object>()
                         .ToList()
                     : new List<object>()
+            },
+            views = new {
+                ensured = defaultViewsEnsured,
+                copiedFromTemplate,
+                templateProjectNumber = viewTemplateProjectNumber,
+                templateOwner = viewTemplateOwner,
+                defaultCoverage = new {
+                    required = ProjectViewCatalog.DefaultViews.Count,
+                    present = defaultViewsEnsured
+                        ? ProjectViewCatalog.DefaultViews.Count - defaultMissingViews.Count
+                        : 0,
+                    missing = defaultMissingViews
+                },
+                recommended = ProjectViewCatalog.DefaultViews
+                    .Select(view => new {
+                        name = view.Name,
+                        layout = view.Layout,
+                        description = view.Description,
+                        filter = view.Filter
+                    })
+                    .Cast<object>()
+                    .ToList(),
+                items = viewsJson
             }
         };
     }

--- a/IntelligenceX.Cli/Todo/ProjectV2Client.cs
+++ b/IntelligenceX.Cli/Todo/ProjectV2Client.cs
@@ -13,6 +13,7 @@ internal sealed class ProjectV2Client {
     internal sealed record OwnerRef(string Login, string NodeId, string OwnerType);
     internal sealed record ProjectRef(string Id, int Number, string Title, string Url);
     internal sealed record ProjectField(string Id, string Name, string DataType, IReadOnlyDictionary<string, string> OptionsByName);
+    internal sealed record ProjectView(string Id, string Name, string Layout, string Url);
     internal sealed record ProjectItem(string Id, string Url, string ContentId, string ContentType);
     internal sealed record ContentRef(string Id, string Url, string ContentType);
 
@@ -136,6 +137,44 @@ mutation($ownerId: ID!, $title: String!) {
 
         return ParseProjectRef(projectObj) ??
                throw new InvalidOperationException("Unable to parse created project details.");
+    }
+
+    public async Task<ProjectRef> CopyProjectAsync(string sourceProjectId, string ownerNodeId, string title, bool includeDraftIssues) {
+        var mutation = """
+mutation($projectId: ID!, $ownerId: ID!, $title: String!, $includeDraftIssues: Boolean!) {
+  copyProjectV2(input: {
+    projectId: $projectId
+    ownerId: $ownerId
+    title: $title
+    includeDraftIssues: $includeDraftIssues
+  }) {
+    projectV2 {
+      id
+      number
+      title
+      url
+    }
+  }
+}
+""";
+
+        var root = await QueryGraphQlAsync(
+            mutation,
+            ("projectId", sourceProjectId),
+            ("ownerId", ownerNodeId),
+            ("title", title),
+            ("includeDraftIssues", includeDraftIssues ? "true" : "false")
+        ).ConfigureAwait(false);
+
+        if (!TryGetProperty(root, "data", out var data) ||
+            !TryGetProperty(data, "copyProjectV2", out var payload) ||
+            !TryGetProperty(payload, "projectV2", out var projectObj) ||
+            projectObj.ValueKind != JsonValueKind.Object) {
+            throw new InvalidOperationException("GitHub GraphQL response missing project copy payload.");
+        }
+
+        return ParseProjectRef(projectObj) ??
+               throw new InvalidOperationException("Unable to parse copied project details.");
     }
 
     public async Task UpdateProjectAsync(string projectId, string? description, bool? isPublic) {
@@ -295,6 +334,94 @@ query($owner: String!, $number: Int!, $cursor: String) {
         }
 
         return fields;
+    }
+
+    public async Task<IReadOnlyDictionary<string, ProjectView>> GetProjectViewsByNameAsync(string owner, int number) {
+        var views = new Dictionary<string, ProjectView>(StringComparer.OrdinalIgnoreCase);
+        string? cursor = null;
+
+        var query = """
+query($owner: String!, $number: Int!, $cursor: String) {
+  user(login: $owner) {
+    projectV2(number: $number) {
+      views(first: 100, after: $cursor) {
+        nodes {
+          id
+          name
+          layout
+          url
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+  organization(login: $owner) {
+    projectV2(number: $number) {
+      views(first: 100, after: $cursor) {
+        nodes {
+          id
+          name
+          layout
+          url
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+""";
+
+        while (true) {
+            var root = await QueryGraphQlAsync(
+                query,
+                ("owner", owner),
+                ("number", number.ToString(CultureInfo.InvariantCulture)),
+                ("cursor", cursor)
+            ).ConfigureAwait(false);
+
+            if (!TryGetProperty(root, "data", out var data)) {
+                break;
+            }
+
+            var connection = GetProjectConnection(data, "views");
+            if (connection is null ||
+                !TryGetProperty(connection.Value, "nodes", out var nodes) ||
+                nodes.ValueKind != JsonValueKind.Array) {
+                break;
+            }
+
+            foreach (var viewNode in nodes.EnumerateArray()) {
+                var id = ReadString(viewNode, "id");
+                var name = ReadString(viewNode, "name");
+                if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(name)) {
+                    continue;
+                }
+
+                var layout = ReadString(viewNode, "layout");
+                var url = ReadString(viewNode, "url");
+                views[name] = new ProjectView(id, name, layout, url);
+            }
+
+            if (!TryGetProperty(connection.Value, "pageInfo", out var pageInfo) ||
+                !TryGetProperty(pageInfo, "hasNextPage", out var hasNextPage) ||
+                hasNextPage.ValueKind != JsonValueKind.True && hasNextPage.ValueKind != JsonValueKind.False ||
+                !hasNextPage.GetBoolean()) {
+                break;
+            }
+
+            cursor = ReadString(pageInfo, "endCursor");
+            if (string.IsNullOrWhiteSpace(cursor)) {
+                break;
+            }
+        }
+
+        return views;
     }
 
     public async Task<IReadOnlyDictionary<string, ProjectItem>> GetProjectItemsByUrlAsync(string owner, int number, int maxItems) {

--- a/IntelligenceX.Cli/Todo/ProjectViewCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectViewCatalog.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace IntelligenceX.Cli.Todo;
+
+internal sealed record ProjectViewDefinition(
+    string Name,
+    string Layout,
+    string Description,
+    string Filter
+);
+
+internal static class ProjectViewCatalog {
+    public static readonly IReadOnlyList<ProjectViewDefinition> DefaultViews = new[] {
+        new ProjectViewDefinition(
+            "IX Queue",
+            "TABLE",
+            "Primary triage queue for open backlog items.",
+            "is:open"),
+        new ProjectViewDefinition(
+            "Merge Candidates",
+            "TABLE",
+            "Items with high merge readiness and aligned signals.",
+            "is:open \"IX Suggested Decision\":\"merge-candidate\""),
+        new ProjectViewDefinition(
+            "Vision Review",
+            "BOARD",
+            "Items grouped by vision-fit outcomes for maintainer review.",
+            "is:open"),
+        new ProjectViewDefinition(
+            "Duplicate Clusters",
+            "TABLE",
+            "Items that belong to duplicate clusters and need consolidation.",
+            "is:open \"Duplicate Cluster\":*")
+    };
+
+    public static IReadOnlyList<ProjectViewDefinition> FindMissingDefaultViews(
+        IReadOnlyDictionary<string, ProjectV2Client.ProjectView> existingViews) {
+        if (existingViews.Count == 0) {
+            return DefaultViews.ToList();
+        }
+
+        return DefaultViews
+            .Where(view => !existingViews.ContainsKey(view.Name))
+            .ToList();
+    }
+}

--- a/IntelligenceX.Tests/Program.Todo.ProjectViews.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectViews.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace IntelligenceX.Tests;
+
+internal static partial class Program {
+#if !NET472
+    private static void TestProjectViewCatalogDefaultsIncludeQueueAndMergeViews() {
+        var names = IntelligenceX.Cli.Todo.ProjectViewCatalog.DefaultViews
+            .Select(view => view.Name)
+            .ToList();
+
+        AssertEqual(true, names.Contains("IX Queue", StringComparer.OrdinalIgnoreCase), "default queue view present");
+        AssertEqual(true, names.Contains("Merge Candidates", StringComparer.OrdinalIgnoreCase), "merge candidates view present");
+        AssertEqual(true, names.Contains("Vision Review", StringComparer.OrdinalIgnoreCase), "vision review view present");
+        AssertEqual(true, names.Contains("Duplicate Clusters", StringComparer.OrdinalIgnoreCase), "duplicate clusters view present");
+    }
+
+    private static void TestProjectViewCatalogFindMissingDefaultViewsReturnsMissingOnly() {
+        var existing = new Dictionary<string, IntelligenceX.Cli.Todo.ProjectV2Client.ProjectView>(StringComparer.OrdinalIgnoreCase) {
+            ["IX Queue"] = new("view1", "IX Queue", "TABLE", "https://example.test/view1"),
+            ["Vision Review"] = new("view2", "Vision Review", "BOARD", "https://example.test/view2")
+        };
+
+        var missing = IntelligenceX.Cli.Todo.ProjectViewCatalog.FindMissingDefaultViews(existing)
+            .Select(view => view.Name)
+            .ToList();
+
+        AssertEqual(true, missing.Contains("Merge Candidates", StringComparer.OrdinalIgnoreCase), "missing merge candidates detected");
+        AssertEqual(true, missing.Contains("Duplicate Clusters", StringComparer.OrdinalIgnoreCase), "missing duplicate clusters detected");
+        AssertEqual(false, missing.Contains("IX Queue", StringComparer.OrdinalIgnoreCase), "existing queue view not flagged");
+    }
+
+    private static void TestProjectViewCatalogFindMissingDefaultViewsReturnsEmptyWhenComplete() {
+        var existing = IntelligenceX.Cli.Todo.ProjectViewCatalog.DefaultViews
+            .ToDictionary(
+                view => view.Name,
+                view => new IntelligenceX.Cli.Todo.ProjectV2Client.ProjectView(
+                    $"id-{view.Name}",
+                    view.Name,
+                    view.Layout,
+                    $"https://example.test/{view.Name}"),
+                StringComparer.OrdinalIgnoreCase);
+
+        var missing = IntelligenceX.Cli.Todo.ProjectViewCatalog.FindMissingDefaultViews(existing);
+        AssertEqual(0, missing.Count, "no missing views when all defaults exist");
+    }
+#endif
+}

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -451,6 +451,9 @@ internal static partial class Program {
         failed += Run("Todo project fields defaults", TestProjectFieldCatalogDefaultsIncludeVisionAndDecisionFields);
         failed += Run("Todo project labels include decision taxonomy", TestProjectLabelCatalogDefaultsIncludeDecisionLabels);
         failed += Run("Todo project labels include dynamic category and tag taxonomy", TestProjectLabelCatalogBuildEnsureCatalogIncludesDynamicCategoryAndTags);
+        failed += Run("Todo project views include queue and merge views", TestProjectViewCatalogDefaultsIncludeQueueAndMergeViews);
+        failed += Run("Todo project views missing detection", TestProjectViewCatalogFindMissingDefaultViewsReturnsMissingOnly);
+        failed += Run("Todo project views full coverage has no missing", TestProjectViewCatalogFindMissingDefaultViewsReturnsEmptyWhenComplete);
         failed += Run("Todo project sync merges vision and canonical", TestProjectSyncBuildEntriesMergesVisionAndCanonical);
         failed += Run("Todo project sync labels include tags and high-confidence match", TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch);
         failed += Run("Todo project sync labels normalize dynamic category and tags", TestProjectSyncBuildLabelsNormalizesDynamicCategoryAndTags);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -98,7 +98,13 @@ Options:
 - `--public` / `--private`
 - `--link-repo` / `--no-link-repo`
 - `--ensure-labels` / `--no-ensure-labels`
+- `--ensure-default-views` / `--no-ensure-default-views`
+- `--view-template-project <n>` copy from a template project to preserve saved views
+- `--view-template-owner <login>` owner for template project lookup
 - `--out <path>` (default `artifacts/triage/ix-project-config.json`)
+
+Note:
+- GitHub API currently lacks a `createProjectV2View` mutation; IX can validate/report default view coverage, and template-copy can preserve ready view layouts.
 
 Expected fields:
 - `Vision Fit` (single-select)
@@ -154,6 +160,9 @@ Options:
 - `--force-workflow-write` overwrite existing workflow file
 - `--skip-vision-scaffold` do not create/update vision file
 - `--force-vision-write` overwrite existing vision file
+- `--view-template-project <n>` pass template-copy through to `project-init`
+- `--view-template-owner <login>` template owner override for `project-init`
+- `--ensure-default-views` / `--no-ensure-default-views` pass-through to `project-init`
 - `--control-issue <n>` set `IX_TRIAGE_CONTROL_ISSUE` to an existing issue number
 - `--create-control-issue` create a control issue and set `IX_TRIAGE_CONTROL_ISSUE`
 - `--control-issue-title <text>` customize the title when creating a control issue


### PR DESCRIPTION
## Summary
- add `ProjectViewCatalog` with default IX view definitions and coverage helpers
- extend `ProjectV2Client` with project copy (`copyProjectV2`) and view listing (`projectV2.views`) support
- extend `todo project-init` with template-copy options for view-preserving bootstrap:
  - `--view-template-project <n>`
  - `--view-template-owner <login>`
  - `--ensure-default-views` / `--no-ensure-default-views`
- extend `todo project-bootstrap` to pass the same view bootstrap options through to `project-init`
- emit default-view coverage details into project config JSON and update docs/internal docs
- add tests for project view catalog defaults and missing-view detection

## Notes
- GitHub GraphQL currently exposes project views but does not expose a `createProjectV2View` mutation.
- This implementation enables reliable automation via template-copy while still reporting default-view coverage when creating from scratch.

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll