### PR TITLE
docs(powershell): add cookbook + troubleshooting with snippet drift checks

### DIFF
--- a/Docs/_index.md
+++ b/Docs/_index.md
@@ -41,6 +41,8 @@ Welcome to the IntelligenceX documentation.
 
 - [PowerShell Overview](/docs/powershell/overview/)
 - [PowerShell Quickstart](/docs/powershell/quickstart/)
+- [PowerShell Cookbook](/docs/powershell/cookbook/)
+- [PowerShell Troubleshooting](/docs/powershell/troubleshooting/)
 
 ## Guides
 

--- a/Docs/powershell/cookbook.md
+++ b/Docs/powershell/cookbook.md
@@ -1,0 +1,84 @@
+# PowerShell Cookbook
+
+Practical PowerShell workflows you can copy, adapt, and run.
+
+## Workflow: Bootstrap A Session
+
+```powershell
+Import-Module ./Module/IntelligenceX.psd1 -Force
+
+$client = Connect-IntelligenceX
+Initialize-IntelligenceX -Client $client -Name "Repo.Automation" -Title "Repo Automation" -Version "1.0.0"
+
+$login = Start-IntelligenceXChatGptLogin -Client $client
+Write-Output "Open: $($login.AuthUrl)"
+Wait-IntelligenceXLogin -Client $client -LoginId $login.LoginId
+Get-IntelligenceXAccount -Client $client
+```
+
+## Workflow: Start A Thread, Chat, Review
+
+```powershell
+$thread = Start-IntelligenceXThread -Client $client -Model "gpt-5.3-codex"
+Send-IntelligenceXMessage -Client $client -ThreadId $thread.Id -Text "Summarize current repo risks."
+
+$review = Start-IntelligenceXReview -Client $client -ThreadId $thread.Id -Delivery immediate -TargetType uncommittedChanges
+$review
+```
+
+## Workflow: Non-Interactive CI (API Key)
+
+```powershell
+Import-Module ./Module/IntelligenceX.psd1 -Force
+
+$client = Connect-IntelligenceX -Transport Native
+Initialize-IntelligenceX -Client $client -Name "CI.PowerShell" -Title "CI PowerShell" -Version "1.0.0"
+Start-IntelligenceXApiKeyLogin -Client $client -ApiKey (Get-Item Env:OPENAI_API_KEY).Value
+
+Invoke-IntelligenceXChat -Client $client -Text "Summarize changed files." -WaitSeconds 20
+Disconnect-IntelligenceX -Client $client
+```
+
+## Workflow: MCP OAuth Onboarding
+
+```powershell
+$status = Get-IntelligenceXMcpServerStatus -Client $client
+$status.Servers | Select-Object Name, AuthStatus
+
+$oauthStatus = [IntelligenceX.OpenAI.AppServer.Models.McpAuthStatus]::OAuth
+$oauthServer = $status.Servers | Where-Object { $_.AuthStatus -eq $oauthStatus } | Select-Object -First 1
+
+if ($oauthServer) {
+    $login = Start-IntelligenceXMcpOAuthLogin -Client $client -ServerName $oauthServer.Name
+    Start-Process $login.AuthUrl
+}
+```
+
+## Workflow: Config Baseline + Validation
+
+```powershell
+Set-IntelligenceXConfigBatch -Client $client -Values @{
+    model = "gpt-5.3-codex"
+    approvalPolicy = "on-failure"
+    stream = $true
+}
+
+$config = Get-IntelligenceXConfig -Client $client
+$config.Config
+$config.Origins["model"]
+```
+
+## Workflow: Script Cleanup Pattern
+
+```powershell
+try {
+    $client = Connect-IntelligenceX
+    Initialize-IntelligenceX -Client $client -Name "Ops.Script" -Title "Ops Script" -Version "1.0.0"
+    Get-IntelligenceXHealth -Client $client
+} finally {
+    if ($client) {
+        Disconnect-IntelligenceX -Client $client
+    }
+}
+```
+

--- a/Docs/powershell/overview.md
+++ b/Docs/powershell/overview.md
@@ -80,5 +80,7 @@ Get-IntelligenceXHealth -Copilot
 ## Next Docs
 
 - Quickstart: [PowerShell Quickstart](/docs/powershell/quickstart/)
+- Recipes: [PowerShell Cookbook](/docs/powershell/cookbook/)
+- Support: [PowerShell Troubleshooting](/docs/powershell/troubleshooting/)
 - Full cmdlet reference: [/api/powershell/](/api/powershell/)
 - Script examples: `Module/Examples`

--- a/Docs/powershell/quickstart.md
+++ b/Docs/powershell/quickstart.md
@@ -85,3 +85,9 @@ Set-IntelligenceXConfigBatch -Values @{
 ```powershell
 Disconnect-IntelligenceX -Client $client
 ```
+
+## Next Steps
+
+- [PowerShell Cookbook](/docs/powershell/cookbook/)
+- [PowerShell Troubleshooting](/docs/powershell/troubleshooting/)
+- [PowerShell API Reference](/api/powershell/)

--- a/Docs/powershell/troubleshooting.md
+++ b/Docs/powershell/troubleshooting.md
@@ -1,0 +1,121 @@
+# PowerShell Troubleshooting
+
+Common issues and direct fixes for IntelligenceX PowerShell usage.
+
+## Connect-IntelligenceX Fails With Executable Not Found
+
+Symptom:
+- `Connect-IntelligenceX -Transport AppServer` throws an error about Codex app-server not found.
+
+Fix:
+```powershell
+Connect-IntelligenceX -Transport AppServer -ExecutablePath "C:\tools\codex.exe"
+```
+
+Fallback:
+```powershell
+Connect-IntelligenceX -Transport Native
+```
+
+## Login Never Completes
+
+Symptom:
+- `Wait-IntelligenceXLogin` times out.
+
+Fix checklist:
+1. Start login again and open the exact URL from `AuthUrl`.
+2. Wait using explicit login id.
+3. Verify account after completion.
+
+```powershell
+$login = Start-IntelligenceXChatGptLogin
+Write-Output $login.AuthUrl
+Wait-IntelligenceXLogin -LoginId $login.LoginId -TimeoutSeconds 300
+Get-IntelligenceXAccount
+```
+
+## Raw Output Needed But Typed Result Missing Field
+
+Use `-Raw` to inspect full payload:
+
+```powershell
+Get-IntelligenceXMcpServerStatus -Raw
+Get-IntelligenceXConfig -Raw
+Invoke-IntelligenceXRpc -Method "config/read"
+```
+
+## MCP OAuth Never Starts
+
+Symptom:
+- No server is found for OAuth workflow.
+
+Fix:
+- Filter using enum-safe auth status.
+- Reload MCP config if files changed.
+
+```powershell
+Invoke-IntelligenceXMcpServerConfigReload
+
+$status = Get-IntelligenceXMcpServerStatus
+$oauthStatus = [IntelligenceX.OpenAI.AppServer.Models.McpAuthStatus]::OAuth
+$oauthServer = $status.Servers | Where-Object { $_.AuthStatus -eq $oauthStatus } | Select-Object -First 1
+
+if ($oauthServer) {
+    Start-IntelligenceXMcpOAuthLogin -ServerName $oauthServer.Name
+}
+```
+
+## Turn Is Stuck Or Running Too Long
+
+```powershell
+Stop-IntelligenceXTurn -ThreadId $thread.Id -TurnId $turn.Id
+```
+
+Then continue from the same thread:
+
+```powershell
+Resume-IntelligenceXThread -ThreadId $thread.Id
+```
+
+## Need To Rewind Conversation State
+
+```powershell
+Restore-IntelligenceXThread -ThreadId $thread.Id -Turns 1
+```
+
+## Health Checks For Diagnostics
+
+```powershell
+Get-IntelligenceXHealth
+Get-IntelligenceXHealth -Copilot
+```
+
+Enable detailed transport diagnostics:
+
+```powershell
+Connect-IntelligenceX -Diagnostics
+Watch-IntelligenceXEvent
+```
+
+## Script Hygiene
+
+Always disconnect in `finally`:
+
+```powershell
+try {
+    $client = Connect-IntelligenceX
+    Initialize-IntelligenceX -Client $client -Name "Troubleshoot" -Title "Troubleshoot" -Version "1.0.0"
+    Get-IntelligenceXHealth -Client $client
+} finally {
+    if ($client) {
+        Disconnect-IntelligenceX -Client $client
+    }
+}
+```
+
+## Related Docs
+
+- [PowerShell Quickstart](/docs/powershell/quickstart/)
+- [PowerShell Cookbook](/docs/powershell/cookbook/)
+- [PowerShell API Reference](/api/powershell/)
+

--- a/Docs/toc.json
+++ b/Docs/toc.json
@@ -56,7 +56,9 @@
     "title": "PowerShell Module",
     "items": [
       { "title": "Overview", "href": "/docs/powershell/overview/" },
-      { "title": "Quickstart", "href": "/docs/powershell/quickstart/" }
+      { "title": "Quickstart", "href": "/docs/powershell/quickstart/" },
+      { "title": "Cookbook", "href": "/docs/powershell/cookbook/" },
+      { "title": "Troubleshooting", "href": "/docs/powershell/troubleshooting/" }
     ]
   },
   {

--- a/IntelligenceX.Tests/Program.PowerShellDocs.cs
+++ b/IntelligenceX.Tests/Program.PowerShellDocs.cs
@@ -1,0 +1,90 @@
+namespace IntelligenceX.Tests;
+
+#if INTELLIGENCEX_REVIEWER
+using System.Text.RegularExpressions;
+
+internal static partial class Program {
+    private static readonly Regex PowerShellFenceRegex = new(
+        "```(?:powershell|pwsh)\\s*\\r?\\n(.*?)\\r?\\n```",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+    private static readonly Regex IntelligenceXCmdletRegex = new(
+        "\\b[A-Za-z]+-IntelligenceX[A-Za-z0-9]+\\b",
+        RegexOptions.Compiled);
+
+    private static void TestPowerShellDocsSnippetsUseExportedCmdlets() {
+        var workspace = ResolveWorkspaceRoot();
+        var docsDirectory = Path.Combine(workspace, "Docs", "powershell");
+        AssertEqual(true, Directory.Exists(docsDirectory), "powershell docs directory exists");
+
+        var exportedCmdlets = LoadExportedCmdletSet(workspace);
+        var markdownFiles = Directory.GetFiles(docsDirectory, "*.md", SearchOption.TopDirectoryOnly);
+        AssertEqual(true, markdownFiles.Length > 0, "powershell docs markdown files discovered");
+
+        var snippetsChecked = 0;
+        foreach (var file in markdownFiles) {
+            var markdown = File.ReadAllText(file);
+            var matches = PowerShellFenceRegex.Matches(markdown);
+            foreach (Match match in matches) {
+                var code = match.Groups[1].Value;
+                ValidateIntelligenceXCmdletReferences(code, file, exportedCmdlets);
+                snippetsChecked++;
+            }
+        }
+
+        AssertEqual(true, snippetsChecked > 0, "powershell docs snippets discovered");
+    }
+
+    private static void TestPowerShellExampleScriptsUseExportedCmdlets() {
+        var workspace = ResolveWorkspaceRoot();
+        var examplesDirectory = Path.Combine(workspace, "Website", "data", "apidocs", "powershell", "examples");
+        AssertEqual(true, Directory.Exists(examplesDirectory), "powershell examples directory exists");
+
+        var exportedCmdlets = LoadExportedCmdletSet(workspace);
+        var scripts = Directory.GetFiles(examplesDirectory, "*.ps1", SearchOption.TopDirectoryOnly);
+        AssertEqual(true, scripts.Length > 0, "powershell example scripts discovered");
+
+        foreach (var script in scripts) {
+            var content = File.ReadAllText(script);
+            ValidateIntelligenceXCmdletReferences(content, script, exportedCmdlets);
+        }
+    }
+
+    private static HashSet<string> LoadExportedCmdletSet(string workspace) {
+        var manifestPath = Path.Combine(workspace, "Module", "IntelligenceX.psd1");
+        AssertEqual(true, File.Exists(manifestPath), "powershell module manifest exists");
+
+        var manifest = File.ReadAllText(manifestPath);
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var matches = IntelligenceXCmdletRegex.Matches(manifest);
+        foreach (Match match in matches) {
+            set.Add(match.Value);
+        }
+
+        AssertEqual(true, set.Count > 0, "exported cmdlets discovered from module manifest");
+        return set;
+    }
+
+    private static void ValidateIntelligenceXCmdletReferences(string content, string source,
+        IReadOnlySet<string> exportedCmdlets) {
+        var unknown = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var matches = IntelligenceXCmdletRegex.Matches(content);
+        foreach (Match match in matches) {
+            var cmdlet = match.Value;
+            if (!seen.Add(cmdlet)) {
+                continue;
+            }
+            if (!exportedCmdlets.Contains(cmdlet)) {
+                unknown.Add(cmdlet);
+            }
+        }
+
+        if (unknown.Count > 0) {
+            throw new InvalidOperationException(
+                $"Unknown IntelligenceX cmdlet reference(s) in '{source}': {string.Join(", ", unknown)}");
+        }
+    }
+}
+#endif
+

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -319,6 +319,8 @@ internal static partial class Program {
         failed += Run("Analysis catalog rule overrides apply", TestAnalysisCatalogRuleOverridesApply);
         failed += Run("Analysis catalog PowerShell overrides apply", () => TestAnalysisCatalogPowerShellOverridesApply());
         failed += Run("Analysis catalog PowerShell docs links", TestAnalysisCatalogPowerShellDocsLinksMatchLearnPattern);
+        failed += Run("PowerShell docs snippets use exported cmdlets", TestPowerShellDocsSnippetsUseExportedCmdlets);
+        failed += Run("PowerShell example scripts use exported cmdlets", TestPowerShellExampleScriptsUseExportedCmdlets);
         failed += Run("Analysis catalog override invalid type falls back", TestAnalysisCatalogOverrideInvalidTypeFallsBack);
         failed += Run("Analysis catalog validator rejects dangling override", TestAnalysisCatalogValidatorRejectsDanglingOverride);
         failed += Run("Analysis hotspots render and state snippet", TestAnalysisHotspotsRenderAndStateSnippet);


### PR DESCRIPTION
## Summary
- add a new PowerShell cookbook page with practical, copy-ready workflows
- add a new PowerShell troubleshooting page with concrete symptoms/fixes and diagnostic patterns
- wire both pages into docs navigation and cross-links from existing PowerShell docs
- add reviewer test coverage to fail when docs/examples reference non-exported `*-IntelligenceX*` cmdlets

## Why
Auto-generated examples in API docs are useful as syntax hints, but users need task-oriented recipes and troubleshooting guidance. This PR makes PowerShell docs much more actionable and adds a regression guard to keep examples aligned with exported cmdlets.

## Validation
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release -f net8.0`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release -f net10.0`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
