### PR TITLE
feat(todo): upsert shared triage control dashboard comment

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -233,6 +233,7 @@ It runs `build-triage-index`, uploads artifacts, and can optionally upsert a con
 when repository variable `IX_TRIAGE_CONTROL_ISSUE` is set.
 For `triage-index-scheduled.yml`, IX upserts a single marker comment (latest only) with the triage index summary.
 For `triage-project-sync.yml`, IX upserts a single marker comment (latest only) that includes both triage and vision markdown summaries.
+Both workflows also upsert a shared `intelligencex:triage-control-dashboard` comment linking to the latest summary comments.
 `todo project-bootstrap --create-control-issue` can set this variable for you automatically.
 
 ## Options

--- a/IntelligenceX.Cli/Templates/triage-index-scheduled.yml
+++ b/IntelligenceX.Cli/Templates/triage-index-scheduled.yml
@@ -68,8 +68,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           MARKER="<!-- intelligencex:triage-index-summary -->"
+          DASHBOARD_MARKER="<!-- intelligencex:triage-control-dashboard -->"
           ISSUE="${{ vars.IX_TRIAGE_CONTROL_ISSUE }}"
           SUMMARY_FILE="artifacts/triage/ix-triage-index-control-summary.md"
+          DASHBOARD_FILE="artifacts/triage/ix-triage-control-dashboard.md"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GENERATED_AT="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
 
@@ -99,10 +101,59 @@ jobs:
                 --method PATCH \
                 "repos/${{ github.repository }}/issues/comments/$EXISTING_ID" \
                 -F "body=@$SUMMARY_FILE" > /dev/null
+              SUMMARY_COMMENT_ID="$EXISTING_ID"
+            else
+              SUMMARY_COMMENT_ID="$(gh api \
+                --method POST \
+                "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+                -F "body=@$SUMMARY_FILE" \
+                --jq '.id')"
+            fi
+
+            PROJECT_SYNC_COMMENT_ID="$(gh api --paginate \
+              "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+              --jq '.[] | select(.body | contains("<!-- intelligencex:triage-project-sync-summary -->")) | .id' \
+              | tail -n 1)"
+
+            TRIAGE_INDEX_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE#issuecomment-$SUMMARY_COMMENT_ID"
+            if [ -n "$PROJECT_SYNC_COMMENT_ID" ]; then
+              PROJECT_SYNC_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE#issuecomment-$PROJECT_SYNC_COMMENT_ID"
+            else
+              PROJECT_SYNC_LINK=""
+            fi
+
+            {
+              echo "$DASHBOARD_MARKER"
+              echo "# IX Triage Control Dashboard"
+              echo
+              echo "- Updated: $GENERATED_AT"
+              echo "- Repo: \`${{ github.repository }}\`"
+              echo "- Workflow run: $RUN_URL"
+              echo
+              echo "## Latest Summaries"
+              echo
+              echo "- Triage Index Sweep: $TRIAGE_INDEX_LINK"
+              if [ -n "$PROJECT_SYNC_LINK" ]; then
+                echo "- Triage Project Sync: $PROJECT_SYNC_LINK"
+              else
+                echo "- Triage Project Sync: _not available yet_"
+              fi
+            } > "$DASHBOARD_FILE"
+
+            DASHBOARD_EXISTING_ID="$(gh api --paginate \
+              "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+              --jq '.[] | select(.body | contains("<!-- intelligencex:triage-control-dashboard -->")) | .id' \
+              | tail -n 1)"
+
+            if [ -n "$DASHBOARD_EXISTING_ID" ]; then
+              gh api \
+                --method PATCH \
+                "repos/${{ github.repository }}/issues/comments/$DASHBOARD_EXISTING_ID" \
+                -F "body=@$DASHBOARD_FILE" > /dev/null
             else
               gh api \
                 --method POST \
                 "repos/${{ github.repository }}/issues/$ISSUE/comments" \
-                -F "body=@$SUMMARY_FILE" > /dev/null
+                -F "body=@$DASHBOARD_FILE" > /dev/null
             fi
           fi

--- a/IntelligenceX.Cli/Templates/triage-project-sync.yml
+++ b/IntelligenceX.Cli/Templates/triage-project-sync.yml
@@ -97,8 +97,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           MARKER="<!-- intelligencex:triage-project-sync-summary -->"
+          DASHBOARD_MARKER="<!-- intelligencex:triage-control-dashboard -->"
           ISSUE="${{ vars.IX_TRIAGE_CONTROL_ISSUE }}"
           SUMMARY_FILE="artifacts/triage/ix-triage-project-sync-summary.md"
+          DASHBOARD_FILE="artifacts/triage/ix-triage-control-dashboard.md"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GENERATED_AT="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
 
@@ -137,10 +139,59 @@ jobs:
                 --method PATCH \
                 "repos/${{ github.repository }}/issues/comments/$EXISTING_ID" \
                 -F "body=@$SUMMARY_FILE" > /dev/null
+              SUMMARY_COMMENT_ID="$EXISTING_ID"
+            else
+              SUMMARY_COMMENT_ID="$(gh api \
+                --method POST \
+                "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+                -F "body=@$SUMMARY_FILE" \
+                --jq '.id')"
+            fi
+
+            TRIAGE_INDEX_COMMENT_ID="$(gh api --paginate \
+              "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+              --jq '.[] | select(.body | contains("<!-- intelligencex:triage-index-summary -->")) | .id' \
+              | tail -n 1)"
+
+            PROJECT_SYNC_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE#issuecomment-$SUMMARY_COMMENT_ID"
+            if [ -n "$TRIAGE_INDEX_COMMENT_ID" ]; then
+              TRIAGE_INDEX_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE#issuecomment-$TRIAGE_INDEX_COMMENT_ID"
+            else
+              TRIAGE_INDEX_LINK=""
+            fi
+
+            {
+              echo "$DASHBOARD_MARKER"
+              echo "# IX Triage Control Dashboard"
+              echo
+              echo "- Updated: $GENERATED_AT"
+              echo "- Repo: \`${{ github.repository }}\`"
+              echo "- Workflow run: $RUN_URL"
+              echo
+              echo "## Latest Summaries"
+              echo
+              if [ -n "$TRIAGE_INDEX_LINK" ]; then
+                echo "- Triage Index Sweep: $TRIAGE_INDEX_LINK"
+              else
+                echo "- Triage Index Sweep: _not available yet_"
+              fi
+              echo "- Triage Project Sync: $PROJECT_SYNC_LINK"
+            } > "$DASHBOARD_FILE"
+
+            DASHBOARD_EXISTING_ID="$(gh api --paginate \
+              "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+              --jq '.[] | select(.body | contains("<!-- intelligencex:triage-control-dashboard -->")) | .id' \
+              | tail -n 1)"
+
+            if [ -n "$DASHBOARD_EXISTING_ID" ]; then
+              gh api \
+                --method PATCH \
+                "repos/${{ github.repository }}/issues/comments/$DASHBOARD_EXISTING_ID" \
+                -F "body=@$DASHBOARD_FILE" > /dev/null
             else
               gh api \
                 --method POST \
                 "repos/${{ github.repository }}/issues/$ISSUE/comments" \
-                -F "body=@$SUMMARY_FILE" > /dev/null
+                -F "body=@$DASHBOARD_FILE" > /dev/null
             fi
           fi

--- a/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
@@ -78,9 +78,11 @@ project={{ProjectNumber}}
             300);
 
         AssertContainsText(rendered, "intelligencex:triage-project-sync-summary", "workflow summary marker present");
+        AssertContainsText(rendered, "intelligencex:triage-control-dashboard", "workflow dashboard marker present");
         AssertContainsText(rendered, "issues/$ISSUE/comments", "workflow reads control issue comments");
         AssertContainsText(rendered, "--method PATCH", "workflow updates existing summary comment");
         AssertContainsText(rendered, "--method POST", "workflow creates summary comment when missing");
+        AssertContainsText(rendered, "Latest Summaries", "workflow dashboard includes latest summaries section");
     }
 
     private static void TestTriageIndexWorkflowTemplateUpsertsControlIssueSummaryComment() {
@@ -88,9 +90,11 @@ project={{ProjectNumber}}
         var rendered = File.ReadAllText(templatePath);
 
         AssertContainsText(rendered, "intelligencex:triage-index-summary", "index workflow summary marker present");
+        AssertContainsText(rendered, "intelligencex:triage-control-dashboard", "index workflow dashboard marker present");
         AssertContainsText(rendered, "issues/$ISSUE/comments", "index workflow reads control issue comments");
         AssertContainsText(rendered, "--method PATCH", "index workflow updates existing summary comment");
         AssertContainsText(rendered, "--method POST", "index workflow creates summary comment when missing");
+        AssertContainsText(rendered, "Latest Summaries", "index workflow dashboard includes latest summaries section");
     }
 
     private static void TestProjectBootstrapBuildControlIssueBodyIncludesProjectContext() {

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -216,6 +216,7 @@ Behavior:
 - Optional control-issue summary comment upsert when repo variable `IX_TRIAGE_CONTROL_ISSUE` is configured.
 - `triage-index-scheduled.yml` upserts a single marker comment with the latest triage index summary on the control issue.
 - `triage-project-sync.yml` upserts a single marker comment with the latest combined triage + vision markdown summary on the control issue.
+- Both workflows also upsert a shared `intelligencex:triage-control-dashboard` comment linking to the latest summary comments.
 - `todo project-bootstrap --create-control-issue` can configure the control issue variable automatically.
 
 ## Legacy Script


### PR DESCRIPTION
## Summary
- add shared control-dashboard upsert flow to both triage workflow templates using marker <!-- intelligencex:triage-control-dashboard -->
- dashboard comment is latest-only and links maintainers to the latest triage-index and project-sync summary comments
- keep both per-workflow summaries as marker-upsert comments and build the dashboard links from their comment ids
- extend workflow template tests to assert dashboard marker and latest-summary section presence
- update docs to describe the shared dashboard comment behavior

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll