### PR TITLE
Make pending-action intent matching script-aware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ When an agent is assigned a PR to improve or unblock, it must iterate until merg
 - Do not gate chat routing or safety behavior on hardcoded natural-language keyword lists (for example English-only verbs like "disable", "run", "can't").
 - Do not special-case compact follow-ups with literal phrases (for example "go ahead", "do it", "run it"). Continuation and nudge eligibility must be shape/context based.
 - For pending-action and execution-contract decisions, prefer structured protocol fields (for example `ix_action_selection.mutating` and `ix:action:v1` `mutating: true|false`) over lexical inference from free text.
+- For intent-token heuristics, keep script awareness: do not require English-like token lengths globally (for example, accept short non-Latin intent tokens when safe) and preserve tests for this behavior.
 - If provider interoperability requires message-text matching, keep it as a structured-first fallback and do not reuse it for chat routing/confirmation logic.
 - When changing Chat routing/safety logic, add or update tests that prove the behavior is language-agnostic.
 - Keep `plan -> execute -> review` quality loops language-neutral too: review eligibility must use structure/shape signals (length, turn state, tool activity), not word lists.

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
@@ -656,6 +656,7 @@ internal sealed partial class ChatServiceSession {
 
         var hasDigit = false;
         var hasLetter = false;
+        var hasNonAscii = false;
         for (var i = 0; i < value.Length; i++) {
             var ch = value[i];
             if (!char.IsLetterOrDigit(ch)) {
@@ -667,6 +668,9 @@ internal sealed partial class ChatServiceSession {
             if (char.IsLetter(ch)) {
                 hasLetter = true;
             }
+            if (ch > 127) {
+                hasNonAscii = true;
+            }
         }
 
         if (hasDigit) {
@@ -677,7 +681,8 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        return value.Length >= 3;
+        var minLength = hasNonAscii ? 2 : 3;
+        return value.Length >= minLength;
     }
 
     private static bool TokenOverlapsPendingActionIntent(string token, IReadOnlyList<string> actionTokens) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
@@ -229,6 +229,48 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenUserUsesShortNonLatinIntentTokens() {
+        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var assistantDraft = """
+            [Action]
+            ix:action:v1
+            id: act_cn_failed
+            title: 失败 登录 报告
+            request: 运行 失败 登录 报告 并 汇总
+            mutating: false
+            reply: /act act_cn_failed
+            """;
+
+        RememberPendingActionsMethod.Invoke(session, new object?[] { "thread-001", assistantDraft });
+        var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", "失败 登录" });
+        var expanded = Assert.IsType<string>(result);
+
+        using var doc = JsonDocument.Parse(expanded);
+        Assert.Equal("act_cn_failed", doc.RootElement.GetProperty("ix_action_selection").GetProperty("id").GetString());
+    }
+
+    [Fact]
+    public void ExpandContinuationUserRequest_DoesNotResolveSinglePendingActionWhenUserUsesOnlyShortAsciiTokens() {
+        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var assistantDraft = """
+            [Action]
+            ix:action:v1
+            id: act_failed4625
+            title: Run failed logon report (4625)
+            request: Run failed logon report on ADO Security and summarize the top five events.
+            mutating: false
+            reply: /act act_failed4625
+            """;
+        var input = "go it";
+
+        RememberPendingActionsMethod.Invoke(session, new object?[] { "thread-001", assistantDraft });
+        var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", input });
+        var expanded = Assert.IsType<string>(result);
+
+        Assert.Equal(input, expanded);
+    }
+
+    [Fact]
     public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenUserUsesNaturalConfirmationWithoutHardcodedPhrase() {
         var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
         var assistantDraft = """


### PR DESCRIPTION
## Summary
- make pending-action intent-token filtering script-aware so short non-Latin tokens are not discarded
- keep ASCII token threshold unchanged to avoid broadening weak filler-token matches
- add regression tests for both cases:
  - resolves short non-Latin intent tokens
  - still does not auto-resolve short ASCII filler tokens
- add AGENTS guidance to preserve script-aware token heuristics in Chat routing work

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll