### PR TITLE
perf(chat-app): shorten cold-start initial sidecar probe

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
@@ -1,0 +1,27 @@
+using System;
+using IntelligenceX.Chat.App;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Tests startup connect timeout policy selection for initial pipe probes.
+/// </summary>
+public sealed class MainWindowStartupConnectTimeoutPolicyTests {
+    /// <summary>
+    /// Ensures startup connect initial probe timeout is short on cold start,
+    /// and remains conservative for user action or known-running sidecar reconnects.
+    /// </summary>
+    [Theory]
+    [InlineData(true, true, 2000)]
+    [InlineData(true, false, 2000)]
+    [InlineData(false, true, 2000)]
+    [InlineData(false, false, 350)]
+    public void ResolveStartupInitialPipeConnectTimeout_ReturnsExpectedTimeout(
+        bool fromUserAction,
+        bool hasTrackedRunningServiceProcess,
+        int expectedTimeoutMs) {
+        var timeout = MainWindow.ResolveStartupInitialPipeConnectTimeout(fromUserAction, hasTrackedRunningServiceProcess);
+        Assert.Equal(TimeSpan.FromMilliseconds(expectedTimeoutMs), timeout);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
@@ -26,6 +26,13 @@ using Windows.Graphics;
 namespace IntelligenceX.Chat.App;
 
 public sealed partial class MainWindow : Window {
+    internal static TimeSpan ResolveStartupInitialPipeConnectTimeout(bool fromUserAction, bool hasTrackedRunningServiceProcess) {
+        if (fromUserAction || hasTrackedRunningServiceProcess) {
+            return StartupInitialPipeConnectTimeout;
+        }
+
+        return StartupInitialPipeConnectColdStartTimeout;
+    }
 
     private async Task ConnectAsync(bool fromUserAction = false) {
         await _connectGate.WaitAsync().ConfigureAwait(false);
@@ -59,10 +66,12 @@ public sealed partial class MainWindow : Window {
             client.MessageReceived += OnServiceMessage;
             client.Disconnected += OnClientDisconnected;
             Exception? initialConnectException = null;
+            var hasTrackedRunningServiceProcess = _serviceProcess is not null && !_serviceProcess.HasExited;
+            var initialPipeConnectTimeout = ResolveStartupInitialPipeConnectTimeout(fromUserAction, hasTrackedRunningServiceProcess);
 
             try {
                 LogStartupConnectPhase("pipe_connect.initial", "begin");
-                await ConnectClientWithTimeoutAsync(client, pipeName, TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                await ConnectClientWithTimeoutAsync(client, pipeName, initialPipeConnectTimeout).ConfigureAwait(false);
                 LogStartupConnectPhase("pipe_connect.initial", "done");
             } catch (Exception ex) {
                 LogStartupConnectPhase("pipe_connect.initial", "failed");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -64,6 +64,8 @@ public sealed partial class MainWindow : Window {
     private static readonly TimeSpan TurnWatchdogHintThreshold = TimeSpan.FromSeconds(20);
     private static readonly TimeSpan WheelForwardCoalesceInterval = TimeSpan.FromMilliseconds(12);
     private static readonly TimeSpan DragMoveWatchdogInterval = TimeSpan.FromMilliseconds(1200);
+    private static readonly TimeSpan StartupInitialPipeConnectTimeout = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan StartupInitialPipeConnectColdStartTimeout = TimeSpan.FromMilliseconds(350);
     private static readonly TimeSpan StartupConnectRetryDelay = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan[] StartupConnectRetryTimeouts = {
         TimeSpan.FromSeconds(6),


### PR DESCRIPTION
## Summary
- reduce startup `pipe_connect.initial` probe time on cold start from 2s to 350ms when startup is not user-triggered and we do not have a tracked running sidecar process
- preserve the previous 2s timeout for user-triggered reconnects and when a tracked sidecar process is already running
- add an explicit timeout policy helper (`ResolveStartupInitialPipeConnectTimeout`) and tests for all policy branches

## Startup profiling (5-run cold launch)
Baseline (after #482):
- AvgProgramToDoneMs: `9987.2`
- AvgStartupFlowMs: `9566.7`
- AvgPhaseConnectMs: `8844.8`

This branch:
- AvgProgramToDoneMs: `8146.8` (`-1840.4 ms`)
- AvgStartupFlowMs: `7715.1` (`-1851.6 ms`)
- AvgPhaseConnectMs: `6975.6` (`-1869.2 ms`)
- AvgConnectPipeInitialAttemptMs: `374.3` (new metric, measured begin -> done/failed)

Note: `AvgConnectHelloMs` remains noisy due cold-first-run outliers; warm runs (iterations 2-5) improved vs baseline.

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release` (passed)
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release` (passed: 192)
