### PR TITLE
perf(chat-app): defer startup model/profile sync from connect path

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
@@ -24,4 +24,17 @@ public sealed class MainWindowStartupConnectTimeoutPolicyTests {
         var timeout = MainWindow.ResolveStartupInitialPipeConnectTimeout(fromUserAction, hasTrackedRunningServiceProcess);
         Assert.Equal(TimeSpan.FromMilliseconds(expectedTimeoutMs), timeout);
     }
+
+    /// <summary>
+    /// Ensures model/profile sync is deferred only during startup flow telemetry capture.
+    /// </summary>
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void ShouldDeferStartupModelProfileSync_ReturnsExpectedValue(
+        bool captureStartupPhaseTelemetry,
+        bool expected) {
+        var shouldDefer = MainWindow.ShouldDeferStartupModelProfileSync(captureStartupPhaseTelemetry);
+        Assert.Equal(expected, shouldDefer);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
@@ -34,6 +34,10 @@ public sealed partial class MainWindow : Window {
         return StartupInitialPipeConnectColdStartTimeout;
     }
 
+    internal static bool ShouldDeferStartupModelProfileSync(bool captureStartupPhaseTelemetry) {
+        return captureStartupPhaseTelemetry;
+    }
+
     private async Task ConnectAsync(bool fromUserAction = false) {
         await _connectGate.WaitAsync().ConfigureAwait(false);
         try {
@@ -169,17 +173,22 @@ public sealed partial class MainWindow : Window {
                 LogStartupConnectPhase("auth_refresh", "failed");
                 throw;
             }
-            try {
-                LogStartupConnectPhase("model_profile_sync", "begin");
-                await SyncConnectedServiceProfileAndModelsAsync(
-                    forceModelRefresh: false,
-                    setProfileNewThread: false,
-                    appendWarnings: false).ConfigureAwait(false);
-                LogStartupConnectPhase("model_profile_sync", "done");
-            } catch (Exception ex) {
-                LogStartupConnectPhase("model_profile_sync", "failed");
-                if (VerboseServiceLogs || _debugMode) {
-                    AppendSystem("Model/profile sync failed: " + ex.Message);
+            if (ShouldDeferStartupModelProfileSync(captureStartupPhaseTelemetry)) {
+                LogStartupConnectPhase("model_profile_sync", "deferred");
+                QueueDeferredStartupModelProfileSync();
+            } else {
+                try {
+                    LogStartupConnectPhase("model_profile_sync", "begin");
+                    await SyncConnectedServiceProfileAndModelsAsync(
+                        forceModelRefresh: false,
+                        setProfileNewThread: false,
+                        appendWarnings: false).ConfigureAwait(false);
+                    LogStartupConnectPhase("model_profile_sync", "done");
+                } catch (Exception ex) {
+                    LogStartupConnectPhase("model_profile_sync", "failed");
+                    if (VerboseServiceLogs || _debugMode) {
+                        AppendSystem("Model/profile sync failed: " + ex.Message);
+                    }
                 }
             }
         } finally {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -281,6 +281,7 @@ public sealed partial class MainWindow : Window {
     private bool _modelKickoffInProgress;
     private bool _autoSignInAttempted;
     private int _startupOnboardingDeferredQueued;
+    private int _startupModelProfileSyncDeferredQueued;
     private string _themePreset = "default";
     private string? _sessionUserNameOverride;
     private string? _sessionAssistantPersonaOverride;
@@ -527,6 +528,37 @@ public sealed partial class MainWindow : Window {
                 StartupLog.Write("StartupPhase.Onboarding done");
             } catch (Exception ex) {
                 StartupLog.Write("StartupPhase.Onboarding failed: " + ex.Message);
+            }
+        });
+    }
+
+    private void QueueDeferredStartupModelProfileSync() {
+        if (_shutdownRequested) {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _startupModelProfileSyncDeferredQueued, 1, 0) != 0) {
+            return;
+        }
+
+        _ = Task.Run(async () => {
+            try {
+                await Task.Delay(150).ConfigureAwait(false);
+                if (_shutdownRequested) {
+                    return;
+                }
+
+                StartupLog.Write("StartupConnect.model_profile_sync begin");
+                await SyncConnectedServiceProfileAndModelsAsync(
+                    forceModelRefresh: false,
+                    setProfileNewThread: false,
+                    appendWarnings: false).ConfigureAwait(false);
+                StartupLog.Write("StartupConnect.model_profile_sync done");
+            } catch (Exception ex) {
+                StartupLog.Write("StartupConnect.model_profile_sync failed");
+                if (VerboseServiceLogs || _debugMode) {
+                    AppendSystem("Model/profile sync failed: " + ex.Message);
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- defer startup `model_profile_sync` during startup telemetry-capture flow and queue it asynchronously after connect instead of inlining it in `ConnectAsync`
- add single-purpose policy helper `ShouldDeferStartupModelProfileSync(...)` and corresponding unit tests
- keep existing inline sync behavior for non-startup reconnect paths

## Changes
- `IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs`
  - add `_startupModelProfileSyncDeferredQueued`
  - add `QueueDeferredStartupModelProfileSync()` one-shot deferred runner with startup telemetry logging
- `IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs`
  - add `ShouldDeferStartupModelProfileSync(bool)`
  - switch startup path to `model_profile_sync deferred` + queued sync
  - preserve existing inline sync for non-startup paths
- `IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs`
  - add theory coverage for `ShouldDeferStartupModelProfileSync`

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
  - Passed: 194, Failed: 0

## Startup timing profile (5 runs each)
Method: parsed `StartupLog` from `Program.Main enter` -> `MainWindow.StartupFlow done`.

### Baseline (commit `1bd2b36`)
- run1: 19320.91 ms
- run2: 3334.67 ms
- run3: 5215.17 ms
- run4: 5317.01 ms
- run5: 5072.86 ms

### This branch
- run1: 17974.07 ms
- run2: 3160.52 ms
- run3: 3224.01 ms
- run4: 2999.70 ms
- run5: 3144.81 ms

### Delta
- cold-start (run1): **-1346.84 ms** (**-6.97%**)
- warm average (runs2-5): **-1602.67 ms** (**-33.85%**)
- all-runs average: **-1551.50 ms** (**-20.28%**)
