### PR TITLE
Improve issue-to-PR matching for triage sync

### DIFF
--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -490,6 +490,13 @@ internal static class ProjectSyncRunner {
                 var matchedIssueUrl = ReadNullableString(item, "matchedIssueUrl");
                 var matchedIssueConfidence = ReadNullableDouble(item, "matchedIssueConfidence");
                 var relatedIssues = ParseRelatedIssueCandidates(item);
+                var matchedPullRequestUrl = ReadNullableString(item, "matchedPullRequestUrl");
+                var matchedPullRequestConfidence = ReadNullableDouble(item, "matchedPullRequestConfidence");
+                var relatedPullRequests = ParseRelatedPullRequestCandidates(item);
+                if (string.IsNullOrWhiteSpace(matchedPullRequestUrl) && relatedPullRequests.Count > 0) {
+                    matchedPullRequestUrl = relatedPullRequests[0].Url;
+                    matchedPullRequestConfidence = relatedPullRequests[0].Confidence;
+                }
                 var decisionSignals = ParsePullRequestSignals(item);
                 if (decisionSignals is not null) {
                     decisionSignalsByUrl[url] = decisionSignals;
@@ -517,6 +524,8 @@ internal static class ProjectSyncRunner {
                     VisionConfidence: null,
                     RelatedIssues: relatedIssues,
                     SuggestedDecision: null,
+                    MatchedPullRequestUrl: matchedPullRequestUrl,
+                    MatchedPullRequestConfidence: matchedPullRequestConfidence,
                     ExistingLabels: existingLabels
                 );
             }
@@ -583,6 +592,13 @@ internal static class ProjectSyncRunner {
 
             if (issueMatchByUrl.TryGetValue(pair.Key, out var byUrlMatch) ||
                 (pair.Value.Number > 0 && issueMatchByNumber.TryGetValue(pair.Value.Number, out byUrlMatch))) {
+                if (!ShouldReplaceIssuePullRequestMatch(
+                        pair.Value.MatchedPullRequestUrl,
+                        pair.Value.MatchedPullRequestConfidence,
+                        byUrlMatch)) {
+                    continue;
+                }
+
                 entriesByUrl[pair.Key] = pair.Value with {
                     MatchedPullRequestUrl = byUrlMatch.Url,
                     MatchedPullRequestConfidence = byUrlMatch.Confidence
@@ -752,6 +768,30 @@ internal static class ProjectSyncRunner {
             return confidenceCompare;
         }
         return number.CompareTo(existing.Number);
+    }
+
+    private static bool ShouldReplaceIssuePullRequestMatch(
+        string? existingPullRequestUrl,
+        double? existingConfidence,
+        RelatedPullRequestCandidate candidate) {
+        if (string.IsNullOrWhiteSpace(existingPullRequestUrl) || !existingConfidence.HasValue) {
+            return true;
+        }
+
+        if (candidate.Confidence > existingConfidence.Value) {
+            return true;
+        }
+
+        if (candidate.Confidence < existingConfidence.Value) {
+            return false;
+        }
+
+        var (existingKind, existingNumber) = ParseKindAndNumberFromUrl(existingPullRequestUrl);
+        if (!existingKind.Equals("pull_request", StringComparison.OrdinalIgnoreCase) || existingNumber <= 0) {
+            return true;
+        }
+
+        return candidate.Number > 0 && candidate.Number < existingNumber;
     }
 
     private static PullRequestDecisionSignals? ParsePullRequestSignals(JsonElement item) {
@@ -1166,6 +1206,36 @@ internal static class ProjectSyncRunner {
             }
 
             results.Add(new RelatedIssueCandidate(
+                Number: number,
+                Url: url,
+                Confidence: Math.Round(Math.Clamp(confidence.Value, 0.0, 1.0), 4, MidpointRounding.AwayFromZero),
+                Reason: reason
+            ));
+        }
+
+        return results
+            .OrderByDescending(candidate => candidate.Confidence)
+            .ThenBy(candidate => candidate.Number)
+            .Take(10)
+            .ToList();
+    }
+
+    private static IReadOnlyList<RelatedPullRequestCandidate> ParseRelatedPullRequestCandidates(JsonElement item) {
+        if (!TryGetProperty(item, "relatedPullRequests", out var relatedProp) || relatedProp.ValueKind != JsonValueKind.Array) {
+            return Array.Empty<RelatedPullRequestCandidate>();
+        }
+
+        var results = new List<RelatedPullRequestCandidate>();
+        foreach (var related in relatedProp.EnumerateArray()) {
+            var number = ReadInt(related, "number");
+            var url = ReadString(related, "url");
+            var confidence = ReadNullableDouble(related, "confidence");
+            var reason = ReadNullableString(related, "reason") ?? string.Empty;
+            if (number <= 0 || string.IsNullOrWhiteSpace(url) || !confidence.HasValue) {
+                continue;
+            }
+
+            results.Add(new RelatedPullRequestCandidate(
                 Number: number,
                 Url: url,
                 Confidence: Math.Round(Math.Clamp(confidence.Value, 0.0, 1.0), 4, MidpointRounding.AwayFromZero),

--- a/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
+++ b/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
@@ -47,6 +47,26 @@ internal static class TriageIndexRunner {
         @"(?i)\bhttps?://github\.com/(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)/issues/(?<num>\d+)\b",
         RegexOptions.Compiled
     );
+    private static readonly Regex ExplicitPullRequestRef = new(
+        @"(?i)\b(?:fix(?:e[sd])?\s+by|close[sd]?\s+by|resolve[sd]?\s+by|implemented\s+in|addressed\s+in)\s+(?:pr|pull\s*request|pull)\s*#(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly Regex DirectPullRequestRef = new(
+        @"(?i)\b(?:pr|pull\s*request|pull)\s*#(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly Regex DirectRepoPullRequestRef = new(
+        @"(?i)\b(?:pr|pull\s*request|pull)\s+(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)#(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly Regex DirectPullRequestUrlRef = new(
+        @"(?i)\b(?:pr|pull\s*request|pull)\s+https?://github\.com/(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)/pull/(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly Regex BarePullRequestUrlRef = new(
+        @"(?i)\bhttps?://github\.com/(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)/pull/(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
 
     internal sealed record PullRequestSignals(
         bool IsDraft,
@@ -143,15 +163,31 @@ internal static class TriageIndexRunner {
         string Reason
     );
 
+    internal sealed record RelatedPullRequestCandidate(
+        int Number,
+        string Url,
+        double Confidence,
+        string Reason
+    );
+
     internal sealed record ItemEnrichment(
         string Category,
         IReadOnlyList<string> Tags,
         string? MatchedIssueUrl,
         double? MatchedIssueConfidence,
-        IReadOnlyList<RelatedIssueCandidate> RelatedIssues
+        IReadOnlyList<RelatedIssueCandidate> RelatedIssues,
+        string? MatchedPullRequestUrl,
+        double? MatchedPullRequestConfidence,
+        IReadOnlyList<RelatedPullRequestCandidate> RelatedPullRequests
     );
 
     private sealed record IssueReferenceHint(
+        int Number,
+        double Confidence,
+        string Reason
+    );
+
+    private sealed record PullRequestReferenceHint(
         int Number,
         double Confidence,
         string Reason
@@ -570,25 +606,43 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         var issueItems = items
             .Where(item => item.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase))
             .ToList();
+        var pullRequestItems = items
+            .Where(item => item.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase))
+            .ToList();
         var rawPrByNumber = pullRequests.ToDictionary(pr => pr.Number);
+        var rawIssueByNumber = issues.ToDictionary(issue => issue.Number);
 
         foreach (var item in items) {
             var (category, tags) = InferCategoryAndTags(item);
 
-            IReadOnlyList<RelatedIssueCandidate> related = Array.Empty<RelatedIssueCandidate>();
+            IReadOnlyList<RelatedIssueCandidate> relatedIssues = Array.Empty<RelatedIssueCandidate>();
+            IReadOnlyList<RelatedPullRequestCandidate> relatedPullRequests = Array.Empty<RelatedPullRequestCandidate>();
             string? matchedIssueUrl = null;
             double? matchedIssueConfidence = null;
+            string? matchedPullRequestUrl = null;
+            double? matchedPullRequestConfidence = null;
 
             if (item.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
                 if (rawPrByNumber.TryGetValue(item.Number, out var rawPr)) {
-                    related = MatchPullRequestToIssues(repo, rawPr.Title, rawPr.Body, issueItems);
+                    relatedIssues = MatchPullRequestToIssues(repo, rawPr.Title, rawPr.Body, issueItems);
                 } else {
-                    related = MatchPullRequestToIssues(repo, item.Title, string.Join(' ', item.ContextTokens), issueItems);
+                    relatedIssues = MatchPullRequestToIssues(repo, item.Title, string.Join(' ', item.ContextTokens), issueItems);
                 }
 
-                if (related.Count > 0) {
-                    matchedIssueUrl = related[0].Url;
-                    matchedIssueConfidence = related[0].Confidence;
+                if (relatedIssues.Count > 0) {
+                    matchedIssueUrl = relatedIssues[0].Url;
+                    matchedIssueConfidence = relatedIssues[0].Confidence;
+                }
+            } else if (item.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase)) {
+                if (rawIssueByNumber.TryGetValue(item.Number, out var rawIssue)) {
+                    relatedPullRequests = MatchIssueToPullRequests(repo, rawIssue.Title, rawIssue.Body, pullRequestItems);
+                } else {
+                    relatedPullRequests = MatchIssueToPullRequests(repo, item.Title, string.Join(' ', item.ContextTokens), pullRequestItems);
+                }
+
+                if (relatedPullRequests.Count > 0) {
+                    matchedPullRequestUrl = relatedPullRequests[0].Url;
+                    matchedPullRequestConfidence = relatedPullRequests[0].Confidence;
                 }
             }
 
@@ -597,7 +651,10 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                 Tags: tags,
                 MatchedIssueUrl: matchedIssueUrl,
                 MatchedIssueConfidence: matchedIssueConfidence,
-                RelatedIssues: related
+                RelatedIssues: relatedIssues,
+                MatchedPullRequestUrl: matchedPullRequestUrl,
+                MatchedPullRequestConfidence: matchedPullRequestConfidence,
+                RelatedPullRequests: relatedPullRequests
             );
         }
 
@@ -744,6 +801,63 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
             .ToList();
     }
 
+    internal static IReadOnlyList<RelatedPullRequestCandidate> MatchIssueToPullRequests(
+        string repo,
+        string issueTitle,
+        string issueBody,
+        IReadOnlyList<TriageIndexItem> pullRequestItems) {
+        if (pullRequestItems.Count == 0) {
+            return Array.Empty<RelatedPullRequestCandidate>();
+        }
+
+        var (owner, name) = SplitRepo(repo);
+        var pullRequestByNumber = pullRequestItems.ToDictionary(item => item.Number);
+        var matchesByNumber = new Dictionary<int, RelatedPullRequestCandidate>();
+
+        foreach (var pullRequestHint in ParseExplicitPullRequestReferences(issueTitle, issueBody, owner, name)) {
+            if (!pullRequestByNumber.TryGetValue(pullRequestHint.Number, out var pullRequest)) {
+                continue;
+            }
+
+            matchesByNumber[pullRequest.Number] = new RelatedPullRequestCandidate(
+                Number: pullRequest.Number,
+                Url: pullRequest.Url,
+                Confidence: pullRequestHint.Confidence,
+                Reason: pullRequestHint.Reason
+            );
+        }
+
+        var issueTitleTokens = Tokenize(issueTitle);
+        var issueContextTokens = Tokenize($"{issueTitle}\n{issueBody}");
+
+        foreach (var pullRequest in pullRequestItems) {
+            if (matchesByNumber.ContainsKey(pullRequest.Number)) {
+                continue;
+            }
+
+            var titleScore = Jaccard(issueTitleTokens, pullRequest.TitleTokens);
+            var contextScore = Jaccard(issueContextTokens, pullRequest.ContextTokens);
+            var blended = Math.Round((titleScore * 0.55) + (contextScore * 0.45), 4, MidpointRounding.AwayFromZero);
+            if (blended < 0.34) {
+                continue;
+            }
+
+            var reason = $"token similarity title={titleScore.ToString("0.00", CultureInfo.InvariantCulture)}, context={contextScore.ToString("0.00", CultureInfo.InvariantCulture)}";
+            matchesByNumber[pullRequest.Number] = new RelatedPullRequestCandidate(
+                Number: pullRequest.Number,
+                Url: pullRequest.Url,
+                Confidence: blended,
+                Reason: reason
+            );
+        }
+
+        return matchesByNumber.Values
+            .OrderByDescending(match => match.Confidence)
+            .ThenBy(match => match.Number)
+            .Take(3)
+            .ToList();
+    }
+
     private static IReadOnlyList<IssueReferenceHint> ParseExplicitIssueReferences(
         string prTitle,
         string prBody,
@@ -841,7 +955,87 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
             .ToList();
     }
 
+    private static IReadOnlyList<PullRequestReferenceHint> ParseExplicitPullRequestReferences(
+        string issueTitle,
+        string issueBody,
+        string owner,
+        string repoName) {
+        var text = $"{issueTitle}\n{issueBody}";
+        var results = new Dictionary<int, PullRequestReferenceHint>();
+
+        static void AddHint(
+            IDictionary<int, PullRequestReferenceHint> map,
+            int number,
+            double confidence,
+            string reason) {
+            if (!map.TryGetValue(number, out var existing) ||
+                confidence > existing.Confidence) {
+                map[number] = new PullRequestReferenceHint(number, confidence, reason);
+            }
+        }
+
+        foreach (Match match in ExplicitPullRequestRef.Matches(text)) {
+            if (TryReadPullRequestNumber(match, out var number)) {
+                AddHint(results, number, 0.98, "explicit pull request reference in issue title/body");
+            }
+        }
+
+        foreach (Match match in DirectPullRequestRef.Matches(text)) {
+            if (TryReadPullRequestNumber(match, out var number)) {
+                AddHint(results, number, 0.93, "direct pull request reference in issue title/body");
+            }
+        }
+
+        foreach (Match match in DirectRepoPullRequestRef.Matches(text)) {
+            var refOwner = match.Groups["owner"].Value;
+            var refRepo = match.Groups["repo"].Value;
+            if (!refOwner.Equals(owner, StringComparison.OrdinalIgnoreCase) ||
+                !refRepo.Equals(repoName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (TryReadPullRequestNumber(match, out var number)) {
+                AddHint(results, number, 0.93, "direct pull request reference in issue title/body");
+            }
+        }
+
+        foreach (Match match in DirectPullRequestUrlRef.Matches(text)) {
+            var refOwner = match.Groups["owner"].Value;
+            var refRepo = match.Groups["repo"].Value;
+            if (!refOwner.Equals(owner, StringComparison.OrdinalIgnoreCase) ||
+                !refRepo.Equals(repoName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (TryReadPullRequestNumber(match, out var number)) {
+                AddHint(results, number, 0.93, "direct pull request reference in issue title/body");
+            }
+        }
+
+        foreach (Match match in BarePullRequestUrlRef.Matches(text)) {
+            var refOwner = match.Groups["owner"].Value;
+            var refRepo = match.Groups["repo"].Value;
+            if (!refOwner.Equals(owner, StringComparison.OrdinalIgnoreCase) ||
+                !refRepo.Equals(repoName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (TryReadPullRequestNumber(match, out var number)) {
+                AddHint(results, number, 0.90, "pull request URL reference in issue title/body");
+            }
+        }
+
+        return results.Values
+            .OrderByDescending(value => value.Confidence)
+            .ThenBy(value => value.Number)
+            .ToList();
+    }
+
     private static bool TryReadIssueNumber(Match match, out int number) {
+        number = 0;
+        return match.Groups["num"].Success &&
+               int.TryParse(match.Groups["num"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out number) &&
+               number > 0;
+    }
+
+    private static bool TryReadPullRequestNumber(Match match, out int number) {
         number = 0;
         return match.Groups["num"].Success &&
                int.TryParse(match.Groups["num"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out number) &&
@@ -1251,7 +1445,18 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                     tags = enrichment?.Tags ?? Array.Empty<string>(),
                     matchedIssueUrl = enrichment?.MatchedIssueUrl,
                     matchedIssueConfidence = enrichment?.MatchedIssueConfidence,
+                    matchedPullRequestUrl = enrichment?.MatchedPullRequestUrl,
+                    matchedPullRequestConfidence = enrichment?.MatchedPullRequestConfidence,
                     relatedIssues = enrichment?.RelatedIssues
+                        .Select(related => new {
+                            number = related.Number,
+                            url = related.Url,
+                            confidence = related.Confidence,
+                            reason = related.Reason
+                        })
+                        .Cast<object>()
+                        .ToList() ?? new List<object>(),
+                    relatedPullRequests = enrichment?.RelatedPullRequests
                         .Select(related => new {
                             number = related.Number,
                             url = related.Url,
@@ -1305,7 +1510,8 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                 duplicateClusters = clusters.Count,
                 duplicateItems = duplicateIds.Count,
                 bestPullRequestCandidates = bestPullRequests.Count,
-                pullRequestsWithMatchedIssue = enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedIssueUrl))
+                pullRequestsWithMatchedIssue = enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedIssueUrl)),
+                issuesWithMatchedPullRequest = enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedPullRequestUrl))
             },
             bestPullRequests = best,
             duplicateClusters = duplicates,
@@ -1341,6 +1547,7 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         sb.AppendLine($"- Duplicate clusters: {clusters.Count}");
         sb.AppendLine($"- Duplicate items: {duplicateIds.Count}");
         sb.AppendLine($"- PRs with matched issue: {enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedIssueUrl))}");
+        sb.AppendLine($"- Issues with matched PR: {enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedPullRequestUrl))}");
         sb.AppendLine();
         sb.AppendLine("## Best PR Candidates");
         sb.AppendLine();

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -395,6 +395,86 @@ internal static partial class Program {
         AssertEqual(true, issue.MatchedPullRequestConfidence.HasValue && issue.MatchedPullRequestConfidence.Value >= 0.89, "issue matched pull request confidence derived");
     }
 
+    private static void TestProjectSyncBuildEntriesPreservesHigherConfidenceIssueSidePullRequestMatch() {
+        const string triageJson = """
+{
+  "items": [
+    {
+      "id": "pr#77",
+      "kind": "pull_request",
+      "number": 77,
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/77",
+      "relatedIssues": [
+        {
+          "number": 120,
+          "url": "https://github.com/EvotecIT/IntelligenceX/issues/120",
+          "confidence": 0.61,
+          "reason": "token overlap"
+        }
+      ]
+    },
+    {
+      "id": "issue#120",
+      "kind": "issue",
+      "number": 120,
+      "url": "https://github.com/EvotecIT/IntelligenceX/issues/120",
+      "matchedPullRequestUrl": "https://github.com/EvotecIT/IntelligenceX/pull/88",
+      "matchedPullRequestConfidence": 0.97
+    }
+  ]
+}
+""";
+
+        using var triageDoc = System.Text.Json.JsonDocument.Parse(triageJson);
+        var entries = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildEntriesFromDocuments(
+            triageDoc.RootElement,
+            null,
+            100);
+
+        var issue = entries.Single(item => item.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase));
+        AssertEqual("https://github.com/EvotecIT/IntelligenceX/pull/88", issue.MatchedPullRequestUrl, "issue-side pull request match preserved");
+        AssertEqual(true, issue.MatchedPullRequestConfidence.HasValue && issue.MatchedPullRequestConfidence.Value >= 0.97, "issue-side confidence preserved");
+    }
+
+    private static void TestProjectSyncBuildEntriesUsesIssueRelatedPullRequestFallback() {
+        const string triageJson = """
+{
+  "items": [
+    {
+      "id": "issue#130",
+      "kind": "issue",
+      "number": 130,
+      "url": "https://github.com/EvotecIT/IntelligenceX/issues/130",
+      "relatedPullRequests": [
+        {
+          "number": 91,
+          "url": "https://github.com/EvotecIT/IntelligenceX/pull/91",
+          "confidence": 0.72,
+          "reason": "token overlap"
+        },
+        {
+          "number": 90,
+          "url": "https://github.com/EvotecIT/IntelligenceX/pull/90",
+          "confidence": 0.88,
+          "reason": "explicit pull request reference in issue title/body"
+        }
+      ]
+    }
+  ]
+}
+""";
+
+        using var triageDoc = System.Text.Json.JsonDocument.Parse(triageJson);
+        var entries = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildEntriesFromDocuments(
+            triageDoc.RootElement,
+            null,
+            100);
+
+        var issue = entries.Single(item => item.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase));
+        AssertEqual("https://github.com/EvotecIT/IntelligenceX/pull/90", issue.MatchedPullRequestUrl, "fallback uses top related pull request");
+        AssertEqual(true, issue.MatchedPullRequestConfidence.HasValue && issue.MatchedPullRequestConfidence.Value >= 0.88, "fallback confidence derived from top related pull request");
+    }
+
     private static void TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence() {
         var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
             Number: 55,

--- a/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
+++ b/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
@@ -170,6 +170,64 @@ internal static partial class Program {
         AssertEqual(true, matches[0].Confidence >= 0.90, "direct reference confidence");
     }
 
+    private static void TestTriageIndexMatchIssueToPullRequestsSupportsDirectPullRequestReference() {
+        var now = DateTimeOffset.UtcNow;
+        var pullRequest58 = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "pr#58",
+            "pull_request",
+            58,
+            "Improve triage label reliability",
+            "https://github.com/EvotecIT/IntelligenceX/pull/58",
+            now,
+            Array.Empty<string>(),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Improve triage label reliability"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Improve triage label reliability"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Improve triage label reliability for issues and pull requests"),
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.PullRequestSignals(false, "MERGEABLE", "APPROVED", "SUCCESS", 8, 180, 40, 4, 3, "dev3"),
+            null
+        );
+
+        var matches = IntelligenceX.Cli.Todo.TriageIndexRunner.MatchIssueToPullRequests(
+            "EvotecIT/IntelligenceX",
+            "Issue triage labels are flaky",
+            "Observed while validating PR #58 in production-like traffic.",
+            new[] { pullRequest58 }
+        );
+
+        AssertEqual(1, matches.Count, "direct pull-request match count");
+        AssertEqual(58, matches[0].Number, "direct pull-request number");
+        AssertEqual(true, matches[0].Confidence >= 0.90, "direct pull-request confidence");
+    }
+
+    private static void TestTriageIndexMatchIssueToPullRequestsSupportsPullRequestUrlReference() {
+        var now = DateTimeOffset.UtcNow;
+        var pullRequest72 = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "pr#72",
+            "pull_request",
+            72,
+            "Add issue to PR linking suggestions",
+            "https://github.com/EvotecIT/IntelligenceX/pull/72",
+            now,
+            Array.Empty<string>(),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Add issue to PR linking suggestions"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Add issue to PR linking suggestions"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Add issue to pull request linking suggestions in triage workflow"),
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.PullRequestSignals(false, "MERGEABLE", "REVIEW_REQUIRED", "SUCCESS", 5, 120, 22, 1, 2, "dev4"),
+            null
+        );
+
+        var matches = IntelligenceX.Cli.Todo.TriageIndexRunner.MatchIssueToPullRequests(
+            "EvotecIT/IntelligenceX",
+            "Need stronger issue to PR linking",
+            "See implementation draft: https://github.com/EvotecIT/IntelligenceX/pull/72",
+            new[] { pullRequest72 }
+        );
+
+        AssertEqual(1, matches.Count, "pull-request URL match count");
+        AssertEqual(72, matches[0].Number, "pull-request URL number");
+        AssertEqual(true, matches[0].Confidence >= 0.90, "pull-request URL confidence");
+    }
+
     private static void TestTriageIndexInferCategoryAndTagsDetectsSecurity() {
         var now = DateTimeOffset.UtcNow;
         var item = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -452,6 +452,8 @@ internal static partial class Program {
         failed += Run("Todo triage index PR scoring", TestTriageIndexScoreRewardsMergeableApprovedPrs);
         failed += Run("Todo triage index PR-issue explicit match", TestTriageIndexMatchPullRequestToIssuesSupportsExplicitReference);
         failed += Run("Todo triage index PR-issue direct match", TestTriageIndexMatchPullRequestToIssuesSupportsDirectIssueReference);
+        failed += Run("Todo triage index issue-PR direct match", TestTriageIndexMatchIssueToPullRequestsSupportsDirectPullRequestReference);
+        failed += Run("Todo triage index issue-PR URL match", TestTriageIndexMatchIssueToPullRequestsSupportsPullRequestUrlReference);
         failed += Run("Todo triage index category/tag inference", TestTriageIndexInferCategoryAndTagsDetectsSecurity);
         failed += Run("Todo vision check out-of-scope classification", TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate);
         failed += Run("Todo vision check aligned classification", TestVisionCheckClassifiesAlignedWhenInTokensMatch);
@@ -485,6 +487,8 @@ internal static partial class Program {
         failed += Run("Todo project sync decision suggests merge-candidate", TestProjectSyncBuildEntriesSuggestsMergeCandidateForBestReadyPr);
         failed += Run("Todo project sync decision suggests defer for blocked PR", TestProjectSyncBuildEntriesSuggestsDeferForBlockedPr);
         failed += Run("Todo project sync derives issue pull-request matches", TestProjectSyncBuildEntriesDerivesIssuePullRequestMatches);
+        failed += Run("Todo project sync preserves higher-confidence issue-side pull-request matches", TestProjectSyncBuildEntriesPreservesHigherConfidenceIssueSidePullRequestMatch);
+        failed += Run("Todo project sync uses issue related pull-request fallback", TestProjectSyncBuildEntriesUsesIssueRelatedPullRequestFallback);
         failed += Run("Todo project sync comment filters by confidence", TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence);
         failed += Run("Todo project sync comment omitted for weak candidates", TestProjectSyncBuildIssueMatchSuggestionCommentReturnsNullWithoutQualifiedCandidates);
         failed += Run("Todo project sync issue backlink comments aggregate PRs", TestProjectSyncBuildIssueBacklinkSuggestionCommentsAggregatesPullRequests);


### PR DESCRIPTION
## Summary
- add issue-to-PR matching in `todo build-triage-index` using explicit pull-request references (`PR #n`, pull URLs) plus token similarity fallback
- include issue-side PR match data in triage output (`matchedPullRequestUrl`, `matchedPullRequestConfidence`, `relatedPullRequests`)
- update `todo project-sync` to ingest issue-side PR match data and keep the strongest confidence signal when merging with reverse-derived matches
- add regression tests for both new matching direction and project-sync merge/fallback behavior

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
