### PR TITLE
feat(todo): improve triage signal quality and project view guidance

### DIFF
--- a/Docs/reviewer/project-bootstrap-sync.md
+++ b/Docs/reviewer/project-bootstrap-sync.md
@@ -87,6 +87,7 @@ intelligencex todo project-sync \
 ## What sync updates
 
 - Project item fields for triage and vision fit.
+- Signal-quality fields (`Signal Quality`, `Signal Quality Score`, `Signal Quality Notes`).
 - Suggested maintainership decision signal (`IX Suggested Decision`).
 - Optional managed label reconciliation for IX taxonomies.
 - Optional assistive cross-link comments for related PR/issue context.
@@ -99,6 +100,8 @@ Template files:
 
 - `IntelligenceX.Cli/Templates/triage-index-scheduled.yml`
 - `IntelligenceX.Cli/Templates/triage-project-sync.yml`
+
+The project-sync workflow template also emits `artifacts/triage/ix-project-view-apply.md` so maintainers can continuously see missing view coverage and recommended columns.
 
 Recommended rollout:
 

--- a/Docs/reviewer/project-views-and-ops.md
+++ b/Docs/reviewer/project-views-and-ops.md
@@ -42,6 +42,8 @@ Useful options:
 - `--issue <n>` upserts plan comment to an existing issue.
 - `--out <path>` writes markdown to custom location.
 
+Both checklist and apply-plan outputs include recommended columns per view. Use those column sets, otherwise triage quality signals stay hidden and the board appears weak.
+
 ## Sync bot feedback into TODO.md
 
 Use this to keep explicit bot checklist tasks visible in one backlog:
@@ -105,7 +107,8 @@ Outputs:
 1. Run `sync-bot-feedback` during PR-review sweeps.
 2. Refresh triage/vision artifacts daily or per release train.
 3. Sync project fields before backlog grooming.
-4. Regenerate view checklist/apply plan when project layout drifts.
+4. Triage `Signal Quality = low` items first and request better PR/issue context before acting on recommendations.
+5. Regenerate view checklist/apply plan when project layout drifts.
 
 ## Related docs
 

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -17,6 +17,7 @@ These commands are assistive. They are not an autonomous production decision sys
 - Scope alignment checks against `VISION.md` (`vision-check`).
 - GitHub Project field sync for triage at scale (`project-init`, `project-sync`, `project-bootstrap`).
 - Maintainer-assist view checklist and apply plan generation (`project-view-checklist`, `project-view-apply`).
+- Signal quality grading (`high`/`medium`/`low`) to separate strong recommendations from weak-context items.
 
 ## Recommended end-to-end flow
 
@@ -67,6 +68,7 @@ intelligencex todo project-view-checklist --config artifacts/triage/ix-project-c
 - Project setup and sync requires GitHub `project` scope (`read:project` also required for sync reads).
 - Issue-posting helpers require issue write permission.
 - Use `--dry-run` on sync commands before enabling mutating operations.
+- Treat low-signal items (`Signal Quality = low`, `ix/signal:low`) as context-gathering tasks, not decision-ready recommendations.
 
 ## Related docs
 

--- a/IntelligenceX.Cli/Templates/triage-project-sync.yml
+++ b/IntelligenceX.Cli/Templates/triage-project-sync.yml
@@ -95,6 +95,23 @@ jobs:
             --apply-labels \
             --apply-link-comments
 
+      - name: Build project view apply plan
+        env:
+          GH_TOKEN: ${{ secrets.IX_PROJECT_TOKEN != '' && secrets.IX_PROJECT_TOKEN || github.token }}
+        run: |
+          OWNER="${{ github.event.inputs.owner }}"
+          if [ -z "$OWNER" ]; then OWNER="{{Owner}}"; fi
+
+          PROJECT_NUMBER="${{ github.event.inputs.project_number }}"
+          if [ -z "$PROJECT_NUMBER" ]; then PROJECT_NUMBER="{{ProjectNumber}}"; fi
+
+          dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- \
+            todo project-view-apply \
+            --repo "${{ github.repository }}" \
+            --owner "$OWNER" \
+            --project "$PROJECT_NUMBER" \
+            --out artifacts/triage/ix-project-view-apply.md
+
       - name: Upload triage artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -134,6 +151,13 @@ jobs:
               echo "## Vision Check"
               echo
               cat artifacts/triage/ix-vision-check.md
+              echo
+            fi
+
+            if [ -f artifacts/triage/ix-project-view-apply.md ]; then
+              echo "## Project View Apply Plan"
+              echo
+              cat artifacts/triage/ix-project-view-apply.md
               echo
             fi
           } > "$SUMMARY_FILE"

--- a/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
@@ -28,6 +28,13 @@ internal static class ProjectFieldCatalog {
             "ci"
         }),
         new ProjectFieldDefinition("Category Confidence", "NUMBER", Array.Empty<string>()),
+        new ProjectFieldDefinition("Signal Quality", "SINGLE_SELECT", new[] {
+            "high",
+            "medium",
+            "low"
+        }),
+        new ProjectFieldDefinition("Signal Quality Score", "NUMBER", Array.Empty<string>()),
+        new ProjectFieldDefinition("Signal Quality Notes", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Tags", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Tag Confidence Summary", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Matched Issue", "TEXT", Array.Empty<string>()),

--- a/IntelligenceX.Cli/Todo/ProjectInitRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectInitRunner.cs
@@ -432,7 +432,8 @@ internal static class ProjectInitRunner {
                         name = view.Name,
                         layout = view.Layout,
                         description = view.Description,
-                        filter = view.Filter
+                        filter = view.Filter,
+                        suggestedColumns = view.SuggestedColumns
                     })
                     .Cast<object>()
                     .ToList(),

--- a/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectLabelCatalog.cs
@@ -87,6 +87,7 @@ internal static class ProjectLabelCatalog {
         new ProjectLabelDefinition("ix/decision:defer", "fbca04", "IX suggested decision is defer."),
         new ProjectLabelDefinition("ix/decision:reject", "d73a4a", "IX suggested decision is reject."),
         new ProjectLabelDefinition("ix/decision:merge-candidate", "1d76db", "IX suggested decision is merge-candidate."),
+        new ProjectLabelDefinition("ix/signal:low", "fbca04", "Signal quality is low and needs maintainer context checks."),
         new ProjectLabelDefinition("ix/duplicate:clustered", "f9d0c4", "Item is part of a duplicate cluster.")
     };
 

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -18,6 +18,7 @@ internal static class ProjectSyncRunner {
     private const double RejectVisionConfidenceThreshold = 0.70;
     private const double AcceptVisionConfidenceThreshold = 0.68;
     private const double MergeCandidateScoreThreshold = 82.0;
+    private const double LowSignalQualityScoreThreshold = 50.0;
 
     internal sealed record RelatedIssueCandidate(
         int Number,
@@ -62,7 +63,10 @@ internal static class ProjectSyncRunner {
         IReadOnlyList<RelatedPullRequestCandidate>? RelatedPullRequests = null,
         IReadOnlyList<string>? ExistingLabels = null,
         double? CategoryConfidence = null,
-        IReadOnlyDictionary<string, double>? TagConfidences = null
+        IReadOnlyDictionary<string, double>? TagConfidences = null,
+        string? SignalQuality = null,
+        double? SignalQualityScore = null,
+        IReadOnlyList<string>? SignalQualityReasons = null
     );
 
     private sealed class Options {
@@ -540,6 +544,9 @@ internal static class ProjectSyncRunner {
                 var categoryConfidence = ReadNullableDouble(item, "categoryConfidence");
                 var tags = ReadStringArray(item, "tags");
                 var tagConfidences = ReadStringDoubleMap(item, "tagConfidences");
+                var signalQuality = NormalizeSignalQuality(ReadNullableString(item, "signalQuality"));
+                var signalQualityScore = ReadNullableDouble(item, "signalQualityScore");
+                var signalQualityReasons = ReadStringArray(item, "signalQualityReasons");
                 var existingLabels = ReadStringArray(item, "labels");
                 var matchedIssueUrl = ReadNullableString(item, "matchedIssueUrl");
                 var matchedIssueConfidence = ReadNullableDouble(item, "matchedIssueConfidence");
@@ -623,7 +630,10 @@ internal static class ProjectSyncRunner {
                     RelatedPullRequests: relatedPullRequests,
                     ExistingLabels: existingLabels,
                     CategoryConfidence: categoryConfidence,
-                    TagConfidences: tagConfidences
+                    TagConfidences: tagConfidences,
+                    SignalQuality: signalQuality,
+                    SignalQualityScore: signalQualityScore,
+                    SignalQualityReasons: signalQualityReasons
                 );
             }
         }
@@ -664,7 +674,8 @@ internal static class ProjectSyncRunner {
                         RelatedIssues: Array.Empty<RelatedIssueCandidate>(),
                         SuggestedDecision: null,
                         RelatedPullRequests: Array.Empty<RelatedPullRequestCandidate>(),
-                        ExistingLabels: Array.Empty<string>()
+                        ExistingLabels: Array.Empty<string>(),
+                        SignalQualityReasons: Array.Empty<string>()
                     );
                 }
             }
@@ -722,6 +733,19 @@ internal static class ProjectSyncRunner {
         };
     }
 
+    private static string? NormalizeSignalQuality(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        return value.Trim().ToLowerInvariant() switch {
+            "high" => "high",
+            "medium" => "medium",
+            "low" => "low",
+            _ => null
+        };
+    }
+
     private static string? SuggestMaintainerDecision(
         ProjectSyncEntry entry,
         bool isBestPullRequest,
@@ -736,6 +760,10 @@ internal static class ProjectSyncRunner {
 
         if (visionFit == "likely-out-of-scope" && visionConfidence >= RejectVisionConfidenceThreshold) {
             return "reject";
+        }
+
+        if (IsLowSignalQuality(entry)) {
+            return "defer";
         }
 
         var blockedBySignals = prSignals is not null && IsBlockedByReviewOrChecks(prSignals);
@@ -758,6 +786,16 @@ internal static class ProjectSyncRunner {
         }
 
         return "defer";
+    }
+
+    private static bool IsLowSignalQuality(ProjectSyncEntry entry) {
+        if (!string.IsNullOrWhiteSpace(entry.SignalQuality) &&
+            entry.SignalQuality.Equals("low", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        return entry.SignalQualityScore.HasValue &&
+               entry.SignalQualityScore.Value < LowSignalQualityScoreThreshold;
     }
 
     private static bool IsStronglyReadyForMerge(PullRequestDecisionSignals signals) {
@@ -992,6 +1030,35 @@ internal static class ProjectSyncRunner {
             updated++;
         }
 
+        if (fields.TryGetValue("Signal Quality", out var signalQualityField)) {
+            if (!string.IsNullOrWhiteSpace(entry.SignalQuality) &&
+                TryResolveOptionId(signalQualityField, entry.SignalQuality, out var signalQualityOptionId)) {
+                await client.SetSingleSelectFieldAsync(projectId, itemId, signalQualityField.Id, signalQualityOptionId).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, signalQualityField.Id).ConfigureAwait(false);
+            }
+            updated++;
+        }
+
+        if (fields.TryGetValue("Signal Quality Score", out var signalQualityScoreField)) {
+            if (entry.SignalQualityScore.HasValue) {
+                await client.SetNumberFieldAsync(projectId, itemId, signalQualityScoreField.Id, entry.SignalQualityScore.Value).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, signalQualityScoreField.Id).ConfigureAwait(false);
+            }
+            updated++;
+        }
+
+        if (fields.TryGetValue("Signal Quality Notes", out var signalQualityNotesField)) {
+            var notes = BuildSignalQualityNotesFieldValue(entry, maxReasons: 4);
+            if (!string.IsNullOrWhiteSpace(notes)) {
+                await client.SetTextFieldAsync(projectId, itemId, signalQualityNotesField.Id, notes).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, signalQualityNotesField.Id).ConfigureAwait(false);
+            }
+            updated++;
+        }
+
         if (fields.TryGetValue("Tags", out var tagsField) && entry.Tags.Count > 0) {
             await client.SetTextFieldAsync(projectId, itemId, tagsField.Id, string.Join(", ", entry.Tags)).ConfigureAwait(false);
             updated++;
@@ -1199,6 +1266,10 @@ internal static class ProjectSyncRunner {
             labels.Add(decisionLabel);
         }
 
+        if (IsLowSignalQuality(entry)) {
+            labels.Add("ix/signal:low");
+        }
+
         if (!string.IsNullOrWhiteSpace(entry.DuplicateCluster)) {
             labels.Add("ix/duplicate:clustered");
         }
@@ -1313,6 +1384,21 @@ internal static class ProjectSyncRunner {
         }
 
         return string.Join(Environment.NewLine, summaryLines);
+    }
+
+    internal static string BuildSignalQualityNotesFieldValue(ProjectSyncEntry entry, int maxReasons) {
+        var limit = Math.Max(1, Math.Min(maxReasons, 10));
+        var reasons = (entry.SignalQualityReasons ?? Array.Empty<string>())
+            .Where(reason => !string.IsNullOrWhiteSpace(reason))
+            .Select(reason => reason.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(limit)
+            .ToList();
+        if (reasons.Count == 0) {
+            return string.Empty;
+        }
+
+        return string.Join(Environment.NewLine, reasons);
     }
 
     internal static string BuildRelatedPullRequestsFieldValue(ProjectSyncEntry entry, int maxPullRequests) {

--- a/IntelligenceX.Cli/Todo/ProjectViewApplyRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectViewApplyRunner.cs
@@ -185,6 +185,7 @@ internal static class ProjectViewApplyRunner {
                 builder.AppendLine($"- [ ] **{view.Name}** (`{view.Layout}`)");
                 builder.AppendLine($"  Suggested filter: `{view.Filter}`");
                 builder.AppendLine($"  Purpose: {view.Description}");
+                builder.AppendLine($"  Suggested columns: {string.Join(", ", view.SuggestedColumns)}");
             }
         }
 
@@ -193,7 +194,7 @@ internal static class ProjectViewApplyRunner {
         builder.AppendLine();
         builder.AppendLine($"1. Open project: {projectUrl}");
         builder.AppendLine("2. Select `+ New view` in GitHub Projects.");
-        builder.AppendLine("3. For each unchecked checklist item above, use the exact view name/layout and suggested filter.");
+        builder.AppendLine("3. For each unchecked checklist item above, use the exact view name/layout, suggested filter, and suggested columns.");
         builder.AppendLine("4. Re-run `intelligencex todo project-view-apply` to confirm coverage.");
 
         if (!directCreateSupported) {

--- a/IntelligenceX.Cli/Todo/ProjectViewCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectViewCatalog.cs
@@ -8,7 +8,8 @@ internal sealed record ProjectViewDefinition(
     string Name,
     string Layout,
     string Description,
-    string Filter
+    string Filter,
+    IReadOnlyList<string> SuggestedColumns
 );
 
 internal static class ProjectViewCatalog {
@@ -16,23 +17,64 @@ internal static class ProjectViewCatalog {
         new ProjectViewDefinition(
             "IX Queue",
             "TABLE",
-            "Primary triage queue for open backlog items.",
-            "is:open"),
+            "Primary pull-request triage queue with decision and confidence signals visible.",
+            "is:open \"Triage Kind\":\"pull_request\"",
+            new[] {
+                "Title",
+                "Status",
+                "Triage Kind",
+                "Signal Quality",
+                "Signal Quality Score",
+                "Vision Fit",
+                "IX Suggested Decision",
+                "Triage Score",
+                "Category",
+                "Category Confidence",
+                "Matched Issue",
+                "Duplicate Cluster"
+            }),
         new ProjectViewDefinition(
             "Merge Candidates",
             "TABLE",
-            "Items with high merge readiness and aligned signals.",
-            "is:open \"IX Suggested Decision\":\"merge-candidate\""),
+            "High-readiness pull requests that are candidates for maintainer merge review.",
+            "is:open \"IX Suggested Decision\":\"merge-candidate\"",
+            new[] {
+                "Title",
+                "Status",
+                "Signal Quality",
+                "Vision Fit",
+                "IX Suggested Decision",
+                "Triage Score",
+                "Category",
+                "Matched Issue"
+            }),
         new ProjectViewDefinition(
             "Vision Review",
             "BOARD",
-            "Items grouped by vision-fit outcomes for maintainer review.",
-            "is:open"),
+            "Maintainer board grouped by vision-fit outcomes with low-signal items visible.",
+            "is:open",
+            new[] {
+                "Title",
+                "Status",
+                "Vision Fit",
+                "Signal Quality",
+                "IX Suggested Decision",
+                "Category"
+            }),
         new ProjectViewDefinition(
             "Duplicate Clusters",
             "TABLE",
             "Items that belong to duplicate clusters and need consolidation.",
-            "is:open \"Duplicate Cluster\":*")
+            "is:open \"Duplicate Cluster\":*",
+            new[] {
+                "Title",
+                "Status",
+                "Duplicate Cluster",
+                "Canonical Item",
+                "Signal Quality",
+                "Triage Score",
+                "Category"
+            })
     };
 
     public static IReadOnlyList<ProjectViewDefinition> FindMissingDefaultViews(

--- a/IntelligenceX.Cli/Todo/ProjectViewChecklistRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectViewChecklistRunner.cs
@@ -155,10 +155,12 @@ internal static class ProjectViewChecklistRunner {
                 if (!string.IsNullOrWhiteSpace(existing.Url)) {
                     builder.AppendLine($"  Link: {existing.Url}");
                 }
+                builder.AppendLine($"  Suggested columns: {string.Join(", ", view.SuggestedColumns)}");
             } else {
                 builder.AppendLine($"- [ ] **{view.Name}** (`{view.Layout}`) - missing");
                 builder.AppendLine($"  Suggested filter: `{view.Filter}`");
                 builder.AppendLine($"  Purpose: {view.Description}");
+                builder.AppendLine($"  Suggested columns: {string.Join(", ", view.SuggestedColumns)}");
             }
         }
 
@@ -167,7 +169,7 @@ internal static class ProjectViewChecklistRunner {
         builder.AppendLine();
         builder.AppendLine($"1. Open project: {projectUrl}");
         builder.AppendLine("2. Select `+ New view` in GitHub Projects.");
-        builder.AppendLine("3. Use the exact view name/layout and suggested filter from checklist items above.");
+        builder.AppendLine("3. Use the exact view name/layout, suggested filter, and suggested columns from checklist items above.");
         builder.AppendLine("4. Re-run `intelligencex todo project-view-checklist` to refresh coverage.");
 
         return builder.ToString().TrimEnd();

--- a/IntelligenceX.Cli/Todo/RepositoryLabelManager.cs
+++ b/IntelligenceX.Cli/Todo/RepositoryLabelManager.cs
@@ -19,6 +19,7 @@ internal static class RepositoryLabelManager {
         "ix/vision:",
         "ix/match:",
         "ix/decision:",
+        "ix/signal:",
         "ix/duplicate:"
     };
 

--- a/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
+++ b/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
@@ -183,6 +183,12 @@ internal static class TriageIndexRunner {
         IReadOnlyList<RelatedPullRequestCandidate> RelatedPullRequests
     );
 
+    internal sealed record SignalQualityAssessment(
+        string Level,
+        double Score,
+        IReadOnlyList<string> Reasons
+    );
+
     private sealed record IssueReferenceHint(
         int Number,
         double Confidence,
@@ -675,6 +681,115 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
     internal static (string Category, IReadOnlyList<string> Tags) InferCategoryAndTags(TriageIndexItem item) {
         var inference = InferCategoryAndTagsWithConfidence(item);
         return (inference.Category, inference.Tags);
+    }
+
+    internal static SignalQualityAssessment AssessSignalQuality(TriageIndexItem item, ItemEnrichment? enrichment) {
+        var score = 40.0;
+        var reasons = new List<string>();
+
+        var titleTokenCount = item.TitleTokens.Count;
+        if (titleTokenCount >= 6) {
+            score += 18;
+            reasons.Add("Title contains strong intent detail.");
+        } else if (titleTokenCount >= 3) {
+            score += 10;
+            reasons.Add("Title contains basic intent detail.");
+        } else {
+            score -= 10;
+            reasons.Add("Title is too short for reliable intent inference.");
+        }
+
+        var contextTokenCount = item.ContextTokens.Count;
+        if (contextTokenCount >= 20) {
+            score += 18;
+            reasons.Add("Description/context is detailed.");
+        } else if (contextTokenCount >= 10) {
+            score += 10;
+            reasons.Add("Description/context has moderate detail.");
+        } else {
+            score -= 12;
+            reasons.Add("Description/context is sparse.");
+        }
+
+        if (item.Labels.Count >= 2) {
+            score += 8;
+            reasons.Add("Labels provide extra classification evidence.");
+        } else if (item.Labels.Count == 1) {
+            score += 4;
+            reasons.Add("Single label provides limited evidence.");
+        } else {
+            score -= 5;
+            reasons.Add("No labels present.");
+        }
+
+        if (item.PullRequest is not null) {
+            if (item.PullRequest.ChangedFiles > 0) {
+                score += 4;
+                reasons.Add("PR change metadata is present.");
+            } else {
+                score -= 6;
+                reasons.Add("PR change metadata is missing.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(item.PullRequest.ReviewDecision)) {
+                score += 4;
+            } else {
+                score -= 3;
+            }
+
+            if (!string.IsNullOrWhiteSpace(item.PullRequest.StatusCheckState)) {
+                score += 4;
+            } else {
+                score -= 3;
+            }
+
+            if (item.PullRequest.Commits > 0) {
+                score += 3;
+            } else {
+                score -= 2;
+            }
+        } else if (item.Issue is not null) {
+            if (item.Issue.Comments >= 2) {
+                score += 6;
+                reasons.Add("Issue discussion provides additional context.");
+            } else if (item.Issue.Comments == 0) {
+                score -= 3;
+                reasons.Add("Issue has no discussion context.");
+            }
+        }
+
+        if (enrichment is not null) {
+            if (enrichment.CategoryConfidence >= 0.75) {
+                score += 8;
+                reasons.Add("Category confidence is high.");
+            } else if (enrichment.CategoryConfidence >= 0.60) {
+                score += 4;
+            } else if (enrichment.CategoryConfidence < 0.50) {
+                score -= 5;
+                reasons.Add("Category confidence is low.");
+            }
+
+            var topMatchConfidence = item.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)
+                ? enrichment.MatchedIssueConfidence
+                : enrichment.MatchedPullRequestConfidence;
+            if (topMatchConfidence.HasValue) {
+                if (topMatchConfidence.Value >= 0.80) {
+                    score += 8;
+                    reasons.Add("Top related-link confidence is high.");
+                } else if (topMatchConfidence.Value >= 0.55) {
+                    score += 4;
+                }
+            }
+        }
+
+        score = Math.Round(Math.Clamp(score, 0, 100), 2, MidpointRounding.AwayFromZero);
+        var level = score >= 75
+            ? "high"
+            : score >= 50
+                ? "medium"
+                : "low";
+
+        return new SignalQualityAssessment(level, score, reasons);
     }
 
     internal static CategoryTagInference InferCategoryAndTagsWithConfidence(TriageIndexItem item) {
@@ -1455,6 +1570,16 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
             reasons.Add("No outstanding discussion bonus.");
         }
 
+        if (item.TitleTokens.Count < 3) {
+            score -= 6;
+            reasons.Add("Sparse-title confidence penalty.");
+        }
+
+        if (item.ContextTokens.Count < 10) {
+            score -= 8;
+            reasons.Add("Sparse-description confidence penalty.");
+        }
+
         var ageDays = Math.Max(0, (nowUtc - item.UpdatedAtUtc).TotalDays);
         if (ageDays <= 1) {
             score += 8;
@@ -1543,6 +1668,14 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
             clusters.SelectMany(cluster => cluster.ItemIds),
             StringComparer.OrdinalIgnoreCase
         );
+        var signalAssessmentsById = scoredItems
+            .ToDictionary(
+                item => item.Item.Id,
+                item => AssessSignalQuality(item.Item, enrichments.TryGetValue(item.Item.Id, out var enrichment) ? enrichment : null),
+                StringComparer.OrdinalIgnoreCase);
+        var highSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "high");
+        var mediumSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "medium");
+        var lowSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "low");
 
         var items = scoredItems
             .OrderByDescending(item => item.Item.UpdatedAtUtc)
@@ -1550,6 +1683,7 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
             .ThenBy(item => item.Item.Number)
             .Select(item => {
                 enrichments.TryGetValue(item.Item.Id, out var enrichment);
+                signalAssessmentsById.TryGetValue(item.Item.Id, out var signalQuality);
                 return new {
                     id = item.Item.Id,
                     kind = item.Item.Kind,
@@ -1586,6 +1720,9 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                         })
                         .Cast<object>()
                         .ToList() ?? new List<object>(),
+                    signalQuality = signalQuality?.Level ?? "low",
+                    signalQualityScore = signalQuality?.Score ?? 0,
+                    signalQualityReasons = signalQuality?.Reasons ?? Array.Empty<string>(),
                     score = item.Score,
                     scoreReasons = item.ScoreReasons,
                     signals = new {
@@ -1632,7 +1769,12 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                 duplicateItems = duplicateIds.Count,
                 bestPullRequestCandidates = bestPullRequests.Count,
                 pullRequestsWithMatchedIssue = enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedIssueUrl)),
-                issuesWithMatchedPullRequest = enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedPullRequestUrl))
+                issuesWithMatchedPullRequest = enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedPullRequestUrl)),
+                signalQuality = new {
+                    high = highSignalCount,
+                    medium = mediumSignalCount,
+                    low = lowSignalCount
+                }
             },
             bestPullRequests = best,
             duplicateClusters = duplicates,
@@ -1651,6 +1793,14 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
             clusters.SelectMany(cluster => cluster.ItemIds),
             StringComparer.OrdinalIgnoreCase
         );
+        var signalAssessmentsById = scoredItems
+            .ToDictionary(
+                item => item.Item.Id,
+                item => AssessSignalQuality(item.Item, enrichments.TryGetValue(item.Item.Id, out var enrichment) ? enrichment : null),
+                StringComparer.OrdinalIgnoreCase);
+        var highSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "high");
+        var mediumSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "medium");
+        var lowSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "low");
 
         var sb = new StringBuilder();
         sb.AppendLine("# IntelligenceX Triage Index");
@@ -1669,6 +1819,7 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         sb.AppendLine($"- Duplicate items: {duplicateIds.Count}");
         sb.AppendLine($"- PRs with matched issue: {enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedIssueUrl))}");
         sb.AppendLine($"- Issues with matched PR: {enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedPullRequestUrl))}");
+        sb.AppendLine($"- Signal quality (high/medium/low): {highSignalCount}/{mediumSignalCount}/{lowSignalCount}");
         sb.AppendLine();
         sb.AppendLine("## Best PR Candidates");
         sb.AppendLine();

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -14,6 +14,9 @@ internal static partial class Program {
         AssertEqual(true, names.Contains("Vision Confidence", StringComparer.OrdinalIgnoreCase), "has Vision Confidence");
         AssertEqual(true, names.Contains("Category", StringComparer.OrdinalIgnoreCase), "has Category");
         AssertEqual(true, names.Contains("Category Confidence", StringComparer.OrdinalIgnoreCase), "has Category Confidence");
+        AssertEqual(true, names.Contains("Signal Quality", StringComparer.OrdinalIgnoreCase), "has Signal Quality");
+        AssertEqual(true, names.Contains("Signal Quality Score", StringComparer.OrdinalIgnoreCase), "has Signal Quality Score");
+        AssertEqual(true, names.Contains("Signal Quality Notes", StringComparer.OrdinalIgnoreCase), "has Signal Quality Notes");
         AssertEqual(true, names.Contains("Tags", StringComparer.OrdinalIgnoreCase), "has Tags");
         AssertEqual(true, names.Contains("Tag Confidence Summary", StringComparer.OrdinalIgnoreCase), "has Tag Confidence Summary");
         AssertEqual(true, names.Contains("Matched Issue", StringComparer.OrdinalIgnoreCase), "has Matched Issue");
@@ -37,6 +40,7 @@ internal static partial class Program {
         AssertEqual(true, labels.Contains("ix/decision:defer", StringComparer.OrdinalIgnoreCase), "decision defer label");
         AssertEqual(true, labels.Contains("ix/decision:reject", StringComparer.OrdinalIgnoreCase), "decision reject label");
         AssertEqual(true, labels.Contains("ix/decision:merge-candidate", StringComparer.OrdinalIgnoreCase), "decision merge-candidate label");
+        AssertEqual(true, labels.Contains("ix/signal:low", StringComparer.OrdinalIgnoreCase), "signal low label");
         AssertEqual(true, labels.Contains("ix/match:linked-pr", StringComparer.OrdinalIgnoreCase), "issue linked-pr label");
         AssertEqual(true, labels.Contains("ix/match:needs-review-pr", StringComparer.OrdinalIgnoreCase), "issue needs-review-pr label");
     }
@@ -150,6 +154,12 @@ internal static partial class Program {
       "url": "https://github.com/EvotecIT/IntelligenceX/pull/410",
       "category": "security",
       "categoryConfidence": 0.83,
+      "signalQuality": "low",
+      "signalQualityScore": 42.5,
+      "signalQualityReasons": [
+        "Description/context is sparse.",
+        "No labels present."
+      ],
       "tags": [ "security", "api" ],
       "tagConfidences": {
         "security": 0.91,
@@ -174,6 +184,10 @@ internal static partial class Program {
         AssertEqual(true, entry.TagConfidences!.ContainsKey("security"), "security tag confidence key");
         AssertEqual(0.91, entry.TagConfidences["security"], "security tag confidence value");
         AssertEqual(0.57, entry.TagConfidences["api"], "api tag confidence value");
+        AssertEqual("low", entry.SignalQuality, "signal quality parsed");
+        AssertEqual(true, entry.SignalQualityScore.HasValue, "signal quality score parsed");
+        AssertEqual(42.5, entry.SignalQualityScore!.Value, "signal quality score value");
+        AssertEqual(true, (entry.SignalQualityReasons?.Count ?? 0) == 2, "signal quality reasons parsed");
     }
 
     private static void TestProjectSyncBuildEntriesSuggestsMergeCandidateForBestReadyPr() {
@@ -273,6 +287,59 @@ internal static partial class Program {
         AssertEqual("defer", pr.SuggestedDecision, "blocked PR suggestion");
     }
 
+    private static void TestProjectSyncBuildEntriesSuggestsDeferForLowSignalPr() {
+        const string triageJson = """
+{
+  "items": [
+    {
+      "id": "pr#37",
+      "kind": "pull_request",
+      "number": 37,
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/37",
+      "score": 94.6,
+      "signalQuality": "low",
+      "signalQualityScore": 41.0,
+      "signals": {
+        "pullRequest": {
+          "isDraft": false,
+          "mergeable": "MERGEABLE",
+          "reviewDecision": "APPROVED",
+          "statusCheckState": "SUCCESS"
+        }
+      }
+    }
+  ],
+  "bestPullRequests": [
+    {
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/37"
+    }
+  ]
+}
+""";
+
+        const string visionJson = """
+{
+  "assessments": [
+    {
+      "url": "https://github.com/EvotecIT/IntelligenceX/pull/37",
+      "classification": "aligned",
+      "confidence": 0.92
+    }
+  ]
+}
+""";
+
+        using var triageDoc = System.Text.Json.JsonDocument.Parse(triageJson);
+        using var visionDoc = System.Text.Json.JsonDocument.Parse(visionJson);
+        var entries = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildEntriesFromDocuments(
+            triageDoc.RootElement,
+            visionDoc.RootElement,
+            100);
+
+        var pr = entries.Single(item => item.Url.EndsWith("/pull/37", StringComparison.OrdinalIgnoreCase));
+        AssertEqual("defer", pr.SuggestedDecision, "low signal PR is deferred");
+    }
+
     private static void TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch() {
         var entry = new IntelligenceX.Cli.Todo.ProjectSyncRunner.ProjectSyncEntry(
             Number: 42,
@@ -364,13 +431,16 @@ internal static partial class Program {
             MatchedIssueConfidence: 0.62,
             VisionFit: null,
             VisionConfidence: null,
-            SuggestedDecision: "defer"
+            SuggestedDecision: "defer",
+            SignalQuality: "low",
+            SignalQualityScore: 41.2
         );
 
         var labels = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildLabelsForEntry(entry);
         AssertEqual(true, labels.Contains("ix/match:needs-review", StringComparer.OrdinalIgnoreCase), "low confidence match review label");
         AssertEqual(false, labels.Contains("ix/match:linked-issue", StringComparer.OrdinalIgnoreCase), "low confidence should not be linked-issue");
         AssertEqual(true, labels.Contains("ix/decision:defer", StringComparer.OrdinalIgnoreCase), "decision defer label");
+        AssertEqual(true, labels.Contains("ix/signal:low", StringComparer.OrdinalIgnoreCase), "low signal label");
     }
 
     private static void TestProjectSyncBuildLabelsUsesRelatedIssueFallbackWhenMatchedIssueMissing() {

--- a/IntelligenceX.Tests/Program.Todo.ProjectViewApply.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectViewApply.cs
@@ -27,6 +27,7 @@ internal static partial class Program {
         AssertContainsText(markdown, "intelligencex:project-view-apply", "apply marker present");
         AssertContainsText(markdown, "Default view coverage: 1/4", "coverage reflects missing defaults");
         AssertContainsText(markdown, "- [ ] **Merge Candidates** (`TABLE`)", "missing default view listed");
+        AssertContainsText(markdown, "Suggested columns:", "suggested columns guidance included");
         AssertContainsText(markdown, "Select `+ New view` in GitHub Projects.", "manual apply step present");
         AssertContainsText(markdown, "public API surface does not expose direct project view creation", "platform note present");
     }

--- a/IntelligenceX.Tests/Program.Todo.ProjectViewChecklist.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectViewChecklist.cs
@@ -26,6 +26,7 @@ internal static partial class Program {
         AssertContainsText(markdown, "Default view coverage: 1/4", "coverage reflects missing defaults");
         AssertContainsText(markdown, "- [x] **IX Queue** (`TABLE`) - present", "existing default view checked");
         AssertContainsText(markdown, "- [ ] **Merge Candidates** (`TABLE`) - missing", "missing default view unchecked");
+        AssertContainsText(markdown, "Suggested columns:", "suggested columns guidance included");
         AssertContainsText(markdown, "https://github.com/orgs/EvotecIT/projects/123/views/1", "existing view link included");
     }
 

--- a/IntelligenceX.Tests/Program.Todo.ProjectViews.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectViews.cs
@@ -15,6 +15,9 @@ internal static partial class Program {
         AssertEqual(true, names.Contains("Merge Candidates", StringComparer.OrdinalIgnoreCase), "merge candidates view present");
         AssertEqual(true, names.Contains("Vision Review", StringComparer.OrdinalIgnoreCase), "vision review view present");
         AssertEqual(true, names.Contains("Duplicate Clusters", StringComparer.OrdinalIgnoreCase), "duplicate clusters view present");
+        AssertEqual(true,
+            IntelligenceX.Cli.Todo.ProjectViewCatalog.DefaultViews.All(view => view.SuggestedColumns.Count > 0),
+            "default views expose suggested columns guidance");
     }
 
     private static void TestProjectViewCatalogFindMissingDefaultViewsReturnsMissingOnly() {

--- a/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
+++ b/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
@@ -287,5 +287,70 @@ internal static partial class Program {
         AssertEqual("feature", weakInference.Category, "weak inference fallback category");
         AssertEqual(true, weakInference.CategoryConfidence < 0.62, "weak category confidence below labeling threshold");
     }
+
+    private static void TestTriageIndexAssessSignalQualityDistinguishesStrongAndWeakContext() {
+        var now = DateTimeOffset.UtcNow;
+        var strong = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "pr#700",
+            "pull_request",
+            700,
+            "Harden authentication token validation in reviewer pipeline",
+            "https://example/pr/700",
+            now,
+            new[] { "security", "reviewer" },
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Harden authentication token validation in reviewer pipeline"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Harden authentication token validation in reviewer pipeline"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Security hardening for auth token validation with explicit issue linkage and tests"),
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.PullRequestSignals(false, "MERGEABLE", "APPROVED", "SUCCESS", 9, 140, 21, 3, 4, "dev"),
+            null
+        );
+        var weak = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "pr#701",
+            "pull_request",
+            701,
+            "Fix",
+            "https://example/pr/701",
+            now,
+            Array.Empty<string>(),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Fix"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Fix"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Fix"),
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.PullRequestSignals(false, "UNKNOWN", string.Empty, string.Empty, 0, 0, 0, 0, 0, "dev"),
+            null
+        );
+
+        var strongInference = IntelligenceX.Cli.Todo.TriageIndexRunner.InferCategoryAndTagsWithConfidence(strong);
+        var weakInference = IntelligenceX.Cli.Todo.TriageIndexRunner.InferCategoryAndTagsWithConfidence(weak);
+        var strongQuality = IntelligenceX.Cli.Todo.TriageIndexRunner.AssessSignalQuality(
+            strong,
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.ItemEnrichment(
+                strongInference.Category,
+                strongInference.CategoryConfidence,
+                strongInference.Tags,
+                strongInference.TagConfidences,
+                MatchedIssueUrl: "https://example/issues/1",
+                MatchedIssueConfidence: 0.91,
+                RelatedIssues: Array.Empty<IntelligenceX.Cli.Todo.TriageIndexRunner.RelatedIssueCandidate>(),
+                MatchedPullRequestUrl: null,
+                MatchedPullRequestConfidence: null,
+                RelatedPullRequests: Array.Empty<IntelligenceX.Cli.Todo.TriageIndexRunner.RelatedPullRequestCandidate>()));
+        var weakQuality = IntelligenceX.Cli.Todo.TriageIndexRunner.AssessSignalQuality(
+            weak,
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.ItemEnrichment(
+                weakInference.Category,
+                weakInference.CategoryConfidence,
+                weakInference.Tags,
+                weakInference.TagConfidences,
+                MatchedIssueUrl: null,
+                MatchedIssueConfidence: null,
+                RelatedIssues: Array.Empty<IntelligenceX.Cli.Todo.TriageIndexRunner.RelatedIssueCandidate>(),
+                MatchedPullRequestUrl: null,
+                MatchedPullRequestConfidence: null,
+                RelatedPullRequests: Array.Empty<IntelligenceX.Cli.Todo.TriageIndexRunner.RelatedPullRequestCandidate>()));
+
+        AssertEqual(true, strongQuality.Score > weakQuality.Score, "strong signal quality score is higher");
+        AssertEqual("high", strongQuality.Level, "strong signal quality level");
+        AssertEqual("low", weakQuality.Level, "weak signal quality level");
+    }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -461,6 +461,7 @@ internal static partial class Program {
         failed += Run("Todo triage index issue-PR URL match", TestTriageIndexMatchIssueToPullRequestsSupportsPullRequestUrlReference);
         failed += Run("Todo triage index category/tag inference", TestTriageIndexInferCategoryAndTagsDetectsSecurity);
         failed += Run("Todo triage index category/tag confidence inference", TestTriageIndexInferCategoryAndTagsWithConfidenceUsesEvidenceStrength);
+        failed += Run("Todo triage index signal-quality inference", TestTriageIndexAssessSignalQualityDistinguishesStrongAndWeakContext);
         failed += Run("Todo vision check out-of-scope classification", TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate);
         failed += Run("Todo vision check aligned classification", TestVisionCheckClassifiesAlignedWhenInTokensMatch);
         failed += Run("Todo vision check explicit reject policy precedence", TestVisionCheckExplicitRejectPolicyTakesPrecedence);
@@ -495,6 +496,7 @@ internal static partial class Program {
         failed += Run("Todo project sync labels use issue related pull-request fallback", TestProjectSyncBuildLabelsUsesIssueRelatedPullRequestFallbackWhenMatchedPullRequestMissing);
         failed += Run("Todo project sync decision suggests merge-candidate", TestProjectSyncBuildEntriesSuggestsMergeCandidateForBestReadyPr);
         failed += Run("Todo project sync decision suggests defer for blocked PR", TestProjectSyncBuildEntriesSuggestsDeferForBlockedPr);
+        failed += Run("Todo project sync decision suggests defer for low-signal PR", TestProjectSyncBuildEntriesSuggestsDeferForLowSignalPr);
         failed += Run("Todo project sync derives issue pull-request matches", TestProjectSyncBuildEntriesDerivesIssuePullRequestMatches);
         failed += Run("Todo project sync preserves higher-confidence issue-side pull-request matches", TestProjectSyncBuildEntriesPreservesHigherConfidenceIssueSidePullRequestMatch);
         failed += Run("Todo project sync uses issue related pull-request fallback", TestProjectSyncBuildEntriesUsesIssueRelatedPullRequestFallback);


### PR DESCRIPTION
## Summary
- improve triage output quality by adding per-item signal quality assessment (`high`/`medium`/`low`) with score + reasons
- reduce weak auto-suggestions by deferring PR decisions when signal quality is low
- sync new signal-quality fields into GitHub Project (`Signal Quality`, `Signal Quality Score`, `Signal Quality Notes`)
- add managed low-signal taxonomy label (`ix/signal:low`) and include it in managed label reconciliation
- strengthen project view guidance with per-view suggested columns so critical fields are actually visible
- enhance checklist/apply markdown to include suggested columns, not just name/layout/filter
- include project-view apply plan generation in triage project-sync workflow artifacts and summary comments
- update reviewer docs to set expectations for low-signal items and maintainer triage flow

## Why this helps
The board looked weak mostly because high-signal fields were often hidden and low-context items were treated too optimistically. This change makes weak-context items explicit and keeps decision suggestions conservative until context improves.

## Validation
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`

Both passed.
