### PR TITLE
feat(todo): upsert control issue sync summary comment

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -231,7 +231,7 @@ A reusable scheduled workflow template is available at:
 
 It runs `build-triage-index`, uploads artifacts, and can optionally post the markdown summary to a control issue
 when repository variable `IX_TRIAGE_CONTROL_ISSUE` is set.
-For `triage-project-sync.yml`, the posted comment includes both triage and vision markdown summaries.
+For `triage-project-sync.yml`, IX upserts a single marker comment (latest only) that includes both triage and vision markdown summaries.
 `todo project-bootstrap --create-control-issue` can set this variable for you automatically.
 
 ## Options

--- a/IntelligenceX.Cli/Templates/triage-project-sync.yml
+++ b/IntelligenceX.Cli/Templates/triage-project-sync.yml
@@ -96,12 +96,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          MARKER="<!-- intelligencex:triage-project-sync-summary -->"
           ISSUE="${{ vars.IX_TRIAGE_CONTROL_ISSUE }}"
           SUMMARY_FILE="artifacts/triage/ix-triage-project-sync-summary.md"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GENERATED_AT="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
 
           {
+            echo "$MARKER"
             echo "# IX Triage Project Sync"
             echo
             echo "- Generated: $GENERATED_AT"
@@ -125,5 +127,20 @@ jobs:
           } > "$SUMMARY_FILE"
 
           if [ -f "$SUMMARY_FILE" ]; then
-            gh issue comment "$ISSUE" --repo "${{ github.repository }}" --body-file "$SUMMARY_FILE"
+            EXISTING_ID="$(gh api --paginate \
+              "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+              --jq '.[] | select(.body | contains("<!-- intelligencex:triage-project-sync-summary -->")) | .id' \
+              | tail -n 1)"
+
+            if [ -n "$EXISTING_ID" ]; then
+              gh api \
+                --method PATCH \
+                "repos/${{ github.repository }}/issues/comments/$EXISTING_ID" \
+                -F "body=@$SUMMARY_FILE" > /dev/null
+            else
+              gh api \
+                --method POST \
+                "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+                -F "body=@$SUMMARY_FILE" > /dev/null
+            fi
           fi

--- a/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
@@ -69,6 +69,20 @@ project={{ProjectNumber}}
         AssertContainsText(rendered, "--apply-link-comments", "workflow enables PR issue suggestion comments");
     }
 
+    private static void TestProjectBootstrapWorkflowTemplateUpsertsControlIssueSummaryComment() {
+        var template = IntelligenceX.Cli.Todo.ProjectBootstrapRunner.LoadWorkflowTemplate();
+        var rendered = IntelligenceX.Cli.Todo.ProjectBootstrapRunner.RenderWorkflowTemplate(
+            template,
+            "EvotecIT",
+            654,
+            300);
+
+        AssertContainsText(rendered, "intelligencex:triage-project-sync-summary", "workflow summary marker present");
+        AssertContainsText(rendered, "issues/$ISSUE/comments", "workflow reads control issue comments");
+        AssertContainsText(rendered, "--method PATCH", "workflow updates existing summary comment");
+        AssertContainsText(rendered, "--method POST", "workflow creates summary comment when missing");
+    }
+
     private static void TestProjectBootstrapBuildControlIssueBodyIncludesProjectContext() {
         var body = IntelligenceX.Cli.Todo.ProjectBootstrapRunner.BuildControlIssueBody(
             "EvotecIT/IntelligenceX",

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -487,6 +487,8 @@ internal static partial class Program {
         failed += Run("Todo project bootstrap clamps max items", TestProjectBootstrapRenderWorkflowTemplateClampsMaxItems);
         failed += Run("Todo project bootstrap renders vision template", TestProjectBootstrapRenderVisionTemplateInjectsContext);
         failed += Run("Todo project bootstrap workflow enables label apply", TestProjectBootstrapWorkflowTemplateEnablesApplyLabels);
+        failed += Run("Todo project bootstrap workflow upserts control issue summary comment",
+            TestProjectBootstrapWorkflowTemplateUpsertsControlIssueSummaryComment);
         failed += Run("Todo project bootstrap control issue body includes context", TestProjectBootstrapBuildControlIssueBodyIncludesProjectContext);
         failed += Run("Todo project bootstrap parses issue url output", TestProjectBootstrapParseIssueNumberFromGhOutputParsesIssueUrl);
         failed += Run("Todo project bootstrap parses trailing issue number", TestProjectBootstrapParseIssueNumberFromGhOutputParsesTrailingInteger);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -214,7 +214,7 @@ Behavior:
 - Scheduled + manual runs.
 - Generates triage index artifacts.
 - Optional control-issue comment when repo variable `IX_TRIAGE_CONTROL_ISSUE` is configured.
-- `triage-project-sync.yml` posts a combined triage + vision markdown summary to the control issue.
+- `triage-project-sync.yml` upserts a single marker comment with the latest combined triage + vision markdown summary on the control issue.
 - `todo project-bootstrap --create-control-issue` can configure the control issue variable automatically.
 
 ## Legacy Script


### PR DESCRIPTION
## Summary
- update 	riage-project-sync.yml control-issue step to upsert a single marker comment instead of posting a new comment every run
- include marker <!-- intelligencex:triage-project-sync-summary --> in the generated summary body
- patch existing marker comment when present; create it when missing
- add bootstrap template test coverage for marker + PATCH/POST upsert paths
- update CLI docs to clarify the control issue comment is latest-only via upsert

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll