### PR TITLE
Aggregate PR issue suggestions from issue-side match signals

### DIFF
--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -218,24 +218,28 @@ internal static class ProjectSyncRunner {
                 }
             }
 
-            if (options.ApplyLinkComments && entry.Number > 0 &&
-                entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
-                var comment = BuildIssueMatchSuggestionComment(
-                    entry,
-                    options.LinkCommentMinConfidence,
-                    options.LinkCommentMaxIssues);
-                if (!string.IsNullOrWhiteSpace(comment)) {
-                    if (options.DryRun) {
-                        prCommentUpserts++;
-                    } else if (await IssueSuggestionCommentManager.UpsertAsync(options.Repo, entry.Number, comment)
-                                   .ConfigureAwait(false)) {
-                        prCommentUpserts++;
-                    }
-                }
-            }
         }
 
         if (options.ApplyLinkComments) {
+            var pullRequestSuggestionComments = BuildPullRequestIssueSuggestionComments(
+                entries,
+                options.LinkCommentMinConfidence,
+                options.LinkCommentMaxIssues);
+
+            foreach (var suggestion in pullRequestSuggestionComments) {
+                if (options.DryRun) {
+                    prCommentUpserts++;
+                    continue;
+                }
+
+                if (await IssueSuggestionCommentManager.UpsertAsync(
+                        options.Repo,
+                        suggestion.Key,
+                        suggestion.Value).ConfigureAwait(false)) {
+                    prCommentUpserts++;
+                }
+            }
+
             var issueBacklinkComments = BuildIssueBacklinkSuggestionComments(
                 entries,
                 options.LinkCommentMinConfidence,
@@ -1097,15 +1101,144 @@ internal static class ProjectSyncRunner {
             $"PR #{candidate.Number.ToString(CultureInfo.InvariantCulture)} | {candidate.Confidence.ToString("0.00", CultureInfo.InvariantCulture)} | {candidate.Url}"));
     }
 
+    internal static IReadOnlyDictionary<int, string> BuildPullRequestIssueSuggestionComments(
+        IReadOnlyList<ProjectSyncEntry> entries,
+        double minConfidence,
+        int maxIssuesPerPullRequest) {
+        var threshold = Math.Clamp(minConfidence, 0.0, 1.0);
+        var pullRequestToCandidates = new Dictionary<int, Dictionary<int, RelatedIssueCandidate>>();
+
+        static void AddPullRequestCandidate(
+            IDictionary<int, Dictionary<int, RelatedIssueCandidate>> pullRequestMap,
+            int pullRequestNumber,
+            RelatedIssueCandidate candidate) {
+            if (pullRequestNumber <= 0 || candidate.Number <= 0 || string.IsNullOrWhiteSpace(candidate.Url)) {
+                return;
+            }
+
+            if (!pullRequestMap.TryGetValue(pullRequestNumber, out var issueMap)) {
+                issueMap = new Dictionary<int, RelatedIssueCandidate>();
+                pullRequestMap[pullRequestNumber] = issueMap;
+            }
+
+            if (issueMap.TryGetValue(candidate.Number, out var existing) &&
+                existing.Confidence >= candidate.Confidence) {
+                return;
+            }
+
+            issueMap[candidate.Number] = candidate;
+        }
+
+        foreach (var entry in entries) {
+            if (entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase) && entry.Number > 0) {
+                var relatedIssues = (entry.RelatedIssues ?? Array.Empty<RelatedIssueCandidate>())
+                    .Where(candidate => candidate.Number > 0 &&
+                                        candidate.Confidence >= threshold &&
+                                        !string.IsNullOrWhiteSpace(candidate.Url))
+                    .ToList();
+
+                foreach (var candidate in relatedIssues) {
+                    AddPullRequestCandidate(pullRequestToCandidates, entry.Number, new RelatedIssueCandidate(
+                        Number: candidate.Number,
+                        Url: candidate.Url,
+                        Confidence: candidate.Confidence,
+                        Reason: candidate.Reason
+                    ));
+                }
+
+                if (!string.IsNullOrWhiteSpace(entry.MatchedIssueUrl) &&
+                    entry.MatchedIssueConfidence.HasValue &&
+                    entry.MatchedIssueConfidence.Value >= threshold) {
+                    var (kind, issueNumber) = ParseKindAndNumberFromUrl(entry.MatchedIssueUrl);
+                    if (kind.Equals("issue", StringComparison.OrdinalIgnoreCase) && issueNumber > 0) {
+                        AddPullRequestCandidate(pullRequestToCandidates, entry.Number, new RelatedIssueCandidate(
+                            Number: issueNumber,
+                            Url: entry.MatchedIssueUrl,
+                            Confidence: entry.MatchedIssueConfidence.Value,
+                            Reason: "matched issue"
+                        ));
+                    }
+                }
+
+                continue;
+            }
+
+            if (!entry.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase) || entry.Number <= 0) {
+                continue;
+            }
+
+            var relatedPullRequests = (entry.RelatedPullRequests ?? Array.Empty<RelatedPullRequestCandidate>())
+                .Where(candidate => candidate.Number > 0 &&
+                                    candidate.Confidence >= threshold &&
+                                    !string.IsNullOrWhiteSpace(candidate.Url))
+                .ToList();
+
+            foreach (var candidate in relatedPullRequests) {
+                AddPullRequestCandidate(pullRequestToCandidates, candidate.Number, new RelatedIssueCandidate(
+                    Number: entry.Number,
+                    Url: entry.Url,
+                    Confidence: candidate.Confidence,
+                    Reason: candidate.Reason
+                ));
+            }
+
+            if (!string.IsNullOrWhiteSpace(entry.MatchedPullRequestUrl) &&
+                entry.MatchedPullRequestConfidence.HasValue &&
+                entry.MatchedPullRequestConfidence.Value >= threshold) {
+                var (kind, pullRequestNumber) = ParseKindAndNumberFromUrl(entry.MatchedPullRequestUrl);
+                if (kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase) && pullRequestNumber > 0) {
+                    AddPullRequestCandidate(pullRequestToCandidates, pullRequestNumber, new RelatedIssueCandidate(
+                        Number: entry.Number,
+                        Url: entry.Url,
+                        Confidence: entry.MatchedPullRequestConfidence.Value,
+                        Reason: "issue-side matched pull request"
+                    ));
+                }
+            }
+        }
+
+        var comments = new Dictionary<int, string>();
+        foreach (var pullRequestCandidates in pullRequestToCandidates) {
+            var comment = BuildIssueMatchSuggestionComment(
+                pullRequestCandidates.Key,
+                pullRequestCandidates.Value.Values.ToList(),
+                threshold,
+                maxIssuesPerPullRequest);
+            if (!string.IsNullOrWhiteSpace(comment)) {
+                comments[pullRequestCandidates.Key] = comment;
+            }
+        }
+
+        return comments;
+    }
+
     internal static string? BuildIssueMatchSuggestionComment(ProjectSyncEntry entry, double minConfidence, int maxIssues) {
         if (!entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase) || entry.Number <= 0) {
             return null;
         }
 
+        return BuildIssueMatchSuggestionComment(
+            entry.Number,
+            entry.RelatedIssues ?? Array.Empty<RelatedIssueCandidate>(),
+            minConfidence,
+            maxIssues);
+    }
+
+    internal static string? BuildIssueMatchSuggestionComment(
+        int pullRequestNumber,
+        IReadOnlyList<RelatedIssueCandidate> candidates,
+        double minConfidence,
+        int maxIssues) {
+        if (pullRequestNumber <= 0 || candidates.Count == 0) {
+            return null;
+        }
+
         var threshold = Math.Clamp(minConfidence, 0.0, 1.0);
         var limit = Math.Max(1, Math.Min(maxIssues, 10));
-        var related = (entry.RelatedIssues ?? Array.Empty<RelatedIssueCandidate>())
-            .Where(candidate => candidate.Confidence >= threshold && !string.IsNullOrWhiteSpace(candidate.Url))
+        var related = candidates
+            .Where(candidate => candidate.Number > 0 &&
+                                candidate.Confidence >= threshold &&
+                                !string.IsNullOrWhiteSpace(candidate.Url))
             .OrderByDescending(candidate => candidate.Confidence)
             .ThenBy(candidate => candidate.Number)
             .Take(limit)

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -531,6 +531,90 @@ internal static partial class Program {
         AssertEqual(false, (comment ?? string.Empty).Contains("issues/12", StringComparison.OrdinalIgnoreCase), "low confidence issue excluded");
     }
 
+    private static void TestProjectSyncBuildPullRequestIssueSuggestionCommentsIncludesIssueSideCandidates() {
+        var entries = new[] {
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 210,
+                Url: "https://github.com/EvotecIT/IntelligenceX/pull/210",
+                Kind: "pull_request",
+                TriageScore: 71.0,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "feature",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: "https://github.com/EvotecIT/IntelligenceX/issues/310",
+                MatchedIssueConfidence: 0.62,
+                VisionFit: "aligned",
+                VisionConfidence: 0.74,
+                RelatedIssues: new[] {
+                    new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedIssueCandidate(310, "https://github.com/EvotecIT/IntelligenceX/issues/310", 0.60, "token overlap")
+                }
+            ),
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 310,
+                Url: "https://github.com/EvotecIT/IntelligenceX/issues/310",
+                Kind: "issue",
+                TriageScore: null,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "feature",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: null,
+                MatchedIssueConfidence: null,
+                VisionFit: null,
+                VisionConfidence: null,
+                RelatedPullRequests: new[] {
+                    new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedPullRequestCandidate(210, "https://github.com/EvotecIT/IntelligenceX/pull/210", 0.87, "explicit pull request reference")
+                }
+            ),
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 311,
+                Url: "https://github.com/EvotecIT/IntelligenceX/issues/311",
+                Kind: "issue",
+                TriageScore: null,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "feature",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: null,
+                MatchedIssueConfidence: null,
+                VisionFit: null,
+                VisionConfidence: null,
+                MatchedPullRequestUrl: "https://github.com/EvotecIT/IntelligenceX/pull/210",
+                MatchedPullRequestConfidence: 0.79
+            ),
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 312,
+                Url: "https://github.com/EvotecIT/IntelligenceX/issues/312",
+                Kind: "issue",
+                TriageScore: null,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "feature",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: null,
+                MatchedIssueConfidence: null,
+                VisionFit: null,
+                VisionConfidence: null,
+                RelatedPullRequests: new[] {
+                    new IntelligenceX.Cli.Todo.ProjectSyncRunner.RelatedPullRequestCandidate(210, "https://github.com/EvotecIT/IntelligenceX/pull/210", 0.41, "weak overlap")
+                }
+            )
+        };
+
+        var comments = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildPullRequestIssueSuggestionComments(
+            entries,
+            minConfidence: 0.55,
+            maxIssuesPerPullRequest: 3);
+
+        AssertEqual(true, comments.ContainsKey(210), "pull request comment generated");
+        var comment = comments[210];
+        AssertContainsText(comment, "<!-- intelligencex:pr-issue-suggestions -->", "pull request marker present");
+        AssertContainsText(comment, "#310 (https://github.com/EvotecIT/IntelligenceX/issues/310) - confidence 0.87", "issue-side confidence supersedes weaker PR-side candidate");
+        AssertContainsText(comment, "#311 (https://github.com/EvotecIT/IntelligenceX/issues/311)", "matched pull request fallback contributes issue");
+        AssertEqual(false, comment.Contains("issues/312", StringComparison.OrdinalIgnoreCase), "below-threshold issue-side candidate excluded");
+    }
+
     private static void TestProjectSyncBuildIssueMatchSuggestionCommentReturnsNullWithoutQualifiedCandidates() {
         var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
             Number: 56,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -491,6 +491,7 @@ internal static partial class Program {
         failed += Run("Todo project sync preserves higher-confidence issue-side pull-request matches", TestProjectSyncBuildEntriesPreservesHigherConfidenceIssueSidePullRequestMatch);
         failed += Run("Todo project sync uses issue related pull-request fallback", TestProjectSyncBuildEntriesUsesIssueRelatedPullRequestFallback);
         failed += Run("Todo project sync comment filters by confidence", TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence);
+        failed += Run("Todo project sync PR comments include issue-side candidates", TestProjectSyncBuildPullRequestIssueSuggestionCommentsIncludesIssueSideCandidates);
         failed += Run("Todo project sync comment omitted for weak candidates", TestProjectSyncBuildIssueMatchSuggestionCommentReturnsNullWithoutQualifiedCandidates);
         failed += Run("Todo project sync issue backlink comments aggregate PRs", TestProjectSyncBuildIssueBacklinkSuggestionCommentsAggregatesPullRequests);
         failed += Run("Todo project sync issue backlink comments include issue-side candidates", TestProjectSyncBuildIssueBacklinkSuggestionCommentsIncludesIssueSideCandidates);


### PR DESCRIPTION
## Summary
- switch PR link-comment publishing to an aggregated pass over all triage entries, not only per-PR entry data
- add `BuildPullRequestIssueSuggestionComments(...)` to combine PR-side related issues with issue-side related PR matches and matched-PR fallbacks
- dedupe issue candidates per PR by keeping the highest-confidence signal
- keep issue backlink aggregation as-is and run both PR + issue comment upserts in one link-comment stage
- add regression coverage proving issue-side candidates now appear in PR suggestion comments

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`