### PR TITLE
Harden startup tool health probes and transcript markdown normalization

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
@@ -210,4 +210,53 @@ public sealed class TranscriptHtmlFormatterTests {
         Assert.DoesNotContain("**GPO-related**", html);
         Assert.DoesNotContain("** unresolved privileged SIDs**", html);
     }
+
+    /// <summary>
+    /// Ensures malformed compact ordered menu text is repaired before HTML rendering so literal markdown markers are not visible.
+    /// </summary>
+    [Fact]
+    public void Format_RepairsCollapsedOrderedMenuWithoutLiteralMarkers() {
+        var options = MarkdownRendererPresets.CreateChatStrictMinimal();
+        var now = new DateTime(2026, 2, 17, 13, 1, 40, DateTimeKind.Local);
+        var text = "Love it 😄\nIf “oki doki” means *“we’re good for now”* — perfect.\n\nQuick next-step menu (pick one and I’ll run it right away):\n1) **Privilege hygiene sweep(Domain Admins + other privileged groups, nested exposure) 2)** Delegation risk audit**(unconstrained / constrained / protocol transition) 3)** Replication + DC health snapshot** (stale links, failing partners, LDAP/Kerberos basics)\n\nOr just say “done” and I’ll keep quiet like a well-configured service.";
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+        Assert.Contains("\n2. **Delegation risk audit** (unconstrained / constrained / protocol transition)", normalized);
+        var html = TranscriptHtmlFormatter.Format(new[] {
+            ("Assistant", text, now)
+        }, "HH:mm:ss", options);
+
+        Assert.Contains("<strong>Privilege hygiene sweep</strong>", html);
+        Assert.Contains("<strong>Delegation risk audit</strong>", html);
+        Assert.Contains("<strong>Replication + DC health snapshot</strong>", html);
+        Assert.DoesNotContain("**", html);
+    }
+
+    /// <summary>
+    /// Ensures kerberos catalog style assistant output renders list/code blocks without leaking literal markdown markers.
+    /// </summary>
+    [Fact]
+    public void Format_RendersKerberosCatalogWithoutLiteralStrongMarkers() {
+        var options = MarkdownRendererPresets.CreateChatStrictMinimal();
+        var now = new DateTime(2026, 2, 17, 15, 40, 11, DateTimeKind.Local);
+        var text = """
+                   Perfect — I pulled the TestimoX Kerberos catalog for your domain context.
+
+                   **Available Kerberos-related rules: 12** (all enabled, built-in).
+                   Top ones to run first:
+
+                   1. `KerberosHealthCheck` (broad high-signal sweep)
+                   2. `DomainKerberosCryptoOverview`
+                   3. `DomainKerberosRc4Only`
+                   """;
+
+        var html = TranscriptHtmlFormatter.Format(new[] {
+            ("Assistant", text, now)
+        }, "HH:mm:ss", options);
+
+        Assert.Contains("Available Kerberos-related rules", html);
+        Assert.Contains("<strong>12</strong>", html);
+        Assert.Contains("<code>KerberosHealthCheck</code>", html);
+        Assert.DoesNotContain("**Available Kerberos-related rules: 12**", html);
+        Assert.DoesNotContain("<dl>", html);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownFormatterTests.cs
@@ -24,4 +24,19 @@ public sealed class TranscriptMarkdownFormatterTests {
         Assert.Contains("hello", markdown);
         Assert.Contains("hi there", markdown);
     }
+
+    /// <summary>
+    /// Ensures markdown export normalizes list-marker artifacts for strict markdown renderers.
+    /// </summary>
+    [Fact]
+    public void Format_NormalizesParenOrderedListMarkers() {
+        var now = new DateTime(2026, 2, 11, 13, 45, 30, DateTimeKind.Local);
+        var markdown = TranscriptMarkdownFormatter.Format(new[] {
+            ("Assistant", "1) First check\n2) Second check", now)
+        }, "HH:mm:ss");
+
+        Assert.Contains("1. First check", markdown);
+        Assert.Contains("2. Second check", markdown);
+        Assert.DoesNotContain("1) First check", markdown);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
@@ -23,6 +23,73 @@ public sealed class TranscriptMarkdownNormalizerTests {
     }
 
     /// <summary>
+    /// Ensures ordered-list markers in <c>1)</c> form are normalized for markdown engines that require <c>1.</c>.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_ConvertsParenOrderedListMarkersToDotStyle() {
+        var text = "1) First check\n2) Second check";
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+
+        Assert.Equal("1. First check\n2. Second check", normalized);
+    }
+
+    /// <summary>
+    /// Ensures ordered-list markers get spacing before strong spans in compact model output.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_AddsMissingSpaceAfterOrderedMarkersBeforeStrongSpans() {
+        var text = "1)**Privilege hygiene sweep**\n2.**Delegation risk audit**";
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+
+        Assert.Equal("1. **Privilege hygiene sweep**\n2. **Delegation risk audit**", normalized);
+    }
+
+    /// <summary>
+    /// Ensures compact ordered-list items chained after closing parenthesis are split into lines.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_SplitsCollapsedOrderedListItemsAfterParenthesis() {
+        var text = "1. **Privilege hygiene sweep**(Domain Admins + nested exposure)2.**Delegation risk audit**(unconstrained)";
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+
+        Assert.Equal(
+            "1. **Privilege hygiene sweep** (Domain Admins + nested exposure)\n2. **Delegation risk audit** (unconstrained)",
+            normalized);
+    }
+
+    /// <summary>
+    /// Ensures single-line collapsed numbered menus are expanded into readable markdown list items.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_ExpandsCollapsedSingleLineNumberedMenuWithStrongDetails() {
+        var text =
+            "1) **Privilege hygiene sweep(Domain Admins + other privileged groups, nested exposure) 2)** Delegation risk audit**(unconstrained / constrained / protocol transition) 3)** Replication + DC health snapshot** (stale links, failing partners, LDAP/Kerberos basics)";
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+
+        Assert.Equal(
+            "1. **Privilege hygiene sweep** (Domain Admins + other privileged groups, nested exposure)\n"
+            + "2. **Delegation risk audit** (unconstrained / constrained / protocol transition)\n"
+            + "3. **Replication + DC health snapshot** (stale links, failing partners, LDAP/Kerberos basics)",
+            normalized);
+    }
+
+    /// <summary>
+    /// Ensures leading strong metric lines are normalized so markdown parsers do not treat them as definition lists.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_RewritesLeadingStrongMetricLineToValueStrong() {
+        var text = "**Available Kerberos-related rules: 12** (all enabled, built-in).";
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+
+        Assert.Equal("Available Kerberos-related rules - **12** (all enabled, built-in).", normalized);
+    }
+
+    /// <summary>
     /// Ensures glued bold/word boundaries are normalized into readable spacing.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/TranscriptMarkdownFormatter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/TranscriptMarkdownFormatter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using IntelligenceX.Chat.App.Rendering;
 
 namespace IntelligenceX.Chat.App.Markdown;
 
@@ -20,14 +21,15 @@ internal static class TranscriptMarkdownFormatter {
         var markdown = new MarkdownComposer();
 
         foreach (var message in messages) {
-            if (string.IsNullOrWhiteSpace(message.Text)) {
+            var normalizedText = TranscriptMarkdownNormalizer.NormalizeForRendering(message.Text);
+            if (string.IsNullOrWhiteSpace(normalizedText)) {
                 continue;
             }
 
             var time = message.Time.ToString(format, CultureInfo.InvariantCulture);
             markdown
                 .Heading($"{message.Role} ({time})", 3)
-                .Raw(message.Text)
+                .Raw(normalizedText)
                 .BlankLine();
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMarkdownNormalizer.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMarkdownNormalizer.cs
@@ -36,6 +36,10 @@ internal static class TranscriptMarkdownNormalizer {
         @"\*\*(?<inner>[^*\r\n]+)\*\*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex LeadingWhitespaceInsideStrongOpenRegex = new(
+        @"(?:(?<=^)|(?<=[\s(\[{>]))\*\*[ \t]+(?=[^\s*\r\n])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static readonly Regex MissingSpaceBeforeBoldMetricRegex = new(
         @"(?<=\s)-(?=\*\*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -60,16 +64,40 @@ internal static class TranscriptMarkdownNormalizer {
         @"(?m)^(?<indent>\s*-\s)\*\*(?<label>[^*\r\n:]+):\*\*\s*(?<value>[^\r\n]*)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex LeadingStrongMetricLineRegex = new(
+        @"(?m)^(?<indent>\s*)\*\*(?<label>[^*\r\n:][^*\r\n]*?):\s*(?<value>[^*\r\n]+)\*\*(?<suffix>[^\r\n]*)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static readonly Regex LegacyRepairSignalRegex = new(
         @"\*\*Status:\s|-\*\*|-\*[A-Za-z]|:\*\*\S",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex CollapsedOrderedListAfterParenRegex = new(
-        @"(?<=\))[ \t]+(?=\d+\.(?:\^\s*|\s+)\S)",
+        @"(?<=\))\s*(?=\d+\.(?:\^\s*|\s*[*_]{2}|\s+)\S)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex CollapsedOrderedListAfterDetailRegex = new(
+        @"(?<=\))\s+(?=\d+[.)]\s*[*_]{0,2}\s*\S)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex CollapsedOrderedListAfterStrongRegex = new(
+        @"(?<=\*\*)\s+(?=\d+[.)]\s*[*_]{0,2}\s*\S)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex OrderedListCaretRegex = new(
         @"(?m)^(?<lead>\s*\d+\.)\s*\^\s*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex OrderedListParenMarkerRegex = new(
+        @"(?m)^(?<indent>\s*)(?<num>\d+)\)(?=\s*\S)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex OrderedListMarkerMissingSpaceRegex = new(
+        @"(?m)^(?<lead>\s*\d+\.)(?=\S)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex TightParenJoinRegex = new(
+        @"(?<=[\p{L}\p{N}\)])\((?=[\p{L}][^\r\n)]*\))",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex AcronymParenJoinRegex = new(
@@ -78,6 +106,14 @@ internal static class TranscriptMarkdownNormalizer {
 
     private static readonly Regex StrongCloseAcronymParenJoinRegex = new(
         @"(?<=\*\*)\((?=[A-Z]{2,})",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex StrongCloseParenJoinRegex = new(
+        @"(?<=\*\*)\((?=[\p{L}][^\r\n)]*\))",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex OrderedItemStrongMissingCloseBeforeParenRegex = new(
+        @"(?m)^(?<lead>\s*\d+\.\s+)\*\*(?<title>[^*\r\n()]+)\((?<detail>[^)\r\n]+)\)\s*$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     public static string NormalizeForRendering(string? text) {
@@ -101,10 +137,23 @@ internal static class TranscriptMarkdownNormalizer {
             value = MissingSpaceBeforeBoldMetricRegex.Replace(value, "- ");
             value = SingleStarMetricRegex.Replace(value, "- **");
             value = CollapsedBulletRegex.Replace(value, "\n- **");
+            value = CollapsedOrderedListAfterDetailRegex.Replace(value, "\n");
+            value = CollapsedOrderedListAfterStrongRegex.Replace(value, "\n");
             value = CollapsedOrderedListAfterParenRegex.Replace(value, "\n");
             value = OrderedListCaretRegex.Replace(value, "${lead} ");
+            value = OrderedListParenMarkerRegex.Replace(value, "${indent}${num}.");
+            value = OrderedListMarkerMissingSpaceRegex.Replace(value, "${lead} ");
+            value = TightParenJoinRegex.Replace(value, " (");
             value = AcronymParenJoinRegex.Replace(value, " (");
             value = StrongCloseAcronymParenJoinRegex.Replace(value, " (");
+            value = StrongCloseParenJoinRegex.Replace(value, " (");
+            value = OrderedItemStrongMissingCloseBeforeParenRegex.Replace(value, static match => {
+                var lead = match.Groups["lead"].Value;
+                var title = match.Groups["title"].Value.Trim();
+                var detail = match.Groups["detail"].Value.Trim();
+                return lead + "**" + title + "** (" + detail + ")";
+            });
+            value = LeadingWhitespaceInsideStrongOpenRegex.Replace(value, "**");
             value = ExpandCollapsedMetricLines(value);
             value = ConvertLegacyMetricMarkdown(value);
             return value;
@@ -156,8 +205,22 @@ internal static class TranscriptMarkdownNormalizer {
                 return value.Length == 0 ? indent + "Status" : indent + "Status **" + value + "**";
             });
 
-        return LegacyBoldMetricBulletRegex.Replace(
+        var strongMetricNormalized = LeadingStrongMetricLineRegex.Replace(
             statusNormalized,
+            match => {
+                var indent = match.Groups["indent"].Value;
+                var label = match.Groups["label"].Value.Trim();
+                var value = match.Groups["value"].Value.Trim();
+                var suffix = match.Groups["suffix"].Value;
+                if (label.Length == 0 || value.Length == 0) {
+                    return match.Value;
+                }
+
+                return indent + label + " - **" + value + "**" + suffix;
+            });
+
+        return LegacyBoldMetricBulletRegex.Replace(
+            strongMetricNormalized,
             match => {
                 var indent = match.Groups["indent"].Value;
                 var label = match.Groups["label"].Value.Trim();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
@@ -85,13 +85,19 @@ internal sealed partial class ChatServiceSession {
             return;
         }
 
-        var timeoutSeconds = ResolveStartupToolHealthTimeoutSeconds(_options.ToolTimeoutSeconds);
         var warnings = new List<string>(_startupWarnings);
         var hasNewWarnings = false;
 
         foreach (var definition in packInfoDefinitions) {
             var metadata = ResolvePackMetadata(definition);
+            var timeoutSeconds = ResolveStartupToolHealthTimeoutSeconds(_options.ToolTimeoutSeconds, metadata.SourceKind);
             var probe = await ToolHealthDiagnostics.ProbeAsync(_registry, definition.Name, timeoutSeconds, cancellationToken).ConfigureAwait(false);
+            if (!probe.Ok && IsToolTimeoutProbe(probe)) {
+                var retryTimeoutSeconds = ResolveStartupToolHealthRetryTimeoutSeconds(timeoutSeconds, metadata.SourceKind);
+                if (retryTimeoutSeconds > timeoutSeconds) {
+                    probe = await ToolHealthDiagnostics.ProbeAsync(_registry, definition.Name, retryTimeoutSeconds, cancellationToken).ConfigureAwait(false);
+                }
+            }
             if (probe.Ok) {
                 continue;
             }
@@ -175,12 +181,29 @@ internal sealed partial class ChatServiceSession {
         return (packId, packName, sourceKind);
     }
 
-    private static int ResolveStartupToolHealthTimeoutSeconds(int configuredTimeoutSeconds) {
+    internal static int ResolveStartupToolHealthTimeoutSeconds(int configuredTimeoutSeconds, ToolPackSourceKind sourceKind) {
         if (configuredTimeoutSeconds <= 0) {
-            return 2;
+            return sourceKind == ToolPackSourceKind.ClosedSource ? 8 : 4;
         }
 
-        return Math.Clamp(configuredTimeoutSeconds, 1, 5);
+        return sourceKind == ToolPackSourceKind.ClosedSource
+            ? Math.Clamp(configuredTimeoutSeconds, 4, 20)
+            : Math.Clamp(configuredTimeoutSeconds, 2, 10);
+    }
+
+    internal static int ResolveStartupToolHealthRetryTimeoutSeconds(int initialTimeoutSeconds, ToolPackSourceKind sourceKind) {
+        if (initialTimeoutSeconds <= 0) {
+            return sourceKind == ToolPackSourceKind.ClosedSource ? 12 : 6;
+        }
+
+        var doubled = initialTimeoutSeconds * 2;
+        return sourceKind == ToolPackSourceKind.ClosedSource
+            ? Math.Clamp(doubled, 10, 30)
+            : Math.Clamp(doubled, 4, 12);
+    }
+
+    private static bool IsToolTimeoutProbe(ToolHealthDiagnostics.ProbeResult probe) {
+        return string.Equals(probe.ErrorCode, "tool_timeout", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string NormalizeHealthErrorCode(string? value) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthTimeoutPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthTimeoutPolicyTests.cs
@@ -1,0 +1,48 @@
+using IntelligenceX.Chat.Abstractions.Policy;
+using IntelligenceX.Chat.Service;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class StartupToolHealthTimeoutPolicyTests {
+    [Theory]
+    [InlineData(0, ToolPackSourceKind.OpenSource, 4)]
+    [InlineData(0, ToolPackSourceKind.Builtin, 4)]
+    [InlineData(0, ToolPackSourceKind.ClosedSource, 8)]
+    public void ResolveStartupToolHealthTimeoutSeconds_UsesSafeDefaultsPerSourceKind(
+        int configuredTimeoutSeconds,
+        ToolPackSourceKind sourceKind,
+        int expectedTimeoutSeconds) {
+        var timeout = ChatServiceSession.ResolveStartupToolHealthTimeoutSeconds(configuredTimeoutSeconds, sourceKind);
+
+        Assert.Equal(expectedTimeoutSeconds, timeout);
+    }
+
+    [Theory]
+    [InlineData(1, ToolPackSourceKind.OpenSource, 2)]
+    [InlineData(60, ToolPackSourceKind.OpenSource, 10)]
+    [InlineData(1, ToolPackSourceKind.ClosedSource, 4)]
+    [InlineData(60, ToolPackSourceKind.ClosedSource, 20)]
+    public void ResolveStartupToolHealthTimeoutSeconds_ClampsConfiguredRanges(
+        int configuredTimeoutSeconds,
+        ToolPackSourceKind sourceKind,
+        int expectedTimeoutSeconds) {
+        var timeout = ChatServiceSession.ResolveStartupToolHealthTimeoutSeconds(configuredTimeoutSeconds, sourceKind);
+
+        Assert.Equal(expectedTimeoutSeconds, timeout);
+    }
+
+    [Theory]
+    [InlineData(4, ToolPackSourceKind.OpenSource, 8)]
+    [InlineData(10, ToolPackSourceKind.OpenSource, 12)]
+    [InlineData(8, ToolPackSourceKind.ClosedSource, 16)]
+    [InlineData(20, ToolPackSourceKind.ClosedSource, 30)]
+    public void ResolveStartupToolHealthRetryTimeoutSeconds_IncreasesWithBoundedCap(
+        int initialTimeoutSeconds,
+        ToolPackSourceKind sourceKind,
+        int expectedTimeoutSeconds) {
+        var timeout = ChatServiceSession.ResolveStartupToolHealthRetryTimeoutSeconds(initialTimeoutSeconds, sourceKind);
+
+        Assert.Equal(expectedTimeoutSeconds, timeout);
+    }
+}


### PR DESCRIPTION
## Summary
- reduce noisy startup tool-health false positives by improving startup probe timeout policy
- apply source-aware startup probe timeouts (closed-source packs get a safer initial timeout range)
- add one automatic retry for startup `tool_timeout` probe results with a bounded higher timeout
- normalize transcript markdown export through the same rendering normalizer path
- expand transcript markdown normalization for compact ordered-list artifacts and strong-span edge cases
- fix kerberos metric-style line rendering (`**Label: value**`) so it no longer renders as a malformed definition list or leaks literal `**`

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~Transcript"`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~StartupToolHealthTimeoutPolicyTests|FullyQualifiedName~ToolHealthDiagnosticsTests"`
