### PR TITLE
feat(todo): add maintainer quick links to triage dashboard

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -234,6 +234,7 @@ when repository variable `IX_TRIAGE_CONTROL_ISSUE` is set.
 For `triage-index-scheduled.yml`, IX upserts a single marker comment (latest only) with the triage index summary.
 For `triage-project-sync.yml`, IX upserts a single marker comment (latest only) that includes both triage and vision markdown summaries.
 Both workflows also upsert a shared `intelligencex:triage-control-dashboard` comment linking to the latest summary comments.
+The dashboard comment also includes quick links for maintainers (control issue, vision file, project board when config is available, project-view apply issue variable, and bootstrap links comment).
 `todo project-bootstrap --create-control-issue` can set this variable for you automatically.
 
 ## Options

--- a/IntelligenceX.Cli/Templates/triage-index-scheduled.yml
+++ b/IntelligenceX.Cli/Templates/triage-index-scheduled.yml
@@ -114,12 +114,36 @@ jobs:
               "repos/${{ github.repository }}/issues/$ISSUE/comments" \
               --jq '.[] | select(.body | contains("<!-- intelligencex:triage-project-sync-summary -->")) | .id' \
               | tail -n 1)"
+            BOOTSTRAP_LINKS_COMMENT_ID="$(gh api --paginate \
+              "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+              --jq '.[] | select(.body | contains("<!-- intelligencex:triage-bootstrap-links -->")) | .id' \
+              | tail -n 1)"
 
+            CONTROL_ISSUE_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE"
+            VISION_URL="${{ github.server_url }}/${{ github.repository }}/blob/${{ github.event.repository.default_branch }}/VISION.md"
             TRIAGE_INDEX_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE#issuecomment-$SUMMARY_COMMENT_ID"
             if [ -n "$PROJECT_SYNC_COMMENT_ID" ]; then
               PROJECT_SYNC_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE#issuecomment-$PROJECT_SYNC_COMMENT_ID"
             else
               PROJECT_SYNC_LINK=""
+            fi
+            if [ -n "$BOOTSTRAP_LINKS_COMMENT_ID" ]; then
+              BOOTSTRAP_LINKS_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE#issuecomment-$BOOTSTRAP_LINKS_COMMENT_ID"
+            else
+              BOOTSTRAP_LINKS_LINK=""
+            fi
+
+            PROJECT_VIEW_APPLY_ISSUE="${{ vars.IX_PROJECT_VIEW_APPLY_ISSUE }}"
+            if [ -n "$PROJECT_VIEW_APPLY_ISSUE" ]; then
+              PROJECT_VIEW_APPLY_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$PROJECT_VIEW_APPLY_ISSUE"
+            else
+              PROJECT_VIEW_APPLY_LINK=""
+            fi
+
+            PROJECT_URL=""
+            PROJECT_CONFIG_PATH="artifacts/triage/ix-project-config.json"
+            if [ -f "$PROJECT_CONFIG_PATH" ] && command -v jq >/dev/null 2>&1; then
+              PROJECT_URL="$(jq -r '.project.url // empty' "$PROJECT_CONFIG_PATH" 2>/dev/null || true)"
             fi
 
             {
@@ -137,6 +161,26 @@ jobs:
                 echo "- Triage Project Sync: $PROJECT_SYNC_LINK"
               else
                 echo "- Triage Project Sync: _not available yet_"
+              fi
+              echo
+              echo "## Maintainer Quick Links"
+              echo
+              echo "- Control issue: $CONTROL_ISSUE_LINK"
+              echo "- Vision doc: $VISION_URL"
+              if [ -n "$PROJECT_URL" ]; then
+                echo "- Project board: $PROJECT_URL"
+              else
+                echo "- Project board: _not available (missing artifacts/triage/ix-project-config.json or jq)_"
+              fi
+              if [ -n "$PROJECT_VIEW_APPLY_LINK" ]; then
+                echo "- Project view apply issue: $PROJECT_VIEW_APPLY_LINK"
+              else
+                echo "- Project view apply issue: _not configured (IX_PROJECT_VIEW_APPLY_ISSUE)_"
+              fi
+              if [ -n "$BOOTSTRAP_LINKS_LINK" ]; then
+                echo "- Bootstrap links comment: $BOOTSTRAP_LINKS_LINK"
+              else
+                echo "- Bootstrap links comment: _not available yet_"
               fi
             } > "$DASHBOARD_FILE"
 

--- a/IntelligenceX.Cli/Templates/triage-project-sync.yml
+++ b/IntelligenceX.Cli/Templates/triage-project-sync.yml
@@ -152,12 +152,36 @@ jobs:
               "repos/${{ github.repository }}/issues/$ISSUE/comments" \
               --jq '.[] | select(.body | contains("<!-- intelligencex:triage-index-summary -->")) | .id' \
               | tail -n 1)"
+            BOOTSTRAP_LINKS_COMMENT_ID="$(gh api --paginate \
+              "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+              --jq '.[] | select(.body | contains("<!-- intelligencex:triage-bootstrap-links -->")) | .id' \
+              | tail -n 1)"
 
+            CONTROL_ISSUE_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE"
+            VISION_URL="${{ github.server_url }}/${{ github.repository }}/blob/${{ github.event.repository.default_branch }}/VISION.md"
             PROJECT_SYNC_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE#issuecomment-$SUMMARY_COMMENT_ID"
             if [ -n "$TRIAGE_INDEX_COMMENT_ID" ]; then
               TRIAGE_INDEX_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE#issuecomment-$TRIAGE_INDEX_COMMENT_ID"
             else
               TRIAGE_INDEX_LINK=""
+            fi
+            if [ -n "$BOOTSTRAP_LINKS_COMMENT_ID" ]; then
+              BOOTSTRAP_LINKS_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE#issuecomment-$BOOTSTRAP_LINKS_COMMENT_ID"
+            else
+              BOOTSTRAP_LINKS_LINK=""
+            fi
+
+            PROJECT_VIEW_APPLY_ISSUE="${{ vars.IX_PROJECT_VIEW_APPLY_ISSUE }}"
+            if [ -n "$PROJECT_VIEW_APPLY_ISSUE" ]; then
+              PROJECT_VIEW_APPLY_LINK="${{ github.server_url }}/${{ github.repository }}/issues/$PROJECT_VIEW_APPLY_ISSUE"
+            else
+              PROJECT_VIEW_APPLY_LINK=""
+            fi
+
+            PROJECT_URL=""
+            PROJECT_CONFIG_PATH="artifacts/triage/ix-project-config.json"
+            if [ -f "$PROJECT_CONFIG_PATH" ] && command -v jq >/dev/null 2>&1; then
+              PROJECT_URL="$(jq -r '.project.url // empty' "$PROJECT_CONFIG_PATH" 2>/dev/null || true)"
             fi
 
             {
@@ -176,6 +200,26 @@ jobs:
                 echo "- Triage Index Sweep: _not available yet_"
               fi
               echo "- Triage Project Sync: $PROJECT_SYNC_LINK"
+              echo
+              echo "## Maintainer Quick Links"
+              echo
+              echo "- Control issue: $CONTROL_ISSUE_LINK"
+              echo "- Vision doc: $VISION_URL"
+              if [ -n "$PROJECT_URL" ]; then
+                echo "- Project board: $PROJECT_URL"
+              else
+                echo "- Project board: _not available (missing artifacts/triage/ix-project-config.json or jq)_"
+              fi
+              if [ -n "$PROJECT_VIEW_APPLY_LINK" ]; then
+                echo "- Project view apply issue: $PROJECT_VIEW_APPLY_LINK"
+              else
+                echo "- Project view apply issue: _not configured (IX_PROJECT_VIEW_APPLY_ISSUE)_"
+              fi
+              if [ -n "$BOOTSTRAP_LINKS_LINK" ]; then
+                echo "- Bootstrap links comment: $BOOTSTRAP_LINKS_LINK"
+              else
+                echo "- Bootstrap links comment: _not available yet_"
+              fi
             } > "$DASHBOARD_FILE"
 
             DASHBOARD_EXISTING_ID="$(gh api --paginate \

--- a/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
@@ -79,10 +79,14 @@ project={{ProjectNumber}}
 
         AssertContainsText(rendered, "intelligencex:triage-project-sync-summary", "workflow summary marker present");
         AssertContainsText(rendered, "intelligencex:triage-control-dashboard", "workflow dashboard marker present");
+        AssertContainsText(rendered, "IX_PROJECT_VIEW_APPLY_ISSUE", "workflow dashboard includes project-view issue variable");
+        AssertContainsText(rendered, "artifacts/triage/ix-project-config.json", "workflow dashboard reads project config when present");
+        AssertContainsText(rendered, "intelligencex:triage-bootstrap-links", "workflow dashboard links bootstrap marker when present");
         AssertContainsText(rendered, "issues/$ISSUE/comments", "workflow reads control issue comments");
         AssertContainsText(rendered, "--method PATCH", "workflow updates existing summary comment");
         AssertContainsText(rendered, "--method POST", "workflow creates summary comment when missing");
         AssertContainsText(rendered, "Latest Summaries", "workflow dashboard includes latest summaries section");
+        AssertContainsText(rendered, "Maintainer Quick Links", "workflow dashboard includes quick links section");
     }
 
     private static void TestTriageIndexWorkflowTemplateUpsertsControlIssueSummaryComment() {
@@ -91,10 +95,14 @@ project={{ProjectNumber}}
 
         AssertContainsText(rendered, "intelligencex:triage-index-summary", "index workflow summary marker present");
         AssertContainsText(rendered, "intelligencex:triage-control-dashboard", "index workflow dashboard marker present");
+        AssertContainsText(rendered, "IX_PROJECT_VIEW_APPLY_ISSUE", "index workflow dashboard includes project-view issue variable");
+        AssertContainsText(rendered, "artifacts/triage/ix-project-config.json", "index workflow dashboard reads project config when present");
+        AssertContainsText(rendered, "intelligencex:triage-bootstrap-links", "index workflow dashboard links bootstrap marker when present");
         AssertContainsText(rendered, "issues/$ISSUE/comments", "index workflow reads control issue comments");
         AssertContainsText(rendered, "--method PATCH", "index workflow updates existing summary comment");
         AssertContainsText(rendered, "--method POST", "index workflow creates summary comment when missing");
         AssertContainsText(rendered, "Latest Summaries", "index workflow dashboard includes latest summaries section");
+        AssertContainsText(rendered, "Maintainer Quick Links", "index workflow dashboard includes quick links section");
     }
 
     private static void TestProjectBootstrapBuildControlIssueBodyIncludesProjectContext() {

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -217,6 +217,7 @@ Behavior:
 - `triage-index-scheduled.yml` upserts a single marker comment with the latest triage index summary on the control issue.
 - `triage-project-sync.yml` upserts a single marker comment with the latest combined triage + vision markdown summary on the control issue.
 - Both workflows also upsert a shared `intelligencex:triage-control-dashboard` comment linking to the latest summary comments.
+- The shared dashboard comment includes quick links: control issue, `VISION.md`, project board (when `artifacts/triage/ix-project-config.json` is available), project-view apply issue (`IX_PROJECT_VIEW_APPLY_ISSUE`), and bootstrap links comment.
 - `todo project-bootstrap --create-control-issue` can configure the control issue variable automatically.
 
 ## Legacy Script


### PR DESCRIPTION
## Summary
- extend shared intelligencex:triage-control-dashboard comments with maintainer quick links
- include links to control issue, VISION.md, project board (when rtifacts/triage/ix-project-config.json and jq are available), project-view apply issue (IX_PROJECT_VIEW_APPLY_ISSUE), and bootstrap-links comment
- apply the same quick-link behavior in both 	riage-index-scheduled.yml and 	riage-project-sync.yml
- extend workflow template tests to assert quick-links section and required markers/variables
- document the dashboard quick-links behavior in user and internal CLI docs

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll