### PR TITLE
Reduce brittle reflection in chat intelligence-loop tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ When an agent is assigned a PR to improve or unblock, it must iterate until merg
 **Testing**
 - Run targeted `dotnet build` or tests if a change touches runtime behavior.
 - Note any skipped tests and why.
+- For Chat routing tests, prefer direct calls to `internal` helpers (via existing `InternalsVisibleTo`) instead of reflection against private methods.
+- For streaming/status tests, avoid reading from actively-written streams; use synchronized snapshots or another thread-safe capture approach.
 
 **Repo-Local Skills**
 - Use repo skills from `/.agents/skills/README.md` for repeatable task execution.

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -71,7 +71,7 @@ internal sealed partial class ChatServiceSession {
         };
     }
 
-    private static int ResolveMaxReviewPasses(ChatRequestOptions? options) {
+    internal static int ResolveMaxReviewPasses(ChatRequestOptions? options) {
         var configured = options?.MaxReviewPasses;
         if (!configured.HasValue || configured.Value <= 0) {
             return DefaultMaxReviewPasses;
@@ -80,7 +80,7 @@ internal sealed partial class ChatServiceSession {
         return Math.Clamp(configured.Value, DefaultMaxReviewPasses, MaxReviewPassesLimit);
     }
 
-    private static int ResolveModelHeartbeatSeconds(ChatRequestOptions? options) {
+    internal static int ResolveModelHeartbeatSeconds(ChatRequestOptions? options) {
         var configured = options?.ModelHeartbeatSeconds;
         if (!configured.HasValue) {
             return DefaultModelHeartbeatSeconds;
@@ -89,7 +89,7 @@ internal sealed partial class ChatServiceSession {
         return Math.Clamp(configured.Value, 0, MaxModelHeartbeatSeconds);
     }
 
-    private static bool TryReadProactiveModeFromRequestText(string requestText, out bool enabled) {
+    internal static bool TryReadProactiveModeFromRequestText(string requestText, out bool enabled) {
         enabled = false;
         var text = requestText ?? string.Empty;
         if (text.Length == 0) {
@@ -120,7 +120,7 @@ internal sealed partial class ChatServiceSession {
         return false;
     }
 
-    private static bool ShouldAttemptResponseQualityReview(
+    internal static bool ShouldAttemptResponseQualityReview(
         string userRequest,
         string assistantDraft,
         bool executionContractApplies,
@@ -164,7 +164,7 @@ internal sealed partial class ChatServiceSession {
         return draft.Contains('?', StringComparison.Ordinal) && tokenCount <= 48 && draft.Length <= 360;
     }
 
-    private static string BuildResponseQualityReviewPrompt(string userRequest, string assistantDraft, bool hasToolActivity, int reviewPassNumber,
+    internal static string BuildResponseQualityReviewPrompt(string userRequest, string assistantDraft, bool hasToolActivity, int reviewPassNumber,
         int maxReviewPasses) {
         var requestText = TrimForPrompt(userRequest, 520);
         var draftText = TrimForPrompt(assistantDraft, 1600);
@@ -191,7 +191,7 @@ internal sealed partial class ChatServiceSession {
             """;
     }
 
-    private static bool ShouldAttemptProactiveFollowUpReview(
+    internal static bool ShouldAttemptProactiveFollowUpReview(
         bool proactiveModeEnabled,
         bool hasToolActivity,
         bool proactiveFollowUpUsed,
@@ -214,7 +214,7 @@ internal sealed partial class ChatServiceSession {
         return ExtractPendingActions(draft).Count == 0;
     }
 
-    private static string BuildProactiveFollowUpReviewPrompt(string userRequest, string assistantDraft) {
+    internal static string BuildProactiveFollowUpReviewPrompt(string userRequest, string assistantDraft) {
         var requestText = TrimForPrompt(userRequest, 520);
         var draftText = TrimForPrompt(assistantDraft, 1800);
         return $$"""
@@ -237,7 +237,7 @@ internal sealed partial class ChatServiceSession {
             """;
     }
 
-    private async Task RunPhaseProgressLoopAsync(
+    internal async Task RunPhaseProgressLoopAsync(
         StreamWriter writer,
         string requestId,
         string threadId,
@@ -299,7 +299,7 @@ internal sealed partial class ChatServiceSession {
         await phaseTask.ConfigureAwait(false);
     }
 
-    private async Task<TurnInfo> RunModelPhaseWithProgressAsync(
+    internal async Task<TurnInfo> RunModelPhaseWithProgressAsync(
         IntelligenceXClient client,
         StreamWriter writer,
         string requestId,
@@ -326,7 +326,7 @@ internal sealed partial class ChatServiceSession {
         return await chatTask.ConfigureAwait(false);
     }
 
-    private Task<TurnInfo> RunReviewOnlyModelPhaseWithProgressAsync(
+    internal Task<TurnInfo> RunReviewOnlyModelPhaseWithProgressAsync(
         IntelligenceXClient client,
         StreamWriter writer,
         string requestId,
@@ -365,7 +365,7 @@ internal sealed partial class ChatServiceSession {
         return copy;
     }
 
-    private static ChatOptions CopyChatOptionsWithoutTools(ChatOptions options, bool? newThreadOverride = null) {
+    internal static ChatOptions CopyChatOptionsWithoutTools(ChatOptions options, bool? newThreadOverride = null) {
         var copy = CopyChatOptions(options, newThreadOverride);
         copy.Tools = null;
         copy.ToolChoice = null;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -12,10 +11,6 @@ using Xunit;
 namespace IntelligenceX.Chat.Tests;
 
 public sealed partial class ChatServiceRoutingTrimTests {
-    private static readonly MethodInfo RunPhaseProgressLoopAsyncMethod =
-        typeof(ChatServiceSession).GetMethod("RunPhaseProgressLoopAsync", BindingFlags.NonPublic | BindingFlags.Instance)
-        ?? throw new InvalidOperationException("RunPhaseProgressLoopAsync not found.");
-
     [Fact]
     public async Task PhaseProgressLoop_EmitsPlanExecuteReviewInOrder() {
         var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
@@ -52,7 +47,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     private static async Task InvokePhaseProgressLoopAsync(ChatServiceSession session, StreamWriter writer, string phaseStatus, string phaseMessage,
         string heartbeatLabel, int heartbeatSeconds, Task phaseTask) {
-        var args = new object?[] {
+        await session.RunPhaseProgressLoopAsync(
             writer,
             "req-intelligence-loop",
             "thread-intelligence-loop",
@@ -61,12 +56,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             heartbeatLabel,
             heartbeatSeconds,
             CancellationToken.None,
-            phaseTask
-        };
-
-        var invoked = RunPhaseProgressLoopAsyncMethod.Invoke(session, args);
-        var task = Assert.IsAssignableFrom<Task>(invoked);
-        await task;
+            phaseTask);
     }
 
     private static List<string> ParseStatuses(byte[] snapshotBytes) {
@@ -162,6 +152,10 @@ public sealed partial class ChatServiceRoutingTrimTests {
         }
 
         public override Task FlushAsync(CancellationToken cancellationToken) {
+            if (cancellationToken.IsCancellationRequested) {
+                return Task.FromCanceled(cancellationToken);
+            }
+
             lock (_sync) {
                 _inner.Flush();
             }
@@ -185,6 +179,10 @@ public sealed partial class ChatServiceRoutingTrimTests {
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {
+            if (cancellationToken.IsCancellationRequested) {
+                return Task.FromCanceled(cancellationToken);
+            }
+
             lock (_sync) {
                 _inner.Write(buffer, offset, count);
             }
@@ -199,6 +197,10 @@ public sealed partial class ChatServiceRoutingTrimTests {
         }
 
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {
+            if (cancellationToken.IsCancellationRequested) {
+                return ValueTask.FromCanceled(cancellationToken);
+            }
+
             lock (_sync) {
                 _inner.Write(buffer.Span);
             }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.Service;
 using IntelligenceX.OpenAI.Chat;
@@ -9,36 +8,10 @@ using Xunit;
 namespace IntelligenceX.Chat.Tests;
 
 public sealed partial class ChatServiceRoutingTrimTests {
-    private static readonly MethodInfo ResolveMaxReviewPassesMethod =
-        typeof(ChatServiceSession).GetMethod("ResolveMaxReviewPasses", BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("ResolveMaxReviewPasses not found.");
-    private static readonly MethodInfo ResolveModelHeartbeatSecondsMethod =
-        typeof(ChatServiceSession).GetMethod("ResolveModelHeartbeatSeconds", BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("ResolveModelHeartbeatSeconds not found.");
-    private static readonly MethodInfo ShouldAttemptResponseQualityReviewMethod =
-        typeof(ChatServiceSession).GetMethod("ShouldAttemptResponseQualityReview", BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("ShouldAttemptResponseQualityReview not found.");
-    private static readonly MethodInfo BuildResponseQualityReviewPromptMethod =
-        typeof(ChatServiceSession).GetMethod("BuildResponseQualityReviewPrompt", BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("BuildResponseQualityReviewPrompt not found.");
-    private static readonly MethodInfo TryReadProactiveModeFromRequestTextMethod =
-        typeof(ChatServiceSession).GetMethod("TryReadProactiveModeFromRequestText", BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("TryReadProactiveModeFromRequestText not found.");
-    private static readonly MethodInfo ShouldAttemptProactiveFollowUpReviewMethod =
-        typeof(ChatServiceSession).GetMethod("ShouldAttemptProactiveFollowUpReview", BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("ShouldAttemptProactiveFollowUpReview not found.");
-    private static readonly MethodInfo BuildProactiveFollowUpReviewPromptMethod =
-        typeof(ChatServiceSession).GetMethod("BuildProactiveFollowUpReviewPrompt", BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("BuildProactiveFollowUpReviewPrompt not found.");
-    private static readonly MethodInfo CopyChatOptionsWithoutToolsMethod =
-        typeof(ChatServiceSession).GetMethod("CopyChatOptionsWithoutTools", BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("CopyChatOptionsWithoutTools not found.");
-
     [Fact]
     public void ResolveMaxReviewPasses_DefaultsToSafeValueWhenUnset() {
-        var result = ResolveMaxReviewPassesMethod.Invoke(null, new object?[] { null });
-
-        Assert.Equal(1, Assert.IsType<int>(result));
+        var result = ChatServiceSession.ResolveMaxReviewPasses(null);
+        Assert.Equal(1, result);
     }
 
     [Theory]
@@ -52,9 +25,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
             MaxReviewPasses = requested
         };
 
-        var result = ResolveMaxReviewPassesMethod.Invoke(null, new object?[] { options });
-
-        Assert.Equal(expected, Assert.IsType<int>(result));
+        var result = ChatServiceSession.ResolveMaxReviewPasses(options);
+        Assert.Equal(expected, result);
     }
 
     [Theory]
@@ -70,9 +42,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
                 ModelHeartbeatSeconds = requested.Value
             };
 
-        var result = ResolveModelHeartbeatSecondsMethod.Invoke(null, new object?[] { options });
-
-        Assert.Equal(expected, Assert.IsType<int>(result));
+        var result = ChatServiceSession.ResolveModelHeartbeatSeconds(options);
+        Assert.Equal(expected, result);
     }
 
     [Theory]
@@ -88,19 +59,20 @@ public sealed partial class ChatServiceRoutingTrimTests {
         int reviewPassesUsed,
         int maxReviewPasses,
         bool expected) {
-        var result = ShouldAttemptResponseQualityReviewMethod.Invoke(
-            null,
-            new object?[] { userRequest, assistantDraft, executionContractApplies, hasToolActivity, reviewPassesUsed, maxReviewPasses });
+        var result = ChatServiceSession.ShouldAttemptResponseQualityReview(
+            userRequest,
+            assistantDraft,
+            executionContractApplies,
+            hasToolActivity,
+            reviewPassesUsed,
+            maxReviewPasses);
 
-        Assert.Equal(expected, Assert.IsType<bool>(result));
+        Assert.Equal(expected, result);
     }
 
     [Fact]
     public void BuildResponseQualityReviewPrompt_EmitsStableMarkerAndPassMetadata() {
-        var result = BuildResponseQualityReviewPromptMethod.Invoke(
-            null,
-            new object?[] { "run diagnostics on dc01", "ok", false, 1, 2 });
-        var text = Assert.IsType<string>(result);
+        var text = ChatServiceSession.BuildResponseQualityReviewPrompt("run diagnostics on dc01", "ok", false, 1, 2);
 
         Assert.Contains("ix:response-review:v1", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Review pass 1/2", text, StringComparison.OrdinalIgnoreCase);
@@ -112,11 +84,9 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("[Proactive execution mode]\nix:proactive-mode:v1\nenabled: false", true, false)]
     [InlineData("no marker", false, false)]
     public void TryReadProactiveModeFromRequestText_ParsesStructuredMarker(string requestText, bool expectedRead, bool expectedEnabled) {
-        var args = new object?[] { requestText, null };
-        var result = TryReadProactiveModeFromRequestTextMethod.Invoke(null, args);
-
-        Assert.Equal(expectedRead, Assert.IsType<bool>(result));
-        Assert.Equal(expectedEnabled, Assert.IsType<bool>(args[1]));
+        var result = ChatServiceSession.TryReadProactiveModeFromRequestText(requestText, out var enabled);
+        Assert.Equal(expectedRead, result);
+        Assert.Equal(expectedEnabled, enabled);
     }
 
     [Theory]
@@ -131,19 +101,18 @@ public sealed partial class ChatServiceRoutingTrimTests {
         bool proactiveFollowUpUsed,
         string assistantDraft,
         bool expected) {
-        var result = ShouldAttemptProactiveFollowUpReviewMethod.Invoke(
-            null,
-            new object?[] { proactiveModeEnabled, hasToolActivity, proactiveFollowUpUsed, assistantDraft });
+        var result = ChatServiceSession.ShouldAttemptProactiveFollowUpReview(
+            proactiveModeEnabled,
+            hasToolActivity,
+            proactiveFollowUpUsed,
+            assistantDraft);
 
-        Assert.Equal(expected, Assert.IsType<bool>(result));
+        Assert.Equal(expected, result);
     }
 
     [Fact]
     public void BuildProactiveFollowUpReviewPrompt_EmitsStableMarkerAndSections() {
-        var result = BuildProactiveFollowUpReviewPromptMethod.Invoke(
-            null,
-            new object?[] { "analyze failed logons", "Current findings..." });
-        var text = Assert.IsType<string>(result);
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt("analyze failed logons", "Current findings...");
 
         Assert.Contains("ix:proactive-followup:v1", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Potential issues to verify", text, StringComparison.OrdinalIgnoreCase);
@@ -159,8 +128,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             ToolChoice = ToolChoice.Auto
         };
 
-        var result = CopyChatOptionsWithoutToolsMethod.Invoke(null, new object?[] { source, false });
-        var copy = Assert.IsType<ChatOptions>(result);
+        var copy = ChatServiceSession.CopyChatOptionsWithoutTools(source, false);
 
         Assert.Null(copy.Tools);
         Assert.Null(copy.ToolChoice);


### PR DESCRIPTION
## Summary
- expose core intelligence-loop helpers in `ChatServiceSession.ChatRouting` as `internal` so tests can target stable seams directly instead of reflection against private members
- update intelligence-loop unit/integration tests to call these helpers directly and remove reflection method lookup/invoke overhead
- keep heartbeat integration capture thread-safe and cancellation-aware by honoring cancellation tokens in custom capture stream async methods
- document this guardrail in `AGENTS.md` to avoid regressions into brittle private-reflection tests and unsafe live-stream parsing

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release`
- `dotnet build IntelligenceX.sln -c Release`