### PR TITLE
Harden project-sync taxonomy labels and PR/issue matching

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -138,7 +138,7 @@ intelligencex todo project-sync \
 Useful options:
 - `--config <path>` to resolve owner/project from `project-init` output.
 - `--ensure-fields` / `--no-ensure-fields`.
-- `--apply-labels` to apply IX labels (`ix/category:*`, `ix/tag:*`, `ix/vision:*`, `ix/match:*`, `ix/decision:*`) on PRs/issues.
+- `--apply-labels` to sync IX labels (`ix/category:*`, `ix/tag:*`, `ix/vision:*`, `ix/match:*`, `ix/decision:*`) on PRs/issues.
 - `--ensure-labels` / `--no-ensure-labels` for label taxonomy management.
 - `--apply-link-comments` to upsert assistive link comments on PRs (related issues) and issues (related PRs).
 - `--project-item-scan-limit <n>` for larger projects.
@@ -148,6 +148,8 @@ Behavior:
 - `IX Suggested Decision` is populated automatically (`accept`, `defer`, `reject`, `merge-candidate`) from combined triage + vision signals.
 - `Maintainer Decision` remains human-owned for final triage decisions.
 - Unknown categories/tags are normalized into dynamic labels (for example `ML Ops` -> `ix/category:ml-ops`, `Release Candidate` -> `ix/tag:release-candidate`) and are auto-created when `--apply-labels --ensure-labels` is used.
+- `--apply-labels` performs managed IX label reconciliation: stale `ix/*` labels for managed families are removed while non-IX maintainer labels are preserved.
+- Issues also receive match taxonomy labels when PR->issue linking signals exist (`ix/match:linked-pr` or `ix/match:needs-review-pr`).
 
 ## Bootstrap project + workflow (recommended first run)
 

--- a/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
@@ -81,6 +81,8 @@ internal static class ProjectLabelCatalog {
 
         new ProjectLabelDefinition("ix/match:linked-issue", "0366d6", "PR has a high-confidence related issue."),
         new ProjectLabelDefinition("ix/match:needs-review", "fbca04", "PR has a low-confidence issue match that needs maintainer review."),
+        new ProjectLabelDefinition("ix/match:linked-pr", "0366d6", "Issue has a high-confidence related pull request."),
+        new ProjectLabelDefinition("ix/match:needs-review-pr", "fbca04", "Issue has a low-confidence related pull request that needs maintainer review."),
         new ProjectLabelDefinition("ix/decision:accept", "0e8a16", "IX suggested decision is accept."),
         new ProjectLabelDefinition("ix/decision:defer", "fbca04", "IX suggested decision is defer."),
         new ProjectLabelDefinition("ix/decision:reject", "d73a4a", "IX suggested decision is reject."),

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -11,6 +11,7 @@ namespace IntelligenceX.Cli.Todo;
 
 internal static class ProjectSyncRunner {
     private const double HighConfidenceIssueMatchLabelThreshold = 0.80;
+    private const double HighConfidencePullRequestMatchLabelThreshold = 0.80;
     private const double DefaultIssueCommentMinConfidence = 0.55;
     private const double RejectVisionConfidenceThreshold = 0.70;
     private const double AcceptVisionConfidenceThreshold = 0.68;
@@ -51,7 +52,10 @@ internal static class ProjectSyncRunner {
         string? VisionFit,
         double? VisionConfidence,
         IReadOnlyList<RelatedIssueCandidate>? RelatedIssues = null,
-        string? SuggestedDecision = null
+        string? SuggestedDecision = null,
+        string? MatchedPullRequestUrl = null,
+        double? MatchedPullRequestConfidence = null,
+        IReadOnlyList<string>? ExistingLabels = null
     );
 
     private sealed class Options {
@@ -201,7 +205,12 @@ internal static class ProjectSyncRunner {
                     if (options.DryRun) {
                         labeled++;
                     } else {
-                        if (await RepositoryLabelManager.AddLabelsAsync(options.Repo, entry.Kind, entry.Number, labels).ConfigureAwait(false)) {
+                        if (await RepositoryLabelManager.SyncManagedLabelsAsync(
+                                options.Repo,
+                                entry.Kind,
+                                entry.Number,
+                                labels,
+                                entry.ExistingLabels).ConfigureAwait(false)) {
                             labeled++;
                         }
                     }
@@ -377,7 +386,7 @@ internal static class ProjectSyncRunner {
         Console.WriteLine("  --project-item-scan-limit <n>  Existing project item scan limit (100-10000, default: 5000)");
         Console.WriteLine("  --ensure-fields          Ensure IX fields exist before sync (default)");
         Console.WriteLine("  --no-ensure-fields       Skip field creation");
-        Console.WriteLine("  --apply-labels           Apply IX labels to PRs/issues from synced signals");
+        Console.WriteLine("  --apply-labels           Sync IX labels on PRs/issues (add missing + remove stale managed IX labels)");
         Console.WriteLine("  --ensure-labels          Ensure IX labels exist before applying labels (default)");
         Console.WriteLine("  --no-ensure-labels       Skip label ensure step");
         Console.WriteLine("  --apply-link-comments    Upsert marker comments on PRs (related issues) and issues (related PRs)");
@@ -477,6 +486,7 @@ internal static class ProjectSyncRunner {
                 var duplicateClusterId = ReadNullableString(item, "duplicateClusterId");
                 var category = ReadNullableString(item, "category");
                 var tags = ReadStringArray(item, "tags");
+                var existingLabels = ReadStringArray(item, "labels");
                 var matchedIssueUrl = ReadNullableString(item, "matchedIssueUrl");
                 var matchedIssueConfidence = ReadNullableDouble(item, "matchedIssueConfidence");
                 var relatedIssues = ParseRelatedIssueCandidates(item);
@@ -506,7 +516,8 @@ internal static class ProjectSyncRunner {
                     VisionFit: null,
                     VisionConfidence: null,
                     RelatedIssues: relatedIssues,
-                    SuggestedDecision: null
+                    SuggestedDecision: null,
+                    ExistingLabels: existingLabels
                 );
             }
         }
@@ -545,7 +556,8 @@ internal static class ProjectSyncRunner {
                         VisionFit: classification,
                         VisionConfidence: confidence,
                         RelatedIssues: Array.Empty<RelatedIssueCandidate>(),
-                        SuggestedDecision: null
+                        SuggestedDecision: null,
+                        ExistingLabels: Array.Empty<string>()
                     );
                 }
             }
@@ -559,6 +571,22 @@ internal static class ProjectSyncRunner {
                 decisionSignals);
             if (!string.IsNullOrWhiteSpace(suggestion)) {
                 entriesByUrl[pair.Key] = pair.Value with { SuggestedDecision = suggestion };
+            }
+        }
+
+        var issueMatchByUrl = BuildIssueToPullRequestMatchByUrl(entriesByUrl.Values);
+        var issueMatchByNumber = BuildIssueToPullRequestMatchByNumber(entriesByUrl.Values);
+        foreach (var pair in entriesByUrl.ToList()) {
+            if (!pair.Value.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            if (issueMatchByUrl.TryGetValue(pair.Key, out var byUrlMatch) ||
+                (pair.Value.Number > 0 && issueMatchByNumber.TryGetValue(pair.Value.Number, out byUrlMatch))) {
+                entriesByUrl[pair.Key] = pair.Value with {
+                    MatchedPullRequestUrl = byUrlMatch.Url,
+                    MatchedPullRequestConfidence = byUrlMatch.Confidence
+                };
             }
         }
 
@@ -656,6 +684,74 @@ internal static class ProjectSyncRunner {
             }
         }
         return urls;
+    }
+
+    private static IReadOnlyDictionary<string, RelatedPullRequestCandidate> BuildIssueToPullRequestMatchByUrl(
+        IEnumerable<ProjectSyncEntry> entries) {
+        var map = new Dictionary<string, RelatedPullRequestCandidate>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries) {
+            if (!entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase) || entry.Number <= 0) {
+                continue;
+            }
+
+            foreach (var candidate in entry.RelatedIssues ?? Array.Empty<RelatedIssueCandidate>()) {
+                if (string.IsNullOrWhiteSpace(candidate.Url) || candidate.Number <= 0) {
+                    continue;
+                }
+
+                if (map.TryGetValue(candidate.Url, out var existing) &&
+                    ComparePullRequestMatch(existing, entry.Number, candidate.Confidence) >= 0) {
+                    continue;
+                }
+
+                map[candidate.Url] = new RelatedPullRequestCandidate(
+                    entry.Number,
+                    entry.Url,
+                    candidate.Confidence,
+                    candidate.Reason
+                );
+            }
+        }
+
+        return map;
+    }
+
+    private static IReadOnlyDictionary<int, RelatedPullRequestCandidate> BuildIssueToPullRequestMatchByNumber(
+        IEnumerable<ProjectSyncEntry> entries) {
+        var map = new Dictionary<int, RelatedPullRequestCandidate>();
+        foreach (var entry in entries) {
+            if (!entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase) || entry.Number <= 0) {
+                continue;
+            }
+
+            foreach (var candidate in entry.RelatedIssues ?? Array.Empty<RelatedIssueCandidate>()) {
+                if (candidate.Number <= 0) {
+                    continue;
+                }
+
+                if (map.TryGetValue(candidate.Number, out var existing) &&
+                    ComparePullRequestMatch(existing, entry.Number, candidate.Confidence) >= 0) {
+                    continue;
+                }
+
+                map[candidate.Number] = new RelatedPullRequestCandidate(
+                    entry.Number,
+                    entry.Url,
+                    candidate.Confidence,
+                    candidate.Reason
+                );
+            }
+        }
+
+        return map;
+    }
+
+    private static int ComparePullRequestMatch(RelatedPullRequestCandidate existing, int number, double confidence) {
+        var confidenceCompare = existing.Confidence.CompareTo(confidence);
+        if (confidenceCompare != 0) {
+            return confidenceCompare;
+        }
+        return number.CompareTo(existing.Number);
     }
 
     private static PullRequestDecisionSignals? ParsePullRequestSignals(JsonElement item) {
@@ -817,6 +913,8 @@ internal static class ProjectSyncRunner {
 
     internal static IReadOnlyList<string> BuildLabelsForEntry(ProjectSyncEntry entry) {
         var labels = new List<string>();
+        var isPullRequest = entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase);
+        var isIssue = entry.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase);
 
         if (ProjectLabelCatalog.TryMapCategoryLabel(entry.Category ?? string.Empty, out var categoryLabel)) {
             labels.Add(categoryLabel);
@@ -829,21 +927,42 @@ internal static class ProjectSyncRunner {
         }
 
         var visionLabel = MapVisionLabel(entry.VisionFit);
-        if (!string.IsNullOrWhiteSpace(visionLabel) && entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
+        if (!string.IsNullOrWhiteSpace(visionLabel) && isPullRequest) {
             labels.Add(visionLabel);
         }
 
-        if (!string.IsNullOrWhiteSpace(entry.MatchedIssueUrl) && entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
-            if (entry.MatchedIssueConfidence.HasValue &&
-                entry.MatchedIssueConfidence.Value >= HighConfidenceIssueMatchLabelThreshold) {
+        var relatedTopCandidate = (entry.RelatedIssues ?? Array.Empty<RelatedIssueCandidate>())
+            .Where(candidate => candidate.Number > 0 && !string.IsNullOrWhiteSpace(candidate.Url))
+            .OrderByDescending(candidate => candidate.Confidence)
+            .ThenBy(candidate => candidate.Number)
+            .FirstOrDefault();
+
+        var effectiveMatchedIssueUrl = !string.IsNullOrWhiteSpace(entry.MatchedIssueUrl)
+            ? entry.MatchedIssueUrl
+            : relatedTopCandidate?.Url;
+        var effectiveMatchedIssueConfidence = entry.MatchedIssueConfidence ??
+                                              relatedTopCandidate?.Confidence;
+
+        if (!string.IsNullOrWhiteSpace(effectiveMatchedIssueUrl) && isPullRequest) {
+            if (effectiveMatchedIssueConfidence.HasValue &&
+                effectiveMatchedIssueConfidence.Value >= HighConfidenceIssueMatchLabelThreshold) {
                 labels.Add("ix/match:linked-issue");
             } else {
                 labels.Add("ix/match:needs-review");
             }
         }
 
+        if (!string.IsNullOrWhiteSpace(entry.MatchedPullRequestUrl) && isIssue) {
+            if (entry.MatchedPullRequestConfidence.HasValue &&
+                entry.MatchedPullRequestConfidence.Value >= HighConfidencePullRequestMatchLabelThreshold) {
+                labels.Add("ix/match:linked-pr");
+            } else {
+                labels.Add("ix/match:needs-review-pr");
+            }
+        }
+
         var decisionLabel = MapSuggestedDecisionLabel(entry.SuggestedDecision);
-        if (!string.IsNullOrWhiteSpace(decisionLabel) && entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
+        if (!string.IsNullOrWhiteSpace(decisionLabel) && isPullRequest) {
             labels.Add(decisionLabel);
         }
 

--- a/IntelligenceX.Cli/Todo/RepositoryLabelManager.cs
+++ b/IntelligenceX.Cli/Todo/RepositoryLabelManager.cs
@@ -8,6 +8,20 @@ using IntelligenceX.Cli.GitHub;
 namespace IntelligenceX.Cli.Todo;
 
 internal static class RepositoryLabelManager {
+    internal sealed record LabelSyncPlan(
+        IReadOnlyList<string> LabelsToAdd,
+        IReadOnlyList<string> LabelsToRemove
+    );
+
+    private static readonly IReadOnlyList<string> ManagedLabelPrefixes = new[] {
+        "ix/category:",
+        "ix/tag:",
+        "ix/vision:",
+        "ix/match:",
+        "ix/decision:",
+        "ix/duplicate:"
+    };
+
     public static async Task EnsureLabelsAsync(string repo, IReadOnlyList<ProjectLabelDefinition> labels) {
         if (labels.Count == 0) {
             return;
@@ -62,6 +76,137 @@ internal static class RepositoryLabelManager {
         }
 
         return true;
+    }
+
+    public static async Task<bool> SyncManagedLabelsAsync(
+        string repo,
+        string kind,
+        int number,
+        IReadOnlyList<string> desiredLabels,
+        IReadOnlyList<string>? existingLabels = null) {
+        if (number <= 0) {
+            return true;
+        }
+
+        IReadOnlyList<string> currentLabels = existingLabels ?? Array.Empty<string>();
+        if (existingLabels is null) {
+            var loaded = await TryGetItemLabelNamesAsync(repo, kind, number).ConfigureAwait(false);
+            if (loaded is null) {
+                return false;
+            }
+            currentLabels = loaded;
+        }
+
+        var plan = BuildManagedLabelSyncPlan(desiredLabels, currentLabels);
+        if (plan.LabelsToAdd.Count == 0 && plan.LabelsToRemove.Count == 0) {
+            return true;
+        }
+
+        var command = kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase) ? "pr" : "issue";
+        var args = new List<string> {
+            command, "edit",
+            number.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "--repo", repo
+        };
+        if (plan.LabelsToAdd.Count > 0) {
+            args.Add("--add-label");
+            args.Add(string.Join(",", plan.LabelsToAdd));
+        }
+        if (plan.LabelsToRemove.Count > 0) {
+            args.Add("--remove-label");
+            args.Add(string.Join(",", plan.LabelsToRemove));
+        }
+
+        var (code, _, stderr) = await GhCli.RunAsync(args.ToArray()).ConfigureAwait(false);
+        if (code != 0) {
+            Console.Error.WriteLine(
+                $"Warning: failed to sync managed labels on {kind} #{number}: {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static LabelSyncPlan BuildManagedLabelSyncPlan(
+        IReadOnlyList<string> desiredLabels,
+        IReadOnlyList<string> currentLabels) {
+        var desired = desiredLabels
+            .Where(label => !string.IsNullOrWhiteSpace(label))
+            .Select(label => label.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var current = currentLabels
+            .Where(label => !string.IsNullOrWhiteSpace(label))
+            .Select(label => label.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var toAdd = desired
+            .Where(label => !current.Contains(label))
+            .OrderBy(label => label, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var toRemove = current
+            .Where(label => IsManagedLabelName(label) && !desired.Contains(label))
+            .OrderBy(label => label, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new LabelSyncPlan(toAdd, toRemove);
+    }
+
+    internal static bool IsManagedLabelName(string labelName) {
+        if (string.IsNullOrWhiteSpace(labelName)) {
+            return false;
+        }
+
+        foreach (var prefix in ManagedLabelPrefixes) {
+            if (labelName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task<IReadOnlyList<string>?> TryGetItemLabelNamesAsync(string repo, string kind, int number) {
+        var command = kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase) ? "pr" : "issue";
+        var (code, stdout, stderr) = await GhCli.RunAsync(
+            command, "view",
+            number.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "--repo", repo,
+            "--json", "labels"
+        ).ConfigureAwait(false);
+        if (code != 0) {
+            Console.Error.WriteLine(
+                $"Warning: failed to list current labels for {kind} #{number}: {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
+            return null;
+        }
+
+        try {
+            using var doc = JsonDocument.Parse(stdout);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object ||
+                !doc.RootElement.TryGetProperty("labels", out var labelsArray) ||
+                labelsArray.ValueKind != JsonValueKind.Array) {
+                return Array.Empty<string>();
+            }
+
+            var labels = new List<string>();
+            foreach (var label in labelsArray.EnumerateArray()) {
+                if (label.ValueKind != JsonValueKind.Object ||
+                    !label.TryGetProperty("name", out var nameProp) ||
+                    nameProp.ValueKind != JsonValueKind.String) {
+                    continue;
+                }
+                var name = nameProp.GetString();
+                if (!string.IsNullOrWhiteSpace(name)) {
+                    labels.Add(name.Trim());
+                }
+            }
+
+            return labels;
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Warning: failed to parse current label JSON for {kind} #{number}: {ex.Message}");
+            return null;
+        }
     }
 
     private static async Task<HashSet<string>> GetExistingLabelNamesAsync(string repo) {

--- a/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
+++ b/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
@@ -31,6 +31,22 @@ internal static class TriageIndexRunner {
         @"(?i)\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?|ref(?:s|erences?)|related to)\s+https?://github\.com/(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)/issues/(?<num>\d+)\b",
         RegexOptions.Compiled
     );
+    private static readonly Regex DirectIssueRef = new(
+        @"(?i)\b(?:issue|bug|ticket|task)\s*#(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly Regex DirectRepoIssueRef = new(
+        @"(?i)\b(?:issue|bug|ticket|task)\s+(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)#(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly Regex DirectIssueUrlRef = new(
+        @"(?i)\b(?:issue|bug|ticket|task)\s+https?://github\.com/(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)/issues/(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly Regex BareIssueUrlRef = new(
+        @"(?i)\bhttps?://github\.com/(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)/issues/(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
 
     internal sealed record PullRequestSignals(
         bool IsDraft,
@@ -133,6 +149,12 @@ internal static class TriageIndexRunner {
         string? MatchedIssueUrl,
         double? MatchedIssueConfidence,
         IReadOnlyList<RelatedIssueCandidate> RelatedIssues
+    );
+
+    private sealed record IssueReferenceHint(
+        int Number,
+        double Confidence,
+        string Reason
     );
 
     private sealed class Options {
@@ -678,16 +700,16 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         var issueByNumber = issueItems.ToDictionary(item => item.Number);
         var matchesByNumber = new Dictionary<int, RelatedIssueCandidate>();
 
-        foreach (var issueNumber in ParseExplicitIssueReferences(prTitle, prBody, owner, name)) {
-            if (!issueByNumber.TryGetValue(issueNumber, out var issue)) {
+        foreach (var issueHint in ParseExplicitIssueReferences(prTitle, prBody, owner, name)) {
+            if (!issueByNumber.TryGetValue(issueHint.Number, out var issue)) {
                 continue;
             }
 
             matchesByNumber[issue.Number] = new RelatedIssueCandidate(
                 Number: issue.Number,
                 Url: issue.Url,
-                Confidence: 0.98,
-                Reason: "explicit issue reference in PR title/body"
+                Confidence: issueHint.Confidence,
+                Reason: issueHint.Reason
             );
         }
 
@@ -722,17 +744,28 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
             .ToList();
     }
 
-    private static IReadOnlyList<int> ParseExplicitIssueReferences(
+    private static IReadOnlyList<IssueReferenceHint> ParseExplicitIssueReferences(
         string prTitle,
         string prBody,
         string owner,
         string repoName) {
         var text = $"{prTitle}\n{prBody}";
-        var results = new HashSet<int>();
+        var results = new Dictionary<int, IssueReferenceHint>();
+
+        static void AddHint(
+            IDictionary<int, IssueReferenceHint> map,
+            int number,
+            double confidence,
+            string reason) {
+            if (!map.TryGetValue(number, out var existing) ||
+                confidence > existing.Confidence) {
+                map[number] = new IssueReferenceHint(number, confidence, reason);
+            }
+        }
 
         foreach (Match match in ExplicitIssueRef.Matches(text)) {
             if (TryReadIssueNumber(match, out var number)) {
-                results.Add(number);
+                AddHint(results, number, 0.98, "explicit issue reference in PR title/body");
             }
         }
 
@@ -744,7 +777,7 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                 continue;
             }
             if (TryReadIssueNumber(match, out var number)) {
-                results.Add(number);
+                AddHint(results, number, 0.98, "explicit issue reference in PR title/body");
             }
         }
 
@@ -756,11 +789,56 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                 continue;
             }
             if (TryReadIssueNumber(match, out var number)) {
-                results.Add(number);
+                AddHint(results, number, 0.98, "explicit issue reference in PR title/body");
             }
         }
 
-        return results.OrderBy(value => value).ToList();
+        foreach (Match match in DirectIssueRef.Matches(text)) {
+            if (TryReadIssueNumber(match, out var number)) {
+                AddHint(results, number, 0.92, "direct issue reference in PR title/body");
+            }
+        }
+
+        foreach (Match match in DirectRepoIssueRef.Matches(text)) {
+            var refOwner = match.Groups["owner"].Value;
+            var refRepo = match.Groups["repo"].Value;
+            if (!refOwner.Equals(owner, StringComparison.OrdinalIgnoreCase) ||
+                !refRepo.Equals(repoName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (TryReadIssueNumber(match, out var number)) {
+                AddHint(results, number, 0.92, "direct issue reference in PR title/body");
+            }
+        }
+
+        foreach (Match match in DirectIssueUrlRef.Matches(text)) {
+            var refOwner = match.Groups["owner"].Value;
+            var refRepo = match.Groups["repo"].Value;
+            if (!refOwner.Equals(owner, StringComparison.OrdinalIgnoreCase) ||
+                !refRepo.Equals(repoName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (TryReadIssueNumber(match, out var number)) {
+                AddHint(results, number, 0.92, "direct issue reference in PR title/body");
+            }
+        }
+
+        foreach (Match match in BareIssueUrlRef.Matches(text)) {
+            var refOwner = match.Groups["owner"].Value;
+            var refRepo = match.Groups["repo"].Value;
+            if (!refOwner.Equals(owner, StringComparison.OrdinalIgnoreCase) ||
+                !refRepo.Equals(repoName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (TryReadIssueNumber(match, out var number)) {
+                AddHint(results, number, 0.90, "issue URL reference in PR title/body");
+            }
+        }
+
+        return results.Values
+            .OrderByDescending(value => value.Confidence)
+            .ThenBy(value => value.Number)
+            .ToList();
     }
 
     private static bool TryReadIssueNumber(Match match, out int number) {

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -29,6 +29,8 @@ internal static partial class Program {
         AssertEqual(true, labels.Contains("ix/decision:defer", StringComparer.OrdinalIgnoreCase), "decision defer label");
         AssertEqual(true, labels.Contains("ix/decision:reject", StringComparer.OrdinalIgnoreCase), "decision reject label");
         AssertEqual(true, labels.Contains("ix/decision:merge-candidate", StringComparer.OrdinalIgnoreCase), "decision merge-candidate label");
+        AssertEqual(true, labels.Contains("ix/match:linked-pr", StringComparer.OrdinalIgnoreCase), "issue linked-pr label");
+        AssertEqual(true, labels.Contains("ix/match:needs-review-pr", StringComparer.OrdinalIgnoreCase), "issue needs-review-pr label");
     }
 
     private static void TestProjectLabelCatalogBuildEnsureCatalogIncludesDynamicCategoryAndTags() {
@@ -297,6 +299,100 @@ internal static partial class Program {
         AssertEqual(true, labels.Contains("ix/match:needs-review", StringComparer.OrdinalIgnoreCase), "low confidence match review label");
         AssertEqual(false, labels.Contains("ix/match:linked-issue", StringComparer.OrdinalIgnoreCase), "low confidence should not be linked-issue");
         AssertEqual(true, labels.Contains("ix/decision:defer", StringComparer.OrdinalIgnoreCase), "decision defer label");
+    }
+
+    private static void TestProjectSyncBuildLabelsUsesRelatedIssueFallbackWhenMatchedIssueMissing() {
+        var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+            Number: 79,
+            Url: "https://github.com/EvotecIT/IntelligenceX/pull/79",
+            Kind: "pull_request",
+            TriageScore: 73.0,
+            DuplicateCluster: null,
+            CanonicalItem: null,
+            Category: "feature",
+            Tags: Array.Empty<string>(),
+            MatchedIssueUrl: null,
+            MatchedIssueConfidence: null,
+            VisionFit: null,
+            VisionConfidence: null,
+            RelatedIssues: new[] {
+                new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(20, "https://github.com/EvotecIT/IntelligenceX/issues/20", 0.87, "explicit issue reference")
+            }
+        );
+
+        var labels = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildLabelsForEntry(entry);
+        AssertEqual(true, labels.Contains("ix/match:linked-issue", StringComparer.OrdinalIgnoreCase), "fallback related issue adds linked-issue label");
+    }
+
+    private static void TestProjectSyncBuildLabelsUsesIssuePullRequestMatchSignals() {
+        var highConfidenceIssue = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+            Number: 120,
+            Url: "https://github.com/EvotecIT/IntelligenceX/issues/120",
+            Kind: "issue",
+            TriageScore: null,
+            DuplicateCluster: null,
+            CanonicalItem: null,
+            Category: "bug",
+            Tags: Array.Empty<string>(),
+            MatchedIssueUrl: null,
+            MatchedIssueConfidence: null,
+            VisionFit: null,
+            VisionConfidence: null,
+            MatchedPullRequestUrl: "https://github.com/EvotecIT/IntelligenceX/pull/77",
+            MatchedPullRequestConfidence: 0.89
+        );
+        var lowConfidenceIssue = highConfidenceIssue with {
+            Number = 121,
+            Url = "https://github.com/EvotecIT/IntelligenceX/issues/121",
+            MatchedPullRequestConfidence = 0.61
+        };
+
+        var highLabels = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildLabelsForEntry(highConfidenceIssue);
+        var lowLabels = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildLabelsForEntry(lowConfidenceIssue);
+
+        AssertEqual(true, highLabels.Contains("ix/match:linked-pr", StringComparer.OrdinalIgnoreCase), "high confidence issue gets linked-pr label");
+        AssertEqual(false, highLabels.Contains("ix/match:needs-review-pr", StringComparer.OrdinalIgnoreCase), "high confidence issue does not get needs-review-pr label");
+        AssertEqual(true, lowLabels.Contains("ix/match:needs-review-pr", StringComparer.OrdinalIgnoreCase), "low confidence issue gets needs-review-pr label");
+        AssertEqual(false, lowLabels.Contains("ix/match:linked-pr", StringComparer.OrdinalIgnoreCase), "low confidence issue does not get linked-pr label");
+    }
+
+    private static void TestProjectSyncBuildEntriesDerivesIssuePullRequestMatches() {
+        const string triageJson = """
+{
+  "items": [
+    {
+      "id": "pr#77",
+      "kind": "pull_request",
+      "number": 77,
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/77",
+      "relatedIssues": [
+        {
+          "number": 120,
+          "url": "https://github.com/EvotecIT/IntelligenceX/issues/120",
+          "confidence": 0.89,
+          "reason": "explicit issue reference in PR title/body"
+        }
+      ]
+    },
+    {
+      "id": "issue#120",
+      "kind": "issue",
+      "number": 120,
+      "url": "https://github.com/EvotecIT/IntelligenceX/issues/120"
+    }
+  ]
+}
+""";
+
+        using var triageDoc = System.Text.Json.JsonDocument.Parse(triageJson);
+        var entries = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildEntriesFromDocuments(
+            triageDoc.RootElement,
+            null,
+            100);
+
+        var issue = entries.Single(item => item.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase));
+        AssertEqual("https://github.com/EvotecIT/IntelligenceX/pull/77", issue.MatchedPullRequestUrl, "issue matched pull request url derived");
+        AssertEqual(true, issue.MatchedPullRequestConfidence.HasValue && issue.MatchedPullRequestConfidence.Value >= 0.89, "issue matched pull request confidence derived");
     }
 
     private static void TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence() {

--- a/IntelligenceX.Tests/Program.Todo.RepositoryLabelSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.RepositoryLabelSync.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+
+namespace IntelligenceX.Tests;
+
+internal static partial class Program {
+#if !NET472
+    private static void TestRepositoryLabelManagerBuildManagedLabelSyncPlanAddsAndRemovesManagedOnly() {
+        var desired = new[] {
+            "ix/category:feature",
+            "ix/tag:api",
+            "ix/match:linked-issue"
+        };
+        var current = new[] {
+            "ix/category:bug",
+            "ix/tag:api",
+            "ix/decision:defer",
+            "bug",
+            "help wanted"
+        };
+
+        var plan = IntelligenceX.Cli.Todo.RepositoryLabelManager.BuildManagedLabelSyncPlan(desired, current);
+
+        AssertEqual(true, plan.LabelsToAdd.Contains("ix/category:feature", StringComparer.OrdinalIgnoreCase), "managed add includes desired missing label");
+        AssertEqual(true, plan.LabelsToAdd.Contains("ix/match:linked-issue", StringComparer.OrdinalIgnoreCase), "managed add includes desired match label");
+        AssertEqual(true, plan.LabelsToRemove.Contains("ix/category:bug", StringComparer.OrdinalIgnoreCase), "managed remove includes stale category label");
+        AssertEqual(true, plan.LabelsToRemove.Contains("ix/decision:defer", StringComparer.OrdinalIgnoreCase), "managed remove includes stale decision label");
+        AssertEqual(false, plan.LabelsToRemove.Contains("bug", StringComparer.OrdinalIgnoreCase), "non-managed labels are preserved");
+        AssertEqual(false, plan.LabelsToRemove.Contains("help wanted", StringComparer.OrdinalIgnoreCase), "non-managed labels are preserved");
+    }
+
+    private static void TestRepositoryLabelManagerBuildManagedLabelSyncPlanNoChangesWhenAligned() {
+        var desired = new[] { "ix/category:feature", "ix/tag:api" };
+        var current = new[] { "ix/category:feature", "ix/tag:api", "enhancement" };
+
+        var plan = IntelligenceX.Cli.Todo.RepositoryLabelManager.BuildManagedLabelSyncPlan(desired, current);
+
+        AssertEqual(0, plan.LabelsToAdd.Count, "no managed adds");
+        AssertEqual(0, plan.LabelsToRemove.Count, "no managed removes");
+    }
+#endif
+}

--- a/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
+++ b/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
@@ -141,6 +141,35 @@ internal static partial class Program {
         AssertEqual(true, matches[0].Confidence >= 0.95, "explicit confidence");
     }
 
+    private static void TestTriageIndexMatchPullRequestToIssuesSupportsDirectIssueReference() {
+        var now = DateTimeOffset.UtcNow;
+        var issue42 = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "issue#42",
+            "issue",
+            42,
+            "Parser crashes on null input",
+            "https://github.com/EvotecIT/IntelligenceX/issues/42",
+            now,
+            Array.Empty<string>(),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Parser crashes on null input"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Parser crashes on null input"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Parser crashes on null input with stack trace"),
+            null,
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.IssueSignals(4, "dev1")
+        );
+
+        var matches = IntelligenceX.Cli.Todo.TriageIndexRunner.MatchPullRequestToIssues(
+            "EvotecIT/IntelligenceX",
+            "Parser null handling follow-up",
+            "Related issue #42; extending guardrails and tests.",
+            new[] { issue42 }
+        );
+
+        AssertEqual(1, matches.Count, "direct reference match count");
+        AssertEqual(42, matches[0].Number, "direct reference issue number");
+        AssertEqual(true, matches[0].Confidence >= 0.90, "direct reference confidence");
+    }
+
     private static void TestTriageIndexInferCategoryAndTagsDetectsSecurity() {
         var now = DateTimeOffset.UtcNow;
         var item = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -443,6 +443,7 @@ internal static partial class Program {
         failed += Run("Todo triage index duplicate clusters", TestTriageIndexDuplicateClustersGroupNearMatches);
         failed += Run("Todo triage index PR scoring", TestTriageIndexScoreRewardsMergeableApprovedPrs);
         failed += Run("Todo triage index PR-issue explicit match", TestTriageIndexMatchPullRequestToIssuesSupportsExplicitReference);
+        failed += Run("Todo triage index PR-issue direct match", TestTriageIndexMatchPullRequestToIssuesSupportsDirectIssueReference);
         failed += Run("Todo triage index category/tag inference", TestTriageIndexInferCategoryAndTagsDetectsSecurity);
         failed += Run("Todo vision check out-of-scope classification", TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate);
         failed += Run("Todo vision check aligned classification", TestVisionCheckClassifiesAlignedWhenInTokensMatch);
@@ -462,13 +463,18 @@ internal static partial class Program {
         failed += Run("Todo project sync labels include tags and high-confidence match", TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch);
         failed += Run("Todo project sync labels normalize dynamic category and tags", TestProjectSyncBuildLabelsNormalizesDynamicCategoryAndTags);
         failed += Run("Todo project sync labels mark low-confidence match for review", TestProjectSyncBuildLabelsUsesNeedsReviewForLowConfidenceIssueMatch);
+        failed += Run("Todo project sync labels use related-issue fallback", TestProjectSyncBuildLabelsUsesRelatedIssueFallbackWhenMatchedIssueMissing);
+        failed += Run("Todo project sync labels issue pull-request matches", TestProjectSyncBuildLabelsUsesIssuePullRequestMatchSignals);
         failed += Run("Todo project sync decision suggests merge-candidate", TestProjectSyncBuildEntriesSuggestsMergeCandidateForBestReadyPr);
         failed += Run("Todo project sync decision suggests defer for blocked PR", TestProjectSyncBuildEntriesSuggestsDeferForBlockedPr);
+        failed += Run("Todo project sync derives issue pull-request matches", TestProjectSyncBuildEntriesDerivesIssuePullRequestMatches);
         failed += Run("Todo project sync comment filters by confidence", TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence);
         failed += Run("Todo project sync comment omitted for weak candidates", TestProjectSyncBuildIssueMatchSuggestionCommentReturnsNullWithoutQualifiedCandidates);
         failed += Run("Todo project sync issue backlink comments aggregate PRs", TestProjectSyncBuildIssueBacklinkSuggestionCommentsAggregatesPullRequests);
         failed += Run("Todo project sync issue backlink comment threshold and limit", TestProjectSyncBuildIssueBacklinkSuggestionCommentRespectsThresholdAndLimit);
         failed += Run("Todo project sync related issues field value", TestProjectSyncBuildRelatedIssuesFieldValueOrdersAndLimitsCandidates);
+        failed += Run("Todo repository label sync plan add/remove managed labels", TestRepositoryLabelManagerBuildManagedLabelSyncPlanAddsAndRemovesManagedOnly);
+        failed += Run("Todo repository label sync plan no-op when aligned", TestRepositoryLabelManagerBuildManagedLabelSyncPlanNoChangesWhenAligned);
         failed += Run("Todo project bootstrap renders project target", TestProjectBootstrapRenderWorkflowTemplateInjectsProjectTarget);
         failed += Run("Todo project bootstrap clamps max items", TestProjectBootstrapRenderWorkflowTemplateClampsMaxItems);
         failed += Run("Todo project bootstrap renders vision template", TestProjectBootstrapRenderVisionTemplateInjectsContext);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -133,8 +133,9 @@ Options:
 - `--max-items <n>` (default `500`)
 - `--project-item-scan-limit <n>` (default `5000`)
 - `--ensure-fields` / `--no-ensure-fields`
-- `--apply-labels`
+- `--apply-labels` (managed IX label sync; stale `ix/*` labels in managed families are removed)
 - `--ensure-labels` / `--no-ensure-labels`
+- `--apply-link-comments`
 - `--dry-run`
 
 ## Project Bootstrap (Project + Workflow in one command)


### PR DESCRIPTION
## Summary
- harden `todo project-sync --apply-labels` by switching from add-only labeling to managed IX label reconciliation (adds missing managed labels and removes stale managed `ix/*` labels while preserving non-IX maintainer labels)
- extend sync signals so issue entries derive related pull request match confidence from PR->issue candidate graph and receive issue-side match labels (`ix/match:linked-pr` / `ix/match:needs-review-pr`)
- improve PR label reliability by falling back to top `relatedIssues` candidate when `matchedIssueUrl` is absent
- expand `ProjectLabelCatalog` defaults with issue-side match labels
- improve `build-triage-index` PR->issue matching by recognizing direct references (`issue #123`, repo-qualified refs, and issue URLs) with explicit confidence tiers
- document updated project-sync apply-label behavior in user and internal CLI docs

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release --no-build`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`

## Test additions
- project-sync issue-side match label coverage
- project-sync fallback from `relatedIssues` when `matchedIssueUrl` is missing
- project-sync issue pull-request match derivation from triage graph
- repository managed label sync-plan add/remove behavior
- triage-index direct issue reference matching (`issue #n`)
