### PR TITLE
Bump OfficeIMO.MarkdownRenderer to 0.1.4

### DIFF
--- a/IntelligenceX.Chat/Directory.Build.props
+++ b/IntelligenceX.Chat/Directory.Build.props
@@ -29,6 +29,6 @@
     <DbaClientXRepoRoot Condition="'$(DbaClientXRepoRoot)' == '' and Exists('$(DbaClientXRepoRootCandidate2)DbaClientX.SQLite\\DbaClientX.SQLite.csproj')">$(DbaClientXRepoRootCandidate2)</DbaClientXRepoRoot>
     <DbaClientXRepoRoot Condition="'$(DbaClientXRepoRoot)' == ''">$(DbaClientXRepoRootCandidate1)</DbaClientXRepoRoot>
 
-    <OfficeImoMarkdownRendererNuGetVersion Condition="'$(OfficeImoMarkdownRendererNuGetVersion)' == ''">0.1.1</OfficeImoMarkdownRendererNuGetVersion>
+    <OfficeImoMarkdownRendererNuGetVersion Condition="'$(OfficeImoMarkdownRendererNuGetVersion)' == ''">0.1.4</OfficeImoMarkdownRendererNuGetVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- bump `OfficeImoMarkdownRendererNuGetVersion` from `0.1.1` to `0.1.4`
- pick up latest OfficeIMO markdown fixes already merged/published

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj --filter "TranscriptHtmlFormatterTests|TranscriptMarkdownNormalizerTests"`