### PR TITLE
perf(chat): reduce startup hello blocking during startup

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
@@ -307,6 +307,11 @@ internal sealed partial class ChatServiceSession {
         return normalized.Length == 0 ? "Probe failed." : normalized;
     }
 
+    private static string CompactStartupToolHealthException(Exception ex) {
+        var message = ToolHealthDiagnostics.CompactOneLine(ex.Message);
+        return message.Length == 0 ? ex.GetType().Name : message;
+    }
+
     private static string ToSourceLabel(ToolPackSourceKind sourceKind) {
         return sourceKind switch {
             ToolPackSourceKind.Builtin => "builtin",
@@ -463,5 +468,32 @@ internal sealed partial class ChatServiceSession {
         public DateTime LastFailedUtc { get; set; }
         public DateTime NextProbeUtc { get; set; }
         public int ConsecutiveFailures { get; set; } = 1;
+    }
+
+    private async Task RunStartupToolHealthPrimingAsync(CancellationToken cancellationToken) {
+        try {
+            using var startupToolHealthCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            startupToolHealthCts.CancelAfter(StartupToolHealthPrimeBudget);
+            await PrimeStartupToolHealthWarningsAsync(startupToolHealthCts.Token).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            // Session shutdown canceled startup priming.
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"[tool health] Startup probe priming failed: {CompactStartupToolHealthException(ex)}");
+        }
+    }
+
+    private static async Task AwaitStartupToolHealthPrimingForHelloAsync(Task startupToolHealthPrimeTask, CancellationToken cancellationToken) {
+        if (startupToolHealthPrimeTask.IsCompleted) {
+            await startupToolHealthPrimeTask.ConfigureAwait(false);
+            return;
+        }
+
+        using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var delayTask = Task.Delay(StartupToolHealthHelloWaitBudget, waitCts.Token);
+        var completedTask = await Task.WhenAny(startupToolHealthPrimeTask, delayTask).ConfigureAwait(false);
+        if (completedTask == startupToolHealthPrimeTask) {
+            waitCts.Cancel();
+            await startupToolHealthPrimeTask.ConfigureAwait(false);
+        }
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
@@ -31,6 +31,7 @@ internal sealed partial class ChatServiceSession {
     private static readonly TimeSpan UserIntentContextMaxAge = TimeSpan.FromMinutes(15);
     private static readonly TimeSpan PendingActionContextMaxAge = TimeSpan.FromMinutes(20);
     private static readonly TimeSpan StartupToolHealthPrimeBudget = TimeSpan.FromSeconds(6);
+    private static readonly TimeSpan StartupToolHealthHelloWaitBudget = TimeSpan.FromMilliseconds(250);
     private readonly ServiceOptions _options;
     private readonly Stream _stream;
     private ToolRegistry _registry;
@@ -124,10 +125,7 @@ internal sealed partial class ChatServiceSession {
     public async Task RunAsync(CancellationToken cancellationToken) {
         var instructions = LoadInstructions(_options);
         _instructions = instructions;
-        using (var startupToolHealthCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)) {
-            startupToolHealthCts.CancelAfter(StartupToolHealthPrimeBudget);
-            await PrimeStartupToolHealthWarningsAsync(startupToolHealthCts.Token).ConfigureAwait(false);
-        }
+        var startupToolHealthPrimeTask = RunStartupToolHealthPrimingAsync(cancellationToken);
 
         using var reader = new StreamReader(_stream, leaveOpen: true);
         using var writer = new StreamWriter(_stream, leaveOpen: true) { AutoFlush = true, NewLine = "\n" };
@@ -163,6 +161,7 @@ internal sealed partial class ChatServiceSession {
 
                 switch (request) {
                     case HelloRequest:
+                        await AwaitStartupToolHealthPrimingForHelloAsync(startupToolHealthPrimeTask, cancellationToken).ConfigureAwait(false);
                         await WriteAsync(writer, new HelloMessage {
                             Kind = ChatServiceMessageKind.Response,
                             RequestId = request.RequestId,


### PR DESCRIPTION
## Summary
- run startup tool-health priming in the background instead of blocking `ChatServiceSession.RunAsync` before request processing starts
- keep startup priming bounded (existing 6s budget), and add defensive error logging for unexpected priming failures
- keep `hello` policy quality by waiting up to 250ms for priming completion before responding

## Startup profiling (5-run cold launch)
Baseline (previous run on `master`):
- AvgProgramToDoneMs: `10186.0`
- AvgStartupFlowMs: `9774.1`
- AvgPhaseConnectMs: `9169.9`
- AvgConnectHelloMs: `4885.8`

This branch:
- AvgProgramToDoneMs: `9987.2` (`-198.8 ms`)
- AvgStartupFlowMs: `9566.7` (`-207.4 ms`)
- AvgPhaseConnectMs: `8844.8` (`-325.1 ms`)
- AvgConnectHelloMs: `4100.3` (`-785.5 ms`)

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release` (passed: 430)
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release` (passed: 188)
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Service/IntelligenceX.Chat.Service.csproj -c Release` (passed)
