### PR TITLE
Fix system log timestamp visibility and add date time modes

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
@@ -40,6 +40,25 @@ public sealed class TranscriptHtmlFormatterTests {
     }
 
     /// <summary>
+    /// Ensures repeated system rows never collapse metadata visibility.
+    /// </summary>
+    [Fact]
+    public void Format_DoesNotHideMetaForSystemContinuations() {
+        var options = MarkdownRendererPresets.CreateChatStrictMinimal();
+        var now = new DateTime(2026, 2, 17, 14, 22, 0, DateTimeKind.Local);
+        var html = TranscriptHtmlFormatter.Format(new[] {
+            ("System", "Restarting local runtime...", now),
+            ("System", "Could not connect to local runtime.", now.AddSeconds(3))
+        }, "yyyy-MM-dd HH:mm:ss", options);
+
+        Assert.Contains("msg-row system", html);
+        Assert.DoesNotContain("msg-row system cont", html);
+        Assert.DoesNotContain("class='meta hidden'", html);
+        Assert.Contains("System &middot; 2026-02-17 14:22:00", html);
+        Assert.Contains("System &middot; 2026-02-17 14:22:03", html);
+    }
+
+    /// <summary>
     /// Ensures blank transcript text is skipped while preserving index progression.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
@@ -437,6 +437,16 @@ public sealed partial class MainWindow : Window {
         }
 
         var normalized = value.Trim();
+        if (string.Equals(normalized, "date-minutes", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(normalized, "date_minutes", StringComparison.OrdinalIgnoreCase)) {
+            return "date-minutes";
+        }
+
+        if (string.Equals(normalized, "date-seconds", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(normalized, "date_seconds", StringComparison.OrdinalIgnoreCase)) {
+            return "date-seconds";
+        }
+
         if (string.Equals(normalized, "minutes", StringComparison.OrdinalIgnoreCase)) {
             return "minutes";
         }
@@ -454,6 +464,16 @@ public sealed partial class MainWindow : Window {
         }
 
         var normalized = value.Trim();
+        if (string.Equals(normalized, "date-minutes", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(normalized, "date_minutes", StringComparison.OrdinalIgnoreCase)) {
+            return "yyyy-MM-dd HH:mm";
+        }
+
+        if (string.Equals(normalized, "date-seconds", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(normalized, "date_seconds", StringComparison.OrdinalIgnoreCase)) {
+            return "yyyy-MM-dd HH:mm:ss";
+        }
+
         if (string.Equals(normalized, "minutes", StringComparison.OrdinalIgnoreCase)) {
             return "HH:mm";
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptHtmlFormatter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptHtmlFormatter.cs
@@ -59,7 +59,9 @@ internal static class TranscriptHtmlFormatter {
             }
 
             var role = ResolveRoleStyle(message.Role);
-            var isContinuation = string.Equals(previousRoleClass, role.RoleClass, StringComparison.Ordinal);
+            var hideContinuationMeta = !string.Equals(role.RoleClass, "system", StringComparison.Ordinal);
+            var isContinuation = hideContinuationMeta
+                && string.Equals(previousRoleClass, role.RoleClass, StringComparison.Ordinal);
             var actionExtraction = string.Equals(message.Role, "Assistant", StringComparison.OrdinalIgnoreCase)
                 ? ExtractPendingActionsForRendering(normalizedText)
                 : new PendingActionExtraction(normalizedText, Array.Empty<PendingActionRenderItem>());

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
@@ -1,8 +1,17 @@
   function renderOptions() {
     loadDebugToolsEnabledForActiveProfile();
     var selector = byId("optTimeMode");
-    if (state.options.timestampMode === "minutes" || state.options.timestampMode === "seconds") {
-      selector.value = state.options.timestampMode;
+    var timestampMode = (state.options.timestampMode || "").toLowerCase();
+    if (timestampMode === "date_minutes") {
+      timestampMode = "date-minutes";
+    } else if (timestampMode === "date_seconds") {
+      timestampMode = "date-seconds";
+    }
+    if (timestampMode === "minutes"
+      || timestampMode === "seconds"
+      || timestampMode === "date-minutes"
+      || timestampMode === "date-seconds") {
+      selector.value = timestampMode;
     } else {
       selector.value = "seconds";
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -219,6 +219,8 @@
           <select id="optTimeMode" class="options-select">
             <option value="seconds">Seconds (HH:mm:ss)</option>
             <option value="minutes">Minutes (HH:mm)</option>
+            <option value="date-seconds">Date + Seconds (yyyy-MM-dd HH:mm:ss)</option>
+            <option value="date-minutes">Date + Minutes (yyyy-MM-dd HH:mm)</option>
           </select>
         </section>
 


### PR DESCRIPTION
## Summary
- keep System transcript rows fully visible even when multiple System messages appear back-to-back (no hidden meta/timestamp)
- add optional date-inclusive timestamp modes (`date-seconds`, `date-minutes`) to state persistence and format resolution
- expose date-inclusive timestamp options in Display settings
- update time mode selector rendering to accept both dash and underscore variants for compatibility
- add regression coverage for repeated System messages with visible timestamp metadata

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~TranscriptHtmlFormatterTests"`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~TranscriptMarkdown"`
