### PR TITLE
perf(chat-service): lazy-connect backend client for startup

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
@@ -19,7 +19,7 @@ internal sealed partial class ChatServiceSession {
     private sealed record SetProfileResult(bool ReconnectClient, bool ModelChanged);
     private sealed record ModelListCacheEntry(string Key, DateTime ExpiresAtUtc, ModelListResult Result);
 
-    private static async ValueTask DisposeClientAsync(IntelligenceXClient client) {
+    private static async ValueTask DisposeClientAsync(IntelligenceXClient? client) {
         if (client is null) {
             return;
         }
@@ -131,8 +131,7 @@ internal sealed partial class ChatServiceSession {
         }
     }
 
-    private async Task<SetProfileResult> HandleSetProfileAsync(IntelligenceXClient client, StreamWriter writer, SetProfileRequest request,
-        CancellationToken cancellationToken) {
+    private async Task<SetProfileResult> HandleSetProfileAsync(StreamWriter writer, SetProfileRequest request, CancellationToken cancellationToken) {
         var name = (request.ProfileName ?? string.Empty).Trim();
         if (name.Length == 0) {
             await WriteAsync(writer, new ErrorMessage {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
@@ -122,6 +122,13 @@ internal sealed partial class ChatServiceSession {
         }
     }
 
+    internal static bool RequestRequiresConnectedClient(ChatServiceRequest request) {
+        return request is EnsureLoginRequest
+               or StartChatGptLoginRequest
+               or ListModelsRequest
+               or ChatRequest;
+    }
+
     public async Task RunAsync(CancellationToken cancellationToken) {
         var instructions = LoadInstructions(_options);
         _instructions = instructions;
@@ -130,7 +137,16 @@ internal sealed partial class ChatServiceSession {
         using var reader = new StreamReader(_stream, leaveOpen: true);
         using var writer = new StreamWriter(_stream, leaveOpen: true) { AutoFlush = true, NewLine = "\n" };
         string? activeThreadId = null;
-        var client = await ConnectClientAsync(cancellationToken).ConfigureAwait(false);
+        IntelligenceXClient? client = null;
+
+        async Task<IntelligenceXClient> GetOrConnectClientAsync() {
+            if (client is not null) {
+                return client;
+            }
+
+            client = await ConnectClientAsync(cancellationToken).ConfigureAwait(false);
+            return client;
+        }
 
         try {
             while (!cancellationToken.IsCancellationRequested) {
@@ -159,6 +175,10 @@ internal sealed partial class ChatServiceSession {
                     continue;
                 }
 
+                var connectedClient = RequestRequiresConnectedClient(request)
+                    ? await GetOrConnectClientAsync().ConfigureAwait(false)
+                    : null;
+
                 switch (request) {
                     case HelloRequest:
                         await AwaitStartupToolHealthPrimingForHelloAsync(startupToolHealthPrimeTask, cancellationToken).ConfigureAwait(false);
@@ -173,11 +193,11 @@ internal sealed partial class ChatServiceSession {
                         break;
 
                     case EnsureLoginRequest login:
-                        await HandleEnsureLoginAsync(client, writer, login, cancellationToken).ConfigureAwait(false);
+                        await HandleEnsureLoginAsync(connectedClient!, writer, login, cancellationToken).ConfigureAwait(false);
                         break;
 
                     case StartChatGptLoginRequest startLogin:
-                        await HandleStartChatGptLoginAsync(client, writer, startLogin, cancellationToken).ConfigureAwait(false);
+                        await HandleStartChatGptLoginAsync(connectedClient!, writer, startLogin, cancellationToken).ConfigureAwait(false);
                         break;
 
                     case ChatGptLoginPromptResponseRequest promptResponse:
@@ -201,11 +221,11 @@ internal sealed partial class ChatServiceSession {
                         break;
 
                     case SetProfileRequest setProfile: {
-                            var setResult = await HandleSetProfileAsync(client, writer, setProfile, cancellationToken).ConfigureAwait(false);
+                            var setResult = await HandleSetProfileAsync(writer, setProfile, cancellationToken).ConfigureAwait(false);
                             if (setResult.ReconnectClient) {
                                 await DisposeClientAsync(client).ConfigureAwait(false);
-                                client = await ConnectClientAsync(cancellationToken).ConfigureAwait(false);
-                            } else if (setResult.ModelChanged) {
+                                client = null;
+                            } else if (setResult.ModelChanged && client is not null) {
                                 // Keep the internal thread model selection consistent with the active profile.
                                 client.ConfigureDefaults(model: _options.Model);
                             }
@@ -218,7 +238,7 @@ internal sealed partial class ChatServiceSession {
                         }
 
                     case ListModelsRequest listModels:
-                        await HandleListModelsAsync(client, writer, listModels, cancellationToken).ConfigureAwait(false);
+                        await HandleListModelsAsync(connectedClient!, writer, listModels, cancellationToken).ConfigureAwait(false);
                         break;
 
                     case ListModelFavoritesRequest listFavorites:
@@ -238,7 +258,7 @@ internal sealed partial class ChatServiceSession {
                         break;
 
                     case ChatRequest chat:
-                        activeThreadId = await HandleChatRequestAsync(client, writer, chat, activeThreadId, cancellationToken).ConfigureAwait(false);
+                        activeThreadId = await HandleChatRequestAsync(connectedClient!, writer, chat, activeThreadId, cancellationToken).ConfigureAwait(false);
                         break;
 
                     default:

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRequestClientConnectionPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRequestClientConnectionPolicyTests.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Service;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class ChatServiceRequestClientConnectionPolicyTests {
+    public static IEnumerable<object[]> RequestConnectionPolicyCases() {
+        yield return new object[] { new HelloRequest { RequestId = "req_hello" }, false };
+        yield return new object[] { new ListToolsRequest { RequestId = "req_tools" }, false };
+        yield return new object[] { new CheckToolHealthRequest { RequestId = "req_health" }, false };
+        yield return new object[] { new ListProfilesRequest { RequestId = "req_profiles" }, false };
+        yield return new object[] { new SetProfileRequest { RequestId = "req_profile_set", ProfileName = "local" }, false };
+        yield return new object[] { new EnsureLoginRequest { RequestId = "req_login" }, true };
+        yield return new object[] { new StartChatGptLoginRequest { RequestId = "req_login_start", TimeoutSeconds = 120 }, true };
+        yield return new object[] { new ListModelsRequest { RequestId = "req_models" }, true };
+        yield return new object[] { new ChatRequest { RequestId = "req_chat", Text = "hello" }, true };
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestConnectionPolicyCases))]
+    public void RequestRequiresConnectedClient_ReturnsExpected(ChatServiceRequest request, bool expected) {
+        var result = ChatServiceSession.RequestRequiresConnectedClient(request);
+
+        Assert.Equal(expected, result);
+    }
+}


### PR DESCRIPTION
## Summary
- stop eagerly connecting `IntelligenceXClient` at `ChatServiceSession.RunAsync` startup
- connect backend client lazily only for requests that require it (`ensure_login`, `chatgpt_login_start`, `list_models`, `chat`)
- keep profile switching behavior stable by:
  - disposing and nulling existing client when a profile change requires reconnect
  - updating defaults only when an existing connected client is present
- add explicit request-policy helper and tests for connection eligibility

## Startup profiling (5-run cold launch)
Baseline (after #483):
- AvgProgramToDoneMs: `8146.8`
- AvgStartupFlowMs: `7715.1`
- AvgPhaseConnectMs: `6975.6`
- AvgConnectHelloMs: `4493.9`

This branch:
- AvgProgramToDoneMs: `6204.1` (`-1942.7 ms`)
- AvgStartupFlowMs: `5906.7` (`-1808.4 ms`)
- AvgPhaseConnectMs: `5171.1` (`-1804.5 ms`)
- AvgConnectHelloMs: `2984.6` (`-1509.3 ms`)

Notes:
- Profiling run was executed with pre-cleanup of stale `IntelligenceX.Chat.App`/`IntelligenceX.Chat.Service` processes per iteration to avoid shared named-pipe contention skew (`intelligencex.chat`).

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release` (passed: 439)
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release` (passed: 192)
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release` (passed)
