### PR TITLE
feat(chat-tools): improve loading UX, add PowerShell hint, and cmd host support

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
@@ -183,6 +183,9 @@ public sealed partial class MainWindow : Window {
             return false;
         }
 
+        var showPowerShellOnboardingHint = enabled
+                                           && string.Equals(normalizedPackId, "powershell", StringComparison.Ordinal)
+                                           && (pack is null || !pack.Enabled);
         var profileSaved = ContainsProfileName(_serviceProfileNames, _appProfileName);
         _pendingServiceLaunchProfileOptions = BuildRuntimePackLaunchProfileOptions(normalizedPackId, enabled, profileSaved);
 
@@ -193,7 +196,29 @@ public sealed partial class MainWindow : Window {
             setProfileNewThread: false,
             appendWarnings: true).ConfigureAwait(false);
 
+        if (showPowerShellOnboardingHint) {
+            AppendPowerShellOnboardingHint();
+        }
+
         return true;
+    }
+
+    private void AppendPowerShellOnboardingHint() {
+        if (_powerShellOnboardingHintShownThisSession) {
+            return;
+        }
+
+        _powerShellOnboardingHintShownThisSession = true;
+        AppendSystem(GetActiveConversation(), """
+[info] PowerShell Runtime enabled.
+
+You can now run shell-backed diagnostics (including cmd host support) through `powershell_run`.
+
+Quick start prompts:
+- `Run powershell_environment_discover and summarize host availability + write policy.`
+- `Run powershell_run with host=cmd and command='ver' using read_only intent.`
+- `Run powershell_run with host=pwsh and command='Get-Service | Select-Object -First 20' using read_only intent.`
+""");
     }
 
     private ServiceLaunchProfileOptions BuildRuntimePackLaunchProfileOptions(string normalizedPackId, bool enabled, bool profileSaved) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -246,6 +246,7 @@ public sealed partial class MainWindow : Window {
             : Array.Empty<object>();
 
         var tools = BuildToolState();
+        var toolsLoading = _isConnected && _sessionPolicy is null;
         var conversations = BuildConversationState();
         var json = JsonSerializer.Serialize(new {
             timestampMode = _timestampMode,
@@ -311,6 +312,7 @@ public sealed partial class MainWindow : Window {
             },
             packs,
             tools,
+            toolsLoading,
             policy = _sessionPolicy is null ? null : new {
                 readOnly = _sessionPolicy.ReadOnly,
                 dangerousToolsEnabled = _sessionPolicy.DangerousToolsEnabled,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -237,6 +237,7 @@ public sealed partial class MainWindow : Window {
     private readonly Dictionary<string, string> _toolRoutingConfidence = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _toolRoutingReason = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, double> _toolRoutingScore = new(StringComparer.OrdinalIgnoreCase);
+    private bool _powerShellOnboardingHintShownThisSession;
     private readonly HashSet<string> _startupToolHealthWarningSignatures = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _startupUnavailablePackSignatures = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, MemorySemanticVectorCacheEntry> _memorySemanticVectorCache = new(StringComparer.OrdinalIgnoreCase);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
@@ -109,7 +109,8 @@
       toolFilter: "",
       policy: null,
       packs: [],
-      tools: []
+      tools: [],
+      toolsLoading: true
     }
   };
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -322,6 +322,11 @@
 
     var order = Object.keys(groups);
     if (order.length === 0) {
+      if (!filter && state.options.toolsLoading === true) {
+        toolsEl.innerHTML = "<div class='options-item'><div class='options-item-title'>Loading tool packs...</div><div class='options-item-sub'>Runtime is still publishing pack metadata.</div></div>";
+        return;
+      }
+
       if (filter) {
         toolsEl.innerHTML = "<div class='options-item'><div class='options-item-title'>No tools match filter</div></div>";
       } else {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
@@ -257,8 +257,26 @@
     state.options.profile = nextOptions.profile || state.options.profile;
     state.options.localModel = nextOptions.localModel || state.options.localModel;
     state.options.policy = nextOptions.policy || null;
-    state.options.packs = nextOptions.packs || [];
-    state.options.tools = nextOptions.tools || [];
+    var incomingPacks = Array.isArray(nextOptions.packs) ? nextOptions.packs : [];
+    var incomingTools = Array.isArray(nextOptions.tools) ? nextOptions.tools : [];
+    if (typeof nextOptions.toolsLoading === "boolean") {
+      state.options.toolsLoading = nextOptions.toolsLoading;
+    } else {
+      state.options.toolsLoading = false;
+    }
+
+    var preservePreviousTools = state.options.toolsLoading
+      && incomingTools.length === 0
+      && Array.isArray(state.options.tools)
+      && state.options.tools.length > 0;
+    if (preservePreviousTools) {
+      if (incomingPacks.length > 0) {
+        state.options.packs = incomingPacks;
+      }
+    } else {
+      state.options.packs = incomingPacks;
+      state.options.tools = incomingTools;
+    }
     loadDebugToolsEnabledForActiveProfile();
     renderOptions();
   };

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolPackBootstrap.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolPackBootstrap.cs
@@ -229,7 +229,7 @@ public static class ToolPackBootstrap {
     private static readonly KnownPackDefinition PowerShellPackDefinition = new(
         "powershell",
         "PowerShell Runtime",
-        "Opt-in PowerShell runtime execution (windows_powershell / pwsh).",
+        "Opt-in shell runtime execution (windows_powershell / pwsh / cmd).",
         ToolCapabilityTier.DangerousWrite,
         IsDangerous: true,
         PackSourceBuiltin);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellEnvironmentDiscoverTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellEnvironmentDiscoverTool.cs
@@ -1,6 +1,5 @@
 using System.Threading;
 using System.Threading.Tasks;
-using IntelligenceX.Engines.PowerShell;
 using IntelligenceX.Json;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
@@ -13,7 +12,7 @@ namespace IntelligenceX.Tools.PowerShell;
 public sealed class PowerShellEnvironmentDiscoverTool : PowerShellToolBase, ITool {
     private static readonly ToolDefinition DefinitionValue = new(
         "powershell_environment_discover",
-        "Discover IX.PowerShell runtime hosts and execution policy (enabled/read-write options). Call this before powershell_run.",
+        "Discover IX.PowerShell runtime hosts (pwsh/windows_powershell/cmd) and execution policy (enabled/read-write options). Call this before powershell_run.",
         ToolSchema.Object().NoAdditionalProperties());
 
     /// <summary>
@@ -28,7 +27,7 @@ public sealed class PowerShellEnvironmentDiscoverTool : PowerShellToolBase, IToo
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var hosts = PowerShellCommandQueryExecutor.GetAvailableHosts();
+        var hosts = GetAvailableRuntimeHosts();
         var preferred = hosts.Count > 0 ? hosts[0] : "none";
 
         var model = new {
@@ -41,7 +40,8 @@ public sealed class PowerShellEnvironmentDiscoverTool : PowerShellToolBase, IToo
             runtime = new {
                 available_hosts = hosts,
                 preferred_default = preferred,
-                has_any_host = hosts.Count > 0
+                has_any_host = hosts.Count > 0,
+                cmd_available = IsCmdHostAvailable()
             },
             limits = new {
                 default_timeout_ms = Options.DefaultTimeoutMs,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellHostsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellHostsTool.cs
@@ -1,6 +1,5 @@
 using System.Threading;
 using System.Threading.Tasks;
-using IntelligenceX.Engines.PowerShell;
 using IntelligenceX.Json;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
@@ -13,7 +12,7 @@ namespace IntelligenceX.Tools.PowerShell;
 public sealed class PowerShellHostsTool : PowerShellToolBase, ITool {
     private static readonly ToolDefinition DefinitionValue = new(
         "powershell_hosts",
-        "List available local PowerShell hosts (pwsh and/or windows_powershell).",
+        "List available local shell hosts (pwsh/windows_powershell/cmd).",
         ToolSchema.Object().NoAdditionalProperties());
 
     /// <summary>
@@ -28,11 +27,12 @@ public sealed class PowerShellHostsTool : PowerShellToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var hosts = PowerShellCommandQueryExecutor.GetAvailableHosts();
+        var hosts = GetAvailableRuntimeHosts();
         var model = new {
             enabled = Options.Enabled,
             available_hosts = hosts,
-            preferred_default = hosts.Count > 0 ? hosts[0] : "none"
+            preferred_default = hosts.Count > 0 ? hosts[0] : "none",
+            cmd_available = IsCmdHostAvailable()
         };
 
         var summary = ToolMarkdown.SummaryFacts(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellPackInfoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellPackInfoTool.cs
@@ -12,7 +12,7 @@ namespace IntelligenceX.Tools.PowerShell;
 public sealed class PowerShellPackInfoTool : PowerShellToolBase, ITool {
     private static readonly ToolDefinition DefinitionValue = new(
         "powershell_pack_info",
-        "Return IX.PowerShell pack capabilities, output contract, and safe usage guidance. Call this first when planning shell execution.",
+        "Return IX.PowerShell pack capabilities, output contract, and safe usage guidance (pwsh/windows_powershell/cmd). Call this first when planning shell execution.",
         ToolSchema.Object().NoAdditionalProperties());
 
     /// <summary>
@@ -34,7 +34,8 @@ public sealed class PowerShellPackInfoTool : PowerShellToolBase, ITool {
             recommendedFlow: new[] {
                 "Call powershell_environment_discover first to read policy, host availability, and runtime limits.",
                 "Use powershell_hosts when you only need host inventory.",
-                "Use powershell_run with intent=read_only by default, and switch to intent=read_write only with explicit approval.",
+                "Use powershell_run with host=pwsh/windows_powershell/cmd and intent=read_only by default.",
+                "Switch to intent=read_write only with explicit approval.",
                 "Prefer short, auditable commands and cap timeout/output when possible."
             },
             flowSteps: new[] {
@@ -56,7 +57,7 @@ public sealed class PowerShellPackInfoTool : PowerShellToolBase, ITool {
                     primaryTools: new[] { "powershell_environment_discover" }),
                 ToolPackGuidance.Capability(
                     id: "host_discovery",
-                    summary: "Report locally available PowerShell hosts (pwsh/windows_powershell).",
+                    summary: "Report locally available shell hosts (pwsh/windows_powershell/cmd).",
                     primaryTools: new[] { "powershell_hosts" }),
                 ToolPackGuidance.Capability(
                     id: "runtime_execution",

--- a/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellRunTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellRunTool.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Engines.PowerShell;
@@ -12,7 +15,7 @@ namespace IntelligenceX.Tools.PowerShell;
 /// Executes command/script text using local PowerShell hosts.
 /// </summary>
 public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
-    private static readonly string[] MutatingVerbPrefixes = {
+    private static readonly string[] PowerShellMutatingVerbPrefixes = {
         "set-",
         "new-",
         "remove-",
@@ -33,7 +36,7 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
         "start-"
     };
 
-    private static readonly string[] MutatingFragments = {
+    private static readonly string[] PowerShellMutatingFragments = {
         "| out-file",
         "| set-content",
         "| add-content",
@@ -43,15 +46,41 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
         " >> "
     };
 
+    private static readonly string[] CmdMutatingVerbPrefixes = {
+        "del ",
+        "erase ",
+        "copy ",
+        "move ",
+        "ren ",
+        "rename ",
+        "mkdir ",
+        "md ",
+        "rmdir ",
+        "rd "
+    };
+
+    private static readonly string[] CmdMutatingFragments = {
+        " > ",
+        " >> ",
+        " copy ",
+        " move ",
+        " del ",
+        " erase ",
+        " rmdir ",
+        " rd "
+    };
+
+    private static readonly UTF8Encoding Utf8NoBom = new(false);
+
     private static readonly ToolDefinition DefinitionValue = new(
         "powershell_run",
-        "Execute a PowerShell command or script in pwsh/windows_powershell (dangerous; read_only default, read_write requires explicit policy and intent).",
+        "Execute a shell command or script via pwsh/windows_powershell/cmd (dangerous; read_only default, read_write requires explicit policy and intent).",
         ToolSchema.Object(
-                ("host", ToolSchema.String("PowerShell host: auto, pwsh, windows_powershell. Default auto.").Enum("auto", "pwsh", "windows_powershell")),
+                ("host", ToolSchema.String("Shell host: auto, pwsh, windows_powershell, cmd. Default auto (PowerShell).").Enum("auto", "pwsh", "windows_powershell", "cmd")),
                 ("intent", ToolSchema.String("Execution intent: read_only (default) or read_write.").Enum("read_only", "read_write")),
                 ("allow_write", ToolSchema.Boolean("Explicit write approval flag for read_write intent. Required when policy enforces explicit write confirmation.")),
-                ("command", ToolSchema.String("Single PowerShell command text. Provide exactly one of command or script.")),
-                ("script", ToolSchema.String("Multi-line PowerShell script text. Provide exactly one of command or script.")),
+                ("command", ToolSchema.String("Single shell command text. Provide exactly one of command or script.")),
+                ("script", ToolSchema.String("Multi-line shell script text. Provide exactly one of command or script.")),
                 ("working_directory", ToolSchema.String("Optional working directory for process execution.")),
                 ("timeout_ms", ToolSchema.Integer("Execution timeout in milliseconds.")),
                 ("max_output_chars", ToolSchema.Integer("Maximum combined output characters to return.")),
@@ -67,15 +96,15 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
     public override ToolDefinition Definition => DefinitionValue;
 
     /// <inheritdoc />
-    protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+    protected override async Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
         if (!Options.Enabled) {
-            return Task.FromResult(ToolResponse.Error(
+            return ToolResponse.Error(
                 errorCode: "disabled",
                 error: "IX.PowerShell pack is disabled by policy.",
                 hints: new[] { "Enable the PowerShell pack explicitly in host/service options before calling powershell_run." },
-                isTransient: false));
+                isTransient: false);
         }
 
         var command = ToolArgs.GetOptionalTrimmed(arguments, "command");
@@ -84,53 +113,53 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
         var hasCommand = !string.IsNullOrWhiteSpace(command);
         var hasScript = !string.IsNullOrWhiteSpace(script);
         if (hasCommand == hasScript) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "Provide exactly one of command or script."));
+            return ToolResponse.Error("invalid_argument", "Provide exactly one of command or script.");
         }
 
         if (!TryParseIntent(ToolArgs.GetOptionalTrimmed(arguments, "intent"), out var intent, out var intentError)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", intentError ?? "Invalid intent value."));
+            return ToolResponse.Error("invalid_argument", intentError ?? "Invalid intent value.");
         }
 
         var allowWrite = ToolArgs.GetBoolean(arguments, "allow_write", defaultValue: false);
         var payload = hasCommand ? command! : script!;
-        var mutatingReason = Options.EnableMutationHeuristic ? DetectMutatingPayloadReason(payload) : null;
+        if (!TryParseHost(ToolArgs.GetOptionalTrimmed(arguments, "host"), out var hostKind, out var hostError)) {
+            return ToolResponse.Error("invalid_argument", hostError ?? "Invalid host value.");
+        }
+
+        var mutatingReason = Options.EnableMutationHeuristic ? DetectMutatingPayloadReason(payload, hostKind) : null;
 
         if (intent == PowerShellExecutionIntent.ReadOnly && mutatingReason is not null) {
-            return Task.FromResult(ToolResponse.Error(
+            return ToolResponse.Error(
                 errorCode: "invalid_argument",
-                error: "Read-only intent rejected a potentially mutating PowerShell payload.",
+                error: "Read-only intent rejected a potentially mutating shell payload.",
                 hints: new[] {
                     $"Detected mutating pattern: {mutatingReason}",
                     "If this is intentional, set intent=read_write.",
                     "If policy requires it, also set allow_write=true."
                 },
-                isTransient: false));
+                isTransient: false);
         }
 
         if (intent == PowerShellExecutionIntent.ReadWrite && !Options.AllowWrite) {
-            return Task.FromResult(ToolResponse.Error(
+            return ToolResponse.Error(
                 errorCode: "disabled",
-                error: "Read-write PowerShell execution is disabled by policy.",
+                error: "Read-write shell execution is disabled by policy.",
                 hints: new[] {
                     "Enable PowerShellToolOptions.AllowWrite to allow read_write intent.",
                     "Keep intent=read_only for non-mutating inventory commands."
                 },
-                isTransient: false));
+                isTransient: false);
         }
 
         if (intent == PowerShellExecutionIntent.ReadWrite && Options.RequireExplicitWriteFlag && !allowWrite) {
-            return Task.FromResult(ToolResponse.Error(
+            return ToolResponse.Error(
                 errorCode: "invalid_argument",
                 error: "Read-write intent requires explicit allow_write=true confirmation.",
                 hints: new[] {
                     "Set allow_write=true for approved mutating actions.",
                     "Use intent=read_only for inventory/diagnostic commands."
                 },
-                isTransient: false));
-        }
-
-        if (!TryParseHost(ToolArgs.GetOptionalTrimmed(arguments, "host"), out var host, out var hostError)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", hostError ?? "Invalid host value."));
+                isTransient: false);
         }
 
         var timeoutMs = ToolArgs.GetCappedInt32(
@@ -148,6 +177,61 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
 
         var includeErrorStream = ToolArgs.GetBoolean(arguments, "include_error_stream", defaultValue: true);
         var workingDirectory = ToolArgs.GetOptionalTrimmed(arguments, "working_directory");
+        var intentText = ToIntentId(intent);
+
+        if (hostKind == ShellHostKind.Cmd) {
+            var cmdResult = await ExecuteCmdAsync(
+                    payload: payload,
+                    includeErrorStream: includeErrorStream,
+                    timeoutMs: timeoutMs,
+                    maxOutputChars: maxOutputChars,
+                    workingDirectory: workingDirectory,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!cmdResult.Success) {
+                return ToolResponse.Error(
+                    errorCode: cmdResult.ErrorCode ?? "query_failed",
+                    error: cmdResult.Error ?? "Command prompt execution failed.",
+                    hints: cmdResult.Hints,
+                    isTransient: string.Equals(cmdResult.ErrorCode, "timeout", StringComparison.Ordinal));
+            }
+
+            var cmdModel = cmdResult.Model!;
+            var cmdMeta = ToolOutputHints.Meta(count: 1, truncated: cmdModel.OutputTruncated)
+                .Add("intent", intentText)
+                .Add("allow_write", allowWrite)
+                .Add("mutation_heuristic_enabled", Options.EnableMutationHeuristic)
+                .Add("mutation_heuristic_matched", mutatingReason is not null);
+
+            if (!string.IsNullOrWhiteSpace(mutatingReason)) {
+                cmdMeta.Add("mutation_heuristic_reason", mutatingReason);
+            }
+
+            var cmdSummary = ToolMarkdown.SummaryFacts(
+                title: "Shell Execution",
+                facts: new[] {
+                    ("Host", cmdModel.Host),
+                    ("ExitCode", cmdModel.ExitCode.ToString()),
+                    ("DurationMs", cmdModel.DurationMs.ToString()),
+                    ("TimedOut", cmdModel.TimedOut ? "true" : "false"),
+                    ("OutputTruncated", cmdModel.OutputTruncated ? "true" : "false"),
+                    ("Intent", intentText),
+                    ("WriteAllowed", allowWrite ? "true" : "false")
+                });
+
+            return ToolResponse.OkModel(
+                model: cmdModel,
+                meta: cmdMeta,
+                summaryMarkdown: cmdSummary,
+                render: ToolOutputHints.RenderCode(language: "text", contentPath: "output"));
+        }
+
+        var host = hostKind switch {
+            ShellHostKind.PowerShell7 => PowerShellHostKind.PowerShell7,
+            ShellHostKind.WindowsPowerShell => PowerShellHostKind.WindowsPowerShell,
+            _ => PowerShellHostKind.Auto
+        };
 
         var attempt = PowerShellCommandQueryExecutor.TryExecute(
             request: new PowerShellCommandQueryRequest {
@@ -161,12 +245,10 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
             },
             cancellationToken: cancellationToken);
         if (!attempt.Success) {
-            return Task.FromResult(ErrorFromFailure(attempt.Failure));
+            return ErrorFromFailure(attempt.Failure);
         }
 
         var result = attempt.Result!;
-        var intentText = ToIntentId(intent);
-
         var meta = ToolOutputHints.Meta(count: 1, truncated: result.OutputTruncated)
             .Add("intent", intentText)
             .Add("allow_write", allowWrite)
@@ -189,15 +271,15 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
                 ("WriteAllowed", allowWrite ? "true" : "false")
             });
 
-        return Task.FromResult(ToolResponse.OkModel(
+        return ToolResponse.OkModel(
             model: result,
             meta: meta,
             summaryMarkdown: summary,
-            render: ToolOutputHints.RenderCode(language: "text", contentPath: "output")));
+            render: ToolOutputHints.RenderCode(language: "text", contentPath: "output"));
     }
 
-    private static bool TryParseHost(string? raw, out PowerShellHostKind host, out string? error) {
-        host = PowerShellHostKind.Auto;
+    private static bool TryParseHost(string? raw, out ShellHostKind host, out string? error) {
+        host = ShellHostKind.Auto;
         error = null;
 
         if (string.IsNullOrWhiteSpace(raw) || string.Equals(raw, "auto", StringComparison.OrdinalIgnoreCase)) {
@@ -205,16 +287,21 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
         }
 
         if (string.Equals(raw, "pwsh", StringComparison.OrdinalIgnoreCase)) {
-            host = PowerShellHostKind.PowerShell7;
+            host = ShellHostKind.PowerShell7;
             return true;
         }
 
         if (string.Equals(raw, "windows_powershell", StringComparison.OrdinalIgnoreCase)) {
-            host = PowerShellHostKind.WindowsPowerShell;
+            host = ShellHostKind.WindowsPowerShell;
             return true;
         }
 
-        error = "host must be one of: auto, pwsh, windows_powershell.";
+        if (string.Equals(raw, "cmd", StringComparison.OrdinalIgnoreCase)) {
+            host = ShellHostKind.Cmd;
+            return true;
+        }
+
+        error = "host must be one of: auto, pwsh, windows_powershell, cmd.";
         return false;
     }
 
@@ -239,7 +326,7 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
         return intent == PowerShellExecutionIntent.ReadWrite ? "read_write" : "read_only";
     }
 
-    private static string? DetectMutatingPayloadReason(string payload) {
+    private static string? DetectMutatingPayloadReason(string payload, ShellHostKind hostKind) {
         if (string.IsNullOrWhiteSpace(payload)) {
             return null;
         }
@@ -253,15 +340,17 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
 
             var lowered = line.ToLowerInvariant();
 
-            for (var j = 0; j < MutatingVerbPrefixes.Length; j++) {
-                var prefix = MutatingVerbPrefixes[j];
+            var verbPrefixes = hostKind == ShellHostKind.Cmd ? CmdMutatingVerbPrefixes : PowerShellMutatingVerbPrefixes;
+            for (var j = 0; j < verbPrefixes.Length; j++) {
+                var prefix = verbPrefixes[j];
                 if (lowered.StartsWith(prefix, StringComparison.Ordinal)) {
                     return $"line starts with '{prefix}'.";
                 }
             }
 
-            for (var j = 0; j < MutatingFragments.Length; j++) {
-                var fragment = MutatingFragments[j];
+            var fragments = hostKind == ShellHostKind.Cmd ? CmdMutatingFragments : PowerShellMutatingFragments;
+            for (var j = 0; j < fragments.Length; j++) {
+                var fragment = fragments[j];
                 if (lowered.Contains(fragment, StringComparison.Ordinal)) {
                     return $"line contains '{fragment.Trim()}'.";
                 }
@@ -271,8 +360,142 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
         return null;
     }
 
+    private static async Task<CmdExecutionAttempt> ExecuteCmdAsync(string payload, bool includeErrorStream, int timeoutMs, int maxOutputChars, string? workingDirectory, CancellationToken cancellationToken) {
+        if (!IsCmdHostAvailable()) {
+            return CmdExecutionAttempt.FromFailure(
+                errorCode: "host_unavailable",
+                error: "cmd host is not available on this machine.",
+                hints: new[] { "Use powershell_environment_discover or powershell_hosts to inspect available hosts." });
+        }
+
+        if (!string.IsNullOrWhiteSpace(workingDirectory) && !Directory.Exists(workingDirectory)) {
+            return CmdExecutionAttempt.FromFailure(
+                errorCode: "invalid_argument",
+                error: "working_directory does not exist.",
+                hints: new[] { "Provide an existing working_directory path or omit this argument." });
+        }
+
+        var cmdPath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
+        var scriptPath = Path.Combine(Path.GetTempPath(), "ix-cmd-" + Guid.NewGuid().ToString("N") + ".cmd");
+        try {
+            await File.WriteAllTextAsync(scriptPath, payload, Utf8NoBom, cancellationToken).ConfigureAwait(false);
+
+            using var process = new Process {
+                StartInfo = new ProcessStartInfo {
+                    FileName = cmdPath,
+                    Arguments = "/d /s /c \"\"" + scriptPath + "\"\"",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                    WorkingDirectory = string.IsNullOrWhiteSpace(workingDirectory)
+                        ? Environment.CurrentDirectory
+                        : workingDirectory!
+                }
+            };
+
+            var stopwatch = Stopwatch.StartNew();
+            process.Start();
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = includeErrorStream
+                ? process.StandardError.ReadToEndAsync()
+                : Task.FromResult(string.Empty);
+
+            var timedOut = false;
+            using var timeoutCts = new CancellationTokenSource(timeoutMs);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+            try {
+                await process.WaitForExitAsync(linkedCts.Token).ConfigureAwait(false);
+            } catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested) {
+                timedOut = true;
+                try {
+                    if (!process.HasExited) {
+                        process.Kill(entireProcessTree: true);
+                    }
+                } catch {
+                    // Ignore best-effort kill failures.
+                }
+
+                await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var stdout = await stdoutTask.ConfigureAwait(false);
+            var stderr = await stderrTask.ConfigureAwait(false);
+            var combinedOutput = includeErrorStream && !string.IsNullOrEmpty(stderr)
+                ? (string.IsNullOrEmpty(stdout) ? stderr : (stdout + Environment.NewLine + stderr))
+                : stdout;
+            var (output, truncated) = TruncateOutput(combinedOutput ?? string.Empty, maxOutputChars);
+
+            if (timedOut) {
+                return CmdExecutionAttempt.FromFailure(
+                    errorCode: "timeout",
+                    error: "cmd execution timed out.",
+                    hints: new[] { "Increase timeout_ms for long-running commands." });
+            }
+
+            return CmdExecutionAttempt.FromSuccess(new CmdExecutionModel(
+                Host: "cmd",
+                ExitCode: process.ExitCode,
+                DurationMs: stopwatch.ElapsedMilliseconds,
+                TimedOut: false,
+                OutputTruncated: truncated,
+                Output: output));
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception ex) {
+            return CmdExecutionAttempt.FromFailure(
+                errorCode: "query_failed",
+                error: "cmd execution failed: " + ex.Message,
+                hints: new[] { "Check command/script syntax and working_directory." });
+        } finally {
+            try {
+                if (File.Exists(scriptPath)) {
+                    File.Delete(scriptPath);
+                }
+            } catch {
+                // Ignore temporary script cleanup failures.
+            }
+        }
+    }
+
+    private static (string Output, bool Truncated) TruncateOutput(string output, int maxChars) {
+        if (string.IsNullOrEmpty(output) || output.Length <= maxChars) {
+            return (output, false);
+        }
+
+        return (output[..maxChars], true);
+    }
+
+    private enum ShellHostKind {
+        Auto,
+        PowerShell7,
+        WindowsPowerShell,
+        Cmd
+    }
+
     private enum PowerShellExecutionIntent {
         ReadOnly,
         ReadWrite
+    }
+
+    private sealed record CmdExecutionModel(
+        string Host,
+        int ExitCode,
+        long DurationMs,
+        bool TimedOut,
+        bool OutputTruncated,
+        string Output);
+
+    private sealed record CmdExecutionAttempt(
+        bool Success,
+        CmdExecutionModel? Model,
+        string? ErrorCode,
+        string? Error,
+        string[]? Hints) {
+        public static CmdExecutionAttempt FromSuccess(CmdExecutionModel model) => new(true, model, null, null, null);
+
+        public static CmdExecutionAttempt FromFailure(string errorCode, string error, string[]? hints = null) => new(false, null, errorCode, error, hints);
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellToolBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using IntelligenceX.Engines.PowerShell;
 using IntelligenceX.Tools.Common;
 
@@ -39,7 +40,7 @@ public abstract class PowerShellToolBase : ToolBase {
         };
 
         if (code == PowerShellCommandQueryFailureCode.HostNotAvailable) {
-            hints.Add("Use powershell_environment_discover or powershell_hosts to check host availability (pwsh/windows_powershell).");
+            hints.Add("Use powershell_environment_discover or powershell_hosts to check host availability (pwsh/windows_powershell/cmd).");
         }
         if (code == PowerShellCommandQueryFailureCode.Timeout) {
             hints.Add("Increase timeout_ms for long-running commands.");
@@ -50,5 +51,29 @@ public abstract class PowerShellToolBase : ToolBase {
             error: message,
             hints: hints.Count == 0 ? null : hints,
             isTransient: code == PowerShellCommandQueryFailureCode.Timeout || code == PowerShellCommandQueryFailureCode.QueryFailed);
+    }
+
+    /// <summary>
+    /// Returns runtime hosts available for powershell_run execution.
+    /// </summary>
+    protected static IReadOnlyList<string> GetAvailableRuntimeHosts() {
+        var hosts = new List<string>(PowerShellCommandQueryExecutor.GetAvailableHosts());
+        if (IsCmdHostAvailable()) {
+            hosts.Add("cmd");
+        }
+
+        return hosts;
+    }
+
+    /// <summary>
+    /// Returns true when cmd.exe is available on this machine.
+    /// </summary>
+    protected static bool IsCmdHostAvailable() {
+        try {
+            var cmdPath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
+            return File.Exists(cmdPath);
+        } catch {
+            return false;
+        }
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellToolPack.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellToolPack.cs
@@ -24,7 +24,7 @@ public sealed class PowerShellToolPack : IToolPack {
         Name = "PowerShell Runtime",
         Tier = ToolCapabilityTier.DangerousWrite,
         IsDangerous = true,
-        Description = "Opt-in PowerShell runtime execution (windows_powershell / pwsh).",
+        Description = "Opt-in shell runtime execution (windows_powershell / pwsh / cmd).",
         SourceKind = "builtin"
     };
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/PowerShellExecutionPolicyTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/PowerShellExecutionPolicyTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,6 +42,42 @@ public class PowerShellExecutionPolicyTests {
         Assert.Equal("invalid_argument", doc.RootElement.GetProperty("error_code").GetString());
         var error = doc.RootElement.GetProperty("error").GetString() ?? string.Empty;
         Assert.Contains("Read-only intent rejected", error);
+    }
+
+    [Fact]
+    public async Task RunTool_ShouldRejectMutatingCmdPayloadInReadOnlyMode() {
+        var tool = new PowerShellRunTool(new PowerShellToolOptions {
+            Enabled = true
+        });
+
+        var json = await tool.InvokeAsync(
+            arguments: new JsonObject()
+                .Add("host", "cmd")
+                .Add("command", "del C:\\temp\\file.txt"),
+            cancellationToken: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.False(doc.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", doc.RootElement.GetProperty("error_code").GetString());
+    }
+
+    [Fact]
+    public async Task RunTool_ShouldRejectInvalidHost() {
+        var tool = new PowerShellRunTool(new PowerShellToolOptions {
+            Enabled = true
+        });
+
+        var json = await tool.InvokeAsync(
+            arguments: new JsonObject()
+                .Add("host", "bash")
+                .Add("command", "echo test"),
+            cancellationToken: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.False(doc.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", doc.RootElement.GetProperty("error_code").GetString());
+        var error = doc.RootElement.GetProperty("error").GetString() ?? string.Empty;
+        Assert.Contains("auto, pwsh, windows_powershell, cmd", error, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/IntelligenceX.Tools/README.md
+++ b/IntelligenceX.Tools/README.md
@@ -39,7 +39,7 @@ and can resolve engine sources from configured local roots when needed.
   - OS/system helpers (keep OS-specific things isolated)
   - Includes `system_pack_info` guidance tool
 - `IntelligenceX.Tools.PowerShell`
-  - Dedicated IX.PowerShell runtime pack for `powershell.exe` / `pwsh` execution (opt-in, dangerous)
+  - Dedicated IX.PowerShell runtime pack for `powershell.exe` / `pwsh` / `cmd.exe` execution (opt-in, dangerous)
   - Includes `powershell_pack_info`, `powershell_environment_discover`, `powershell_hosts`, and `powershell_run`
   - `powershell_run` uses explicit `intent` (`read_only`/`read_write`) with policy-gated write controls
   - Engine-first via `IntelligenceX.Engines.PowerShell`


### PR DESCRIPTION
## Summary
This PR delivers the agreed 1/2/3 batch:

1. Tools loading UX
- Adds an explicit `toolsLoading` UI state from runtime policy hydration.
- Prevents transient "No tools registered" flicker while runtime metadata is still loading.
- Shows a clear "Loading tool packs..." placeholder during pack discovery.

2. PowerShell onboarding hint
- When `PowerShell Runtime` is enabled from Options > Tools, a one-time session hint is appended in chat.
- Includes concrete quick-start prompts for `powershell_environment_discover` and `powershell_run` (`cmd` + `pwsh`).

3. CMD support in PowerShell pack
- Extends `powershell_run` host support with `cmd` (in addition to `auto/pwsh/windows_powershell`).
- Adds cmd execution path with timeout, output truncation, working directory, and structured response parity.
- Extends host discovery/pack info docs and metadata to include cmd availability.
- Keeps read-only safety heuristics active for cmd payloads as well.

Also updates bootstrap/README descriptions so capability is discoverable in UI and docs.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release`

All passed locally.