### PR TITLE
Fix chat rendering: inline code, bold spacing, and /act action chips

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
@@ -112,4 +112,42 @@ public sealed class TranscriptHtmlFormatterTests {
         Assert.DoesNotContain("**Servers checked:**", html);
         Assert.DoesNotContain("**Replication edges:**", html);
     }
+
+    /// <summary>
+    /// Ensures pending action markdown summary lines render as actionable chips instead of raw /act text lines.
+    /// </summary>
+    [Fact]
+    public void Format_RendersPendingActionsAsActionChips() {
+        var options = MarkdownRendererPresets.CreateChatStrictMinimal();
+        var now = new DateTime(2026, 2, 15, 20, 36, 14, DateTimeKind.Local);
+        var html = TranscriptHtmlFormatter.Format(new[] {
+            ("Assistant", """
+                          You can run one of these follow-up actions:
+                          1. Run failed logon report (4625) on ADO Security (`/act act_failed4625`)
+                          2. Pull account lockout events (4740) (`/act act_lockout4740`)
+                          """, now)
+        }, "HH:mm:ss", options);
+
+        Assert.Contains("ix-action-cta", html);
+        Assert.Contains("class='ix-action-btn'", html);
+        Assert.Contains("data-act-cmd='/act act_failed4625'", html);
+        Assert.Contains("data-act-cmd='/act act_lockout4740'", html);
+        Assert.DoesNotContain("You can run one of these follow-up actions:", html);
+        Assert.DoesNotContain("`/act act_failed4625`", html);
+    }
+
+    /// <summary>
+    /// Ensures inline backtick spans always end up as code tags in transcript HTML.
+    /// </summary>
+    [Fact]
+    public void Format_AlwaysRendersInlineBackticksAsCodeTags() {
+        var options = MarkdownRendererPresets.CreateChatStrictMinimal();
+        var now = new DateTime(2026, 2, 15, 23, 18, 6, DateTimeKind.Local);
+        var html = TranscriptHtmlFormatter.Format(new[] {
+            ("Assistant", "Use `/act act_ad0_sys3210_msg` to run it.", now)
+        }, "HH:mm:ss", options);
+
+        Assert.Contains("<code>/act act_ad0_sys3210_msg</code>", html);
+        Assert.DoesNotContain("`/act act_ad0_sys3210_msg`", html);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
@@ -23,6 +23,18 @@ public sealed class TranscriptMarkdownNormalizerTests {
     }
 
     /// <summary>
+    /// Ensures glued bold/word boundaries are normalized into readable spacing.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_SplitsGluedBoldWordBoundaries() {
+        var text = "Status **Healthy**next and check **Now**please.";
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+
+        Assert.Equal("Status **Healthy** next and check **Now** please.", normalized);
+    }
+
+    /// <summary>
     /// Ensures collapsed inline bullets are split into proper markdown list lines.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptHtmlFormatter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptHtmlFormatter.cs
@@ -18,6 +18,18 @@ internal static class TranscriptHtmlFormatter {
     private static readonly Regex AssistantOutcomePrefixRegex = new(
         @"^\[(?<kind>[a-z_]+)\]\s*(?<headline>[^\r\n]*)",
         RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex PendingActionLineRegex = new(
+        @"^\s*(?<index>\d+)\.\s+(?<label>.+?)\s+\((?:`)?(?<command>/act\s+(?<id>[^\s)`]+))(?:`)?\)\s*$",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex PendingActionHeadingRegex = new(
+        @"^\s*You can run one of these follow-up actions:\s*$",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex InlineCodeFallbackRegex = new(
+        @"(?<!`)`(?<code>[^`\r\n]+?)`(?!`)",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex PreBlockRegex = new(
+        @"<pre\b[\s\S]*?</pre>",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
     /// Builds transcript HTML for the chat shell.
@@ -48,7 +60,15 @@ internal static class TranscriptHtmlFormatter {
 
             var role = ResolveRoleStyle(message.Role);
             var isContinuation = string.Equals(previousRoleClass, role.RoleClass, StringComparison.Ordinal);
-            var bodyHtml = RenderBodyHtml(normalizedText, markdownOptions);
+            var actionExtraction = string.Equals(message.Role, "Assistant", StringComparison.OrdinalIgnoreCase)
+                ? ExtractPendingActionsForRendering(normalizedText)
+                : new PendingActionExtraction(normalizedText, Array.Empty<PendingActionRenderItem>());
+            var bodyHtml = string.IsNullOrWhiteSpace(actionExtraction.CleanedText)
+                ? string.Empty
+                : RenderBodyHtml(actionExtraction.CleanedText, markdownOptions);
+            if (actionExtraction.Actions.Count > 0) {
+                bodyHtml = AppendPendingActionChips(bodyHtml, actionExtraction.Actions);
+            }
             var bubbleClass = "bubble";
             if (TryRenderAssistantOutcomeCallout(message.Role, normalizedText, markdownOptions, out var calloutHtml)) {
                 bodyHtml = calloutHtml;
@@ -199,10 +219,129 @@ internal static class TranscriptHtmlFormatter {
 
     private static string RenderBodyHtml(string text, MarkdownRendererOptions markdownOptions) {
         try {
-            return MarkdownRenderer.RenderBodyHtml(text, markdownOptions);
+            var html = MarkdownRenderer.RenderBodyHtml(text, markdownOptions);
+            return EnsureInlineCodeHtml(html);
         } catch {
-            return "<article class='markdown-body'><p>" + WebUtility.HtmlEncode(text) + "</p></article>";
+            return EnsureInlineCodeHtml("<article class='markdown-body'><p>" + WebUtility.HtmlEncode(text) + "</p></article>");
         }
+    }
+
+    private static PendingActionExtraction ExtractPendingActionsForRendering(string text) {
+        if (string.IsNullOrWhiteSpace(text)) {
+            return new PendingActionExtraction(string.Empty, Array.Empty<PendingActionRenderItem>());
+        }
+
+        var normalized = text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        var lines = normalized.Split('\n');
+        var kept = new List<string>(lines.Length);
+        var actions = new List<PendingActionRenderItem>();
+        var inFence = false;
+
+        for (var i = 0; i < lines.Length; i++) {
+            var line = lines[i] ?? string.Empty;
+            var trimmed = line.Trim();
+            if (IsFenceBoundary(trimmed)) {
+                inFence = !inFence;
+                kept.Add(line);
+                continue;
+            }
+
+            if (!inFence) {
+                var match = PendingActionLineRegex.Match(trimmed);
+                if (match.Success) {
+                    if (!int.TryParse(match.Groups["index"].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var ordinal)) {
+                        ordinal = actions.Count + 1;
+                    }
+
+                    var label = match.Groups["label"].Value.Trim();
+                    var command = match.Groups["command"].Value.Trim();
+                    var id = match.Groups["id"].Value.Trim();
+                    if (label.Length > 0 && command.Length > 0 && id.Length > 0) {
+                        actions.Add(new PendingActionRenderItem(ordinal, label, command, id));
+                        continue;
+                    }
+                }
+
+                if (actions.Count > 0 && PendingActionHeadingRegex.IsMatch(trimmed)) {
+                    continue;
+                }
+            }
+
+            kept.Add(line);
+        }
+
+        if (actions.Count > 0) {
+            kept.RemoveAll(line => PendingActionHeadingRegex.IsMatch((line ?? string.Empty).Trim()));
+        }
+
+        var cleanedText = Regex.Replace(string.Join('\n', kept).Trim(), @"\n{3,}", "\n\n");
+        return new PendingActionExtraction(cleanedText, actions);
+    }
+
+    private static bool IsFenceBoundary(string line) =>
+        !string.IsNullOrWhiteSpace(line) && line.StartsWith("```", StringComparison.Ordinal);
+
+    private static string AppendPendingActionChips(string bodyHtml, IReadOnlyList<PendingActionRenderItem> actions) {
+        if (actions is null || actions.Count == 0) {
+            return bodyHtml;
+        }
+
+        var encoder = HtmlEncoder.Default;
+        var sb = new StringBuilder(bodyHtml ?? string.Empty);
+        sb.Append("<section class='ix-action-cta'><div class='ix-action-cta-title'>Follow-up actions</div><div class='ix-action-cta-list'>");
+        for (var i = 0; i < actions.Count; i++) {
+            var action = actions[i];
+            sb.Append("<button type='button' class='ix-action-btn' data-act-cmd='")
+                .Append(encoder.Encode(action.Command))
+                .Append("' data-act-id='")
+                .Append(encoder.Encode(action.Id))
+                .Append("' aria-label='Run follow-up action ")
+                .Append(action.Ordinal.ToString(CultureInfo.InvariantCulture))
+                .Append("'>")
+                .Append("<span class='ix-action-ordinal'>")
+                .Append(action.Ordinal.ToString(CultureInfo.InvariantCulture))
+                .Append(".</span>")
+                .Append("<span class='ix-action-label'>")
+                .Append(encoder.Encode(action.Label))
+                .Append("</span>")
+                .Append("<code class='ix-action-command'>")
+                .Append(encoder.Encode(action.Command))
+                .Append("</code>")
+                .Append("</button>");
+        }
+        sb.Append("</div></section>");
+        return sb.ToString();
+    }
+
+    private static string EnsureInlineCodeHtml(string html) {
+        if (string.IsNullOrEmpty(html) || html.IndexOf('`', StringComparison.Ordinal) < 0) {
+            return html;
+        }
+
+        var preBlocks = PreBlockRegex.Matches(html);
+        if (preBlocks.Count == 0) {
+            return InlineCodeFallbackRegex.Replace(html, match => "<code>" + match.Groups["code"].Value + "</code>");
+        }
+
+        var sb = new StringBuilder(html.Length + 32);
+        var cursor = 0;
+        for (var i = 0; i < preBlocks.Count; i++) {
+            var pre = preBlocks[i];
+            if (pre.Index > cursor) {
+                var segment = html[cursor..pre.Index];
+                sb.Append(InlineCodeFallbackRegex.Replace(segment, match => "<code>" + match.Groups["code"].Value + "</code>"));
+            }
+
+            sb.Append(pre.Value);
+            cursor = pre.Index + pre.Length;
+        }
+
+        if (cursor < html.Length) {
+            var tail = html[cursor..];
+            sb.Append(InlineCodeFallbackRegex.Replace(tail, match => "<code>" + match.Groups["code"].Value + "</code>"));
+        }
+
+        return sb.ToString();
     }
 
     private static RoleStyle ResolveRoleStyle(string? role) {
@@ -221,5 +360,7 @@ internal static class TranscriptHtmlFormatter {
         return new RoleStyle("system", "System", "S");
     }
 
+    private readonly record struct PendingActionRenderItem(int Ordinal, string Label, string Command, string Id);
+    private readonly record struct PendingActionExtraction(string CleanedText, IReadOnlyList<PendingActionRenderItem> Actions);
     private readonly record struct RoleStyle(string RoleClass, string DisplayName, string Avatar);
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMarkdownNormalizer.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMarkdownNormalizer.cs
@@ -26,6 +26,10 @@ internal static class TranscriptMarkdownNormalizer {
         @"(?<=:\*\*)(?=\S)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex TightBoldSuffixRegex = new(
+        @"(\*\*[^*\r\n]+\*\*)(?=[\p{L}\p{N}])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static readonly Regex MissingSpaceBeforeBoldMetricRegex = new(
         @"(?<=\s)-(?=\*\*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -64,6 +68,7 @@ internal static class TranscriptMarkdownNormalizer {
         normalized = NumberedChoiceJoinRegex.Replace(normalized, "$1 ");
         normalized = LetterToNumberedChoiceJoinRegex.Replace(normalized, " ");
         normalized = TightBoldValueRegex.Replace(normalized, " ");
+        normalized = TightBoldSuffixRegex.Replace(normalized, "$1 ");
         normalized = MissingSpaceBeforeBoldMetricRegex.Replace(normalized, "- ");
         normalized = SingleStarMetricRegex.Replace(normalized, "- **");
         normalized = CollapsedBulletRegex.Replace(normalized, "\n- **");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.chat.css
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.chat.css
@@ -378,10 +378,81 @@ pre:hover .code-copy-btn {
   font-size: 0.9em;
 }
 
+.bubble .markdown-body :not(pre) > code {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 7px;
+  border: 1px solid var(--ix-code-border);
+  background: var(--ix-code-bg);
+  color: #d9ebff;
+}
+
 .bubble .markdown-body pre code {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   word-break: break-word;
+}
+
+.ix-action-cta {
+  margin: 10px 0 0;
+  padding-top: 9px;
+  border-top: 1px solid rgba(164, 201, 240, 0.22);
+}
+
+.ix-action-cta-title {
+  font-size: 11px;
+  color: var(--ix-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 8px;
+}
+
+.ix-action-cta-list {
+  display: grid;
+  gap: 7px;
+}
+
+.ix-action-btn {
+  width: 100%;
+  border: 1px solid rgba(106, 160, 214, 0.56);
+  background: linear-gradient(180deg, rgba(33, 71, 112, 0.82) 0%, rgba(20, 49, 82, 0.8) 100%);
+  color: var(--ix-text-primary);
+  border-radius: 10px;
+  padding: 8px 10px;
+  cursor: pointer;
+  text-align: left;
+  display: grid;
+  gap: 4px;
+}
+
+.ix-action-btn:hover {
+  border-color: rgba(134, 189, 246, 0.88);
+  background: linear-gradient(180deg, rgba(37, 80, 124, 0.88) 0%, rgba(23, 56, 93, 0.84) 100%);
+}
+
+.ix-action-btn.done {
+  border-color: rgba(112, 214, 159, 0.85);
+}
+
+.ix-action-ordinal {
+  font-size: 12px;
+  font-weight: 700;
+  color: #cce6ff;
+}
+
+.ix-action-label {
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.ix-action-command {
+  justify-self: start;
+  font-size: 11.5px;
+  border: 1px solid rgba(164, 201, 240, 0.32);
+  border-radius: 7px;
+  padding: 1px 6px;
+  background: rgba(8, 26, 45, 0.65);
+  color: #cae8ff;
 }
 
 .bubble .markdown-body table {
@@ -536,4 +607,3 @@ pre:hover .code-copy-btn {
   opacity: 0.55;
   cursor: default;
 }
-

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.22.bindings.wheel.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.22.bindings.wheel.js
@@ -150,6 +150,21 @@
   });
 
   document.addEventListener("click", function(e) {
+    var actionBtn = e.target.closest(".ix-action-btn");
+    if (actionBtn && !actionBtn.disabled) {
+      var cmd = (actionBtn.getAttribute("data-act-cmd") || "").trim();
+      if (!cmd) {
+        return;
+      }
+
+      post("send", { text: cmd });
+      actionBtn.classList.add("done");
+      setTimeout(function() {
+        actionBtn.classList.remove("done");
+      }, 900);
+      return;
+    }
+
     var copyBtn = e.target.closest(".msg-copy-btn");
     if (!copyBtn) {
       return;


### PR DESCRIPTION
## Summary
- render assistant pending-action list lines as clickable action chips in chat bubbles
- wire action chip clicks to send the corresponding \/act <id>\ command automatically
- add inline-code fallback conversion so backtick spans always render as \<code>\
- improve markdown normalization for glued bold-to-word spacing artifacts
- style inline code and action chips for clearer readability

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --nologo
