### PR TITLE
Fix chat action UX: strip loose action blocks and auto-execute single follow-ups

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ActionModelProtocolTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ActionModelProtocolTests.cs
@@ -11,7 +11,7 @@ public sealed class ActionModelProtocolTests {
     /// Ensures pending action protocol blocks are removed from visible text and converted to a concise action summary.
     /// </summary>
     [Fact]
-    public void TryStripAndExtractPendingActions_StripsProtocolAndBuildsVisibleSummary() {
+    public void TryStripAndExtractPendingActions_StripsProtocolAndKeepsVisibleText() {
         const string text = """
                             I can retry this with safer defaults.
 
@@ -32,8 +32,31 @@ public sealed class ActionModelProtocolTests {
         Assert.Equal("act_ad0_sys_top5_bare", actions[0].Id);
 
         var visible = ActionModelProtocol.MergeVisibleTextWithPendingActions(cleaned, actions);
-        Assert.Contains("follow-up actions", visible, System.StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("`/act act_ad0_sys_top5_bare`", visible);
+        Assert.Equal("I can retry this with safer defaults.", visible);
+    }
+
+    /// <summary>
+    /// Ensures loose action blocks without the [Action]/marker envelope are still stripped and captured.
+    /// </summary>
+    [Fact]
+    public void TryStripAndExtractPendingActions_StripsLooseActionBlockWithoutEnvelope() {
+        const string text = """
+                            id
+                            act_repl_now
+                            title
+                            Run fresh AD replication summary now
+                            request
+                            Execute ad_replication_summary for current forest/domain scope and return current health, failed edges, stale links, and top replication errors.
+                            reply
+                            /act act_repl_now
+                            """;
+
+        var normalized = ActionModelProtocol.TryStripAndExtractPendingActions(text, out var actions, out var cleaned);
+
+        Assert.True(normalized);
+        Assert.Single(actions);
+        Assert.Equal("act_repl_now", actions[0].Id);
+        Assert.Equal(string.Empty, cleaned);
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/ActionModelProtocol.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/ActionModelProtocol.cs
@@ -12,6 +12,9 @@ internal static class ActionModelProtocol {
     private const string ActionHeader = "[Action]";
     private const string ActionMarker = "ix:action:v1";
     private const int MaxActionParsingChars = 64 * 1024;
+    private static readonly Regex LooseActionBlockRegex = new(
+        @"(?is)(?:^|\n)\s*id\s*:?\s*(?<id>[^\r\n]+)\s*\r?\n\s*title\s*:?\s*(?<title>[^\r\n]*)\s*\r?\n\s*request\s*:?\s*(?<request>.*?)\r?\n\s*reply\s*:?\s*(?<reply>[^\r\n]+)",
+        RegexOptions.CultureInvariant);
 
     public static bool TryStripAndExtractPendingActions(
         string? assistantText,
@@ -77,6 +80,7 @@ internal static class ActionModelProtocol {
             for (var j = markerIndex + 1; j < lines.Length; j++) {
                 var current = lines[j] ?? string.Empty;
                 var trimmedCurrent = current.Trim();
+                endExclusive = j + 1;
                 if (IsFenceBoundary(trimmedCurrent)) {
                     endExclusive = j;
                     break;
@@ -146,7 +150,16 @@ internal static class ActionModelProtocol {
         }
 
         if (!markerSeen) {
-            return false;
+            if (!TryStripLoosePendingActions(normalized, out var looseActions, out var looseCleanedText)) {
+                return false;
+            }
+
+            actions = looseActions
+                .GroupBy(x => x.Id, StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.First())
+                .ToArray();
+            cleanedText = looseCleanedText;
+            return true;
         }
 
         var kept = new List<string>(lines.Length);
@@ -185,17 +198,7 @@ internal static class ActionModelProtocol {
         !string.IsNullOrWhiteSpace(line) && line.StartsWith("```", StringComparison.Ordinal);
 
     public static string MergeVisibleTextWithPendingActions(string cleanedText, IReadOnlyList<AssistantPendingAction> actions) {
-        var text = (cleanedText ?? string.Empty).Trim();
-        if (actions is null || actions.Count == 0) {
-            return text;
-        }
-
-        var summary = BuildPendingActionSummary(actions);
-        if (summary.Length == 0) {
-            return text;
-        }
-
-        return text.Length == 0 ? summary : text + "\n\n" + summary;
+        return (cleanedText ?? string.Empty).Trim();
     }
 
     private static string BuildPendingActionSummary(IReadOnlyList<AssistantPendingAction> actions) {
@@ -246,6 +249,89 @@ internal static class ActionModelProtocol {
 
         value = line[(idx + 1)..].Trim();
         return true;
+    }
+
+    private static bool TryStripLoosePendingActions(
+        string normalizedText,
+        out IReadOnlyList<AssistantPendingAction> actions,
+        out string cleanedText) {
+        cleanedText = normalizedText;
+        actions = Array.Empty<AssistantPendingAction>();
+        if (string.IsNullOrWhiteSpace(normalizedText) || normalizedText.Length > MaxActionParsingChars) {
+            return false;
+        }
+
+        var matches = LooseActionBlockRegex.Matches(normalizedText);
+        if (matches.Count == 0) {
+            return false;
+        }
+
+        var extracted = new List<AssistantPendingAction>();
+        var removeRanges = new List<(int Start, int EndExclusive)>();
+
+        for (var i = 0; i < matches.Count && extracted.Count < 6; i++) {
+            var match = matches[i];
+            if (!match.Success) {
+                continue;
+            }
+            if (IsInsideCodeFence(normalizedText, match.Index)) {
+                continue;
+            }
+
+            var id = (match.Groups["id"].Value ?? string.Empty).Trim();
+            var title = (match.Groups["title"].Value ?? string.Empty).Trim();
+            var request = Regex.Replace((match.Groups["request"].Value ?? string.Empty).Trim(), @"\s+", " ");
+            var reply = (match.Groups["reply"].Value ?? string.Empty).Trim();
+            if (id.Length == 0 || !LooksLikeValidActionReply(reply, id)) {
+                continue;
+            }
+
+            extracted.Add(new AssistantPendingAction(id, title, request, reply));
+            removeRanges.Add((match.Index, match.Index + match.Length));
+        }
+
+        if (extracted.Count == 0) {
+            return false;
+        }
+
+        var sb = new StringBuilder(normalizedText.Length);
+        var cursor = 0;
+        for (var i = 0; i < removeRanges.Count; i++) {
+            var (start, endExclusive) = removeRanges[i];
+            if (start > cursor) {
+                sb.Append(normalizedText, cursor, start - cursor);
+            }
+            cursor = Math.Max(cursor, endExclusive);
+        }
+        if (cursor < normalizedText.Length) {
+            sb.Append(normalizedText, cursor, normalizedText.Length - cursor);
+        }
+
+        cleanedText = Regex.Replace(sb.ToString().Trim(), @"\n{3,}", "\n\n");
+        actions = extracted
+            .GroupBy(x => x.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToArray();
+        return true;
+    }
+
+    private static bool IsInsideCodeFence(string text, int index) {
+        var value = text ?? string.Empty;
+        if (value.Length == 0 || index <= 0) {
+            return false;
+        }
+
+        var prefixLength = Math.Min(index, value.Length);
+        var prefix = value[..prefixLength].Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        var lines = prefix.Split('\n');
+        var inFence = false;
+        for (var i = 0; i < lines.Length; i++) {
+            if (IsFenceBoundary((lines[i] ?? string.Empty).Trim())) {
+                inFence = !inFence;
+            }
+        }
+
+        return inFence;
     }
 
     private static bool LooksLikeValidActionReply(string reply, string id) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -144,11 +144,38 @@ internal sealed partial class ChatServiceSession {
         var toolReceiptCorrectionUsed = false;
         var noToolExecutionWatchdogUsed = false;
         var executionContractEscapeUsed = false;
+        var autoPendingActionReplayUsed = false;
 
         for (var round = 0; round < Math.Max(1, maxRounds); round++) {
             var extracted = ToolCallParser.Extract(turn);
             if (extracted.Count == 0) {
                 var text = EasyChatResult.FromTurn(turn).Text ?? string.Empty;
+
+                if (!autoPendingActionReplayUsed
+                    && toolCalls.Count == 0
+                    && toolOutputs.Count == 0
+                    && LooksLikeContinuationFollowUp(userRequest)
+                    && TryBuildSinglePendingActionSelectionPayload(text, out var autoSelectionPayload, out var autoActionId)) {
+                    autoPendingActionReplayUsed = true;
+                    routedUserRequest = autoSelectionPayload;
+                    executionContractApplies = ShouldEnforceExecuteOrExplainContract(routedUserRequest);
+
+                    await TryWriteStatusAsync(
+                            writer,
+                            request.RequestId,
+                            threadId,
+                            status: "thinking",
+                            message: $"Executing follow-up action {autoActionId} directly.")
+                        .ConfigureAwait(false);
+                    turn = await ChatWithToolSchemaRecoveryAsync(
+                            client,
+                            ChatInput.FromText(autoSelectionPayload),
+                            CopyChatOptions(options, newThreadOverride: false),
+                            turnToken)
+                        .ConfigureAwait(false);
+                    continue;
+                }
+
                 var shouldAttemptExecutionNudge = false;
                 var executionNudgeReason = executionNudgeUsed
                     ? "execution_nudge_already_used"

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace IntelligenceX.Chat.Service;
 
@@ -12,6 +13,9 @@ internal sealed partial class ChatServiceSession {
     private const int MaxActionParsingChars = 64 * 1024;
     private const int MaxPendingActionAssistantContextChars = 4096;
     private const int MaxFallbackChoiceActionTitleChars = 96;
+    private static readonly Regex LooseActionBlockRegex = new(
+        @"(?is)(?:^|\n)\s*id\s*:?\s*(?<id>[^\r\n]+)\s*\r?\n\s*title\s*:?\s*(?<title>[^\r\n]*)\s*\r?\n\s*request\s*:?\s*(?<request>.*?)\r?\n\s*reply\s*:?\s*(?<reply>[^\r\n]+)",
+        RegexOptions.CultureInvariant);
     private static readonly char[] PendingActionConfirmationQuestionPunctuation = new[] { '?', '？', '¿', '؟' };
     private static readonly char[] PendingActionConfirmationDisqualifierPunctuation = new[] { ':', ';', '\uFF1A', '\uFF1B' }; // ： ；
     private static readonly char[] PendingActionConfirmationStructuredDisqualifierChars =
@@ -56,9 +60,16 @@ internal sealed partial class ChatServiceSession {
 
         var text = assistantText ?? string.Empty;
         var markerIdx = text.IndexOf(ActionMarker, StringComparison.OrdinalIgnoreCase);
-        bool fromFallbackChoices;
-        List<PendingAction> actions;
-        if (markerIdx < 0) {
+        if (markerIdx >= 0 && text.Length > MaxActionParsingChars) {
+            // Keep a window around the first marker to cap worst-case parsing work.
+            var start = Math.Max(0, markerIdx - 256);
+            var len = Math.Min(MaxActionParsingChars, text.Length - start);
+            text = text.Substring(start, len);
+        }
+
+        var actions = ExtractPendingActions(text);
+        var fromFallbackChoices = false;
+        if (actions.Count == 0 && markerIdx < 0) {
             // Fallback: allow compact assistant choice lists (for example bullet options) to be
             // selected naturally on the next user turn, even when the model omitted ix:action blocks.
             actions = ExtractFallbackChoicePendingActions(text);
@@ -69,16 +80,6 @@ internal sealed partial class ChatServiceSession {
             }
 
             fromFallbackChoices = true;
-        } else {
-            if (text.Length > MaxActionParsingChars) {
-                // Keep a window around the first marker to cap worst-case parsing work.
-                var start = Math.Max(0, markerIdx - 256);
-                var len = Math.Min(MaxActionParsingChars, text.Length - start);
-                text = text.Substring(start, len);
-            }
-
-            actions = ExtractPendingActions(text);
-            fromFallbackChoices = false;
         }
 
         var assistantContext = text.Length <= MaxPendingActionAssistantContextChars
@@ -290,6 +291,40 @@ internal sealed partial class ChatServiceSession {
             outcome: "match",
             reason: matchReason,
             selectedActionId: selected.Value.Id);
+        return true;
+    }
+
+    private static bool TryBuildSinglePendingActionSelectionPayload(string assistantDraft, out string payloadJson, out string actionId) {
+        payloadJson = string.Empty;
+        actionId = string.Empty;
+
+        var actions = ExtractPendingActions(assistantDraft);
+        if (actions.Count == 0) {
+            actions = ExtractFallbackChoicePendingActions(assistantDraft);
+        }
+        if (actions.Count != 1) {
+            return false;
+        }
+
+        var action = actions[0];
+        actionId = (action.Id ?? string.Empty).Trim();
+        if (actionId.Length == 0) {
+            return false;
+        }
+
+        var title = (action.Title ?? string.Empty).Trim();
+        var request = string.IsNullOrWhiteSpace(action.Request) ? title : action.Request.Trim();
+        if (request.Length == 0) {
+            return false;
+        }
+
+        payloadJson = JsonSerializer.Serialize(new {
+            ix_action_selection = new {
+                id = actionId,
+                title,
+                request = CollapseWhitespace(request).Trim()
+            }
+        });
         return true;
     }
 
@@ -839,8 +874,9 @@ internal sealed partial class ChatServiceSession {
             return new List<PendingAction>();
         }
 
-        // Cheap precheck to avoid parsing when the marker isn't present.
-        if (text.IndexOf(ActionMarker, StringComparison.OrdinalIgnoreCase) < 0) {
+        // Cheap precheck to avoid parsing when neither the standard marker nor a loose action shape is present.
+        if (text.IndexOf(ActionMarker, StringComparison.OrdinalIgnoreCase) < 0
+            && !LooksLikeLooseActionBlockCandidate(text)) {
             return new List<PendingAction>();
         }
 
@@ -959,7 +995,94 @@ internal sealed partial class ChatServiceSession {
             actions = actions.Where(a => a.Id.Length > 0 && seen.Add(a.Id)).ToList();
         }
 
+        if (actions.Count == 0 && text.IndexOf(ActionMarker, StringComparison.OrdinalIgnoreCase) < 0) {
+            actions = ExtractLoosePendingActions(text);
+        }
+
         return actions;
+    }
+
+    private static bool LooksLikeLooseActionBlockCandidate(string text) {
+        var value = text ?? string.Empty;
+        if (value.Length == 0) {
+            return false;
+        }
+
+        if (value.IndexOf("/act", StringComparison.OrdinalIgnoreCase) < 0) {
+            return false;
+        }
+
+        return value.IndexOf("id", StringComparison.OrdinalIgnoreCase) >= 0
+               && value.IndexOf("request", StringComparison.OrdinalIgnoreCase) >= 0
+               && value.IndexOf("reply", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static List<PendingAction> ExtractLoosePendingActions(string assistantText) {
+        var text = assistantText ?? string.Empty;
+        if (text.Length == 0) {
+            return new List<PendingAction>();
+        }
+
+        var actions = new List<PendingAction>();
+        var matches = LooseActionBlockRegex.Matches(text);
+        for (var i = 0; i < matches.Count && actions.Count < 6; i++) {
+            var match = matches[i];
+            if (!match.Success) {
+                continue;
+            }
+            if (IsInsideCodeFence(text, match.Index)) {
+                continue;
+            }
+
+            var id = (match.Groups["id"].Value ?? string.Empty).Trim();
+            var title = (match.Groups["title"].Value ?? string.Empty).Trim();
+            var request = CollapseWhitespace((match.Groups["request"].Value ?? string.Empty).Trim());
+            var reply = (match.Groups["reply"].Value ?? string.Empty).Trim();
+
+            if (id.Length == 0) {
+                continue;
+            }
+            if (!LooksLikeValidActionReply(reply, id)) {
+                continue;
+            }
+            if (id.Length > 64) {
+                id = id[..64];
+            }
+            if (title.Length > 200) {
+                title = title[..200];
+            }
+            if (request.Length > 600) {
+                request = request[..600];
+            }
+
+            actions.Add(new PendingAction(Id: id, Title: title, Request: request));
+        }
+
+        if (actions.Count > 1) {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            actions = actions.Where(a => a.Id.Length > 0 && seen.Add(a.Id)).ToList();
+        }
+
+        return actions;
+    }
+
+    private static bool IsInsideCodeFence(string text, int index) {
+        var value = text ?? string.Empty;
+        if (value.Length == 0 || index <= 0) {
+            return false;
+        }
+
+        var prefixLength = Math.Min(index, value.Length);
+        var lines = SplitLines(value[..prefixLength]);
+        var inFence = false;
+        for (var i = 0; i < lines.Count; i++) {
+            var trimmed = (lines[i] ?? string.Empty).Trim();
+            if (trimmed.StartsWith("```", StringComparison.Ordinal)) {
+                inFence = !inFence;
+            }
+        }
+
+        return inFence;
     }
 
     private static bool LooksLikeValidActionReply(string reply, string id) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
@@ -608,6 +608,31 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("forest-wide replication", expanded, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Ensures loose pending-action blocks (without ix:action marker envelope) can still be selected via /act.
+    /// </summary>
+    [Fact]
+    public void ExpandContinuationUserRequest_ResolvesActCommandFromLoosePendingActionBlock() {
+        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var assistantDraft = """
+            id
+            act_repl_now
+            title
+            Run fresh AD replication summary now
+            request
+            Execute ad_replication_summary for current forest/domain scope and return current health, failed edges, stale links, and top replication errors.
+            reply
+            /act act_repl_now
+            """;
+
+        RememberPendingActionsMethod.Invoke(session, new object?[] { "thread-001", assistantDraft });
+        var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", "/act act_repl_now" });
+        var expanded = Assert.IsType<string>(result);
+
+        Assert.Contains("ad_replication_summary", expanded, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ix_action_selection", expanded, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesMultiLinePendingActionRequest() {
         var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);


### PR DESCRIPTION
Summary:
- add robust parsing for loose action blocks (id/title/request/reply) even when ix:action:v1 envelope is missing
- prevent action extraction from fenced code content
- auto-execute a single assistant-proposed follow-up action for compact continuation turns (for example go ahead?) instead of bouncing users into a manual /act step
- keep assistant-visible text clean by stripping protocol blocks and removing extra follow-up summary nudging text

Validation:
- dotnet build IntelligenceX.Chat/IntelligenceX.Chat.sln -c Release
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter FullyQualifiedName~ActionModelProtocolTests
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter FullyQualifiedName~ChatServiceRoutingTrimTests