### PR TITLE
todo: sync category and tag confidence fields to project

### DIFF
--- a/Docs/cli/todo.md
+++ b/Docs/cli/todo.md
@@ -113,7 +113,7 @@ intelligencex todo project-init \
 Notes:
 - Creates a project (or initializes an existing one with `--project <n>`).
 - Can copy from a prepared template project with `--view-template-project <n>` to preserve saved GitHub views.
-- Ensures required custom fields such as `Vision Fit`, `Category`, `Tags`, `Matched Issue`, `Matched Issue Reason`, `Matched Pull Request`, `Matched Pull Request Reason`, `Triage Score`, `Duplicate Cluster`, and `IX Suggested Decision`.
+- Ensures required custom fields such as `Vision Fit`, `Category`, `Category Confidence`, `Tags`, `Tag Confidence Summary`, `Matched Issue`, `Matched Issue Reason`, `Matched Pull Request`, `Matched Pull Request Reason`, `Triage Score`, `Duplicate Cluster`, and `IX Suggested Decision`.
 - Ensures IX label taxonomy in the repo by default (`--no-ensure-labels` to skip).
 - Validates default IX view coverage by default (`--no-ensure-default-views` to skip).
 - Writes a reusable config file containing owner/project/field metadata.
@@ -149,6 +149,7 @@ Behavior:
 - `Maintainer Decision` remains human-owned for final triage decisions.
 - Unknown categories/tags are normalized into dynamic labels (for example `ML Ops` -> `ix/category:ml-ops`, `Release Candidate` -> `ix/tag:release-candidate`) and are auto-created when `--apply-labels --ensure-labels` is used.
 - Category/tag labels are confidence-gated for reliability: category labels require `categoryConfidence >= 0.62` and tag labels require `tagConfidences[tag] >= 0.60` when those confidence fields are present in triage output.
+- Category confidence and per-tag confidence summaries are synced into project fields (`Category Confidence`, `Tag Confidence Summary`) when triage confidence data is available.
 - `--apply-labels` performs managed IX label reconciliation: stale `ix/*` labels for managed families are removed while non-IX maintainer labels are preserved.
 - Issues also receive match taxonomy labels when PR->issue linking signals exist (`ix/match:linked-pr` or `ix/match:needs-review-pr`).
 - Match-related project fields (`Matched Issue*`, `Related Issues`, `Matched Pull Request*`, `Related Pull Requests`) are cleared when no longer present in current triage outputs to prevent stale project metadata.

--- a/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
@@ -27,7 +27,9 @@ internal static class ProjectFieldCatalog {
             "testing",
             "ci"
         }),
+        new ProjectFieldDefinition("Category Confidence", "NUMBER", Array.Empty<string>()),
         new ProjectFieldDefinition("Tags", "TEXT", Array.Empty<string>()),
+        new ProjectFieldDefinition("Tag Confidence Summary", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Matched Issue", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Matched Issue Confidence", "NUMBER", Array.Empty<string>()),
         new ProjectFieldDefinition("Matched Issue Reason", "TEXT", Array.Empty<string>()),

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -983,8 +983,27 @@ internal static class ProjectSyncRunner {
             }
         }
 
+        if (fields.TryGetValue("Category Confidence", out var categoryConfidenceField)) {
+            if (entry.CategoryConfidence.HasValue) {
+                await client.SetNumberFieldAsync(projectId, itemId, categoryConfidenceField.Id, entry.CategoryConfidence.Value).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, categoryConfidenceField.Id).ConfigureAwait(false);
+            }
+            updated++;
+        }
+
         if (fields.TryGetValue("Tags", out var tagsField) && entry.Tags.Count > 0) {
             await client.SetTextFieldAsync(projectId, itemId, tagsField.Id, string.Join(", ", entry.Tags)).ConfigureAwait(false);
+            updated++;
+        }
+
+        if (fields.TryGetValue("Tag Confidence Summary", out var tagConfidenceSummaryField)) {
+            var tagConfidenceSummary = BuildTagConfidenceSummaryFieldValue(entry, maxTags: 10);
+            if (!string.IsNullOrWhiteSpace(tagConfidenceSummary)) {
+                await client.SetTextFieldAsync(projectId, itemId, tagConfidenceSummaryField.Id, tagConfidenceSummary).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, tagConfidenceSummaryField.Id).ConfigureAwait(false);
+            }
             updated++;
         }
 
@@ -1257,6 +1276,43 @@ internal static class ProjectSyncRunner {
         }
 
         return NormalizeCommentReason(reason);
+    }
+
+    internal static string BuildTagConfidenceSummaryFieldValue(ProjectSyncEntry entry, int maxTags) {
+        var limit = Math.Max(1, Math.Min(maxTags, 20));
+        if (entry.TagConfidences is null || entry.TagConfidences.Count == 0) {
+            return string.Empty;
+        }
+
+        var normalized = entry.TagConfidences
+            .Where(pair => !string.IsNullOrWhiteSpace(pair.Key))
+            .Select(pair => new KeyValuePair<string, double>(pair.Key.Trim(), Math.Clamp(pair.Value, 0, 1)))
+            .ToList();
+        if (normalized.Count == 0) {
+            return string.Empty;
+        }
+
+        var tagSet = entry.Tags
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var selected = tagSet.Count > 0
+            ? normalized.Where(pair => tagSet.Contains(pair.Key)).ToList()
+            : normalized;
+        if (selected.Count == 0) {
+            selected = normalized;
+        }
+
+        var summaryLines = selected
+            .OrderByDescending(pair => pair.Value)
+            .ThenBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+            .Take(limit)
+            .Select(pair => $"{pair.Key}: {pair.Value.ToString("0.00", CultureInfo.InvariantCulture)}")
+            .ToList();
+        if (summaryLines.Count == 0) {
+            return string.Empty;
+        }
+
+        return string.Join(Environment.NewLine, summaryLines);
     }
 
     internal static string BuildRelatedPullRequestsFieldValue(ProjectSyncEntry entry, int maxPullRequests) {

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -13,7 +13,9 @@ internal static partial class Program {
         AssertEqual(true, names.Contains("Vision Fit", StringComparer.OrdinalIgnoreCase), "has Vision Fit");
         AssertEqual(true, names.Contains("Vision Confidence", StringComparer.OrdinalIgnoreCase), "has Vision Confidence");
         AssertEqual(true, names.Contains("Category", StringComparer.OrdinalIgnoreCase), "has Category");
+        AssertEqual(true, names.Contains("Category Confidence", StringComparer.OrdinalIgnoreCase), "has Category Confidence");
         AssertEqual(true, names.Contains("Tags", StringComparer.OrdinalIgnoreCase), "has Tags");
+        AssertEqual(true, names.Contains("Tag Confidence Summary", StringComparer.OrdinalIgnoreCase), "has Tag Confidence Summary");
         AssertEqual(true, names.Contains("Matched Issue", StringComparer.OrdinalIgnoreCase), "has Matched Issue");
         AssertEqual(true, names.Contains("Matched Issue Confidence", StringComparer.OrdinalIgnoreCase), "has Matched Issue Confidence");
         AssertEqual(true, names.Contains("Matched Issue Reason", StringComparer.OrdinalIgnoreCase), "has Matched Issue Reason");
@@ -1086,6 +1088,58 @@ internal static partial class Program {
 
         var normalized = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildMatchReasonFieldValue(" explicit issue reference \r\n in PR body ");
         AssertEqual("explicit issue reference in PR body", normalized, "reason whitespace normalized");
+    }
+
+    private static void TestProjectSyncBuildTagConfidenceSummaryFieldValueOrdersAndLimitsCandidates() {
+        var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+            Number: 57,
+            Url: "https://github.com/EvotecIT/IntelligenceX/pull/57",
+            Kind: "pull_request",
+            TriageScore: 70.0,
+            DuplicateCluster: null,
+            CanonicalItem: null,
+            Category: "feature",
+            Tags: new[] { "security", "api", "docs" },
+            MatchedIssueUrl: null,
+            MatchedIssueConfidence: null,
+            VisionFit: null,
+            VisionConfidence: null,
+            TagConfidences: new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase) {
+                ["security"] = 0.91,
+                ["api"] = 0.57,
+                ["docs"] = 0.77,
+                ["maintenance"] = 0.88
+            }
+        );
+
+        var value = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildTagConfidenceSummaryFieldValue(entry, maxTags: 2);
+        AssertContainsText(value, "security: 0.91", "highest confidence tag included first");
+        AssertContainsText(value, "docs: 0.77", "second highest confidence tag included");
+        AssertEqual(false, value.Contains("api: 0.57", StringComparison.OrdinalIgnoreCase), "limited to top maxTags entries");
+        AssertEqual(false, value.Contains("maintenance: 0.88", StringComparison.OrdinalIgnoreCase), "non-tag confidence excluded when entry tags are present");
+    }
+
+    private static void TestProjectSyncBuildTagConfidenceSummaryFieldValueFallsBackToConfidenceMap() {
+        var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
+            Number: 58,
+            Url: "https://github.com/EvotecIT/IntelligenceX/pull/58",
+            Kind: "pull_request",
+            TriageScore: 71.0,
+            DuplicateCluster: null,
+            CanonicalItem: null,
+            Category: "feature",
+            Tags: new[] { "api" },
+            MatchedIssueUrl: null,
+            MatchedIssueConfidence: null,
+            VisionFit: null,
+            VisionConfidence: null,
+            TagConfidences: new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase) {
+                ["security"] = 0.73
+            }
+        );
+
+        var value = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildTagConfidenceSummaryFieldValue(entry, maxTags: 3);
+        AssertContainsText(value, "security: 0.73", "falls back to full confidence map when tag names do not overlap");
     }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -506,6 +506,10 @@ internal static partial class Program {
         failed += Run("Todo project sync related issues field value", TestProjectSyncBuildRelatedIssuesFieldValueOrdersAndLimitsCandidates);
         failed += Run("Todo project sync related pull requests field value", TestProjectSyncBuildRelatedPullRequestsFieldValueOrdersAndLimitsCandidates);
         failed += Run("Todo project sync match reason field value", TestProjectSyncBuildMatchReasonFieldValueNormalizesReasonText);
+        failed += Run("Todo project sync tag confidence summary field value",
+            TestProjectSyncBuildTagConfidenceSummaryFieldValueOrdersAndLimitsCandidates);
+        failed += Run("Todo project sync tag confidence summary fallback",
+            TestProjectSyncBuildTagConfidenceSummaryFieldValueFallsBackToConfidenceMap);
         failed += Run("Todo repository label sync plan add/remove managed labels", TestRepositoryLabelManagerBuildManagedLabelSyncPlanAddsAndRemovesManagedOnly);
         failed += Run("Todo repository label sync plan no-op when aligned", TestRepositoryLabelManagerBuildManagedLabelSyncPlanNoChangesWhenAligned);
         failed += Run("Todo project bootstrap renders project target", TestProjectBootstrapRenderWorkflowTemplateInjectsProjectTarget);


### PR DESCRIPTION
## Summary
- add two default GitHub Project fields for triage confidence metadata: `Category Confidence` and `Tag Confidence Summary`
- sync these fields in `todo project-sync` so maintainers can inspect model confidence directly in project views
- add deterministic formatting for tag-confidence summary values (sorted, capped, newline-delimited)
- extend tests and CLI docs to cover the new field schema and summary behavior

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll