### PR TITLE
Setup triage bootstrap: auto-create project view apply issue

### DIFF
--- a/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
@@ -55,7 +55,7 @@ internal static partial class SetupRunner {
         Console.WriteLine("  --cleanup-allowed-edits <comma-list>");
         Console.WriteLine("  --cleanup-post-edit-comment <true|false>");
         Console.WriteLine("  --with-config (also write .intelligencex/reviewer.json)");
-        Console.WriteLine("  --triage-bootstrap (also bootstrap IX triage project schema + workflow + VISION.md + control issue variable)");
+        Console.WriteLine("  --triage-bootstrap (also bootstrap IX triage project schema + workflow + VISION.md + assistive issue variables)");
         Console.WriteLine("  --upgrade (update managed sections instead of skipping)");
         Console.WriteLine("  --update-secret (refresh INTELLIGENCEX_AUTH_B64 only)");
         Console.WriteLine("  --skip-secret (skip secret update during setup)");

--- a/IntelligenceX.Cli/Setup/SetupRunner.TriageBootstrap.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.TriageBootstrap.cs
@@ -13,7 +13,9 @@ internal static partial class SetupRunner {
     private const string DefaultTriageWorkflowPath = ".github/workflows/ix-triage-project-sync.yml";
     private const string DefaultVisionPath = "VISION.md";
     private const string DefaultControlIssueTitle = "IX Triage Control";
+    private const string DefaultProjectViewApplyIssueTitle = "IX Project View Apply Plan";
     private const string TriageControlIssueVariableName = "IX_TRIAGE_CONTROL_ISSUE";
+    private const string ProjectViewApplyIssueVariableName = "IX_PROJECT_VIEW_APPLY_ISSUE";
     private static readonly SemaphoreSlim ProjectInitLock = new(1, 1);
 
     private static async Task<List<FilePlan>> PlanTriageBootstrapFilesAsync(
@@ -87,6 +89,14 @@ internal static partial class SetupRunner {
                 repoFullName,
                 projectOwner,
                 projectNumber).ConfigureAwait(false);
+
+            await EnsureProjectViewApplyIssueConfiguredAsync(
+                github,
+                owner,
+                repo,
+                repoFullName,
+                projectOwner,
+                projectNumber).ConfigureAwait(false);
         }
 
         return plans;
@@ -94,6 +104,14 @@ internal static partial class SetupRunner {
 
     internal static bool ShouldProvisionTriageControlIssue(string? variableValue) {
         return !TryParsePositiveInt(variableValue, out _);
+    }
+
+    internal static bool ShouldProvisionProjectViewApplyIssue(string? issueVariableValue, int missingViews, bool directCreateSupported) {
+        if (missingViews <= 0 || directCreateSupported) {
+            return false;
+        }
+
+        return !TryParsePositiveInt(issueVariableValue, out _);
     }
 
     private static bool TryParsePositiveInt(string? value, out int number) {
@@ -144,6 +162,71 @@ internal static partial class SetupRunner {
             Console.Error.WriteLine(
                 $"Warning: triage bootstrap could not auto-configure {TriageControlIssueVariableName}. " +
                 $"Run `intelligencex todo project-bootstrap --repo {repoFullName} --create-control-issue` after setup. ({ex.Message})");
+        }
+    }
+
+    private static async Task EnsureProjectViewApplyIssueConfiguredAsync(
+        GitHubApi github,
+        string owner,
+        string repo,
+        string repoFullName,
+        string projectOwner,
+        int projectNumber) {
+        string? existingViewIssue = null;
+        try {
+            existingViewIssue = await github.TryGetRepositoryVariableAsync(
+                owner,
+                repo,
+                ProjectViewApplyIssueVariableName).ConfigureAwait(false);
+        } catch (Exception ex) {
+            Console.Error.WriteLine(
+                $"Warning: triage bootstrap could not read {ProjectViewApplyIssueVariableName}. " +
+                $"View-apply issue auto-provision may be skipped. ({ex.Message})");
+            return;
+        }
+
+        if (TryParsePositiveInt(existingViewIssue, out _)) {
+            return;
+        }
+
+        try {
+            var client = new ProjectV2Client();
+            var project = await client.TryGetProjectAsync(projectOwner, projectNumber).ConfigureAwait(false);
+            if (project is null) {
+                Console.Error.WriteLine(
+                    $"Warning: triage bootstrap could not resolve project {projectOwner}#{projectNumber} for view apply planning.");
+                return;
+            }
+
+            var views = await client.GetProjectViewsByNameAsync(projectOwner, projectNumber).ConfigureAwait(false);
+            var directCreateSupported = await client.SupportsProjectViewCreationAsync().ConfigureAwait(false);
+            var missingViews = ProjectViewCatalog.FindMissingDefaultViews(views).Count;
+            if (!ShouldProvisionProjectViewApplyIssue(existingViewIssue, missingViews, directCreateSupported)) {
+                return;
+            }
+
+            var markdown = ProjectViewApplyRunner.BuildApplyMarkdown(
+                repoFullName,
+                projectOwner,
+                projectNumber,
+                project.Url,
+                views,
+                directCreateSupported,
+                DateTimeOffset.UtcNow);
+
+            var issueNumber = await github.CreateIssueAsync(owner, repo, DefaultProjectViewApplyIssueTitle, markdown)
+                .ConfigureAwait(false);
+            await github.UpsertRepositoryVariableAsync(
+                owner,
+                repo,
+                ProjectViewApplyIssueVariableName,
+                issueNumber.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+
+            Console.WriteLine($"Configured {ProjectViewApplyIssueVariableName} to #{issueNumber}.");
+        } catch (Exception ex) {
+            Console.Error.WriteLine(
+                $"Warning: triage bootstrap could not auto-configure {ProjectViewApplyIssueVariableName}. " +
+                $"Run `intelligencex todo project-view-apply --repo {repoFullName} --create-issue` after setup. ({ex.Message})");
         }
     }
 

--- a/IntelligenceX.Cli/Setup/SetupRunner.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.cs
@@ -664,7 +664,7 @@ internal static partial class SetupRunner {
             extras.Add("exports analyzer configs for IDE support");
         }
         if (includeTriageBootstrap) {
-            extras.Add("bootstraps IX triage project automation (VISION.md + project sync workflow + control issue variable)");
+            extras.Add("bootstraps IX triage project automation (VISION.md + project sync workflow + assistive issue variables)");
         }
 
         if (extras.Count == 0) {

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -49,6 +49,38 @@ internal static partial class Program {
             "triage control issue should not be provisioned when variable valid");
     }
 
+    private static void TestSetupProjectViewApplyIssueProvisionDecision() {
+        AssertEqual(false, SetupRunner.ShouldProvisionProjectViewApplyIssue(
+                issueVariableValue: "14",
+                missingViews: 3,
+                directCreateSupported: false),
+            "project view issue should not be provisioned when variable is valid");
+
+        AssertEqual(false, SetupRunner.ShouldProvisionProjectViewApplyIssue(
+                issueVariableValue: null,
+                missingViews: 0,
+                directCreateSupported: false),
+            "project view issue should not be provisioned when no views are missing");
+
+        AssertEqual(false, SetupRunner.ShouldProvisionProjectViewApplyIssue(
+                issueVariableValue: null,
+                missingViews: 2,
+                directCreateSupported: true),
+            "project view issue should not be provisioned when direct create is supported");
+
+        AssertEqual(true, SetupRunner.ShouldProvisionProjectViewApplyIssue(
+                issueVariableValue: null,
+                missingViews: 2,
+                directCreateSupported: false),
+            "project view issue should be provisioned when missing views and variable absent");
+
+        AssertEqual(true, SetupRunner.ShouldProvisionProjectViewApplyIssue(
+                issueVariableValue: "oops",
+                missingViews: 1,
+                directCreateSupported: false),
+            "project view issue should be provisioned when variable is invalid");
+    }
+
     private static void TestSetupArgsIncludeAnalysisRunStrictOption() {
         var plan = new SetupPlan("owner/repo") {
             AnalysisEnabled = true,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -81,6 +81,7 @@ internal static partial class Program {
         failed += Run("Setup args disable analysis omits gate and packs", TestSetupArgsDisableAnalysisOmitsGateAndPacks);
         failed += Run("Setup args include triage bootstrap", TestSetupArgsIncludeTriageBootstrap);
         failed += Run("Setup triage control issue provision decision", TestSetupTriageControlIssueProvisionDecision);
+        failed += Run("Setup project view apply issue provision decision", TestSetupProjectViewApplyIssueProvisionDecision);
         failed += Run("Setup args include OpenAI account routing", TestSetupArgsIncludeOpenAiAccountRouting);
         failed += Run("Setup args include OpenAI account routing with primary only",
             TestSetupArgsIncludeOpenAiAccountRoutingWithPrimaryOnly);


### PR DESCRIPTION
## Summary
- extend `setup --triage-bootstrap` to auto-provision a second assistive issue variable for project view setup (`IX_PROJECT_VIEW_APPLY_ISSUE`)
- when default GitHub Project views are missing and direct API creation is unavailable, auto-create an `IX Project View Apply Plan` issue and store its issue number in repo variables
- keep behavior idempotent by skipping when the variable already points to a valid issue number
- update setup help/PR copy text to reflect assistive issue variable bootstrap
- add tests for project-view issue provisioning decision logic

## Why this helps
Maintainers who work fully in GitHub immediately get a concrete checklist issue for missing Project views, alongside the triage control issue, without manual CLI follow-up.

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll