### PR TITLE
Make chat follow-up heuristics Unicode-aware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,10 +88,12 @@ When an agent is assigned a PR to improve or unblock, it must iterate until merg
 **Language-Neutral Routing Guardrails (Chat)**
 - Do not gate chat routing or safety behavior on hardcoded natural-language keyword lists (for example English-only verbs like "disable", "run", "can't").
 - Do not special-case compact follow-ups with literal phrases (for example "go ahead", "do it", "run it"). Continuation and nudge eligibility must be shape/context based.
+- Do not assume ASCII-only punctuation in routing heuristics. Question/follow-up signals must stay Unicode-aware (for example `?`, `？`, `¿`, `؟`) and covered by tests.
 - For pending-action and execution-contract decisions, prefer structured protocol fields (for example `ix_action_selection.mutating` and `ix:action:v1` `mutating: true|false`) over lexical inference from free text.
 - For intent-token heuristics, keep script awareness: do not require English-like token lengths globally (for example, accept short non-Latin intent tokens when safe) and preserve tests for this behavior.
 - If provider interoperability requires message-text matching, keep it as a structured-first fallback and do not reuse it for chat routing/confirmation logic.
 - When changing Chat routing/safety logic, add or update tests that prove the behavior is language-agnostic.
+- Replace repeated heuristic magic numbers with named constants in shared helpers/files to prevent drift between routing and confirmation paths.
 - Keep `plan -> execute -> review` quality loops language-neutral too: review eligibility must use structure/shape signals (length, turn state, tool activity), not word lists.
 - Preserve progress transparency for long turns: emit phase/status updates (including heartbeats for long model phases) instead of adding blocking confirmation gates.
 - When proactive behavior is needed, use structured prompt markers (for example `ix:proactive-mode:v1` with `enabled: true|false`) instead of lexical intent detection.

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.cs
@@ -150,7 +150,7 @@ internal sealed partial class ChatServiceSession {
             return true;
         }
 
-        return draft.Contains('?', StringComparison.Ordinal) && tokenCount <= 48 && draft.Length <= 360;
+        return ContainsQuestionSignal(draft) && tokenCount <= 48 && draft.Length <= 360;
     }
 
     internal static string BuildResponseQualityReviewPrompt(string userRequest, string assistantDraft, bool hasToolActivity, int reviewPassNumber,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
@@ -211,7 +211,7 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        var asksAnotherQuestion = draft.Contains('?', StringComparison.Ordinal);
+        var asksAnotherQuestion = ContainsQuestionSignal(draft);
         if (asksAnotherQuestion) {
             if (echoedCallToAction || AssistantDraftReferencesUserRequest(request, draft)) {
                 reason = "assistant_question_linked_to_follow_up";
@@ -804,7 +804,7 @@ internal sealed partial class ChatServiceSession {
             return true;
         }
 
-        return tokenCount <= 8 && normalized.Length <= 80 && normalized.Contains('?', StringComparison.Ordinal);
+        return tokenCount <= 8 && normalized.Length <= 80 && ContainsQuestionSignal(normalized);
     }
 
     private static bool LooksLikeContextualFollowUpForExecutionNudge(string userRequest, string assistantDraft) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.Cta.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.Cta.cs
@@ -5,6 +5,11 @@ using System.Text;
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
+    private const int MaxCompactCallToActionLength = 96;
+    private const int MaxCompactCallToActionTokenCount = 8;
+    private const int MaxCompactCallToActionTokenScan = 12;
+    private const int MaxPendingActionCallToActionTokens = 6;
+
     private static string NormalizeCompactCallToActionToken(string text) {
         // Assistant CTAs often appear in prose with trailing ':' / ';' (including fullwidth variants) that users
         // should not have to repeat, and that we explicitly disqualify for confirmation.
@@ -45,7 +50,7 @@ internal sealed partial class ChatServiceSession {
             }
 
             tokens.Add(token);
-            if (tokens.Count >= 6) {
+            if (tokens.Count >= MaxPendingActionCallToActionTokens) {
                 break;
             }
         }
@@ -55,7 +60,7 @@ internal sealed partial class ChatServiceSession {
 
     private static bool LooksLikeCompactCallToActionToken(string token) {
         var value = (token ?? string.Empty).Trim();
-        if (value.Length == 0 || value.Length > 96) {
+        if (value.Length == 0 || value.Length > MaxCompactCallToActionLength) {
             return false;
         }
 
@@ -70,8 +75,8 @@ internal sealed partial class ChatServiceSession {
         }
 
         // Keep it lean: only short, phrase-like tokens.
-        var tokens = CountLetterDigitTokens(value, maxTokens: 12);
-        return tokens is > 0 and <= 8;
+        var tokens = CountLetterDigitTokens(value, maxTokens: MaxCompactCallToActionTokenScan);
+        return tokens is > 0 and <= MaxCompactCallToActionTokenCount;
     }
 
     private static bool UserMatchesPendingActionCallToActionTokens(string userText, IReadOnlyList<string> tokens) {
@@ -80,7 +85,7 @@ internal sealed partial class ChatServiceSession {
         }
 
         var raw = (userText ?? string.Empty).Trim();
-        if (raw.Length == 0 || raw.Length > 96) {
+        if (raw.Length == 0 || raw.Length > MaxCompactCallToActionLength) {
             return false;
         }
 
@@ -96,7 +101,7 @@ internal sealed partial class ChatServiceSession {
         }
 
         var request = NormalizeCompactText(raw);
-        if (request.Length == 0 || request.Length > 96) {
+        if (request.Length == 0 || request.Length > MaxCompactCallToActionLength) {
             return false;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.IntentParsing.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.IntentParsing.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 
 namespace IntelligenceX.Chat.Service;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.TextSignals.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.TextSignals.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace IntelligenceX.Chat.Service;
+
+internal sealed partial class ChatServiceSession {
+    // Keep question detection script-agnostic for compact follow-ups and review loops.
+    private static readonly char[] QuestionSignalPunctuation = new[] { '?', '？', '¿', '؟' };
+
+    private static bool ContainsQuestionSignal(string text) {
+        var value = text ?? string.Empty;
+        return value.IndexOfAny(QuestionSignalPunctuation) >= 0;
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
@@ -455,7 +455,7 @@ internal sealed partial class ChatServiceSession {
 
         return tokenCount <= 8
                && normalized.Length <= 96
-               && normalized.Contains('?', StringComparison.Ordinal);
+               && ContainsQuestionSignal(normalized);
     }
 
     private sealed class ToolRoutingStats {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -71,6 +71,24 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ResponseQualityReviewEval_AllowsLongDraftWithUnicodeQuestionSignal() {
+        var draft =
+            "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty " +
+            "twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo " +
+            "thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight thirtynine forty？";
+
+        var result = ChatServiceSession.ShouldAttemptResponseQualityReview(
+            "show latest failed logons",
+            draft,
+            executionContractApplies: false,
+            hasToolActivity: false,
+            reviewPassesUsed: 0,
+            maxReviewPasses: 1);
+
+        Assert.True(result);
+    }
+
+    [Fact]
     public void BuildResponseQualityReviewPrompt_EmitsStableMarkerAndPassMetadata() {
         var text = ChatServiceSession.BuildResponseQualityReviewPrompt("run diagnostics on dc01", "ok", false, 1, 2);
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
@@ -20,6 +20,9 @@ public sealed partial class ChatServiceRoutingTrimTests {
     private static readonly MethodInfo LooksLikeContinuationFollowUpMethod =
         typeof(ChatServiceSession).GetMethod("LooksLikeContinuationFollowUp", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("LooksLikeContinuationFollowUp not found.");
+    private static readonly MethodInfo LooksLikeCompactFollowUpMethod =
+        typeof(ChatServiceSession).GetMethod("LooksLikeCompactFollowUp", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("LooksLikeCompactFollowUp not found.");
     private static readonly MethodInfo CountLetterDigitTokensMethod =
         typeof(ChatServiceSession).GetMethod("CountLetterDigitTokens", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("CountLetterDigitTokens not found.");
@@ -212,6 +215,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("dzialaj")]
     [InlineData("uruchom to")]
     [InlineData("dalej?")]
+    [InlineData("please continue failed logon report for ado？")]
+    [InlineData("please continue failed logon report for ado؟")]
     [InlineData("继续")]
     [InlineData("继续执行")]
     [InlineData("xqzz ltmv")]
@@ -513,6 +518,28 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new object?[] { userRequest, assistantDraft, true, 0, 0, true });
 
         Assert.False(Assert.IsType<bool>(result));
+    }
+
+    [Fact]
+    public void ShouldAttemptToolExecutionNudge_DoesNotTriggerOnUnlinkedUnicodeQuestionDraft() {
+        var userRequest = "run now";
+        var assistantDraft = "Czy na pewno？";
+
+        var result = ShouldAttemptToolExecutionNudgeMethod.Invoke(
+            null,
+            new object?[] { userRequest, assistantDraft, true, 0, 0, true });
+
+        Assert.False(Assert.IsType<bool>(result));
+    }
+
+    [Theory]
+    [InlineData("please continue failed logon report for ado?", true)]
+    [InlineData("please continue failed logon report for ado？", true)]
+    [InlineData("please continue failed logon report for ado؟", true)]
+    [InlineData("please continue failed logon report for ado", false)]
+    public void LooksLikeCompactFollowUp_RecognizesUnicodeQuestionPunctuation(string userRequest, bool expected) {
+        var result = LooksLikeCompactFollowUpMethod.Invoke(null, new object?[] { userRequest });
+        Assert.Equal(expected, Assert.IsType<bool>(result));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- make compact-follow-up and review question-signal detection Unicode-aware (`?`, `？`, `¿`, `؟`) instead of ASCII-only checks
- add shared `ContainsQuestionSignal(...)` helper in `ChatServiceSession.TextSignals.cs` and reuse it in continuation routing, tool nudge routing, and response-quality review eligibility
- replace repeated CTA magic numbers in pending-action confirmation matching with named constants
- remove unused `System.Linq` import from pending-action intent parsing split file
- add tests for Unicode question punctuation in follow-up detection and nudge/review paths
- extend `AGENTS.md` language-neutral routing guardrails to explicitly require Unicode-aware punctuation handling and named heuristic constants

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release`
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`