### PR TITLE
Derive PR matched issue fallback from related issue signals

### DIFF
--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -535,6 +535,20 @@ internal static class ProjectSyncRunner {
                 var matchedIssueUrl = ReadNullableString(item, "matchedIssueUrl");
                 var matchedIssueConfidence = ReadNullableDouble(item, "matchedIssueConfidence");
                 var relatedIssues = ParseRelatedIssueCandidates(item);
+                if (string.IsNullOrWhiteSpace(matchedIssueUrl) && relatedIssues.Count > 0) {
+                    matchedIssueUrl = relatedIssues[0].Url;
+                    matchedIssueConfidence = relatedIssues[0].Confidence;
+                } else if (!string.IsNullOrWhiteSpace(matchedIssueUrl) && !matchedIssueConfidence.HasValue) {
+                    var confidenceFromRelated = relatedIssues
+                        .Where(candidate => candidate.Number > 0 &&
+                                            !string.IsNullOrWhiteSpace(candidate.Url) &&
+                                            candidate.Url.Equals(matchedIssueUrl, StringComparison.OrdinalIgnoreCase))
+                        .OrderByDescending(candidate => candidate.Confidence)
+                        .FirstOrDefault();
+                    if (confidenceFromRelated is not null) {
+                        matchedIssueConfidence = confidenceFromRelated.Confidence;
+                    }
+                }
                 var matchedPullRequestUrl = ReadNullableString(item, "matchedPullRequestUrl");
                 var matchedPullRequestConfidence = ReadNullableDouble(item, "matchedPullRequestConfidence");
                 var relatedPullRequests = ParseRelatedPullRequestCandidates(item);

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -504,6 +504,85 @@ internal static partial class Program {
         AssertEqual(true, issue.MatchedPullRequestConfidence.HasValue && issue.MatchedPullRequestConfidence.Value >= 0.88, "fallback confidence derived from top related pull request");
     }
 
+    private static void TestProjectSyncBuildEntriesUsesPullRequestRelatedIssueFallback() {
+        const string triageJson = """
+{
+  "items": [
+    {
+      "id": "pr#141",
+      "kind": "pull_request",
+      "number": 141,
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/141",
+      "relatedIssues": [
+        {
+          "number": 201,
+          "url": "https://github.com/EvotecIT/IntelligenceX/issues/201",
+          "confidence": 0.88,
+          "reason": "explicit issue reference in PR title/body"
+        },
+        {
+          "number": 202,
+          "url": "https://github.com/EvotecIT/IntelligenceX/issues/202",
+          "confidence": 0.71,
+          "reason": "token overlap"
+        }
+      ]
+    }
+  ]
+}
+""";
+
+        using var triageDoc = System.Text.Json.JsonDocument.Parse(triageJson);
+        var entries = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildEntriesFromDocuments(
+            triageDoc.RootElement,
+            null,
+            100);
+
+        var pullRequest = entries.Single(item => item.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase));
+        AssertEqual("https://github.com/EvotecIT/IntelligenceX/issues/201", pullRequest.MatchedIssueUrl, "fallback uses top related issue");
+        AssertEqual(true, pullRequest.MatchedIssueConfidence.HasValue && pullRequest.MatchedIssueConfidence.Value >= 0.88, "fallback confidence derived from top related issue");
+    }
+
+    private static void TestProjectSyncBuildEntriesDerivesMissingMatchedIssueConfidenceFromRelatedIssues() {
+        const string triageJson = """
+{
+  "items": [
+    {
+      "id": "pr#142",
+      "kind": "pull_request",
+      "number": 142,
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/142",
+      "matchedIssueUrl": "https://github.com/EvotecIT/IntelligenceX/issues/220",
+      "relatedIssues": [
+        {
+          "number": 220,
+          "url": "https://github.com/EvotecIT/IntelligenceX/issues/220",
+          "confidence": 0.64,
+          "reason": "token overlap"
+        },
+        {
+          "number": 221,
+          "url": "https://github.com/EvotecIT/IntelligenceX/issues/221",
+          "confidence": 0.90,
+          "reason": "explicit issue reference in PR title/body"
+        }
+      ]
+    }
+  ]
+}
+""";
+
+        using var triageDoc = System.Text.Json.JsonDocument.Parse(triageJson);
+        var entries = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildEntriesFromDocuments(
+            triageDoc.RootElement,
+            null,
+            100);
+
+        var pullRequest = entries.Single(item => item.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase));
+        AssertEqual("https://github.com/EvotecIT/IntelligenceX/issues/220", pullRequest.MatchedIssueUrl, "explicit matched issue url preserved");
+        AssertEqual(true, pullRequest.MatchedIssueConfidence.HasValue && pullRequest.MatchedIssueConfidence.Value >= 0.64, "matched issue confidence derived from same related issue");
+    }
+
     private static void TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence() {
         var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
             Number: 55,

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -490,6 +490,8 @@ internal static partial class Program {
         failed += Run("Todo project sync derives issue pull-request matches", TestProjectSyncBuildEntriesDerivesIssuePullRequestMatches);
         failed += Run("Todo project sync preserves higher-confidence issue-side pull-request matches", TestProjectSyncBuildEntriesPreservesHigherConfidenceIssueSidePullRequestMatch);
         failed += Run("Todo project sync uses issue related pull-request fallback", TestProjectSyncBuildEntriesUsesIssueRelatedPullRequestFallback);
+        failed += Run("Todo project sync uses pull-request related issue fallback", TestProjectSyncBuildEntriesUsesPullRequestRelatedIssueFallback);
+        failed += Run("Todo project sync derives missing matched issue confidence from related issues", TestProjectSyncBuildEntriesDerivesMissingMatchedIssueConfidenceFromRelatedIssues);
         failed += Run("Todo project sync comment filters by confidence", TestProjectSyncBuildIssueMatchSuggestionCommentFiltersByConfidence);
         failed += Run("Todo project sync PR comments include issue-side candidates", TestProjectSyncBuildPullRequestIssueSuggestionCommentsIncludesIssueSideCandidates);
         failed += Run("Todo project sync stale comment targets for pull requests", TestProjectSyncBuildStaleSuggestionCommentTargetsForPullRequests);


### PR DESCRIPTION
## Summary
- derive PR-side `Matched Issue` fallback from top `relatedIssues` candidate when explicit `matchedIssueUrl` is missing
- derive missing `matchedIssueConfidence` from the matching related-issue candidate when explicit URL exists but confidence is absent
- add regression tests for both fallback paths

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`