### PR TITLE
Recover replay action from single-action assistant drafts

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
@@ -777,7 +777,7 @@ internal sealed partial class ChatServiceSession {
         var requestText = TrimForPrompt(userRequest, 1200);
         var draftText = TrimForPrompt(assistantDraft, 1200);
         var reasonCode = string.IsNullOrWhiteSpace(reason) ? "no_tool_calls_after_retries" : reason.Trim();
-        var replayActionBlock = BuildExecutionContractReplayActionBlock(userRequest);
+        var replayActionBlock = BuildExecutionContractReplayActionBlock(userRequest, assistantDraft);
         return $$"""
             [Execution blocked]
             {{ExecutionContractMarker}}
@@ -796,8 +796,8 @@ internal sealed partial class ChatServiceSession {
             """;
     }
 
-    private static string BuildExecutionContractReplayActionBlock(string userRequest) {
-        if (!TryParseActionSelectionForReplay(userRequest, out var actionId, out var actionTitle, out var actionRequest)) {
+    private static string BuildExecutionContractReplayActionBlock(string userRequest, string assistantDraft) {
+        if (!TryResolveReplayActionForExecutionContract(userRequest, assistantDraft, out var actionId, out var actionTitle, out var actionRequest)) {
             return string.Empty;
         }
 
@@ -810,6 +810,48 @@ internal sealed partial class ChatServiceSession {
             request: {{actionRequest}}
             reply: /act {{actionId}}
             """;
+    }
+
+    private static bool TryResolveReplayActionForExecutionContract(string userRequest, string assistantDraft, out string actionId, out string actionTitle, out string actionRequest) {
+        if (TryParseActionSelectionForReplay(userRequest, out actionId, out actionTitle, out actionRequest)) {
+            return true;
+        }
+
+        return TryParseSinglePendingActionForReplay(assistantDraft, out actionId, out actionTitle, out actionRequest);
+    }
+
+    private static bool TryParseSinglePendingActionForReplay(string assistantDraft, out string actionId, out string actionTitle, out string actionRequest) {
+        actionId = string.Empty;
+        actionTitle = string.Empty;
+        actionRequest = string.Empty;
+
+        var actions = ExtractPendingActions(assistantDraft);
+        if (actions.Count == 0) {
+            actions = ExtractFallbackChoicePendingActions(assistantDraft);
+        }
+        if (actions.Count != 1) {
+            return false;
+        }
+
+        var action = actions[0];
+        actionId = NormalizeReplayActionIdToken(action.Id);
+        if (actionId.Length == 0) {
+            return false;
+        }
+
+        actionTitle = NormalizeReplayActionText(action.Title, maxChars: 200);
+        actionRequest = NormalizeReplayActionText(action.Request, maxChars: 600);
+        if (actionRequest.Length == 0) {
+            actionRequest = actionTitle;
+        }
+        if (actionRequest.Length == 0) {
+            actionRequest = "Retry selected action.";
+        }
+        if (actionTitle.Length == 0) {
+            actionTitle = actionRequest;
+        }
+
+        return true;
     }
 
     private static bool TryParseActionSelectionForReplay(string userRequest, out string actionId, out string actionTitle, out string actionRequest) {
@@ -862,25 +904,7 @@ internal sealed partial class ChatServiceSession {
     private static string NormalizeReplayActionId(JsonElement id) {
         switch (id.ValueKind) {
             case JsonValueKind.String: {
-                    var token = ReadFirstToken((id.GetString() ?? string.Empty).Trim());
-                    if (token.Length == 0) {
-                        return string.Empty;
-                    }
-
-                    var sb = new StringBuilder(Math.Min(token.Length, 64));
-                    for (var i = 0; i < token.Length && sb.Length < 64; i++) {
-                        var ch = token[i];
-                        if (char.IsWhiteSpace(ch) || char.IsControl(ch)) {
-                            continue;
-                        }
-                        if (ch == ':' || ch == ';') {
-                            continue;
-                        }
-
-                        sb.Append(ch);
-                    }
-
-                    return sb.ToString().Trim();
+                    return NormalizeReplayActionIdToken(id.GetString() ?? string.Empty);
                 }
             case JsonValueKind.Number:
                 if (!id.TryGetInt64(out var numericId) || numericId <= 0) {
@@ -891,6 +915,28 @@ internal sealed partial class ChatServiceSession {
             default:
                 return string.Empty;
         }
+    }
+
+    private static string NormalizeReplayActionIdToken(string idToken) {
+        var token = ReadFirstToken((idToken ?? string.Empty).Trim());
+        if (token.Length == 0) {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(Math.Min(token.Length, 64));
+        for (var i = 0; i < token.Length && sb.Length < 64; i++) {
+            var ch = token[i];
+            if (char.IsWhiteSpace(ch) || char.IsControl(ch)) {
+                continue;
+            }
+            if (ch == ':' || ch == ';') {
+                continue;
+            }
+
+            sb.Append(ch);
+        }
+
+        return sb.ToString().Trim();
     }
 
     private static string TryReadReplayActionSelectionText(JsonElement selection, string propertyName) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
@@ -196,6 +196,39 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildExecutionContractBlockerText_EmbedsReplayableActionEnvelopeForSingleActionAssistantDraft() {
+        var draft = """
+            Pulling failed logons from ADO now would be the next step.
+            You can run one of these follow-up actions:
+            1. Run failed logon report (4625) on ADO Security (/act act_failed4625)
+            """;
+        var result = BuildExecutionContractBlockerTextMethod.Invoke(
+            null,
+            new object?[] { "failed logons please", draft, "no_tool_calls_after_watchdog_retry" });
+        var text = Assert.IsType<string>(result);
+
+        Assert.Contains("[Action]", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ix:action:v1", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("id: act_failed4625", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("reply: /act act_failed4625", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildExecutionContractBlockerText_DoesNotEmbedReplayableActionEnvelopeForAmbiguousAssistantDraft() {
+        var draft = """
+            You can run one of these follow-up actions:
+            1. Run failed logon report (4625) on ADO Security (/act act_failed4625)
+            2. Pull account lockout events (4740) on ADO Security (/act act_lockouts4740)
+            """;
+        var result = BuildExecutionContractBlockerTextMethod.Invoke(
+            null,
+            new object?[] { "security log please", draft, "no_tool_calls_after_watchdog_retry" });
+        var text = Assert.IsType<string>(result);
+
+        Assert.DoesNotContain("ix:action:v1", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void ShouldSkipWeightedRouting_TrueForActionSelectionPayload() {
         var request = "{\"ix_action_selection\":{\"id\":\"act_001\",\"title\":\"Run\",\"request\":\"Run it.\"}}";
         var result = ShouldSkipWeightedRoutingMethod.Invoke(null, new object?[] { request });


### PR DESCRIPTION
## Summary
- improve execution-contract recovery so replay action blocks are still generated when user request is plain text but assistant draft contains exactly one actionable choice
- recover replay actions from either explicit `[Action]` blocks or single fallback choices in assistant drafts
- keep ambiguity safe by refusing replay block generation when assistant draft has multiple actions
- add regression tests for single-action recovery and multi-action ambiguity guard

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "BuildExecutionContractBlockerText"
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRoutingTrimTests"
