### PR TITLE
docs(chat,tools): add production safety disclaimers

### DIFF
--- a/Docs/chat/overview.md
+++ b/Docs/chat/overview.md
@@ -7,6 +7,12 @@ description: Windows desktop tray application for AI conversations with tool cal
 
 IX Chat is a Windows desktop application that lives in your system tray, providing instant access to AI-powered conversations. Built with WinUI 3 and WebView2, it combines a native desktop experience with a modern web-based chat interface.
 
+## Production Safety Notice
+
+- IX Chat and enabled tool packs can execute commands, read/write files, and call external services.
+- Do not attach IX Chat directly to production infrastructure, production secrets, or unattended auto-approval flows.
+- Validate behavior in isolated dev/staging first, keep human review in the loop, and use least-privilege credentials.
+
 ## Key Features
 
 - **System Tray Integration** -- Always accessible from your Windows taskbar via [H.NotifyIcon](https://github.com/HavenDV/H.NotifyIcon)

--- a/Docs/chat/quickstart.md
+++ b/Docs/chat/quickstart.md
@@ -7,6 +7,12 @@ description: Install and run IX Chat on Windows.
 
 Get IX Chat running on your Windows machine in a few minutes.
 
+## Production Safety Notice
+
+- This quickstart is intended for local development and evaluation workflows.
+- Do not point IX Chat at production systems or production credentials until you have explicit policy controls and approvals in place.
+- Use isolated test/staging environments first and keep a human approval step for any mutating tool actions.
+
 ## Prerequisites
 
 - Windows 10 (1809+) or Windows 11

--- a/Docs/tools/governance.md
+++ b/Docs/tools/governance.md
@@ -7,6 +7,12 @@ description: Naming, metadata ownership, source semantics, and client delivery r
 
 This document defines how tool packs must declare metadata and how hosts should consume it.
 
+## Production Safety Notice
+
+- Tool-pack enablement can grant high-impact capabilities (for example command execution or sensitive data access).
+- Do not run permissive tool policies directly against production systems by default.
+- Require explicit approval workflows, least-privilege credentials, environment isolation, and audit logging before production rollout.
+
 ## 1. Metadata Ownership
 
 Tool-pack identity and presentation metadata must originate in the pack descriptor (`ToolPackDescriptor`) inside `IntelligenceX.Tools.*`.

--- a/Docs/tools/overview.md
+++ b/Docs/tools/overview.md
@@ -7,6 +7,12 @@ description: Real IntelligenceX tool packs, source model, and how they are loade
 
 IX Tools are tool packs used by IntelligenceX hosts (especially IX Chat) to expose local capabilities to AI models.
 
+## Production Safety Notice
+
+- Tool packs can expose sensitive read/write operations, command execution, and environment access.
+- Do not enable broad tool access directly against production assets without strict policy gates, approval controls, and audit requirements.
+- Start in isolated dev/staging environments with least-privilege identities and narrow allowlists.
+
 ## Source Model
 
 IntelligenceX.Chat classifies packs with a runtime `sourceKind`:


### PR DESCRIPTION
## Summary
- add explicit production safety notices to IX Chat docs
- add explicit production safety notices to IX Tools docs
- clarify that chat/tools workflows should be validated in dev/staging with human approvals before production usage

## Updated Pages
- `Docs/chat/overview.md`
- `Docs/chat/quickstart.md`
- `Docs/tools/overview.md`
- `Docs/tools/governance.md`

## Why
These warnings make safe usage expectations explicit and visible in the first docs users read for chat/tooling.
