### PR TITLE
docs(reviewer): add first-party projects + PR monitoring guides

### DIFF
--- a/Docs/_index.md
+++ b/Docs/_index.md
@@ -12,6 +12,7 @@ Welcome to the IntelligenceX documentation.
 - [Getting Started](/docs/getting-started/)
 - [Reviewer Onboarding Wizard](/docs/reviewer/onboarding-wizard/)
 - [CLI Quick Start](/docs/cli/quickstart/)
+- [Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
 
 ## GitHub Actions Reviewer
 
@@ -21,6 +22,9 @@ Welcome to the IntelligenceX documentation.
 - [Reviewer Configuration](/docs/reviewer/configuration/)
 - [Reviewer Security & Trust](/docs/reviewer/security-trust/)
 - [Reviewer Static Analysis](/docs/reviewer/static-analysis/)
+- [Reviewer Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
+- [Reviewer Project Bootstrap and Sync](/docs/reviewer/project-bootstrap-sync/)
+- [Reviewer Project Views and Operations](/docs/reviewer/project-views-and-ops/)
 
 ## CLI Tools
 

--- a/Docs/reviewer/overview.md
+++ b/Docs/reviewer/overview.md
@@ -16,6 +16,9 @@ Related docs:
 - [Understanding Reviewer Output](/docs/reviewer/review-output/)
 - [Configuration](/docs/reviewer/configuration/)
 - [Security and Trust](/docs/reviewer/security-trust/)
+- [Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
+- [Project Bootstrap and Sync](/docs/reviewer/project-bootstrap-sync/)
+- [Project Views and Operations](/docs/reviewer/project-views-and-ops/)
 
 ## Runtime Flow
 

--- a/Docs/reviewer/project-bootstrap-sync.md
+++ b/Docs/reviewer/project-bootstrap-sync.md
@@ -1,0 +1,112 @@
+# Project Bootstrap and Sync
+
+Use this flow to set up a GitHub Project for triage and keep it continuously synced with IntelligenceX backlog artifacts.
+
+## Important disclaimer
+
+This pipeline is assistive. It should not be treated as an autonomous production approval/merge system.
+
+- Keep a human owner for final triage and merge decisions.
+- Use project fields as signals, not hard gates.
+- Start with `--dry-run` for any mutating sync rollout.
+
+## Prerequisites
+
+- GitHub token with `project` scope.
+- For sync reads/writes: `read:project` + `project`.
+- For issue/comment operations: issue write permissions.
+
+## First-run bootstrap (recommended)
+
+`project-bootstrap` is the fastest path for new adopters.
+
+```bash
+intelligencex todo project-bootstrap \
+  --repo EvotecIT/IntelligenceX \
+  --owner EvotecIT \
+  --create-control-issue \
+  --control-issue-title "IX Triage Control"
+```
+
+Default outputs:
+
+- `artifacts/triage/ix-project-config.json`
+- `.github/workflows/ix-triage-project-sync.yml`
+- `VISION.md` (scaffolded if missing)
+
+## Initialize an existing project
+
+If you already have a GitHub Project, initialize IX fields/metadata with `project-init`:
+
+```bash
+intelligencex todo project-init \
+  --repo EvotecIT/IntelligenceX \
+  --owner EvotecIT \
+  --project 123 \
+  --out artifacts/triage/ix-project-config.json
+```
+
+Useful options:
+
+- `--view-template-project <n>` and `--view-template-owner <login>` to preserve existing saved views from a template project.
+- `--ensure-default-views` to validate recommended view coverage.
+- `--no-ensure-labels` to skip taxonomy setup when labels are managed elsewhere.
+
+## Sync triage and vision into project fields
+
+After generating triage artifacts, run `project-sync`:
+
+```bash
+intelligencex todo project-sync \
+  --config artifacts/triage/ix-project-config.json \
+  --triage artifacts/triage/ix-triage-index.json \
+  --vision artifacts/triage/ix-vision-check.json \
+  --max-items 500
+```
+
+Dry-run example:
+
+```bash
+intelligencex todo project-sync \
+  --config artifacts/triage/ix-project-config.json \
+  --dry-run
+```
+
+Extended sync example with labels and link comments:
+
+```bash
+intelligencex todo project-sync \
+  --config artifacts/triage/ix-project-config.json \
+  --apply-labels \
+  --ensure-labels \
+  --apply-link-comments \
+  --link-comment-min-confidence 0.55 \
+  --link-comment-max-issues 3
+```
+
+## What sync updates
+
+- Project item fields for triage and vision fit.
+- Suggested maintainership decision signal (`IX Suggested Decision`).
+- Optional managed label reconciliation for IX taxonomies.
+- Optional assistive cross-link comments for related PR/issue context.
+
+## Scheduled automation
+
+The bootstrap command writes a workflow that can run this continuously.
+
+Template files:
+
+- `IntelligenceX.Cli/Templates/triage-index-scheduled.yml`
+- `IntelligenceX.Cli/Templates/triage-project-sync.yml`
+
+Recommended rollout:
+
+1. Run sync manually with `--dry-run`.
+2. Run one controlled write sync.
+3. Enable schedule after maintainers validate resulting field quality.
+
+## Related docs
+
+- [Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
+- [Project Views and Operations](/docs/reviewer/project-views-and-ops/)

--- a/Docs/reviewer/project-views-and-ops.md
+++ b/Docs/reviewer/project-views-and-ops.md
@@ -1,0 +1,113 @@
+# Project Views and Operations
+
+This page covers maintainer-facing operations after project setup: view checklist/apply planning, bot-feedback sync, triage index generation, and vision drift checks.
+
+## Important disclaimer
+
+These commands provide assistive operational intelligence, not unattended production governance.
+
+- Keep human review in the loop for merge/close/defer decisions.
+- Use output confidence and links as context, not as sole authority.
+
+## View checklist and apply plan
+
+GitHub Project views are not fully creatable through public API mutations today. IntelligenceX therefore provides deterministic checklist/apply-plan guidance.
+
+### Build a checklist of recommended views
+
+```bash
+intelligencex todo project-view-checklist \
+  --config artifacts/triage/ix-project-config.json \
+  --create-issue
+```
+
+Useful options:
+
+- `--issue <n>` upserts checklist comment on an existing issue.
+- `--issue-title <text>` customizes title when creating issue.
+- `--print` emits markdown to stdout.
+
+### Build an apply plan for missing views
+
+```bash
+intelligencex todo project-view-apply \
+  --config artifacts/triage/ix-project-config.json \
+  --create-issue \
+  --open-web
+```
+
+Useful options:
+
+- `--fail-if-missing` exits with code `2` when recommended views are missing.
+- `--issue <n>` upserts plan comment to an existing issue.
+- `--out <path>` writes markdown to custom location.
+
+## Sync bot feedback into TODO.md
+
+Use this to keep explicit bot checklist tasks visible in one backlog:
+
+```bash
+intelligencex todo sync-bot-feedback --repo EvotecIT/IntelligenceX
+```
+
+Create issues for unchecked tasks:
+
+```bash
+intelligencex todo sync-bot-feedback \
+  --repo EvotecIT/IntelligenceX \
+  --create-issues \
+  --label ix-bot-feedback \
+  --max-issues 20
+```
+
+Behavior notes:
+
+- Imports explicit markdown task-list items only (`- [ ]` / `- [x]`).
+- Preserves existing checkbox state in `TODO.md` where possible.
+- Uses stable markers for issue deduplication when `--create-issues` is enabled.
+
+## Build triage and vision artifacts
+
+### Build triage index
+
+```bash
+intelligencex todo build-triage-index \
+  --repo EvotecIT/IntelligenceX \
+  --max-prs 300 \
+  --max-issues 300 \
+  --duplicate-threshold 0.82 \
+  --best-limit 20
+```
+
+Outputs:
+
+- `artifacts/triage/ix-triage-index.json`
+- `artifacts/triage/ix-triage-index.md`
+
+### Run vision check
+
+```bash
+intelligencex todo vision-check \
+  --repo EvotecIT/IntelligenceX \
+  --vision VISION.md \
+  --refresh-index \
+  --drift-threshold 0.70 \
+  --no-fail-on-drift
+```
+
+Outputs:
+
+- `artifacts/triage/ix-vision-check.json`
+- `artifacts/triage/ix-vision-check.md`
+
+## Suggested maintainer cadence
+
+1. Run `sync-bot-feedback` during PR-review sweeps.
+2. Refresh triage/vision artifacts daily or per release train.
+3. Sync project fields before backlog grooming.
+4. Regenerate view checklist/apply plan when project layout drifts.
+
+## Related docs
+
+- [Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
+- [Project Bootstrap and Sync](/docs/reviewer/project-bootstrap-sync/)

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -1,0 +1,75 @@
+# Projects + PR Monitoring
+
+IntelligenceX includes a GitHub-native maintainer control plane for PR and issue backlog monitoring using the `intelligencex todo ...` command family.
+
+## Important disclaimer
+
+These commands are assistive. They are not an autonomous production decision system.
+
+- Treat `category`, `tags`, `IX Suggested Decision`, duplicate clusters, and scope classification as recommendations.
+- Keep final decisions human-owned (`Maintainer Decision`, merge, close, defer).
+- Do not wire this into unattended production mutation flows without explicit human review gates.
+
+## What this gives you
+
+- Bot-review checklist sync into `TODO.md` (`sync-bot-feedback`).
+- Backlog indexing and duplicate clustering across open PRs/issues (`build-triage-index`).
+- Scope alignment checks against `VISION.md` (`vision-check`).
+- GitHub Project field sync for triage at scale (`project-init`, `project-sync`, `project-bootstrap`).
+- Maintainer-assist view checklist and apply plan generation (`project-view-checklist`, `project-view-apply`).
+
+## Recommended end-to-end flow
+
+1. Pull explicit bot checklist items into `TODO.md`.
+2. Build triage index artifacts.
+3. Run vision alignment check.
+4. Bootstrap or initialize GitHub Project.
+5. Sync triage + vision into project fields.
+6. Generate project view checklist and apply plan for maintainers.
+
+## End-to-end example
+
+```bash
+# 1) Sync explicit bot checklist items to TODO.md
+intelligencex todo sync-bot-feedback --repo EvotecIT/IntelligenceX
+
+# 2) Build triage index artifacts
+intelligencex todo build-triage-index --repo EvotecIT/IntelligenceX
+
+# 3) Check backlog against VISION.md
+intelligencex todo vision-check --repo EvotecIT/IntelligenceX --vision VISION.md
+
+# 4) Bootstrap project + workflow + vision scaffold
+intelligencex todo project-bootstrap --repo EvotecIT/IntelligenceX --owner EvotecIT
+
+# 5) Sync triage + vision into project fields
+intelligencex todo project-sync --config artifacts/triage/ix-project-config.json --max-items 500
+
+# 6) Generate a maintainer view checklist
+intelligencex todo project-view-checklist --config artifacts/triage/ix-project-config.json --create-issue
+```
+
+## Command quick map
+
+| Command | Purpose | Typical output |
+| --- | --- | --- |
+| `sync-bot-feedback` | Extract explicit bot checklist tasks and keep them tracked in `TODO.md` | Updated `TODO.md` (optional GitHub issues) |
+| `build-triage-index` | Build PR/issue inventory, duplicate clusters, and best PR ranking | `artifacts/triage/ix-triage-index.json`, `.md` |
+| `vision-check` | Compare backlog against `VISION.md` scope | `artifacts/triage/ix-vision-check.json`, `.md` |
+| `project-init` | Create/initialize GitHub Project fields + metadata | `artifacts/triage/ix-project-config.json` |
+| `project-sync` | Push triage/vision signals to project items and optional labels/comments | Project field updates, optional comment/label updates |
+| `project-bootstrap` | First-run bootstrap for project + workflow + vision scaffold | Project config + workflow + `VISION.md` scaffold |
+| `project-view-checklist` | Build checklist of recommended project views | `artifacts/triage/ix-project-view-checklist.md` |
+| `project-view-apply` | Build deterministic plan to apply missing views | `artifacts/triage/ix-project-view-apply.md` |
+
+## Permissions and safety
+
+- Project setup and sync requires GitHub `project` scope (`read:project` also required for sync reads).
+- Issue-posting helpers require issue write permission.
+- Use `--dry-run` on sync commands before enabling mutating operations.
+
+## Related docs
+
+- [Project Bootstrap and Sync](/docs/reviewer/project-bootstrap-sync/)
+- [Project Views and Operations](/docs/reviewer/project-views-and-ops/)
+- [Reviewer Overview](/docs/reviewer/overview/)

--- a/Docs/toc.json
+++ b/Docs/toc.json
@@ -14,7 +14,10 @@
       { "title": "Web Onboarding Flow", "href": "/docs/reviewer/web-onboarding/" },
       { "title": "Configuration", "href": "/docs/reviewer/configuration/" },
       { "title": "Security & Trust", "href": "/docs/reviewer/security-trust/" },
-      { "title": "Static Analysis", "href": "/docs/reviewer/static-analysis/" }
+      { "title": "Static Analysis", "href": "/docs/reviewer/static-analysis/" },
+      { "title": "Projects + PR Monitoring", "href": "/docs/reviewer/projects-pr-monitoring/" },
+      { "title": "Project Bootstrap and Sync", "href": "/docs/reviewer/project-bootstrap-sync/" },
+      { "title": "Project Views and Operations", "href": "/docs/reviewer/project-views-and-ops/" }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- add first-party reviewer docs for GitHub Projects + PR monitoring
- add detailed, practical pages for bootstrap/sync and day-2 operations (views/checklist/apply, triage, vision, bot feedback)
- wire these pages into reviewer navigation, reviewer overview links, and docs front page quick links
- include explicit assistive-only disclaimer language (not unattended production decision automation)

## Docs added
- `Docs/reviewer/projects-pr-monitoring.md`
- `Docs/reviewer/project-bootstrap-sync.md`
- `Docs/reviewer/project-views-and-ops.md`

## Navigation updates
- `Docs/toc.json`
- `Docs/_index.md`
- `Docs/reviewer/overview.md`

## Notes
- command examples and option guidance are aligned with current `intelligencex todo ... --help` output
