### PR TITLE
perf(chat): defer onboarding kickoff and add startup phase telemetry

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
@@ -30,6 +30,13 @@ public sealed partial class MainWindow : Window {
     private async Task ConnectAsync(bool fromUserAction = false) {
         await _connectGate.WaitAsync().ConfigureAwait(false);
         try {
+            var captureStartupPhaseTelemetry = !fromUserAction && Volatile.Read(ref _startupFlowState) == 1;
+            void LogStartupConnectPhase(string phase, string state) {
+                if (captureStartupPhaseTelemetry) {
+                    StartupLog.Write("StartupConnect." + phase + " " + state);
+                }
+            }
+
             if (_client is not null && await IsClientAliveAsync(_client).ConfigureAwait(false)) {
                 _isConnected = true;
                 StopAutoReconnectLoop();
@@ -54,12 +61,18 @@ public sealed partial class MainWindow : Window {
             Exception? initialConnectException = null;
 
             try {
+                LogStartupConnectPhase("pipe_connect.initial", "begin");
                 await ConnectClientWithTimeoutAsync(client, pipeName, TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                LogStartupConnectPhase("pipe_connect.initial", "done");
             } catch (Exception ex) {
+                LogStartupConnectPhase("pipe_connect.initial", "failed");
                 initialConnectException = ex;
 
+                LogStartupConnectPhase("ensure_sidecar", "begin");
                 if (await EnsureServiceRunningAsync(pipeName).ConfigureAwait(false)) {
+                    LogStartupConnectPhase("ensure_sidecar", "done");
                     Exception? sidecarConnectException = null;
+                    LogStartupConnectPhase("pipe_connect.retry", "begin");
                     for (var attempt = 0; attempt < StartupConnectRetryTimeouts.Length; attempt++) {
                         try {
                             await ConnectClientWithTimeoutAsync(client, pipeName, StartupConnectRetryTimeouts[attempt]).ConfigureAwait(false);
@@ -78,6 +91,7 @@ public sealed partial class MainWindow : Window {
                     }
 
                     if (sidecarConnectException is not null) {
+                        LogStartupConnectPhase("pipe_connect.retry", "failed");
                         await client.DisposeAsync().ConfigureAwait(false);
                         _isConnected = false;
                         await SetStatusAsync(SessionStatus.ConnectFailed()).ConfigureAwait(false);
@@ -90,7 +104,9 @@ public sealed partial class MainWindow : Window {
                         }
                         return;
                     }
+                    LogStartupConnectPhase("pipe_connect.retry", "done");
                 } else {
+                    LogStartupConnectPhase("ensure_sidecar", "failed");
                     await client.DisposeAsync().ConfigureAwait(false);
                     _isConnected = false;
                     await SetStatusAsync(SessionStatus.ConnectFailed()).ConfigureAwait(false);
@@ -109,9 +125,12 @@ public sealed partial class MainWindow : Window {
             await SetStatusAsync(SessionStatus.Connected()).ConfigureAwait(false);
 
             try {
+                LogStartupConnectPhase("hello", "begin");
                 var hello = await _client.RequestAsync<HelloMessage>(new HelloRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
                 _sessionPolicy = hello.Policy;
+                LogStartupConnectPhase("hello", "done");
             } catch (Exception ex) {
+                LogStartupConnectPhase("hello", "failed");
                 _sessionPolicy = null;
                 if (VerboseServiceLogs || _debugMode) {
                     AppendSystem(SystemNotice.HelloFailed(ex.Message));
@@ -119,9 +138,12 @@ public sealed partial class MainWindow : Window {
             }
 
             try {
+                LogStartupConnectPhase("list_tools", "begin");
                 var toolList = await _client.RequestAsync<ToolListMessage>(new ListToolsRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
                 UpdateToolCatalog(toolList.Tools);
+                LogStartupConnectPhase("list_tools", "done");
             } catch (Exception ex) {
+                LogStartupConnectPhase("list_tools", "failed");
                 if (VerboseServiceLogs || _debugMode) {
                     AppendSystem(SystemNotice.ListToolsFailed(ex.Message));
                 }
@@ -130,13 +152,23 @@ public sealed partial class MainWindow : Window {
             AppendStartupToolHealthWarningsFromPolicy();
             AppendUnavailablePacksFromPolicy();
 
-            _ = await RefreshAuthenticationStateAsync(updateStatus: true).ConfigureAwait(false);
+            LogStartupConnectPhase("auth_refresh", "begin");
             try {
+                _ = await RefreshAuthenticationStateAsync(updateStatus: true).ConfigureAwait(false);
+                LogStartupConnectPhase("auth_refresh", "done");
+            } catch {
+                LogStartupConnectPhase("auth_refresh", "failed");
+                throw;
+            }
+            try {
+                LogStartupConnectPhase("model_profile_sync", "begin");
                 await SyncConnectedServiceProfileAndModelsAsync(
                     forceModelRefresh: false,
                     setProfileNewThread: false,
                     appendWarnings: false).ConfigureAwait(false);
+                LogStartupConnectPhase("model_profile_sync", "done");
             } catch (Exception ex) {
+                LogStartupConnectPhase("model_profile_sync", "failed");
                 if (VerboseServiceLogs || _debugMode) {
                     AppendSystem("Model/profile sync failed: " + ex.Message);
                 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -278,6 +278,7 @@ public sealed partial class MainWindow : Window {
     private bool _modelKickoffAttempted;
     private bool _modelKickoffInProgress;
     private bool _autoSignInAttempted;
+    private int _startupOnboardingDeferredQueued;
     private string _themePreset = "default";
     private string? _sessionUserNameOverride;
     private string? _sessionAssistantPersonaOverride;
@@ -482,17 +483,50 @@ public sealed partial class MainWindow : Window {
     private async Task RunStartupFlowAsync() {
         try {
             StartupLog.Write("MainWindow.StartupFlow begin");
+            StartupLog.Write("StartupPhase.WebView begin");
             await EnsureWebViewInitializedAsync().ConfigureAwait(false);
+            StartupLog.Write("StartupPhase.WebView done");
+            StartupLog.Write("StartupPhase.AppState begin");
             await EnsureAppStateLoadedAsync().ConfigureAwait(false);
+            StartupLog.Write("StartupPhase.AppState done");
+            StartupLog.Write("StartupPhase.Connect begin");
             await EnsureStartupConnectedAsync().ConfigureAwait(false);
+            StartupLog.Write("StartupPhase.Connect done");
+            StartupLog.Write("StartupPhase.Auth begin");
             await EnsureFirstRunAuthenticatedAsync().ConfigureAwait(false);
-            await EnsureOnboardingStartedAsync().ConfigureAwait(false);
+            StartupLog.Write("StartupPhase.Auth done");
+            StartupLog.Write("StartupPhase.Onboarding deferred");
+            QueueDeferredStartupOnboarding();
             Interlocked.Exchange(ref _startupFlowState, 2);
             StartupLog.Write("MainWindow.StartupFlow done");
         } catch (Exception ex) {
             Interlocked.Exchange(ref _startupFlowState, 0);
             StartupLog.Write("MainWindow.StartupFlow failed: " + ex);
         }
+    }
+
+    private void QueueDeferredStartupOnboarding() {
+        if (_shutdownRequested) {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _startupOnboardingDeferredQueued, 1, 0) != 0) {
+            return;
+        }
+
+        _ = Task.Run(async () => {
+            try {
+                await Task.Delay(250).ConfigureAwait(false);
+                if (_shutdownRequested) {
+                    return;
+                }
+                StartupLog.Write("StartupPhase.Onboarding begin");
+                await EnsureOnboardingStartedAsync().ConfigureAwait(false);
+                StartupLog.Write("StartupPhase.Onboarding done");
+            } catch (Exception ex) {
+                StartupLog.Write("StartupPhase.Onboarding failed: " + ex.Message);
+            }
+        });
     }
 
     private void EnsureRestoredIfMinimized() {


### PR DESCRIPTION
## Summary
This PR reduces startup-path blocking and improves startup diagnostics for the chat app.

1. Defer onboarding kickoff off the critical startup path
- `MainWindow.StartupFlow` no longer awaits onboarding kickoff before writing `MainWindow.StartupFlow done`.
- Startup flow now queues deferred onboarding (`QueueDeferredStartupOnboarding`) to run shortly after startup completion.
- Added shutdown-safe guards so deferred kickoff does not run during teardown.

2. Add startup phase telemetry
- Added startup phase markers in `RunStartupFlowAsync`:
  - `StartupPhase.WebView begin/done`
  - `StartupPhase.AppState begin/done`
  - `StartupPhase.Connect begin/done`
  - `StartupPhase.Auth begin/done`
  - `StartupPhase.Onboarding deferred/begin/done`
- Added granular `ConnectAsync` startup logs (only while startup flow is active):
  - `StartupConnect.pipe_connect.initial`
  - `StartupConnect.ensure_sidecar`
  - `StartupConnect.pipe_connect.retry`
  - `StartupConnect.hello`
  - `StartupConnect.list_tools`
  - `StartupConnect.auth_refresh`
  - `StartupConnect.model_profile_sync`

## Why
Recent profiling showed most startup latency after sidecar connect, in post-connect startup work. Deferring onboarding kickoff and adding phase-level telemetry makes startup faster and remaining hotspots easier to isolate.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`

All passed locally.
