### PR TITLE
Add contiguous non-Latin pending-action regression coverage

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
@@ -668,6 +668,7 @@ internal sealed partial class ChatServiceSession {
             if (char.IsLetter(ch)) {
                 hasLetter = true;
             }
+            // Heuristic only: this is not full script detection; it keeps short non-Latin intent tokens eligible.
             if (ch > 127) {
                 hasNonAscii = true;
             }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
@@ -250,6 +250,27 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenUserUsesContiguousNonLatinIntentToken() {
+        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var assistantDraft = """
+            [Action]
+            ix:action:v1
+            id: act_cn_compact
+            title: 失败登录报告
+            request: 运行失败登录报告并汇总
+            mutating: false
+            reply: /act act_cn_compact
+            """;
+
+        RememberPendingActionsMethod.Invoke(session, new object?[] { "thread-001", assistantDraft });
+        var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", "失败登录报告" });
+        var expanded = Assert.IsType<string>(result);
+
+        using var doc = JsonDocument.Parse(expanded);
+        Assert.Equal("act_cn_compact", doc.RootElement.GetProperty("ix_action_selection").GetProperty("id").GetString());
+    }
+
+    [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveSinglePendingActionWhenUserUsesOnlyShortAsciiTokens() {
         var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
         var assistantDraft = """


### PR DESCRIPTION
## Summary
- add a clarifying code comment that ch > 127 is a heuristic for keeping short non-Latin intent tokens eligible
- add regression coverage for contiguous non-Latin intent input (no spaces) in pending-action auto-selection
- keep behavior unchanged otherwise

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release
- dotnet build IntelligenceX.sln -c Release