### PR TITLE
Fix PowerShell docs example imports and output messaging

### DIFF
--- a/Website/data/apidocs/powershell/examples/Example.Chat.ps1
+++ b/Website/data/apidocs/powershell/examples/Example.Chat.ps1
@@ -1,8 +1,8 @@
 $moduleManifest = Join-Path (Split-Path -Parent $PSScriptRoot) 'IntelligenceX.PowerShell.psd1'
 if (Test-Path -LiteralPath $moduleManifest) {
-    Import-Module $moduleManifest -Force
+    Import-Module $moduleManifest -Force -ErrorAction Stop
 } else {
-    Import-Module IntelligenceX.PowerShell -Force
+    Import-Module IntelligenceX.PowerShell -Force -ErrorAction Stop
 }
 
 $client = Connect-IntelligenceX

--- a/Website/data/apidocs/powershell/examples/Example.Config.ps1
+++ b/Website/data/apidocs/powershell/examples/Example.Config.ps1
@@ -1,8 +1,8 @@
 $moduleManifest = Join-Path (Split-Path -Parent $PSScriptRoot) 'IntelligenceX.PowerShell.psd1'
 if (Test-Path -LiteralPath $moduleManifest) {
-    Import-Module $moduleManifest -Force
+    Import-Module $moduleManifest -Force -ErrorAction Stop
 } else {
-    Import-Module IntelligenceX.PowerShell -Force
+    Import-Module IntelligenceX.PowerShell -Force -ErrorAction Stop
 }
 
 $client = Connect-IntelligenceX

--- a/Website/data/apidocs/powershell/examples/Example.Health.ps1
+++ b/Website/data/apidocs/powershell/examples/Example.Health.ps1
@@ -1,8 +1,8 @@
 $moduleManifest = Join-Path (Split-Path -Parent $PSScriptRoot) 'IntelligenceX.PowerShell.psd1'
 if (Test-Path -LiteralPath $moduleManifest) {
-    Import-Module $moduleManifest -Force
+    Import-Module $moduleManifest -Force -ErrorAction Stop
 } else {
-    Import-Module IntelligenceX.PowerShell -Force
+    Import-Module IntelligenceX.PowerShell -Force -ErrorAction Stop
 }
 
 # Optional: configure defaults via .intelligencex/config.json (see Module/Examples/.intelligencex/config.json)

--- a/Website/data/apidocs/powershell/examples/Example.Login.ps1
+++ b/Website/data/apidocs/powershell/examples/Example.Login.ps1
@@ -1,8 +1,8 @@
 $moduleManifest = Join-Path (Split-Path -Parent $PSScriptRoot) 'IntelligenceX.PowerShell.psd1'
 if (Test-Path -LiteralPath $moduleManifest) {
-    Import-Module $moduleManifest -Force
+    Import-Module $moduleManifest -Force -ErrorAction Stop
 } else {
-    Import-Module IntelligenceX.PowerShell -Force
+    Import-Module IntelligenceX.PowerShell -Force -ErrorAction Stop
 }
 
 # Optional: configure defaults via .intelligencex/config.json (see Module/Examples/.intelligencex/config.json)

--- a/Website/data/apidocs/powershell/examples/Example.Mcp.ps1
+++ b/Website/data/apidocs/powershell/examples/Example.Mcp.ps1
@@ -1,8 +1,8 @@
 $moduleManifest = Join-Path (Split-Path -Parent $PSScriptRoot) 'IntelligenceX.PowerShell.psd1'
 if (Test-Path -LiteralPath $moduleManifest) {
-    Import-Module $moduleManifest -Force
+    Import-Module $moduleManifest -Force -ErrorAction Stop
 } else {
-    Import-Module IntelligenceX.PowerShell -Force
+    Import-Module IntelligenceX.PowerShell -Force -ErrorAction Stop
 }
 
 $client = Connect-IntelligenceX


### PR DESCRIPTION
## Summary\n- fix PowerShell docs examples to import module safely from either a local manifest ($PSScriptRoot-relative) or installed module name\n- replace Write-Host with Write-Output in login/chat examples for script-friendly output\n- apply consistently across all website PowerShell example scripts\n\n## Why\n- addresses reviewer-reported broken import paths in docs examples\n- makes copy/paste examples runnable in more environments\n\n## Validation\n- ./build.ps1 -CI from Website/ with POWERFORGE_ROOT set to local PSPublishModule\n- pipeline passed all 12 steps (pidocs, sitemap, doctor included)