### PR TITLE
feat(setup): ensure IX labels during triage bootstrap

### DIFF
--- a/IntelligenceX.Cli/Setup/SetupRunner.GitHubApi.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.GitHubApi.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using IntelligenceX.Cli.Todo;
 using Sodium;
 
 namespace IntelligenceX.Cli.Setup;
@@ -80,6 +81,7 @@ internal static partial class SetupRunner {
 
     private sealed class GitHubApi : IDisposable {
         private readonly HttpClient _http;
+        public readonly record struct EnsureRepositoryLabelsResult(int CreatedCount, int TotalCount);
 
         public GitHubApi(string token, string apiBaseUrl) {
             _http = new HttpClient {
@@ -295,6 +297,48 @@ internal static partial class SetupRunner {
             await PatchJsonAsync($"/repos/{owner}/{repo}/actions/variables/{escapedName}", payload).ConfigureAwait(false);
         }
 
+        public async Task<EnsureRepositoryLabelsResult> EnsureRepositoryLabelsAsync(
+            string owner,
+            string repo,
+            IReadOnlyList<ProjectLabelDefinition> labels) {
+            if (labels is null) {
+                throw new ArgumentNullException(nameof(labels));
+            }
+            if (labels.Count == 0) {
+                return new EnsureRepositoryLabelsResult(0, 0);
+            }
+
+            var existing = await GetRepositoryLabelNamesAsync(owner, repo).ConfigureAwait(false);
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var createdCount = 0;
+            var totalCount = 0;
+            foreach (var label in labels) {
+                if (string.IsNullOrWhiteSpace(label.Name) || !seen.Add(label.Name)) {
+                    continue;
+                }
+
+                totalCount++;
+                if (existing.Contains(label.Name)) {
+                    continue;
+                }
+
+                var result = await PostJsonAsync(
+                    $"/repos/{owner}/{repo}/labels",
+                    new {
+                        name = label.Name,
+                        color = label.Color,
+                        description = label.Description
+                    },
+                    allowConflict: true).ConfigureAwait(false);
+                if (result is not null) {
+                    createdCount++;
+                    existing.Add(label.Name);
+                }
+            }
+
+            return new EnsureRepositoryLabelsResult(createdCount, totalCount);
+        }
+
         private async Task<(long Id, string Body)?> TryFindIssueCommentByMarkerAsync(
             string owner,
             string repo,
@@ -333,6 +377,35 @@ internal static partial class SetupRunner {
             }
 
             return null;
+        }
+
+        private async Task<HashSet<string>> GetRepositoryLabelNamesAsync(string owner, string repo) {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var page = 1; page <= 10; page++) {
+                var json = await GetJsonAsync($"/repos/{owner}/{repo}/labels?per_page=100&page={page}").ConfigureAwait(false);
+                if (json.ValueKind != JsonValueKind.Array || json.GetArrayLength() == 0) {
+                    return names;
+                }
+
+                var count = 0;
+                foreach (var item in json.EnumerateArray()) {
+                    count++;
+                    if (!item.TryGetProperty("name", out var nameProp) || nameProp.ValueKind != JsonValueKind.String) {
+                        continue;
+                    }
+
+                    var name = nameProp.GetString();
+                    if (!string.IsNullOrWhiteSpace(name)) {
+                        names.Add(name.Trim());
+                    }
+                }
+
+                if (count < 100) {
+                    return names;
+                }
+            }
+
+            return names;
         }
 
         public async Task SetSecretAsync(string owner, string repo, string name, string value) {

--- a/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.HelpAndParsing.cs
@@ -55,7 +55,7 @@ internal static partial class SetupRunner {
         Console.WriteLine("  --cleanup-allowed-edits <comma-list>");
         Console.WriteLine("  --cleanup-post-edit-comment <true|false>");
         Console.WriteLine("  --with-config (also write .intelligencex/reviewer.json)");
-        Console.WriteLine("  --triage-bootstrap (also bootstrap IX triage project schema + workflow + VISION.md + assistive issues + links comment)");
+        Console.WriteLine("  --triage-bootstrap (also bootstrap IX triage project schema + workflow + VISION.md + labels + assistive issues + links comment)");
         Console.WriteLine("  --upgrade (update managed sections instead of skipping)");
         Console.WriteLine("  --update-secret (refresh INTELLIGENCEX_AUTH_B64 only)");
         Console.WriteLine("  --skip-secret (skip secret update during setup)");

--- a/IntelligenceX.Cli/Setup/SetupRunner.TriageBootstrap.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.TriageBootstrap.cs
@@ -20,6 +20,7 @@ internal static partial class SetupRunner {
     private static readonly SemaphoreSlim ProjectInitLock = new(1, 1);
     private readonly record struct AssistiveIssueState(int? IssueNumber);
     private readonly record struct ProjectViewApplyIssueState(int? IssueNumber, int MissingViews, bool DirectCreateSupported);
+    private readonly record struct LabelProvisionState(int CreatedCount, int TotalCount, bool Failed);
 
     private static async Task<List<FilePlan>> PlanTriageBootstrapFilesAsync(
         GitHubApi github,
@@ -101,6 +102,14 @@ internal static partial class SetupRunner {
                 projectOwner,
                 projectNumber).ConfigureAwait(false);
 
+            var labelProvisionState = await EnsureTriageLabelsConfiguredAsync(
+                github,
+                owner,
+                repo,
+                repoFullName,
+                projectOwner,
+                projectNumber).ConfigureAwait(false);
+
             if (controlIssueState.IssueNumber.HasValue) {
                 await UpsertBootstrapLinksCommentAsync(
                     github,
@@ -112,7 +121,8 @@ internal static partial class SetupRunner {
                     controlIssueState.IssueNumber.Value,
                     viewApplyIssueState.IssueNumber,
                     viewApplyIssueState.MissingViews,
-                    viewApplyIssueState.DirectCreateSupported).ConfigureAwait(false);
+                    viewApplyIssueState.DirectCreateSupported,
+                    labelProvisionState).ConfigureAwait(false);
             }
         }
 
@@ -138,13 +148,27 @@ internal static partial class SetupRunner {
         int controlIssueNumber,
         int? viewApplyIssueNumber,
         int missingViews,
-        bool directCreateSupported) {
+        bool directCreateSupported,
+        int labelsCreatedCount,
+        int labelsTotalCount,
+        bool labelsEnsureFailed) {
         var builder = new System.Text.StringBuilder();
         builder.AppendLine(BootstrapLinksCommentMarker);
         builder.AppendLine("## IX Triage Bootstrap Links");
         builder.AppendLine();
         builder.AppendLine($"- Project target: `{projectOwner}#{projectNumber}`");
         builder.AppendLine($"- Control issue: #{controlIssueNumber} ({BuildIssueUrl(repoFullName, controlIssueNumber)})");
+        if (labelsEnsureFailed) {
+            builder.AppendLine(
+                $"- IX labels: ensure failed (run `intelligencex todo project-init --repo {repoFullName} --owner {projectOwner} --project {projectNumber.ToString(CultureInfo.InvariantCulture)} --ensure-labels --no-link-repo --no-ensure-default-views`).");
+        } else if (labelsTotalCount > 0 && labelsCreatedCount > 0) {
+            builder.AppendLine(
+                $"- IX labels: ensured ({labelsTotalCount.ToString(CultureInfo.InvariantCulture)} tracked, {labelsCreatedCount.ToString(CultureInfo.InvariantCulture)} created this run).");
+        } else if (labelsTotalCount > 0) {
+            builder.AppendLine($"- IX labels: ensured (all {labelsTotalCount.ToString(CultureInfo.InvariantCulture)} already present).");
+        } else {
+            builder.AppendLine("- IX labels: not configured.");
+        }
         if (viewApplyIssueNumber.HasValue) {
             builder.AppendLine(
                 $"- Project view apply issue: #{viewApplyIssueNumber.Value} ({BuildIssueUrl(repoFullName, viewApplyIssueNumber.Value)})");
@@ -307,6 +331,39 @@ internal static partial class SetupRunner {
         }
     }
 
+    private static async Task<LabelProvisionState> EnsureTriageLabelsConfiguredAsync(
+        GitHubApi github,
+        string owner,
+        string repo,
+        string repoFullName,
+        string projectOwner,
+        int projectNumber) {
+        try {
+            var result = await github.EnsureRepositoryLabelsAsync(owner, repo, ProjectLabelCatalog.DefaultLabels)
+                .ConfigureAwait(false);
+            if (result.CreatedCount > 0) {
+                Console.WriteLine(
+                    $"Ensured IX labels ({result.TotalCount.ToString(CultureInfo.InvariantCulture)} tracked, " +
+                    $"{result.CreatedCount.ToString(CultureInfo.InvariantCulture)} created).");
+            } else {
+                Console.WriteLine(
+                    $"Ensured IX labels ({result.TotalCount.ToString(CultureInfo.InvariantCulture)} tracked, all already present).");
+            }
+
+            return new LabelProvisionState(
+                CreatedCount: result.CreatedCount,
+                TotalCount: result.TotalCount,
+                Failed: false);
+        } catch (Exception ex) {
+            Console.Error.WriteLine(
+                $"Warning: triage bootstrap could not ensure IX labels. Run `intelligencex todo project-init --repo {repoFullName} --owner {projectOwner} --project {projectNumber.ToString(CultureInfo.InvariantCulture)} --ensure-labels --no-link-repo --no-ensure-default-views` after setup. ({ex.Message})");
+            return new LabelProvisionState(
+                CreatedCount: 0,
+                TotalCount: ProjectLabelCatalog.DefaultLabels.Count,
+                Failed: true);
+        }
+    }
+
     private static async Task UpsertBootstrapLinksCommentAsync(
         GitHubApi github,
         string owner,
@@ -317,7 +374,8 @@ internal static partial class SetupRunner {
         int controlIssueNumber,
         int? viewApplyIssueNumber,
         int missingViews,
-        bool directCreateSupported) {
+        bool directCreateSupported,
+        LabelProvisionState labelProvisionState) {
         try {
             var comment = BuildTriageBootstrapLinksComment(
                 repoFullName,
@@ -326,7 +384,10 @@ internal static partial class SetupRunner {
                 controlIssueNumber,
                 viewApplyIssueNumber,
                 missingViews,
-                directCreateSupported);
+                directCreateSupported,
+                labelProvisionState.CreatedCount,
+                labelProvisionState.TotalCount,
+                labelProvisionState.Failed);
             await github.UpsertIssueCommentWithMarkerAsync(
                 owner,
                 repo,

--- a/IntelligenceX.Cli/Setup/SetupRunner.cs
+++ b/IntelligenceX.Cli/Setup/SetupRunner.cs
@@ -664,7 +664,7 @@ internal static partial class SetupRunner {
             extras.Add("exports analyzer configs for IDE support");
         }
         if (includeTriageBootstrap) {
-            extras.Add("bootstraps IX triage project automation (VISION.md + project sync workflow + assistive issues + links comment)");
+            extras.Add("bootstraps IX triage project automation (VISION.md + project sync workflow + labels + assistive issues + links comment)");
         }
 
         if (extras.Count == 0) {

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -89,11 +89,15 @@ internal static partial class Program {
             controlIssueNumber: 11,
             viewApplyIssueNumber: 22,
             missingViews: 3,
-            directCreateSupported: false);
+            directCreateSupported: false,
+            labelsCreatedCount: 4,
+            labelsTotalCount: 24,
+            labelsEnsureFailed: false);
 
         AssertContainsText(comment, "intelligencex:triage-bootstrap-links", "bootstrap links marker");
         AssertContainsText(comment, "https://github.com/owner/repo/issues/11", "control issue link present");
         AssertContainsText(comment, "https://github.com/owner/repo/issues/22", "view apply issue link present");
+        AssertContainsText(comment, "IX labels: ensured (24 tracked, 4 created this run).", "labels ensured summary present");
         AssertContainsText(comment, "Maintainer Entry Point", "maintainer entry point section present");
     }
 
@@ -105,10 +109,31 @@ internal static partial class Program {
             controlIssueNumber: 11,
             viewApplyIssueNumber: null,
             missingViews: 2,
-            directCreateSupported: false);
+            directCreateSupported: false,
+            labelsCreatedCount: 0,
+            labelsTotalCount: 24,
+            labelsEnsureFailed: false);
 
         AssertContainsText(comment, "auto-provision failed", "missing view issue fallback text present");
         AssertContainsText(comment, "project-view-apply --create-issue", "manual recovery command hint present");
+    }
+
+    private static void TestSetupTriageBootstrapLinksCommentHandlesLabelEnsureFailure() {
+        var comment = SetupRunner.BuildTriageBootstrapLinksComment(
+            repoFullName: "owner/repo",
+            projectOwner: "owner",
+            projectNumber: 123,
+            controlIssueNumber: 11,
+            viewApplyIssueNumber: null,
+            missingViews: 0,
+            directCreateSupported: true,
+            labelsCreatedCount: 0,
+            labelsTotalCount: 24,
+            labelsEnsureFailed: true);
+
+        AssertContainsText(comment, "IX labels: ensure failed", "label failure summary present");
+        AssertContainsText(comment, "project-init --repo owner/repo --owner owner --project 123 --ensure-labels --no-link-repo --no-ensure-default-views",
+            "label recovery command hint present");
     }
 
     private static void TestSetupArgsIncludeAnalysisRunStrictOption() {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -86,6 +86,8 @@ internal static partial class Program {
             TestSetupTriageBootstrapLinksCommentIncludesAssistiveIssueLinks);
         failed += Run("Setup triage bootstrap links comment handles missing view issue",
             TestSetupTriageBootstrapLinksCommentHandlesMissingViewIssue);
+        failed += Run("Setup triage bootstrap links comment handles label ensure failure",
+            TestSetupTriageBootstrapLinksCommentHandlesLabelEnsureFailure);
         failed += Run("Setup args include OpenAI account routing", TestSetupArgsIncludeOpenAiAccountRouting);
         failed += Run("Setup args include OpenAI account routing with primary only",
             TestSetupArgsIncludeOpenAiAccountRoutingWithPrimaryOnly);


### PR DESCRIPTION
## Summary
- ensure default IX triage labels during every --triage-bootstrap run (including repos with existing project config)
- add GitHub REST helpers in setup API client to list/create missing labels idempotently
- extend triage bootstrap links marker comment with label provisioning status and a concrete recovery command
- update setup help/PR summary text to include labels in triage bootstrap scope
- add tests for links comment label status success and failure paths

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll