### PR TITLE
chore(skills): add PowerShell parity and script pair guard

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -14,3 +14,5 @@ Repo-local skills that make agents more consistent across onboarding, setup, ana
 - Never edit Website files unless explicitly requested.
 - Run the minimum command set needed to prove the change.
 - Use `gh` for PR/checks/comment workflows.
+- Prefer native shell scripts for your environment (`.sh` for Bash, `.ps1` for PowerShell).
+- Script parity is enforced by unit tests (`dotnet test IntelligenceX.UnitTests/IntelligenceX.UnitTests.csproj -c Release --filter SkillScriptParityTests`).

--- a/.agents/skills/intelligencex-analysis-gate/SKILL.md
+++ b/.agents/skills/intelligencex-analysis-gate/SKILL.md
@@ -27,10 +27,13 @@ Use this skill when changing analysis behavior or static-analysis policy:
 
 ## Commands
 - Run suite:
-  - `.agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.sh fast`
-  - `.agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.sh full`
+  - Bash: `.agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.sh fast`
+  - Bash: `.agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.sh full`
+  - PowerShell: `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.ps1 -Mode fast`
+  - PowerShell: `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.ps1 -Mode full`
 - Optional duplication performance benchmark:
-  - `.agents/skills/intelligencex-analysis-gate/scripts/benchmark-duplication.sh`
+  - Bash: `.agents/skills/intelligencex-analysis-gate/scripts/benchmark-duplication.sh`
+  - PowerShell: `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-analysis-gate/scripts/benchmark-duplication.ps1`
   - Environment knobs: `FILES`, `LINES`, `LANGUAGE`, `FRAMEWORK`, `KEEP_WORKDIR`, `WORKDIR`
 
 ## Fail-Fast Rules

--- a/.agents/skills/intelligencex-analysis-gate/scripts/benchmark-duplication.ps1
+++ b/.agents/skills/intelligencex-analysis-gate/scripts/benchmark-duplication.ps1
@@ -1,0 +1,220 @@
+param()
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-Checked([string[]] $Command) {
+    & $Command[0] $Command[1..($Command.Length - 1)]
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed: $($Command -join ' ')"
+    }
+}
+
+function Resolve-RepoRoot {
+    try {
+        return (git rev-parse --show-toplevel).Trim()
+    } catch {
+        throw "ERROR: unable to resolve git repo root."
+    }
+}
+
+function Normalize-Language([string] $Language) {
+    switch ($Language.ToLowerInvariant()) {
+        "csharp" { return @{ Name = "csharp"; Ext = ".cs" } }
+        "cs" { return @{ Name = "csharp"; Ext = ".cs" } }
+        "powershell" { return @{ Name = "powershell"; Ext = ".ps1" } }
+        "ps" { return @{ Name = "powershell"; Ext = ".ps1" } }
+        "javascript" { return @{ Name = "javascript"; Ext = ".js" } }
+        "js" { return @{ Name = "javascript"; Ext = ".js" } }
+        "typescript" { return @{ Name = "typescript"; Ext = ".ts" } }
+        "ts" { return @{ Name = "typescript"; Ext = ".ts" } }
+        "python" { return @{ Name = "python"; Ext = ".py" } }
+        "py" { return @{ Name = "python"; Ext = ".py" } }
+        default {
+            throw "ERROR: unsupported LANGUAGE '$Language'. Use csharp|powershell|javascript|typescript|python."
+        }
+    }
+}
+
+function New-SourceFile([string] $Path, [string] $LanguageName, [int] $Index, [int] $Lines) {
+    $builder = [System.Text.StringBuilder]::new()
+    switch ($LanguageName) {
+        "csharp" {
+            [void] $builder.AppendLine("namespace Bench;")
+            [void] $builder.AppendLine("public class C$Index {")
+            [void] $builder.AppendLine("    public int Sum$Index(int input) {")
+            [void] $builder.AppendLine("        var total = 0;")
+            [void] $builder.AppendLine("        total += input;")
+            for ($j = 1; $j -le $Lines; $j++) {
+                [void] $builder.AppendLine("        total += $j;")
+            }
+            [void] $builder.AppendLine("        return total;")
+            [void] $builder.AppendLine("    }")
+            [void] $builder.AppendLine("}")
+        }
+        "powershell" {
+            [void] $builder.AppendLine("function Get-Sum$Index {")
+            [void] $builder.AppendLine("    param([int]`$InputValue)")
+            [void] $builder.AppendLine("    `$total = 0")
+            [void] $builder.AppendLine("    `$total += `$InputValue")
+            for ($j = 1; $j -le $Lines; $j++) {
+                [void] $builder.AppendLine("    `$total += $j")
+            }
+            [void] $builder.AppendLine("    return `$total")
+            [void] $builder.AppendLine("}")
+        }
+        "javascript" {
+            [void] $builder.AppendLine("export function sum$Index(inputValue) {")
+            [void] $builder.AppendLine("  let total = 0;")
+            [void] $builder.AppendLine("  total += inputValue;")
+            for ($j = 1; $j -le $Lines; $j++) {
+                [void] $builder.AppendLine("  total += $j;")
+            }
+            [void] $builder.AppendLine("  return total;")
+            [void] $builder.AppendLine("}")
+        }
+        "typescript" {
+            [void] $builder.AppendLine("export function sum$Index(inputValue: number): number {")
+            [void] $builder.AppendLine("  let total = 0;")
+            [void] $builder.AppendLine("  total += inputValue;")
+            for ($j = 1; $j -le $Lines; $j++) {
+                [void] $builder.AppendLine("  total += $j;")
+            }
+            [void] $builder.AppendLine("  return total;")
+            [void] $builder.AppendLine("}")
+        }
+        "python" {
+            [void] $builder.AppendLine("def sum_$Index(input_value):")
+            [void] $builder.AppendLine("    total = 0")
+            [void] $builder.AppendLine("    total += input_value")
+            for ($j = 1; $j -le $Lines; $j++) {
+                [void] $builder.AppendLine("    total += $j")
+            }
+            [void] $builder.AppendLine("    return total")
+        }
+        default {
+            throw "ERROR: unsupported language template '$LanguageName'."
+        }
+    }
+    Set-Content -LiteralPath $Path -Value $builder.ToString() -Encoding UTF8
+}
+
+$repoRoot = Resolve-RepoRoot
+Set-Location -LiteralPath $repoRoot
+
+$files = [int]($env:FILES ?? "200")
+$lines = [int]($env:LINES ?? "120")
+$language = $env:LANGUAGE
+if ([string]::IsNullOrWhiteSpace($language)) {
+    $language = "csharp"
+}
+$framework = $env:FRAMEWORK
+if ([string]::IsNullOrWhiteSpace($framework)) {
+    $framework = "net8.0"
+}
+$keepWorkDir = ("" + ($env:KEEP_WORKDIR ?? "0")).Trim() -eq "1"
+$workDir = ("" + $env:WORKDIR).Trim()
+if ([string]::IsNullOrWhiteSpace($workDir)) {
+    $workDir = Join-Path ([System.IO.Path]::GetTempPath()) ("ix-dup-bench-" + [Guid]::NewGuid().ToString("N"))
+}
+
+$languageInfo = Normalize-Language $language
+$languageName = [string]$languageInfo.Name
+$ext = [string]$languageInfo.Ext
+$extWithoutDot = $ext.TrimStart(".")
+
+try {
+    New-Item -ItemType Directory -Force -Path (Join-Path $workDir ".intelligencex") | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $workDir "Analysis/Catalog/rules/internal") | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $workDir "Analysis/Packs") | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $workDir "src") | Out-Null
+
+    Set-Content -LiteralPath (Join-Path $workDir ".intelligencex/reviewer.json") -Value @'
+{
+  "analysis": {
+    "enabled": true,
+    "packs": ["intelligencex-maintainability-default"]
+  }
+}
+'@ -Encoding UTF8
+
+    Set-Content -LiteralPath (Join-Path $workDir "Analysis/Catalog/rules/internal/IXDUP001.json") -Value @"
+{
+  "id": "IXDUP001",
+  "language": "internal",
+  "tool": "IntelligenceX.Maintainability",
+  "toolRuleId": "IXDUP001",
+  "title": "Duplication benchmark rule",
+  "description": "Synthetic duplication benchmark rule.",
+  "category": "Maintainability",
+  "defaultSeverity": "warning",
+  "tags": [
+    "max-duplication-percent:25",
+    "dup-window-lines:8",
+    "include-ext:$extWithoutDot"
+  ]
+}
+"@ -Encoding UTF8
+
+    Set-Content -LiteralPath (Join-Path $workDir "Analysis/Packs/intelligencex-maintainability-default.json") -Value @'
+{
+  "id": "intelligencex-maintainability-default",
+  "label": "IntelligenceX Maintainability",
+  "rules": ["IXDUP001"]
+}
+'@ -Encoding UTF8
+
+    Write-Host "Generating synthetic sources: files=$files lines=$lines language=$languageName workspace=$workDir"
+    for ($i = 1; $i -le $files; $i++) {
+        $filePath = Join-Path $workDir ("src/sample_" + $i + $ext)
+        New-SourceFile -Path $filePath -LanguageName $languageName -Index $i -Lines $lines
+    }
+
+    $start = Get-Date
+    Invoke-Checked @(
+        "dotnet", "run", "--project", "IntelligenceX.Cli/IntelligenceX.Cli.csproj", "--framework", $framework, "--",
+        "analyze", "run",
+        "--workspace", $workDir,
+        "--config", (Join-Path $workDir ".intelligencex/reviewer.json"),
+        "--out", (Join-Path $workDir "artifacts")
+    )
+    $elapsed = ((Get-Date) - $start).TotalSeconds
+
+    $metricsFile = Join-Path $workDir "artifacts/intelligencex.duplication.json"
+    if (-not (Test-Path -LiteralPath $metricsFile -PathType Leaf)) {
+        throw "ERROR: expected duplication metrics file was not produced: $metricsFile"
+    }
+
+    $metrics = Get-Content -LiteralPath $metricsFile -Raw | ConvertFrom-Json
+    $totalSignificant = [int]($metrics.totalSignificantLines ?? 0)
+    $duplicatedSignificant = [int]($metrics.duplicatedSignificantLines ?? 0)
+    $overallPercent = [double]($metrics.overallDuplicatedPercent ?? 0)
+
+    if ($elapsed -le 0) {
+        $filesPerSecond = 0
+        $linesPerSecond = 0
+    } else {
+        $filesPerSecond = $files / $elapsed
+        $linesPerSecond = $totalSignificant / $elapsed
+    }
+
+    Write-Host "Duplication benchmark complete"
+    Write-Host ("- Elapsed seconds: {0:N3}" -f $elapsed)
+    Write-Host "- Files generated: $files"
+    Write-Host "- Significant lines: $totalSignificant"
+    Write-Host "- Duplicated significant lines: $duplicatedSignificant"
+    Write-Host ("- Overall duplicated percent: {0}" -f $overallPercent)
+    Write-Host ("- Throughput (files/sec): {0:N2}" -f $filesPerSecond)
+    Write-Host ("- Throughput (significant-lines/sec): {0:N2}" -f $linesPerSecond)
+} finally {
+    if ($keepWorkDir) {
+        Write-Host "Workspace preserved at: $workDir"
+    } else {
+        try {
+            if (Test-Path -LiteralPath $workDir) {
+                Remove-Item -LiteralPath $workDir -Recurse -Force
+            }
+        } catch {
+            # Best-effort cleanup.
+        }
+    }
+}

--- a/.agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.ps1
+++ b/.agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.ps1
@@ -1,0 +1,54 @@
+param(
+    [ValidateSet("fast", "full")]
+    [string] $Mode = "fast"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Find-RepoRoot {
+    $dir = (Get-Location).Path
+    while ($true) {
+        if (Test-Path -LiteralPath (Join-Path $dir "IntelligenceX.sln")) {
+            return $dir
+        }
+
+        $parent = Split-Path -LiteralPath $dir -Parent
+        if ([string]::IsNullOrWhiteSpace($parent) -or $parent -eq $dir) {
+            return $null
+        }
+        $dir = $parent
+    }
+}
+
+function Invoke-Checked([string[]] $Command) {
+    & $Command[0] $Command[1..($Command.Length - 1)]
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed: $($Command -join ' ')"
+    }
+}
+
+$repoRoot = $env:REPO_ROOT
+if ([string]::IsNullOrWhiteSpace($repoRoot)) {
+    $repoRoot = Find-RepoRoot
+}
+if ([string]::IsNullOrWhiteSpace($repoRoot)) {
+    Write-Error "ERROR: could not locate repo root (expected to find IntelligenceX.sln)"
+    exit 1
+}
+
+Set-Location -LiteralPath $repoRoot
+
+function Run-Fast {
+    Invoke-Checked @("dotnet", "run", "--project", "IntelligenceX.Cli/IntelligenceX.Cli.csproj", "--framework", "net8.0", "--", "analyze", "validate-catalog", "--workspace", ".")
+    Invoke-Checked @("dotnet", "run", "--project", "IntelligenceX.Cli/IntelligenceX.Cli.csproj", "--framework", "net8.0", "--", "analyze", "run", "--config", ".intelligencex/reviewer.json", "--out", "artifacts", "--framework", "net8.0")
+}
+
+if ($Mode -eq "full") {
+    Invoke-Checked @("dotnet", "build", "IntelligenceX.sln", "-c", "Release")
+    Invoke-Checked @("dotnet", "test", "IntelligenceX.sln", "-c", "Release", "--no-build", "-v", "minimal")
+    Invoke-Checked @("dotnet", "./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll")
+    Invoke-Checked @("dotnet", "./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll")
+}
+
+Run-Fast
+Write-Host "OK: analysis suite completed ($Mode)"

--- a/.agents/skills/intelligencex-first-pr-rollout/SKILL.md
+++ b/.agents/skills/intelligencex-first-pr-rollout/SKILL.md
@@ -24,7 +24,8 @@ Use this skill to verify the first live reviewer run after onboarding/setup is h
 
 ## Commands
 - Run verification:
-  - `.agents/skills/intelligencex-first-pr-rollout/scripts/verify-first-pr-rollout.sh --repo <owner/name> --pr <number> --require-config --require-analysis-sections`
+  - Bash: `.agents/skills/intelligencex-first-pr-rollout/scripts/verify-first-pr-rollout.sh --repo <owner/name> --pr <number> --require-config --require-analysis-sections`
+  - PowerShell: `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-first-pr-rollout/scripts/verify-first-pr-rollout.ps1 -Repo <owner/name> -Pr <number> -RequireConfig -RequireAnalysisSections`
 
 ## Fail-Fast Rules
 - Stop if GitHub auth is missing.

--- a/.agents/skills/intelligencex-first-pr-rollout/scripts/verify-first-pr-rollout.ps1
+++ b/.agents/skills/intelligencex-first-pr-rollout/scripts/verify-first-pr-rollout.ps1
@@ -1,0 +1,165 @@
+param(
+    [string] $Repo = "",
+    [string] $Pr = "",
+    [string] $OutDir = "artifacts/first-pr-rollout",
+    [switch] $RequireConfig,
+    [switch] $RequireAnalysisSections
+)
+
+$ErrorActionPreference = "Stop"
+
+function Fail([string] $Message) {
+    Write-Error $Message
+    exit 1
+}
+
+function Ensure-Tool([string] $Tool) {
+    if (-not (Get-Command $Tool -ErrorAction SilentlyContinue)) {
+        Fail "ERROR: $Tool is required"
+    }
+}
+
+function Invoke-GhJson([string[]] $Args) {
+    $output = & gh @Args
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh command failed: gh $($Args -join ' ')"
+    }
+    return $output
+}
+
+if ([string]::IsNullOrWhiteSpace($Repo) -or [string]::IsNullOrWhiteSpace($Pr)) {
+    Fail "ERROR: --Repo and --Pr are required"
+}
+
+Ensure-Tool "gh"
+Ensure-Tool "rg"
+
+& gh auth status *> $null
+if ($LASTEXITCODE -ne 0) {
+    Fail "ERROR: gh auth status failed; login required"
+}
+
+$root = ""
+try {
+    $root = (git rev-parse --show-toplevel 2>$null).Trim()
+} catch {
+    $root = ""
+}
+if ([string]::IsNullOrWhiteSpace($root)) {
+    $root = (Get-Location).Path
+}
+Set-Location -LiteralPath $root
+
+$stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$safeRepo = $Repo.Replace("/", "_")
+$runDir = Join-Path $OutDir ("$safeRepo-pr$Pr-$stamp")
+New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+
+$prJsonPath = Join-Path $runDir "pr.json"
+$checksPath = Join-Path $runDir "checks.txt"
+$commentsPath = Join-Path $runDir "comments.txt"
+$workflowPath = Join-Path $runDir "workflow.review-intelligencex.yml"
+$reviewerPath = Join-Path $runDir "reviewer.json"
+
+$prJson = Invoke-GhJson @("pr", "view", $Pr, "--repo", $Repo, "--json", "number,url,state,mergeable,mergeStateStatus,statusCheckRollup")
+$prJson | Set-Content -LiteralPath $prJsonPath -Encoding UTF8
+
+try {
+    $checks = & gh pr checks $Pr --repo $Repo
+    $checks | Set-Content -LiteralPath $checksPath -Encoding UTF8
+} catch {
+    if ($null -ne $checks) {
+        $checks | Set-Content -LiteralPath $checksPath -Encoding UTF8
+    }
+}
+
+$comments = Invoke-GhJson @("pr", "view", $Pr, "--repo", $Repo, "--json", "comments", "--jq", ".comments[].body")
+$comments | Set-Content -LiteralPath $commentsPath -Encoding UTF8
+
+$defaultBranch = (Invoke-GhJson @("repo", "view", $Repo, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name")).Trim()
+if ([string]::IsNullOrWhiteSpace($defaultBranch) -or $defaultBranch -eq "null") {
+    Fail "ERROR: failed to resolve default branch"
+}
+
+$workflowContentB64 = Invoke-GhJson @("api", "repos/$Repo/contents/.github/workflows/review-intelligencex.yml?ref=$defaultBranch", "--jq", ".content")
+$workflowBytes = [Convert]::FromBase64String(($workflowContentB64 -replace "\s", ""))
+[System.IO.File]::WriteAllBytes($workflowPath, $workflowBytes)
+
+try {
+    $reviewerContentB64 = Invoke-GhJson @("api", "repos/$Repo/contents/.intelligencex/reviewer.json?ref=$defaultBranch", "--jq", ".content")
+    $reviewerBytes = [Convert]::FromBase64String(($reviewerContentB64 -replace "\s", ""))
+    [System.IO.File]::WriteAllBytes($reviewerPath, $reviewerBytes)
+} catch {
+    # reviewer.json may be absent in some modes; validation below controls requirement.
+}
+
+$validator = Join-Path $root ".agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.ps1"
+if (Test-Path -LiteralPath $validator -PathType Leaf) {
+    & $validator $workflowPath
+    if ($LASTEXITCODE -ne 0) {
+        Fail "ERROR: workflow managed block validation failed"
+    }
+} else {
+    $wf = Get-Content -LiteralPath $workflowPath -Raw
+    if ($wf -notmatch "(?m)^# INTELLIGENCEX:BEGIN\s*$") {
+        Fail "ERROR: workflow missing INTELLIGENCEX:BEGIN"
+    }
+    if ($wf -notmatch "(?m)^# INTELLIGENCEX:END\s*$") {
+        Fail "ERROR: workflow missing INTELLIGENCEX:END"
+    }
+}
+
+if ($RequireConfig) {
+    if (-not (Test-Path -LiteralPath $reviewerPath -PathType Leaf) -or [string]::IsNullOrWhiteSpace((Get-Content -LiteralPath $reviewerPath -Raw))) {
+        Fail "ERROR: reviewer config required but missing on default branch"
+    }
+}
+
+function Require-CheckSuccess([string] $Name) {
+    $conclusion = (Invoke-GhJson @("pr", "view", $Pr, "--repo", $Repo, "--json", "statusCheckRollup", "--jq", ".statusCheckRollup[] | select(.name == `"$Name`") | .conclusion")) | Select-Object -First 1
+    if ([string]::IsNullOrWhiteSpace($conclusion)) {
+        Fail "ERROR: required check not found: $Name"
+    }
+    if ($conclusion.Trim().ToUpperInvariant() -ne "SUCCESS") {
+        Fail "ERROR: check '$Name' is not SUCCESS (got: $conclusion)"
+    }
+}
+
+Require-CheckSuccess "Static Analysis Gate"
+Require-CheckSuccess "AI Review (Fail-Open)"
+Require-CheckSuccess "Ubuntu"
+
+$commentsRaw = Get-Content -LiteralPath $commentsPath -Raw
+if ($commentsRaw -notmatch "<!-- intelligencex:summary -->") {
+    Fail "ERROR: reviewer sticky summary marker not found"
+}
+if ($commentsRaw -notmatch "Reviewed commit:") {
+    Fail "ERROR: reviewed commit label not found in comments"
+}
+if ($commentsRaw -notmatch "Diff range:") {
+    Fail "ERROR: diff range label not found in comments"
+}
+
+if ($RequireAnalysisSections) {
+    if ($commentsRaw -notmatch "### Static Analysis Policy") {
+        Fail "ERROR: Static Analysis Policy section not found"
+    }
+    if ($commentsRaw -notmatch "### Static Analysis") {
+        Fail "ERROR: Static Analysis section not found"
+    }
+}
+
+Write-Host "OK: first PR rollout verification passed"
+Write-Host "repo=$Repo"
+Write-Host "pr=$Pr"
+Write-Host "default_branch=$defaultBranch"
+Write-Host "snapshot_dir=$runDir"
+Write-Host "pr_json=$prJsonPath"
+Write-Host "checks_txt=$checksPath"
+Write-Host "comments_txt=$commentsPath"
+Write-Host "workflow_yaml=$workflowPath"
+if (Test-Path -LiteralPath $reviewerPath -PathType Leaf) {
+    Write-Host "reviewer_json=$reviewerPath"
+} else {
+    Write-Host "reviewer_json=missing"
+}

--- a/.agents/skills/intelligencex-onboarding-setup/SKILL.md
+++ b/.agents/skills/intelligencex-onboarding-setup/SKILL.md
@@ -27,11 +27,14 @@ Use this skill when work touches onboarding/setup behavior in:
 
 ## Commands
 - Preflight:
-  - `.agents/skills/intelligencex-onboarding-setup/scripts/preflight.sh`
+  - Bash: `.agents/skills/intelligencex-onboarding-setup/scripts/preflight.sh`
+  - PowerShell: `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-onboarding-setup/scripts/preflight.ps1`
 - Fast validation:
-  - `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh fast`
+  - Bash: `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh fast`
+  - PowerShell: `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-onboarding-setup/scripts/local-validate.ps1 -Mode fast`
 - Full validation:
-  - `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh full`
+  - Bash: `.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.sh full`
+  - PowerShell: `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-onboarding-setup/scripts/local-validate.ps1 -Mode full`
 
 ## Fail-Fast Rules
 - Stop if preflight fails (dirty tree, wrong branch, missing tools).

--- a/.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.ps1
+++ b/.agents/skills/intelligencex-onboarding-setup/scripts/local-validate.ps1
@@ -1,0 +1,26 @@
+param(
+    [ValidateSet("fast", "full")]
+    [string] $Mode = "fast"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-Checked([string[]] $Command) {
+    & $Command[0] $Command[1..($Command.Length - 1)]
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed: $($Command -join ' ')"
+    }
+}
+
+$repoRoot = (git rev-parse --show-toplevel).Trim()
+Set-Location -LiteralPath $repoRoot
+
+Invoke-Checked @("dotnet", "build", "IntelligenceX.sln", "-c", "Release")
+Invoke-Checked @("dotnet", "test", "IntelligenceX.sln", "-c", "Release", "--no-build", "-v", "minimal")
+
+if ($Mode -eq "full") {
+    Invoke-Checked @("dotnet", "./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll")
+    Invoke-Checked @("dotnet", "./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll")
+}
+
+Write-Host "OK: onboarding validation completed ($Mode)"

--- a/.agents/skills/intelligencex-onboarding-setup/scripts/preflight.ps1
+++ b/.agents/skills/intelligencex-onboarding-setup/scripts/preflight.ps1
@@ -1,0 +1,43 @@
+param()
+
+$ErrorActionPreference = "Stop"
+
+function Fail([string] $Message) {
+    Write-Error $Message
+    exit 1
+}
+
+try {
+    $repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+} catch {
+    $repoRoot = ""
+}
+
+if ([string]::IsNullOrWhiteSpace($repoRoot)) {
+    Fail "ERROR: not inside a git repository"
+}
+
+Set-Location -LiteralPath $repoRoot
+
+foreach ($tool in @("git", "dotnet", "rg", "gh")) {
+    if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+        Fail "ERROR: required tool not found: $tool"
+    }
+}
+
+$branch = (git branch --show-current).Trim()
+if (-not $branch.StartsWith("codex/")) {
+    Fail "ERROR: branch must start with codex/ (current: $branch)"
+}
+
+$allowDirty = ("" + $env:ALLOW_DIRTY).Trim()
+if ($allowDirty -ne "1") {
+    $dirty = git status --porcelain
+    if (-not [string]::IsNullOrWhiteSpace(($dirty | Out-String))) {
+        Fail "ERROR: working tree is not clean (set ALLOW_DIRTY=1 to override)"
+    }
+}
+
+Write-Host "OK: preflight passed"
+Write-Host "repo=$repoRoot"
+Write-Host "branch=$branch"

--- a/.agents/skills/intelligencex-pr-unblock-loop/SKILL.md
+++ b/.agents/skills/intelligencex-pr-unblock-loop/SKILL.md
@@ -25,9 +25,11 @@ Use this skill when a PR must be unblocked/merged and checks or bot comments req
 
 ## Commands
 - Snapshot state:
-  - `.agents/skills/intelligencex-pr-unblock-loop/scripts/gather-pr-state.sh <pr-number>`
+  - Bash: `.agents/skills/intelligencex-pr-unblock-loop/scripts/gather-pr-state.sh <pr-number>`
+  - PowerShell: `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-pr-unblock-loop/scripts/gather-pr-state.ps1 <pr-number>`
 - Watch checks:
-  - `.agents/skills/intelligencex-pr-unblock-loop/scripts/watch-checks.sh <pr-number>`
+  - Bash: `.agents/skills/intelligencex-pr-unblock-loop/scripts/watch-checks.sh <pr-number>`
+  - PowerShell: `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-pr-unblock-loop/scripts/watch-checks.ps1 <pr-number>`
 
 ## Fail-Fast Rules
 - Do not churn code for infra-blocked failures.

--- a/.agents/skills/intelligencex-pr-unblock-loop/scripts/gather-pr-state.ps1
+++ b/.agents/skills/intelligencex-pr-unblock-loop/scripts/gather-pr-state.ps1
@@ -1,0 +1,23 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $PrNumber
+)
+
+$ErrorActionPreference = "Stop"
+
+$repo = "EvotecIT/IntelligenceX"
+$repoRoot = (git rev-parse --show-toplevel).Trim()
+$artifactDir = Join-Path $repoRoot ("artifacts/pr-" + $PrNumber)
+New-Item -ItemType Directory -Force -Path $artifactDir | Out-Null
+
+gh pr view $PrNumber --repo $repo --json number,title,headRefName,baseRefName,state,mergeable,mergeStateStatus,url | Set-Content -Path (Join-Path $artifactDir "pr.json") -Encoding UTF8
+
+try {
+    gh pr checks $PrNumber --repo $repo | Set-Content -Path (Join-Path $artifactDir "checks.txt") -Encoding UTF8
+} catch {
+    # Keep snapshot flow resilient, matching the shell script behavior.
+}
+
+gh pr view $PrNumber --repo $repo --comments --json comments | Set-Content -Path (Join-Path $artifactDir "comments.json") -Encoding UTF8
+
+Write-Host "Saved PR snapshot to: $artifactDir"

--- a/.agents/skills/intelligencex-pr-unblock-loop/scripts/watch-checks.ps1
+++ b/.agents/skills/intelligencex-pr-unblock-loop/scripts/watch-checks.ps1
@@ -1,0 +1,7 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $PrNumber
+)
+
+$ErrorActionPreference = "Stop"
+gh pr checks $PrNumber --repo EvotecIT/IntelligenceX --watch --interval 10

--- a/.agents/skills/intelligencex-reviewer-bootstrap/SKILL.md
+++ b/.agents/skills/intelligencex-reviewer-bootstrap/SKILL.md
@@ -29,9 +29,11 @@ Use this skill when setting up or validating IntelligenceX Reviewer onboarding i
 
 ## Core Commands
 - Dry-run + extraction + checks:
-  - `.agents/skills/intelligencex-reviewer-bootstrap/scripts/bootstrap-dry-run.sh --repo <owner/name> --mode setup`
+  - Bash: `.agents/skills/intelligencex-reviewer-bootstrap/scripts/bootstrap-dry-run.sh --repo <owner/name> --mode setup`
+  - PowerShell: `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-reviewer-bootstrap/scripts/bootstrap-dry-run.ps1 -Repo <owner/name> -Mode setup`
 - Validate existing committed workflow in current repo:
-  - `.agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.sh .github/workflows/review-intelligencex.yml`
+  - Bash: `.agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.sh .github/workflows/review-intelligencex.yml`
+  - PowerShell: `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.ps1 .github/workflows/review-intelligencex.yml`
 
 ## Modes
 - `setup`: write/update workflow + reviewer config

--- a/.agents/skills/intelligencex-reviewer-bootstrap/scripts/bootstrap-dry-run.ps1
+++ b/.agents/skills/intelligencex-reviewer-bootstrap/scripts/bootstrap-dry-run.ps1
@@ -1,0 +1,164 @@
+param(
+    [string] $Repo = "",
+    [ValidateSet("setup", "update-secret", "cleanup")]
+    [string] $Mode = "setup",
+    [ValidateSet("enabled", "disabled")]
+    [string] $Analysis = "enabled",
+    [string] $Packs = "all-50",
+    [switch] $ExplicitSecrets,
+    [string] $OutDir = "artifacts/bootstrap-dry-run",
+    [string] $Token = "",
+    [string] $Branch = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Fail([string] $Message) {
+    Write-Error $Message
+    exit 1
+}
+
+function Extract-Section([string] $Content, [string] $SectionName) {
+    $startMarker = "--- $SectionName ---"
+    $lines = $Content -split "`r?`n"
+    $capture = $false
+    $result = [System.Collections.Generic.List[string]]::new()
+    foreach ($line in $lines) {
+        if (-not $capture) {
+            if ($line -eq $startMarker) {
+                $capture = $true
+            }
+            continue
+        }
+
+        if ($line.StartsWith("--- ")) {
+            break
+        }
+        $result.Add($line)
+    }
+    return ($result -join [Environment]::NewLine).TrimEnd()
+}
+
+if ([string]::IsNullOrWhiteSpace($Repo)) {
+    Fail "ERROR: --repo is required"
+}
+
+if ([string]::IsNullOrWhiteSpace($Token)) {
+    $Token = ("" + $env:INTELLIGENCEX_GITHUB_TOKEN).Trim()
+}
+if ([string]::IsNullOrWhiteSpace($Token)) {
+    $Token = ("" + $env:GITHUB_TOKEN).Trim()
+}
+if ([string]::IsNullOrWhiteSpace($Token)) {
+    $Token = ("" + $env:GH_TOKEN).Trim()
+}
+if ([string]::IsNullOrWhiteSpace($Token)) {
+    try {
+        $Token = (gh auth token 2>$null).Trim()
+    } catch {
+        $Token = ""
+    }
+}
+if ([string]::IsNullOrWhiteSpace($Token)) {
+    Fail "ERROR: GitHub token not found. Provide --Token or set GITHUB_TOKEN/GH_TOKEN/INTELLIGENCEX_GITHUB_TOKEN."
+}
+
+$root = (git rev-parse --show-toplevel).Trim()
+Set-Location -LiteralPath $root
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+$stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$safeRepo = $Repo.Replace("/", "_")
+$runDir = Join-Path $OutDir ("$safeRepo-$Mode-$stamp")
+New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+
+$rawLog = Join-Path $runDir "setup-dry-run.txt"
+$reviewerJson = Join-Path $runDir "reviewer.generated.json"
+$workflowYaml = Join-Path $runDir "workflow.generated.yml"
+
+$cmd = [System.Collections.Generic.List[string]]::new()
+$cmd.AddRange(@(
+    "run", "--project", "IntelligenceX.Cli/IntelligenceX.Cli.csproj", "--framework", "net8.0", "--",
+    "setup",
+    "--repo", $Repo,
+    "--github-token", $Token,
+    "--dry-run"
+))
+
+if (-not [string]::IsNullOrWhiteSpace($Branch)) {
+    $cmd.AddRange(@("--branch", $Branch))
+}
+
+switch ($Mode) {
+    "setup" {
+        $cmd.AddRange(@("--with-config", "--skip-secret"))
+        if ($Analysis -eq "enabled") {
+            $cmd.AddRange(@("--analysis-enabled", "true", "--analysis-packs", $Packs))
+        } else {
+            $cmd.AddRange(@("--analysis-enabled", "false"))
+        }
+        if ($ExplicitSecrets) {
+            $cmd.Add("--explicit-secrets")
+        }
+    }
+    "update-secret" {
+        $cmd.Add("--update-secret")
+    }
+    "cleanup" {
+        $cmd.AddRange(@("--cleanup", "--keep-secret"))
+    }
+}
+
+$output = & dotnet $cmd 2>&1
+if ($LASTEXITCODE -ne 0) {
+    $output | Tee-Object -FilePath $rawLog
+    Fail "ERROR: setup dry-run command failed."
+}
+$output | Tee-Object -FilePath $rawLog | Out-Host
+$rawContent = ($output -join [Environment]::NewLine)
+
+$reviewerSection = Extract-Section -Content $rawContent -SectionName ".intelligencex/reviewer.json"
+$workflowSection = Extract-Section -Content $rawContent -SectionName ".github/workflows/review-intelligencex.yml"
+
+Set-Content -LiteralPath $reviewerJson -Value $reviewerSection -Encoding UTF8
+Set-Content -LiteralPath $workflowYaml -Value $workflowSection -Encoding UTF8
+
+if ($Mode -eq "setup") {
+    if (-not (Test-Path -LiteralPath $reviewerJson) -or [string]::IsNullOrWhiteSpace((Get-Content -LiteralPath $reviewerJson -Raw))) {
+        Fail "ERROR: setup mode expected reviewer config block in dry-run output."
+    }
+    $reviewerContent = Get-Content -LiteralPath $reviewerJson -Raw
+    if ($reviewerContent -notmatch '"review"\s*:\s*\{') {
+        Fail "ERROR: generated reviewer config missing review block."
+    }
+    if ($Analysis -eq "enabled" -and $reviewerContent -notmatch '"analysis"\s*:\s*\{') {
+        Fail "ERROR: analysis requested but generated reviewer config has no analysis block."
+    }
+}
+
+if ($Mode -ne "update-secret") {
+    if (-not (Test-Path -LiteralPath $workflowYaml) -or [string]::IsNullOrWhiteSpace((Get-Content -LiteralPath $workflowYaml -Raw))) {
+        Fail "ERROR: expected workflow block in dry-run output."
+    }
+
+    $workflowContent = Get-Content -LiteralPath $workflowYaml -Raw
+    if ($workflowContent -notmatch "(?m)^# INTELLIGENCEX:BEGIN\s*$") {
+        Fail "ERROR: generated workflow missing INTELLIGENCEX:BEGIN marker."
+    }
+    if ($workflowContent -notmatch "(?m)^# INTELLIGENCEX:END\s*$") {
+        Fail "ERROR: generated workflow missing INTELLIGENCEX:END marker."
+    }
+    if ($workflowContent -notmatch "(?m)^\s*uses:\s+.+review-intelligencex\.yml@") {
+        Fail "ERROR: generated workflow missing reusable review workflow reference."
+    }
+}
+
+Write-Host "OK: bootstrap dry-run checks passed"
+Write-Host "run_dir=$runDir"
+Write-Host "raw_log=$rawLog"
+if (-not [string]::IsNullOrWhiteSpace((Get-Content -LiteralPath $reviewerJson -Raw))) {
+    Write-Host "reviewer_json=$reviewerJson"
+}
+if (-not [string]::IsNullOrWhiteSpace((Get-Content -LiteralPath $workflowYaml -Raw))) {
+    Write-Host "workflow_yaml=$workflowYaml"
+}

--- a/.agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.ps1
+++ b/.agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.ps1
@@ -1,0 +1,45 @@
+param(
+    [string] $WorkflowPath = ".github/workflows/review-intelligencex.yml"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Fail([string] $Message) {
+    Write-Error $Message
+    exit 1
+}
+
+if (-not (Test-Path -LiteralPath $WorkflowPath -PathType Leaf)) {
+    Fail "ERROR: workflow file not found: $WorkflowPath"
+}
+
+$content = Get-Content -LiteralPath $WorkflowPath -Raw
+
+if ($content -notmatch "(?m)^# INTELLIGENCEX:BEGIN\s*$") {
+    Fail "ERROR: missing INTELLIGENCEX:BEGIN marker"
+}
+if ($content -notmatch "(?m)^# INTELLIGENCEX:END\s*$") {
+    Fail "ERROR: missing INTELLIGENCEX:END marker"
+}
+if ($content -notmatch "(?m)^\s*review:\s*$") {
+    Fail "ERROR: missing review job in workflow"
+}
+if ($content -notmatch "(?m)^\s*uses:\s+.+review-intelligencex\.yml@") {
+    Fail "ERROR: missing reusable review workflow reference"
+}
+if ($content -notmatch "(?m)^\s*provider:\s+") {
+    Fail "ERROR: missing provider input in managed block"
+}
+if ($content -notmatch "(?m)^\s*model:\s+") {
+    Fail "ERROR: missing model input in managed block"
+}
+
+if ($content -match "(?m)^\s*secrets:\s*inherit\s*$") {
+    Write-Host "OK: workflow uses inherited secrets"
+} elseif ($content -match "INTELLIGENCEX_AUTH_B64") {
+    Write-Host "OK: workflow uses explicit secrets block"
+} else {
+    Fail "ERROR: workflow has neither secrets: inherit nor explicit INTELLIGENCEX secrets"
+}
+
+Write-Host "OK: managed workflow validation passed ($WorkflowPath)"

--- a/IntelligenceX.UnitTests/SkillScriptParityTests.cs
+++ b/IntelligenceX.UnitTests/SkillScriptParityTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace IntelligenceX.UnitTests;
+
+public sealed class SkillScriptParityTests {
+    [Fact]
+    public void EachSkillShellScript_HasPowerShellPeer() {
+        var repoRoot = FindRepoRoot();
+        var skillsRoot = Path.Combine(repoRoot, ".agents", "skills");
+        Assert.True(Directory.Exists(skillsRoot), "Skills directory was not found: " + skillsRoot);
+
+        var shellScripts = Directory
+            .EnumerateFiles(skillsRoot, "*.sh", SearchOption.AllDirectories)
+            .Where(path => path.Contains(Path.DirectorySeparatorChar + "scripts" + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Assert.NotEmpty(shellScripts);
+
+        var missingPowerShellPeers = new List<string>();
+        for (var i = 0; i < shellScripts.Length; i++) {
+            var shellPath = shellScripts[i];
+            var powerShellPath = Path.ChangeExtension(shellPath, ".ps1");
+            if (!File.Exists(powerShellPath)) {
+                missingPowerShellPeers.Add(Path.GetRelativePath(repoRoot, shellPath));
+            }
+        }
+
+        Assert.True(
+            missingPowerShellPeers.Count == 0,
+            "Missing PowerShell script peers for: " + string.Join(", ", missingPowerShellPeers));
+    }
+
+    private static string FindRepoRoot() {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null) {
+            if (File.Exists(Path.Combine(dir.FullName, "IntelligenceX.sln"))) {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root from " + AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
Closes #475

## Summary
Adds native PowerShell parity for repo-local skill scripts so Windows users can run skills without Git Bash/WSL.

### What changed
1. Added `.ps1` peers for all existing skill `scripts/*.sh` entrypoints:
- onboarding setup: `preflight.ps1`, `local-validate.ps1`
- analysis gate: `run-analysis-suite.ps1`, `benchmark-duplication.ps1`
- PR unblock loop: `gather-pr-state.ps1`, `watch-checks.ps1`
- reviewer bootstrap: `bootstrap-dry-run.ps1`, `verify-managed-workflow.ps1`
- first PR rollout: `verify-first-pr-rollout.ps1`

2. Updated skill docs to show both Bash and PowerShell commands in each `SKILL.md`.

3. Updated `.agents/skills/README.md` with cross-platform guidance and a parity validation command.

4. Added automated parity guard:
- `IntelligenceX.UnitTests/SkillScriptParityTests.cs`
- Verifies every `/.agents/skills/**/scripts/*.sh` has a matching `.ps1` peer.

## Validation
- Script pairing audit: all `scripts/*.sh` have `scripts/*.ps1`
- PowerShell parse check: all `scripts/*.ps1` parse cleanly
- `dotnet test IntelligenceX.UnitTests/IntelligenceX.UnitTests.csproj -c Release --filter SkillScriptParityTests`

All passed locally.
