### PR TITLE
feat(todo): upsert triage index control issue summary

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -229,8 +229,9 @@ A reusable scheduled workflow template is available at:
 - `IntelligenceX.Cli/Templates/triage-index-scheduled.yml`
 - `IntelligenceX.Cli/Templates/triage-project-sync.yml`
 
-It runs `build-triage-index`, uploads artifacts, and can optionally post the markdown summary to a control issue
+It runs `build-triage-index`, uploads artifacts, and can optionally upsert a control-issue summary comment
 when repository variable `IX_TRIAGE_CONTROL_ISSUE` is set.
+For `triage-index-scheduled.yml`, IX upserts a single marker comment (latest only) with the triage index summary.
 For `triage-project-sync.yml`, IX upserts a single marker comment (latest only) that includes both triage and vision markdown summaries.
 `todo project-bootstrap --create-control-issue` can set this variable for you automatically.
 

--- a/IntelligenceX.Cli/Templates/triage-index-scheduled.yml
+++ b/IntelligenceX.Cli/Templates/triage-index-scheduled.yml
@@ -67,7 +67,42 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          MARKER="<!-- intelligencex:triage-index-summary -->"
           ISSUE="${{ vars.IX_TRIAGE_CONTROL_ISSUE }}"
-          if [ -f artifacts/triage/ix-triage-index.md ]; then
-            gh issue comment "$ISSUE" --repo "${{ github.repository }}" --body-file artifacts/triage/ix-triage-index.md
+          SUMMARY_FILE="artifacts/triage/ix-triage-index-control-summary.md"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          GENERATED_AT="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+
+          {
+            echo "$MARKER"
+            echo "# IX Triage Index Sweep"
+            echo
+            echo "- Generated: $GENERATED_AT"
+            echo "- Repo: \`${{ github.repository }}\`"
+            echo "- Workflow run: $RUN_URL"
+            echo
+            if [ -f artifacts/triage/ix-triage-index.md ]; then
+              cat artifacts/triage/ix-triage-index.md
+            else
+              echo "_No triage summary file found at artifacts/triage/ix-triage-index.md._"
+            fi
+          } > "$SUMMARY_FILE"
+
+          if [ -f "$SUMMARY_FILE" ]; then
+            EXISTING_ID="$(gh api --paginate \
+              "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+              --jq '.[] | select(.body | contains("<!-- intelligencex:triage-index-summary -->")) | .id' \
+              | tail -n 1)"
+
+            if [ -n "$EXISTING_ID" ]; then
+              gh api \
+                --method PATCH \
+                "repos/${{ github.repository }}/issues/comments/$EXISTING_ID" \
+                -F "body=@$SUMMARY_FILE" > /dev/null
+            else
+              gh api \
+                --method POST \
+                "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+                -F "body=@$SUMMARY_FILE" > /dev/null
+            fi
           fi

--- a/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
@@ -83,6 +83,16 @@ project={{ProjectNumber}}
         AssertContainsText(rendered, "--method POST", "workflow creates summary comment when missing");
     }
 
+    private static void TestTriageIndexWorkflowTemplateUpsertsControlIssueSummaryComment() {
+        var templatePath = Path.Combine("IntelligenceX.Cli", "Templates", "triage-index-scheduled.yml");
+        var rendered = File.ReadAllText(templatePath);
+
+        AssertContainsText(rendered, "intelligencex:triage-index-summary", "index workflow summary marker present");
+        AssertContainsText(rendered, "issues/$ISSUE/comments", "index workflow reads control issue comments");
+        AssertContainsText(rendered, "--method PATCH", "index workflow updates existing summary comment");
+        AssertContainsText(rendered, "--method POST", "index workflow creates summary comment when missing");
+    }
+
     private static void TestProjectBootstrapBuildControlIssueBodyIncludesProjectContext() {
         var body = IntelligenceX.Cli.Todo.ProjectBootstrapRunner.BuildControlIssueBody(
             "EvotecIT/IntelligenceX",

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -489,6 +489,8 @@ internal static partial class Program {
         failed += Run("Todo project bootstrap workflow enables label apply", TestProjectBootstrapWorkflowTemplateEnablesApplyLabels);
         failed += Run("Todo project bootstrap workflow upserts control issue summary comment",
             TestProjectBootstrapWorkflowTemplateUpsertsControlIssueSummaryComment);
+        failed += Run("Todo triage index workflow upserts control issue summary comment",
+            TestTriageIndexWorkflowTemplateUpsertsControlIssueSummaryComment);
         failed += Run("Todo project bootstrap control issue body includes context", TestProjectBootstrapBuildControlIssueBodyIncludesProjectContext);
         failed += Run("Todo project bootstrap parses issue url output", TestProjectBootstrapParseIssueNumberFromGhOutputParsesIssueUrl);
         failed += Run("Todo project bootstrap parses trailing issue number", TestProjectBootstrapParseIssueNumberFromGhOutputParsesTrailingInteger);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -213,7 +213,8 @@ Template path:
 Behavior:
 - Scheduled + manual runs.
 - Generates triage index artifacts.
-- Optional control-issue comment when repo variable `IX_TRIAGE_CONTROL_ISSUE` is configured.
+- Optional control-issue summary comment upsert when repo variable `IX_TRIAGE_CONTROL_ISSUE` is configured.
+- `triage-index-scheduled.yml` upserts a single marker comment with the latest triage index summary on the control issue.
 - `triage-project-sync.yml` upserts a single marker comment with the latest combined triage + vision markdown summary on the control issue.
 - `todo project-bootstrap --create-control-issue` can configure the control issue variable automatically.
 


### PR DESCRIPTION
## Summary
- update 	riage-index-scheduled.yml to upsert a single control-issue marker comment instead of posting a new comment every run
- add marker <!-- intelligencex:triage-index-summary --> and include run metadata in the generated control summary
- patch existing marker comment when present; create it when missing
- add test coverage validating marker + PATCH/POST upsert behavior in the triage index workflow template
- update user/internal docs to clarify triage index control comments are latest-only via upsert

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll