### PR TITLE
docs(api): enforce rich PowerShell/C# XML docs quality

### DIFF
--- a/IntelligenceX.Tests/Program.PowerShellDocs.cs
+++ b/IntelligenceX.Tests/Program.PowerShellDocs.cs
@@ -2,6 +2,7 @@ namespace IntelligenceX.Tests;
 
 #if INTELLIGENCEX_REVIEWER
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 internal static partial class Program {
     private static readonly Regex PowerShellFenceRegex = new(
@@ -11,6 +12,16 @@ internal static partial class Program {
     private static readonly Regex IntelligenceXCmdletRegex = new(
         "\\b[A-Za-z]+-IntelligenceX[A-Za-z0-9]+\\b",
         RegexOptions.Compiled);
+
+    private static readonly XNamespace CommandNs = "http://schemas.microsoft.com/maml/dev/command/2004/10";
+    private static readonly XNamespace MamlNs = "http://schemas.microsoft.com/maml/2004/10";
+
+    private static readonly string[] OpenAiApiDocFiles = new[] {
+        Path.Combine("IntelligenceX", "Providers", "OpenAI", "IntelligenceXClient.cs"),
+        Path.Combine("IntelligenceX", "Providers", "OpenAI", "AppServer", "AppServerClient.cs"),
+        Path.Combine("IntelligenceX", "Providers", "OpenAI", "AppServer", "AppServerClient.AccountAndThreads.cs"),
+        Path.Combine("IntelligenceX", "Providers", "OpenAI", "AppServer", "AppServerClient.ConfigAndRuntime.cs")
+    };
 
     private static void TestPowerShellDocsSnippetsUseExportedCmdlets() {
         var workspace = ResolveWorkspaceRoot();
@@ -50,6 +61,147 @@ internal static partial class Program {
         }
     }
 
+    private static void TestPowerShellCmdletSourceXmlDocsAreRich() {
+        var workspace = ResolveWorkspaceRoot();
+        var cmdletDirectory = Path.Combine(workspace, "IntelligenceX.PowerShell");
+        AssertEqual(true, Directory.Exists(cmdletDirectory), "powershell cmdlet source directory exists");
+
+        var cmdletFiles = Directory.GetFiles(cmdletDirectory, "Cmdlet*.cs", SearchOption.TopDirectoryOnly);
+        AssertEqual(true, cmdletFiles.Length > 0, "powershell cmdlet files discovered");
+
+        foreach (var file in cmdletFiles) {
+            var text = File.ReadAllText(file);
+            var fileName = Path.GetFileName(file);
+
+            AssertEqual(true, text.Contains("<para type=\"synopsis\">", StringComparison.Ordinal),
+                $"cmdlet synopsis exists in {fileName}");
+            AssertEqual(true, text.Contains("<para type=\"description\">", StringComparison.Ordinal),
+                $"cmdlet description exists in {fileName}");
+
+            var examples = Regex.Matches(text, "<example>", RegexOptions.Compiled).Count;
+            AssertEqual(true, examples >= 3, $"cmdlet examples >= 3 in {fileName}");
+
+            ValidateCmdletParameterXmlDocs(fileName, text);
+        }
+    }
+
+    private static void TestPowerShellHelpXmlCoversAllCmdletsWithRichDocs() {
+        var workspace = ResolveWorkspaceRoot();
+        var exportedCmdlets = LoadExportedCmdletSet(workspace);
+        var helpPath = Path.Combine(workspace, "Website", "data", "apidocs", "powershell", "IntelligenceX.PowerShell.dll-Help.xml");
+        AssertEqual(true, File.Exists(helpPath), "powershell help xml exists");
+
+        var document = XDocument.Load(helpPath);
+        var commands = document.Root?.Elements(CommandNs + "command").ToArray() ?? Array.Empty<XElement>();
+        AssertEqual(true, commands.Length > 0, "powershell help xml commands discovered");
+
+        var commandByName = new Dictionary<string, XElement>(StringComparer.OrdinalIgnoreCase);
+        foreach (var command in commands) {
+            var name = command.Element(CommandNs + "details")?.Element(CommandNs + "name")?.Value;
+            if (string.IsNullOrWhiteSpace(name)) {
+                continue;
+            }
+            commandByName[name] = command;
+        }
+
+        foreach (var cmdlet in exportedCmdlets.OrderBy(static c => c, StringComparer.OrdinalIgnoreCase)) {
+            AssertEqual(true, commandByName.TryGetValue(cmdlet, out var command),
+                $"help xml entry exists for {cmdlet}");
+
+            var detailParas = command!
+                .Element(CommandNs + "details")?
+                .Element(MamlNs + "description")?
+                .Elements(MamlNs + "para")
+                .Where(static p => !string.IsNullOrWhiteSpace(p.Value))
+                .ToArray() ?? Array.Empty<XElement>();
+            AssertEqual(true, detailParas.Length >= 2, $"help xml detail description has at least 2 paragraphs for {cmdlet}");
+
+            var examples = command
+                .Element(CommandNs + "examples")?
+                .Elements(CommandNs + "example")
+                .ToArray() ?? Array.Empty<XElement>();
+            AssertEqual(true, examples.Length >= 3, $"help xml has at least 3 examples for {cmdlet}");
+            foreach (var example in examples) {
+                var code = example.Element("code")?.Value
+                    ?? example.Element(XName.Get("code", "http://schemas.microsoft.com/maml/dev/2004/10"))?.Value
+                    ?? string.Empty;
+                AssertEqual(true, !string.IsNullOrWhiteSpace(code), $"help xml example code is non-empty for {cmdlet}");
+            }
+
+            var parameters = command
+                .Element(CommandNs + "parameters")?
+                .Elements(CommandNs + "parameter")
+                .ToArray() ?? Array.Empty<XElement>();
+            foreach (var parameter in parameters) {
+                var parameterName = parameter.Element(MamlNs + "name")?.Value ?? "<unknown>";
+                var paraCount = parameter
+                    .Element(MamlNs + "description")?
+                    .Elements(MamlNs + "para")
+                    .Count(static p => !string.IsNullOrWhiteSpace(p.Value)) ?? 0;
+                AssertEqual(true, paraCount > 0,
+                    $"help xml parameter description exists for {cmdlet}:{parameterName}");
+            }
+        }
+    }
+
+    private static void TestOpenAiClientCSharpXmlDocsAreComplete() {
+        var workspace = ResolveWorkspaceRoot();
+        foreach (var relativePath in OpenAiApiDocFiles) {
+            var filePath = Path.Combine(workspace, relativePath);
+            AssertEqual(true, File.Exists(filePath), $"csharp api doc file exists: {relativePath}");
+
+            var lines = File.ReadAllLines(filePath);
+            for (var i = 0; i < lines.Length; i++) {
+                if (!Regex.IsMatch(lines[i], "^\\s{4}public\\s+", RegexOptions.Compiled)) {
+                    continue;
+                }
+                if (Regex.IsMatch(lines[i], "^\\s{4}public\\s+(?:event|sealed\\s+class|interface|enum)\\s+", RegexOptions.Compiled)) {
+                    continue;
+                }
+                if (!lines[i].Contains('(')) {
+                    continue;
+                }
+
+                var signature = lines[i].Trim();
+                var j = i;
+                while (!Regex.IsMatch(signature, "\\)\\s*(\\{|=>)\\s*$", RegexOptions.Compiled) && j + 1 < lines.Length) {
+                    j++;
+                    signature = $"{signature} {lines[j].Trim()}";
+                }
+
+                var methodMatch = Regex.Match(
+                    signature,
+                    "^public\\s+(?:static\\s+)?(?:async\\s+)?(?<return>[A-Za-z0-9_<>\\[\\],?.]+)\\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\\s*\\((?<params>.*)\\)\\s*(?:\\{|=>)\\s*$",
+                    RegexOptions.Compiled);
+                if (!methodMatch.Success) {
+                    continue;
+                }
+
+                var returnType = methodMatch.Groups["return"].Value;
+                var methodName = methodMatch.Groups["name"].Value;
+                var parameters = methodMatch.Groups["params"].Value;
+                var docBlock = ReadXmlDocBlock(lines, i);
+
+                AssertEqual(true, !string.IsNullOrWhiteSpace(docBlock),
+                    $"xml doc block exists for {relativePath}:{methodName}");
+                AssertEqual(true, docBlock.Contains("<summary>", StringComparison.Ordinal) &&
+                    docBlock.Contains("</summary>", StringComparison.Ordinal),
+                    $"xml summary exists for {relativePath}:{methodName}");
+
+                foreach (var parameterName in ExtractParameterNames(parameters)) {
+                    var token = $"<param name=\"{parameterName}\">";
+                    AssertEqual(true, docBlock.Contains(token, StringComparison.Ordinal),
+                        $"xml param doc exists for {relativePath}:{methodName}:{parameterName}");
+                }
+
+                if (!string.Equals(returnType, "void", StringComparison.Ordinal)) {
+                    AssertEqual(true, docBlock.Contains("<returns>", StringComparison.Ordinal),
+                        $"xml returns doc exists for {relativePath}:{methodName}");
+                }
+            }
+        }
+    }
+
     private static HashSet<string> LoadExportedCmdletSet(string workspace) {
         var manifestPath = Path.Combine(workspace, "Module", "IntelligenceX.psd1");
         AssertEqual(true, File.Exists(manifestPath), "powershell module manifest exists");
@@ -85,6 +237,164 @@ internal static partial class Program {
                 $"Unknown IntelligenceX cmdlet reference(s) in '{source}': {string.Join(", ", unknown)}");
         }
     }
+
+    private static void ValidateCmdletParameterXmlDocs(string fileName, string text) {
+        var lines = text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        for (var i = 0; i < lines.Length; i++) {
+            if (!Regex.IsMatch(lines[i], "^\\s*public\\s+[^\\(]+\\s+(?<name>\\w+)\\s*\\{", RegexOptions.Compiled)) {
+                continue;
+            }
+
+            var propertyMatch = Regex.Match(lines[i], "^\\s*public\\s+[^\\(]+\\s+(?<name>\\w+)\\s*\\{", RegexOptions.Compiled);
+            var propertyName = propertyMatch.Groups["name"].Value;
+
+            var j = i - 1;
+            while (j >= 0 && string.IsNullOrWhiteSpace(lines[j])) {
+                j--;
+            }
+            if (j < 0 || !Regex.IsMatch(lines[j], "^\\s*\\]", RegexOptions.Compiled)) {
+                continue;
+            }
+
+            var attrStart = j;
+            while (attrStart >= 0) {
+                if (Regex.IsMatch(lines[attrStart], "^\\s*\\[[^\\]]+\\]\\s*$", RegexOptions.Compiled) ||
+                    string.IsNullOrWhiteSpace(lines[attrStart])) {
+                    attrStart--;
+                    continue;
+                }
+                break;
+            }
+            attrStart++;
+            if (attrStart < 0 || attrStart >= lines.Length) {
+                continue;
+            }
+
+            var hasParameterAttribute = false;
+            for (var k = attrStart; k < i; k++) {
+                if (Regex.IsMatch(lines[k], "^\\s*\\[Parameter\\(", RegexOptions.Compiled)) {
+                    hasParameterAttribute = true;
+                    break;
+                }
+            }
+            if (!hasParameterAttribute) {
+                continue;
+            }
+
+            var docStart = attrStart - 1;
+            while (docStart >= 0 && string.IsNullOrWhiteSpace(lines[docStart])) {
+                docStart--;
+            }
+            if (docStart < 0 || !Regex.IsMatch(lines[docStart], "^\\s*///", RegexOptions.Compiled)) {
+                throw new InvalidOperationException($"Missing XML doc block for parameter {propertyName} in {fileName}.");
+            }
+            while (docStart >= 0 && Regex.IsMatch(lines[docStart], "^\\s*///", RegexOptions.Compiled)) {
+                docStart--;
+            }
+            docStart++;
+
+            var block = string.Join("\n", lines.Skip(docStart).Take(attrStart - docStart));
+            if (!block.Contains("<summary>", StringComparison.Ordinal) ||
+                !block.Contains("</summary>", StringComparison.Ordinal)) {
+                throw new InvalidOperationException($"Missing XML summary for parameter {propertyName} in {fileName}.");
+            }
+            if (!block.Contains("<para type=\"description\">", StringComparison.Ordinal)) {
+                throw new InvalidOperationException($"Missing XML description paragraph for parameter {propertyName} in {fileName}.");
+            }
+        }
+    }
+
+    private static string ReadXmlDocBlock(IReadOnlyList<string> lines, int declarationLine) {
+        var i = declarationLine - 1;
+        while (i >= 0 && string.IsNullOrWhiteSpace(lines[i])) {
+            i--;
+        }
+        if (i < 0 || !Regex.IsMatch(lines[i], "^\\s*///", RegexOptions.Compiled)) {
+            return string.Empty;
+        }
+
+        var docLines = new List<string>();
+        while (i >= 0 && Regex.IsMatch(lines[i], "^\\s*///", RegexOptions.Compiled)) {
+            docLines.Add(lines[i].Trim());
+            i--;
+        }
+        docLines.Reverse();
+        return string.Join("\n", docLines);
+    }
+
+    private static IReadOnlyList<string> ExtractParameterNames(string rawParameters) {
+        if (string.IsNullOrWhiteSpace(rawParameters)) {
+            return Array.Empty<string>();
+        }
+
+        var chunks = new List<string>();
+        var current = new List<char>();
+        var angleDepth = 0;
+        var parenDepth = 0;
+        for (var i = 0; i < rawParameters.Length; i++) {
+            var ch = rawParameters[i];
+            switch (ch) {
+                case '<':
+                    angleDepth++;
+                    break;
+                case '>':
+                    if (angleDepth > 0) {
+                        angleDepth--;
+                    }
+                    break;
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    if (parenDepth > 0) {
+                        parenDepth--;
+                    }
+                    break;
+                case ',':
+                    if (angleDepth == 0 && parenDepth == 0) {
+                        chunks.Add(new string(current.ToArray()));
+                        current.Clear();
+                        continue;
+                    }
+                    break;
+            }
+            current.Add(ch);
+        }
+        if (current.Count > 0) {
+            chunks.Add(new string(current.ToArray()));
+        }
+
+        var parameterNames = new List<string>();
+        foreach (var chunk in chunks) {
+            var part = chunk.Trim();
+            if (part.Length == 0) {
+                continue;
+            }
+
+            var equalsIndex = part.IndexOf('=');
+            if (equalsIndex >= 0) {
+                part = part.Substring(0, equalsIndex).Trim();
+            }
+
+            part = Regex.Replace(part, "^\\s*(?:this|params|ref|out|in)\\s+", string.Empty, RegexOptions.Compiled);
+            var tokens = Regex.Split(part, "\\s+")
+                .Where(static t => !string.IsNullOrWhiteSpace(t))
+                .ToArray();
+            if (tokens.Length == 0) {
+                continue;
+            }
+
+            var name = tokens[^1]
+                .Trim()
+                .TrimEnd('?');
+            name = Regex.Replace(name, "[^A-Za-z0-9_]", string.Empty, RegexOptions.Compiled);
+            if (name.Length == 0) {
+                continue;
+            }
+            parameterNames.Add(name);
+        }
+
+        return parameterNames;
+    }
 }
 #endif
-

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -321,6 +321,9 @@ internal static partial class Program {
         failed += Run("Analysis catalog PowerShell docs links", TestAnalysisCatalogPowerShellDocsLinksMatchLearnPattern);
         failed += Run("PowerShell docs snippets use exported cmdlets", TestPowerShellDocsSnippetsUseExportedCmdlets);
         failed += Run("PowerShell example scripts use exported cmdlets", TestPowerShellExampleScriptsUseExportedCmdlets);
+        failed += Run("PowerShell cmdlet source XML docs are rich", TestPowerShellCmdletSourceXmlDocsAreRich);
+        failed += Run("PowerShell help XML covers all cmdlets with rich docs", TestPowerShellHelpXmlCoversAllCmdletsWithRichDocs);
+        failed += Run("OpenAI client C# XML docs are complete", TestOpenAiClientCSharpXmlDocsAreComplete);
         failed += Run("Analysis catalog override invalid type falls back", TestAnalysisCatalogOverrideInvalidTypeFallsBack);
         failed += Run("Analysis catalog validator rejects dangling override", TestAnalysisCatalogValidatorRejectsDanglingOverride);
         failed += Run("Analysis hotspots render and state snippet", TestAnalysisHotspotsRenderAndStateSnippet);

--- a/IntelligenceX/Providers/OpenAI/AppServer/AppServerClient.AccountAndThreads.cs
+++ b/IntelligenceX/Providers/OpenAI/AppServer/AppServerClient.AccountAndThreads.cs
@@ -21,6 +21,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// Starts a ChatGPT login flow.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ChatGptLoginStart.</returns>
     public async Task<ChatGptLoginStart> StartChatGptLoginAsync(CancellationToken cancellationToken = default) {
         var parameters = new JsonObject().Add("type", "chatgpt");
         var result = await CallWithRetryAsync("account/login/start", parameters, false, cancellationToken).ConfigureAwait(false);
@@ -38,6 +39,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// </summary>
     /// <param name="apiKey">API key.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task LoginWithApiKeyAsync(string apiKey, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(apiKey, nameof(apiKey));
         LoginStarted?.Invoke(this, new LoginEventArgs("apikey"));
@@ -57,6 +59,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// Reads account information.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to AccountInfo.</returns>
     public async Task<AccountInfo> ReadAccountAsync(CancellationToken cancellationToken = default) {
         var result = await CallWithRetryAsync("account/read", (JsonObject?)null, true, cancellationToken).ConfigureAwait(false);
         var obj = result?.AsObject();
@@ -70,6 +73,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// Logs out of the current session.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task LogoutAsync(CancellationToken cancellationToken = default)
         => CallWithRetryAsync("account/logout", (JsonObject?)null, false, cancellationToken);
 
@@ -81,6 +85,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="approvalPolicy">Optional approval policy.</param>
     /// <param name="sandbox">Optional sandbox mode.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ThreadInfo.</returns>
     public async Task<ThreadInfo> StartThreadAsync(string model, string? currentDirectory = null, string? approvalPolicy = null,
         string? sandbox = null, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(model, nameof(model));
@@ -112,6 +117,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="threadId">Thread id.</param>
     /// <param name="text">Prompt text.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to TurnInfo.</returns>
     public async Task<TurnInfo> StartTurnAsync(string threadId, string text, CancellationToken cancellationToken = default) {
         return await StartTurnAsync(threadId, text, null, null, null, null, cancellationToken).ConfigureAwait(false);
     }
@@ -126,6 +132,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="approvalPolicy">Optional approval policy.</param>
     /// <param name="sandboxPolicy">Optional sandbox policy.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to TurnInfo.</returns>
     public async Task<TurnInfo> StartTurnAsync(string threadId, string text, string? model, string? currentDirectory,
         string? approvalPolicy, SandboxPolicy? sandboxPolicy, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(threadId, nameof(threadId));
@@ -151,6 +158,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="approvalPolicy">Optional approval policy.</param>
     /// <param name="sandboxPolicy">Optional sandbox policy.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to TurnInfo.</returns>
     public async Task<TurnInfo> StartTurnAsync(string threadId, JsonArray input, string? model, string? currentDirectory,
         string? approvalPolicy, SandboxPolicy? sandboxPolicy, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(threadId, nameof(threadId));
@@ -191,6 +199,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// </summary>
     /// <param name="threadId">Thread id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ThreadInfo.</returns>
     public async Task<ThreadInfo> ResumeThreadAsync(string threadId, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(threadId, nameof(threadId));
         var parameters = new JsonObject().Add("threadId", threadId);
@@ -208,6 +217,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// </summary>
     /// <param name="threadId">Thread id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ThreadInfo.</returns>
     public async Task<ThreadInfo> ForkThreadAsync(string threadId, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(threadId, nameof(threadId));
         var parameters = new JsonObject().Add("threadId", threadId);
@@ -228,6 +238,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="sortKey">Sort key.</param>
     /// <param name="modelProviders">Optional model provider filter.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ThreadListResult.</returns>
     public async Task<ThreadListResult> ListThreadsAsync(string? cursor = null, int? limit = null, string? sortKey = null,
         IReadOnlyList<string>? modelProviders = null, CancellationToken cancellationToken = default) {
         var parameters = new JsonObject();
@@ -260,6 +271,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// Lists currently loaded thread ids.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ThreadIdListResult.</returns>
     public async Task<ThreadIdListResult> ListLoadedThreadsAsync(CancellationToken cancellationToken = default) {
         var result = await CallWithRetryAsync("thread/loaded/list", (JsonObject?)null, true, cancellationToken).ConfigureAwait(false);
         var obj = result?.AsObject();
@@ -274,6 +286,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// </summary>
     /// <param name="threadId">Thread id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task ArchiveThreadAsync(string threadId, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(threadId, nameof(threadId));
         var parameters = new JsonObject().Add("threadId", threadId);
@@ -286,6 +299,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="threadId">Thread id.</param>
     /// <param name="turns">Number of turns to roll back.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ThreadInfo.</returns>
     public async Task<ThreadInfo> RollbackThreadAsync(string threadId, int turns, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(threadId, nameof(threadId));
         var parameters = new JsonObject()
@@ -306,6 +320,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="threadId">Thread id.</param>
     /// <param name="turnId">Turn id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task InterruptTurnAsync(string threadId, string turnId, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(threadId, nameof(threadId));
         Guard.NotNullOrWhiteSpace(turnId, nameof(turnId));
@@ -322,6 +337,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="delivery">Delivery channel.</param>
     /// <param name="target">Review target.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ReviewStartResult.</returns>
     public async Task<ReviewStartResult> StartReviewAsync(string threadId, string delivery, ReviewTarget target, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(threadId, nameof(threadId));
         Guard.NotNullOrWhiteSpace(delivery, nameof(delivery));
@@ -345,6 +361,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// </summary>
     /// <param name="request">Command execution request.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to CommandExecResult.</returns>
     public async Task<CommandExecResult> ExecuteCommandAsync(CommandExecRequest request, CancellationToken cancellationToken = default) {
         Guard.NotNull(request, nameof(request));
 

--- a/IntelligenceX/Providers/OpenAI/AppServer/AppServerClient.ConfigAndRuntime.cs
+++ b/IntelligenceX/Providers/OpenAI/AppServer/AppServerClient.ConfigAndRuntime.cs
@@ -21,6 +21,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// Lists available models.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ModelListResult.</returns>
     public async Task<ModelListResult> ListModelsAsync(CancellationToken cancellationToken = default) {
         var result = await CallWithRetryAsync("model/list", (JsonObject?)null, true, cancellationToken).ConfigureAwait(false);
         var obj = result?.AsObject();
@@ -34,6 +35,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// Lists available collaboration modes.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to CollaborationModeListResult.</returns>
     public async Task<CollaborationModeListResult> ListCollaborationModesAsync(CancellationToken cancellationToken = default) {
         var result = await CallWithRetryAsync("collaborationMode/list", (JsonObject?)null, true, cancellationToken).ConfigureAwait(false);
         var obj = result?.AsObject();
@@ -49,6 +51,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="cwds">Optional working directories to query.</param>
     /// <param name="forceReload">Whether to force reload.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to SkillListResult.</returns>
     public async Task<SkillListResult> ListSkillsAsync(IReadOnlyList<string>? cwds = null, bool? forceReload = null,
         CancellationToken cancellationToken = default) {
         var parameters = new JsonObject();
@@ -76,6 +79,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="path">Skill path.</param>
     /// <param name="enabled">Whether the skill is enabled.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task WriteSkillConfigAsync(string path, bool enabled, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(path, nameof(path));
         var parameters = new JsonObject()
@@ -272,6 +276,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// </summary>
     /// <param name="questions">Questions to prompt.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to UserInputResponse.</returns>
     public async Task<UserInputResponse> RequestUserInputAsync(IReadOnlyList<string> questions, CancellationToken cancellationToken = default) {
         Guard.NotNull(questions, nameof(questions));
         var array = new JsonArray();
@@ -292,6 +297,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// </summary>
     /// <param name="content">Feedback content.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task UploadFeedbackAsync(string content, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(content, nameof(content));
         var parameters = new JsonObject().Add("content", content);
@@ -304,6 +310,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="method">Method name.</param>
     /// <param name="parameters">Optional parameters.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to JsonValue?.</returns>
     public Task<JsonValue?> CallAsync(string method, JsonObject? parameters, CancellationToken cancellationToken = default) {
         return _rpc.CallAsync(method, parameters, cancellationToken);
     }
@@ -314,6 +321,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="method">Method name.</param>
     /// <param name="parameters">Optional parameters.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task NotifyAsync(string method, JsonObject? parameters, CancellationToken cancellationToken = default) {
         return _rpc.NotifyAsync(method, parameters, cancellationToken);
     }
@@ -323,6 +331,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// </summary>
     /// <param name="loginId">Optional login id to match.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task WaitForLoginCompletionAsync(string? loginId = null, CancellationToken cancellationToken = default) {
         var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/IntelligenceX/Providers/OpenAI/AppServer/AppServerClient.cs
+++ b/IntelligenceX/Providers/OpenAI/AppServer/AppServerClient.cs
@@ -90,6 +90,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// </summary>
     /// <param name="options">Optional app-server options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to AppServerClient.</returns>
     public static async Task<AppServerClient> StartAsync(AppServerOptions? options = null, CancellationToken cancellationToken = default) {
         options ??= new AppServerOptions();
         options.Validate();
@@ -174,6 +175,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// </summary>
     /// <param name="clientInfo">Client identity information.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public async Task InitializeAsync(ClientInfo clientInfo, CancellationToken cancellationToken = default) {
         Guard.NotNull(clientInfo, nameof(clientInfo));
 
@@ -193,6 +195,7 @@ public sealed partial class AppServerClient : IDisposable {
     /// <param name="method">Optional method override.</param>
     /// <param name="timeout">Optional timeout.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to HealthCheckResult.</returns>
     public async Task<HealthCheckResult> HealthCheckAsync(string? method = null, TimeSpan? timeout = null,
         CancellationToken cancellationToken = default) {
         var sw = Stopwatch.StartNew();

--- a/IntelligenceX/Providers/OpenAI/IntelligenceXClient.cs
+++ b/IntelligenceX/Providers/OpenAI/IntelligenceXClient.cs
@@ -84,6 +84,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <summary>
     /// Returns the underlying app-server client or throws if not active.
     /// </summary>
+    /// <returns>The resulting AppServerClient.</returns>
     public AppServerClient RequireAppServer() {
         var client = _transport.RawAppServerClient;
         if (client is null) {
@@ -97,6 +98,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// </summary>
     /// <param name="options">Optional client options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to IntelligenceXClient.</returns>
     public static async Task<IntelligenceXClient> ConnectAsync(IntelligenceXClientOptions? options = null, CancellationToken cancellationToken = default) {
         options ??= new IntelligenceXClientOptions();
         options.Validate();
@@ -130,6 +132,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// </summary>
     /// <param name="clientInfo">Client identity information.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task InitializeAsync(ClientInfo clientInfo, CancellationToken cancellationToken = default) {
         return _transport.InitializeAsync(clientInfo, cancellationToken);
     }
@@ -140,6 +143,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <param name="method">Optional method name to call.</param>
     /// <param name="timeout">Optional timeout.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to HealthCheckResult.</returns>
     public Task<HealthCheckResult> HealthCheckAsync(string? method = null, TimeSpan? timeout = null,
         CancellationToken cancellationToken = default) {
         return _transport.HealthCheckAsync(method, timeout, cancellationToken);
@@ -149,6 +153,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// Retrieves account information.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to AccountInfo.</returns>
     public Task<AccountInfo> GetAccountAsync(CancellationToken cancellationToken = default) {
         return _transport.GetAccountAsync(cancellationToken);
     }
@@ -157,6 +162,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// Logs out of the current session.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task LogoutAsync(CancellationToken cancellationToken = default) {
         return _transport.LogoutAsync(cancellationToken);
     }
@@ -165,6 +171,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// Lists available models.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ModelListResult.</returns>
     public Task<ModelListResult> ListModelsAsync(CancellationToken cancellationToken = default) {
         return _transport.ListModelsAsync(cancellationToken);
     }
@@ -173,6 +180,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// Starts a ChatGPT login flow.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ChatGptLoginStart.</returns>
     public Task<ChatGptLoginStart> LoginChatGptAsync(CancellationToken cancellationToken = default) {
         return LoginChatGptAsync(null, null, true, null, cancellationToken);
     }
@@ -185,6 +193,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <param name="useLocalListener">Whether to use a local listener.</param>
     /// <param name="timeout">Optional timeout.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ChatGptLoginStart.</returns>
     public Task<ChatGptLoginStart> LoginChatGptAsync(Action<string>? onUrl, Func<string, Task<string>>? onPrompt,
         bool useLocalListener = true, TimeSpan? timeout = null, CancellationToken cancellationToken = default) {
         var resolvedTimeout = timeout ?? TimeSpan.FromMinutes(3);
@@ -199,6 +208,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <param name="useLocalListener">Whether to use a local listener.</param>
     /// <param name="timeout">Optional timeout.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public async Task LoginChatGptAndWaitAsync(Action<string>? onUrl = null, Func<string, Task<string>>? onPrompt = null,
         bool useLocalListener = true, TimeSpan? timeout = null, CancellationToken cancellationToken = default) {
         await LoginChatGptAsync(onUrl, onPrompt, useLocalListener, timeout, cancellationToken).ConfigureAwait(false);
@@ -213,6 +223,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <param name="useLocalListener">Whether to use a local listener.</param>
     /// <param name="timeout">Optional timeout.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public async Task EnsureChatGptLoginAsync(bool forceLogin = false, Action<string>? onUrl = null, Func<string, Task<string>>? onPrompt = null,
         bool useLocalListener = true, TimeSpan? timeout = null, CancellationToken cancellationToken = default) {
         if (!forceLogin) {
@@ -234,6 +245,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// </summary>
     /// <param name="apiKey">API key.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task LoginApiKeyAsync(string apiKey, CancellationToken cancellationToken = default) {
         return _transport.LoginApiKeyAsync(apiKey, cancellationToken);
     }
@@ -246,6 +258,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <param name="approvalPolicy">Optional approval policy.</param>
     /// <param name="sandbox">Optional sandbox policy name.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ThreadInfo.</returns>
     public async Task<ThreadInfo> StartNewThreadAsync(string? model = null, string? currentDirectory = null, string? approvalPolicy = null,
         string? sandbox = null, CancellationToken cancellationToken = default) {
         var thread = await _transport.StartThreadAsync(model ?? _defaultModel, currentDirectory, approvalPolicy, sandbox, cancellationToken)
@@ -259,6 +272,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// </summary>
     /// <param name="threadId">Thread id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to ThreadInfo.</returns>
     public Task<ThreadInfo> UseThreadAsync(string threadId, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(threadId, nameof(threadId));
         _currentThreadId = threadId;
@@ -271,6 +285,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <param name="text">Prompt text.</param>
     /// <param name="model">Optional model override.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to TurnInfo.</returns>
     public async Task<TurnInfo> ChatAsync(string text, string? model = null, CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(text, nameof(text));
         var input = Chat.ChatInput.FromText(text);
@@ -284,6 +299,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <param name="imagePath">Local image path.</param>
     /// <param name="options">Chat options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to TurnInfo.</returns>
     public async Task<TurnInfo> ChatWithImagePathAsync(string text, string imagePath, Chat.ChatOptions? options = null,
         CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(text, nameof(text));
@@ -299,6 +315,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <param name="imageUrl">Image URL.</param>
     /// <param name="options">Chat options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to TurnInfo.</returns>
     public async Task<TurnInfo> ChatWithImageUrlAsync(string text, string imageUrl, Chat.ChatOptions? options = null,
         CancellationToken cancellationToken = default) {
         Guard.NotNullOrWhiteSpace(text, nameof(text));
@@ -313,6 +330,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <param name="input">Chat input.</param>
     /// <param name="options">Chat options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to TurnInfo.</returns>
     public async Task<TurnInfo> ChatAsync(Chat.ChatInput input, Chat.ChatOptions? options = null, CancellationToken cancellationToken = default) {
         Guard.NotNull(input, nameof(input));
         options ??= new Chat.ChatOptions();
@@ -450,6 +468,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <summary>
     /// Disposes the client and underlying transport asynchronously.
     /// </summary>
+    /// <returns>A value task that completes when the operation finishes.</returns>
     public ValueTask DisposeAsync() {
         _transport.DeltaReceived -= OnDeltaReceived;
         _transport.RpcCallStarted -= OnRpcCallStarted;
@@ -465,6 +484,7 @@ public sealed class IntelligenceXClient : IDisposable
     /// <summary>
     /// Disposes the client and underlying transport asynchronously.
     /// </summary>
+    /// <returns>A task that completes when the operation finishes.</returns>
     public Task DisposeAsync() {
         _transport.DeltaReceived -= OnDeltaReceived;
         _transport.RpcCallStarted -= OnRpcCallStarted;


### PR DESCRIPTION
## Summary
- expand C# XML documentation coverage for core OpenAI client APIs by adding missing `<returns>` docs across:
  - `IntelligenceXClient`
  - `AppServerClient`
  - `AppServerClient.AccountAndThreads`
  - `AppServerClient.ConfigAndRuntime`
- add strict reviewer tests that enforce docs quality for PowerShell and C# surfaces:
  - PowerShell docs snippets and example scripts reference only exported cmdlets (existing)
  - every PowerShell cmdlet source file has synopsis + description + at least 3 examples
  - generated PowerShell help XML covers every exported cmdlet with rich descriptions/examples/parameter docs
  - core OpenAI public C# methods include XML summary/param/returns docs

## Why
This pushes docs quality from “good right now” to “hard to regress.”
The API website and PowerShell cmdlet pages now have stronger metadata guarantees, and reviewer checks will fail early if future changes reduce docs usefulness.

## Validation
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release -f net8.0`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release -f net10.0`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
