### PR TITLE
Fix confusing runtime switch flow and duplicate local runtime restarts

### DIFF
--- a/Docs/apps/chat-local-providers.md
+++ b/Docs/apps/chat-local-providers.md
@@ -23,8 +23,9 @@ For the WinUI desktop app (`Build/Run-ChatApp.ps1`):
    - **Use ChatGPT Runtime** (`native`)
    - **Use LM Studio Runtime** (`compatible-http` + LM Studio base URL)
    - **Use Copilot Subscription** (`copilot-cli`)
-3. Click **Refresh Models** after switching runtime or changing endpoint details.
-4. Use **Show Advanced Runtime** when you need explicit transport/base URL/API key/manual model overrides.
+3. Runtime actions apply immediately and show an in-progress state while the runtime restarts.
+4. Click **Refresh Models** after switching runtime or changing endpoint details when you want a forced re-probe.
+5. Use **Show Advanced Runtime** when you need explicit transport/base URL/API key/manual model overrides.
 
 Advanced presets:
 - **Use LM Studio Runtime**: `http://127.0.0.1:1234/v1`
@@ -37,6 +38,7 @@ Notes:
 - Leaving API key empty keeps the currently saved compatible-http key unchanged.
 - Use **Clear Saved API Key** to remove the saved compatible-http key from the active profile.
 - The panel shows active runtime/model status so you can confirm what is currently used.
+- While a runtime switch is running, runtime buttons are temporarily disabled to avoid duplicate restarts.
 
 ## Model Discovery and Runtime Detection
 
@@ -44,6 +46,10 @@ Notes:
 - If localhost is not available, IX Chat also probes your currently configured `compatible-http` base URL.
 - This helps external endpoints (for example remote LM Studio or Azure/OpenAI-compatible gateways) reflect real availability.
 - For LM Studio endpoints, IX Chat also reads LM Studio catalog metadata (state, quantization, architecture, context lengths, capabilities) when available and surfaces it in the runtime model picker/state note.
+
+Troubleshooting:
+- `Couldn't connect to local runtime after startup: Timed out waiting for service pipe.` indicates the selected runtime transport did not become reachable in time.
+- For LM Studio, verify Local Server is running and `http://127.0.0.1:1234/v1/models` returns data before retrying.
 
 ## Security Model
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
@@ -114,4 +114,17 @@ public sealed class UiShellAssetsTests {
         Assert.DoesNotContain("if (!isCompatible) {\n        baseInput.value = \"\";", script, StringComparison.Ordinal);
         Assert.DoesNotContain("if (!isCompatible) {\n        apiKeyInput.value = \"\";", script, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// Ensures runtime apply guards duplicate submits and flips runtime UI state immediately.
+    /// </summary>
+    [Fact]
+    public void Load_IncludesRuntimeApplyInFlightGuardAndOptimisticUiUpdate() {
+        var bindingsPath = Path.Combine(UiDirectory, "Shell.20.bindings.js");
+        var script = File.ReadAllText(bindingsPath);
+
+        Assert.Contains("if (local.isApplying === true) {", script, StringComparison.Ordinal);
+        Assert.Contains("state.options.localModel.isApplying = true;", script, StringComparison.Ordinal);
+        Assert.Contains("renderLocalModelOptions();", script, StringComparison.Ordinal);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -160,60 +160,74 @@ public sealed partial class MainWindow : Window {
     }
 
     private async Task ApplyLocalProviderAsync(string? transportValue, string? baseUrlValue, string? modelValue, string? apiKeyValue, bool clearApiKey, bool forceModelRefresh) {
-        if (_isSending) {
-            await SetStatusAsync("Finish the active response before changing local runtime settings.").ConfigureAwait(false);
+        if (Interlocked.CompareExchange(ref _localProviderApplyInFlight, 1, 0) != 0) {
+            await SetStatusAsync("Runtime switch already in progress.").ConfigureAwait(false);
             return;
         }
 
-        var rawTransport = (transportValue ?? string.Empty).Trim();
-        var normalizedTransport = NormalizeLocalProviderTransport(rawTransport);
-        var normalizedBaseUrl = NormalizeLocalProviderBaseUrl(baseUrlValue, normalizedTransport, rawTransport);
-        var normalizedModel = NormalizeLocalProviderModel(modelValue, normalizedTransport);
-        var clearApiKeyRequested = clearApiKey && string.Equals(normalizedTransport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase);
-        var normalizedApiKey = NormalizeLocalProviderApiKey(apiKeyValue, normalizedTransport);
-        var hasApiKeyUpdate = clearApiKeyRequested || normalizedApiKey is not null;
+        try {
+            await SetStatusAsync("Applying runtime settings...").ConfigureAwait(false);
+            await PublishOptionsStateAsync().ConfigureAwait(false);
 
-        var changed = !string.Equals(_localProviderTransport, normalizedTransport, StringComparison.OrdinalIgnoreCase)
-                      || !string.Equals(_localProviderBaseUrl ?? string.Empty, normalizedBaseUrl ?? string.Empty, StringComparison.OrdinalIgnoreCase)
-                      || !string.Equals(_localProviderModel, normalizedModel, StringComparison.Ordinal)
-                      || hasApiKeyUpdate;
+            if (_isSending) {
+                await SetStatusAsync("Finish the active response before changing local runtime settings.").ConfigureAwait(false);
+                return;
+            }
 
-        _localProviderTransport = normalizedTransport;
-        _localProviderBaseUrl = normalizedBaseUrl;
-        _localProviderModel = normalizedModel;
-        _appState.LocalProviderTransport = _localProviderTransport;
-        _appState.LocalProviderBaseUrl = _localProviderBaseUrl;
-        _appState.LocalProviderModel = _localProviderModel;
+            var rawTransport = (transportValue ?? string.Empty).Trim();
+            var normalizedTransport = NormalizeLocalProviderTransport(rawTransport);
+            var normalizedBaseUrl = NormalizeLocalProviderBaseUrl(baseUrlValue, normalizedTransport, rawTransport);
+            var normalizedModel = NormalizeLocalProviderModel(modelValue, normalizedTransport);
+            var clearApiKeyRequested = clearApiKey && string.Equals(normalizedTransport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase);
+            var normalizedApiKey = NormalizeLocalProviderApiKey(apiKeyValue, normalizedTransport);
+            var hasApiKeyUpdate = clearApiKeyRequested || normalizedApiKey is not null;
 
-        var profileSaved = ContainsProfileName(_serviceProfileNames, _appProfileName);
-        await PersistAppStateAsync().ConfigureAwait(false);
+            var changed = !string.Equals(_localProviderTransport, normalizedTransport, StringComparison.OrdinalIgnoreCase)
+                          || !string.Equals(_localProviderBaseUrl ?? string.Empty, normalizedBaseUrl ?? string.Empty, StringComparison.OrdinalIgnoreCase)
+                          || !string.Equals(_localProviderModel, normalizedModel, StringComparison.Ordinal)
+                          || hasApiKeyUpdate;
 
-        if (!changed && profileSaved) {
-            await RefreshModelsFromUiAsync(forceModelRefresh).ConfigureAwait(false);
-            return;
+            _localProviderTransport = normalizedTransport;
+            _localProviderBaseUrl = normalizedBaseUrl;
+            _localProviderModel = normalizedModel;
+            _appState.LocalProviderTransport = _localProviderTransport;
+            _appState.LocalProviderBaseUrl = _localProviderBaseUrl;
+            _appState.LocalProviderModel = _localProviderModel;
+
+            var profileSaved = ContainsProfileName(_serviceProfileNames, _appProfileName);
+            await PersistAppStateAsync().ConfigureAwait(false);
+            await PublishOptionsStateAsync().ConfigureAwait(false);
+
+            if (!changed && profileSaved) {
+                await RefreshModelsFromUiAsync(forceModelRefresh).ConfigureAwait(false);
+                return;
+            }
+
+            ClearConversationThreadIds();
+            await PersistAppStateAsync().ConfigureAwait(false);
+
+            _pendingServiceLaunchProfileOptions = new ServiceLaunchProfileOptions {
+                LoadProfileName = profileSaved ? _appProfileName : null,
+                SaveProfileName = _appProfileName,
+                Model = _localProviderModel,
+                OpenAITransport = _localProviderTransport,
+                OpenAIBaseUrl = _localProviderBaseUrl,
+                OpenAIApiKey = normalizedApiKey,
+                ClearOpenAIApiKey = clearApiKeyRequested,
+                OpenAIStreaming = true,
+                OpenAIAllowInsecureHttp = ShouldAllowInsecureHttp(_localProviderTransport, _localProviderBaseUrl)
+            };
+
+            await RestartSidecarAsync().ConfigureAwait(false);
+            await RefreshLocalRuntimeDetectionAsync(publishOptions: false).ConfigureAwait(false);
+            await SyncConnectedServiceProfileAndModelsAsync(
+                forceModelRefresh: true,
+                setProfileNewThread: false,
+                appendWarnings: true).ConfigureAwait(false);
+        } finally {
+            Interlocked.Exchange(ref _localProviderApplyInFlight, 0);
+            await PublishOptionsStateAsync().ConfigureAwait(false);
         }
-
-        ClearConversationThreadIds();
-        await PersistAppStateAsync().ConfigureAwait(false);
-
-        _pendingServiceLaunchProfileOptions = new ServiceLaunchProfileOptions {
-            LoadProfileName = profileSaved ? _appProfileName : null,
-            SaveProfileName = _appProfileName,
-            Model = _localProviderModel,
-            OpenAITransport = _localProviderTransport,
-            OpenAIBaseUrl = _localProviderBaseUrl,
-            OpenAIApiKey = normalizedApiKey,
-            ClearOpenAIApiKey = clearApiKeyRequested,
-            OpenAIStreaming = true,
-            OpenAIAllowInsecureHttp = ShouldAllowInsecureHttp(_localProviderTransport, _localProviderBaseUrl)
-        };
-
-        await RestartSidecarAsync().ConfigureAwait(false);
-        await RefreshLocalRuntimeDetectionAsync(publishOptions: false).ConfigureAwait(false);
-        await SyncConnectedServiceProfileAndModelsAsync(
-            forceModelRefresh: true,
-            setProfileNewThread: false,
-            appendWarnings: true).ConfigureAwait(false);
     }
 
     private async Task ReconnectServiceSessionAsync() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -289,6 +289,7 @@ public sealed partial class MainWindow : Window {
             localModel = new {
                 transport = _localProviderTransport,
                 baseUrl = _localProviderBaseUrl ?? string.Empty,
+                isApplying = Volatile.Read(ref _localProviderApplyInFlight) != 0,
                 modelsEndpoint = string.Equals(_localProviderTransport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase)
                     ? BuildModelsProbeUrl(_localProviderBaseUrl ?? string.Empty)
                     : string.Empty,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -310,6 +310,7 @@ public sealed partial class MainWindow : Window {
     private readonly object _autoReconnectSync = new();
     private CancellationTokenSource? _autoReconnectCts;
     private Task? _autoReconnectTask;
+    private int _localProviderApplyInFlight;
 
     private sealed class ConversationRuntime {
         public required string Id { get; init; }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -637,6 +637,7 @@
 
   function renderLocalModelOptions() {
     var local = state.options.localModel || {};
+    var isApplying = local.isApplying === true;
     var transport = normalizeLocalTransport(local.transport);
     var isCompatible = transport === "compatible-http";
     var isCopilotCli = transport === "copilot-cli";
@@ -707,7 +708,9 @@
 
     var simpleHint = byId("optLocalSimpleHint");
     if (simpleHint) {
-      if (transport === "native") {
+      if (isApplying) {
+        simpleHint.textContent = "Applying runtime settings. Please wait for the runtime to restart.";
+      } else if (transport === "native") {
         simpleHint.textContent = "ChatGPT runtime is active. Switch to LM Studio runtime to use local models.";
       } else if (isCopilotCli) {
         simpleHint.textContent = "Copilot subscription runtime is active. Use Sign In to authenticate your GitHub Copilot account.";
@@ -727,12 +730,14 @@
       var isNative = transport === "native";
       useOpenAiRuntimeButton.textContent = isNative ? "ChatGPT Runtime Active" : "Use ChatGPT Runtime";
       useOpenAiRuntimeButton.classList.toggle("options-btn-active", isNative);
+      useOpenAiRuntimeButton.disabled = isApplying;
     }
 
     var connectLmStudioButton = byId("btnConnectLmStudio");
     if (connectLmStudioButton) {
       connectLmStudioButton.textContent = lmStudioConnected ? "LM Studio Runtime Active" : "Use LM Studio Runtime";
       connectLmStudioButton.classList.toggle("options-btn-active", lmStudioConnected);
+      connectLmStudioButton.disabled = isApplying;
       connectLmStudioButton.title = runtimeDetectionHasRun && !lmStudioAvailable && !lmStudioConnected
         ? "LM Studio was not detected. Start LM Studio and click Auto Detect Runtime in Advanced Runtime."
         : "";
@@ -742,6 +747,7 @@
     if (useCopilotRuntimeButton) {
       useCopilotRuntimeButton.textContent = isCopilotCli ? "Copilot Subscription Active" : "Use Copilot Subscription";
       useCopilotRuntimeButton.classList.toggle("options-btn-active", isCopilotCli);
+      useCopilotRuntimeButton.disabled = isApplying;
       useCopilotRuntimeButton.title = isCopilotCli
         ? ""
         : "Uses GitHub Copilot subscription sign-in (no API key required).";
@@ -749,8 +755,16 @@
 
     var refreshModelsButton = byId("btnRefreshModels");
     if (refreshModelsButton) {
-      refreshModelsButton.disabled = transport === "native";
-      refreshModelsButton.title = transport === "native" ? "Switch to Copilot or compatible runtime to refresh models." : "";
+      refreshModelsButton.disabled = isApplying || transport === "native";
+      refreshModelsButton.title = isApplying
+        ? "Runtime switch in progress."
+        : (transport === "native" ? "Switch to Copilot or compatible runtime to refresh models." : "");
+    }
+
+    var applyRuntimeButton = byId("btnApplyLocalProvider");
+    if (applyRuntimeButton) {
+      applyRuntimeButton.disabled = isApplying;
+      applyRuntimeButton.textContent = isApplying ? "Applying Runtime..." : "Apply Runtime";
     }
 
     var advancedShouldBeOpen = isRuntimeAdvancedOpen();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -751,6 +751,10 @@
   }
 
   function applyLocalProviderSettings(forceRefresh, clearApiKey) {
+    var local = ((state.options || {}).localModel || {});
+    if (local.isApplying === true) {
+      return;
+    }
     var transport = normalizeLocalTransportValue(byId("optLocalTransport").value || "native");
     var baseUrl = transportUsesCompatibleHttp(transport)
       ? (byId("optLocalBaseUrl").value || "").trim()
@@ -762,6 +766,16 @@
       : "";
     if (shouldClearApiKey) {
       apiKey = "";
+    }
+    if (state.options) {
+      if (!state.options.localModel) {
+        state.options.localModel = {};
+      }
+      state.options.localModel.transport = transport;
+      state.options.localModel.baseUrl = baseUrl;
+      state.options.localModel.model = model;
+      state.options.localModel.isApplying = true;
+      renderLocalModelOptions();
     }
     post("apply_local_provider", {
       transport: transport,

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -40,11 +40,19 @@ Markdown renderer dependency resolution is automatic:
 
 Inside the app:
 
-1. Open **Options -> Profile -> Model Runtime**.
-2. Click **Connect LM Studio**.
+1. Open **Options -> Runtime**.
+2. Click one of the runtime actions:
+   - **Use ChatGPT Runtime**
+   - **Use LM Studio Runtime**
+   - **Use Copilot Subscription**
 3. Wait for model discovery to populate and choose a discovered model if needed.
-4. Use **Advanced Runtime** only when you need custom transport/base URL/API key/manual model options.
-5. Click **Apply Runtime** after changing model/runtime options.
+4. Use **Show Advanced Runtime** only when you need custom transport/base URL/API key/manual model options (LM Studio/Ollama/Azure/other compatible endpoints).
+5. If you see **Applying Runtime...**, wait for restart and model refresh to complete before clicking runtime buttons again.
+6. Use **Refresh Models** to force model re-discovery after runtime changes.
+
+Troubleshooting:
+- `Couldn't connect to local runtime after startup: Timed out waiting for service pipe.` usually means the selected runtime endpoint is not reachable yet.
+- For LM Studio, ensure Local Server is enabled and reachable at `http://127.0.0.1:1234/v1` (or set your custom endpoint in **Advanced Runtime**).
 
 Reference: `Docs/apps/chat-local-providers.md`
 


### PR DESCRIPTION
## Summary
- prevent duplicate runtime-switch restarts by adding an in-flight apply guard in app runtime apply flow
- publish runtime options state at apply start/finish so Runtime tab reflects selected transport immediately
- disable runtime action buttons while apply is in progress and show explicit "Applying Runtime..." status
- add client-side optimistic runtime state update to flip active runtime button/badge instantly on click
- update runtime docs and README troubleshooting for service-pipe timeout and Runtime-tab flow

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --no-restore
- smoke: `http://127.0.0.1:1234/v1/models` returned 200 with 6 models in this environment
