### PR TITLE
feat(setup): upsert triage bootstrap links on control issue

### DIFF
--- a/IntelligenceX.Cli/Setup/SetupRunner.GitHubApi.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.GitHubApi.cs
@@ -213,6 +213,44 @@ internal static partial class SetupRunner {
             return number;
         }
 
+        public async Task UpsertIssueCommentWithMarkerAsync(
+            string owner,
+            string repo,
+            int issueNumber,
+            string marker,
+            string body) {
+            if (issueNumber <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(issueNumber), issueNumber, "Issue number must be positive.");
+            }
+            if (string.IsNullOrWhiteSpace(marker)) {
+                throw new ArgumentException("Marker is required.", nameof(marker));
+            }
+
+            var normalizedBody = string.IsNullOrWhiteSpace(body)
+                ? marker
+                : body.Contains(marker, StringComparison.Ordinal)
+                    ? body
+                    : $"{marker}{Environment.NewLine}{body}";
+
+            var existing = await TryFindIssueCommentByMarkerAsync(owner, repo, issueNumber, marker).ConfigureAwait(false);
+            if (existing.HasValue) {
+                var existingBody = existing.Value.Body ?? string.Empty;
+                if (string.Equals(existingBody.Trim(), normalizedBody.Trim(), StringComparison.Ordinal)) {
+                    return;
+                }
+
+                await PatchJsonAsync(
+                    $"/repos/{owner}/{repo}/issues/comments/{existing.Value.Id}",
+                    new { body = normalizedBody }).ConfigureAwait(false);
+                return;
+            }
+
+            await PostJsonAsync(
+                $"/repos/{owner}/{repo}/issues/{issueNumber}/comments",
+                new { body = normalizedBody },
+                allowConflict: false).ConfigureAwait(false);
+        }
+
         public async Task<string?> TryGetRepositoryVariableAsync(string owner, string repo, string name) {
             if (string.IsNullOrWhiteSpace(name)) {
                 throw new ArgumentException("Variable name is required.", nameof(name));
@@ -255,6 +293,46 @@ internal static partial class SetupRunner {
             }
 
             await PatchJsonAsync($"/repos/{owner}/{repo}/actions/variables/{escapedName}", payload).ConfigureAwait(false);
+        }
+
+        private async Task<(long Id, string Body)?> TryFindIssueCommentByMarkerAsync(
+            string owner,
+            string repo,
+            int issueNumber,
+            string marker) {
+            for (var page = 1; page <= 10; page++) {
+                var url = $"/repos/{owner}/{repo}/issues/{issueNumber}/comments?per_page=100&page={page}";
+                var json = await GetJsonAsync(url).ConfigureAwait(false);
+                if (json.ValueKind != JsonValueKind.Array || json.GetArrayLength() == 0) {
+                    return null;
+                }
+
+                var count = 0;
+                foreach (var item in json.EnumerateArray()) {
+                    count++;
+                    if (!item.TryGetProperty("id", out var idProp) ||
+                        idProp.ValueKind != JsonValueKind.Number ||
+                        !idProp.TryGetInt64(out var commentId) ||
+                        commentId <= 0) {
+                        continue;
+                    }
+
+                    if (!item.TryGetProperty("body", out var bodyProp) || bodyProp.ValueKind != JsonValueKind.String) {
+                        continue;
+                    }
+
+                    var body = bodyProp.GetString() ?? string.Empty;
+                    if (body.Contains(marker, StringComparison.Ordinal)) {
+                        return (commentId, body);
+                    }
+                }
+
+                if (count < 100) {
+                    return null;
+                }
+            }
+
+            return null;
         }
 
         public async Task SetSecretAsync(string owner, string repo, string name, string value) {

--- a/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
@@ -55,7 +55,7 @@ internal static partial class SetupRunner {
         Console.WriteLine("  --cleanup-allowed-edits <comma-list>");
         Console.WriteLine("  --cleanup-post-edit-comment <true|false>");
         Console.WriteLine("  --with-config (also write .intelligencex/reviewer.json)");
-        Console.WriteLine("  --triage-bootstrap (also bootstrap IX triage project schema + workflow + VISION.md + assistive issue variables)");
+        Console.WriteLine("  --triage-bootstrap (also bootstrap IX triage project schema + workflow + VISION.md + assistive issues + links comment)");
         Console.WriteLine("  --upgrade (update managed sections instead of skipping)");
         Console.WriteLine("  --update-secret (refresh INTELLIGENCEX_AUTH_B64 only)");
         Console.WriteLine("  --skip-secret (skip secret update during setup)");

--- a/IntelligenceX.Cli/Setup/SetupRunner.TriageBootstrap.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.TriageBootstrap.cs
@@ -16,7 +16,10 @@ internal static partial class SetupRunner {
     private const string DefaultProjectViewApplyIssueTitle = "IX Project View Apply Plan";
     private const string TriageControlIssueVariableName = "IX_TRIAGE_CONTROL_ISSUE";
     private const string ProjectViewApplyIssueVariableName = "IX_PROJECT_VIEW_APPLY_ISSUE";
+    private const string BootstrapLinksCommentMarker = "<!-- intelligencex:triage-bootstrap-links -->";
     private static readonly SemaphoreSlim ProjectInitLock = new(1, 1);
+    private readonly record struct AssistiveIssueState(int? IssueNumber);
+    private readonly record struct ProjectViewApplyIssueState(int? IssueNumber, int MissingViews, bool DirectCreateSupported);
 
     private static async Task<List<FilePlan>> PlanTriageBootstrapFilesAsync(
         GitHubApi github,
@@ -82,7 +85,7 @@ internal static partial class SetupRunner {
         };
 
         if (!options.DryRun) {
-            await EnsureControlIssueConfiguredAsync(
+            var controlIssueState = await EnsureControlIssueConfiguredAsync(
                 github,
                 owner,
                 repo,
@@ -90,13 +93,27 @@ internal static partial class SetupRunner {
                 projectOwner,
                 projectNumber).ConfigureAwait(false);
 
-            await EnsureProjectViewApplyIssueConfiguredAsync(
+            var viewApplyIssueState = await EnsureProjectViewApplyIssueConfiguredAsync(
                 github,
                 owner,
                 repo,
                 repoFullName,
                 projectOwner,
                 projectNumber).ConfigureAwait(false);
+
+            if (controlIssueState.IssueNumber.HasValue) {
+                await UpsertBootstrapLinksCommentAsync(
+                    github,
+                    owner,
+                    repo,
+                    repoFullName,
+                    projectOwner,
+                    projectNumber,
+                    controlIssueState.IssueNumber.Value,
+                    viewApplyIssueState.IssueNumber,
+                    viewApplyIssueState.MissingViews,
+                    viewApplyIssueState.DirectCreateSupported).ConfigureAwait(false);
+            }
         }
 
         return plans;
@@ -114,6 +131,40 @@ internal static partial class SetupRunner {
         return !TryParsePositiveInt(issueVariableValue, out _);
     }
 
+    internal static string BuildTriageBootstrapLinksComment(
+        string repoFullName,
+        string projectOwner,
+        int projectNumber,
+        int controlIssueNumber,
+        int? viewApplyIssueNumber,
+        int missingViews,
+        bool directCreateSupported) {
+        var builder = new System.Text.StringBuilder();
+        builder.AppendLine(BootstrapLinksCommentMarker);
+        builder.AppendLine("## IX Triage Bootstrap Links");
+        builder.AppendLine();
+        builder.AppendLine($"- Project target: `{projectOwner}#{projectNumber}`");
+        builder.AppendLine($"- Control issue: #{controlIssueNumber} ({BuildIssueUrl(repoFullName, controlIssueNumber)})");
+        if (viewApplyIssueNumber.HasValue) {
+            builder.AppendLine(
+                $"- Project view apply issue: #{viewApplyIssueNumber.Value} ({BuildIssueUrl(repoFullName, viewApplyIssueNumber.Value)})");
+        } else if (directCreateSupported) {
+            builder.AppendLine("- Project view apply issue: not required (GitHub API can create project views directly).");
+        } else if (missingViews <= 0) {
+            builder.AppendLine("- Project view apply issue: not required (default IX project views already present).");
+        } else {
+            builder.AppendLine(
+                "- Project view apply issue: unavailable (auto-provision failed; run `intelligencex todo project-view-apply --create-issue`).");
+        }
+        builder.AppendLine();
+        builder.AppendLine("### Maintainer Entry Point");
+        builder.AppendLine();
+        builder.AppendLine("1. Open the latest workflow summary in this control issue.");
+        builder.AppendLine("2. Use the linked project-view issue (if present) to complete missing default project views.");
+        builder.AppendLine("3. Triage PRs/issues in the GitHub Project using IX fields and labels.");
+        return builder.ToString().TrimEnd();
+    }
+
     private static bool TryParsePositiveInt(string? value, out int number) {
         number = 0;
         if (string.IsNullOrWhiteSpace(value)) {
@@ -124,7 +175,11 @@ internal static partial class SetupRunner {
                number > 0;
     }
 
-    private static async Task EnsureControlIssueConfiguredAsync(
+    private static string BuildIssueUrl(string repoFullName, int issueNumber) {
+        return $"https://github.com/{repoFullName}/issues/{issueNumber.ToString(CultureInfo.InvariantCulture)}";
+    }
+
+    private static async Task<AssistiveIssueState> EnsureControlIssueConfiguredAsync(
         GitHubApi github,
         string owner,
         string repo,
@@ -141,11 +196,11 @@ internal static partial class SetupRunner {
             Console.Error.WriteLine(
                 $"Warning: triage bootstrap could not read {TriageControlIssueVariableName}. " +
                 $"Configure it manually if needed. ({ex.Message})");
-            return;
+            return new AssistiveIssueState(null);
         }
 
-        if (!ShouldProvisionTriageControlIssue(existingControlIssue)) {
-            return;
+        if (TryParsePositiveInt(existingControlIssue, out var existingIssueNumber)) {
+            return new AssistiveIssueState(existingIssueNumber);
         }
 
         try {
@@ -158,14 +213,16 @@ internal static partial class SetupRunner {
                 issueNumber.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
 
             Console.WriteLine($"Configured {TriageControlIssueVariableName} to #{issueNumber}.");
+            return new AssistiveIssueState(issueNumber);
         } catch (Exception ex) {
             Console.Error.WriteLine(
                 $"Warning: triage bootstrap could not auto-configure {TriageControlIssueVariableName}. " +
                 $"Run `intelligencex todo project-bootstrap --repo {repoFullName} --create-control-issue` after setup. ({ex.Message})");
+            return new AssistiveIssueState(null);
         }
     }
 
-    private static async Task EnsureProjectViewApplyIssueConfiguredAsync(
+    private static async Task<ProjectViewApplyIssueState> EnsureProjectViewApplyIssueConfiguredAsync(
         GitHubApi github,
         string owner,
         string repo,
@@ -182,11 +239,17 @@ internal static partial class SetupRunner {
             Console.Error.WriteLine(
                 $"Warning: triage bootstrap could not read {ProjectViewApplyIssueVariableName}. " +
                 $"View-apply issue auto-provision may be skipped. ({ex.Message})");
-            return;
+            return new ProjectViewApplyIssueState(
+                IssueNumber: null,
+                MissingViews: 0,
+                DirectCreateSupported: false);
         }
 
-        if (TryParsePositiveInt(existingViewIssue, out _)) {
-            return;
+        if (TryParsePositiveInt(existingViewIssue, out var existingIssueNumber)) {
+            return new ProjectViewApplyIssueState(
+                IssueNumber: existingIssueNumber,
+                MissingViews: 0,
+                DirectCreateSupported: false);
         }
 
         try {
@@ -195,14 +258,20 @@ internal static partial class SetupRunner {
             if (project is null) {
                 Console.Error.WriteLine(
                     $"Warning: triage bootstrap could not resolve project {projectOwner}#{projectNumber} for view apply planning.");
-                return;
+                return new ProjectViewApplyIssueState(
+                    IssueNumber: null,
+                    MissingViews: 0,
+                    DirectCreateSupported: false);
             }
 
             var views = await client.GetProjectViewsByNameAsync(projectOwner, projectNumber).ConfigureAwait(false);
             var directCreateSupported = await client.SupportsProjectViewCreationAsync().ConfigureAwait(false);
             var missingViews = ProjectViewCatalog.FindMissingDefaultViews(views).Count;
             if (!ShouldProvisionProjectViewApplyIssue(existingViewIssue, missingViews, directCreateSupported)) {
-                return;
+                return new ProjectViewApplyIssueState(
+                    IssueNumber: null,
+                    MissingViews: missingViews,
+                    DirectCreateSupported: directCreateSupported);
             }
 
             var markdown = ProjectViewApplyRunner.BuildApplyMarkdown(
@@ -223,10 +292,51 @@ internal static partial class SetupRunner {
                 issueNumber.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
 
             Console.WriteLine($"Configured {ProjectViewApplyIssueVariableName} to #{issueNumber}.");
+            return new ProjectViewApplyIssueState(
+                IssueNumber: issueNumber,
+                MissingViews: missingViews,
+                DirectCreateSupported: directCreateSupported);
         } catch (Exception ex) {
             Console.Error.WriteLine(
                 $"Warning: triage bootstrap could not auto-configure {ProjectViewApplyIssueVariableName}. " +
                 $"Run `intelligencex todo project-view-apply --repo {repoFullName} --create-issue` after setup. ({ex.Message})");
+            return new ProjectViewApplyIssueState(
+                IssueNumber: null,
+                MissingViews: 0,
+                DirectCreateSupported: false);
+        }
+    }
+
+    private static async Task UpsertBootstrapLinksCommentAsync(
+        GitHubApi github,
+        string owner,
+        string repo,
+        string repoFullName,
+        string projectOwner,
+        int projectNumber,
+        int controlIssueNumber,
+        int? viewApplyIssueNumber,
+        int missingViews,
+        bool directCreateSupported) {
+        try {
+            var comment = BuildTriageBootstrapLinksComment(
+                repoFullName,
+                projectOwner,
+                projectNumber,
+                controlIssueNumber,
+                viewApplyIssueNumber,
+                missingViews,
+                directCreateSupported);
+            await github.UpsertIssueCommentWithMarkerAsync(
+                owner,
+                repo,
+                controlIssueNumber,
+                BootstrapLinksCommentMarker,
+                comment).ConfigureAwait(false);
+            Console.WriteLine($"Updated bootstrap links comment on issue #{controlIssueNumber}.");
+        } catch (Exception ex) {
+            Console.Error.WriteLine(
+                $"Warning: triage bootstrap could not upsert links comment on issue #{controlIssueNumber}. ({ex.Message})");
         }
     }
 

--- a/IntelligenceX.Cli/Setup/SetupRunner.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.cs
@@ -664,7 +664,7 @@ internal static partial class SetupRunner {
             extras.Add("exports analyzer configs for IDE support");
         }
         if (includeTriageBootstrap) {
-            extras.Add("bootstraps IX triage project automation (VISION.md + project sync workflow + assistive issue variables)");
+            extras.Add("bootstraps IX triage project automation (VISION.md + project sync workflow + assistive issues + links comment)");
         }
 
         if (extras.Count == 0) {

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -81,6 +81,36 @@ internal static partial class Program {
             "project view issue should be provisioned when variable is invalid");
     }
 
+    private static void TestSetupTriageBootstrapLinksCommentIncludesAssistiveIssueLinks() {
+        var comment = SetupRunner.BuildTriageBootstrapLinksComment(
+            repoFullName: "owner/repo",
+            projectOwner: "owner",
+            projectNumber: 123,
+            controlIssueNumber: 11,
+            viewApplyIssueNumber: 22,
+            missingViews: 3,
+            directCreateSupported: false);
+
+        AssertContainsText(comment, "intelligencex:triage-bootstrap-links", "bootstrap links marker");
+        AssertContainsText(comment, "https://github.com/owner/repo/issues/11", "control issue link present");
+        AssertContainsText(comment, "https://github.com/owner/repo/issues/22", "view apply issue link present");
+        AssertContainsText(comment, "Maintainer Entry Point", "maintainer entry point section present");
+    }
+
+    private static void TestSetupTriageBootstrapLinksCommentHandlesMissingViewIssue() {
+        var comment = SetupRunner.BuildTriageBootstrapLinksComment(
+            repoFullName: "owner/repo",
+            projectOwner: "owner",
+            projectNumber: 123,
+            controlIssueNumber: 11,
+            viewApplyIssueNumber: null,
+            missingViews: 2,
+            directCreateSupported: false);
+
+        AssertContainsText(comment, "auto-provision failed", "missing view issue fallback text present");
+        AssertContainsText(comment, "project-view-apply --create-issue", "manual recovery command hint present");
+    }
+
     private static void TestSetupArgsIncludeAnalysisRunStrictOption() {
         var plan = new SetupPlan("owner/repo") {
             AnalysisEnabled = true,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -82,6 +82,10 @@ internal static partial class Program {
         failed += Run("Setup args include triage bootstrap", TestSetupArgsIncludeTriageBootstrap);
         failed += Run("Setup triage control issue provision decision", TestSetupTriageControlIssueProvisionDecision);
         failed += Run("Setup project view apply issue provision decision", TestSetupProjectViewApplyIssueProvisionDecision);
+        failed += Run("Setup triage bootstrap links comment includes assistive issue links",
+            TestSetupTriageBootstrapLinksCommentIncludesAssistiveIssueLinks);
+        failed += Run("Setup triage bootstrap links comment handles missing view issue",
+            TestSetupTriageBootstrapLinksCommentHandlesMissingViewIssue);
         failed += Run("Setup args include OpenAI account routing", TestSetupArgsIncludeOpenAiAccountRouting);
         failed += Run("Setup args include OpenAI account routing with primary only",
             TestSetupArgsIncludeOpenAiAccountRoutingWithPrimaryOnly);


### PR DESCRIPTION
## Summary
- add a triage bootstrap links marker comment that is upserted on the control issue
- include quick links to the control issue and project-view apply issue when present
- keep bootstrap idempotent by updating the existing marker comment instead of posting duplicates
- add GitHub API helpers for marker-based issue comment upsert
- add setup tests covering links comment rendering paths

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll