### PR TITLE
perf(chat): speed up runtime startup and reduce restart churn

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX;
+using IntelligenceX.Chat.Abstractions.Protocol;
 
 namespace IntelligenceX.Chat.App;
 
@@ -104,6 +105,24 @@ internal sealed class ChatAppStateStore : IDisposable {
                 .ToList();
         }
 
+        if (payload.CachedModels is { Count: > 250 }) {
+            payload.CachedModels = payload.CachedModels
+                .Take(250)
+                .ToList();
+        }
+
+        if (payload.CachedFavoriteModels is { Count: > 100 }) {
+            payload.CachedFavoriteModels = payload.CachedFavoriteModels
+                .Take(100)
+                .ToList();
+        }
+
+        if (payload.CachedRecentModels is { Count: > 100 }) {
+            payload.CachedRecentModels = payload.CachedRecentModels
+                .Take(100)
+                .ToList();
+        }
+
         var json = JsonSerializer.Serialize(payload, _json);
 
         _db.ExecuteNonQuery(
@@ -181,6 +200,14 @@ internal sealed class ChatAppState {
     public bool ProactiveModeEnabled { get; set; } = true;
     public bool PersistentMemoryEnabled { get; set; } = true;
     public List<ChatMemoryFactState> MemoryFacts { get; set; } = new();
+    public string CachedModelsTransport { get; set; } = "native";
+    public string? CachedModelsBaseUrl { get; set; }
+    public List<ModelInfoDto> CachedModels { get; set; } = new();
+    public List<string> CachedFavoriteModels { get; set; } = new();
+    public List<string> CachedRecentModels { get; set; } = new();
+    public bool CachedModelListIsStale { get; set; }
+    public string? CachedModelListWarning { get; set; }
+    public DateTime? CachedModelsUpdatedUtc { get; set; }
     public bool OnboardingCompleted { get; set; }
     public string? ActiveConversationId { get; set; }
     public string? ThreadId { get; set; }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -146,9 +146,13 @@ public sealed partial class MainWindow : Window {
                 _appState.LocalProviderModel = _localProviderModel;
                 await PersistAppStateAsync().ConfigureAwait(false);
             }
+
+            CaptureModelCatalogCacheIntoAppState();
+            QueuePersistAppState();
         } catch (Exception ex) {
             _modelListIsStale = true;
             _modelListWarning = "Model discovery failed: " + ex.Message;
+            CaptureModelCatalogCacheIntoAppState();
             if (appendWarnings && (VerboseServiceLogs || _debugMode)) {
                 AppendSystem(_modelListWarning);
             }
@@ -160,73 +164,124 @@ public sealed partial class MainWindow : Window {
     }
 
     private async Task ApplyLocalProviderAsync(string? transportValue, string? baseUrlValue, string? modelValue, string? apiKeyValue, bool clearApiKey, bool forceModelRefresh) {
+        var request = new LocalProviderApplyRequest(
+            Transport: transportValue,
+            BaseUrl: baseUrlValue,
+            Model: modelValue,
+            ApiKey: apiKeyValue,
+            ClearApiKey: clearApiKey,
+            ForceModelRefresh: forceModelRefresh);
+
         if (Interlocked.CompareExchange(ref _localProviderApplyInFlight, 1, 0) != 0) {
-            await SetStatusAsync("Runtime switch already in progress.").ConfigureAwait(false);
+            QueuePendingLocalProviderApply(request);
+            await SetStatusAsync("Runtime switch already in progress. Queued latest settings.").ConfigureAwait(false);
             return;
         }
 
         try {
-            await SetStatusAsync("Applying runtime settings...").ConfigureAwait(false);
-            await PublishOptionsStateAsync().ConfigureAwait(false);
+            var current = request;
+            while (true) {
+                await ApplyLocalProviderCoreAsync(current).ConfigureAwait(false);
+                if (!TryTakePendingLocalProviderApply(out var pending)) {
+                    break;
+                }
 
-            if (_isSending) {
-                await SetStatusAsync("Finish the active response before changing local runtime settings.").ConfigureAwait(false);
-                return;
+                if (pending == current) {
+                    continue;
+                }
+
+                current = pending;
             }
-
-            var rawTransport = (transportValue ?? string.Empty).Trim();
-            var normalizedTransport = NormalizeLocalProviderTransport(rawTransport);
-            var normalizedBaseUrl = NormalizeLocalProviderBaseUrl(baseUrlValue, normalizedTransport, rawTransport);
-            var normalizedModel = NormalizeLocalProviderModel(modelValue, normalizedTransport);
-            var clearApiKeyRequested = clearApiKey && string.Equals(normalizedTransport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase);
-            var normalizedApiKey = NormalizeLocalProviderApiKey(apiKeyValue, normalizedTransport);
-            var hasApiKeyUpdate = clearApiKeyRequested || normalizedApiKey is not null;
-
-            var changed = !string.Equals(_localProviderTransport, normalizedTransport, StringComparison.OrdinalIgnoreCase)
-                          || !string.Equals(_localProviderBaseUrl ?? string.Empty, normalizedBaseUrl ?? string.Empty, StringComparison.OrdinalIgnoreCase)
-                          || !string.Equals(_localProviderModel, normalizedModel, StringComparison.Ordinal)
-                          || hasApiKeyUpdate;
-
-            _localProviderTransport = normalizedTransport;
-            _localProviderBaseUrl = normalizedBaseUrl;
-            _localProviderModel = normalizedModel;
-            _appState.LocalProviderTransport = _localProviderTransport;
-            _appState.LocalProviderBaseUrl = _localProviderBaseUrl;
-            _appState.LocalProviderModel = _localProviderModel;
-
-            var profileSaved = ContainsProfileName(_serviceProfileNames, _appProfileName);
-            await PersistAppStateAsync().ConfigureAwait(false);
-            await PublishOptionsStateAsync().ConfigureAwait(false);
-
-            if (!changed && profileSaved) {
-                await RefreshModelsFromUiAsync(forceModelRefresh).ConfigureAwait(false);
-                return;
-            }
-
-            ClearConversationThreadIds();
-            await PersistAppStateAsync().ConfigureAwait(false);
-
-            _pendingServiceLaunchProfileOptions = new ServiceLaunchProfileOptions {
-                LoadProfileName = profileSaved ? _appProfileName : null,
-                SaveProfileName = _appProfileName,
-                Model = _localProviderModel,
-                OpenAITransport = _localProviderTransport,
-                OpenAIBaseUrl = _localProviderBaseUrl,
-                OpenAIApiKey = normalizedApiKey,
-                ClearOpenAIApiKey = clearApiKeyRequested,
-                OpenAIStreaming = true,
-                OpenAIAllowInsecureHttp = ShouldAllowInsecureHttp(_localProviderTransport, _localProviderBaseUrl)
-            };
-
-            await RestartSidecarAsync().ConfigureAwait(false);
-            await RefreshLocalRuntimeDetectionAsync(publishOptions: false).ConfigureAwait(false);
-            await SyncConnectedServiceProfileAndModelsAsync(
-                forceModelRefresh: true,
-                setProfileNewThread: false,
-                appendWarnings: true).ConfigureAwait(false);
         } finally {
             Interlocked.Exchange(ref _localProviderApplyInFlight, 0);
             await PublishOptionsStateAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task ApplyLocalProviderCoreAsync(LocalProviderApplyRequest request) {
+        await SetStatusAsync("Applying runtime settings...").ConfigureAwait(false);
+        await PublishOptionsStateAsync().ConfigureAwait(false);
+
+        if (_isSending) {
+            await SetStatusAsync("Finish the active response before changing local runtime settings.").ConfigureAwait(false);
+            return;
+        }
+
+        var rawTransport = (request.Transport ?? string.Empty).Trim();
+        var normalizedTransport = NormalizeLocalProviderTransport(rawTransport);
+        var normalizedBaseUrl = NormalizeLocalProviderBaseUrl(request.BaseUrl, normalizedTransport, rawTransport);
+        var normalizedModel = NormalizeLocalProviderModel(request.Model, normalizedTransport);
+        var clearApiKeyRequested = request.ClearApiKey && string.Equals(normalizedTransport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase);
+        var normalizedApiKey = NormalizeLocalProviderApiKey(request.ApiKey, normalizedTransport);
+        var hasApiKeyUpdate = clearApiKeyRequested || normalizedApiKey is not null;
+
+        var changed = !string.Equals(_localProviderTransport, normalizedTransport, StringComparison.OrdinalIgnoreCase)
+                      || !string.Equals(_localProviderBaseUrl ?? string.Empty, normalizedBaseUrl ?? string.Empty, StringComparison.OrdinalIgnoreCase)
+                      || !string.Equals(_localProviderModel, normalizedModel, StringComparison.Ordinal)
+                      || hasApiKeyUpdate;
+
+        _localProviderTransport = normalizedTransport;
+        _localProviderBaseUrl = normalizedBaseUrl;
+        _localProviderModel = normalizedModel;
+        _appState.LocalProviderTransport = _localProviderTransport;
+        _appState.LocalProviderBaseUrl = _localProviderBaseUrl;
+        _appState.LocalProviderModel = _localProviderModel;
+
+        var profileSaved = ContainsProfileName(_serviceProfileNames, _appProfileName);
+        CaptureModelCatalogCacheIntoAppState();
+        await PersistAppStateAsync().ConfigureAwait(false);
+        await PublishOptionsStateAsync().ConfigureAwait(false);
+
+        if (!changed && profileSaved) {
+            await RefreshModelsFromUiAsync(request.ForceModelRefresh).ConfigureAwait(false);
+            return;
+        }
+
+        ClearConversationThreadIds();
+        await PersistAppStateAsync().ConfigureAwait(false);
+
+        _pendingServiceLaunchProfileOptions = new ServiceLaunchProfileOptions {
+            LoadProfileName = profileSaved ? _appProfileName : null,
+            SaveProfileName = _appProfileName,
+            Model = _localProviderModel,
+            OpenAITransport = _localProviderTransport,
+            OpenAIBaseUrl = _localProviderBaseUrl,
+            OpenAIApiKey = normalizedApiKey,
+            ClearOpenAIApiKey = clearApiKeyRequested,
+            OpenAIStreaming = true,
+            OpenAIAllowInsecureHttp = ShouldAllowInsecureHttp(_localProviderTransport, _localProviderBaseUrl)
+        };
+
+        await RestartSidecarAsync().ConfigureAwait(false);
+        await RefreshLocalRuntimeDetectionAsync(publishOptions: false).ConfigureAwait(false);
+        await SyncConnectedServiceProfileAndModelsAsync(
+            forceModelRefresh: true,
+            setProfileNewThread: false,
+            appendWarnings: true).ConfigureAwait(false);
+    }
+
+    private void QueuePendingLocalProviderApply(LocalProviderApplyRequest request) {
+        lock (_localProviderApplySync) {
+            _pendingLocalProviderApply = request;
+        }
+    }
+
+    private bool TryTakePendingLocalProviderApply(out LocalProviderApplyRequest request) {
+        lock (_localProviderApplySync) {
+            if (_pendingLocalProviderApply is null) {
+                request = new LocalProviderApplyRequest(
+                    Transport: null,
+                    BaseUrl: null,
+                    Model: null,
+                    ApiKey: null,
+                    ClearApiKey: false,
+                    ForceModelRefresh: false);
+                return false;
+            }
+
+            request = _pendingLocalProviderApply;
+            _pendingLocalProviderApply = null;
+            return true;
         }
     }
 
@@ -361,6 +416,87 @@ public sealed partial class MainWindow : Window {
         }
 
         return false;
+    }
+
+    private void RestoreCachedModelCatalogFromAppState() {
+        var cacheTransport = NormalizeLocalProviderTransport(_appState.CachedModelsTransport);
+        var cacheBaseUrl = NormalizeLocalProviderBaseUrl(_appState.CachedModelsBaseUrl, cacheTransport, cacheTransport);
+        var sameRuntime = string.Equals(cacheTransport, _localProviderTransport, StringComparison.OrdinalIgnoreCase)
+                          && string.Equals(cacheBaseUrl ?? string.Empty, _localProviderBaseUrl ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+
+        if (!sameRuntime) {
+            _availableModels = Array.Empty<ModelInfoDto>();
+            _favoriteModels = Array.Empty<string>();
+            _recentModels = Array.Empty<string>();
+            _modelListIsStale = false;
+            _modelListWarning = null;
+            return;
+        }
+
+        _availableModels = _appState.CachedModels is { Count: > 0 }
+            ? NormalizeModelList(_appState.CachedModels.ToArray())
+            : Array.Empty<ModelInfoDto>();
+        _favoriteModels = _appState.CachedFavoriteModels is { Count: > 0 }
+            ? NormalizeModelNames(_appState.CachedFavoriteModels.ToArray())
+            : Array.Empty<string>();
+        _recentModels = _appState.CachedRecentModels is { Count: > 0 }
+            ? NormalizeModelNames(_appState.CachedRecentModels.ToArray())
+            : Array.Empty<string>();
+        _modelListIsStale = _availableModels.Length > 0 || _appState.CachedModelListIsStale;
+        _modelListWarning = string.IsNullOrWhiteSpace(_appState.CachedModelListWarning)
+            ? (_availableModels.Length > 0 ? "Showing cached models while runtime connects." : null)
+            : _appState.CachedModelListWarning.Trim();
+    }
+
+    private void CaptureModelCatalogCacheIntoAppState() {
+        _appState.CachedModelsTransport = _localProviderTransport;
+        _appState.CachedModelsBaseUrl = _localProviderBaseUrl;
+        _appState.CachedModels = CloneModelList(_availableModels);
+        _appState.CachedFavoriteModels = new List<string>(_favoriteModels);
+        _appState.CachedRecentModels = new List<string>(_recentModels);
+        _appState.CachedModelListIsStale = _modelListIsStale;
+        _appState.CachedModelListWarning = _modelListWarning;
+        _appState.CachedModelsUpdatedUtc = DateTime.UtcNow;
+    }
+
+    private static List<ModelInfoDto> CloneModelList(ModelInfoDto[] models) {
+        if (models is null || models.Length == 0) {
+            return new List<ModelInfoDto>();
+        }
+
+        const int maxCachedModels = 250;
+        var limit = Math.Min(models.Length, maxCachedModels);
+        var clone = new List<ModelInfoDto>(limit);
+        for (var i = 0; i < limit; i++) {
+            var model = models[i];
+            if (model is null || string.IsNullOrWhiteSpace(model.Model)) {
+                continue;
+            }
+
+            clone.Add(new ModelInfoDto {
+                Id = model.Id,
+                Model = model.Model,
+                DisplayName = model.DisplayName,
+                Description = model.Description,
+                IsDefault = model.IsDefault,
+                OwnedBy = model.OwnedBy,
+                Publisher = model.Publisher,
+                Architecture = model.Architecture,
+                Quantization = model.Quantization,
+                CompatibilityType = model.CompatibilityType,
+                RuntimeState = model.RuntimeState,
+                ModelType = model.ModelType,
+                MaxContextLength = model.MaxContextLength,
+                LoadedContextLength = model.LoadedContextLength,
+                Capabilities = model.Capabilities is { Length: > 0 } ? NormalizeModelNames(model.Capabilities) : Array.Empty<string>(),
+                DefaultReasoningEffort = model.DefaultReasoningEffort,
+                SupportedReasoningEfforts = model.SupportedReasoningEfforts is { Length: > 0 }
+                    ? model.SupportedReasoningEfforts
+                    : Array.Empty<ReasoningEffortOptionDto>()
+            });
+        }
+
+        return clone;
     }
 
     private static bool ShouldAllowInsecureHttp(string transport, string? baseUrl) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
@@ -60,19 +60,19 @@ public sealed partial class MainWindow : Window {
 
                 if (await EnsureServiceRunningAsync(pipeName).ConfigureAwait(false)) {
                     Exception? sidecarConnectException = null;
-                    var startupConnectTimeouts = new[] {
-                        TimeSpan.FromSeconds(15),
-                        TimeSpan.FromSeconds(30)
-                    };
-                    for (var attempt = 0; attempt < startupConnectTimeouts.Length; attempt++) {
+                    for (var attempt = 0; attempt < StartupConnectRetryTimeouts.Length; attempt++) {
                         try {
-                            await ConnectClientWithTimeoutAsync(client, pipeName, startupConnectTimeouts[attempt]).ConfigureAwait(false);
+                            await ConnectClientWithTimeoutAsync(client, pipeName, StartupConnectRetryTimeouts[attempt]).ConfigureAwait(false);
                             sidecarConnectException = null;
                             break;
                         } catch (Exception ex2) {
                             sidecarConnectException = ex2;
-                            if (attempt + 1 < startupConnectTimeouts.Length) {
-                                await Task.Delay(TimeSpan.FromMilliseconds(350)).ConfigureAwait(false);
+                            if (_serviceProcess is { HasExited: true }) {
+                                break;
+                            }
+
+                            if (attempt + 1 < StartupConnectRetryTimeouts.Length) {
+                                await Task.Delay(StartupConnectRetryDelay).ConfigureAwait(false);
                             }
                         }
                     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
@@ -51,6 +51,7 @@ public sealed partial class MainWindow : Window {
             _appState.LocalProviderTransport = _localProviderTransport;
             _appState.LocalProviderBaseUrl = _localProviderBaseUrl;
             _appState.LocalProviderModel = _localProviderModel;
+            CaptureModelCatalogCacheIntoAppState();
             _appState.MemoryFacts = NormalizeMemoryFacts(_appState.MemoryFacts);
             _appState.ActiveConversationId = _activeConversationId;
             _appState.ThreadId = activeConversation.ThreadId;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -64,6 +64,12 @@ public sealed partial class MainWindow : Window {
     private static readonly TimeSpan TurnWatchdogHintThreshold = TimeSpan.FromSeconds(20);
     private static readonly TimeSpan WheelForwardCoalesceInterval = TimeSpan.FromMilliseconds(12);
     private static readonly TimeSpan DragMoveWatchdogInterval = TimeSpan.FromMilliseconds(1200);
+    private static readonly TimeSpan StartupConnectRetryDelay = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan[] StartupConnectRetryTimeouts = {
+        TimeSpan.FromSeconds(6),
+        TimeSpan.FromSeconds(10),
+        TimeSpan.FromSeconds(14)
+    };
     private static readonly Regex UserNameIntentRegex = new(@"\b(?:you can call me|call me|my name is|name is|set my name to|change my name to)\s+(?<value>[^,\.\!\?\r\n]{1,64})", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex PersonaIntentRegex = new(@"\b(?:assistant\s+persona|persona|style|tone|mode)\s*(?:is|to|=|:)\s*(?<value>[^,\.\!\?\r\n]{2,180})", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex PersonaUseIntentRegex = new(@"\b(?:use|switch to|go with)\s+(?<value>[^,\.\!\?\r\n]{2,180})\s+(?:persona|style|tone|mode)\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
@@ -312,6 +318,8 @@ public sealed partial class MainWindow : Window {
     private CancellationTokenSource? _autoReconnectCts;
     private Task? _autoReconnectTask;
     private int _localProviderApplyInFlight;
+    private readonly object _localProviderApplySync = new();
+    private LocalProviderApplyRequest? _pendingLocalProviderApply;
 
     private sealed class ConversationRuntime {
         public required string Id { get; init; }
@@ -322,6 +330,13 @@ public sealed partial class MainWindow : Window {
     }
 
     private sealed record QueuedTurn(string Text, string? ConversationId, DateTime EnqueuedUtc);
+    private sealed record LocalProviderApplyRequest(
+        string? Transport,
+        string? BaseUrl,
+        string? Model,
+        string? ApiKey,
+        bool ClearApiKey,
+        bool ForceModelRefresh);
 
     private sealed record TurnMetricsSnapshot(
         DateTime CompletedUtc,
@@ -1202,11 +1217,7 @@ public sealed partial class MainWindow : Window {
         _localRuntimeDetectedName = null;
         _localRuntimeDetectedBaseUrl = null;
         _localRuntimeDetectionWarning = null;
-        _availableModels = Array.Empty<ModelInfoDto>();
-        _favoriteModels = Array.Empty<string>();
-        _recentModels = Array.Empty<string>();
-        _modelListIsStale = false;
-        _modelListWarning = null;
+        RestoreCachedModelCatalogFromAppState();
         _serviceProfileNames = Array.Empty<string>();
 
         if (!string.IsNullOrWhiteSpace(_appState.TimestampMode)) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Chat.Abstractions.Policy;
@@ -12,6 +13,13 @@ using IntelligenceX.Tools;
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
+    private const int StartupToolHealthBackoffMaxExponent = 6;
+    private const string StartupToolHealthCacheFileName = "startup-tool-health-cache-v1.json";
+    private static readonly JsonSerializerOptions StartupToolHealthCacheJson = new() {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = false
+    };
+
     private async Task HandleToolHealthAsync(StreamWriter writer, CheckToolHealthRequest request, CancellationToken cancellationToken) {
         var timeoutSeconds = request.ToolTimeoutSeconds ?? _options.ToolTimeoutSeconds;
         if (timeoutSeconds < 0 || timeoutSeconds > 3600) {
@@ -87,34 +95,71 @@ internal sealed partial class ChatServiceSession {
 
         var warnings = new List<string>(_startupWarnings);
         var hasNewWarnings = false;
+        var cache = LoadStartupToolHealthCache();
+        var cacheUpdated = false;
 
-        foreach (var definition in packInfoDefinitions) {
-            var metadata = ResolvePackMetadata(definition);
-            var timeoutSeconds = ResolveStartupToolHealthTimeoutSeconds(_options.ToolTimeoutSeconds, metadata.SourceKind, metadata.PackId);
-            var probe = await ToolHealthDiagnostics.ProbeAsync(_registry, definition.Name, timeoutSeconds, cancellationToken).ConfigureAwait(false);
-            if (!probe.Ok && IsToolTimeoutProbe(probe)) {
-                var retryTimeoutSeconds = ResolveStartupToolHealthRetryTimeoutSeconds(timeoutSeconds, metadata.SourceKind, metadata.PackId);
-                if (retryTimeoutSeconds > timeoutSeconds) {
-                    probe = await ToolHealthDiagnostics.ProbeAsync(_registry, definition.Name, retryTimeoutSeconds, cancellationToken).ConfigureAwait(false);
+        try {
+            foreach (var definition in packInfoDefinitions) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var metadata = ResolvePackMetadata(definition);
+                var cacheKey = BuildStartupToolHealthCacheKey(metadata.SourceKind, metadata.PackId, definition.Name);
+                var nowUtc = DateTime.UtcNow;
+                if (cache.TryGetValue(cacheKey, out var cachedFailure)
+                    && ShouldSkipStartupToolHealthProbe(nowUtc, cachedFailure.NextProbeUtc)) {
+                    continue;
                 }
-            }
-            if (probe.Ok) {
-                continue;
-            }
 
-            var sourceLabel = ToSourceLabel(metadata.SourceKind);
-            var packLabel = metadata.PackId.Length == 0 ? "unknown" : metadata.PackId;
-            var prefix = ShouldDowngradeStartupToolHealthFailure(metadata.SourceKind, probe.ErrorCode)
-                ? "[tool health notice]"
-                : "[tool health]";
-            var warning = $"{prefix}[{sourceLabel}][{packLabel}] {probe.ToolName} failed ({NormalizeHealthErrorCode(probe.ErrorCode)}): {NormalizeHealthError(probe.Error)}";
-            if (warnings.Any(existing => string.Equals(existing, warning, StringComparison.OrdinalIgnoreCase))) {
-                continue;
-            }
+                var timeoutSeconds = ResolveStartupToolHealthTimeoutSeconds(_options.ToolTimeoutSeconds, metadata.SourceKind, metadata.PackId);
+                var probe = await ToolHealthDiagnostics.ProbeAsync(_registry, definition.Name, timeoutSeconds, cancellationToken).ConfigureAwait(false);
+                if (!probe.Ok && IsToolTimeoutProbe(probe)) {
+                    var retryTimeoutSeconds = ResolveStartupToolHealthRetryTimeoutSeconds(timeoutSeconds, metadata.SourceKind, metadata.PackId);
+                    if (retryTimeoutSeconds > timeoutSeconds) {
+                        probe = await ToolHealthDiagnostics.ProbeAsync(_registry, definition.Name, retryTimeoutSeconds, cancellationToken).ConfigureAwait(false);
+                    }
+                }
 
-            warnings.Add(warning);
-            hasNewWarnings = true;
-            Console.Error.WriteLine($"[pack warning] {warning}");
+                if (probe.Ok) {
+                    if (cache.Remove(cacheKey)) {
+                        cacheUpdated = true;
+                    }
+                    continue;
+                }
+
+                var sourceLabel = ToSourceLabel(metadata.SourceKind);
+                var packLabel = metadata.PackId.Length == 0 ? "unknown" : metadata.PackId;
+                var prefix = ShouldDowngradeStartupToolHealthFailure(metadata.SourceKind, probe.ErrorCode)
+                    ? "[tool health notice]"
+                    : "[tool health]";
+                var warning = $"{prefix}[{sourceLabel}][{packLabel}] {probe.ToolName} failed ({NormalizeHealthErrorCode(probe.ErrorCode)}): {NormalizeHealthError(probe.Error)}";
+                if (!warnings.Any(existing => string.Equals(existing, warning, StringComparison.OrdinalIgnoreCase))) {
+                    warnings.Add(warning);
+                    hasNewWarnings = true;
+                    Console.Error.WriteLine($"[pack warning] {warning}");
+                }
+
+                var errorCode = NormalizeHealthErrorCode(probe.ErrorCode);
+                var nextFailureCount = ResolveNextFailureCount(cachedFailure, errorCode);
+                var nextProbeUtc = ComputeNextStartupToolHealthProbeUtc(
+                    nowUtc,
+                    metadata.SourceKind,
+                    metadata.PackId,
+                    errorCode,
+                    nextFailureCount);
+                cache[cacheKey] = new StartupToolHealthCacheEntry(
+                    ErrorCode: errorCode,
+                    Error: NormalizeHealthError(probe.Error),
+                    LastFailedUtc: nowUtc,
+                    NextProbeUtc: nextProbeUtc,
+                    ConsecutiveFailures: nextFailureCount);
+                cacheUpdated = true;
+            }
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            // Startup priming is best-effort and bounded by the startup budget.
+        } finally {
+            if (cacheUpdated) {
+                SaveStartupToolHealthCache(cache);
+            }
         }
 
         if (hasNewWarnings) {
@@ -226,6 +271,28 @@ internal sealed partial class ChatServiceSession {
                && string.Equals((errorCode ?? string.Empty).Trim(), "tool_timeout", StringComparison.OrdinalIgnoreCase);
     }
 
+    internal static bool ShouldSkipStartupToolHealthProbe(DateTime nowUtc, DateTime nextProbeUtc) {
+        return nextProbeUtc > nowUtc;
+    }
+
+    internal static DateTime ComputeNextStartupToolHealthProbeUtc(
+        DateTime nowUtc,
+        ToolPackSourceKind sourceKind,
+        string? packId,
+        string? errorCode,
+        int consecutiveFailures) {
+        var floor = ResolveStartupToolHealthBackoffFloorMinutes(sourceKind, packId, errorCode);
+        var ceiling = ResolveStartupToolHealthBackoffCeilingMinutes(sourceKind, packId, errorCode);
+        var exponent = Math.Clamp(consecutiveFailures - 1, 0, StartupToolHealthBackoffMaxExponent);
+        var multiplier = 1 << exponent;
+        var delayMinutes = Math.Min(ceiling, floor * multiplier);
+        if (delayMinutes <= 0) {
+            delayMinutes = floor;
+        }
+
+        return nowUtc.AddMinutes(delayMinutes);
+    }
+
     private static bool IsToolTimeoutProbe(ToolHealthDiagnostics.ProbeResult probe) {
         return string.Equals(probe.ErrorCode, "tool_timeout", StringComparison.OrdinalIgnoreCase);
     }
@@ -247,5 +314,154 @@ internal sealed partial class ChatServiceSession {
             ToolPackSourceKind.OpenSource => "open_source",
             _ => "unknown"
         };
+    }
+
+    private static int ResolveStartupToolHealthBackoffFloorMinutes(ToolPackSourceKind sourceKind, string? packId, string? errorCode) {
+        var normalizedPackId = ToolPackBootstrap.NormalizePackId(packId);
+        var normalizedErrorCode = NormalizeHealthErrorCode(errorCode);
+        var isTimeout = string.Equals(normalizedErrorCode, "tool_timeout", StringComparison.OrdinalIgnoreCase);
+        var isTestimoX = string.Equals(normalizedPackId, "testimox", StringComparison.OrdinalIgnoreCase);
+
+        if (isTimeout) {
+            if (isTestimoX) {
+                return 20;
+            }
+
+            return sourceKind == ToolPackSourceKind.ClosedSource ? 10 : 5;
+        }
+
+        return sourceKind == ToolPackSourceKind.ClosedSource ? 4 : 2;
+    }
+
+    private static int ResolveStartupToolHealthBackoffCeilingMinutes(ToolPackSourceKind sourceKind, string? packId, string? errorCode) {
+        var normalizedPackId = ToolPackBootstrap.NormalizePackId(packId);
+        var normalizedErrorCode = NormalizeHealthErrorCode(errorCode);
+        var isTimeout = string.Equals(normalizedErrorCode, "tool_timeout", StringComparison.OrdinalIgnoreCase);
+        var isTestimoX = string.Equals(normalizedPackId, "testimox", StringComparison.OrdinalIgnoreCase);
+
+        if (isTimeout) {
+            if (isTestimoX) {
+                return 180;
+            }
+
+            return sourceKind == ToolPackSourceKind.ClosedSource ? 120 : 45;
+        }
+
+        return sourceKind == ToolPackSourceKind.ClosedSource ? 30 : 20;
+    }
+
+    private static string BuildStartupToolHealthCacheKey(ToolPackSourceKind sourceKind, string packId, string toolName) {
+        return ToSourceLabel(sourceKind)
+               + "|"
+               + ToolPackBootstrap.NormalizePackId(packId)
+               + "|"
+               + (toolName ?? string.Empty).Trim().ToLowerInvariant();
+    }
+
+    private static int ResolveNextFailureCount(StartupToolHealthCacheEntry? previous, string nextErrorCode) {
+        if (previous is null) {
+            return 1;
+        }
+
+        if (string.Equals(previous.ErrorCode, nextErrorCode, StringComparison.OrdinalIgnoreCase)) {
+            return Math.Clamp(previous.ConsecutiveFailures + 1, 1, 64);
+        }
+
+        return 1;
+    }
+
+    private static Dictionary<string, StartupToolHealthCacheEntry> LoadStartupToolHealthCache() {
+        var path = ResolveStartupToolHealthCachePath();
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
+            return new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        try {
+            var json = File.ReadAllText(path);
+            var payload = JsonSerializer.Deserialize<StartupToolHealthCachePayload>(json, StartupToolHealthCacheJson);
+            if (payload?.Entries is null || payload.Entries.Count == 0) {
+                return new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            var map = new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < payload.Entries.Count; i++) {
+                var entry = payload.Entries[i];
+                if (string.IsNullOrWhiteSpace(entry.Key)) {
+                    continue;
+                }
+
+                map[entry.Key] = new StartupToolHealthCacheEntry(
+                    ErrorCode: NormalizeHealthErrorCode(entry.ErrorCode),
+                    Error: NormalizeHealthError(entry.Error),
+                    LastFailedUtc: entry.LastFailedUtc,
+                    NextProbeUtc: entry.NextProbeUtc,
+                    ConsecutiveFailures: Math.Clamp(entry.ConsecutiveFailures, 1, 64));
+            }
+
+            return map;
+        } catch {
+            return new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private static void SaveStartupToolHealthCache(Dictionary<string, StartupToolHealthCacheEntry> cache) {
+        var path = ResolveStartupToolHealthCachePath();
+        if (string.IsNullOrWhiteSpace(path)) {
+            return;
+        }
+
+        try {
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
+                Directory.CreateDirectory(directory);
+            }
+
+            var payload = new StartupToolHealthCachePayload {
+                Entries = cache
+                    .Select(static pair => new StartupToolHealthCachePayloadEntry {
+                        Key = pair.Key,
+                        ErrorCode = pair.Value.ErrorCode,
+                        Error = pair.Value.Error,
+                        LastFailedUtc = pair.Value.LastFailedUtc,
+                        NextProbeUtc = pair.Value.NextProbeUtc,
+                        ConsecutiveFailures = pair.Value.ConsecutiveFailures
+                    })
+                    .ToList()
+            };
+
+            var json = JsonSerializer.Serialize(payload, StartupToolHealthCacheJson);
+            File.WriteAllText(path, json);
+        } catch {
+            // Ignore cache write failures.
+        }
+    }
+
+    private static string ResolveStartupToolHealthCachePath() {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(localAppData)) {
+            return Path.Combine(Path.GetTempPath(), "IntelligenceX.Chat", StartupToolHealthCacheFileName);
+        }
+
+        return Path.Combine(localAppData, "IntelligenceX.Chat", StartupToolHealthCacheFileName);
+    }
+
+    private sealed record StartupToolHealthCacheEntry(
+        string ErrorCode,
+        string Error,
+        DateTime LastFailedUtc,
+        DateTime NextProbeUtc,
+        int ConsecutiveFailures);
+
+    private sealed class StartupToolHealthCachePayload {
+        public List<StartupToolHealthCachePayloadEntry> Entries { get; set; } = new();
+    }
+
+    private sealed class StartupToolHealthCachePayloadEntry {
+        public string Key { get; set; } = string.Empty;
+        public string? ErrorCode { get; set; }
+        public string? Error { get; set; }
+        public DateTime LastFailedUtc { get; set; }
+        public DateTime NextProbeUtc { get; set; }
+        public int ConsecutiveFailures { get; set; } = 1;
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
@@ -30,6 +30,7 @@ internal sealed partial class ChatServiceSession {
     private const int MaxTrackedPendingActionContexts = 256;
     private static readonly TimeSpan UserIntentContextMaxAge = TimeSpan.FromMinutes(15);
     private static readonly TimeSpan PendingActionContextMaxAge = TimeSpan.FromMinutes(20);
+    private static readonly TimeSpan StartupToolHealthPrimeBudget = TimeSpan.FromSeconds(6);
     private readonly ServiceOptions _options;
     private readonly Stream _stream;
     private ToolRegistry _registry;
@@ -123,7 +124,10 @@ internal sealed partial class ChatServiceSession {
     public async Task RunAsync(CancellationToken cancellationToken) {
         var instructions = LoadInstructions(_options);
         _instructions = instructions;
-        await PrimeStartupToolHealthWarningsAsync(cancellationToken).ConfigureAwait(false);
+        using (var startupToolHealthCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)) {
+            startupToolHealthCts.CancelAfter(StartupToolHealthPrimeBudget);
+            await PrimeStartupToolHealthWarningsAsync(startupToolHealthCts.Token).ConfigureAwait(false);
+        }
 
         using var reader = new StreamReader(_stream, leaveOpen: true);
         using var writer = new StreamWriter(_stream, leaveOpen: true) { AutoFlush = true, NewLine = "\n" };

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthTimeoutPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthTimeoutPolicyTests.cs
@@ -86,4 +86,52 @@ public sealed class StartupToolHealthTimeoutPolicyTests {
 
         Assert.Equal(expected, result);
     }
+
+    [Fact]
+    public void ShouldSkipStartupToolHealthProbe_TrueWhenNextProbeIsInFuture() {
+        var now = new DateTime(2026, 2, 17, 12, 0, 0, DateTimeKind.Utc);
+        var nextProbe = now.AddMinutes(5);
+
+        var result = ChatServiceSession.ShouldSkipStartupToolHealthProbe(now, nextProbe);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldSkipStartupToolHealthProbe_FalseWhenNextProbeIsDue() {
+        var now = new DateTime(2026, 2, 17, 12, 0, 0, DateTimeKind.Utc);
+        var nextProbe = now.AddMinutes(-1);
+
+        var result = ChatServiceSession.ShouldSkipStartupToolHealthProbe(now, nextProbe);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ComputeNextStartupToolHealthProbeUtc_UsesLongerBackoffForTestimoXTimeouts() {
+        var now = new DateTime(2026, 2, 17, 12, 0, 0, DateTimeKind.Utc);
+
+        var next = ChatServiceSession.ComputeNextStartupToolHealthProbeUtc(
+            nowUtc: now,
+            sourceKind: ToolPackSourceKind.ClosedSource,
+            packId: "testimox",
+            errorCode: "tool_timeout",
+            consecutiveFailures: 1);
+
+        Assert.Equal(now.AddMinutes(20), next);
+    }
+
+    [Fact]
+    public void ComputeNextStartupToolHealthProbeUtc_ExponentiallyBacksOffOnRepeatedFailures() {
+        var now = new DateTime(2026, 2, 17, 12, 0, 0, DateTimeKind.Utc);
+
+        var next = ChatServiceSession.ComputeNextStartupToolHealthProbeUtc(
+            nowUtc: now,
+            sourceKind: ToolPackSourceKind.OpenSource,
+            packId: "system",
+            errorCode: "tool_timeout",
+            consecutiveFailures: 3);
+
+        Assert.Equal(now.AddMinutes(20), next);
+    }
 }


### PR DESCRIPTION
## Summary
Improves startup/runtime responsiveness across the 3 requested areas.

1. Startup metadata warm/caching
- Persist local model catalog metadata in app state (`cached models/favorites/recents` + warning/stale state).
- Restore cached model catalog on profile load when runtime endpoint matches, so options UI has immediate model context while runtime reconnects.
- Refresh path now updates cached model metadata opportunistically.

2. Debounced single-flight runtime switching
- `apply_local_provider` now uses a single-flight execution with "latest request wins" queueing.
- If users trigger multiple runtime changes quickly, we no longer spam restarts; we apply current change and drain one latest pending request.
- Status now reports queued runtime changes instead of dropping them.

3. Probe scheduling/backoff + startup budget
- Startup tool-health priming is now bounded by a startup budget (6s) so service startup does not block on long-running probes.
- Added persisted startup tool-health backoff cache (`%LOCALAPPDATA%/IntelligenceX.Chat/startup-tool-health-cache-v1.json`) with exponential backoff for repeated failures/timeouts.
- Repeated non-critical probe timeouts (notably slow/optional packs) are skipped until next backoff window, reducing reconnect churn and noisy startup warnings.

Additional runtime responsiveness tweak
- Sidecar startup connect retry profile now uses shorter bounded retries with early break when service exits, reducing long waits per failed startup cycle.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`

All passed locally.