### PR TITLE
Expand AD, EventLog, System, and TestimoX toolpacks

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ActiveDirectory/AdGpoChangesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ActiveDirectory/AdGpoChangesTool.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ADPlayground.Gpo;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+
+namespace IntelligenceX.Tools.ActiveDirectory;
+
+/// <summary>
+/// Lists recently changed Group Policy Objects for a domain (read-only, capped).
+/// </summary>
+public sealed class AdGpoChangesTool : ActiveDirectoryToolBase, ITool {
+    private const int MaxViewTop = 5000;
+
+    private static readonly ToolDefinition DefinitionValue = new(
+        "ad_gpo_changes",
+        "List recently changed Group Policy Objects for a domain (read-only, capped).",
+        ToolSchema.Object(
+                ("domain_name", ToolSchema.String("Domain DNS name to query.")),
+                ("since_utc", ToolSchema.String("Optional ISO-8601 UTC lower bound for last modification timestamp.")),
+                ("max_results", ToolSchema.Integer("Maximum rows to return (capped).")))
+            .WithTableViewOptions()
+            .Required("domain_name")
+            .NoAdditionalProperties());
+
+    private sealed record AdGpoChangesResult(
+        string DomainName,
+        DateTime? SinceUtc,
+        int Scanned,
+        bool Truncated,
+        IReadOnlyList<GpoListItem> Items);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AdGpoChangesTool"/> class.
+    /// </summary>
+    public AdGpoChangesTool(ActiveDirectoryToolOptions options) : base(options) { }
+
+    /// <inheritdoc />
+    public override ToolDefinition Definition => DefinitionValue;
+
+    /// <inheritdoc />
+    protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name") ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(domainName)) {
+            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
+        }
+
+        if (!ToolTime.TryParseUtcOptional(ToolArgs.GetOptionalTrimmed(arguments, "since_utc"), out var sinceUtc, out var sinceError)) {
+            return Task.FromResult(ToolResponse.Error("invalid_argument", $"since_utc: {sinceError}"));
+        }
+
+        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var items = new List<GpoListItem>(Math.Min(maxResults, 512));
+        var scanned = 0;
+        var truncated = false;
+
+        try {
+            foreach (var item in GpoChangeHistoryService.GetChanges(domainName, sinceUtc)) {
+                cancellationToken.ThrowIfCancellationRequested();
+                scanned++;
+
+                if (items.Count >= maxResults) {
+                    truncated = true;
+                    break;
+                }
+
+                items.Add(item);
+            }
+        } catch (ArgumentException ex) {
+            return Task.FromResult(ToolResponse.Error("invalid_argument", ex.Message));
+        } catch (InvalidOperationException ex) {
+            return Task.FromResult(ToolResponse.Error("query_failed", ex.Message));
+        } catch (Exception ex) {
+            return Task.FromResult(ToolResponse.Error("query_failed", $"GPO change query failed: {ex.Message}"));
+        }
+
+        var result = new AdGpoChangesResult(
+            DomainName: domainName,
+            SinceUtc: sinceUtc,
+            Scanned: scanned,
+            Truncated: truncated,
+            Items: items);
+
+        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+            arguments: arguments,
+            model: result,
+            sourceRows: items,
+            viewRowsPath: "items_view",
+            title: "Active Directory: GPO changes (preview)",
+            maxTop: MaxViewTop,
+            baseTruncated: truncated,
+            response: out var response,
+            scanned: scanned,
+            metaMutate: meta => {
+                meta.Add("domain_name", domainName);
+                meta.Add("max_results", maxResults);
+                if (sinceUtc.HasValue) {
+                    meta.Add("since_utc", ToolTime.FormatUtc(sinceUtc));
+                }
+            });
+        return Task.FromResult(response);
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ActiveDirectory/AdGpoHealthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ActiveDirectory/AdGpoHealthTool.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ADPlayground;
+using ADPlayground.Gpo;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+
+namespace IntelligenceX.Tools.ActiveDirectory;
+
+/// <summary>
+/// Evaluates health for one or more GPO IDs using LDAP + SYSVOL probes (read-only, capped).
+/// </summary>
+public sealed class AdGpoHealthTool : ActiveDirectoryToolBase, ITool {
+    private const int MaxViewTop = 5000;
+
+    private static readonly ToolDefinition DefinitionValue = new(
+        "ad_gpo_health",
+        "Evaluate LDAP/SYSVOL health for one or more GPO IDs (read-only, capped).",
+        ToolSchema.Object(
+                ("domain_name", ToolSchema.String("Optional domain DNS name. Defaults to current domain when available.")),
+                ("gpo_ids", ToolSchema.Array(ToolSchema.String("GPO GUID in standard format (with or without braces)."), "GPO GUIDs to evaluate.")),
+                ("max_results", ToolSchema.Integer("Maximum GPO IDs to process (capped).")))
+            .WithTableViewOptions()
+            .Required("gpo_ids")
+            .NoAdditionalProperties());
+
+    private sealed record AdGpoHealthResult(
+        string DomainName,
+        int RequestedCount,
+        bool Truncated,
+        IReadOnlyList<GpoHealthRow> Rows);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AdGpoHealthTool"/> class.
+    /// </summary>
+    public AdGpoHealthTool(ActiveDirectoryToolOptions options) : base(options) { }
+
+    /// <inheritdoc />
+    public override ToolDefinition Definition => DefinitionValue;
+
+    /// <inheritdoc />
+    protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var domainName = ResolveDomainName(arguments);
+        if (string.IsNullOrWhiteSpace(domainName)) {
+            return Task.FromResult(ToolResponse.Error(
+                "not_configured",
+                "domain_name is required when the current domain cannot be discovered.",
+                hints: new[] {
+                    "Pass domain_name explicitly (for example: corp.contoso.com).",
+                    "Call ad_environment_discover first to verify reachable domain context."
+                },
+                isTransient: false));
+        }
+
+        var rawIds = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("gpo_ids"));
+        if (rawIds.Count == 0) {
+            return Task.FromResult(ToolResponse.Error("invalid_argument", "gpo_ids must contain at least one GUID."));
+        }
+
+        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var requestedCount = rawIds.Count;
+        var truncated = requestedCount > maxResults;
+        if (rawIds.Count > maxResults) {
+            rawIds = rawIds.GetRange(0, maxResults);
+        }
+
+        var ids = new List<Guid>(rawIds.Count);
+        for (var i = 0; i < rawIds.Count; i++) {
+            var raw = rawIds[i];
+            if (!Guid.TryParse(raw, out var parsed)) {
+                return Task.FromResult(ToolResponse.Error("invalid_argument", $"gpo_ids[{i}] is not a valid GUID."));
+            }
+            ids.Add(parsed);
+        }
+
+        var rows = new List<GpoHealthRow>(ids.Count);
+        foreach (var id in ids) {
+            cancellationToken.ThrowIfCancellationRequested();
+            rows.Add(GpoHealthService.EvaluateSingle(domainName, id));
+        }
+
+        var result = new AdGpoHealthResult(
+            DomainName: domainName,
+            RequestedCount: requestedCount,
+            Truncated: truncated,
+            Rows: rows);
+
+        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+            arguments: arguments,
+            model: result,
+            sourceRows: rows,
+            viewRowsPath: "rows_view",
+            title: "Active Directory: GPO health (preview)",
+            maxTop: MaxViewTop,
+            baseTruncated: truncated,
+            response: out var response,
+            scanned: rows.Count,
+            metaMutate: meta => {
+                meta.Add("domain_name", domainName);
+                meta.Add("requested_count", requestedCount);
+                meta.Add("processed_count", rows.Count);
+                meta.Add("max_results", maxResults);
+            });
+        return Task.FromResult(response);
+    }
+
+    private static string? ResolveDomainName(JsonObject? arguments) {
+        var explicitDomainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
+        if (!string.IsNullOrWhiteSpace(explicitDomainName)) {
+            return explicitDomainName;
+        }
+
+        return DomainHelper.TryGetCurrentDomainName(out var currentDomain) && !string.IsNullOrWhiteSpace(currentDomain)
+            ? currentDomain
+            : null;
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ActiveDirectory/AdGpoListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ActiveDirectory/AdGpoListTool.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ADPlayground.Gpo;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+
+namespace IntelligenceX.Tools.ActiveDirectory;
+
+/// <summary>
+/// Lists Group Policy Objects across a forest or a single domain (read-only, capped).
+/// </summary>
+public sealed class AdGpoListTool : ActiveDirectoryToolBase, ITool {
+    private const int MaxViewTop = 5000;
+
+    private static readonly IReadOnlyDictionary<string, GpoConsistency> ConsistencyByName =
+        new Dictionary<string, GpoConsistency>(StringComparer.OrdinalIgnoreCase) {
+            ["ad_and_sysvol"] = GpoConsistency.AdAndSysvol,
+            ["ad_only"] = GpoConsistency.AdOnly,
+            ["sysvol_only"] = GpoConsistency.SysvolOnly
+        };
+
+    private static readonly IReadOnlyDictionary<string, GpoLinkState> LinkStateByName =
+        new Dictionary<string, GpoLinkState>(StringComparer.OrdinalIgnoreCase) {
+            ["unlinked"] = GpoLinkState.Unlinked,
+            ["linked_enabled"] = GpoLinkState.LinkedEnabled,
+            ["linked_disabled"] = GpoLinkState.LinkedDisabled,
+            ["linked_broken"] = GpoLinkState.LinkedBroken
+        };
+
+    private static readonly IReadOnlyDictionary<GpoConsistency, string> ConsistencyNames =
+        new Dictionary<GpoConsistency, string> {
+            [GpoConsistency.AdAndSysvol] = "ad_and_sysvol",
+            [GpoConsistency.AdOnly] = "ad_only",
+            [GpoConsistency.SysvolOnly] = "sysvol_only"
+        };
+
+    private static readonly IReadOnlyDictionary<GpoLinkState, string> LinkStateNames =
+        new Dictionary<GpoLinkState, string> {
+            [GpoLinkState.Unlinked] = "unlinked",
+            [GpoLinkState.LinkedEnabled] = "linked_enabled",
+            [GpoLinkState.LinkedDisabled] = "linked_disabled",
+            [GpoLinkState.LinkedBroken] = "linked_broken"
+        };
+
+    private static readonly ToolDefinition DefinitionValue = new(
+        "ad_gpo_list",
+        "List Group Policy Objects across a forest or domain with optional filters (read-only, capped).",
+        ToolSchema.Object(
+                ("forest_name", ToolSchema.String("Optional forest DNS name (defaults to current forest).")),
+                ("domain_name", ToolSchema.String("Optional domain DNS name filter.")),
+                ("name_contains", ToolSchema.String("Optional case-insensitive substring filter for GPO display name.")),
+                ("consistency", ToolSchema.String("Optional GPO AD/SYSVOL consistency filter.").Enum("any", "ad_and_sysvol", "ad_only", "sysvol_only")),
+                ("link_state", ToolSchema.String("Optional link-state filter.").Enum("any", "unlinked", "linked_enabled", "linked_disabled", "linked_broken")),
+                ("modified_since_utc", ToolSchema.String("Optional ISO-8601 UTC lower bound for last modification timestamp.")),
+                ("max_results", ToolSchema.Integer("Maximum rows to return (capped).")))
+            .WithTableViewOptions()
+            .NoAdditionalProperties());
+
+    private sealed record AdGpoListResult(
+        string? ForestName,
+        string? DomainName,
+        int Scanned,
+        bool Truncated,
+        IReadOnlyList<GpoListItem> Items);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AdGpoListTool"/> class.
+    /// </summary>
+    public AdGpoListTool(ActiveDirectoryToolOptions options) : base(options) { }
+
+    /// <inheritdoc />
+    public override ToolDefinition Definition => DefinitionValue;
+
+    /// <inheritdoc />
+    protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
+        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
+        var nameContains = ToolArgs.GetOptionalTrimmed(arguments, "name_contains");
+
+        if (!ToolEnumBinders.TryParseOptional(
+                ToolArgs.GetOptionalTrimmed(arguments, "consistency"),
+                ConsistencyByName,
+                "consistency",
+                out GpoConsistency? consistency,
+                out var consistencyError)) {
+            return Task.FromResult(ToolResponse.Error("invalid_argument", consistencyError ?? "Invalid consistency value."));
+        }
+
+        if (!ToolEnumBinders.TryParseOptional(
+                ToolArgs.GetOptionalTrimmed(arguments, "link_state"),
+                LinkStateByName,
+                "link_state",
+                out GpoLinkState? linkState,
+                out var linkStateError)) {
+            return Task.FromResult(ToolResponse.Error("invalid_argument", linkStateError ?? "Invalid link_state value."));
+        }
+
+        if (!ToolTime.TryParseUtcOptional(ToolArgs.GetOptionalTrimmed(arguments, "modified_since_utc"), out var modifiedSinceUtc, out var modifiedSinceError)) {
+            return Task.FromResult(ToolResponse.Error("invalid_argument", $"modified_since_utc: {modifiedSinceError}"));
+        }
+
+        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var items = new List<GpoListItem>(Math.Min(maxResults, 512));
+        var scanned = 0;
+        var truncated = false;
+
+        try {
+            foreach (var item in GpoListService.GetList(forestName, domainName)) {
+                cancellationToken.ThrowIfCancellationRequested();
+                scanned++;
+
+                if (!Matches(item, nameContains, modifiedSinceUtc, consistency, linkState)) {
+                    continue;
+                }
+
+                if (items.Count >= maxResults) {
+                    truncated = true;
+                    break;
+                }
+
+                items.Add(item);
+            }
+        } catch (ArgumentException ex) {
+            return Task.FromResult(ToolResponse.Error("invalid_argument", ex.Message));
+        } catch (InvalidOperationException ex) {
+            return Task.FromResult(ToolResponse.Error("query_failed", ex.Message));
+        } catch (Exception ex) {
+            return Task.FromResult(ToolResponse.Error("query_failed", $"GPO list query failed: {ex.Message}"));
+        }
+
+        var result = new AdGpoListResult(
+            ForestName: forestName,
+            DomainName: domainName,
+            Scanned: scanned,
+            Truncated: truncated,
+            Items: items);
+
+        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+            arguments: arguments,
+            model: result,
+            sourceRows: items,
+            viewRowsPath: "items_view",
+            title: "Active Directory: GPO list (preview)",
+            maxTop: MaxViewTop,
+            baseTruncated: truncated,
+            response: out var response,
+            scanned: scanned,
+            metaMutate: meta => {
+                meta.Add("max_results", maxResults);
+                if (!string.IsNullOrWhiteSpace(domainName)) {
+                    meta.Add("domain_name", domainName);
+                }
+                if (!string.IsNullOrWhiteSpace(forestName)) {
+                    meta.Add("forest_name", forestName);
+                }
+                if (!string.IsNullOrWhiteSpace(nameContains)) {
+                    meta.Add("name_contains", nameContains);
+                }
+                if (consistency.HasValue) {
+                    meta.Add("consistency", ToolEnumBinders.ToName(consistency.Value, ConsistencyNames));
+                }
+                if (linkState.HasValue) {
+                    meta.Add("link_state", ToolEnumBinders.ToName(linkState.Value, LinkStateNames));
+                }
+                if (modifiedSinceUtc.HasValue) {
+                    meta.Add("modified_since_utc", ToolTime.FormatUtc(modifiedSinceUtc));
+                }
+            });
+        return Task.FromResult(response);
+    }
+
+    private static bool Matches(
+        GpoListItem item,
+        string? nameContains,
+        DateTime? modifiedSinceUtc,
+        GpoConsistency? consistency,
+        GpoLinkState? linkState) {
+        if (!string.IsNullOrWhiteSpace(nameContains) &&
+            item.DisplayName.IndexOf(nameContains, StringComparison.OrdinalIgnoreCase) < 0) {
+            return false;
+        }
+
+        if (modifiedSinceUtc.HasValue && item.Modified.ToUniversalTime() < modifiedSinceUtc.Value) {
+            return false;
+        }
+
+        if (consistency.HasValue && item.Consistency != consistency.Value) {
+            return false;
+        }
+
+        if (linkState.HasValue && item.LinkState != linkState.Value) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ActiveDirectory/AdPackInfoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ActiveDirectory/AdPackInfoTool.cs
@@ -35,6 +35,7 @@ public sealed class AdPackInfoTool : ActiveDirectoryToolBase, ITool {
                 "Call ad_environment_discover first to learn effective domain_controller/search_base_dn and candidate DCs.",
                 "Use ad_forest_discover to make forest scope explicit and get a receipt (domains/trusts/DCs discovered and how).",
                 "Use ad_search/ad_groups_list/ad_spn_search for broad discovery.",
+                "Use ad_gpo_list/ad_gpo_changes/ad_gpo_health for GPO inventory, timeline, and hygiene diagnostics.",
                 "Use ad_object_resolve to avoid N+1 object lookups when correlating identities.",
                 "Use ad_ldap_query_paged for large exploratory queries and continue with cursor.",
                 "Use ad_search_facets/ad_replication_summary/ad_delegation_audit/ad_spn_stats for aggregated diagnostics.",
@@ -44,6 +45,9 @@ public sealed class AdPackInfoTool : ActiveDirectoryToolBase, ITool {
                 ToolPackGuidance.FlowStep(
                     goal: "Discover candidate AD objects",
                     suggestedTools: new[] { "ad_search", "ad_groups_list", "ad_spn_search" }),
+                ToolPackGuidance.FlowStep(
+                    goal: "Assess GPO inventory, changes, and health",
+                    suggestedTools: new[] { "ad_gpo_list", "ad_gpo_changes", "ad_gpo_health" }),
                 ToolPackGuidance.FlowStep(
                     goal: "Discover forest scope and enumerate domains/DCs/trusts",
                     suggestedTools: new[] { "ad_forest_discover" }),
@@ -70,6 +74,10 @@ public sealed class AdPackInfoTool : ActiveDirectoryToolBase, ITool {
                     id: "ad_diagnostics",
                     summary: "Provide LDAP diagnostics and aggregated security/replication insights.",
                     primaryTools: new[] { "ad_ldap_diagnostics", "ad_search_facets", "ad_replication_summary", "ad_delegation_audit", "ad_spn_stats" }),
+                ToolPackGuidance.Capability(
+                    id: "gpo_hygiene",
+                    summary: "Inspect Group Policy inventory, modification history, and AD/SYSVOL health state.",
+                    primaryTools: new[] { "ad_gpo_list", "ad_gpo_changes", "ad_gpo_health" }),
                 ToolPackGuidance.Capability(
                     id: "ad_runtime_monitoring",
                     summary: "Run ADPlayground.Monitoring probes (ldap/dns/kerberos/ntp/replication) for server or domain scope.",

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ActiveDirectory/ToolRegistryActiveDirectoryExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ActiveDirectory/ToolRegistryActiveDirectoryExtensions.cs
@@ -60,6 +60,9 @@ public static class ToolRegistryActiveDirectoryExtensions {
         yield return new AdPackInfoTool(options);
         yield return new AdEnvironmentDiscoverTool(options);
         yield return new AdForestDiscoverTool(options);
+        yield return new AdGpoListTool(options);
+        yield return new AdGpoChangesTool(options);
+        yield return new AdGpoHealthTool(options);
         yield return new AdDomainInfoTool(options);
         yield return new AdDomainControllersTool(options);
         yield return new AdSpnSearchTool(options);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolTableView.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolTableView.cs
@@ -128,26 +128,41 @@ public static class ToolTableView {
             return false;
         }
 
-        var allowed = new HashSet<string>(allowedColumns.Where(static x => !string.IsNullOrWhiteSpace(x)), StringComparer.OrdinalIgnoreCase);
+        var allowedList = allowedColumns
+            .Where(static x => !string.IsNullOrWhiteSpace(x))
+            .Select(static x => x.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var allowed = new HashSet<string>(allowedList, StringComparer.OrdinalIgnoreCase);
         if (allowed.Count == 0) {
             error = "No columns are available for projection.";
             return false;
         }
 
-        var requestedColumns = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("columns"));
-        if (requestedColumns.Count > 0) {
-            foreach (var column in requestedColumns) {
-                if (!allowed.Contains(column)) {
+        var requestedColumnsRaw = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("columns"));
+        var requestedColumns = new List<string>(requestedColumnsRaw.Count);
+        var seenRequestedColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (requestedColumnsRaw.Count > 0) {
+            foreach (var column in requestedColumnsRaw) {
+                if (!TryResolveAllowedColumnKey(column, allowedList, allowed, out var resolved)) {
                     error = $"columns contains unsupported value '{column}'.";
                     return false;
+                }
+
+                if (seenRequestedColumns.Add(resolved)) {
+                    requestedColumns.Add(resolved);
                 }
             }
         }
 
         var sortBy = ToolArgs.GetOptionalTrimmed(arguments, "sort_by");
-        if (!string.IsNullOrWhiteSpace(sortBy) && !allowed.Contains(sortBy)) {
-            error = $"sort_by must be one of: {string.Join(", ", allowedColumns)}.";
-            return false;
+        if (!string.IsNullOrWhiteSpace(sortBy)) {
+            if (!TryResolveAllowedColumnKey(sortBy, allowedList, allowed, out var resolvedSortBy)) {
+                error = $"sort_by must be one of: {string.Join(", ", allowedColumns)}.";
+                return false;
+            }
+
+            sortBy = resolvedSortBy;
         }
 
         var sortDirection = ToolTableSortDirection.Asc;
@@ -172,6 +187,98 @@ public static class ToolTableView {
             Top = top
         };
         return true;
+    }
+
+    private static bool TryResolveAllowedColumnKey(
+        string? requested,
+        IReadOnlyList<string> allowedList,
+        IReadOnlySet<string> allowedSet,
+        out string resolved) {
+        resolved = string.Empty;
+        var requestedTrimmed = (requested ?? string.Empty).Trim();
+        if (requestedTrimmed.Length == 0) {
+            return false;
+        }
+
+        if (allowedSet.Contains(requestedTrimmed)) {
+            // Keep canonical casing/spelling from allowed columns.
+            for (var i = 0; i < allowedList.Count; i++) {
+                if (string.Equals(allowedList[i], requestedTrimmed, StringComparison.OrdinalIgnoreCase)) {
+                    resolved = allowedList[i];
+                    return true;
+                }
+            }
+
+            resolved = requestedTrimmed;
+            return true;
+        }
+
+        var requestedCanonical = CanonicalizeColumnKey(requestedTrimmed);
+        if (requestedCanonical.Length == 0) {
+            return false;
+        }
+
+        var canonicalMatches = FindCanonicalMatches(requestedCanonical, allowedList, requireSuffixMatch: false);
+        if (canonicalMatches.Count == 1) {
+            resolved = canonicalMatches[0];
+            return true;
+        }
+        if (canonicalMatches.Count > 1) {
+            return false;
+        }
+
+        // Fuzzy fallback for common model aliases like "deprecated" -> "is_deprecated".
+        var suffixMatches = FindCanonicalMatches(requestedCanonical, allowedList, requireSuffixMatch: true);
+        if (suffixMatches.Count == 1) {
+            resolved = suffixMatches[0];
+            return true;
+        }
+
+        return false;
+    }
+
+    private static List<string> FindCanonicalMatches(string requestedCanonical, IReadOnlyList<string> allowedList, bool requireSuffixMatch) {
+        var matches = new List<string>();
+        for (var i = 0; i < allowedList.Count; i++) {
+            var candidate = allowedList[i];
+            var candidateCanonical = CanonicalizeColumnKey(candidate);
+            if (candidateCanonical.Length == 0) {
+                continue;
+            }
+
+            if (!requireSuffixMatch) {
+                if (string.Equals(candidateCanonical, requestedCanonical, StringComparison.OrdinalIgnoreCase)) {
+                    matches.Add(candidate);
+                }
+                continue;
+            }
+
+            if (candidateCanonical.Length >= requestedCanonical.Length
+                && candidateCanonical.EndsWith(requestedCanonical, StringComparison.OrdinalIgnoreCase)) {
+                matches.Add(candidate);
+            }
+        }
+
+        return matches;
+    }
+
+    private static string CanonicalizeColumnKey(string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return string.Empty;
+        }
+
+        Span<char> buffer = stackalloc char[value.Length];
+        var index = 0;
+        for (var i = 0; i < value.Length; i++) {
+            var ch = value[i];
+            if (!char.IsLetterOrDigit(ch)) {
+                continue;
+            }
+
+            buffer[index++] = char.ToLowerInvariant(ch);
+        }
+
+        return index == 0 ? string.Empty : new string(buffer[..index]);
     }
 
     /// <summary>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsCatalogTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsCatalogTool.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+
+namespace IntelligenceX.Tools.EventLog;
+
+/// <summary>
+/// Lists EventViewerX named-event rules that can be queried by the named-events tool surface.
+/// </summary>
+public sealed class EventLogNamedEventsCatalogTool : EventLogToolBase, ITool {
+    private const int MaxViewTop = 5000;
+    private const int MaxCategoryFilters = 16;
+    private const int MaxEventIdsPerRowCap = 256;
+    private static readonly string[] CategoryNames = EventLogNamedEventsHelper.GetKnownCategories().ToArray();
+
+    private static readonly ToolDefinition DefinitionValue = new(
+        "eventlog_named_events_catalog",
+        "List EventViewerX named-event rules with query aliases, categories, channels, and mapped Event IDs.",
+        ToolSchema.Object(
+                ("name_contains", ToolSchema.String("Optional case-insensitive filter applied to enum_name/query_name/category.")),
+                ("categories", ToolSchema.Array(ToolSchema.String("Category name (for example: active_directory, kerberos, group_policy).").Enum(CategoryNames), "Optional category filter list.")),
+                ("available_only", ToolSchema.Boolean("When true, return only named events with discovered log/event-id mappings.")),
+                ("include_event_ids", ToolSchema.Boolean("When true, include event_ids arrays in each row (default true).")),
+                ("max_event_ids_per_row", ToolSchema.Integer("Maximum event IDs returned per row when include_event_ids=true (capped).")),
+                ("max_results", ToolSchema.Integer("Maximum rows to return (capped).")))
+            .WithTableViewOptions()
+            .NoAdditionalProperties());
+
+    private sealed record NamedEventsCatalogViewRow(
+        string EnumName,
+        string QueryName,
+        string Category,
+        IReadOnlyList<string> LogNames,
+        IReadOnlyList<int> EventIds,
+        int EventIdCount,
+        bool Available);
+
+    private sealed record NamedEventsCatalogResult(
+        int Total,
+        int Matched,
+        bool Truncated,
+        bool IncludeEventIds,
+        int MaxEventIdsPerRow,
+        IReadOnlyList<NamedEventsCatalogViewRow> Items);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventLogNamedEventsCatalogTool"/> class.
+    /// </summary>
+    public EventLogNamedEventsCatalogTool(EventLogToolOptions options) : base(options) { }
+
+    /// <inheritdoc />
+    public override ToolDefinition Definition => DefinitionValue;
+
+    /// <inheritdoc />
+    protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var filter = ToolArgs.GetOptionalTrimmed(arguments, "name_contains");
+        var availableOnly = ToolArgs.GetBoolean(arguments, "available_only");
+        var includeEventIds = arguments?.GetBoolean("include_event_ids") ?? true;
+        var maxEventIdsPerRow = ToolArgs.GetCappedInt32(arguments, "max_event_ids_per_row", 32, 1, MaxEventIdsPerRowCap);
+        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+
+        var categoriesFilter = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("categories"));
+        List<string>? categories = null;
+        if (categoriesFilter.Count > 0) {
+            if (!EventLogNamedEventsHelper.TryParseCategories(categoriesFilter, MaxCategoryFilters, out var parsedCategories, out var categoryError)) {
+                return Task.FromResult(ToolResponse.Error("invalid_argument", categoryError ?? "Invalid categories argument."));
+            }
+
+            categories = parsedCategories;
+        }
+
+        var all = EventLogNamedEventsHelper.GetCatalogRows();
+        IEnumerable<EventLogNamedEventCatalogRow> query = all;
+        if (!string.IsNullOrWhiteSpace(filter)) {
+            query = query.Where(row =>
+                row.EnumName.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                row.QueryName.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                row.Category.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+        if (categories is not null && categories.Count > 0) {
+            var set = new HashSet<string>(categories, StringComparer.OrdinalIgnoreCase);
+            query = query.Where(row => set.Contains(row.Category));
+        }
+        if (availableOnly) {
+            query = query.Where(static row => row.Available);
+        }
+
+        var matchedRows = query.ToList();
+        var truncated = matchedRows.Count > maxResults;
+        var selectedRawRows = truncated ? matchedRows.Take(maxResults).ToList() : matchedRows;
+        var selectedRows = selectedRawRows
+            .Select(row => new NamedEventsCatalogViewRow(
+                EnumName: row.EnumName,
+                QueryName: row.QueryName,
+                Category: row.Category,
+                LogNames: row.LogNames,
+                EventIds: includeEventIds ? row.EventIds.Take(maxEventIdsPerRow).ToArray() : Array.Empty<int>(),
+                EventIdCount: row.EventIdCount,
+                Available: row.Available))
+            .ToList();
+
+        var result = new NamedEventsCatalogResult(
+            Total: all.Count,
+            Matched: matchedRows.Count,
+            Truncated: truncated,
+            IncludeEventIds: includeEventIds,
+            MaxEventIdsPerRow: maxEventIdsPerRow,
+            Items: selectedRows);
+
+        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+            arguments: arguments,
+            model: result,
+            sourceRows: selectedRows,
+            viewRowsPath: "items_view",
+            title: "Named events catalog (preview)",
+            maxTop: MaxViewTop,
+            baseTruncated: truncated,
+            response: out var response,
+            scanned: selectedRows.Count,
+            metaMutate: meta => {
+                meta.Add("total", all.Count);
+                meta.Add("matched", matchedRows.Count);
+                meta.Add("max_results", maxResults);
+                meta.Add("available_only", availableOnly);
+                meta.Add("include_event_ids", includeEventIds);
+                if (includeEventIds) {
+                    meta.Add("max_event_ids_per_row", maxEventIdsPerRow);
+                }
+                if (!string.IsNullOrWhiteSpace(filter)) {
+                    meta.Add("name_contains", filter);
+                }
+                if (categories is not null && categories.Count > 0) {
+                    meta.Add("categories", ToolJson.ToJsonArray(categories));
+                }
+            });
+        return Task.FromResult(response);
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsHelper.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsHelper.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EventViewerX;
+
+namespace IntelligenceX.Tools.EventLog;
+
+internal static class EventLogNamedEventsHelper {
+    private static readonly Lazy<IReadOnlyList<EventLogNamedEventCatalogRow>> CatalogRows = new(BuildCatalogRows);
+    private static readonly IReadOnlyDictionary<string, NamedEvents> ParseMap = BuildParseMap();
+    private static readonly IReadOnlyList<string> KnownCategories = BuildKnownCategories();
+
+    internal static IReadOnlyList<EventLogNamedEventCatalogRow> GetCatalogRows() {
+        return CatalogRows.Value;
+    }
+
+    internal static bool TryParseMany(
+        IReadOnlyList<string> values,
+        int maxItems,
+        out List<NamedEvents> parsed,
+        out string? error) {
+        parsed = new List<NamedEvents>();
+        error = null;
+
+        if (values is null || values.Count == 0) {
+            error = "named_events must contain at least one value.";
+            return false;
+        }
+
+        if (maxItems > 0 && values.Count > maxItems) {
+            error = $"named_events supports at most {maxItems} values per call.";
+            return false;
+        }
+
+        var seen = new HashSet<NamedEvents>();
+        for (var i = 0; i < values.Count; i++) {
+            var value = values[i];
+            if (!TryParseOne(value, out var parsedValue)) {
+                error = $"named_events[{i}] ('{value}') is not recognized. Call eventlog_named_events_catalog to list valid names.";
+                return false;
+            }
+
+            if (seen.Add(parsedValue)) {
+                parsed.Add(parsedValue);
+            }
+        }
+
+        if (parsed.Count == 0) {
+            error = "named_events must contain at least one valid value.";
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool TryParseOne(string? value, out NamedEvents parsed) {
+        parsed = default;
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        var normalized = NormalizeKey(value);
+        return ParseMap.TryGetValue(normalized, out parsed);
+    }
+
+    internal static string GetEnumName(NamedEvents value) {
+        return value.ToString();
+    }
+
+    internal static string GetQueryName(NamedEvents value) {
+        return ToSnakeCase(value.ToString());
+    }
+
+    internal static string GetCategory(NamedEvents value) {
+        return ResolveCategory(value.ToString());
+    }
+
+    internal static IReadOnlyList<string> GetKnownCategories() {
+        return KnownCategories;
+    }
+
+    internal static bool TryNormalizeCategory(string? value, out string normalized) {
+        normalized = string.Empty;
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        var candidate = ToSnakeCase(value.Trim());
+        if (string.IsNullOrWhiteSpace(candidate)) {
+            return false;
+        }
+
+        for (var i = 0; i < KnownCategories.Count; i++) {
+            var known = KnownCategories[i];
+            if (string.Equals(known, candidate, StringComparison.OrdinalIgnoreCase)) {
+                normalized = known;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool TryParseCategories(
+        IReadOnlyList<string> values,
+        int maxItems,
+        out List<string> categories,
+        out string? error) {
+        categories = new List<string>();
+        error = null;
+
+        if (values is null || values.Count == 0) {
+            error = "categories must contain at least one value.";
+            return false;
+        }
+
+        if (maxItems > 0 && values.Count > maxItems) {
+            error = $"categories supports at most {maxItems} values per call.";
+            return false;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < values.Count; i++) {
+            var value = values[i];
+            if (!TryNormalizeCategory(value, out var normalized)) {
+                error = $"categories[{i}] ('{value}') is not recognized. Call eventlog_named_events_catalog to list valid categories.";
+                return false;
+            }
+
+            if (seen.Add(normalized)) {
+                categories.Add(normalized);
+            }
+        }
+
+        if (categories.Count == 0) {
+            error = "categories must contain at least one valid value.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static IReadOnlyList<EventLogNamedEventCatalogRow> BuildCatalogRows() {
+        var rows = new List<EventLogNamedEventCatalogRow>();
+        foreach (var value in Enum.GetValues<NamedEvents>().OrderBy(static x => x.ToString(), StringComparer.OrdinalIgnoreCase)) {
+            var enumName = value.ToString();
+            var queryName = ToSnakeCase(enumName);
+            var category = GetCategory(value);
+
+            var mapping = EventObjectSlim.GetEventInfoForNamedEvents(new List<NamedEvents> { value });
+            var logNames = mapping.Keys
+                .Where(static x => !string.IsNullOrWhiteSpace(x))
+                .OrderBy(static x => x, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var eventIds = mapping.Values
+                .SelectMany(static x => x)
+                .Distinct()
+                .OrderBy(static x => x)
+                .ToArray();
+
+            rows.Add(new EventLogNamedEventCatalogRow(
+                EnumName: enumName,
+                QueryName: queryName,
+                Category: category,
+                LogNames: logNames,
+                EventIds: eventIds,
+                EventIdCount: eventIds.Length,
+                Available: logNames.Length > 0 && eventIds.Length > 0));
+        }
+
+        return rows;
+    }
+
+    private static IReadOnlyDictionary<string, NamedEvents> BuildParseMap() {
+        var map = new Dictionary<string, NamedEvents>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in Enum.GetValues<NamedEvents>()) {
+            var enumName = value.ToString();
+            map[NormalizeKey(enumName)] = value;
+            map[NormalizeKey(ToSnakeCase(enumName))] = value;
+        }
+        return map;
+    }
+
+    private static IReadOnlyList<string> BuildKnownCategories() {
+        var categories = Enum.GetValues<NamedEvents>()
+            .Select(GetCategory)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return categories;
+    }
+
+    private static string ResolveCategory(string enumName) {
+        if (enumName.StartsWith("AD", StringComparison.Ordinal)) {
+            return "active_directory";
+        }
+        if (enumName.StartsWith("Gpo", StringComparison.OrdinalIgnoreCase)) {
+            return "group_policy";
+        }
+        if (enumName.StartsWith("Kerberos", StringComparison.OrdinalIgnoreCase)) {
+            return "kerberos";
+        }
+        if (enumName.StartsWith("IIS", StringComparison.OrdinalIgnoreCase)) {
+            return "iis";
+        }
+        if (enumName.StartsWith("HyperV", StringComparison.OrdinalIgnoreCase)) {
+            return "hyperv";
+        }
+        if (enumName.StartsWith("AAD", StringComparison.OrdinalIgnoreCase)) {
+            return "azure_ad";
+        }
+        if (enumName.StartsWith("Sql", StringComparison.OrdinalIgnoreCase)) {
+            return "sql";
+        }
+        if (enumName.StartsWith("Dhcp", StringComparison.OrdinalIgnoreCase)) {
+            return "dhcp";
+        }
+        if (enumName.StartsWith("Network", StringComparison.OrdinalIgnoreCase)) {
+            return "network";
+        }
+        if (enumName.StartsWith("BitLocker", StringComparison.OrdinalIgnoreCase)) {
+            return "bitlocker";
+        }
+        if (enumName.StartsWith("Logs", StringComparison.OrdinalIgnoreCase)) {
+            return "logging";
+        }
+        if (enumName.StartsWith("OS", StringComparison.OrdinalIgnoreCase)) {
+            return "os";
+        }
+        if (enumName.StartsWith("ClientGroupPolicies", StringComparison.OrdinalIgnoreCase)) {
+            return "group_policy_client";
+        }
+
+        return "other";
+    }
+
+    private static string NormalizeKey(string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(value.Length);
+        for (var i = 0; i < value.Length; i++) {
+            var c = value[i];
+            if (char.IsLetterOrDigit(c)) {
+                sb.Append(char.ToLowerInvariant(c));
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string ToSnakeCase(string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(value.Length + 8);
+        for (var i = 0; i < value.Length; i++) {
+            var c = value[i];
+            if (!char.IsLetterOrDigit(c)) {
+                if (sb.Length > 0 && sb[^1] != '_') {
+                    sb.Append('_');
+                }
+                continue;
+            }
+
+            if (i > 0) {
+                var prev = value[i - 1];
+                var next = i + 1 < value.Length ? value[i + 1] : '\0';
+
+                var shouldSplitUpper =
+                    char.IsUpper(c) &&
+                    (char.IsLower(prev) || char.IsDigit(prev) || (char.IsUpper(prev) && next != '\0' && char.IsLower(next)));
+                var shouldSplitDigit = char.IsDigit(c) && !char.IsDigit(prev);
+                var shouldSplitLetter = char.IsLetter(c) && char.IsDigit(prev);
+
+                if ((shouldSplitUpper || shouldSplitDigit || shouldSplitLetter) && sb.Length > 0 && sb[^1] != '_') {
+                    sb.Append('_');
+                }
+            }
+
+            sb.Append(char.ToLowerInvariant(c));
+        }
+
+        return sb.ToString().Trim('_');
+    }
+}
+
+internal sealed record EventLogNamedEventCatalogRow(
+    string EnumName,
+    string QueryName,
+    string Category,
+    IReadOnlyList<string> LogNames,
+    IReadOnlyList<int> EventIds,
+    int EventIdCount,
+    bool Available);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryTool.cs
@@ -1,0 +1,509 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using EventViewerX;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+
+namespace IntelligenceX.Tools.EventLog;
+
+/// <summary>
+/// Queries EventViewerX named-event rules and returns normalized rows for agent reasoning.
+/// </summary>
+public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
+    private const int MaxNamedEvents = 24;
+    private const int MaxCategoryFilters = 16;
+    private const int MaxMachines = 32;
+    private const int MaxPayloadKeys = 64;
+    private const int MaxThreadsCap = 8;
+    private const int MaxViewTop = 5000;
+
+    private static readonly string[] CategoryNames = EventLogNamedEventsHelper.GetKnownCategories().ToArray();
+    private static readonly string[] TimePeriodNames = Enum.GetValues<TimePeriod>()
+        .Select(static value => ToSnakeCase(value.ToString()))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .OrderBy(static x => x, StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+    private static readonly IReadOnlyDictionary<string, TimePeriod> TimePeriodByName = BuildTimePeriodMap();
+
+    private static readonly ToolDefinition DefinitionValue = new(
+        "eventlog_named_events_query",
+        "Query EventViewerX named-event rules (for example AD/Kerberos/GPO detections) with optional machine/time filters.",
+        ToolSchema.Object(
+                ("named_events", ToolSchema.Array(ToolSchema.String("Named event identifier (enum_name or query_name from eventlog_named_events_catalog)."), "Named events to execute.")),
+                ("categories", ToolSchema.Array(ToolSchema.String("Named-event category from eventlog_named_events_catalog.").Enum(CategoryNames), "Optional category list used to expand named_events.")),
+                ("machine_name", ToolSchema.String("Optional single remote machine name/FQDN. Omit for local machine.")),
+                ("machine_names", ToolSchema.Array(ToolSchema.String(), "Optional remote machine names/FQDNs. Combined with machine_name.")),
+                ("time_period", ToolSchema.String("Optional relative time window. Mutually exclusive with start_time_utc/end_time_utc.").Enum(TimePeriodNames)),
+                ("start_time_utc", ToolSchema.String("ISO-8601 UTC lower bound (optional).")),
+                ("end_time_utc", ToolSchema.String("ISO-8601 UTC upper bound (optional).")),
+                ("log_name", ToolSchema.String("Optional exact log-name filter applied to normalized rows (for example Security/System/Application).")),
+                ("event_ids", ToolSchema.Array(ToolSchema.Integer(), "Optional Event ID filter applied after rule evaluation.")),
+                ("max_events_per_named_event", ToolSchema.Integer("Optional per-rule cap to prevent one named event from dominating results.")),
+                ("max_events", ToolSchema.Integer("Maximum events to return (capped).")),
+                ("max_threads", ToolSchema.Integer("Maximum query concurrency (capped).")),
+                ("include_payload", ToolSchema.Boolean("When true, include payload object (default true).")),
+                ("payload_keys", ToolSchema.Array(ToolSchema.String("Payload field name in snake_case."), "Optional payload key allowlist when include_payload=true.")))
+            .WithTableViewOptions()
+            .NoAdditionalProperties());
+
+    private sealed record NamedEventsQueryRow(
+        string NamedEvent,
+        string RuleType,
+        int EventId,
+        long? RecordId,
+        string GatheredFrom,
+        string GatheredLogName,
+        string? WhenUtc,
+        string? Who,
+        string? ObjectAffected,
+        string? Computer,
+        string? Action,
+        object Payload);
+
+    private sealed record NamedEventsQueryResult(
+        IReadOnlyList<string> RequestedNamedEvents,
+        IReadOnlyList<string> EffectiveMachines,
+        DateTime? StartTimeUtc,
+        DateTime? EndTimeUtc,
+        int MaxEvents,
+        int MaxThreads,
+        bool Truncated,
+        IReadOnlyList<NamedEventsQueryRow> Events);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventLogNamedEventsQueryTool"/> class.
+    /// </summary>
+    public EventLogNamedEventsQueryTool(EventLogToolOptions options) : base(options) { }
+
+    /// <inheritdoc />
+    public override ToolDefinition Definition => DefinitionValue;
+
+    /// <inheritdoc />
+    protected override async Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var rawNamedEvents = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("named_events"));
+        var rawCategories = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("categories"));
+        if (rawNamedEvents.Count == 0 && rawCategories.Count == 0) {
+            return ToolResponse.Error("invalid_argument", "Provide at least one of: named_events, categories.");
+        }
+
+        var namedEvents = new List<NamedEvents>();
+        if (rawNamedEvents.Count > 0) {
+            if (!EventLogNamedEventsHelper.TryParseMany(rawNamedEvents, MaxNamedEvents, out var parsedNamedEvents, out var namedEventsError)) {
+                return ToolResponse.Error("invalid_argument", namedEventsError ?? "Invalid named_events argument.");
+            }
+
+            namedEvents.AddRange(parsedNamedEvents);
+        }
+
+        List<string>? categories = null;
+        if (rawCategories.Count > 0) {
+            if (!EventLogNamedEventsHelper.TryParseCategories(rawCategories, MaxCategoryFilters, out var parsedCategories, out var categoriesError)) {
+                return ToolResponse.Error("invalid_argument", categoriesError ?? "Invalid categories argument.");
+            }
+
+            categories = parsedCategories;
+            var categorySet = new HashSet<string>(categories, StringComparer.OrdinalIgnoreCase);
+            foreach (var namedEvent in Enum.GetValues<NamedEvents>()) {
+                if (!categorySet.Contains(EventLogNamedEventsHelper.GetCategory(namedEvent))) {
+                    continue;
+                }
+
+                if (!namedEvents.Contains(namedEvent)) {
+                    namedEvents.Add(namedEvent);
+                }
+            }
+        }
+
+        if (namedEvents.Count == 0) {
+            return ToolResponse.Error("invalid_argument", "No named events resolved from provided filters.");
+        }
+        if (namedEvents.Count > MaxNamedEvents) {
+            return ToolResponse.Error("invalid_argument", $"Resolved named events exceed limit ({MaxNamedEvents}). Narrow your filters.");
+        }
+
+        var timePeriodRaw = ToolArgs.GetOptionalTrimmed(arguments, "time_period");
+        var hasExplicitTimeRange = !string.IsNullOrWhiteSpace(ToolArgs.GetOptionalTrimmed(arguments, "start_time_utc")) ||
+                                   !string.IsNullOrWhiteSpace(ToolArgs.GetOptionalTrimmed(arguments, "end_time_utc"));
+        if (!string.IsNullOrWhiteSpace(timePeriodRaw) && hasExplicitTimeRange) {
+            return ToolResponse.Error("invalid_argument", "time_period cannot be combined with start_time_utc/end_time_utc.");
+        }
+
+        DateTime? startUtc;
+        DateTime? endUtc;
+        TimePeriod? timePeriod = null;
+        if (!string.IsNullOrWhiteSpace(timePeriodRaw)) {
+            if (!TryParseTimePeriod(timePeriodRaw, out var parsedTimePeriod, out var timePeriodError)) {
+                return ToolResponse.Error("invalid_argument", timePeriodError ?? "Invalid time_period value.");
+            }
+            timePeriod = parsedTimePeriod;
+            startUtc = null;
+            endUtc = null;
+        } else {
+            if (!ToolTime.TryParseUtcRange(arguments, "start_time_utc", "end_time_utc", out startUtc, out endUtc, out var timeErr)) {
+                return ToolResponse.Error("invalid_argument", timeErr ?? "Invalid time range.");
+            }
+        }
+
+        var logNameFilter = ToolArgs.GetOptionalTrimmed(arguments, "log_name");
+        var eventIds = ToolArgs.TryReadPositiveInt32Array(arguments?.GetArray("event_ids"), "event_ids", out var eventIdsError);
+        if (!string.IsNullOrWhiteSpace(eventIdsError)) {
+            return ToolResponse.Error("invalid_argument", eventIdsError);
+        }
+        var eventIdSet = eventIds is null ? null : new HashSet<int>(eventIds);
+
+        var maxEvents = ToolArgs.GetCappedInt32(arguments, "max_events", Options.MaxResults, 1, Options.MaxResults);
+        var maxThreads = ToolArgs.GetCappedInt32(arguments, "max_threads", 4, 1, MaxThreadsCap);
+        var maxEventsPerNamedEvent = ToolArgs.ToPositiveInt32OrNull(arguments?.GetInt64("max_events_per_named_event"), maxEvents);
+        var includePayload = arguments?.GetBoolean("include_payload") ?? true;
+        var payloadKeys = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("payload_keys"));
+        if (payloadKeys.Count > MaxPayloadKeys) {
+            return ToolResponse.Error("invalid_argument", $"payload_keys supports at most {MaxPayloadKeys} values.");
+        }
+        var payloadKeySet = payloadKeys.Count > 0
+            ? new HashSet<string>(payloadKeys.Select(ToSnakeCase), StringComparer.OrdinalIgnoreCase)
+            : null;
+
+        var machines = ResolveMachines(arguments, maxItems: MaxMachines);
+
+        var rows = new List<NamedEventsQueryRow>(Math.Min(maxEvents, 256));
+        var perNamedEventCount = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var filteredOut = 0;
+        var truncated = false;
+
+        try {
+            await foreach (var item in SearchEvents.FindEventsByNamedEvents(
+                               typeEventsList: namedEvents,
+                               machineNames: machines.Count > 0 ? machines.Cast<string?>().ToList() : null,
+                               startTime: startUtc,
+                               endTime: endUtc,
+                               timePeriod: timePeriod,
+                               maxThreads: maxThreads,
+                               maxEvents: maxEvents,
+                               cancellationToken: cancellationToken)) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var namedEventName = ResolveNamedEventName(item);
+                if (maxEventsPerNamedEvent.HasValue) {
+                    var currentCount = perNamedEventCount.TryGetValue(namedEventName, out var c) ? c : 0;
+                    if (currentCount >= maxEventsPerNamedEvent.Value) {
+                        filteredOut++;
+                        continue;
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(logNameFilter) &&
+                    !string.Equals(item.GatheredLogName, logNameFilter, StringComparison.OrdinalIgnoreCase)) {
+                    filteredOut++;
+                    continue;
+                }
+
+                if (eventIdSet is not null && !eventIdSet.Contains(item.EventID)) {
+                    filteredOut++;
+                    continue;
+                }
+
+                rows.Add(ToRow(item, namedEventName, includePayload, payloadKeySet));
+                perNamedEventCount[namedEventName] = perNamedEventCount.TryGetValue(namedEventName, out var count) ? count + 1 : 1;
+                if (rows.Count >= maxEvents) {
+                    truncated = true;
+                    break;
+                }
+            }
+        } catch (ArgumentException ex) {
+            return ToolResponse.Error("invalid_argument", ex.Message);
+        } catch (InvalidOperationException ex) {
+            return ToolResponse.Error("query_failed", ex.Message);
+        } catch (Exception ex) {
+            return ToolResponse.Error("query_failed", $"Named events query failed: {ex.Message}");
+        }
+
+        var result = new NamedEventsQueryResult(
+            RequestedNamedEvents: namedEvents.Select(EventLogNamedEventsHelper.GetQueryName).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(static x => x, StringComparer.OrdinalIgnoreCase).ToArray(),
+            EffectiveMachines: machines,
+            StartTimeUtc: startUtc,
+            EndTimeUtc: endUtc,
+            MaxEvents: maxEvents,
+            MaxThreads: maxThreads,
+            Truncated: truncated,
+            Events: rows);
+
+        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+            arguments: arguments,
+            model: result,
+            sourceRows: rows,
+            viewRowsPath: "events_view",
+            title: "Named events (preview)",
+            maxTop: MaxViewTop,
+            baseTruncated: truncated,
+            response: out var response,
+            scanned: rows.Count,
+            metaMutate: meta => {
+                meta.Add("requested_named_events_count", namedEvents.Count);
+                meta.Add("max_events", maxEvents);
+                meta.Add("max_threads", maxThreads);
+                meta.Add("include_payload", includePayload);
+                if (maxEventsPerNamedEvent.HasValue) {
+                    meta.Add("max_events_per_named_event", maxEventsPerNamedEvent.Value);
+                }
+                if (!string.IsNullOrWhiteSpace(logNameFilter)) {
+                    meta.Add("log_name", logNameFilter);
+                }
+                if (eventIdSet is not null) {
+                    meta.Add("event_ids", ToolJson.ToJsonArray(eventIdSet.OrderBy(static x => x)));
+                }
+                if (categories is not null && categories.Count > 0) {
+                    meta.Add("categories", ToolJson.ToJsonArray(categories));
+                }
+                if (payloadKeySet is not null && payloadKeySet.Count > 0) {
+                    meta.Add("payload_keys", ToolJson.ToJsonArray(payloadKeySet.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase)));
+                }
+                if (machines.Count > 0) {
+                    meta.Add("machines_count", machines.Count);
+                }
+                meta.Add("filtered_out", filteredOut);
+                if (startUtc.HasValue) {
+                    meta.Add("start_time_utc", ToolTime.FormatUtc(startUtc));
+                }
+                if (endUtc.HasValue) {
+                    meta.Add("end_time_utc", ToolTime.FormatUtc(endUtc));
+                }
+                if (timePeriod.HasValue) {
+                    meta.Add("time_period", ToSnakeCase(timePeriod.Value.ToString()));
+                }
+            });
+        return response;
+    }
+
+    private static List<string> ResolveMachines(JsonObject? arguments, int maxItems) {
+        var machines = new List<string>();
+
+        var singleMachine = ToolArgs.GetOptionalTrimmed(arguments, "machine_name");
+        if (!string.IsNullOrWhiteSpace(singleMachine)) {
+            machines.Add(singleMachine);
+        }
+
+        var machineNames = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("machine_names"));
+        for (var i = 0; i < machineNames.Count; i++) {
+            var machine = machineNames[i];
+            if (string.IsNullOrWhiteSpace(machine)) {
+                continue;
+            }
+
+            if (!machines.Contains(machine, StringComparer.OrdinalIgnoreCase)) {
+                machines.Add(machine);
+            }
+
+            if (machines.Count >= maxItems) {
+                break;
+            }
+        }
+
+        return machines;
+    }
+
+    private static NamedEventsQueryRow ToRow(
+        EventObjectSlim item,
+        string namedEvent,
+        bool includePayload,
+        HashSet<string>? payloadKeySet) {
+        var fullPayload = ExtractPayload(item);
+        var payload = includePayload
+            ? ProjectPayload(fullPayload, payloadKeySet)
+            : new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+
+        return new NamedEventsQueryRow(
+            NamedEvent: namedEvent,
+            RuleType: item.GetType().Name,
+            EventId: item.EventID,
+            RecordId: item.RecordID,
+            GatheredFrom: item.GatheredFrom,
+            GatheredLogName: item.GatheredLogName,
+            WhenUtc: ReadPayloadUtc(fullPayload, "when"),
+            Who: ReadPayloadString(fullPayload, "who"),
+            ObjectAffected: ReadPayloadString(fullPayload, "object_affected"),
+            Computer: ReadPayloadString(fullPayload, "computer"),
+            Action: ReadPayloadString(fullPayload, "action"),
+            Payload: payload);
+    }
+
+    private static string ResolveNamedEventName(EventObjectSlim item) {
+        return EventLogNamedEventsHelper.TryParseOne(item.Type, out var parsedNamedEvent)
+            ? EventLogNamedEventsHelper.GetQueryName(parsedNamedEvent)
+            : ToSnakeCase(item.Type);
+    }
+
+    private static Dictionary<string, object?> ExtractPayload(EventObjectSlim item) {
+        var payload = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        var type = item.GetType();
+
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance)) {
+            if (!ShouldIncludeField(field)) {
+                continue;
+            }
+
+            var value = field.GetValue(item);
+            payload[ToSnakeCase(field.Name)] = NormalizeValue(value);
+        }
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
+            if (!ShouldIncludeProperty(property)) {
+                continue;
+            }
+
+            var key = ToSnakeCase(property.Name);
+            if (payload.ContainsKey(key)) {
+                continue;
+            }
+
+            object? value;
+            try {
+                value = property.GetValue(item);
+            } catch {
+                continue;
+            }
+
+            payload[key] = NormalizeValue(value);
+        }
+
+        return payload;
+    }
+
+    private static Dictionary<string, object?> ProjectPayload(
+        Dictionary<string, object?> payload,
+        HashSet<string>? payloadKeySet) {
+        if (payloadKeySet is null || payloadKeySet.Count == 0) {
+            return payload;
+        }
+
+        var projected = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var key in payloadKeySet) {
+            if (payload.TryGetValue(key, out var value)) {
+                projected[key] = value;
+            }
+        }
+
+        return projected;
+    }
+
+    private static bool ShouldIncludeField(FieldInfo field) {
+        if (field is null) {
+            return false;
+        }
+
+        if (field.Name.StartsWith("_", StringComparison.Ordinal)) {
+            return false;
+        }
+
+        if (string.Equals(field.Name, nameof(EventObjectSlim.EventID), StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(field.Name, nameof(EventObjectSlim.RecordID), StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(field.Name, nameof(EventObjectSlim.GatheredFrom), StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(field.Name, nameof(EventObjectSlim.GatheredLogName), StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        if (string.Equals(field.FieldType.Name, "EventObject", StringComparison.Ordinal)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool ShouldIncludeProperty(PropertyInfo property) {
+        if (property is null || !property.CanRead || property.GetMethod is null || !property.GetMethod.IsPublic) {
+            return false;
+        }
+
+        if (property.GetIndexParameters().Length != 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static object? NormalizeValue(object? value) {
+        if (value is null) {
+            return null;
+        }
+
+        if (value is DateTime dateTime) {
+            return dateTime.ToUniversalTime().ToString("O");
+        }
+
+        if (value is DateTimeOffset dateTimeOffset) {
+            return dateTimeOffset.ToUniversalTime().ToString("O");
+        }
+
+        if (value is Enum enumValue) {
+            return enumValue.ToString();
+        }
+
+        return value;
+    }
+
+    private static string? ReadPayloadString(IReadOnlyDictionary<string, object?> payload, string key) {
+        if (!payload.TryGetValue(key, out var value) || value is null) {
+            return null;
+        }
+
+        var text = value.ToString();
+        return string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+    }
+
+    private static string? ReadPayloadUtc(IReadOnlyDictionary<string, object?> payload, string key) {
+        if (!payload.TryGetValue(key, out var value) || value is null) {
+            return null;
+        }
+
+        if (value is string text && DateTime.TryParse(text, out var parsed)) {
+            return parsed.ToUniversalTime().ToString("O");
+        }
+
+        if (value is DateTime dateTime) {
+            return dateTime.ToUniversalTime().ToString("O");
+        }
+
+        return value.ToString();
+    }
+
+    private static string ToSnakeCase(string name) {
+        if (string.IsNullOrWhiteSpace(name)) {
+            return string.Empty;
+        }
+
+        return JsonNamingPolicy.SnakeCaseLower.ConvertName(name);
+    }
+
+    private static bool TryParseTimePeriod(string raw, out TimePeriod timePeriod, out string? error) {
+        timePeriod = default;
+        error = null;
+
+        var normalized = ToSnakeCase(raw);
+        if (string.IsNullOrWhiteSpace(normalized)) {
+            error = "time_period is required when provided.";
+            return false;
+        }
+
+        if (TimePeriodByName.TryGetValue(normalized, out timePeriod)) {
+            return true;
+        }
+
+        error = $"time_period must be one of: {string.Join(", ", TimePeriodNames)}.";
+        return false;
+    }
+
+    private static IReadOnlyDictionary<string, TimePeriod> BuildTimePeriodMap() {
+        var map = new Dictionary<string, TimePeriod>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in Enum.GetValues<TimePeriod>()) {
+            map[ToSnakeCase(value.ToString())] = value;
+        }
+        return map;
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogPackInfoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogPackInfoTool.cs
@@ -45,6 +45,7 @@ public sealed class EventLogPackInfoTool : EventLogToolBase, ITool {
                 "Use eventlog_top_events for quick triage (top N most recent events from a live channel, local or remote).",
                 "Use eventlog_evtx_query or eventlog_live_query for event evidence.",
                 "Use eventlog_evtx_stats/eventlog_live_stats for top-level aggregation.",
+                "Use eventlog_named_events_catalog/eventlog_named_events_query for rule-based, intent-level detections (AD/Kerberos/GPO/etc).",
                 "For remote live logs, pass machine_name (and optional session_timeout_ms) to eventlog_live_query/eventlog_live_stats.",
                 "Use security report tools for lockouts/logons/failures when investigating authentication incidents.",
                 "For AD identity correlation: call ad_environment_discover, then ad_search using eventlog report ad_correlation candidates."
@@ -60,6 +61,9 @@ public sealed class EventLogPackInfoTool : EventLogToolBase, ITool {
                 ToolPackGuidance.FlowStep(
                     goal: "Build aggregate signal baselines",
                     suggestedTools: new[] { "eventlog_evtx_stats", "eventlog_live_stats" }),
+                ToolPackGuidance.FlowStep(
+                    goal: "Run named-event rule detections",
+                    suggestedTools: new[] { "eventlog_named_events_catalog", "eventlog_named_events_query" }),
                 ToolPackGuidance.FlowStep(
                     goal: "Investigate authentication incidents",
                     suggestedTools: new[] { "eventlog_evtx_report_failed_logons", "eventlog_evtx_report_account_lockouts", "eventlog_evtx_report_user_logons" }),
@@ -81,6 +85,10 @@ public sealed class EventLogPackInfoTool : EventLogToolBase, ITool {
                     id: "security_reports",
                     summary: "Produce focused lockout/logon/failure views for security investigations.",
                     primaryTools: new[] { "eventlog_evtx_report_failed_logons", "eventlog_evtx_report_account_lockouts", "eventlog_evtx_report_user_logons" }),
+                ToolPackGuidance.Capability(
+                    id: "named_event_rules",
+                    summary: "Run EventViewerX named-event rule detections and return normalized evidence rows.",
+                    primaryTools: new[] { "eventlog_named_events_catalog", "eventlog_named_events_query" }),
                 ToolPackGuidance.Capability(
                     id: "ad_correlation_hints",
                     summary: "Emit AD follow-up hints/candidate identities from security report aggregates.",

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/ToolRegistryEventLogExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/ToolRegistryEventLogExtensions.cs
@@ -60,6 +60,8 @@ public static class ToolRegistryEventLogExtensions {
         yield return new EventLogPackInfoTool(options);
         yield return new EventLogChannelListTool(options);
         yield return new EventLogProviderListTool(options);
+        yield return new EventLogNamedEventsCatalogTool(options);
+        yield return new EventLogNamedEventsQueryTool(options);
         yield return new EventLogTopEventsTool(options);
         yield return new EventLogLiveQueryTool(options);
         yield return new EventLogLiveStatsTool(options);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPackInfoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPackInfoTool.cs
@@ -35,6 +35,7 @@ public sealed class SystemPackInfoTool : SystemToolBase, ITool {
             recommendedFlow: new[] {
                 "Call system_info or system_hardware_summary for baseline context.",
                 "Use list tools (processes/services/ports/adapters/firewall/disks/features) for evidence collection.",
+                "Use system_security_options when you need a registry-backed snapshot of Windows security-option posture.",
                 "Use optional projection arguments only when the user asks for specific columns or sorting."
             },
             flowSteps: new[] {
@@ -43,7 +44,7 @@ public sealed class SystemPackInfoTool : SystemToolBase, ITool {
                     suggestedTools: new[] { "system_info", "system_hardware_summary", "system_whoami" }),
                 ToolPackGuidance.FlowStep(
                     goal: "Collect process/network/security evidence",
-                    suggestedTools: new[] { "system_process_list", "system_ports_list", "system_network_adapters", "system_firewall_rules", "system_firewall_profiles" }),
+                    suggestedTools: new[] { "system_process_list", "system_ports_list", "system_network_adapters", "system_firewall_rules", "system_firewall_profiles", "system_security_options" }),
                 ToolPackGuidance.FlowStep(
                     goal: "Collect storage/feature configuration evidence",
                     suggestedTools: new[] { "system_logical_disks_list", "system_disks_list", "system_features_list", "system_scheduled_tasks_list", "system_service_list" })
@@ -55,8 +56,8 @@ public sealed class SystemPackInfoTool : SystemToolBase, ITool {
                     primaryTools: new[] { "system_info", "system_hardware_identity", "system_hardware_summary", "system_whoami" }),
                 ToolPackGuidance.Capability(
                     id: "runtime_evidence",
-                    summary: "Enumerate processes, services, ports, adapters, firewall rules and profiles.",
-                    primaryTools: new[] { "system_process_list", "system_service_list", "system_ports_list", "system_network_adapters", "system_firewall_rules", "system_firewall_profiles" }),
+                    summary: "Enumerate processes, services, ports, adapters, firewall rules/profiles, and security-option posture.",
+                    primaryTools: new[] { "system_process_list", "system_service_list", "system_ports_list", "system_network_adapters", "system_firewall_rules", "system_firewall_profiles", "system_security_options" }),
                 ToolPackGuidance.Capability(
                     id: "platform_configuration",
                     summary: "Inventory disks, devices, features, scheduled tasks, and optional WSL state.",

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemSecurityOptionsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemSecurityOptionsTool.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ComputerX.SecurityPolicy;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+
+namespace IntelligenceX.Tools.System;
+
+/// <summary>
+/// Returns Windows Security Options policy state from registry (read-only).
+/// </summary>
+public sealed class SystemSecurityOptionsTool : SystemToolBase, ITool {
+    private static readonly ToolDefinition DefinitionValue = new(
+        "system_security_options",
+        "Return Windows Security Options policy state from registry (read-only).",
+        ToolSchema.Object(
+                ("computer_name", ToolSchema.String("Optional remote computer name. Omit for local machine.")))
+            .NoAdditionalProperties());
+
+    private sealed record SecurityOptionsResult(string ComputerName, SecurityOptionsState SecurityOptions);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SystemSecurityOptionsTool"/> class.
+    /// </summary>
+    public SystemSecurityOptionsTool(SystemToolOptions options) : base(options) { }
+
+    /// <inheritdoc />
+    public override ToolDefinition Definition => DefinitionValue;
+
+    /// <inheritdoc />
+    protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!OperatingSystem.IsWindows()) {
+            return Task.FromResult(ToolResponse.Error("not_supported", "system_security_options is available only on Windows hosts."));
+        }
+
+        var computerName = ToolArgs.GetOptionalTrimmed(arguments, "computer_name");
+        var target = string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName;
+
+        try {
+            var state = SecurityOptionsQuery.Get(computerName);
+            var model = new SecurityOptionsResult(target, state);
+
+            return Task.FromResult(ToolResponse.OkFactsModel(
+                model: model,
+                title: "System Security Options",
+                facts: new[] {
+                    ("Computer", target),
+                    ("RestrictAnonymous", state.RestrictAnonymous?.ToString() ?? string.Empty),
+                    ("RequireSmbSigningServer", state.RequireSmbSigningServer?.ToString() ?? string.Empty),
+                    ("Smb1", state.Smb1?.ToString() ?? string.Empty)
+                },
+                meta: null,
+                keyHeader: "Field",
+                valueHeader: "Value",
+                truncated: false,
+                render: null));
+        } catch (ArgumentException ex) {
+            return Task.FromResult(ToolResponse.Error("invalid_argument", ex.Message));
+        } catch (Exception ex) {
+            return Task.FromResult(ToolResponse.Error("query_failed", $"Security options query failed: {ex.Message}"));
+        }
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/ToolRegistrySystemExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/ToolRegistrySystemExtensions.cs
@@ -70,6 +70,7 @@ public static class ToolRegistrySystemExtensions {
             yield return new SystemScheduledTasksListTool(options);
             yield return new SystemFirewallRulesTool(options);
             yield return new SystemFirewallProfilesTool(options);
+            yield return new SystemSecurityOptionsTool(options);
             yield return new SystemLogicalDisksListTool(options);
             yield return new SystemDisksListTool(options);
             yield return new SystemDevicesSummaryTool(options);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXPackInfoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXPackInfoTool.cs
@@ -32,8 +32,10 @@ public sealed class TestimoXPackInfoTool : TestimoXToolBase, ITool {
             engine: "TestimoX",
             tools: ToolRegistryTestimoXExtensions.GetRegisteredToolNames(Options),
             recommendedFlow: new[] {
-                "Call testimox_rules_list to discover available rules and metadata (scope/categories/tags/cost).",
-                "Select a focused subset of rules (prefer explicit names over broad all-rules execution).",
+                "Call testimox_rules_list to discover available rules and metadata (scope/source_type/origin/categories/tags/cost).",
+                "When you need deterministic pagination, call testimox_rules_list with page_size + offset (or cursor) and continue from next_offset/next_cursor.",
+                "Select a focused subset using explicit names and/or selectors (patterns/categories/tags/source_type/rule_origin).",
+                "Apply execution scope controls when needed (include_domains/include_domain_controllers/exclude_* and include_trusted_domains).",
                 "Call testimox_rules_run and correlate run output with AD/system/eventlog evidence."
             },
             flowSteps: new[] {
@@ -50,11 +52,11 @@ public sealed class TestimoXPackInfoTool : TestimoXToolBase, ITool {
             capabilities: new[] {
                 ToolPackGuidance.Capability(
                     id: "rule_catalog",
-                    summary: "Enumerate TestimoX rules with metadata (scope, categories, tags, cost, visibility).",
+                    summary: "Enumerate TestimoX rules with metadata (scope, source_type, origin, categories, tags, cost, visibility).",
                     primaryTools: new[] { "testimox_rules_list" }),
                 ToolPackGuidance.Capability(
                     id: "rule_execution",
-                    summary: "Run selected TestimoX rules and return typed per-rule outcomes for downstream reasoning.",
+                    summary: "Run selected TestimoX rules using explicit names and/or selectors; return typed per-rule outcomes for downstream reasoning.",
                     primaryTools: new[] { "testimox_rules_run" })
             },
             toolCatalog: ToolRegistryTestimoXExtensions.GetRegisteredToolCatalog(Options),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRuleSelectionHelper.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRuleSelectionHelper.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using TestimoX.Definitions;
+using TestimoX.Execution;
+
+namespace IntelligenceX.Tools.TestimoX;
+
+internal static class TestimoXRuleSelectionHelper {
+    internal const string RuleOriginAny = "any";
+    internal const string RuleOriginBuiltin = "builtin";
+    internal const string RuleOriginExternal = "external";
+    internal const int MaxRuleNamePatterns = 64;
+
+    internal static readonly string[] SourceTypeNames = {
+        "powershell",
+        "csharp"
+    };
+
+    internal static readonly string[] RuleOriginNames = {
+        RuleOriginAny,
+        RuleOriginBuiltin,
+        RuleOriginExternal
+    };
+
+    internal static bool TryParseSourceTypes(
+        IReadOnlyList<string> requestedValues,
+        out HashSet<string>? parsedSourceTypes,
+        out string? error) {
+        parsedSourceTypes = null;
+        error = null;
+
+        if (requestedValues is null || requestedValues.Count == 0) {
+            return true;
+        }
+
+        var parsed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < requestedValues.Count; i++) {
+            var raw = requestedValues[i];
+            var normalized = NormalizeSourceType(raw);
+            if (normalized.Length == 0) {
+                error = $"source_types[{i}] ('{raw}') is invalid. Allowed values: powershell, csharp.";
+                return false;
+            }
+            parsed.Add(normalized);
+        }
+
+        parsedSourceTypes = parsed.Count == 0 ? null : parsed;
+        return true;
+    }
+
+    internal static bool TryParseRuleOrigin(string? rawValue, out string ruleOrigin, out string? error) {
+        error = null;
+        var normalized = NormalizeRuleOrigin(rawValue);
+        if (normalized.Length == 0) {
+            error = $"rule_origin must be one of: {string.Join(", ", RuleOriginNames)}.";
+            ruleOrigin = RuleOriginAny;
+            return false;
+        }
+
+        ruleOrigin = normalized;
+        return true;
+    }
+
+    internal static string GetSourceType(Rule? rule) {
+        if (rule?.Source is null) {
+            return "powershell";
+        }
+
+        return NormalizeSourceType(rule.Source.SourceType.ToString()) switch {
+            "csharp" => "csharp",
+            _ => "powershell"
+        };
+    }
+
+    internal static bool MatchesSourceType(Rule rule, HashSet<string>? sourceTypeFilter) {
+        if (sourceTypeFilter is null || sourceTypeFilter.Count == 0) {
+            return true;
+        }
+
+        return sourceTypeFilter.Contains(GetSourceType(rule));
+    }
+
+    internal static string ResolveRuleOrigin(Rule rule, bool usingExternalDirectory, HashSet<string>? builtinRuleNames) {
+        if (!usingExternalDirectory) {
+            return RuleOriginBuiltin;
+        }
+
+        var name = rule.Name ?? string.Empty;
+        if (name.Length == 0) {
+            return RuleOriginExternal;
+        }
+
+        if (builtinRuleNames is not null && builtinRuleNames.Contains(name)) {
+            return RuleOriginBuiltin;
+        }
+
+        return RuleOriginExternal;
+    }
+
+    internal static async Task<HashSet<string>> DiscoverBuiltinRuleNamesAsync(CancellationToken cancellationToken) {
+        var runner = new TestimoRunner();
+        var baseline = await runner.DiscoverRulesAsync(
+            includeDisabled: true,
+            ct: cancellationToken,
+            powerShellRulesDirectory: null).ConfigureAwait(false);
+
+        return new HashSet<string>(
+            baseline
+                .Select(static x => x.Name)
+                .Where(static x => !string.IsNullOrWhiteSpace(x)),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal static bool MatchesAnyPattern(Rule rule, IReadOnlyList<string> patterns) {
+        if (patterns is null || patterns.Count == 0) {
+            return true;
+        }
+
+        var name = rule.Name ?? string.Empty;
+        var displayName = rule.DisplayName ?? string.Empty;
+        for (var i = 0; i < patterns.Count; i++) {
+            var pattern = patterns[i];
+            if (WildcardMatch(name, pattern) || WildcardMatch(displayName, pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool ContainsIgnoreCase(string? value, string term) {
+        return !string.IsNullOrWhiteSpace(value) && value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static string NormalizeSourceType(string? value) {
+        var canonical = Canonicalize(value);
+        return canonical switch {
+            "powershell" => "powershell",
+            "ps" => "powershell",
+            "csharp" => "csharp",
+            "cs" => "csharp",
+            "dotnet" => "csharp",
+            _ => string.Empty
+        };
+    }
+
+    private static string NormalizeRuleOrigin(string? value) {
+        var canonical = Canonicalize(value);
+        return canonical switch {
+            "" => RuleOriginAny,
+            "any" => RuleOriginAny,
+            "all" => RuleOriginAny,
+            "*" => RuleOriginAny,
+            "builtin" => RuleOriginBuiltin,
+            "bundled" => RuleOriginBuiltin,
+            "default" => RuleOriginBuiltin,
+            "external" => RuleOriginExternal,
+            "custom" => RuleOriginExternal,
+            "user" => RuleOriginExternal,
+            _ => string.Empty
+        };
+    }
+
+    private static string Canonicalize(string? value) {
+        return (value ?? string.Empty).Trim().ToLowerInvariant()
+            .Replace("-", string.Empty, StringComparison.Ordinal)
+            .Replace("_", string.Empty, StringComparison.Ordinal)
+            .Replace(".", string.Empty, StringComparison.Ordinal)
+            .Replace(" ", string.Empty, StringComparison.Ordinal);
+    }
+
+    private static bool WildcardMatch(string? value, string pattern) {
+        var candidate = value ?? string.Empty;
+        if (pattern.IndexOf('*') < 0 && pattern.IndexOf('?') < 0) {
+            return string.Equals(candidate, pattern, StringComparison.OrdinalIgnoreCase);
+        }
+
+        var regexPattern = "^" +
+                           Regex.Escape(pattern)
+                               .Replace("\\*", ".*", StringComparison.Ordinal)
+                               .Replace("\\?", ".", StringComparison.Ordinal) +
+                           "$";
+        return Regex.IsMatch(candidate, regexPattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesListTool.cs
@@ -17,15 +17,20 @@ namespace IntelligenceX.Tools.TestimoX;
 public sealed class TestimoXRulesListTool : TestimoXToolBase, ITool {
     private static readonly ToolDefinition DefinitionValue = new(
         "testimox_rules_list",
-        "List TestimoX rules with metadata (scope, categories, tags, cost, visibility).",
+        "List TestimoX rules with metadata (scope, source_type, origin, categories, tags, cost, visibility).",
         ToolSchema.Object(
                 ("include_disabled", ToolSchema.Boolean("Include rules marked disabled. Default false.")),
                 ("include_hidden", ToolSchema.Boolean("Include hidden rules. Default false.")),
                 ("include_deprecated", ToolSchema.Boolean("Include deprecated rules. Default true.")),
                 ("search_text", ToolSchema.String("Optional case-insensitive search across rule name/display/description.")),
+                ("source_types", ToolSchema.Array(ToolSchema.String("Rule source type.").Enum(TestimoXRuleSelectionHelper.SourceTypeNames), "Optional source type filters (any-match).")),
+                ("rule_origin", ToolSchema.String("Optional origin filter. 'builtin' means bundled rules, 'external' means rules introduced through powershell_rules_directory.").Enum(TestimoXRuleSelectionHelper.RuleOriginNames)),
                 ("categories", ToolSchema.Array(ToolSchema.String(), "Optional category-name filters (any-match).")),
                 ("tags", ToolSchema.Array(ToolSchema.String(), "Optional tag filters (any-match).")),
-                ("max_rules", ToolSchema.Integer("Maximum rules returned (capped).")))
+                ("powershell_rules_directory", ToolSchema.String("Optional path to user PowerShell rule scripts.")),
+                ("page_size", ToolSchema.Integer("Optional number of rules to return in this page.")),
+                ("offset", ToolSchema.Integer("Optional zero-based offset into matched rules (for paging).")),
+                ("cursor", ToolSchema.String("Optional opaque paging cursor (alternative to offset).")))
             .WithTableViewOptions()
             .NoAdditionalProperties());
 
@@ -53,21 +58,37 @@ public sealed class TestimoXRulesListTool : TestimoXToolBase, ITool {
         var includeHidden = ToolArgs.GetBoolean(arguments, "include_hidden", defaultValue: false);
         var includeDeprecated = ToolArgs.GetBoolean(arguments, "include_deprecated", defaultValue: true);
         var searchText = ToolArgs.GetOptionalTrimmed(arguments, "search_text");
+        var requestedSourceTypes = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("source_types"));
+        if (!TestimoXRuleSelectionHelper.TryParseSourceTypes(requestedSourceTypes, out var sourceTypeFilter, out var sourceTypeError)) {
+            return ToolResponse.Error("invalid_argument", sourceTypeError ?? "Invalid source_types argument.");
+        }
+        if (!TestimoXRuleSelectionHelper.TryParseRuleOrigin(
+                ToolArgs.GetOptionalTrimmed(arguments, "rule_origin"),
+                out var ruleOrigin,
+                out var ruleOriginError)) {
+            return ToolResponse.Error("invalid_argument", ruleOriginError ?? "Invalid rule_origin argument.");
+        }
         var requestedCategories = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("categories"));
         var requestedTags = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("tags"));
-        var maxRules = ToolArgs.GetCappedInt32(
-            arguments: arguments,
-            key: "max_rules",
-            defaultValue: Options.MaxRulesInCatalog,
-            minInclusive: 1,
-            maxInclusive: Options.MaxRulesInCatalog);
+        var powerShellRulesDirectory = ToolArgs.GetOptionalTrimmed(arguments, "powershell_rules_directory");
+        var pageSize = ResolvePageSize(arguments);
+        if (!TryReadOffset(arguments, out var offset, out var offsetError)) {
+            return ToolResponse.Error("invalid_argument", offsetError ?? "Invalid offset argument.");
+        }
 
         List<Rule> discovered;
+        var usingExternalDirectory = !string.IsNullOrWhiteSpace(powerShellRulesDirectory);
+        HashSet<string>? builtinRuleNames = null;
         try {
             var runner = new TestimoRunner();
             discovered = await runner.DiscoverRulesAsync(
                 includeDisabled: true,
-                ct: cancellationToken).ConfigureAwait(false);
+                ct: cancellationToken,
+                powerShellRulesDirectory: powerShellRulesDirectory).ConfigureAwait(false);
+
+            if (usingExternalDirectory) {
+                builtinRuleNames = await TestimoXRuleSelectionHelper.DiscoverBuiltinRuleNamesAsync(cancellationToken).ConfigureAwait(false);
+            }
         } catch (OperationCanceledException) {
             throw;
         } catch (Exception ex) {
@@ -88,9 +109,13 @@ public sealed class TestimoXRulesListTool : TestimoXToolBase, ITool {
         if (!string.IsNullOrWhiteSpace(searchText)) {
             var term = searchText.Trim();
             filtered = filtered.Where(rule =>
-                ContainsIgnoreCase(rule.Name, term) ||
-                ContainsIgnoreCase(rule.DisplayName, term) ||
-                ContainsIgnoreCase(rule.Description, term));
+                TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.Name, term) ||
+                TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.DisplayName, term) ||
+                TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.Description, term));
+        }
+
+        if (sourceTypeFilter is { Count: > 0 }) {
+            filtered = filtered.Where(rule => TestimoXRuleSelectionHelper.MatchesSourceType(rule, sourceTypeFilter));
         }
 
         if (requestedCategories.Count > 0) {
@@ -103,31 +128,55 @@ public sealed class TestimoXRulesListTool : TestimoXToolBase, ITool {
             filtered = filtered.Where(rule => rule.Tags.Any(tag => requested.Contains(tag)));
         }
 
-        var rows = filtered
+        if (!string.Equals(ruleOrigin, TestimoXRuleSelectionHelper.RuleOriginAny, StringComparison.OrdinalIgnoreCase)) {
+            filtered = filtered.Where(rule =>
+                string.Equals(
+                    TestimoXRuleSelectionHelper.ResolveRuleOrigin(rule, usingExternalDirectory, builtinRuleNames),
+                    ruleOrigin,
+                    StringComparison.OrdinalIgnoreCase));
+        }
+
+        var matchedRows = filtered
             .OrderBy(static x => x.Name, StringComparer.OrdinalIgnoreCase)
-            .Take(maxRules + 1)
-            .Select(static rule => new TestimoRuleCatalogRow(
+            .Select(rule => new TestimoRuleCatalogRow(
                 RuleName: rule.Name,
                 DisplayName: rule.DisplayName,
                 Description: rule.Description,
+                SourceType: TestimoXRuleSelectionHelper.GetSourceType(rule),
                 Enabled: rule.Enable,
                 Visibility: rule.Visibility.ToString(),
                 IsDeprecated: rule.IsDeprecated,
                 Scope: rule.Scope.ToString(),
                 PermissionRequired: rule.PermissionRequired.ToString(),
                 Cost: rule.Cost.ToString(),
+                RuleOrigin: TestimoXRuleSelectionHelper.ResolveRuleOrigin(rule, usingExternalDirectory, builtinRuleNames),
                 Categories: rule.Category.Select(static x => x.ToString()).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(static x => x, StringComparer.OrdinalIgnoreCase).ToArray(),
                 Tags: rule.Tags.Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(static x => x, StringComparer.OrdinalIgnoreCase).ToArray()))
             .ToList();
 
-        var truncated = rows.Count > maxRules;
-        if (truncated) {
-            rows = rows.Take(maxRules).ToList();
+        if (offset > matchedRows.Count) {
+            offset = matchedRows.Count;
         }
+
+        var pageRows = matchedRows.Skip(offset);
+        var rows = pageSize.HasValue
+            ? pageRows.Take(pageSize.Value).ToList()
+            : pageRows.ToList();
+        var truncatedByPage = pageSize.HasValue && offset + rows.Count < matchedRows.Count;
+        var truncated = truncatedByPage;
+        var nextOffset = truncatedByPage ? offset + rows.Count : (int?)null;
+        var nextCursor = nextOffset.HasValue ? OffsetCursor.Encode(nextOffset.Value) : string.Empty;
 
         var model = new TestimoRulesCatalogResult(
             DiscoveredCount: discovered.Count,
-            MatchedCount: rows.Count,
+            MatchedCount: matchedRows.Count,
+            ReturnedCount: rows.Count,
+            Offset: offset,
+            PageSize: pageSize,
+            NextOffset: nextOffset,
+            NextCursor: nextCursor,
+            TruncatedByPackCap: false,
+            TruncatedByPage: truncatedByPage,
             Truncated: truncated,
             Rules: rows);
 
@@ -137,20 +186,39 @@ public sealed class TestimoXRulesListTool : TestimoXToolBase, ITool {
             sourceRows: rows,
             viewRowsPath: "rules_view",
             title: "TestimoX rules (preview)",
-            maxTop: Options.MaxRulesInCatalog,
+            maxTop: Math.Max(Options.MaxRulesInCatalog, matchedRows.Count),
             baseTruncated: truncated,
             response: out var response,
-            scanned: discovered.Count);
+            scanned: discovered.Count,
+            metaMutate: meta => {
+                meta.Add("matched_count", matchedRows.Count);
+                meta.Add("returned_count", rows.Count);
+                meta.Add("offset", offset);
+                if (pageSize.HasValue) {
+                    meta.Add("page_size", pageSize.Value);
+                }
+                if (nextOffset.HasValue) {
+                    meta.Add("next_offset", nextOffset.Value);
+                }
+                if (!string.IsNullOrWhiteSpace(nextCursor)) {
+                    meta.Add("next_cursor", nextCursor);
+                }
+                meta.Add("truncated_by_pack_cap", false);
+                meta.Add("truncated_by_page", truncatedByPage);
+            });
         return response;
-    }
-
-    private static bool ContainsIgnoreCase(string? value, string term) {
-        return !string.IsNullOrWhiteSpace(value) && value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private sealed record TestimoRulesCatalogResult(
         int DiscoveredCount,
         int MatchedCount,
+        int ReturnedCount,
+        int Offset,
+        int? PageSize,
+        int? NextOffset,
+        string NextCursor,
+        bool TruncatedByPackCap,
+        bool TruncatedByPage,
         bool Truncated,
         IReadOnlyList<TestimoRuleCatalogRow> Rules);
 
@@ -158,12 +226,88 @@ public sealed class TestimoXRulesListTool : TestimoXToolBase, ITool {
         string RuleName,
         string DisplayName,
         string Description,
+        string SourceType,
         bool Enabled,
         string Visibility,
         bool IsDeprecated,
         string Scope,
         string PermissionRequired,
         string Cost,
+        string RuleOrigin,
         IReadOnlyList<string> Categories,
         IReadOnlyList<string> Tags);
+
+    private int? ResolvePageSize(JsonObject? arguments) {
+        if (!HasArgument(arguments, "page_size") && !HasArgument(arguments, "max_rules")) {
+            return null;
+        }
+
+        var pageSize = ToolArgs.GetCappedInt32(
+            arguments: arguments,
+            key: "page_size",
+            defaultValue: Options.MaxRulesInCatalog,
+            minInclusive: 1,
+            maxInclusive: Options.MaxRulesInCatalog);
+
+        // Backward-compatible alias for older callers.
+        if (!HasArgument(arguments, "page_size") && HasArgument(arguments, "max_rules")) {
+            pageSize = ToolArgs.GetCappedInt32(
+                arguments: arguments,
+                key: "max_rules",
+                defaultValue: pageSize,
+                minInclusive: 1,
+                maxInclusive: Options.MaxRulesInCatalog);
+        }
+
+        return pageSize;
+    }
+
+    private static bool TryReadOffset(JsonObject? arguments, out int offset, out string? error) {
+        offset = 0;
+        error = null;
+
+        var rawCursor = ToolArgs.GetOptionalTrimmed(arguments, "cursor");
+        var cursorOffset = 0;
+        if (!string.IsNullOrWhiteSpace(rawCursor)) {
+            if (!OffsetCursor.TryDecode(rawCursor, out var decoded) || decoded < 0 || decoded > int.MaxValue) {
+                error = "cursor is invalid. Use cursor returned by previous page response.";
+                return false;
+            }
+
+            cursorOffset = (int)decoded;
+        }
+
+        var rawOffset = arguments?.GetInt64("offset");
+        if (!rawOffset.HasValue) {
+            offset = cursorOffset;
+            return true;
+        }
+
+        if (rawOffset.Value < 0 || rawOffset.Value > int.MaxValue) {
+            error = "offset must be between 0 and 2147483647.";
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(rawCursor) && rawOffset.Value != cursorOffset) {
+            error = "Provide either cursor or offset (or keep them aligned), not conflicting values.";
+            return false;
+        }
+
+        offset = (int)rawOffset.Value;
+        return true;
+    }
+
+    private static bool HasArgument(JsonObject? arguments, string name) {
+        if (arguments is null || string.IsNullOrWhiteSpace(name)) {
+            return false;
+        }
+
+        foreach (var kv in arguments) {
+            if (string.Equals((kv.Key ?? string.Empty).Trim(), name, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesRunTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesRunTool.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using IntelligenceX.Json;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
+using TestimoX;
 using TestimoX.Configuration;
 using TestimoX.Definitions;
 using TestimoX.Execution;
@@ -17,11 +18,32 @@ namespace IntelligenceX.Tools.TestimoX;
 /// Executes a selected subset of TestimoX rules and returns typed run outcomes.
 /// </summary>
 public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
+    private const int MaxDomainFilters = 32;
+    private const int MaxDomainControllerFilters = 64;
+
     private static readonly ToolDefinition DefinitionValue = new(
         "testimox_rules_run",
         "Run selected TestimoX rules and return typed per-rule outcomes.",
         ToolSchema.Object(
-                ("rule_names", ToolSchema.Array(ToolSchema.String(), "Rule names to execute (required).")),
+                ("rule_names", ToolSchema.Array(ToolSchema.String(), "Explicit rule names to execute.")),
+                ("rule_name_patterns", ToolSchema.Array(ToolSchema.String("Wildcard pattern matched against rule_name/display_name (for example: *kerberos*)."), "Optional wildcard selectors.")),
+                ("search_text", ToolSchema.String("Optional case-insensitive search across rule name/display/description.")),
+                ("categories", ToolSchema.Array(ToolSchema.String(), "Optional category-name filters (any-match).")),
+                ("tags", ToolSchema.Array(ToolSchema.String(), "Optional tag filters (any-match).")),
+                ("source_types", ToolSchema.Array(ToolSchema.String("Rule source type.").Enum(TestimoXRuleSelectionHelper.SourceTypeNames), "Optional source type filters (any-match).")),
+                ("rule_origin", ToolSchema.String("Optional origin filter. 'builtin' means bundled rules, 'external' means rules introduced through powershell_rules_directory.").Enum(TestimoXRuleSelectionHelper.RuleOriginNames)),
+                ("run_all_enabled_when_no_selection", ToolSchema.Boolean("When true, auto-select all enabled/visible/non-deprecated rules if no other selectors are provided.")),
+                ("include_disabled_for_selection", ToolSchema.Boolean("Include disabled rules when evaluating patterns/search/category/tag/source filters. Default false.")),
+                ("include_hidden_for_selection", ToolSchema.Boolean("Include hidden rules when evaluating filters. Default false.")),
+                ("include_deprecated_for_selection", ToolSchema.Boolean("Include deprecated rules when evaluating filters. Default true.")),
+                ("max_selected_rules", ToolSchema.Integer("Maximum selected rules after all filters (capped).")),
+                ("domain_name", ToolSchema.String("Optional domain DNS name shortcut (added to include_domains).")),
+                ("domain_controller", ToolSchema.String("Optional domain controller shortcut (added to include_domain_controllers).")),
+                ("include_domains", ToolSchema.Array(ToolSchema.String(), "Optional domain DNS names to include for discovery/query scope.")),
+                ("exclude_domains", ToolSchema.Array(ToolSchema.String(), "Optional domain DNS names to exclude from discovery/query scope.")),
+                ("include_domain_controllers", ToolSchema.Array(ToolSchema.String(), "Optional domain controllers to include for discovery/query scope.")),
+                ("exclude_domain_controllers", ToolSchema.Array(ToolSchema.String(), "Optional domain controllers to exclude from discovery/query scope.")),
+                ("include_trusted_domains", ToolSchema.Boolean("When true, discovery includes trusted-forest domains. Default false.")),
                 ("concurrency", ToolSchema.Integer("Execution concurrency (capped).")),
                 ("preflight", ToolSchema.String("Preflight mode. Default soft.").Enum("soft", "strict", "enforce", "off")),
                 ("include_superseded_rules", ToolSchema.Boolean("Include rules marked superseded. Default false.")),
@@ -29,7 +51,6 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
                 ("include_test_results", ToolSchema.Boolean("Include per-test rows for each executed rule. Default true.")),
                 ("include_rule_results", ToolSchema.Boolean("Include capped raw rule result rows. Default false.")),
                 ("max_result_rows_per_rule", ToolSchema.Integer("Maximum raw result rows per rule when include_rule_results=true (capped).")))
-            .Required("rule_names")
             .WithTableViewOptions()
             .NoAdditionalProperties());
 
@@ -54,8 +75,83 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
         }
 
         var requestedRuleNames = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("rule_names"));
-        if (requestedRuleNames.Count == 0) {
-            return ToolResponse.Error("invalid_argument", "rule_names must contain at least one rule name.");
+        var ruleNamePatterns = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("rule_name_patterns"));
+        if (ruleNamePatterns.Count > TestimoXRuleSelectionHelper.MaxRuleNamePatterns) {
+            return ToolResponse.Error(
+                "invalid_argument",
+                $"rule_name_patterns supports at most {TestimoXRuleSelectionHelper.MaxRuleNamePatterns} values.");
+        }
+
+        var searchText = ToolArgs.GetOptionalTrimmed(arguments, "search_text");
+        var requestedCategories = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("categories"));
+        var requestedTags = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("tags"));
+        var requestedSourceTypes = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("source_types"));
+        if (!TestimoXRuleSelectionHelper.TryParseSourceTypes(
+                requestedSourceTypes,
+                out var sourceTypeFilter,
+                out var sourceTypeError)) {
+            return ToolResponse.Error("invalid_argument", sourceTypeError ?? "Invalid source_types argument.");
+        }
+        if (!TestimoXRuleSelectionHelper.TryParseRuleOrigin(
+                ToolArgs.GetOptionalTrimmed(arguments, "rule_origin"),
+                out var ruleOrigin,
+                out var ruleOriginError)) {
+            return ToolResponse.Error("invalid_argument", ruleOriginError ?? "Invalid rule_origin argument.");
+        }
+
+        var runAllEnabledWhenNoSelection = ToolArgs.GetBoolean(arguments, "run_all_enabled_when_no_selection", defaultValue: false);
+        var includeDisabledForSelection = ToolArgs.GetBoolean(arguments, "include_disabled_for_selection", defaultValue: false);
+        var includeHiddenForSelection = ToolArgs.GetBoolean(arguments, "include_hidden_for_selection", defaultValue: false);
+        var includeDeprecatedForSelection = ToolArgs.GetBoolean(arguments, "include_deprecated_for_selection", defaultValue: true);
+        var maxSelectedRules = ToolArgs.GetCappedInt32(
+            arguments: arguments,
+            key: "max_selected_rules",
+            defaultValue: Options.MaxRulesPerRun,
+            minInclusive: 1,
+            maxInclusive: Options.MaxRulesPerRun);
+        var includeTrustedDomains = ToolArgs.GetBoolean(arguments, "include_trusted_domains", defaultValue: false);
+
+        var includeDomains = BuildScopeList(
+            ToolArgs.GetOptionalTrimmed(arguments, "domain_name"),
+            ToolArgs.ReadDistinctStringArray(arguments?.GetArray("include_domains")),
+            MaxDomainFilters,
+            "include_domains/domain_name",
+            out var includeDomainError);
+        if (!string.IsNullOrWhiteSpace(includeDomainError)) {
+            return ToolResponse.Error("invalid_argument", includeDomainError);
+        }
+
+        var excludeDomains = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("exclude_domains"));
+        if (excludeDomains.Count > MaxDomainFilters) {
+            return ToolResponse.Error("invalid_argument", $"exclude_domains supports at most {MaxDomainFilters} values.");
+        }
+
+        var includeDomainControllers = BuildScopeList(
+            ToolArgs.GetOptionalTrimmed(arguments, "domain_controller"),
+            ToolArgs.ReadDistinctStringArray(arguments?.GetArray("include_domain_controllers")),
+            MaxDomainControllerFilters,
+            "include_domain_controllers/domain_controller",
+            out var includeDomainControllerError);
+        if (!string.IsNullOrWhiteSpace(includeDomainControllerError)) {
+            return ToolResponse.Error("invalid_argument", includeDomainControllerError);
+        }
+
+        var excludeDomainControllers = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("exclude_domain_controllers"));
+        if (excludeDomainControllers.Count > MaxDomainControllerFilters) {
+            return ToolResponse.Error("invalid_argument", $"exclude_domain_controllers supports at most {MaxDomainControllerFilters} values.");
+        }
+
+        var hasSelectorFilters =
+            ruleNamePatterns.Count > 0 ||
+            !string.IsNullOrWhiteSpace(searchText) ||
+            requestedCategories.Count > 0 ||
+            requestedTags.Count > 0 ||
+            sourceTypeFilter is { Count: > 0 } ||
+            !string.Equals(ruleOrigin, TestimoXRuleSelectionHelper.RuleOriginAny, StringComparison.OrdinalIgnoreCase);
+        if (!runAllEnabledWhenNoSelection && requestedRuleNames.Count == 0 && !hasSelectorFilters) {
+            return ToolResponse.Error(
+                "invalid_argument",
+                "Provide at least one selection input: rule_names, rule_name_patterns, search_text, categories, tags, source_types, rule_origin, or set run_all_enabled_when_no_selection=true.");
         }
         if (requestedRuleNames.Count > Options.MaxRulesPerRun) {
             return ToolResponse.Error(
@@ -89,23 +185,28 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
 
         TestimoRunner runner;
         List<Rule> discoveredRules;
+        var usingExternalDirectory = !string.IsNullOrWhiteSpace(powerShellRulesDirectory);
+        HashSet<string>? builtinRuleNames = null;
         try {
             runner = new TestimoRunner();
             discoveredRules = await runner.DiscoverRulesAsync(
                 includeDisabled: true,
                 ct: cancellationToken,
                 powerShellRulesDirectory: powerShellRulesDirectory).ConfigureAwait(false);
+            if (usingExternalDirectory) {
+                builtinRuleNames = await TestimoXRuleSelectionHelper.DiscoverBuiltinRuleNamesAsync(cancellationToken).ConfigureAwait(false);
+            }
         } catch (OperationCanceledException) {
             throw;
         } catch (Exception ex) {
             return ToolResponse.Error("query_failed", $"TestimoX rule discovery failed: {ex.Message}");
         }
 
-        var available = new HashSet<string>(
-            discoveredRules.Select(static x => x.Name),
-            StringComparer.OrdinalIgnoreCase);
+        var availableByName = discoveredRules
+            .Where(static x => !string.IsNullOrWhiteSpace(x.Name))
+            .ToDictionary(static x => x.Name, StringComparer.OrdinalIgnoreCase);
         var unknown = requestedRuleNames
-            .Where(name => !available.Contains(name))
+            .Where(name => !availableByName.ContainsKey(name))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(static x => x, StringComparer.OrdinalIgnoreCase)
             .ToArray();
@@ -116,6 +217,86 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
                 hints: new[] { "Call testimox_rules_list first to discover valid rule names." },
                 isTransient: false);
         }
+
+        var selectedRules = new Dictionary<string, Rule>(StringComparer.OrdinalIgnoreCase);
+        foreach (var requestedRuleName in requestedRuleNames) {
+            selectedRules[requestedRuleName] = availableByName[requestedRuleName];
+        }
+
+        if (hasSelectorFilters || runAllEnabledWhenNoSelection) {
+            IEnumerable<Rule> candidates = discoveredRules;
+
+            if (!includeDisabledForSelection) {
+                candidates = candidates.Where(static x => x.Enable);
+            }
+            if (!includeHiddenForSelection) {
+                candidates = candidates.Where(static x => x.Visibility != RuleVisibility.Hidden);
+            }
+            if (!includeDeprecatedForSelection) {
+                candidates = candidates.Where(static x => !x.IsDeprecated);
+            }
+
+            if (ruleNamePatterns.Count > 0) {
+                candidates = candidates.Where(rule => TestimoXRuleSelectionHelper.MatchesAnyPattern(rule, ruleNamePatterns));
+            }
+
+            if (!string.IsNullOrWhiteSpace(searchText)) {
+                var term = searchText.Trim();
+                candidates = candidates.Where(rule =>
+                    TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.Name, term) ||
+                    TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.DisplayName, term) ||
+                    TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.Description, term));
+            }
+
+            if (requestedCategories.Count > 0) {
+                var requested = new HashSet<string>(requestedCategories, StringComparer.OrdinalIgnoreCase);
+                candidates = candidates.Where(rule => rule.Category.Any(cat => requested.Contains(cat.ToString())));
+            }
+
+            if (requestedTags.Count > 0) {
+                var requested = new HashSet<string>(requestedTags, StringComparer.OrdinalIgnoreCase);
+                candidates = candidates.Where(rule => rule.Tags.Any(tag => requested.Contains(tag)));
+            }
+
+            if (sourceTypeFilter is { Count: > 0 }) {
+                candidates = candidates.Where(rule => TestimoXRuleSelectionHelper.MatchesSourceType(rule, sourceTypeFilter));
+            }
+
+            if (!string.Equals(ruleOrigin, TestimoXRuleSelectionHelper.RuleOriginAny, StringComparison.OrdinalIgnoreCase)) {
+                candidates = candidates.Where(rule =>
+                    string.Equals(
+                        TestimoXRuleSelectionHelper.ResolveRuleOrigin(rule, usingExternalDirectory, builtinRuleNames),
+                        ruleOrigin,
+                        StringComparison.OrdinalIgnoreCase));
+            }
+
+            foreach (var rule in candidates.OrderBy(static x => x.Name, StringComparer.OrdinalIgnoreCase)) {
+                if (!string.IsNullOrWhiteSpace(rule.Name)) {
+                    selectedRules[rule.Name] = rule;
+                }
+            }
+        }
+
+        if (selectedRules.Count == 0) {
+            return ToolResponse.Error(
+                "invalid_argument",
+                "Selection resolved to zero rules. Broaden filters or call testimox_rules_list to discover available rules.");
+        }
+
+        if (selectedRules.Count > maxSelectedRules) {
+            return ToolResponse.Error(
+                "invalid_argument",
+                $"Selected rules exceed max_selected_rules ({maxSelectedRules}). Narrow filters or run in batches.");
+        }
+        if (selectedRules.Count > Options.MaxRulesPerRun) {
+            return ToolResponse.Error(
+                "invalid_argument",
+                $"Selected rules exceed the pack cap ({Options.MaxRulesPerRun}). Narrow filters or run in batches.");
+        }
+
+        var selectedRuleNames = selectedRules.Keys
+            .OrderBy(static x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 
         TestimoRunResult run;
         try {
@@ -134,8 +315,18 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
                 PowerShellRulesDirectory = powerShellRulesDirectory
             };
 
+            var engine = new Testimo {
+                IncludeDomains = includeDomains.Count == 0 ? null : includeDomains.ToArray(),
+                ExcludeDomains = excludeDomains.Count == 0 ? null : excludeDomains.ToArray(),
+                IncludeDomainControllers = includeDomainControllers.Count == 0 ? null : includeDomainControllers.ToArray(),
+                ExcludeDomainControllers = excludeDomainControllers.Count == 0 ? null : excludeDomainControllers.ToArray(),
+                IncludeTrustedDomains = includeTrustedDomains,
+                PowerShellRulesDirectory = powerShellRulesDirectory
+            };
+
             run = await runner.RunAsync(
-                ruleNames: requestedRuleNames,
+                engine: engine,
+                ruleNames: selectedRuleNames,
                 config: config,
                 ct: cancellationToken).ConfigureAwait(false);
         } catch (OperationCanceledException) {
@@ -153,12 +344,30 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
                 row,
                 includeTestResults: includeTestResults,
                 includeRuleResults: includeRuleResults,
-                maxResultRowsPerRule: maxResultRowsPerRule))
+                maxResultRowsPerRule: maxResultRowsPerRule,
+                usingExternalDirectory: usingExternalDirectory,
+                builtinRuleNames: builtinRuleNames))
             .ToList();
 
         var model = new TestimoRunResultModel(
             RequestedRuleNames: requestedRuleNames,
+            RequestedRuleNamePatterns: ruleNamePatterns,
+            SearchText: searchText,
+            Categories: requestedCategories,
+            Tags: requestedTags,
+            SourceTypes: sourceTypeFilter is null
+                ? Array.Empty<string>()
+                : sourceTypeFilter.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase).ToArray(),
+            RuleOrigin: ruleOrigin,
+            RunAllEnabledWhenNoSelection: runAllEnabledWhenNoSelection,
+            IncludeTrustedDomains: includeTrustedDomains,
+            IncludeDomains: includeDomains,
+            ExcludeDomains: excludeDomains,
+            IncludeDomainControllers: includeDomainControllers,
+            ExcludeDomainControllers: excludeDomainControllers,
+            SelectedRuleNames: selectedRuleNames,
             RequestedRuleCount: requestedRuleNames.Count,
+            SelectedRuleCount: selectedRuleNames.Length,
             ExecutedRuleCount: run.RuleCount,
             FailedRuleCount: run.FailedRules,
             SkippedRuleCount: run.SkippedRules,
@@ -184,7 +393,9 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
         RuleComplete row,
         bool includeTestResults,
         bool includeRuleResults,
-        int maxResultRowsPerRule) {
+        int maxResultRowsPerRule,
+        bool usingExternalDirectory,
+        HashSet<string>? builtinRuleNames) {
         var testRows = includeTestResults
             ? row.TestResults.Select(static test => new TestimoRuleTestRunRow(
                 Name: test.Name,
@@ -198,9 +409,16 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
             ? ReadRawRows(row, maxResultRowsPerRule)
             : Array.Empty<object?>();
 
+        var sourceType = TestimoXRuleSelectionHelper.GetSourceType(row.Rule);
+        var ruleOrigin = row.Rule is null
+            ? (usingExternalDirectory ? TestimoXRuleSelectionHelper.RuleOriginExternal : TestimoXRuleSelectionHelper.RuleOriginBuiltin)
+            : TestimoXRuleSelectionHelper.ResolveRuleOrigin(row.Rule, usingExternalDirectory, builtinRuleNames);
+
         return new TestimoRuleRunRow(
             RuleName: row.RuleName,
             DisplayName: row.Rule?.DisplayName ?? string.Empty,
+            SourceType: sourceType,
+            RuleOrigin: ruleOrigin,
             Scope: row.Rule?.Scope.ToString() ?? string.Empty,
             OverallStatus: row.OverallStatus.ToString(),
             OverallStatusText: row.OverallStatusText,
@@ -254,6 +472,37 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
         }
     }
 
+    private static IReadOnlyList<string> BuildScopeList(
+        string? singleValue,
+        IReadOnlyList<string> manyValues,
+        int maxItems,
+        string label,
+        out string? error) {
+        error = null;
+        var list = new List<string>(manyValues.Count + 1);
+        if (!string.IsNullOrWhiteSpace(singleValue)) {
+            list.Add(singleValue.Trim());
+        }
+
+        for (var i = 0; i < manyValues.Count; i++) {
+            var value = manyValues[i];
+            if (string.IsNullOrWhiteSpace(value)) {
+                continue;
+            }
+
+            if (!list.Contains(value, StringComparer.OrdinalIgnoreCase)) {
+                list.Add(value.Trim());
+            }
+        }
+
+        if (list.Count > maxItems) {
+            error = $"{label} supports at most {maxItems} values.";
+            return Array.Empty<string>();
+        }
+
+        return list;
+    }
+
     private static bool TryParsePreflightMode(string? raw, out PreflightMode mode, out string? error) {
         mode = PreflightMode.Soft;
         error = null;
@@ -277,7 +526,21 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
 
     private sealed record TestimoRunResultModel(
         IReadOnlyList<string> RequestedRuleNames,
+        IReadOnlyList<string> RequestedRuleNamePatterns,
+        string? SearchText,
+        IReadOnlyList<string> Categories,
+        IReadOnlyList<string> Tags,
+        IReadOnlyList<string> SourceTypes,
+        string RuleOrigin,
+        bool RunAllEnabledWhenNoSelection,
+        bool IncludeTrustedDomains,
+        IReadOnlyList<string> IncludeDomains,
+        IReadOnlyList<string> ExcludeDomains,
+        IReadOnlyList<string> IncludeDomainControllers,
+        IReadOnlyList<string> ExcludeDomainControllers,
+        IReadOnlyList<string> SelectedRuleNames,
         int RequestedRuleCount,
+        int SelectedRuleCount,
         int ExecutedRuleCount,
         int FailedRuleCount,
         int SkippedRuleCount,
@@ -289,6 +552,8 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
     private sealed record TestimoRuleRunRow(
         string RuleName,
         string DisplayName,
+        string SourceType,
+        string RuleOrigin,
         string Scope,
         string OverallStatus,
         string OverallStatusText,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXToolOptions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXToolOptions.cs
@@ -12,7 +12,7 @@ public sealed class TestimoXToolOptions {
     public bool Enabled { get; set; } = true;
 
     /// <summary>
-    /// Maximum number of rules returned by catalog queries.
+    /// Maximum page size accepted by catalog queries when callers request paged output.
     /// </summary>
     public int MaxRulesInCatalog { get; set; } = 2000;
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
@@ -60,6 +60,8 @@ public class ToolDefinitionContractTests {
             "ad_stale_accounts",
             "ad_spn_stats",
             "eventlog_pack_info",
+            "eventlog_named_events_catalog",
+            "eventlog_named_events_query",
             "eventlog_evtx_report_user_logons",
             "eventlog_evtx_report_failed_logons",
             "eventlog_evtx_report_account_lockouts"
@@ -82,6 +84,7 @@ public class ToolDefinitionContractTests {
         Assert.Contains("system_pack_info", names);
         Assert.Contains("system_firewall_rules", names);
         Assert.Contains("system_firewall_profiles", names);
+        Assert.Contains("system_security_options", names);
         Assert.Contains("system_logical_disks_list", names);
         Assert.Contains("system_disks_list", names);
         Assert.Contains("system_devices_summary", names);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSchemaSnapshotTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSchemaSnapshotTests.cs
@@ -122,6 +122,24 @@ public class ToolSchemaSnapshotTests {
         };
 
         yield return new object[] {
+            "ad_gpo_list",
+            new[] { "forest_name", "domain_name", "name_contains", "consistency", "link_state", "modified_since_utc", "max_results", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "ad_gpo_changes",
+            new[] { "domain_name", "since_utc", "max_results", "columns", "sort_by", "sort_direction", "top" },
+            new[] { "domain_name" }
+        };
+
+        yield return new object[] {
+            "ad_gpo_health",
+            new[] { "domain_name", "gpo_ids", "max_results", "columns", "sort_by", "sort_direction", "top" },
+            new[] { "gpo_ids" }
+        };
+
+        yield return new object[] {
             "ad_group_members",
             new[] { "identity", "search_base_dn", "domain_controller", "max_members" },
             new[] { "identity" }
@@ -256,6 +274,18 @@ public class ToolSchemaSnapshotTests {
         yield return new object[] {
             "eventlog_evtx_find",
             new[] { "query", "log_name", "max_results" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "eventlog_named_events_catalog",
+            new[] { "name_contains", "categories", "available_only", "include_event_ids", "max_event_ids_per_row", "max_results", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "eventlog_named_events_query",
+            new[] { "named_events", "categories", "machine_name", "machine_names", "time_period", "start_time_utc", "end_time_utc", "log_name", "event_ids", "max_events_per_named_event", "max_events", "max_threads", "include_payload", "payload_keys", "columns", "sort_by", "sort_direction", "top" },
             Array.Empty<string>()
         };
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolTableViewTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolTableViewTests.cs
@@ -24,6 +24,43 @@ public class ToolTableViewTests {
     }
 
     [Fact]
+    public void TryParse_ShouldResolveProjectionAliasesForColumnsAndSortBy() {
+        var args = new JsonObject()
+            .Add("columns", new JsonArray().Add("rule_name").Add("deprecated"))
+            .Add("sort_by", "deprecated")
+            .Add("sort_direction", "desc");
+
+        var ok = ToolTableView.TryParse(
+            arguments: args,
+            allowedColumns: new[] { "rule_name", "is_deprecated", "scope" },
+            maxTop: 100,
+            request: out var request,
+            error: out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Equal(new[] { "rule_name", "is_deprecated" }, request.Columns);
+        Assert.Equal("is_deprecated", request.SortBy);
+        Assert.Equal(ToolTableSortDirection.Desc, request.SortDirection);
+    }
+
+    [Fact]
+    public void TryParse_ShouldRejectAmbiguousSuffixAlias() {
+        var args = new JsonObject()
+            .Add("columns", new JsonArray().Add("status"));
+
+        var ok = ToolTableView.TryParse(
+            arguments: args,
+            allowedColumns: new[] { "overall_status", "preflight_status", "rule_name" },
+            maxTop: 100,
+            request: out _,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.Contains("unsupported", error ?? string.Empty);
+    }
+
+    [Fact]
     public void Apply_ShouldSelectSortAndTopRows() {
         var rows = new[] {
             new Row(2, "b", 2048),


### PR DESCRIPTION
## Summary
- add AD GPO-focused tools: `ad_gpo_list`, `ad_gpo_changes`, `ad_gpo_health`
- add EventViewerX named-event tools: `eventlog_named_events_catalog`, `eventlog_named_events_query`
- add `system_security_options` for registry-backed security-policy posture snapshot
- expand TestimoX rule discovery/execution:
  - catalog paging (`page_size`/`offset`/`cursor`)
  - selection filters (patterns/search/categories/tags/source-type/origin)
  - domain/DC execution scope controls (`include_*` / `exclude_*`, trusted domains)
- improve table-view projection parsing with canonical alias resolution for `columns`/`sort_by`
- update pack guidance/registry wiring and schema/contract tests

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`