### PR TITLE
Website: fix heading order, meta descriptions, and contrast

### DIFF
--- a/Website/static/css/api.css
+++ b/Website/static/css/api.css
@@ -169,7 +169,7 @@ p { color: var(--pf-muted); margin: 0 0 1rem; }
 .filter-button {
   background: var(--pf-bg-alt);
   border: 1px solid var(--pf-border);
-  color: var(--pf-muted);
+  color: var(--pf-ink);
   border-radius: 999px;
   padding: 0.25rem 0.6rem;
   font-size: 0.7rem;
@@ -243,7 +243,7 @@ p { color: var(--pf-muted); margin: 0 0 1rem; }
 .nav-section-header .type-count {
   margin-left: auto;
   font-size: 0.65rem;
-  color: var(--pf-muted);
+  color: var(--pf-ink);
   font-weight: 400;
 }
 
@@ -341,7 +341,7 @@ p { color: var(--pf-muted); margin: 0 0 1rem; }
 /* ===== Namespace Groups (main content) ===== */
 .namespace-group { margin-bottom: 1.5rem; }
 .namespace-group h3 { font-size: 1.1rem; margin-bottom: 0.75rem; }
-.namespace-group h3 .count { font-size: 0.8rem; font-weight: 400; color: var(--pf-muted); }
+.namespace-group h3 .count { font-size: 0.8rem; font-weight: 400; color: var(--pf-ink); }
 
 .type-chips { display: flex; flex-wrap: wrap; gap: 0.5rem; }
 
@@ -353,7 +353,7 @@ p { color: var(--pf-muted); margin: 0 0 1rem; }
   gap: 0.375rem;
   padding: 0.3rem 0.625rem;
   font-size: 0.8rem;
-  color: var(--pf-muted);
+  color: var(--pf-ink);
   background: var(--pf-bg-alt);
   border: 1px solid var(--pf-border);
   border-radius: 100px;
@@ -386,6 +386,7 @@ p { color: var(--pf-muted); margin: 0 0 1rem; }
   white-space: nowrap;
   text-decoration: none;
   font-weight: 600;
+  color: var(--pf-ink);
 }
 
 .type-chip.class .chip-icon { background: rgba(0, 217, 255, 0.2); color: var(--pf-accent); }
@@ -821,8 +822,10 @@ blockquote {
 .nav-icon { color: var(--pf-muted); display: flex; align-items: center; text-decoration: none; }
 .nav-icon:hover { color: var(--pf-accent); }
 .ix-header svg, .ix-actions svg, .nav-icon svg, .nav-cta svg { width: 22px; height: 22px; flex-shrink: 0; }
-.nav-cta { display: inline-flex; align-items: center; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; background: var(--pf-btn-primary-bg); color: var(--pf-btn-primary-text); border-radius: var(--pf-radius-sm); transition: all 0.2s; text-decoration: none; }
-.nav-cta:hover { opacity: 0.9; transform: translateY(-1px); box-shadow: var(--pf-shadow-button); color: var(--pf-btn-primary-text); }
+.nav-cta { display: inline-flex; align-items: center; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 700; background: var(--pf-btn-primary-bg); color: #062A38; border-radius: var(--pf-radius-sm); transition: all 0.2s; text-decoration: none; }
+.nav-cta:hover { opacity: 0.92; transform: translateY(-1px); box-shadow: var(--pf-shadow-button); color: #062A38; }
+[data-theme="light"] .nav-cta { background: #0E7490; color: #F8FAFC; }
+[data-theme="light"] .nav-cta:hover { background: #0C677F; color: #F8FAFC; }
 
 /* ===== Footer ===== */
 .ix-footer { border-top: 1px solid var(--pf-border); padding: 3rem 0 2rem; margin-top: 0; background: var(--pf-bg-alt); }
@@ -830,7 +833,7 @@ blockquote {
 .ix-footer-grid { display: grid; grid-template-columns: 2fr repeat(3, 1fr); gap: 2rem; margin-bottom: 2rem; }
 .ix-footer-logo { display: flex; align-items: center; gap: 0.5rem; font-weight: 600; margin-bottom: 0.75rem; color: var(--pf-ink-strong, #fff); }
 .ix-footer-tagline { font-size: 0.875rem; color: var(--pf-muted); margin: 0; line-height: 1.5; }
-.ix-footer-col h4 { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--pf-ink); margin-bottom: 0.75rem; }
+.ix-footer-heading { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--pf-ink); margin: 0 0 0.75rem; font-weight: 600; }
 .ix-footer-col ul { list-style: none; padding: 0; margin: 0; }
 .ix-footer-col li { margin-bottom: 0.375rem; }
 .ix-footer-col a { font-size: 0.875rem; color: var(--pf-muted); text-decoration: none; }
@@ -849,7 +852,7 @@ blockquote {
 .member-actions button {
     background: var(--pf-bg-alt);
     border: 1px solid var(--pf-border);
-    color: var(--pf-muted);
+    color: var(--pf-ink);
     border-radius: 999px;
     padding: 0.25rem 0.6rem;
     font-size: 0.7rem;
@@ -873,7 +876,7 @@ blockquote {
 .sidebar-tools button {
     background: var(--pf-bg-alt);
     border: 1px solid var(--pf-border);
-    color: var(--pf-muted);
+    color: var(--pf-ink);
     border-radius: 999px;
     padding: 0.25rem 0.6rem;
     font-size: 0.7rem;
@@ -889,14 +892,14 @@ blockquote {
 
 .sidebar-count {
     font-size: 0.75rem;
-    color: var(--pf-muted);
+    color: var(--pf-ink);
     padding: 0 1rem 0.5rem;
 }
 
 .sidebar-reset {
     background: var(--pf-bg-alt);
     border: 1px solid var(--pf-border);
-    color: var(--pf-muted);
+    color: var(--pf-ink);
     border-radius: var(--pf-radius-sm);
     padding: 0.35rem 0.6rem;
     font-size: 0.7rem;

--- a/Website/static/css/docs.css
+++ b/Website/static/css/docs.css
@@ -166,6 +166,15 @@
 .docs-main .markdown-body h2 { margin-top: 2.5rem; padding-top: 1.5rem; border-top: 1px solid var(--pf-border); }
 .docs-main .markdown-body h3 { margin-top: 2rem; }
 
+.page-toc-title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--pf-ink);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
 /* ===== Responsive ===== */
 @media (max-width: 768px) {
   .docs-layout { grid-template-columns: 1fr; gap: 1rem; }

--- a/Website/static/css/main.css
+++ b/Website/static/css/main.css
@@ -43,8 +43,10 @@ p { margin: 0 0 1rem; color: var(--pf-muted); }
 .nav-icon { color: var(--pf-muted); display: flex; align-items: center; }
 .nav-icon:hover { color: var(--pf-accent); }
 .ix-header svg, .ix-actions svg, .nav-icon svg, .nav-cta svg { width: 22px; height: 22px; flex-shrink: 0; }
-.nav-cta { display: inline-flex; align-items: center; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; background: var(--pf-btn-primary-bg); color: var(--pf-btn-primary-text); border-radius: var(--pf-radius-sm); transition: all 0.2s; }
-.nav-cta:hover { opacity: 0.9; transform: translateY(-1px); box-shadow: var(--pf-shadow-button); color: var(--pf-btn-primary-text); }
+.nav-cta { display: inline-flex; align-items: center; padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 700; background: var(--pf-btn-primary-bg); color: #062A38; border-radius: var(--pf-radius-sm); transition: all 0.2s; }
+.nav-cta:hover { opacity: 0.92; transform: translateY(-1px); box-shadow: var(--pf-shadow-button); color: #062A38; }
+[data-theme="light"] .nav-cta { background: #0E7490; color: #F8FAFC; }
+[data-theme="light"] .nav-cta:hover { background: #0C677F; color: #F8FAFC; }
 .ix-nav-toggle { display: none; background: none; border: none; color: var(--pf-muted); cursor: pointer; padding: 0.25rem; }
 
 /* ===== Footer ===== */
@@ -54,7 +56,7 @@ p { margin: 0 0 1rem; color: var(--pf-muted); }
 .ix-footer-brand { }
 .ix-footer-logo { display: flex; align-items: center; gap: 0.5rem; font-weight: 600; margin-bottom: 0.75rem; color: var(--pf-ink-strong, #fff); }
 .ix-footer-tagline { font-size: 0.875rem; color: var(--pf-muted); margin: 0; line-height: 1.5; }
-.ix-footer-col h4 { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--pf-ink); margin-bottom: 0.75rem; }
+.ix-footer-heading { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--pf-ink); margin: 0 0 0.75rem; font-weight: 600; }
 .ix-footer-col ul { list-style: none; padding: 0; margin: 0; }
 .ix-footer-col li { margin-bottom: 0.375rem; }
 .ix-footer-col a { font-size: 0.875rem; color: var(--pf-muted); }

--- a/Website/themes/intelligencex/layouts/base.html
+++ b/Website/themes/intelligencex/layouts/base.html
@@ -5,6 +5,9 @@
   <script>(function(){var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme:light)').matches?'light':'dark');document.documentElement.setAttribute('data-theme',t)})()</script>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ page.title }} | IntelligenceX</title>
+  {{ if description_meta_html == "" }}
+  <meta name="description" content="IntelligenceX documentation, API reference, and tooling guides." />
+  {{ end }}
   {{ description_meta_html }}
   {{ canonical_html }}
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/Website/themes/intelligencex/layouts/docs.html
+++ b/Website/themes/intelligencex/layouts/docs.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ page.title }} | IntelligenceX Docs</title>
+  {{ if description_meta_html == "" }}
+  <meta name="description" content="IntelligenceX documentation, guides, and onboarding references." />
+  {{ end }}
   {{ description_meta_html }}
   {{ canonical_html }}
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/Website/themes/intelligencex/layouts/home.html
+++ b/Website/themes/intelligencex/layouts/home.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ page.title }}</title>
+  {{ if description_meta_html == "" }}
+  <meta name="description" content="IntelligenceX platform overview, product capabilities, and getting started resources." />
+  {{ end }}
   {{ description_meta_html }}
   {{ canonical_html }}
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/Website/themes/intelligencex/layouts/page.html
+++ b/Website/themes/intelligencex/layouts/page.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ page.title }} | IntelligenceX</title>
+  {{ if description_meta_html == "" }}
+  <meta name="description" content="IntelligenceX product documentation and platform updates." />
+  {{ end }}
   {{ description_meta_html }}
   {{ canonical_html }}
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/Website/themes/intelligencex/layouts/showcase.html
+++ b/Website/themes/intelligencex/layouts/showcase.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ page.title }}</title>
+  {{ if description_meta_html == "" }}
+  <meta name="description" content="Real-world IntelligenceX workflows and implementation showcase." />
+  {{ end }}
   {{ description_meta_html }}
   {{ canonical_html }}
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/Website/themes/intelligencex/partials/api-footer.html
+++ b/Website/themes/intelligencex/partials/api-footer.html
@@ -12,7 +12,7 @@
         <p class="ix-footer-tagline">AI-powered code review using your own ChatGPT or Copilot account. Zero trust, full control.</p>
       </div>
       <div class="ix-footer-col">
-        <h4>Documentation</h4>
+        <p class="ix-footer-heading">Documentation</p>
         <ul>
           <li><a href="/docs/reviewer/overview/">Reviewer</a></li>
           <li><a href="/docs/cli/overview/">CLI Tools</a></li>
@@ -22,7 +22,7 @@
         </ul>
       </div>
       <div class="ix-footer-col">
-        <h4>Resources</h4>
+        <p class="ix-footer-heading">Resources</p>
         <ul>
           <li><a href="/docs/getting-started/">Getting Started</a></li>
           <li><a href="/docs/security/">Security &amp; Trust</a></li>
@@ -33,7 +33,7 @@
         </ul>
       </div>
       <div class="ix-footer-col">
-        <h4>Company</h4>
+        <p class="ix-footer-heading">Company</p>
         <ul>
           <li><a href="https://evotec.xyz" target="_blank" rel="noopener">Evotec Services</a></li>
           <li><a href="https://evotec.xyz/hub" target="_blank" rel="noopener">Blog</a></li>

--- a/Website/themes/intelligencex/partials/api-header.html
+++ b/Website/themes/intelligencex/partials/api-header.html
@@ -15,7 +15,7 @@
   --pf-code-bg: #0D1117;
   --pf-code-border: rgba(71, 85, 105, 0.5);
   --pf-btn-primary-bg: #00D9FF;
-  --pf-btn-primary-text: #0A0E1A;
+  --pf-btn-primary-text: #062A38;
   --pf-btn-ghost-border: rgba(148, 163, 184, 0.4);
   --pf-radius-sm: 8px;
   --pf-shadow-button: 0 8px 24px rgba(0, 217, 255, 0.15);
@@ -40,8 +40,8 @@
   --pf-card-bg: rgba(255, 255, 255, 0.7);
   --pf-code-bg: #F1F5F9;
   --pf-code-border: rgba(148, 163, 184, 0.4);
-  --pf-btn-primary-bg: #0891B2;
-  --pf-btn-primary-text: #FFFFFF;
+  --pf-btn-primary-bg: #0E7490;
+  --pf-btn-primary-text: #F8FAFC;
   --pf-btn-ghost-border: rgba(100, 116, 139, 0.3);
   --pf-shadow-button: 0 8px 24px rgba(8, 145, 178, 0.12);
   --pf-success: #059669;

--- a/Website/themes/intelligencex/partials/footer.html
+++ b/Website/themes/intelligencex/partials/footer.html
@@ -13,7 +13,7 @@
       </div>
       {{ if navigation.menus && navigation.menus.size > 1 }}
       <div class="ix-footer-col">
-        <h4>Documentation</h4>
+        <p class="ix-footer-heading">Documentation</p>
         <ul>
           {{ for link in navigation.menus[1].items }}
           <li><a href="{{ link.url }}">{{ link.title }}</a></li>
@@ -23,7 +23,7 @@
       {{ end }}
       {{ if navigation.menus && navigation.menus.size > 2 }}
       <div class="ix-footer-col">
-        <h4>Resources</h4>
+        <p class="ix-footer-heading">Resources</p>
         <ul>
           {{ for link in navigation.menus[2].items }}
           <li><a href="{{ link.url }}">{{ link.title }}</a></li>
@@ -33,7 +33,7 @@
       {{ end }}
       {{ if navigation.menus && navigation.menus.size > 3 }}
       <div class="ix-footer-col">
-        <h4>Company</h4>
+        <p class="ix-footer-heading">Company</p>
         <ul>
           {{ for link in navigation.menus[3].items }}
           <li><a href="{{ link.url }}">{{ link.title }}</a></li>

--- a/Website/themes/intelligencex/partials/theme-tokens.html
+++ b/Website/themes/intelligencex/partials/theme-tokens.html
@@ -50,8 +50,8 @@
   --pf-code-border: rgba(148, 163, 184, 0.4);
   --pf-glow-primary: rgba(8, 145, 178, 0.08);
   --pf-glow-secondary: rgba(124, 58, 237, 0.06);
-  --pf-btn-primary-bg: #0891B2;
-  --pf-btn-primary-text: #062431;
+  --pf-btn-primary-bg: #0E7490;
+  --pf-btn-primary-text: #F8FAFC;
   --pf-btn-secondary-bg: rgba(124, 58, 237, 0.1);
   --pf-btn-secondary-border: rgba(124, 58, 237, 0.4);
   --pf-btn-ghost-border: rgba(100, 116, 139, 0.3);

--- a/Website/themes/intelligencex/partials/toc.html
+++ b/Website/themes/intelligencex/partials/toc.html
@@ -1,4 +1,4 @@
 <nav class="page-toc" aria-label="On this page">
-  <h4>On This Page</h4>
+  <p class="page-toc-title">On This Page</p>
   {{ toc_html }}
 </nav>


### PR DESCRIPTION
## Summary
- remove non-sequential footer/TOC headings that triggered Lighthouse heading-order warnings
- add layout-level fallback meta descriptions for docs/home/page/showcase layouts
- improve CTA and API UI contrast (buttons, filter chips, counts, sidebar controls)
- align dark/light button tokens for accessible foreground/background contrast

## Validation
- ./build.ps1 -CI -PowerForgeRoot C:\\Support\\GitHub\\PSPublishModule
- build + verify + apidocs + optimize + doctor all succeeded locally