### PR TITLE
Add transcript markdown regressions for strong-span rendering

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
@@ -172,4 +172,24 @@ public sealed class TranscriptHtmlFormatterTests {
         Assert.Contains("<code>/act act_ad0_sys3210_msg</code>", html);
         Assert.DoesNotContain("`/act act_ad0_sys3210_msg`", html);
     }
+
+    /// <summary>
+    /// Ensures common strong-emphasis phrases from assistant prose render as strong tags, not literal markers.
+    /// </summary>
+    [Fact]
+    public void Format_RendersCommonStrongPhrasesWithoutLiteralMarkers() {
+        var options = MarkdownRendererPresets.CreateChatStrictMinimal();
+        var now = new DateTime(2026, 2, 16, 13, 6, 34, DateTimeKind.Local);
+        var html = TranscriptHtmlFormatter.Format(new[] {
+            ("Assistant", "If you want, I can run a **“Top 8 high-signal security pack”** now, or list only **GPO-related** reports.", now),
+            ("Assistant", "Those were ** unresolved privileged SIDs** in a group sweep.", now.AddSeconds(1))
+        }, "HH:mm:ss", options);
+
+        Assert.Contains("<strong>“Top 8 high-signal security pack”</strong>", html);
+        Assert.Contains("<strong>GPO-related</strong>", html);
+        Assert.Contains("<strong>unresolved privileged SIDs</strong>", html);
+        Assert.DoesNotContain("**“Top 8 high-signal security pack”**", html);
+        Assert.DoesNotContain("**GPO-related**", html);
+        Assert.DoesNotContain("** unresolved privileged SIDs**", html);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
@@ -142,4 +142,17 @@ public sealed class TranscriptMarkdownNormalizerTests {
         Assert.Contains("\n2. **Foreign/trusted principal no longer resolvable**", normalized);
         Assert.DoesNotContain("2.^", normalized);
     }
+
+    /// <summary>
+    /// Ensures strong spans with smart quotes and hyphenated terms remain parseable.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_PreservesQuotedAndHyphenatedStrongSpans() {
+        var text =
+            "Run **“Top 8 high-signal security pack”** now, or only **GPO-related** reports.";
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+
+        Assert.Equal(text, normalized);
+    }
 }


### PR DESCRIPTION
Adds regression tests for strong-span rendering/normalization patterns observed in chat transcripts, including smart quotes, hyphenated terms, and spaced strong markers.