### PR TITLE
Add project-view-apply maintainer workflow

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -199,6 +199,27 @@ Useful options:
 - `--issue <n>` to upsert the checklist comment on an existing issue.
 - `--create-issue` and `--issue-title <text>` to create a dedicated checklist issue.
 
+## Build project view apply plan (maintainer assist)
+
+Generate a deterministic apply plan for missing default GitHub Project views and optionally post it to an issue.
+
+```bash
+intelligencex todo project-view-apply \
+  --config artifacts/triage/ix-project-config.json \
+  --create-issue \
+  --open-web
+```
+
+Useful options:
+- `--owner <login>` and `--project <n>` to target project directly.
+- `--repo <owner/name>` for issue posting context.
+- `--out <path>` to choose apply-plan markdown output path.
+- `--print` to emit apply-plan markdown to stdout.
+- `--issue <n>` to upsert the apply-plan comment on an existing issue.
+- `--create-issue` and `--issue-title <text>` to create a dedicated apply-plan issue.
+- `--open-web` to open the project UI after plan generation.
+- `--fail-if-missing` to exit with code `2` when recommended views are missing.
+
 ## GitHub Actions template
 
 A reusable scheduled workflow template is available at:

--- a/IntelligenceX.Cli/Program.Help.cs
+++ b/IntelligenceX.Cli/Program.Help.cs
@@ -70,6 +70,7 @@ internal static partial class Program {
         Console.WriteLine("  todo project-sync        Sync triage/vision artifacts into GitHub Project items and fields");
         Console.WriteLine("  todo project-bootstrap   Bootstrap project + workflow + VISION.md for GitHub-native maintainer triage");
         Console.WriteLine("  todo project-view-checklist  Build maintainer checklist for missing/default GitHub Project views");
+        Console.WriteLine("  todo project-view-apply  Generate deterministic apply plan for missing GitHub Project views");
         Console.WriteLine();
         Console.WriteLine("Release commands:");
         Console.WriteLine("  release notes    Generate release notes from git tags/commits");

--- a/IntelligenceX.Cli/Todo/ProjectV2Client.cs
+++ b/IntelligenceX.Cli/Todo/ProjectV2Client.cs
@@ -424,6 +424,36 @@ query($owner: String!, $number: Int!, $cursor: String) {
         return views;
     }
 
+    public async Task<bool> SupportsProjectViewCreationAsync() {
+        var query = """
+query {
+  __type(name: "Mutation") {
+    fields {
+      name
+    }
+  }
+}
+""";
+
+        var root = await QueryGraphQlAsync(query).ConfigureAwait(false);
+        if (!TryGetProperty(root, "data", out var data) ||
+            !TryGetProperty(data, "__type", out var mutationType) ||
+            mutationType.ValueKind != JsonValueKind.Object ||
+            !TryGetProperty(mutationType, "fields", out var fields) ||
+            fields.ValueKind != JsonValueKind.Array) {
+            return false;
+        }
+
+        foreach (var field in fields.EnumerateArray()) {
+            var name = ReadString(field, "name");
+            if (name.Equals("createProjectV2View", StringComparison.Ordinal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public async Task<IReadOnlyDictionary<string, ProjectItem>> GetProjectItemsByUrlAsync(string owner, int number, int maxItems) {
         var items = new Dictionary<string, ProjectItem>(StringComparer.OrdinalIgnoreCase);
         if (maxItems <= 0) {

--- a/IntelligenceX.Cli/Todo/ProjectViewApplyRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectViewApplyRunner.cs
@@ -1,0 +1,442 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using IntelligenceX.Cli.GitHub;
+
+namespace IntelligenceX.Cli.Todo;
+
+internal static class ProjectViewApplyRunner {
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+    internal const string CommentMarker = "<!-- intelligencex:project-view-apply -->";
+    private const string DefaultRepo = "EvotecIT/IntelligenceX";
+    private const string DefaultConfigPath = "artifacts/triage/ix-project-config.json";
+    private const string DefaultOutputPath = "artifacts/triage/ix-project-view-apply.md";
+    private const string DefaultIssueTitle = "IX Project View Apply Plan";
+
+    private sealed class Options {
+        public string Repo { get; set; } = DefaultRepo;
+        public string? Owner { get; set; }
+        public int? ProjectNumber { get; set; }
+        public string ConfigPath { get; set; } = DefaultConfigPath;
+        public string OutputPath { get; set; } = DefaultOutputPath;
+        public bool Print { get; set; }
+        public int? IssueNumber { get; set; }
+        public bool CreateIssue { get; set; }
+        public string IssueTitle { get; set; } = DefaultIssueTitle;
+        public bool OpenWeb { get; set; }
+        public bool FailIfMissing { get; set; }
+        public bool ShowHelp { get; set; }
+        public bool ParseFailed { get; set; }
+    }
+
+    public static async Task<int> RunAsync(string[] args) {
+        var options = ParseOptions(args);
+        if (options.ShowHelp) {
+            PrintHelp();
+            return options.ParseFailed ? 1 : 0;
+        }
+
+        var (authCode, _, authErr) = await GhCli.RunAsync("auth", "status").ConfigureAwait(false);
+        if (authCode != 0) {
+            Console.Error.WriteLine("gh is not authenticated. Run `gh auth login`.");
+            if (!string.IsNullOrWhiteSpace(authErr)) {
+                Console.Error.WriteLine(authErr.Trim());
+            }
+            return 1;
+        }
+
+        if (!TryResolveProjectTarget(options, out var owner, out var projectNumber, out var repo, out var resolveError)) {
+            Console.Error.WriteLine(resolveError);
+            return 1;
+        }
+
+        var client = new ProjectV2Client();
+        ProjectV2Client.ProjectRef project;
+        try {
+            project = await client.TryGetProjectAsync(owner, projectNumber).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Project {projectNumber} was not found for owner '{owner}'.");
+        } catch (Exception ex) {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+
+        IReadOnlyDictionary<string, ProjectV2Client.ProjectView> views;
+        try {
+            views = await client.GetProjectViewsByNameAsync(owner, projectNumber).ConfigureAwait(false);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Failed to list project views: {ex.Message}");
+            return 1;
+        }
+
+        var directCreateSupported = false;
+        try {
+            directCreateSupported = await client.SupportsProjectViewCreationAsync().ConfigureAwait(false);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Warning: unable to probe project view creation capability: {ex.Message}");
+        }
+
+        var missing = ProjectViewCatalog.FindMissingDefaultViews(views);
+        var markdown = BuildApplyMarkdown(
+            repo,
+            owner,
+            projectNumber,
+            project.Url,
+            views,
+            directCreateSupported,
+            DateTimeOffset.UtcNow);
+
+        WriteText(options.OutputPath, markdown);
+
+        int? issueNumber = null;
+        var issueCreated = false;
+        var commentUpserted = false;
+
+        if (options.CreateIssue) {
+            var createResult = await CreateIssueAsync(repo, options.IssueTitle, markdown).ConfigureAwait(false);
+            if (!createResult.Success) {
+                Console.Error.WriteLine(createResult.Error);
+                return 1;
+            }
+            issueNumber = createResult.IssueNumber;
+            issueCreated = true;
+        } else if (options.IssueNumber.HasValue) {
+            issueNumber = options.IssueNumber.Value;
+            commentUpserted = await IssueSuggestionCommentManager.UpsertAsync(
+                repo,
+                issueNumber.Value,
+                markdown,
+                CommentMarker).ConfigureAwait(false);
+        }
+
+        if (options.Print) {
+            Console.WriteLine(markdown);
+        }
+
+        if (options.OpenWeb) {
+            var (webCode, _, webErr) = await GhCli.RunAsync(
+                "project", "view",
+                projectNumber.ToString(CultureInfo.InvariantCulture),
+                "--owner", owner,
+                "--web").ConfigureAwait(false);
+            if (webCode != 0) {
+                Console.Error.WriteLine($"Warning: failed to open project web UI: {webErr.Trim()}");
+            }
+        }
+
+        var present = ProjectViewCatalog.DefaultViews.Count - missing.Count;
+        Console.WriteLine($"Project view apply target: {owner}#{projectNumber} ({project.Url})");
+        Console.WriteLine($"Default view coverage: {present}/{ProjectViewCatalog.DefaultViews.Count}");
+        Console.WriteLine($"Missing default views: {missing.Count}");
+        Console.WriteLine($"Direct API view-create support: {(directCreateSupported ? "available" : "unavailable")}");
+        Console.WriteLine($"Apply plan output: {options.OutputPath}");
+        if (issueCreated && issueNumber.HasValue) {
+            Console.WriteLine($"Apply-plan issue created: #{issueNumber.Value}");
+        } else if (issueNumber.HasValue) {
+            Console.WriteLine($"Apply-plan comment upsert target: issue #{issueNumber.Value}");
+            Console.WriteLine(commentUpserted
+                ? "Apply-plan comment upserted."
+                : "Warning: apply-plan comment upsert failed.");
+        }
+
+        if (missing.Count > 0 && options.FailIfMissing) {
+            Console.Error.WriteLine("Missing recommended default views were detected and --fail-if-missing is enabled.");
+            return 2;
+        }
+
+        return 0;
+    }
+
+    internal static string BuildApplyMarkdown(
+        string repo,
+        string owner,
+        int projectNumber,
+        string projectUrl,
+        IReadOnlyDictionary<string, ProjectV2Client.ProjectView> viewsByName,
+        bool directCreateSupported,
+        DateTimeOffset generatedAtUtc) {
+        var missing = ProjectViewCatalog.FindMissingDefaultViews(viewsByName);
+        var present = ProjectViewCatalog.DefaultViews.Count - missing.Count;
+
+        var builder = new StringBuilder();
+        builder.AppendLine(CommentMarker);
+        builder.AppendLine("# IX Project View Apply Plan");
+        builder.AppendLine();
+        builder.AppendLine($"- Generated: {generatedAtUtc.UtcDateTime:yyyy-MM-dd HH:mm:ss} UTC");
+        builder.AppendLine($"- Repo: `{repo}`");
+        builder.AppendLine($"- Project: `{owner}#{projectNumber}`");
+        if (!string.IsNullOrWhiteSpace(projectUrl)) {
+            builder.AppendLine($"- Project URL: {projectUrl}");
+        }
+        builder.AppendLine($"- Default view coverage: {present}/{ProjectViewCatalog.DefaultViews.Count}");
+        builder.AppendLine($"- Missing default views: {missing.Count}");
+        builder.AppendLine($"- Direct API view-create support: {(directCreateSupported ? "available" : "unavailable")}");
+        builder.AppendLine();
+        builder.AppendLine("## Missing View Checklist");
+        builder.AppendLine();
+
+        if (missing.Count == 0) {
+            builder.AppendLine("- [x] All recommended IX default views are present.");
+        } else {
+            foreach (var view in missing) {
+                builder.AppendLine($"- [ ] **{view.Name}** (`{view.Layout}`)");
+                builder.AppendLine($"  Suggested filter: `{view.Filter}`");
+                builder.AppendLine($"  Purpose: {view.Description}");
+            }
+        }
+
+        builder.AppendLine();
+        builder.AppendLine("## Apply Steps");
+        builder.AppendLine();
+        builder.AppendLine($"1. Open project: {projectUrl}");
+        builder.AppendLine("2. Select `+ New view` in GitHub Projects.");
+        builder.AppendLine("3. For each unchecked checklist item above, use the exact view name/layout and suggested filter.");
+        builder.AppendLine("4. Re-run `intelligencex todo project-view-apply` to confirm coverage.");
+
+        if (!directCreateSupported) {
+            builder.AppendLine();
+            builder.AppendLine("## Platform Note");
+            builder.AppendLine();
+            builder.AppendLine(
+                "GitHub's current public API surface does not expose direct project view creation, so this command prepares a deterministic maintainer apply plan.");
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private static Options ParseOptions(string[] args) {
+        var options = new Options();
+        for (var i = 0; i < args.Length; i++) {
+            var arg = args[i];
+            switch (arg) {
+                case "-h":
+                case "--help":
+                    options.ShowHelp = true;
+                    break;
+                case "--repo":
+                    if (i + 1 < args.Length) {
+                        options.Repo = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--owner":
+                    if (i + 1 < args.Length) {
+                        options.Owner = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--project":
+                    if (i + 1 < args.Length &&
+                        int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var projectNumber) &&
+                        projectNumber > 0) {
+                        options.ProjectNumber = projectNumber;
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--config":
+                    if (i + 1 < args.Length) {
+                        options.ConfigPath = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--out":
+                    if (i + 1 < args.Length) {
+                        options.OutputPath = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--print":
+                    options.Print = true;
+                    break;
+                case "--issue":
+                    if (i + 1 < args.Length &&
+                        int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var issueNumber) &&
+                        issueNumber > 0) {
+                        options.IssueNumber = issueNumber;
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--create-issue":
+                    options.CreateIssue = true;
+                    break;
+                case "--issue-title":
+                    if (i + 1 < args.Length) {
+                        options.IssueTitle = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--open-web":
+                    options.OpenWeb = true;
+                    break;
+                case "--fail-if-missing":
+                    options.FailIfMissing = true;
+                    break;
+                default:
+                    Console.Error.WriteLine($"Unknown option: {arg}");
+                    options.ParseFailed = true;
+                    options.ShowHelp = true;
+                    break;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Repo) || !options.Repo.Contains('/')) {
+            options.ParseFailed = true;
+            options.ShowHelp = true;
+        }
+
+        if (options.CreateIssue && options.IssueNumber.HasValue) {
+            Console.Error.WriteLine("Choose either --issue <n> or --create-issue, not both.");
+            options.ParseFailed = true;
+            options.ShowHelp = true;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.IssueTitle)) {
+            options.IssueTitle = DefaultIssueTitle;
+        }
+
+        return options;
+    }
+
+    private static void PrintHelp() {
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  intelligencex todo project-view-apply [options]");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --owner <login>         Project owner login (required unless --config resolves it)");
+        Console.WriteLine("  --project <n>           Project number (required unless --config resolves it)");
+        Console.WriteLine("  --repo <owner/name>     Repository context (default: EvotecIT/IntelligenceX)");
+        Console.WriteLine("  --config <path>         Project config JSON from project-init (default: artifacts/triage/ix-project-config.json)");
+        Console.WriteLine("  --out <path>            Apply-plan markdown output path (default: artifacts/triage/ix-project-view-apply.md)");
+        Console.WriteLine("  --print                 Print apply-plan markdown to stdout");
+        Console.WriteLine("  --issue <n>             Upsert apply-plan comment on an existing issue");
+        Console.WriteLine("  --create-issue          Create an apply-plan issue with rendered markdown body");
+        Console.WriteLine("  --issue-title <text>    Apply-plan issue title when --create-issue is used");
+        Console.WriteLine("  --open-web              Open project web UI after plan generation");
+        Console.WriteLine("  --fail-if-missing       Exit with code 2 when recommended views are missing");
+        Console.WriteLine();
+        Console.WriteLine("Required token scopes: `project` and issue write access for issue posting.");
+    }
+
+    private static bool TryResolveProjectTarget(
+        Options options,
+        out string owner,
+        out int projectNumber,
+        out string repo,
+        out string error) {
+        owner = options.Owner?.Trim() ?? string.Empty;
+        projectNumber = options.ProjectNumber ?? 0;
+        repo = options.Repo?.Trim() ?? string.Empty;
+        error = string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(owner) && projectNumber > 0) {
+            return true;
+        }
+
+        if (!File.Exists(options.ConfigPath)) {
+            error = "Owner/project not provided and project config file was not found. Use --owner/--project or run `todo project-init` first.";
+            return false;
+        }
+
+        try {
+            using var doc = JsonDocument.Parse(File.ReadAllText(options.ConfigPath));
+            var root = doc.RootElement;
+
+            if (string.IsNullOrWhiteSpace(owner)) {
+                owner = ReadString(root, "owner");
+            }
+
+            if (projectNumber <= 0 &&
+                TryGetProperty(root, "project", out var projectObj) &&
+                projectObj.ValueKind == JsonValueKind.Object) {
+                projectNumber = ReadInt(projectObj, "number");
+            }
+
+            if (string.IsNullOrWhiteSpace(repo)) {
+                repo = ReadString(root, "repo");
+            }
+        } catch (Exception ex) {
+            error = $"Failed to parse project config at {options.ConfigPath}: {ex.Message}";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(owner) || projectNumber <= 0) {
+            error = "Unable to resolve owner/project from arguments or config.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static async Task<(bool Success, int IssueNumber, string Error)> CreateIssueAsync(
+        string repo,
+        string title,
+        string body) {
+        var (code, stdout, stderr) = await GhCli.RunAsync(
+            TimeSpan.FromSeconds(90),
+            "issue", "create",
+            "--repo", repo,
+            "--title", title,
+            "--body", body).ConfigureAwait(false);
+
+        if (code != 0) {
+            return (
+                false,
+                0,
+                $"Failed to create apply-plan issue in '{repo}': {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
+        }
+
+        if (!ProjectBootstrapRunner.TryParseIssueNumberFromGhOutput(stdout, out var issueNumber)) {
+            return (false, 0, "Apply-plan issue was created but issue number could not be parsed from `gh issue create` output.");
+        }
+
+        return (true, issueNumber, string.Empty);
+    }
+
+    private static bool TryGetProperty(JsonElement root, string name, out JsonElement value) {
+        value = default;
+        return root.ValueKind == JsonValueKind.Object && root.TryGetProperty(name, out value);
+    }
+
+    private static string ReadString(JsonElement root, string name) {
+        if (!TryGetProperty(root, name, out var value) || value.ValueKind != JsonValueKind.String) {
+            return string.Empty;
+        }
+        return value.GetString() ?? string.Empty;
+    }
+
+    private static int ReadInt(JsonElement root, string name) {
+        if (!TryGetProperty(root, name, out var value) || value.ValueKind != JsonValueKind.Number || !value.TryGetInt32(out var number)) {
+            return 0;
+        }
+        return number;
+    }
+
+    private static void WriteText(string path, string content) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return;
+        }
+        var fullPath = Path.GetFullPath(path);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrWhiteSpace(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+        File.WriteAllText(fullPath, content, Utf8NoBom);
+    }
+}

--- a/IntelligenceX.Cli/Todo/TodoRunner.cs
+++ b/IntelligenceX.Cli/Todo/TodoRunner.cs
@@ -21,6 +21,7 @@ internal static class TodoRunner {
             "project-sync" => ProjectSyncRunner.RunAsync(rest),
             "project-bootstrap" => ProjectBootstrapRunner.RunAsync(rest),
             "project-view-checklist" => ProjectViewChecklistRunner.RunAsync(rest),
+            "project-view-apply" => ProjectViewApplyRunner.RunAsync(rest),
             _ => Task.FromResult(PrintHelpReturn(command))
         };
     }
@@ -48,6 +49,7 @@ internal static class TodoRunner {
         Console.WriteLine("  intelligencex todo project-sync [options]");
         Console.WriteLine("  intelligencex todo project-bootstrap [options]");
         Console.WriteLine("  intelligencex todo project-view-checklist [options]");
+        Console.WriteLine("  intelligencex todo project-view-apply [options]");
         Console.WriteLine();
         Console.WriteLine("Use `intelligencex todo sync-bot-feedback --help` for options.");
         Console.WriteLine("Use `intelligencex todo build-triage-index --help` for options.");
@@ -56,5 +58,6 @@ internal static class TodoRunner {
         Console.WriteLine("Use `intelligencex todo project-sync --help` for options.");
         Console.WriteLine("Use `intelligencex todo project-bootstrap --help` for options.");
         Console.WriteLine("Use `intelligencex todo project-view-checklist --help` for options.");
+        Console.WriteLine("Use `intelligencex todo project-view-apply --help` for options.");
     }
 }

--- a/IntelligenceX.Tests/Program.Todo.ProjectViewApply.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectViewApply.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace IntelligenceX.Tests;
+
+internal static partial class Program {
+#if !NET472
+    private static void TestProjectViewApplyMarkdownIncludesMissingViewsAndPlatformNote() {
+        var existingViews = new Dictionary<string, IntelligenceX.Cli.Todo.ProjectV2Client.ProjectView>(StringComparer.OrdinalIgnoreCase) {
+            ["IX Queue"] = new(
+                "view1",
+                "IX Queue",
+                "TABLE",
+                "https://github.com/orgs/EvotecIT/projects/123/views/1")
+        };
+
+        var markdown = IntelligenceX.Cli.Todo.ProjectViewApplyRunner.BuildApplyMarkdown(
+            "EvotecIT/IntelligenceX",
+            "EvotecIT",
+            123,
+            "https://github.com/orgs/EvotecIT/projects/123",
+            existingViews,
+            directCreateSupported: false,
+            new DateTimeOffset(2026, 02, 15, 23, 10, 00, TimeSpan.Zero));
+
+        AssertContainsText(markdown, "intelligencex:project-view-apply", "apply marker present");
+        AssertContainsText(markdown, "Default view coverage: 1/4", "coverage reflects missing defaults");
+        AssertContainsText(markdown, "- [ ] **Merge Candidates** (`TABLE`)", "missing default view listed");
+        AssertContainsText(markdown, "Select `+ New view` in GitHub Projects.", "manual apply step present");
+        AssertContainsText(markdown, "public API surface does not expose direct project view creation", "platform note present");
+    }
+
+    private static void TestProjectViewApplyMarkdownAllViewsPresentShowsCompletedChecklist() {
+        var existingViews = IntelligenceX.Cli.Todo.ProjectViewCatalog.DefaultViews
+            .ToDictionary(
+                view => view.Name,
+                view => new IntelligenceX.Cli.Todo.ProjectV2Client.ProjectView(
+                    $"id-{view.Name}",
+                    view.Name,
+                    view.Layout,
+                    $"https://example.local/{view.Name.Replace(' ', '-')}"),
+                StringComparer.OrdinalIgnoreCase);
+
+        var markdown = IntelligenceX.Cli.Todo.ProjectViewApplyRunner.BuildApplyMarkdown(
+            "EvotecIT/IntelligenceX",
+            "EvotecIT",
+            123,
+            "https://github.com/orgs/EvotecIT/projects/123",
+            existingViews,
+            directCreateSupported: true,
+            new DateTimeOffset(2026, 02, 15, 23, 15, 00, TimeSpan.Zero));
+
+        AssertContainsText(markdown, "Default view coverage: 4/4", "coverage reflects all defaults present");
+        AssertContainsText(markdown, "Missing default views: 0", "missing count is zero");
+        AssertContainsText(markdown, "- [x] All recommended IX default views are present.", "completed checklist message");
+        AssertContainsText(markdown, "Direct API view-create support: available", "capability line included");
+    }
+#endif
+}

--- a/IntelligenceX.Tests/Program.Todo.cs
+++ b/IntelligenceX.Tests/Program.Todo.cs
@@ -23,6 +23,7 @@ internal static partial class Program {
             AssertContainsText(output, "project-sync", "todo help includes project sync command");
             AssertContainsText(output, "project-bootstrap", "todo help includes project bootstrap command");
             AssertContainsText(output, "project-view-checklist", "todo help includes project view checklist command");
+            AssertContainsText(output, "project-view-apply", "todo help includes project view apply command");
         } finally {
             Console.SetOut(originalOut);
             Console.SetError(originalError);

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -456,6 +456,8 @@ internal static partial class Program {
         failed += Run("Todo project views full coverage has no missing", TestProjectViewCatalogFindMissingDefaultViewsReturnsEmptyWhenComplete);
         failed += Run("Todo project view checklist markdown includes marker and coverage", TestProjectViewChecklistMarkdownIncludesMarkerAndCoverage);
         failed += Run("Todo project view checklist markdown includes apply instructions", TestProjectViewChecklistMarkdownIncludesApplyInstructions);
+        failed += Run("Todo project view apply markdown includes missing views and platform note", TestProjectViewApplyMarkdownIncludesMissingViewsAndPlatformNote);
+        failed += Run("Todo project view apply markdown all views present shows completed checklist", TestProjectViewApplyMarkdownAllViewsPresentShowsCompletedChecklist);
         failed += Run("Todo project sync merges vision and canonical", TestProjectSyncBuildEntriesMergesVisionAndCanonical);
         failed += Run("Todo project sync labels include tags and high-confidence match", TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch);
         failed += Run("Todo project sync labels normalize dynamic category and tags", TestProjectSyncBuildLabelsNormalizesDynamicCategoryAndTags);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -184,6 +184,25 @@ Options:
 - `--create-issue` create issue with checklist markdown body
 - `--issue-title <text>` custom issue title when creating
 
+## Project View Apply Plan (Maintainer Assist)
+
+Generate a deterministic apply plan for missing default views and optionally post it on an issue:
+
+```bash
+intelligencex todo project-view-apply --config artifacts/triage/ix-project-config.json --create-issue --open-web
+```
+
+Options:
+- `--owner <login>` and `--project <n>` target project directly
+- `--repo <owner/name>` repository context for issue posting
+- `--out <path>` output markdown path
+- `--print` print markdown to stdout
+- `--issue <n>` upsert comment on existing issue
+- `--create-issue` create issue with apply-plan markdown body
+- `--issue-title <text>` custom issue title when creating
+- `--open-web` open project web UI after generating plan
+- `--fail-if-missing` exit with code `2` when recommended views are missing
+
 ## Workflow Template
 
 Template path:


### PR DESCRIPTION
## Summary
- add `intelligencex todo project-view-apply` to generate a deterministic maintainer apply-plan for missing default IX Project views
- add `ProjectV2Client.SupportsProjectViewCreationAsync()` capability probe so we report whether direct API view creation is available
- support issue workflows for apply plans (`--create-issue` / `--issue <n>`), markdown output (`--out`, `--print`), optional project UI open (`--open-web`), and strict exit mode (`--fail-if-missing`)
- wire command into todo routing/help and top-level CLI help
- document the new command in user docs and internal CLI docs
- add tests for apply-plan markdown coverage and todo help exposure

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release --no-build`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
