### PR TITLE
Polish intelligence-loop nullability and cancellation tests

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -71,6 +71,7 @@ internal sealed partial class ChatServiceSession {
         };
     }
 
+    // Internal seam for deterministic chat-loop tests and shared routing behavior.
     internal static int ResolveMaxReviewPasses(ChatRequestOptions? options) {
         var configured = options?.MaxReviewPasses;
         if (!configured.HasValue || configured.Value <= 0) {
@@ -89,7 +90,7 @@ internal sealed partial class ChatServiceSession {
         return Math.Clamp(configured.Value, 0, MaxModelHeartbeatSeconds);
     }
 
-    internal static bool TryReadProactiveModeFromRequestText(string requestText, out bool enabled) {
+    internal static bool TryReadProactiveModeFromRequestText(string? requestText, out bool enabled) {
         enabled = false;
         var text = requestText ?? string.Empty;
         if (text.Length == 0) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
@@ -45,6 +45,26 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.True(reviewIndex >= 0 && heartbeatIndex > reviewIndex);
     }
 
+    [Fact]
+    public async Task SynchronizedCaptureStream_FlushAsync_CanceledTokenReturnsCanceledTask() {
+        using var stream = new SynchronizedCaptureStream();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await stream.FlushAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task SynchronizedCaptureStream_WriteAsync_CanceledTokenReturnsCanceledTask() {
+        using var stream = new SynchronizedCaptureStream();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var payload = new byte[] { 1, 2, 3 };
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await stream.WriteAsync(payload, 0, payload.Length, cts.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await stream.WriteAsync(payload.AsMemory(), cts.Token));
+    }
+
     private static async Task InvokePhaseProgressLoopAsync(ChatServiceSession session, StreamWriter writer, string phaseStatus, string phaseMessage,
         string heartbeatLabel, int heartbeatSeconds, Task phaseTask) {
         await session.RunPhaseProgressLoopAsync(


### PR DESCRIPTION
## Summary
- clarify internal helper seam intent in chat routing with a focused comment at the intelligence-loop helper boundary
- make proactive-mode parser nullability contract explicit by accepting `string?` (`TryReadProactiveModeFromRequestText`)
- add cancellation-semantic regression tests for synchronized stream capture (`FlushAsync` and both `WriteAsync` paths) to lock in canceled-task behavior

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release`
- `dotnet build IntelligenceX.sln -c Release`