### PR TITLE
Align failure descriptor wording across chat and tools

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
@@ -42,7 +42,7 @@ public sealed class ToolRunMarkdownFormatterTests {
     /// Ensures structured tool failure fields are rendered in debug markdown.
     /// </summary>
     [Fact]
-    public void Format_RendersFailureContractAndHints() {
+    public void Format_RendersFailureDescriptorAndHints() {
         var tools = new ToolRunDto {
             Calls = new[] {
                 new ToolCallDto {
@@ -66,7 +66,7 @@ public sealed class ToolRunMarkdownFormatterTests {
         var markdown = ToolRunMarkdownFormatter.Format(tools, _ => "AD Replication Check");
 
         Assert.Contains("#### AD Replication Check", markdown);
-        Assert.Contains("failure contract: code: `tool_timeout` | retryable: yes", markdown);
+        Assert.Contains("failure descriptor: code: `tool_timeout` | retryable: yes", markdown);
         Assert.Contains("error: Tool timed out after 60s.", markdown);
         Assert.Contains("- Narrow scope to one DC.", markdown);
         Assert.Contains("- Retry with a longer timeout.", markdown);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.cs
@@ -36,7 +36,7 @@ internal static class ToolRunMarkdownFormatter {
 
             markdown.Heading(toolLabel, 4);
             if (hasError) {
-                AppendFailureContract(markdown, output);
+                AppendFailureDescriptor(markdown, output);
             }
 
             var summary = NormalizeSummaryMarkdown(output.SummaryMarkdown, toolLabel);
@@ -204,7 +204,7 @@ internal static class ToolRunMarkdownFormatter {
         return hasPipe;
     }
 
-    private static void AppendFailureContract(MarkdownComposer markdown, ToolOutputDto output) {
+    private static void AppendFailureDescriptor(MarkdownComposer markdown, ToolOutputDto output) {
         var detailParts = new List<string>();
         var errorCode = (output.ErrorCode ?? string.Empty).Trim();
         var errorMessage = (output.Error ?? string.Empty).Trim();
@@ -216,7 +216,7 @@ internal static class ToolRunMarkdownFormatter {
             detailParts.Add("retryable: " + (output.IsTransient.Value ? "yes" : "no"));
         }
         if (detailParts.Count > 0) {
-            markdown.Quote("failure contract: " + string.Join(" | ", detailParts));
+            markdown.Quote("failure descriptor: " + string.Join(" | ", detailParts));
         }
 
         if (errorMessage.Length > 0) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolFailureMapper.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolFailureMapper.cs
@@ -3,7 +3,7 @@ using System;
 namespace IntelligenceX.Tools.Common;
 
 /// <summary>
-/// Maps typed engine/tool failure contracts to stable tool error envelopes.
+/// Maps typed engine/tool failure descriptors to stable tool error envelopes.
 /// </summary>
 public static class ToolFailureMapper {
     /// <summary>


### PR DESCRIPTION
## Summary
- align user-facing/debug wording from `failure contract` to `failure descriptor`
- rename formatter helper to `AppendFailureDescriptor` for code-level consistency
- update markdown formatter test expectations to match new phrasing
- update `ToolFailureMapper` XML summary wording to `failure descriptors`

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter FullyQualifiedName~ToolRunMarkdownFormatterTests`
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.Common/IntelligenceX.Tools.Common.csproj -c Release /p:UseAppHost=false`
