### PR TITLE
Improve IX auto-label reliability with confidence gating

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -148,6 +148,7 @@ Behavior:
 - `IX Suggested Decision` is populated automatically (`accept`, `defer`, `reject`, `merge-candidate`) from combined triage + vision signals.
 - `Maintainer Decision` remains human-owned for final triage decisions.
 - Unknown categories/tags are normalized into dynamic labels (for example `ML Ops` -> `ix/category:ml-ops`, `Release Candidate` -> `ix/tag:release-candidate`) and are auto-created when `--apply-labels --ensure-labels` is used.
+- Category/tag labels are confidence-gated for reliability: category labels require `categoryConfidence >= 0.62` and tag labels require `tagConfidences[tag] >= 0.60` when those confidence fields are present in triage output.
 - `--apply-labels` performs managed IX label reconciliation: stale `ix/*` labels for managed families are removed while non-IX maintainer labels are preserved.
 - Issues also receive match taxonomy labels when PR->issue linking signals exist (`ix/match:linked-pr` or `ix/match:needs-review-pr`).
 - Match-related project fields (`Matched Issue*`, `Related Issues`, `Matched Pull Request*`, `Related Pull Requests`) are cleared when no longer present in current triage outputs to prevent stale project metadata.

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -12,6 +12,8 @@ namespace IntelligenceX.Cli.Todo;
 internal static class ProjectSyncRunner {
     private const double HighConfidenceIssueMatchLabelThreshold = 0.80;
     private const double HighConfidencePullRequestMatchLabelThreshold = 0.80;
+    private const double CategoryLabelConfidenceThreshold = 0.62;
+    private const double TagLabelConfidenceThreshold = 0.60;
     private const double DefaultIssueCommentMinConfidence = 0.55;
     private const double RejectVisionConfidenceThreshold = 0.70;
     private const double AcceptVisionConfidenceThreshold = 0.68;
@@ -58,7 +60,9 @@ internal static class ProjectSyncRunner {
         double? MatchedPullRequestConfidence = null,
         string? MatchedPullRequestReason = null,
         IReadOnlyList<RelatedPullRequestCandidate>? RelatedPullRequests = null,
-        IReadOnlyList<string>? ExistingLabels = null
+        IReadOnlyList<string>? ExistingLabels = null,
+        double? CategoryConfidence = null,
+        IReadOnlyDictionary<string, double>? TagConfidences = null
     );
 
     private sealed class Options {
@@ -150,9 +154,10 @@ internal static class ProjectSyncRunner {
 
         if (options.ApplyLabels && options.EnsureLabels && !options.DryRun) {
             try {
+                var (categoryLabels, tagLabels) = BuildLabelTaxonomyForEntries(entries);
                 var labelsToEnsure = ProjectLabelCatalog.BuildEnsureLabelCatalog(
-                    entries.Select(entry => entry.Category),
-                    entries.SelectMany(entry => entry.Tags));
+                    categoryLabels,
+                    tagLabels);
                 await RepositoryLabelManager.EnsureLabelsAsync(options.Repo, labelsToEnsure).ConfigureAwait(false);
             } catch (Exception ex) {
                 Console.Error.WriteLine($"Failed to ensure labels before apply-labels: {ex.Message}");
@@ -532,7 +537,9 @@ internal static class ProjectSyncRunner {
                 var triageScore = ReadNullableDouble(item, "score");
                 var duplicateClusterId = ReadNullableString(item, "duplicateClusterId");
                 var category = ReadNullableString(item, "category");
+                var categoryConfidence = ReadNullableDouble(item, "categoryConfidence");
                 var tags = ReadStringArray(item, "tags");
+                var tagConfidences = ReadStringDoubleMap(item, "tagConfidences");
                 var existingLabels = ReadStringArray(item, "labels");
                 var matchedIssueUrl = ReadNullableString(item, "matchedIssueUrl");
                 var matchedIssueConfidence = ReadNullableDouble(item, "matchedIssueConfidence");
@@ -614,7 +621,9 @@ internal static class ProjectSyncRunner {
                     MatchedPullRequestConfidence: matchedPullRequestConfidence,
                     MatchedPullRequestReason: matchedPullRequestReason,
                     RelatedPullRequests: relatedPullRequests,
-                    ExistingLabels: existingLabels
+                    ExistingLabels: existingLabels,
+                    CategoryConfidence: categoryConfidence,
+                    TagConfidences: tagConfidences
                 );
             }
         }
@@ -1107,12 +1116,14 @@ internal static class ProjectSyncRunner {
         var isPullRequest = entry.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase);
         var isIssue = entry.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase);
 
-        if (ProjectLabelCatalog.TryMapCategoryLabel(entry.Category ?? string.Empty, out var categoryLabel)) {
+        if (ShouldApplyCategoryLabel(entry) &&
+            ProjectLabelCatalog.TryMapCategoryLabel(entry.Category ?? string.Empty, out var categoryLabel)) {
             labels.Add(categoryLabel);
         }
 
         foreach (var tag in entry.Tags) {
-            if (ProjectLabelCatalog.TryMapTagLabel(tag, out var tagLabel)) {
+            if (ShouldApplyTagLabel(entry, tag) &&
+                ProjectLabelCatalog.TryMapTagLabel(tag, out var tagLabel)) {
                 labels.Add(tagLabel);
             }
         }
@@ -1177,6 +1188,51 @@ internal static class ProjectSyncRunner {
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(label => label, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    private static bool ShouldApplyCategoryLabel(ProjectSyncEntry entry) {
+        if (!entry.CategoryConfidence.HasValue) {
+            // Backward-compatible default for legacy triage artifacts without confidence fields.
+            return true;
+        }
+
+        return entry.CategoryConfidence.Value >= CategoryLabelConfidenceThreshold;
+    }
+
+    private static bool ShouldApplyTagLabel(ProjectSyncEntry entry, string tag) {
+        if (string.IsNullOrWhiteSpace(tag)) {
+            return false;
+        }
+
+        if (entry.TagConfidences is null ||
+            !entry.TagConfidences.TryGetValue(tag, out var confidence)) {
+            // Backward-compatible default for legacy triage artifacts without confidence fields.
+            return true;
+        }
+
+        return confidence >= TagLabelConfidenceThreshold;
+    }
+
+    private static (IReadOnlyList<string> Categories, IReadOnlyList<string> Tags) BuildLabelTaxonomyForEntries(
+        IReadOnlyList<ProjectSyncEntry> entries) {
+        var categories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var tags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries) {
+            foreach (var label in BuildLabelsForEntry(entry)) {
+                if (label.StartsWith("ix/category:", StringComparison.OrdinalIgnoreCase)) {
+                    categories.Add(label["ix/category:".Length..]);
+                    continue;
+                }
+
+                if (label.StartsWith("ix/tag:", StringComparison.OrdinalIgnoreCase)) {
+                    tags.Add(label["ix/tag:".Length..]);
+                }
+            }
+        }
+
+        return (
+            categories.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToList(),
+            tags.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToList());
     }
 
     internal static string BuildRelatedIssuesFieldValue(ProjectSyncEntry entry, int maxIssues) {
@@ -1748,6 +1804,29 @@ internal static class ProjectSyncRunner {
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    private static IReadOnlyDictionary<string, double> ReadStringDoubleMap(JsonElement obj, string name) {
+        if (!TryGetProperty(obj, name, out var prop) || prop.ValueKind != JsonValueKind.Object) {
+            return new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var values = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+        foreach (var property in prop.EnumerateObject()) {
+            var key = property.Name?.Trim();
+            if (string.IsNullOrWhiteSpace(key)) {
+                continue;
+            }
+
+            if (property.Value.ValueKind != JsonValueKind.Number ||
+                !property.Value.TryGetDouble(out var confidence)) {
+                continue;
+            }
+
+            values[key] = Math.Clamp(confidence, 0, 1);
+        }
+
+        return values;
     }
 
     private static int ReadInt(JsonElement obj, string name) {

--- a/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
+++ b/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
@@ -172,7 +172,9 @@ internal static class TriageIndexRunner {
 
     internal sealed record ItemEnrichment(
         string Category,
+        double CategoryConfidence,
         IReadOnlyList<string> Tags,
+        IReadOnlyDictionary<string, double> TagConfidences,
         string? MatchedIssueUrl,
         double? MatchedIssueConfidence,
         IReadOnlyList<RelatedIssueCandidate> RelatedIssues,
@@ -613,7 +615,7 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         var rawIssueByNumber = issues.ToDictionary(issue => issue.Number);
 
         foreach (var item in items) {
-            var (category, tags) = InferCategoryAndTags(item);
+            var inference = InferCategoryAndTagsWithConfidence(item);
 
             IReadOnlyList<RelatedIssueCandidate> relatedIssues = Array.Empty<RelatedIssueCandidate>();
             IReadOnlyList<RelatedPullRequestCandidate> relatedPullRequests = Array.Empty<RelatedPullRequestCandidate>();
@@ -647,8 +649,10 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
             }
 
             enrichments[item.Id] = new ItemEnrichment(
-                Category: category,
-                Tags: tags,
+                Category: inference.Category,
+                CategoryConfidence: inference.CategoryConfidence,
+                Tags: inference.Tags,
+                TagConfidences: inference.TagConfidences,
                 MatchedIssueUrl: matchedIssueUrl,
                 MatchedIssueConfidence: matchedIssueConfidence,
                 RelatedIssues: relatedIssues,
@@ -661,8 +665,22 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         return enrichments;
     }
 
+    internal sealed record CategoryTagInference(
+        string Category,
+        double CategoryConfidence,
+        IReadOnlyList<string> Tags,
+        IReadOnlyDictionary<string, double> TagConfidences
+    );
+
     internal static (string Category, IReadOnlyList<string> Tags) InferCategoryAndTags(TriageIndexItem item) {
+        var inference = InferCategoryAndTagsWithConfidence(item);
+        return (inference.Category, inference.Tags);
+    }
+
+    internal static CategoryTagInference InferCategoryAndTagsWithConfidence(TriageIndexItem item) {
         var tokens = new HashSet<string>(item.ContextTokens, StringComparer.OrdinalIgnoreCase);
+        var titleTokens = new HashSet<string>(item.TitleTokens, StringComparer.OrdinalIgnoreCase);
+        var labelTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var token in item.TitleTokens) {
             tokens.Add(token);
         }
@@ -670,25 +688,51 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         foreach (var label in item.Labels) {
             foreach (var token in Tokenize(label)) {
                 tokens.Add(token);
+                labelTokens.Add(token);
             }
         }
 
-        bool HasAny(params string[] candidates) {
+        static int CountMatches(HashSet<string> source, IReadOnlyList<string> candidates) {
+            var matches = 0;
             foreach (var candidate in candidates) {
-                if (tokens.Contains(candidate)) {
-                    return true;
+                if (source.Contains(candidate)) {
+                    matches++;
                 }
             }
-            return false;
+            return matches;
         }
 
-        var isSecurity = HasAny("security", "vulnerability", "vulnerabilities", "auth", "authorization", "xss", "injection", "cve", "secret", "secrets");
-        var isBug = HasAny("bug", "bugs", "error", "errors", "failure", "failures", "exception", "exceptions", "crash", "regression", "defect", "defects");
-        var isPerformance = HasAny("performance", "perf", "latency", "throughput", "memory", "cpu");
-        var isDocs = HasAny("docs", "doc", "documentation", "readme", "wiki", "changelog");
-        var isTesting = HasAny("test", "tests", "testing", "unittest", "integration", "e2e");
-        var isCi = HasAny("ci", "pipeline", "workflows", "workflow", "actions", "github", "build");
-        var isMaintenance = HasAny("refactor", "cleanup", "chore", "maintenance", "bump", "upgrade", "dependency", "dependencies", "deps");
+        var securityTokens = new[] { "security", "vulnerability", "vulnerabilities", "auth", "authorization", "xss", "injection", "cve", "secret", "secrets" };
+        var bugTokens = new[] { "bug", "bugs", "error", "errors", "failure", "failures", "exception", "exceptions", "crash", "regression", "defect", "defects" };
+        var performanceTokens = new[] { "performance", "perf", "latency", "throughput", "memory", "cpu" };
+        var docsTokens = new[] { "docs", "doc", "documentation", "readme", "wiki", "changelog" };
+        var testingTokens = new[] { "test", "tests", "testing", "unittest", "integration", "e2e" };
+        var ciTokens = new[] { "ci", "pipeline", "workflows", "workflow", "actions", "github", "build" };
+        var maintenanceTokens = new[] { "refactor", "cleanup", "chore", "maintenance", "bump", "upgrade", "dependency", "dependencies", "deps" };
+        var featureTokens = new[] { "feature", "features", "enhancement", "enhancements" };
+        var apiTokens = new[] { "api", "apis" };
+        var uxTokens = new[] { "ui", "ux", "frontend", "website" };
+        var dependencyTokens = new[] { "dependency", "dependencies", "deps", "nuget", "package", "packages" };
+
+        var securityMatches = CountMatches(tokens, securityTokens);
+        var bugMatches = CountMatches(tokens, bugTokens);
+        var performanceMatches = CountMatches(tokens, performanceTokens);
+        var docsMatches = CountMatches(tokens, docsTokens);
+        var testingMatches = CountMatches(tokens, testingTokens);
+        var ciMatches = CountMatches(tokens, ciTokens);
+        var maintenanceMatches = CountMatches(tokens, maintenanceTokens);
+        var featureMatches = CountMatches(tokens, featureTokens);
+        var apiMatches = CountMatches(tokens, apiTokens);
+        var uxMatches = CountMatches(tokens, uxTokens);
+        var dependencyMatches = CountMatches(tokens, dependencyTokens);
+
+        var isSecurity = securityMatches > 0;
+        var isBug = bugMatches > 0;
+        var isPerformance = performanceMatches > 0;
+        var isDocs = docsMatches > 0;
+        var isTesting = testingMatches > 0;
+        var isCi = ciMatches > 0;
+        var isMaintenance = maintenanceMatches > 0;
 
         var category = isSecurity ? "security"
             : isBug ? "bug"
@@ -697,50 +741,125 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
             : isTesting ? "testing"
             : isCi ? "ci"
             : isMaintenance ? "maintenance"
+            : featureMatches > 0 ? "feature"
             : "feature";
 
-        var tags = new List<string>();
-        if (isSecurity) {
-            tags.Add("security");
-        }
-        if (isBug) {
-            tags.Add("bugfix");
-        }
-        if (isPerformance) {
-            tags.Add("performance");
-        }
-        if (isDocs) {
-            tags.Add("docs");
-        }
-        if (isTesting) {
-            tags.Add("testing");
-        }
-        if (isCi) {
-            tags.Add("ci");
-        }
-        if (isMaintenance) {
-            tags.Add("maintenance");
-        }
-        if (HasAny("api", "apis")) {
-            tags.Add("api");
-        }
-        if (HasAny("ui", "ux", "frontend", "website")) {
-            tags.Add("ux");
-        }
-        if (HasAny("dependency", "dependencies", "deps", "nuget", "package", "packages")) {
-            tags.Add("dependencies");
-        }
-        if (tags.Count == 0) {
-            tags.Add(category);
+        double ComputeConfidence(int matchCount, bool hasLabelEvidence, bool hasTitleEvidence, double baseConfidence) {
+            var confidence = baseConfidence;
+            if (matchCount > 0) {
+                confidence += 0.08;
+                confidence += Math.Min(0.16, (matchCount - 1) * 0.04);
+            }
+            if (hasLabelEvidence) {
+                confidence += 0.10;
+            }
+            if (hasTitleEvidence) {
+                confidence += 0.07;
+            }
+
+            return Math.Round(Math.Clamp(confidence, 0.35, 0.98), 2, MidpointRounding.AwayFromZero);
         }
 
-        return (
+        int ResolveCategoryMatches() {
+            return category switch {
+                "security" => securityMatches,
+                "bug" => bugMatches,
+                "performance" => performanceMatches,
+                "documentation" => docsMatches,
+                "testing" => testingMatches,
+                "ci" => ciMatches,
+                "maintenance" => maintenanceMatches,
+                _ => featureMatches
+            };
+        }
+
+        IReadOnlyList<string> ResolveCategoryCandidates() {
+            return category switch {
+                "security" => securityTokens,
+                "bug" => bugTokens,
+                "performance" => performanceTokens,
+                "documentation" => docsTokens,
+                "testing" => testingTokens,
+                "ci" => ciTokens,
+                "maintenance" => maintenanceTokens,
+                _ => featureTokens
+            };
+        }
+
+        var categoryCandidates = ResolveCategoryCandidates();
+        var categoryConfidence = ComputeConfidence(
+            ResolveCategoryMatches(),
+            CountMatches(labelTokens, categoryCandidates) > 0,
+            CountMatches(titleTokens, categoryCandidates) > 0,
+            category.Equals("feature", StringComparison.OrdinalIgnoreCase) ? 0.48 : 0.60);
+
+        var tags = new List<string>();
+        var tagConfidenceByName = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+        void AddTag(string tag, int matchCount, IReadOnlyList<string> evidenceTokens, double baseConfidence) {
+            tags.Add(tag);
+            var confidence = ComputeConfidence(
+                matchCount,
+                CountMatches(labelTokens, evidenceTokens) > 0,
+                CountMatches(titleTokens, evidenceTokens) > 0,
+                baseConfidence);
+
+            if (tagConfidenceByName.TryGetValue(tag, out var existing)) {
+                tagConfidenceByName[tag] = Math.Max(existing, confidence);
+            } else {
+                tagConfidenceByName[tag] = confidence;
+            }
+        }
+
+        if (isSecurity) {
+            AddTag("security", securityMatches, securityTokens, 0.58);
+        }
+        if (isBug) {
+            AddTag("bugfix", bugMatches, bugTokens, 0.58);
+        }
+        if (isPerformance) {
+            AddTag("performance", performanceMatches, performanceTokens, 0.58);
+        }
+        if (isDocs) {
+            AddTag("docs", docsMatches, docsTokens, 0.58);
+        }
+        if (isTesting) {
+            AddTag("testing", testingMatches, testingTokens, 0.58);
+        }
+        if (isCi) {
+            AddTag("ci", ciMatches, ciTokens, 0.58);
+        }
+        if (isMaintenance) {
+            AddTag("maintenance", maintenanceMatches, maintenanceTokens, 0.58);
+        }
+        if (apiMatches > 0) {
+            AddTag("api", apiMatches, apiTokens, 0.56);
+        }
+        if (uxMatches > 0) {
+            AddTag("ux", uxMatches, uxTokens, 0.56);
+        }
+        if (dependencyMatches > 0) {
+            AddTag("dependencies", dependencyMatches, dependencyTokens, 0.56);
+        }
+        if (tags.Count == 0) {
+            AddTag(category, ResolveCategoryMatches(), categoryCandidates, Math.Max(0.44, categoryConfidence - 0.08));
+        }
+
+        var normalizedTags = tags
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase)
+            .Take(8)
+            .ToList();
+        var normalizedTagConfidences = normalizedTags
+            .ToDictionary(
+                tag => tag,
+                tag => tagConfidenceByName.TryGetValue(tag, out var confidence) ? confidence : 0.50,
+                StringComparer.OrdinalIgnoreCase);
+
+        return new CategoryTagInference(
             Category: category,
-            Tags: tags
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase)
-                .Take(8)
-                .ToList()
+            CategoryConfidence: categoryConfidence,
+            Tags: normalizedTags,
+            TagConfidences: normalizedTagConfidences
         );
     }
 
@@ -1442,7 +1561,9 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                     dedupeKey = string.Join("-", item.Item.TitleTokens.Take(8)),
                     duplicateClusterId = item.DuplicateClusterId,
                     category = enrichment?.Category,
+                    categoryConfidence = enrichment?.CategoryConfidence,
                     tags = enrichment?.Tags ?? Array.Empty<string>(),
+                    tagConfidences = enrichment?.TagConfidences ?? new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase),
                     matchedIssueUrl = enrichment?.MatchedIssueUrl,
                     matchedIssueConfidence = enrichment?.MatchedIssueConfidence,
                     matchedPullRequestUrl = enrichment?.MatchedPullRequestUrl,

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 
 namespace IntelligenceX.Tests;
@@ -134,6 +135,43 @@ internal static partial class Program {
         AssertEqual("cluster-1", issue.DuplicateCluster, "duplicate cluster preserved");
         AssertEqual("https://github.com/EvotecIT/IntelligenceX/pull/10", issue.CanonicalItem, "issue canonical resolved");
         AssertEqual(true, string.IsNullOrWhiteSpace(issue.SuggestedDecision), "issues do not get automated decision");
+    }
+
+    private static void TestProjectSyncBuildEntriesParsesCategoryAndTagConfidences() {
+        const string triageJson = """
+{
+  "items": [
+    {
+      "id": "pr#410",
+      "kind": "pull_request",
+      "number": 410,
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/410",
+      "category": "security",
+      "categoryConfidence": 0.83,
+      "tags": [ "security", "api" ],
+      "tagConfidences": {
+        "security": 0.91,
+        "api": 0.57
+      }
+    }
+  ]
+}
+""";
+
+        using var triageDoc = System.Text.Json.JsonDocument.Parse(triageJson);
+        var entries = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildEntriesFromDocuments(
+            triageDoc.RootElement,
+            null,
+            100);
+
+        AssertEqual(1, entries.Count, "entries count");
+        var entry = entries[0];
+        AssertEqual(true, entry.CategoryConfidence.HasValue, "category confidence parsed");
+        AssertEqual(0.83, entry.CategoryConfidence!.Value, "category confidence value");
+        AssertEqual(true, entry.TagConfidences is not null, "tag confidence map parsed");
+        AssertEqual(true, entry.TagConfidences!.ContainsKey("security"), "security tag confidence key");
+        AssertEqual(0.91, entry.TagConfidences["security"], "security tag confidence value");
+        AssertEqual(0.57, entry.TagConfidences["api"], "api tag confidence value");
     }
 
     private static void TestProjectSyncBuildEntriesSuggestsMergeCandidateForBestReadyPr() {
@@ -281,6 +319,33 @@ internal static partial class Program {
         AssertEqual(true, labels.Contains("ix/category:ml-ops", StringComparer.OrdinalIgnoreCase), "dynamic category label");
         AssertEqual(true, labels.Contains("ix/tag:release-candidate", StringComparer.OrdinalIgnoreCase), "dynamic tag label");
         AssertEqual(true, labels.Contains("ix/tag:docs", StringComparer.OrdinalIgnoreCase), "known normalized alias tag label");
+    }
+
+    private static void TestProjectSyncBuildLabelsSkipsLowConfidenceCategoryAndTags() {
+        var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+            Number: 89,
+            Url: "https://github.com/EvotecIT/IntelligenceX/pull/89",
+            Kind: "pull_request",
+            TriageScore: 72.0,
+            DuplicateCluster: null,
+            CanonicalItem: null,
+            Category: "security",
+            Tags: new[] { "security", "api" },
+            MatchedIssueUrl: null,
+            MatchedIssueConfidence: null,
+            VisionFit: null,
+            VisionConfidence: null,
+            CategoryConfidence: 0.58,
+            TagConfidences: new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase) {
+                ["security"] = 0.55,
+                ["api"] = 0.71
+            }
+        );
+
+        var labels = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildLabelsForEntry(entry);
+        AssertEqual(false, labels.Contains("ix/category:security", StringComparer.OrdinalIgnoreCase), "low confidence category label skipped");
+        AssertEqual(false, labels.Contains("ix/tag:security", StringComparer.OrdinalIgnoreCase), "low confidence tag label skipped");
+        AssertEqual(true, labels.Contains("ix/tag:api", StringComparer.OrdinalIgnoreCase), "high confidence tag label kept");
     }
 
     private static void TestProjectSyncBuildLabelsUsesNeedsReviewForLowConfidenceIssueMatch() {

--- a/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
+++ b/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
@@ -249,5 +249,43 @@ internal static partial class Program {
         AssertEqual("security", category, "security category");
         AssertEqual(true, tags.Contains("security", StringComparer.OrdinalIgnoreCase), "security tag");
     }
+
+    private static void TestTriageIndexInferCategoryAndTagsWithConfidenceUsesEvidenceStrength() {
+        var now = DateTimeOffset.UtcNow;
+        var strongEvidenceItem = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "pr#99",
+            "pull_request",
+            99,
+            "Security hardening for auth flow",
+            "https://example/pr/99",
+            now,
+            new[] { "security", "authentication" },
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Security hardening for auth flow"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Security hardening for auth flow"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Fix auth token security checks and API validation"),
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.PullRequestSignals(false, "MERGEABLE", "APPROVED", "SUCCESS", 4, 24, 5, 1, 1, "dev"),
+            null
+        );
+
+        var weakEvidenceItem = strongEvidenceItem with {
+            Id = "pr#100",
+            Number = 100,
+            Title = "Add helper utility",
+            Labels = Array.Empty<string>(),
+            NormalizedTitle = IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Add helper utility"),
+            TitleTokens = IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Add helper utility"),
+            ContextTokens = IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("utility helper support")
+        };
+
+        var strongInference = IntelligenceX.Cli.Todo.TriageIndexRunner.InferCategoryAndTagsWithConfidence(strongEvidenceItem);
+        var weakInference = IntelligenceX.Cli.Todo.TriageIndexRunner.InferCategoryAndTagsWithConfidence(weakEvidenceItem);
+
+        AssertEqual("security", strongInference.Category, "strong inference category");
+        AssertEqual(true, strongInference.CategoryConfidence >= 0.80, "strong category confidence");
+        AssertEqual(true, strongInference.TagConfidences.TryGetValue("security", out var securityConfidence) && securityConfidence >= 0.75,
+            "strong security tag confidence");
+        AssertEqual("feature", weakInference.Category, "weak inference fallback category");
+        AssertEqual(true, weakInference.CategoryConfidence < 0.62, "weak category confidence below labeling threshold");
+    }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -455,6 +455,7 @@ internal static partial class Program {
         failed += Run("Todo triage index issue-PR direct match", TestTriageIndexMatchIssueToPullRequestsSupportsDirectPullRequestReference);
         failed += Run("Todo triage index issue-PR URL match", TestTriageIndexMatchIssueToPullRequestsSupportsPullRequestUrlReference);
         failed += Run("Todo triage index category/tag inference", TestTriageIndexInferCategoryAndTagsDetectsSecurity);
+        failed += Run("Todo triage index category/tag confidence inference", TestTriageIndexInferCategoryAndTagsWithConfidenceUsesEvidenceStrength);
         failed += Run("Todo vision check out-of-scope classification", TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate);
         failed += Run("Todo vision check aligned classification", TestVisionCheckClassifiesAlignedWhenInTokensMatch);
         failed += Run("Todo vision check explicit reject policy precedence", TestVisionCheckExplicitRejectPolicyTakesPrecedence);
@@ -479,8 +480,10 @@ internal static partial class Program {
         failed += Run("Todo project view apply markdown includes missing views and platform note", TestProjectViewApplyMarkdownIncludesMissingViewsAndPlatformNote);
         failed += Run("Todo project view apply markdown all views present shows completed checklist", TestProjectViewApplyMarkdownAllViewsPresentShowsCompletedChecklist);
         failed += Run("Todo project sync merges vision and canonical", TestProjectSyncBuildEntriesMergesVisionAndCanonical);
+        failed += Run("Todo project sync parses category/tag confidence fields", TestProjectSyncBuildEntriesParsesCategoryAndTagConfidences);
         failed += Run("Todo project sync labels include tags and high-confidence match", TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch);
         failed += Run("Todo project sync labels normalize dynamic category and tags", TestProjectSyncBuildLabelsNormalizesDynamicCategoryAndTags);
+        failed += Run("Todo project sync labels skip low-confidence category/tags", TestProjectSyncBuildLabelsSkipsLowConfidenceCategoryAndTags);
         failed += Run("Todo project sync labels mark low-confidence match for review", TestProjectSyncBuildLabelsUsesNeedsReviewForLowConfidenceIssueMatch);
         failed += Run("Todo project sync labels use related-issue fallback", TestProjectSyncBuildLabelsUsesRelatedIssueFallbackWhenMatchedIssueMissing);
         failed += Run("Todo project sync labels issue pull-request matches", TestProjectSyncBuildLabelsUsesIssuePullRequestMatchSignals);


### PR DESCRIPTION
## Summary
- extend triage enrichment output with categoryConfidence and 	agConfidences
- add confidence-aware category/tag inference helper while keeping existing category/tag API compatibility
- parse confidence fields in project-sync entries and gate category/tag label application by thresholds
- align --ensure-labels dynamic category/tag creation with labels that pass confidence gating
- add tests for confidence inference, confidence field parsing, and low-confidence label suppression
- document confidence-gated label behavior in todo CLI docs

## Reliability thresholds
- category labels apply when categoryConfidence >= 0.62 (when confidence is present)
- tag labels apply when 	agConfidences[tag] >= 0.60 (when confidence is present)
- legacy triage artifacts without confidence fields keep previous behavior

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll