### PR TITLE
Website: align FAQ schema and keep rebuild green

### DIFF
--- a/Website/content/pages/faq.md
+++ b/Website/content/pages/faq.md
@@ -7,5 +7,5 @@ layout: page
 ---
 
 <div class="faq-list">
-    {{< faq data="faq" >}}
+    {{< faq data="faq.sections" >}}
 </div>

--- a/Website/data/faq.json
+++ b/Website/data/faq.json
@@ -1,57 +1,59 @@
-[
-  {
-    "title": "Frequently Asked Questions",
-    "items": [
-      {
-        "id": "code-safe",
-        "question": "Is my code safe? Do you see it?",
-        "answer": "IntelligenceX has no backend service. Your code diffs go directly from GitHub Actions to your chosen AI provider (ChatGPT or Copilot). We never see, store, or process your code."
-      },
-      {
-        "id": "own-login",
-        "question": "Why do I use my own ChatGPT or Copilot login?",
-        "answer": "This is the zero-trust design. You authenticate with your own account. No shared API keys, no pooled quotas, no third-party billing. You control the credentials, stored in GitHub Actions secrets that only your workflows can access."
-      },
-      {
-        "id": "byo-app",
-        "question": "What is 'Bring Your Own GitHub App'?",
-        "answer": "Instead of trusting our GitHub App, you can create your own App under your organization. This gives you branded bot identity, fine-grained permissions, and full audit control. The CLI wizard supports this flow natively."
-      },
-      {
-        "id": "providers",
-        "question": "Which AI providers are supported?",
-        "answer": "ChatGPT (native transport via OAuth) and GitHub Copilot (via Copilot CLI). You configure the provider and model in .intelligencex/reviewer.json."
-      },
-      {
-        "id": "get-started",
-        "question": "How do I get started?",
-        "answer": "Run 'intelligencex setup autodetect' first, then use 'intelligencex setup wizard' or 'intelligencex setup web'. Onboarding is path-first (new setup, fix auth, cleanup, maintenance) and runs entirely on your machine."
-      },
-      {
-        "id": "autodetect",
-        "question": "Can IntelligenceX detect what path I should take?",
-        "answer": "Yes. Auto-detect runs doctor-style checks (auth/config/GitHub access) and suggests a path before repo selection. It helps you choose between first-time setup, auth refresh, or maintenance."
-      },
-      {
-        "id": "cleanup-maintenance",
-        "question": "How do cleanup and maintenance differ?",
-        "answer": "Cleanup removes workflow/config (and optionally secrets). Maintenance inspects current state first, then guides you to setup, update-secret, or cleanup depending on findings."
-      },
-      {
-        "id": "platforms",
-        "question": "What platforms are supported?",
-        "answer": "Windows, macOS, and Linux. The CLI and library target .NET 8+ and .NET 10+, the PowerShell module supports netstandard2.0, net472, and net8.0. The reviewer runs on any GitHub Actions runner."
-      },
-      {
-        "id": "customize",
-        "question": "Can I customize the review behavior?",
-        "answer": "Yes. Choose from presets (balanced, picky, security, performance, tests, minimal) or write custom JSON config. Control review mode (inline, summary, hybrid), length, output style, and auto-resolve behavior."
-      },
-      {
-        "id": "codex",
-        "question": "Is this similar to Claude Code or Codex?",
-        "answer": "The reviewer produces structured, Codex-style output integrated into your GitHub PR workflow. It supports inline comments with code suggestions, summary reviews, and hybrid mode."
-      }
-    ]
-  }
-]
+{
+  "sections": [
+    {
+      "title": "Frequently Asked Questions",
+      "items": [
+        {
+          "id": "code-safe",
+          "question": "Is my code safe? Do you see it?",
+          "answer": "IntelligenceX has no backend service. Your code diffs go directly from GitHub Actions to your chosen AI provider (ChatGPT or Copilot). We never see, store, or process your code."
+        },
+        {
+          "id": "own-login",
+          "question": "Why do I use my own ChatGPT or Copilot login?",
+          "answer": "This is the zero-trust design. You authenticate with your own account. No shared API keys, no pooled quotas, no third-party billing. You control the credentials, stored in GitHub Actions secrets that only your workflows can access."
+        },
+        {
+          "id": "byo-app",
+          "question": "What is 'Bring Your Own GitHub App'?",
+          "answer": "Instead of trusting our GitHub App, you can create your own App under your organization. This gives you branded bot identity, fine-grained permissions, and full audit control. The CLI wizard supports this flow natively."
+        },
+        {
+          "id": "providers",
+          "question": "Which AI providers are supported?",
+          "answer": "ChatGPT (native transport via OAuth) and GitHub Copilot (via Copilot CLI). You configure the provider and model in .intelligencex/reviewer.json."
+        },
+        {
+          "id": "get-started",
+          "question": "How do I get started?",
+          "answer": "Run 'intelligencex setup autodetect' first, then use 'intelligencex setup wizard' or 'intelligencex setup web'. Onboarding is path-first (new setup, fix auth, cleanup, maintenance) and runs entirely on your machine."
+        },
+        {
+          "id": "autodetect",
+          "question": "Can IntelligenceX detect what path I should take?",
+          "answer": "Yes. Auto-detect runs doctor-style checks (auth/config/GitHub access) and suggests a path before repo selection. It helps you choose between first-time setup, auth refresh, or maintenance."
+        },
+        {
+          "id": "cleanup-maintenance",
+          "question": "How do cleanup and maintenance differ?",
+          "answer": "Cleanup removes workflow/config (and optionally secrets). Maintenance inspects current state first, then guides you to setup, update-secret, or cleanup depending on findings."
+        },
+        {
+          "id": "platforms",
+          "question": "What platforms are supported?",
+          "answer": "Windows, macOS, and Linux. The CLI and library target .NET 8+ and .NET 10+, the PowerShell module supports netstandard2.0, net472, and net8.0. The reviewer runs on any GitHub Actions runner."
+        },
+        {
+          "id": "customize",
+          "question": "Can I customize the review behavior?",
+          "answer": "Yes. Choose from presets (balanced, picky, security, performance, tests, minimal) or write custom JSON config. Control review mode (inline, summary, hybrid), length, output style, and auto-resolve behavior."
+        },
+        {
+          "id": "codex",
+          "question": "Is this similar to Claude Code or Codex?",
+          "answer": "The reviewer produces structured, Codex-style output integrated into your GitHub PR workflow. It supports inline comments with code suggestions, summary reviews, and hybrid mode."
+        }
+      ]
+    }
+  ]
+}

--- a/Website/themes/intelligencex/partials/sections/faq-preview.html
+++ b/Website/themes/intelligencex/partials/sections/faq-preview.html
@@ -7,7 +7,7 @@
 
     <div class="faq-list">
         <div class="pf-faq">
-            {{ for section in data.faq }}
+            {{ for section in data.faq.sections }}
             <div class="pf-faq-section">
                 {{ for item in section.items }}
                 <div class="pf-faq-item" id="faq-{{ item.id }}">


### PR DESCRIPTION
## Summary
- normalize FAQ data contract to expected object shape with `sections` array in `Website/data/faq.json`
- update FAQ consumers to the new data path:
  - `Website/content/pages/faq.md` shortcode now uses `faq.sections`
  - `Website/themes/intelligencex/partials/sections/faq-preview.html` now iterates `data.faq.sections`
- run a full CI-mode website rebuild to confirm API docs + sitemap pipeline remains green

## Validation
- `./build.ps1 -CI` from `Website/`
- Result: full pipeline passed, including both API surfaces and sitemap generation
- Verify warning resolved: no more `Data file 'data/faq.json' missing required array 'sections'`

## Notes
- `/api/` and `/api/powershell/` remain present in generated `_site/sitemap.xml`
- `robots.txt` still points to `https://intelligencex.dev/sitemap.xml`
