### PR TITLE
Clean stale match comments and fields during project sync

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -140,7 +140,7 @@ Useful options:
 - `--ensure-fields` / `--no-ensure-fields`.
 - `--apply-labels` to sync IX labels (`ix/category:*`, `ix/tag:*`, `ix/vision:*`, `ix/match:*`, `ix/decision:*`) on PRs/issues.
 - `--ensure-labels` / `--no-ensure-labels` for label taxonomy management.
-- `--apply-link-comments` to upsert assistive link comments on PRs (related issues) and issues (related PRs).
+- `--apply-link-comments` to upsert assistive link comments on PRs (related issues) and issues (related PRs), and remove stale managed suggestion comments.
 - `--project-item-scan-limit <n>` for larger projects.
 - `--dry-run` for a no-write sync preview.
 
@@ -150,6 +150,7 @@ Behavior:
 - Unknown categories/tags are normalized into dynamic labels (for example `ML Ops` -> `ix/category:ml-ops`, `Release Candidate` -> `ix/tag:release-candidate`) and are auto-created when `--apply-labels --ensure-labels` is used.
 - `--apply-labels` performs managed IX label reconciliation: stale `ix/*` labels for managed families are removed while non-IX maintainer labels are preserved.
 - Issues also receive match taxonomy labels when PR->issue linking signals exist (`ix/match:linked-pr` or `ix/match:needs-review-pr`).
+- Match-related project fields (`Matched Issue*`, `Related Issues`, `Matched Pull Request*`, `Related Pull Requests`) are cleared when no longer present in current triage outputs to prevent stale project metadata.
 
 ## Bootstrap project + workflow (recommended first run)
 

--- a/IntelligenceX.Cli/Todo/IssueSuggestionCommentManager.cs
+++ b/IntelligenceX.Cli/Todo/IssueSuggestionCommentManager.cs
@@ -17,16 +17,20 @@ internal static class IssueSuggestionCommentManager {
             return false;
         }
 
-        var existingCommentId = await TryFindManagedCommentIdAsync(repo, issueNumber, marker).ConfigureAwait(false);
-        if (existingCommentId.HasValue) {
+        var existingCommentIds = await TryFindManagedCommentIdsAsync(repo, issueNumber, marker).ConfigureAwait(false);
+        if (existingCommentIds.Count > 0) {
+            var existingCommentId = existingCommentIds[0];
             var (updateCode, _, updateErr) = await GhCli.RunAsync(
                 "api",
                 "--method", "PATCH",
-                $"repos/{repo}/issues/comments/{existingCommentId.Value.ToString(CultureInfo.InvariantCulture)}",
+                $"repos/{repo}/issues/comments/{existingCommentId.ToString(CultureInfo.InvariantCulture)}",
                 "-f", $"body={commentBody}"
             ).ConfigureAwait(false);
 
             if (updateCode == 0) {
+                foreach (var duplicateId in existingCommentIds.Skip(1)) {
+                    await TryDeleteCommentByIdAsync(repo, issueNumber, duplicateId, marker, suppressErrors: true).ConfigureAwait(false);
+                }
                 return true;
             }
 
@@ -50,7 +54,27 @@ internal static class IssueSuggestionCommentManager {
         return false;
     }
 
-    private static async Task<long?> TryFindManagedCommentIdAsync(string repo, int issueNumber, string marker) {
+    public static async Task<bool> DeleteAsync(string repo, int issueNumber, string marker = CommentMarker) {
+        if (string.IsNullOrWhiteSpace(repo) || issueNumber <= 0 || string.IsNullOrWhiteSpace(marker)) {
+            return false;
+        }
+
+        var existingCommentIds = await TryFindManagedCommentIdsAsync(repo, issueNumber, marker).ConfigureAwait(false);
+        if (existingCommentIds.Count == 0) {
+            return false;
+        }
+
+        var deleted = false;
+        foreach (var commentId in existingCommentIds) {
+            if (await TryDeleteCommentByIdAsync(repo, issueNumber, commentId, marker, suppressErrors: false).ConfigureAwait(false)) {
+                deleted = true;
+            }
+        }
+
+        return deleted;
+    }
+
+    private static async Task<IReadOnlyList<long>> TryFindManagedCommentIdsAsync(string repo, int issueNumber, string marker) {
         var (code, stdout, stderr) = await GhCli.RunAsync(
             "api",
             $"repos/{repo}/issues/{issueNumber.ToString(CultureInfo.InvariantCulture)}/comments?per_page=100"
@@ -58,16 +82,16 @@ internal static class IssueSuggestionCommentManager {
         if (code != 0) {
             Console.Error.WriteLine(
                 $"Warning: failed to list issue comments for {repo}#{issueNumber}: {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
-            return null;
+            return Array.Empty<long>();
         }
 
         try {
             using var doc = JsonDocument.Parse(stdout);
             if (doc.RootElement.ValueKind != JsonValueKind.Array) {
-                return null;
+                return Array.Empty<long>();
             }
 
-            var matches = new List<long>();
+            var matches = new HashSet<long>();
             foreach (var item in doc.RootElement.EnumerateArray()) {
                 if (!item.TryGetProperty("body", out var bodyProp) || bodyProp.ValueKind != JsonValueKind.String) {
                     continue;
@@ -88,13 +112,38 @@ internal static class IssueSuggestionCommentManager {
             }
 
             if (matches.Count == 0) {
-                return null;
+                return Array.Empty<long>();
             }
 
-            return matches.Max();
+            return matches
+                .OrderByDescending(id => id)
+                .ToList();
         } catch (Exception ex) {
             Console.Error.WriteLine($"Warning: failed to parse issue comments JSON for {repo}#{issueNumber}: {ex.Message}");
-            return null;
+            return Array.Empty<long>();
         }
+    }
+
+    private static async Task<bool> TryDeleteCommentByIdAsync(
+        string repo,
+        int issueNumber,
+        long commentId,
+        string marker,
+        bool suppressErrors) {
+        var (deleteCode, _, deleteErr) = await GhCli.RunAsync(
+            "api",
+            "--method", "DELETE",
+            $"repos/{repo}/issues/comments/{commentId.ToString(CultureInfo.InvariantCulture)}"
+        ).ConfigureAwait(false);
+        if (deleteCode == 0) {
+            return true;
+        }
+
+        if (!suppressErrors) {
+            Console.Error.WriteLine(
+                $"Warning: failed to delete managed suggestion comment ({marker}) for {repo}#{issueNumber}: {(string.IsNullOrWhiteSpace(deleteErr) ? "unknown error" : deleteErr.Trim())}");
+        }
+
+        return false;
     }
 }

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -166,6 +166,8 @@ internal static class ProjectSyncRunner {
         var labeled = 0;
         var prCommentUpserts = 0;
         var issueCommentUpserts = 0;
+        var prCommentDeletes = 0;
+        var issueCommentDeletes = 0;
 
         foreach (var entry in entries) {
             processed++;
@@ -225,6 +227,10 @@ internal static class ProjectSyncRunner {
                 entries,
                 options.LinkCommentMinConfidence,
                 options.LinkCommentMaxIssues);
+            var stalePullRequestCommentTargets = BuildStaleSuggestionCommentTargets(
+                entries,
+                "pull_request",
+                pullRequestSuggestionComments);
 
             foreach (var suggestion in pullRequestSuggestionComments) {
                 if (options.DryRun) {
@@ -240,10 +246,28 @@ internal static class ProjectSyncRunner {
                 }
             }
 
+            foreach (var pullRequestNumber in stalePullRequestCommentTargets) {
+                if (options.DryRun) {
+                    prCommentDeletes++;
+                    continue;
+                }
+
+                if (await IssueSuggestionCommentManager.DeleteAsync(
+                        options.Repo,
+                        pullRequestNumber,
+                        IssueSuggestionCommentManager.CommentMarker).ConfigureAwait(false)) {
+                    prCommentDeletes++;
+                }
+            }
+
             var issueBacklinkComments = BuildIssueBacklinkSuggestionComments(
                 entries,
                 options.LinkCommentMinConfidence,
                 options.LinkCommentMaxIssues);
+            var staleIssueBacklinkCommentTargets = BuildStaleSuggestionCommentTargets(
+                entries,
+                "issue",
+                issueBacklinkComments);
 
             foreach (var suggestion in issueBacklinkComments) {
                 if (options.DryRun) {
@@ -259,6 +283,20 @@ internal static class ProjectSyncRunner {
                     issueCommentUpserts++;
                 }
             }
+
+            foreach (var issueNumber in staleIssueBacklinkCommentTargets) {
+                if (options.DryRun) {
+                    issueCommentDeletes++;
+                    continue;
+                }
+
+                if (await IssueSuggestionCommentManager.DeleteAsync(
+                        options.Repo,
+                        issueNumber,
+                        IssueSuggestionCommentManager.IssueBacklinkCommentMarker).ConfigureAwait(false)) {
+                    issueCommentDeletes++;
+                }
+            }
         }
 
         Console.WriteLine($"Project sync target: {owner}#{projectNumber} ({project.Url})");
@@ -270,7 +308,9 @@ internal static class ProjectSyncRunner {
         }
         if (options.ApplyLinkComments) {
             Console.WriteLine($"PR suggestion comments upserted: {prCommentUpserts}");
+            Console.WriteLine($"PR suggestion comments deleted: {prCommentDeletes}");
             Console.WriteLine($"Issue backlink comments upserted: {issueCommentUpserts}");
+            Console.WriteLine($"Issue backlink comments deleted: {issueCommentDeletes}");
         }
         Console.WriteLine($"Skipped unresolved items: {skippedMissing}");
         Console.WriteLine(options.DryRun ? "Dry run complete (no project updates were written)." : "Project sync complete.");
@@ -394,7 +434,7 @@ internal static class ProjectSyncRunner {
         Console.WriteLine("  --apply-labels           Sync IX labels on PRs/issues (add missing + remove stale managed IX labels)");
         Console.WriteLine("  --ensure-labels          Ensure IX labels exist before applying labels (default)");
         Console.WriteLine("  --no-ensure-labels       Skip label ensure step");
-        Console.WriteLine("  --apply-link-comments    Upsert marker comments on PRs (related issues) and issues (related PRs)");
+        Console.WriteLine("  --apply-link-comments    Upsert marker comments on PRs/issues and delete stale managed suggestion comments");
         Console.WriteLine("  --link-comment-min-confidence <0-1>  Min confidence for suggestion comments (default: 0.55)");
         Console.WriteLine("  --link-comment-max-issues <n>  Max related issues to include per PR comment (1-10, default: 3)");
         Console.WriteLine("  --dry-run                Compute sync plan without writing project changes");
@@ -874,6 +914,8 @@ internal static class ProjectSyncRunner {
         IReadOnlyDictionary<string, ProjectV2Client.ProjectField> fields,
         ProjectSyncEntry entry) {
         var updated = 0;
+        var isPullRequest = entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase);
+        var isIssue = entry.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase);
 
         if (fields.TryGetValue("Triage Score", out var triageScoreField) && entry.TriageScore.HasValue) {
             await client.SetNumberFieldAsync(projectId, itemId, triageScoreField.Id, entry.TriageScore.Value).ConfigureAwait(false);
@@ -894,41 +936,61 @@ internal static class ProjectSyncRunner {
             updated++;
         }
 
-        if (fields.TryGetValue("Matched Issue", out var matchedIssueField) && !string.IsNullOrWhiteSpace(entry.MatchedIssueUrl)) {
-            await client.SetTextFieldAsync(projectId, itemId, matchedIssueField.Id, entry.MatchedIssueUrl).ConfigureAwait(false);
+        if (isPullRequest && fields.TryGetValue("Matched Issue", out var matchedIssueField)) {
+            if (!string.IsNullOrWhiteSpace(entry.MatchedIssueUrl)) {
+                await client.SetTextFieldAsync(projectId, itemId, matchedIssueField.Id, entry.MatchedIssueUrl).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, matchedIssueField.Id).ConfigureAwait(false);
+            }
             updated++;
         }
 
-        if (fields.TryGetValue("Matched Issue Confidence", out var matchedIssueConfidenceField) && entry.MatchedIssueConfidence.HasValue) {
-            await client.SetNumberFieldAsync(projectId, itemId, matchedIssueConfidenceField.Id, entry.MatchedIssueConfidence.Value).ConfigureAwait(false);
+        if (isPullRequest && fields.TryGetValue("Matched Issue Confidence", out var matchedIssueConfidenceField)) {
+            if (entry.MatchedIssueConfidence.HasValue) {
+                await client.SetNumberFieldAsync(projectId, itemId, matchedIssueConfidenceField.Id, entry.MatchedIssueConfidence.Value).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, matchedIssueConfidenceField.Id).ConfigureAwait(false);
+            }
             updated++;
         }
 
-        if (fields.TryGetValue("Related Issues", out var relatedIssuesField)) {
+        if (isPullRequest && fields.TryGetValue("Related Issues", out var relatedIssuesField)) {
             var relatedIssuesValue = BuildRelatedIssuesFieldValue(entry, maxIssues: 3);
             if (!string.IsNullOrWhiteSpace(relatedIssuesValue)) {
                 await client.SetTextFieldAsync(projectId, itemId, relatedIssuesField.Id, relatedIssuesValue).ConfigureAwait(false);
-                updated++;
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, relatedIssuesField.Id).ConfigureAwait(false);
             }
-        }
-
-        if (fields.TryGetValue("Matched Pull Request", out var matchedPullRequestField) && !string.IsNullOrWhiteSpace(entry.MatchedPullRequestUrl)) {
-            await client.SetTextFieldAsync(projectId, itemId, matchedPullRequestField.Id, entry.MatchedPullRequestUrl).ConfigureAwait(false);
             updated++;
         }
 
-        if (fields.TryGetValue("Matched Pull Request Confidence", out var matchedPullRequestConfidenceField) &&
-            entry.MatchedPullRequestConfidence.HasValue) {
-            await client.SetNumberFieldAsync(projectId, itemId, matchedPullRequestConfidenceField.Id, entry.MatchedPullRequestConfidence.Value).ConfigureAwait(false);
+        if (isIssue && fields.TryGetValue("Matched Pull Request", out var matchedPullRequestField)) {
+            if (!string.IsNullOrWhiteSpace(entry.MatchedPullRequestUrl)) {
+                await client.SetTextFieldAsync(projectId, itemId, matchedPullRequestField.Id, entry.MatchedPullRequestUrl).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, matchedPullRequestField.Id).ConfigureAwait(false);
+            }
             updated++;
         }
 
-        if (fields.TryGetValue("Related Pull Requests", out var relatedPullRequestsField)) {
+        if (isIssue &&
+            fields.TryGetValue("Matched Pull Request Confidence", out var matchedPullRequestConfidenceField)) {
+            if (entry.MatchedPullRequestConfidence.HasValue) {
+                await client.SetNumberFieldAsync(projectId, itemId, matchedPullRequestConfidenceField.Id, entry.MatchedPullRequestConfidence.Value).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, matchedPullRequestConfidenceField.Id).ConfigureAwait(false);
+            }
+            updated++;
+        }
+
+        if (isIssue && fields.TryGetValue("Related Pull Requests", out var relatedPullRequestsField)) {
             var relatedPullRequestsValue = BuildRelatedPullRequestsFieldValue(entry, maxPullRequests: 3);
             if (!string.IsNullOrWhiteSpace(relatedPullRequestsValue)) {
                 await client.SetTextFieldAsync(projectId, itemId, relatedPullRequestsField.Id, relatedPullRequestsValue).ConfigureAwait(false);
-                updated++;
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, relatedPullRequestsField.Id).ConfigureAwait(false);
             }
+            updated++;
         }
 
         if (fields.TryGetValue("Duplicate Cluster", out var duplicateField) && !string.IsNullOrWhiteSpace(entry.DuplicateCluster)) {
@@ -1210,6 +1272,25 @@ internal static class ProjectSyncRunner {
         }
 
         return comments;
+    }
+
+    internal static IReadOnlyList<int> BuildStaleSuggestionCommentTargets(
+        IReadOnlyList<ProjectSyncEntry> entries,
+        string kind,
+        IReadOnlyDictionary<int, string> activeComments) {
+        if (string.IsNullOrWhiteSpace(kind) || entries.Count == 0) {
+            return Array.Empty<int>();
+        }
+
+        var activeNumbers = new HashSet<int>(activeComments.Keys);
+        return entries
+            .Where(entry => entry.Number > 0 &&
+                            entry.Kind.Equals(kind, StringComparison.OrdinalIgnoreCase) &&
+                            !activeNumbers.Contains(entry.Number))
+            .Select(entry => entry.Number)
+            .Distinct()
+            .OrderBy(number => number)
+            .ToList();
     }
 
     internal static string? BuildIssueMatchSuggestionComment(ProjectSyncEntry entry, double minConfidence, int maxIssues) {

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -615,6 +615,132 @@ internal static partial class Program {
         AssertEqual(false, comment.Contains("issues/312", StringComparison.OrdinalIgnoreCase), "below-threshold issue-side candidate excluded");
     }
 
+    private static void TestProjectSyncBuildStaleSuggestionCommentTargetsForPullRequests() {
+        var entries = new[] {
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 501,
+                Url: "https://github.com/EvotecIT/IntelligenceX/pull/501",
+                Kind: "pull_request",
+                TriageScore: 80.0,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "feature",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: null,
+                MatchedIssueConfidence: null,
+                VisionFit: null,
+                VisionConfidence: null),
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 502,
+                Url: "https://github.com/EvotecIT/IntelligenceX/pull/502",
+                Kind: "pull_request",
+                TriageScore: 82.0,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "feature",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: null,
+                MatchedIssueConfidence: null,
+                VisionFit: null,
+                VisionConfidence: null),
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 601,
+                Url: "https://github.com/EvotecIT/IntelligenceX/issues/601",
+                Kind: "issue",
+                TriageScore: null,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "feature",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: null,
+                MatchedIssueConfidence: null,
+                VisionFit: null,
+                VisionConfidence: null)
+        };
+
+        var activeComments = new Dictionary<int, string> {
+            [501] = "active"
+        };
+
+        var staleTargets = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildStaleSuggestionCommentTargets(
+            entries,
+            kind: "pull_request",
+            activeComments: activeComments);
+
+        AssertEqual(1, staleTargets.Count, "single stale pull request comment target");
+        AssertEqual(502, staleTargets[0], "pull request without active suggestion is stale target");
+    }
+
+    private static void TestProjectSyncBuildStaleSuggestionCommentTargetsForIssuesDedupesAndSorts() {
+        var entries = new[] {
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 702,
+                Url: "https://github.com/EvotecIT/IntelligenceX/issues/702",
+                Kind: "issue",
+                TriageScore: null,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "bug",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: null,
+                MatchedIssueConfidence: null,
+                VisionFit: null,
+                VisionConfidence: null),
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 700,
+                Url: "https://github.com/EvotecIT/IntelligenceX/issues/700",
+                Kind: "issue",
+                TriageScore: null,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "bug",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: null,
+                MatchedIssueConfidence: null,
+                VisionFit: null,
+                VisionConfidence: null),
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 701,
+                Url: "https://github.com/EvotecIT/IntelligenceX/issues/701",
+                Kind: "issue",
+                TriageScore: null,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "bug",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: null,
+                MatchedIssueConfidence: null,
+                VisionFit: null,
+                VisionConfidence: null),
+            new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+                Number: 700,
+                Url: "https://github.com/EvotecIT/IntelligenceX/issues/700",
+                Kind: "issue",
+                TriageScore: null,
+                DuplicateCluster: null,
+                CanonicalItem: null,
+                Category: "bug",
+                Tags: Array.Empty<string>(),
+                MatchedIssueUrl: null,
+                MatchedIssueConfidence: null,
+                VisionFit: null,
+                VisionConfidence: null)
+        };
+
+        var activeComments = new Dictionary<int, string> {
+            [701] = "active"
+        };
+
+        var staleTargets = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildStaleSuggestionCommentTargets(
+            entries,
+            kind: "issue",
+            activeComments: activeComments);
+
+        AssertEqual(2, staleTargets.Count, "two stale issue comment targets");
+        AssertEqual(700, staleTargets[0], "sorted stale issue target #1");
+        AssertEqual(702, staleTargets[1], "sorted stale issue target #2");
+    }
+
     private static void TestProjectSyncBuildIssueMatchSuggestionCommentReturnsNullWithoutQualifiedCandidates() {
         var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
             Number: 56,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -492,6 +492,8 @@ internal static partial class Program {
         failed += Run("Todo project sync uses issue related pull-request fallback", TestProjectSyncBuildEntriesUsesIssueRelatedPullRequestFallback);
         failed += Run("Todo project sync comment filters by confidence", TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence);
         failed += Run("Todo project sync PR comments include issue-side candidates", TestProjectSyncBuildPullRequestIssueSuggestionCommentsIncludesIssueSideCandidates);
+        failed += Run("Todo project sync stale comment targets for pull requests", TestProjectSyncBuildStaleSuggestionCommentTargetsForPullRequests);
+        failed += Run("Todo project sync stale comment targets for issues", TestProjectSyncBuildStaleSuggestionCommentTargetsForIssuesDedupesAndSorts);
         failed += Run("Todo project sync comment omitted for weak candidates", TestProjectSyncBuildIssueMatchSuggestionCommentReturnsNullWithoutQualifiedCandidates);
         failed += Run("Todo project sync issue backlink comments aggregate PRs", TestProjectSyncBuildIssueBacklinkSuggestionCommentsAggregatesPullRequests);
         failed += Run("Todo project sync issue backlink comments include issue-side candidates", TestProjectSyncBuildIssueBacklinkSuggestionCommentsIncludesIssueSideCandidates);


### PR DESCRIPTION
## Summary
- add stale managed-comment cleanup to `todo project-sync --apply-link-comments` for both PR issue-suggestion comments and issue backlink comments
- harden managed comment lifecycle by deduping marker comments (keep latest, delete older duplicates)
- clear stale match-related project fields during sync when current triage data no longer provides values
- add tests for stale comment cleanup target selection and update docs/help text for the new behavior

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`