### PR TITLE
Integrate IX.OfficeIMO pack into chat bootstrap

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
@@ -61,6 +61,7 @@ internal static partial class Program {
         public int AdMaxResults { get; set; } = 1000;
         public bool EnablePowerShellPack { get; set; }
         public bool EnableTestimoXPack { get; set; } = true;
+        public bool EnableOfficeImoPack { get; set; } = true;
         public bool EnableDefaultPluginPaths { get; set; } = true;
         public List<string> PluginPaths { get; } = new();
 
@@ -232,6 +233,12 @@ internal static partial class Program {
                         break;
                     case "--disable-testimox-pack":
                         options.EnableTestimoXPack = false;
+                        break;
+                    case "--enable-officeimo-pack":
+                        options.EnableOfficeImoPack = true;
+                        break;
+                    case "--disable-officeimo-pack":
+                        options.EnableOfficeImoPack = false;
                         break;
                     case "--plugin-path":
                         if (!TryGetValue(args, ref i, out var pluginPath, out error)) {
@@ -430,6 +437,7 @@ internal static partial class Program {
             AdMaxResults = profile.AdMaxResults;
             EnablePowerShellPack = profile.EnablePowerShellPack;
             EnableTestimoXPack = profile.EnableTestimoXPack;
+            EnableOfficeImoPack = profile.EnableOfficeImoPack;
             EnableDefaultPluginPaths = profile.EnableDefaultPluginPaths;
             PluginPaths.Clear();
             if (profile.PluginPaths is { Count: > 0 }) {
@@ -477,6 +485,7 @@ internal static partial class Program {
                 AdMaxResults = AdMaxResults,
                 EnablePowerShellPack = EnablePowerShellPack,
                 EnableTestimoXPack = EnableTestimoXPack,
+                EnableOfficeImoPack = EnableOfficeImoPack,
                 EnableDefaultPluginPaths = EnableDefaultPluginPaths
             };
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Policy.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Policy.cs
@@ -36,6 +36,7 @@ internal static partial class Program {
             AdMaxResults = options.AdMaxResults,
             EnablePowerShellPack = options.EnablePowerShellPack,
             EnableTestimoXPack = options.EnableTestimoXPack,
+            EnableOfficeImoPack = options.EnableOfficeImoPack,
             EnableDefaultPluginPaths = options.EnableDefaultPluginPaths,
             PluginPaths = options.PluginPaths.ToArray(),
             OnBootstrapWarning = onBootstrapWarning

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.cs
@@ -57,6 +57,7 @@ internal static partial class Program {
         Console.WriteLine($"Redaction: {(options.Redact ? "on" : "off")}");
         Console.WriteLine($"IX.PowerShell pack: {(options.EnablePowerShellPack ? "enabled (dangerous)" : "disabled")}");
         Console.WriteLine($"IX.TestimoX pack: {(options.EnableTestimoXPack ? "enabled" : "disabled")}");
+        Console.WriteLine($"IX.OfficeIMO pack: {(options.EnableOfficeImoPack ? "enabled" : "disabled")}");
         Console.WriteLine($"Allowed roots: {(options.AllowedRoots.Count == 0 ? "(none)" : string.Join("; ", options.AllowedRoots))}");
         var authPath = ResolveAuthPath(options);
         if (!string.IsNullOrWhiteSpace(authPath)) {
@@ -904,6 +905,8 @@ internal static partial class Program {
         Console.WriteLine("  --enable-powershell-pack  Enable dangerous IX.PowerShell runtime tools (default: off).");
         Console.WriteLine("  --enable-testimox-pack  Enable IX.TestimoX diagnostics tools (default: on).");
         Console.WriteLine("  --disable-testimox-pack Disable IX.TestimoX diagnostics tools.");
+        Console.WriteLine("  --enable-officeimo-pack  Enable IX.OfficeIMO document ingestion tools (default: on).");
+        Console.WriteLine("  --disable-officeimo-pack Disable IX.OfficeIMO document ingestion tools.");
         Console.WriteLine("  --plugin-path <PATH>    Additional folder-based plugin path (repeatable).");
         Console.WriteLine("  --no-default-plugin-paths Disable default plugin paths (%LOCALAPPDATA% and app ./plugins).");
         Console.WriteLine("  --max-table-rows <N>    Max rows to show in table-like output (0 = no limit; default: 0).");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Profiles/InMemoryServiceProfileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Profiles/InMemoryServiceProfileStore.cs
@@ -57,6 +57,7 @@ internal sealed class InMemoryServiceProfileStore : IServiceProfileStore {
             EnablePowerShellPack = profile.EnablePowerShellPack,
             PowerShellAllowWrite = profile.PowerShellAllowWrite,
             EnableTestimoXPack = profile.EnableTestimoXPack,
+            EnableOfficeImoPack = profile.EnableOfficeImoPack,
             EnableDefaultPluginPaths = profile.EnableDefaultPluginPaths,
             PluginPaths = new List<string>(profile.PluginPaths ?? new List<string>()),
             InstructionsFile = profile.InstructionsFile,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Profiles/ServiceProfile.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Profiles/ServiceProfile.cs
@@ -36,6 +36,7 @@ internal sealed class ServiceProfile {
     public bool EnablePowerShellPack { get; set; }
     public bool PowerShellAllowWrite { get; set; }
     public bool EnableTestimoXPack { get; set; } = true;
+    public bool EnableOfficeImoPack { get; set; } = true;
     public bool EnableDefaultPluginPaths { get; set; } = true;
     public List<string> PluginPaths { get; set; } = new();
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Profiles/SqliteServiceProfileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Profiles/SqliteServiceProfileStore.cs
@@ -70,6 +70,7 @@ CREATE TABLE IF NOT EXISTS {ProfileTable} (
   enable_powershell_pack INTEGER NOT NULL,
   powershell_allow_write INTEGER NOT NULL,
   enable_testimox_pack INTEGER NOT NULL,
+  enable_officeimo_pack INTEGER NOT NULL DEFAULT 1,
   enable_default_plugin_paths INTEGER NOT NULL,
   updated_utc TEXT NOT NULL
 );
@@ -93,6 +94,8 @@ CREATE TABLE IF NOT EXISTS {PluginPathsTable} (
 CREATE INDEX IF NOT EXISTS ix_service_profiles_updated_utc ON {ProfileTable}(updated_utc);
 CREATE INDEX IF NOT EXISTS ix_service_profiles_transport_kind ON {ProfileTable}(transport_kind);
 ");
+
+        EnsureColumnExists(ProfileTable, "enable_officeimo_pack", "INTEGER NOT NULL DEFAULT 1");
     }
 
     private bool HasLegacyJsonSchema() {
@@ -111,6 +114,30 @@ CREATE INDEX IF NOT EXISTS ix_service_profiles_transport_kind ON {ProfileTable}(
             return false;
         } catch {
             return false;
+        }
+    }
+
+    private void EnsureColumnExists(string tableName, string columnName, string columnDefinition) {
+        if (string.IsNullOrWhiteSpace(tableName) || string.IsNullOrWhiteSpace(columnName) || string.IsNullOrWhiteSpace(columnDefinition)) {
+            return;
+        }
+
+        try {
+            var result = _db.Query(_dbPath, $"PRAGMA table_info('{tableName}')");
+            if (result is not DataTable dt || dt.Rows.Count == 0) {
+                return;
+            }
+
+            foreach (DataRow row in dt.Rows) {
+                var name = row["name"]?.ToString();
+                if (string.Equals(name, columnName, StringComparison.OrdinalIgnoreCase)) {
+                    return;
+                }
+            }
+
+            _db.ExecuteNonQuery(_dbPath, $"ALTER TABLE {tableName} ADD COLUMN {columnName} {columnDefinition};");
+        } catch {
+            // Best-effort schema evolution; keep startup resilient.
         }
     }
 
@@ -150,6 +177,7 @@ SELECT
   enable_powershell_pack,
   powershell_allow_write,
   enable_testimox_pack,
+  enable_officeimo_pack,
   enable_default_plugin_paths
 FROM {ProfileTable}
 WHERE name = @name
@@ -202,6 +230,7 @@ LIMIT 1;",
             EnablePowerShellPack = ReadBool(r, "enable_powershell_pack", defaultValue: false),
             PowerShellAllowWrite = ReadBool(r, "powershell_allow_write", defaultValue: false),
             EnableTestimoXPack = ReadBool(r, "enable_testimox_pack", defaultValue: true),
+            EnableOfficeImoPack = ReadBool(r, "enable_officeimo_pack", defaultValue: true),
             EnableDefaultPluginPaths = ReadBool(r, "enable_default_plugin_paths", defaultValue: true)
         };
 
@@ -234,7 +263,7 @@ INSERT INTO {ProfileTable} (
   max_tool_rounds, parallel_tools, turn_timeout_seconds, tool_timeout_seconds,
   instructions_file, max_table_rows, max_sample, redact,
   ad_domain_controller, ad_default_search_base_dn, ad_max_results,
-  enable_powershell_pack, powershell_allow_write, enable_testimox_pack,
+  enable_powershell_pack, powershell_allow_write, enable_testimox_pack, enable_officeimo_pack,
   enable_default_plugin_paths, updated_utc
 )
 VALUES (
@@ -244,7 +273,7 @@ VALUES (
   @max_tool_rounds, @parallel_tools, @turn_timeout_seconds, @tool_timeout_seconds,
   @instructions_file, @max_table_rows, @max_sample, @redact,
   @ad_domain_controller, @ad_default_search_base_dn, @ad_max_results,
-  @enable_powershell_pack, @powershell_allow_write, @enable_testimox_pack,
+  @enable_powershell_pack, @powershell_allow_write, @enable_testimox_pack, @enable_officeimo_pack,
   @enable_default_plugin_paths, @updated_utc
 )
 ON CONFLICT(name) DO UPDATE SET
@@ -273,6 +302,7 @@ ON CONFLICT(name) DO UPDATE SET
   enable_powershell_pack = excluded.enable_powershell_pack,
   powershell_allow_write = excluded.powershell_allow_write,
   enable_testimox_pack = excluded.enable_testimox_pack,
+  enable_officeimo_pack = excluded.enable_officeimo_pack,
   enable_default_plugin_paths = excluded.enable_default_plugin_paths,
   updated_utc = excluded.updated_utc;",
                 parameters: new Dictionary<string, object?> {
@@ -303,6 +333,7 @@ ON CONFLICT(name) DO UPDATE SET
                     ["@enable_powershell_pack"] = profile.EnablePowerShellPack ? 1 : 0,
                     ["@powershell_allow_write"] = profile.PowerShellAllowWrite ? 1 : 0,
                     ["@enable_testimox_pack"] = profile.EnableTestimoXPack ? 1 : 0,
+                    ["@enable_officeimo_pack"] = profile.EnableOfficeImoPack ? 1 : 0,
                     ["@enable_default_plugin_paths"] = profile.EnableDefaultPluginPaths ? 1 : 0,
                     ["@updated_utc"] = now
                 });

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
@@ -446,6 +446,7 @@ internal sealed partial class ChatServiceSession {
             EnablePowerShellPack = _options.EnablePowerShellPack,
             PowerShellAllowWrite = _options.PowerShellAllowWrite,
             EnableTestimoXPack = _options.EnableTestimoXPack,
+            EnableOfficeImoPack = _options.EnableOfficeImoPack,
             EnableDefaultPluginPaths = _options.EnableDefaultPluginPaths,
             PluginPaths = _options.PluginPaths.ToArray(),
             OnBootstrapWarning = warning => RecordBootstrapWarning(startupWarnings, warning)

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
@@ -75,6 +75,7 @@ internal sealed partial class ChatServiceSession {
             EnablePowerShellPack = _options.EnablePowerShellPack,
             PowerShellAllowWrite = _options.PowerShellAllowWrite,
             EnableTestimoXPack = _options.EnableTestimoXPack,
+            EnableOfficeImoPack = _options.EnableOfficeImoPack,
             EnableDefaultPluginPaths = _options.EnableDefaultPluginPaths,
             PluginPaths = _options.PluginPaths.ToArray(),
             OnBootstrapWarning = warning => RecordBootstrapWarning(startupWarnings, warning)

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -44,6 +44,7 @@ internal sealed class ServiceOptions {
     public bool EnablePowerShellPack { get; set; }
     public bool PowerShellAllowWrite { get; set; }
     public bool EnableTestimoXPack { get; set; } = true;
+    public bool EnableOfficeImoPack { get; set; } = true;
     public bool EnableDefaultPluginPaths { get; set; } = true;
     public List<string> PluginPaths { get; } = new();
 
@@ -308,6 +309,14 @@ internal sealed class ServiceOptions {
                 options.EnableTestimoXPack = false;
                 continue;
             }
+            if (arg is "--enable-officeimo-pack") {
+                options.EnableOfficeImoPack = true;
+                continue;
+            }
+            if (arg is "--disable-officeimo-pack") {
+                options.EnableOfficeImoPack = false;
+                continue;
+            }
             if (arg is "--plugin-path") {
                 if (!TryConsume(args, ref i, out var value, out error)) {
                     return options;
@@ -422,6 +431,8 @@ internal sealed class ServiceOptions {
         Console.WriteLine("  --powershell-allow-write  Allow read_write intent in IX.PowerShell tools (default: off).");
         Console.WriteLine("  --enable-testimox-pack  Enable IX.TestimoX diagnostics tools (default: on).");
         Console.WriteLine("  --disable-testimox-pack Disable IX.TestimoX diagnostics tools.");
+        Console.WriteLine("  --enable-officeimo-pack  Enable IX.OfficeIMO document ingestion tools (default: on).");
+        Console.WriteLine("  --disable-officeimo-pack Disable IX.OfficeIMO document ingestion tools.");
         Console.WriteLine("  --plugin-path <PATH>    Additional folder-based plugin path (repeatable).");
         Console.WriteLine("  --no-default-plugin-paths Disable default plugin paths (%LOCALAPPDATA% and app ./plugins).");
         Console.WriteLine("  --max-table-rows <N>    Max rows to show in table-like output (0 = no limit; default: 0).");
@@ -522,6 +533,7 @@ internal sealed class ServiceOptions {
         EnablePowerShellPack = profile.EnablePowerShellPack;
         PowerShellAllowWrite = profile.PowerShellAllowWrite;
         EnableTestimoXPack = profile.EnableTestimoXPack;
+        EnableOfficeImoPack = profile.EnableOfficeImoPack;
         EnableDefaultPluginPaths = profile.EnableDefaultPluginPaths;
         PluginPaths.Clear();
         if (profile.PluginPaths != null && profile.PluginPaths.Count > 0) {
@@ -558,6 +570,7 @@ internal sealed class ServiceOptions {
             EnablePowerShellPack = EnablePowerShellPack,
             PowerShellAllowWrite = PowerShellAllowWrite,
             EnableTestimoXPack = EnableTestimoXPack,
+            EnableOfficeImoPack = EnableOfficeImoPack,
             EnableDefaultPluginPaths = EnableDefaultPluginPaths,
             PluginPaths = new List<string>(PluginPaths),
             InstructionsFile = InstructionsFile,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ServiceOptionsProfileBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ServiceOptionsProfileBootstrapTests.cs
@@ -17,6 +17,7 @@ public sealed class ServiceOptionsProfileBootstrapTests {
         Assert.True(string.IsNullOrWhiteSpace(error));
         Assert.Equal(0, options.MaxTableRows);
         Assert.Equal(0, options.MaxSample);
+        Assert.True(options.EnableOfficeImoPack);
     }
 
     [Fact]
@@ -66,6 +67,17 @@ public sealed class ServiceOptionsProfileBootstrapTests {
         } finally {
             TryDelete(dbPath);
         }
+    }
+
+    [Fact]
+    public void Parse_Allows_Disabling_And_Enabling_OfficeImoPack() {
+        var disabled = ServiceOptions.Parse(new[] { "--disable-officeimo-pack" }, out var disabledError);
+        Assert.True(string.IsNullOrWhiteSpace(disabledError));
+        Assert.False(disabled.EnableOfficeImoPack);
+
+        var enabled = ServiceOptions.Parse(new[] { "--disable-officeimo-pack", "--enable-officeimo-pack" }, out var enabledError);
+        Assert.True(string.IsNullOrWhiteSpace(enabledError));
+        Assert.True(enabled.EnableOfficeImoPack);
     }
 
     private static void TryDelete(string path) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
@@ -30,4 +30,37 @@ public sealed class ToolPackBootstrapMetadataTests {
         var normalized = ToolPackBootstrap.NormalizePackId(input);
         Assert.Equal(expected, normalized);
     }
+
+    [Fact]
+    public void CreateDefaultReadOnlyPacks_IncludesOfficeImoPack_ByDefault() {
+        var packs = ToolPackBootstrap.CreateDefaultReadOnlyPacks(new ToolPackBootstrapOptions {
+            EnableFileSystemPack = false,
+            EnableSystemPack = false,
+            EnableActiveDirectoryPack = false,
+            EnablePowerShellPack = false,
+            EnableTestimoXPack = false,
+            EnableEmailPack = false,
+            EnableReviewerSetupPack = false,
+            EnableDefaultPluginPaths = false
+        });
+
+        Assert.Contains(packs, static pack => string.Equals(pack.Descriptor.Id, "officeimo", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void CreateDefaultReadOnlyPacks_RespectsDisableOfficeImoPack() {
+        var packs = ToolPackBootstrap.CreateDefaultReadOnlyPacks(new ToolPackBootstrapOptions {
+            EnableFileSystemPack = false,
+            EnableSystemPack = false,
+            EnableActiveDirectoryPack = false,
+            EnablePowerShellPack = false,
+            EnableTestimoXPack = false,
+            EnableOfficeImoPack = false,
+            EnableEmailPack = false,
+            EnableReviewerSetupPack = false,
+            EnableDefaultPluginPaths = false
+        });
+
+        Assert.DoesNotContain(packs, static pack => string.Equals(pack.Descriptor.Id, "officeimo", StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/IntelligenceX.Chat.Tooling.csproj
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/IntelligenceX.Chat.Tooling.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.System\IntelligenceX.Tools.System.csproj" />
     <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.PowerShell\IntelligenceX.Tools.PowerShell.csproj" />
     <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.TestimoX\IntelligenceX.Tools.TestimoX.csproj" />
+    <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.OfficeIMO\IntelligenceX.Tools.OfficeIMO.csproj" />
     <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.ReviewerSetup\IntelligenceX.Tools.ReviewerSetup.csproj" />
   </ItemGroup>
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/PluginFolderToolPackLoader.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/PluginFolderToolPackLoader.cs
@@ -532,6 +532,7 @@ internal static class PluginFolderToolPackLoader {
             "ad" => options.EnableActiveDirectoryPack,
             "powershell" => options.EnablePowerShellPack,
             "testimox" => options.EnableTestimoXPack,
+            "officeimo" => options.EnableOfficeImoPack,
             "reviewer_setup" => options.EnableReviewerSetupPack,
             "email" => options.EnableEmailPack,
             _ => true

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolPackBootstrap.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolPackBootstrap.cs
@@ -59,6 +59,11 @@ public sealed record ToolPackBootstrapOptions {
     public bool EnableTestimoXPack { get; init; } = true;
 
     /// <summary>
+    /// Enables IX.OfficeIMO read-only document ingestion pack when available.
+    /// </summary>
+    public bool EnableOfficeImoPack { get; init; } = true;
+
+    /// <summary>
     /// Enables reviewer setup guidance pack.
     /// </summary>
     public bool EnableReviewerSetupPack { get; init; } = true;
@@ -134,6 +139,8 @@ public static class ToolPackBootstrap {
     private const string PowerShellOptionsTypeName = "IntelligenceX.Tools.PowerShell.PowerShellToolOptions, IntelligenceX.Tools.PowerShell";
     private const string TestimoXPackTypeName = "IntelligenceX.Tools.TestimoX.TestimoXToolPack, IntelligenceX.Tools.TestimoX";
     private const string TestimoXOptionsTypeName = "IntelligenceX.Tools.TestimoX.TestimoXToolOptions, IntelligenceX.Tools.TestimoX";
+    private const string OfficeImoPackTypeName = "IntelligenceX.Tools.OfficeIMO.OfficeImoToolPack, IntelligenceX.Tools.OfficeIMO";
+    private const string OfficeImoOptionsTypeName = "IntelligenceX.Tools.OfficeIMO.OfficeImoToolOptions, IntelligenceX.Tools.OfficeIMO";
     private const string EmailPackTypeName = "IntelligenceX.Tools.Email.EmailToolPack, IntelligenceX.Tools.Email";
     private const string EmailOptionsTypeName = "IntelligenceX.Tools.Email.EmailToolOptions, IntelligenceX.Tools.Email";
 
@@ -229,6 +236,19 @@ public static class ToolPackBootstrap {
                 optionsTypeName: TestimoXOptionsTypeName,
                 configureOptions: testimoOptions => {
                     SetPropertyIfPresent(testimoOptions, "Enabled", true);
+                },
+                warnWhenUnavailable: true,
+                onWarning: options.OnBootstrapWarning);
+        }
+
+        if (options.EnableOfficeImoPack) {
+            TryAddPack(
+                packs,
+                packLabel: "IX.OfficeIMO",
+                packTypeName: OfficeImoPackTypeName,
+                optionsTypeName: OfficeImoOptionsTypeName,
+                configureOptions: officeImoOptions => {
+                    AddStringListValuesIfPresent(officeImoOptions, "AllowedRoots", allowedRoots);
                 },
                 warnWhenUnavailable: true,
                 onWarning: options.OnBootstrapWarning);


### PR DESCRIPTION
## Summary
- integrate `IX.OfficeIMO` into default chat tool pack bootstrap
- add `EnableOfficeImoPack` toggle (default: enabled) across host/service bootstrap options
- add host/service CLI switches: `--enable-officeimo-pack` / `--disable-officeimo-pack`
- persist toggle in profile model and SQLite store (`enable_officeimo_pack`) with best-effort schema migration for existing DBs
- include `IntelligenceX.Tools.OfficeIMO` in chat tooling project references
- add tests for default pack inclusion + disable behavior and service option parsing

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj --filter "ToolPackBootstrapMetadataTests|ServiceOptionsProfileBootstrapTests|PluginFolderLoaderTests"`
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Host/IntelligenceX.Chat.Host.csproj -c Debug`