### PR TITLE
Setup triage bootstrap: auto-provision control issue variable

### DIFF
--- a/IntelligenceX.Cli/Setup/SetupRunner.GitHubApi.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.GitHubApi.cs
@@ -195,6 +195,68 @@ internal static partial class SetupRunner {
             return result.Value.GetProperty("html_url").GetString();
         }
 
+        public async Task<int> CreateIssueAsync(string owner, string repo, string title, string body) {
+            var payload = new {
+                title,
+                body
+            };
+            var result = await PostJsonAsync($"/repos/{owner}/{repo}/issues", payload, allowConflict: false)
+                .ConfigureAwait(false);
+            if (result is null ||
+                !result.Value.TryGetProperty("number", out var numberProp) ||
+                numberProp.ValueKind != JsonValueKind.Number ||
+                !numberProp.TryGetInt32(out var number) ||
+                number <= 0) {
+                throw new InvalidOperationException("GitHub issue create response did not include a valid issue number.");
+            }
+
+            return number;
+        }
+
+        public async Task<string?> TryGetRepositoryVariableAsync(string owner, string repo, string name) {
+            if (string.IsNullOrWhiteSpace(name)) {
+                throw new ArgumentException("Variable name is required.", nameof(name));
+            }
+
+            var escapedName = Uri.EscapeDataString(name);
+            using var response = await _http.GetAsync($"/repos/{owner}/{repo}/actions/variables/{escapedName}").ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound) {
+                return null;
+            }
+            if (!response.IsSuccessStatusCode) {
+                throw new InvalidOperationException(FormatGitHubFailure(response, content));
+            }
+
+            using var doc = JsonDocument.Parse(content);
+            if (doc.RootElement.TryGetProperty("value", out var valueProp) &&
+                valueProp.ValueKind == JsonValueKind.String) {
+                return valueProp.GetString();
+            }
+
+            throw new InvalidOperationException($"Repository variable '{name}' response did not include a value.");
+        }
+
+        public async Task UpsertRepositoryVariableAsync(string owner, string repo, string name, string value) {
+            if (string.IsNullOrWhiteSpace(name)) {
+                throw new ArgumentException("Variable name is required.", nameof(name));
+            }
+
+            var payload = new {
+                name,
+                value
+            };
+            var escapedName = Uri.EscapeDataString(name);
+            var existing = await TryGetRepositoryVariableAsync(owner, repo, name).ConfigureAwait(false);
+            if (existing is null) {
+                await PostJsonAsync($"/repos/{owner}/{repo}/actions/variables", payload, allowConflict: false)
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            await PatchJsonAsync($"/repos/{owner}/{repo}/actions/variables/{escapedName}", payload).ConfigureAwait(false);
+        }
+
         public async Task SetSecretAsync(string owner, string repo, string name, string value) {
             var publicKeyJson = await GetJsonAsync($"/repos/{owner}/{repo}/actions/secrets/public-key").ConfigureAwait(false);
             var key = publicKeyJson.GetProperty("key").GetString();
@@ -285,6 +347,18 @@ internal static partial class SetupRunner {
             var json = JsonSerializer.Serialize(payload, JsonOptions);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
             using var response = await _http.PutAsync(url, content).ConfigureAwait(false);
+            var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) {
+                throw new InvalidOperationException(FormatGitHubFailure(response, responseText));
+            }
+        }
+
+        private async Task PatchJsonAsync(string url, object payload) {
+            var json = JsonSerializer.Serialize(payload, JsonOptions);
+            using var request = new HttpRequestMessage(HttpMethod.Patch, url) {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+            using var response = await _http.SendAsync(request).ConfigureAwait(false);
             var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             if (!response.IsSuccessStatusCode) {
                 throw new InvalidOperationException(FormatGitHubFailure(response, responseText));

--- a/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
@@ -55,7 +55,7 @@ internal static partial class SetupRunner {
         Console.WriteLine("  --cleanup-allowed-edits <comma-list>");
         Console.WriteLine("  --cleanup-post-edit-comment <true|false>");
         Console.WriteLine("  --with-config (also write .intelligencex/reviewer.json)");
-        Console.WriteLine("  --triage-bootstrap (also bootstrap IX triage project schema + workflow + VISION.md)");
+        Console.WriteLine("  --triage-bootstrap (also bootstrap IX triage project schema + workflow + VISION.md + control issue variable)");
         Console.WriteLine("  --upgrade (update managed sections instead of skipping)");
         Console.WriteLine("  --update-secret (refresh INTELLIGENCEX_AUTH_B64 only)");
         Console.WriteLine("  --skip-secret (skip secret update during setup)");

--- a/IntelligenceX.Cli/Setup/SetupRunner.TriageBootstrap.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.TriageBootstrap.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,6 +12,8 @@ internal static partial class SetupRunner {
     private const string DefaultTriageProjectConfigPath = "artifacts/triage/ix-project-config.json";
     private const string DefaultTriageWorkflowPath = ".github/workflows/ix-triage-project-sync.yml";
     private const string DefaultVisionPath = "VISION.md";
+    private const string DefaultControlIssueTitle = "IX Triage Control";
+    private const string TriageControlIssueVariableName = "IX_TRIAGE_CONTROL_ISSUE";
     private static readonly SemaphoreSlim ProjectInitLock = new(1, 1);
 
     private static async Task<List<FilePlan>> PlanTriageBootstrapFilesAsync(
@@ -76,7 +79,72 @@ internal static partial class SetupRunner {
             PlanWrite(DefaultVisionPath, existingVision?.Content, visionContent, options.Force)
         };
 
+        if (!options.DryRun) {
+            await EnsureControlIssueConfiguredAsync(
+                github,
+                owner,
+                repo,
+                repoFullName,
+                projectOwner,
+                projectNumber).ConfigureAwait(false);
+        }
+
         return plans;
+    }
+
+    internal static bool ShouldProvisionTriageControlIssue(string? variableValue) {
+        return !TryParsePositiveInt(variableValue, out _);
+    }
+
+    private static bool TryParsePositiveInt(string? value, out int number) {
+        number = 0;
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        return int.TryParse(value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out number) &&
+               number > 0;
+    }
+
+    private static async Task EnsureControlIssueConfiguredAsync(
+        GitHubApi github,
+        string owner,
+        string repo,
+        string repoFullName,
+        string projectOwner,
+        int projectNumber) {
+        string? existingControlIssue = null;
+        try {
+            existingControlIssue = await github.TryGetRepositoryVariableAsync(
+                owner,
+                repo,
+                TriageControlIssueVariableName).ConfigureAwait(false);
+        } catch (Exception ex) {
+            Console.Error.WriteLine(
+                $"Warning: triage bootstrap could not read {TriageControlIssueVariableName}. " +
+                $"Configure it manually if needed. ({ex.Message})");
+            return;
+        }
+
+        if (!ShouldProvisionTriageControlIssue(existingControlIssue)) {
+            return;
+        }
+
+        try {
+            var body = ProjectBootstrapRunner.BuildControlIssueBody(repoFullName, projectOwner, projectNumber);
+            var issueNumber = await github.CreateIssueAsync(owner, repo, DefaultControlIssueTitle, body).ConfigureAwait(false);
+            await github.UpsertRepositoryVariableAsync(
+                owner,
+                repo,
+                TriageControlIssueVariableName,
+                issueNumber.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+
+            Console.WriteLine($"Configured {TriageControlIssueVariableName} to #{issueNumber}.");
+        } catch (Exception ex) {
+            Console.Error.WriteLine(
+                $"Warning: triage bootstrap could not auto-configure {TriageControlIssueVariableName}. " +
+                $"Run `intelligencex todo project-bootstrap --repo {repoFullName} --create-control-issue` after setup. ({ex.Message})");
+        }
     }
 
     private static async Task<string> CreateTriageProjectConfigAsync(string repoFullName, string gitHubToken) {

--- a/IntelligenceX.Cli/Setup/SetupRunner.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.cs
@@ -664,7 +664,7 @@ internal static partial class SetupRunner {
             extras.Add("exports analyzer configs for IDE support");
         }
         if (includeTriageBootstrap) {
-            extras.Add("bootstraps IX triage project automation (VISION.md + project sync workflow)");
+            extras.Add("bootstraps IX triage project automation (VISION.md + project sync workflow + control issue variable)");
         }
 
         if (extras.Count == 0) {

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -36,6 +36,19 @@ internal static partial class Program {
         }, args, "setup args triage bootstrap");
     }
 
+    private static void TestSetupTriageControlIssueProvisionDecision() {
+        AssertEqual(true, SetupRunner.ShouldProvisionTriageControlIssue(null),
+            "triage control issue should be provisioned when variable missing");
+        AssertEqual(true, SetupRunner.ShouldProvisionTriageControlIssue(string.Empty),
+            "triage control issue should be provisioned when variable empty");
+        AssertEqual(true, SetupRunner.ShouldProvisionTriageControlIssue("abc"),
+            "triage control issue should be provisioned when variable non-numeric");
+        AssertEqual(true, SetupRunner.ShouldProvisionTriageControlIssue("0"),
+            "triage control issue should be provisioned when variable non-positive");
+        AssertEqual(false, SetupRunner.ShouldProvisionTriageControlIssue("42"),
+            "triage control issue should not be provisioned when variable valid");
+    }
+
     private static void TestSetupArgsIncludeAnalysisRunStrictOption() {
         var plan = new SetupPlan("owner/repo") {
             AnalysisEnabled = true,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -80,6 +80,7 @@ internal static partial class Program {
         failed += Run("Setup args include analysis export path", TestSetupArgsIncludeAnalysisExportPath);
         failed += Run("Setup args disable analysis omits gate and packs", TestSetupArgsDisableAnalysisOmitsGateAndPacks);
         failed += Run("Setup args include triage bootstrap", TestSetupArgsIncludeTriageBootstrap);
+        failed += Run("Setup triage control issue provision decision", TestSetupTriageControlIssueProvisionDecision);
         failed += Run("Setup args include OpenAI account routing", TestSetupArgsIncludeOpenAiAccountRouting);
         failed += Run("Setup args include OpenAI account routing with primary only",
             TestSetupArgsIncludeOpenAiAccountRoutingWithPrimaryOnly);


### PR DESCRIPTION
## Summary
- make `setup --triage-bootstrap` provision a GitHub control issue automatically when `IX_TRIAGE_CONTROL_ISSUE` is missing/invalid
- add setup-side GitHub API helpers for issue creation and repository variable upsert (REST-based, no `gh` dependency)
- keep behavior idempotent by skipping provisioning when the variable already points to a valid issue number
- clarify setup help/PR copy to mention control issue variable bootstrap
- add tests for control-issue provisioning decision logic

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll