### PR TITLE
feat(todo): add PR operational signals (size/risk/readiness/freshness)

### DIFF
--- a/Docs/reviewer/project-bootstrap-sync.md
+++ b/Docs/reviewer/project-bootstrap-sync.md
@@ -88,6 +88,7 @@ intelligencex todo project-sync \
 
 - Project item fields for triage and vision fit.
 - Signal-quality fields (`Signal Quality`, `Signal Quality Score`, `Signal Quality Notes`).
+- Operational PR fields (`PR Size`, `PR Churn Risk`, `PR Merge Readiness`, `PR Freshness`).
 - Suggested maintainership decision signal (`IX Suggested Decision`).
 - Optional managed label reconciliation for IX taxonomies.
 - Optional assistive cross-link comments for related PR/issue context.

--- a/Docs/reviewer/project-views-and-ops.md
+++ b/Docs/reviewer/project-views-and-ops.md
@@ -43,6 +43,7 @@ Useful options:
 - `--out <path>` writes markdown to custom location.
 
 Both checklist and apply-plan outputs include recommended columns per view. Use those column sets, otherwise triage quality signals stay hidden and the board appears weak.
+Recommended columns now include operational PR signals such as `PR Size`, `PR Churn Risk`, `PR Merge Readiness`, and `PR Freshness`.
 
 ## Sync bot feedback into TODO.md
 

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -18,6 +18,7 @@ These commands are assistive. They are not an autonomous production decision sys
 - GitHub Project field sync for triage at scale (`project-init`, `project-sync`, `project-bootstrap`).
 - Maintainer-assist view checklist and apply plan generation (`project-view-checklist`, `project-view-apply`).
 - Signal quality grading (`high`/`medium`/`low`) to separate strong recommendations from weak-context items.
+- Operational PR signals (`PR Size`, `PR Churn Risk`, `PR Merge Readiness`, `PR Freshness`) for faster triage.
 
 ## Recommended end-to-end flow
 

--- a/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
@@ -35,6 +35,29 @@ internal static class ProjectFieldCatalog {
         }),
         new ProjectFieldDefinition("Signal Quality Score", "NUMBER", Array.Empty<string>()),
         new ProjectFieldDefinition("Signal Quality Notes", "TEXT", Array.Empty<string>()),
+        new ProjectFieldDefinition("PR Size", "SINGLE_SELECT", new[] {
+            "xsmall",
+            "small",
+            "medium",
+            "large",
+            "xlarge"
+        }),
+        new ProjectFieldDefinition("PR Churn Risk", "SINGLE_SELECT", new[] {
+            "low",
+            "medium",
+            "high"
+        }),
+        new ProjectFieldDefinition("PR Merge Readiness", "SINGLE_SELECT", new[] {
+            "ready",
+            "needs-review",
+            "blocked"
+        }),
+        new ProjectFieldDefinition("PR Freshness", "SINGLE_SELECT", new[] {
+            "fresh",
+            "recent",
+            "aging",
+            "stale"
+        }),
         new ProjectFieldDefinition("Tags", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Tag Confidence Summary", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Matched Issue", "TEXT", Array.Empty<string>()),

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -66,7 +66,11 @@ internal static class ProjectSyncRunner {
         IReadOnlyDictionary<string, double>? TagConfidences = null,
         string? SignalQuality = null,
         double? SignalQualityScore = null,
-        IReadOnlyList<string>? SignalQualityReasons = null
+        IReadOnlyList<string>? SignalQualityReasons = null,
+        string? PullRequestSize = null,
+        string? PullRequestChurnRisk = null,
+        string? PullRequestMergeReadiness = null,
+        string? PullRequestFreshness = null
     );
 
     private sealed class Options {
@@ -547,6 +551,10 @@ internal static class ProjectSyncRunner {
                 var signalQuality = NormalizeSignalQuality(ReadNullableString(item, "signalQuality"));
                 var signalQualityScore = ReadNullableDouble(item, "signalQualityScore");
                 var signalQualityReasons = ReadStringArray(item, "signalQualityReasons");
+                var pullRequestSize = NormalizePullRequestSize(ReadNullableString(item, "prSizeBand"));
+                var pullRequestChurnRisk = NormalizePullRequestChurnRisk(ReadNullableString(item, "prChurnRisk"));
+                var pullRequestMergeReadiness = NormalizePullRequestMergeReadiness(ReadNullableString(item, "prMergeReadiness"));
+                var pullRequestFreshness = NormalizePullRequestFreshness(ReadNullableString(item, "prFreshness"));
                 var existingLabels = ReadStringArray(item, "labels");
                 var matchedIssueUrl = ReadNullableString(item, "matchedIssueUrl");
                 var matchedIssueConfidence = ReadNullableDouble(item, "matchedIssueConfidence");
@@ -633,7 +641,11 @@ internal static class ProjectSyncRunner {
                     TagConfidences: tagConfidences,
                     SignalQuality: signalQuality,
                     SignalQualityScore: signalQualityScore,
-                    SignalQualityReasons: signalQualityReasons
+                    SignalQualityReasons: signalQualityReasons,
+                    PullRequestSize: pullRequestSize,
+                    PullRequestChurnRisk: pullRequestChurnRisk,
+                    PullRequestMergeReadiness: pullRequestMergeReadiness,
+                    PullRequestFreshness: pullRequestFreshness
                 );
             }
         }
@@ -742,6 +754,61 @@ internal static class ProjectSyncRunner {
             "high" => "high",
             "medium" => "medium",
             "low" => "low",
+            _ => null
+        };
+    }
+
+    private static string? NormalizePullRequestSize(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        return value.Trim().ToLowerInvariant() switch {
+            "xsmall" => "xsmall",
+            "small" => "small",
+            "medium" => "medium",
+            "large" => "large",
+            "xlarge" => "xlarge",
+            _ => null
+        };
+    }
+
+    private static string? NormalizePullRequestChurnRisk(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        return value.Trim().ToLowerInvariant() switch {
+            "low" => "low",
+            "medium" => "medium",
+            "high" => "high",
+            _ => null
+        };
+    }
+
+    private static string? NormalizePullRequestMergeReadiness(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        return value.Trim().ToLowerInvariant() switch {
+            "ready" => "ready",
+            "needs-review" => "needs-review",
+            "blocked" => "blocked",
+            _ => null
+        };
+    }
+
+    private static string? NormalizePullRequestFreshness(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        return value.Trim().ToLowerInvariant() switch {
+            "fresh" => "fresh",
+            "recent" => "recent",
+            "aging" => "aging",
+            "stale" => "stale",
             _ => null
         };
     }
@@ -1055,6 +1122,50 @@ internal static class ProjectSyncRunner {
                 await client.SetTextFieldAsync(projectId, itemId, signalQualityNotesField.Id, notes).ConfigureAwait(false);
             } else {
                 await client.ClearFieldAsync(projectId, itemId, signalQualityNotesField.Id).ConfigureAwait(false);
+            }
+            updated++;
+        }
+
+        if (fields.TryGetValue("PR Size", out var pullRequestSizeField)) {
+            if (isPullRequest &&
+                !string.IsNullOrWhiteSpace(entry.PullRequestSize) &&
+                TryResolveOptionId(pullRequestSizeField, entry.PullRequestSize, out var optionId)) {
+                await client.SetSingleSelectFieldAsync(projectId, itemId, pullRequestSizeField.Id, optionId).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, pullRequestSizeField.Id).ConfigureAwait(false);
+            }
+            updated++;
+        }
+
+        if (fields.TryGetValue("PR Churn Risk", out var pullRequestChurnRiskField)) {
+            if (isPullRequest &&
+                !string.IsNullOrWhiteSpace(entry.PullRequestChurnRisk) &&
+                TryResolveOptionId(pullRequestChurnRiskField, entry.PullRequestChurnRisk, out var optionId)) {
+                await client.SetSingleSelectFieldAsync(projectId, itemId, pullRequestChurnRiskField.Id, optionId).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, pullRequestChurnRiskField.Id).ConfigureAwait(false);
+            }
+            updated++;
+        }
+
+        if (fields.TryGetValue("PR Merge Readiness", out var pullRequestMergeReadinessField)) {
+            if (isPullRequest &&
+                !string.IsNullOrWhiteSpace(entry.PullRequestMergeReadiness) &&
+                TryResolveOptionId(pullRequestMergeReadinessField, entry.PullRequestMergeReadiness, out var optionId)) {
+                await client.SetSingleSelectFieldAsync(projectId, itemId, pullRequestMergeReadinessField.Id, optionId).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, pullRequestMergeReadinessField.Id).ConfigureAwait(false);
+            }
+            updated++;
+        }
+
+        if (fields.TryGetValue("PR Freshness", out var pullRequestFreshnessField)) {
+            if (isPullRequest &&
+                !string.IsNullOrWhiteSpace(entry.PullRequestFreshness) &&
+                TryResolveOptionId(pullRequestFreshnessField, entry.PullRequestFreshness, out var optionId)) {
+                await client.SetSingleSelectFieldAsync(projectId, itemId, pullRequestFreshnessField.Id, optionId).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, pullRequestFreshnessField.Id).ConfigureAwait(false);
             }
             updated++;
         }

--- a/IntelligenceX.Cli/Todo/ProjectViewCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectViewCatalog.cs
@@ -23,6 +23,10 @@ internal static class ProjectViewCatalog {
                 "Title",
                 "Status",
                 "Triage Kind",
+                "PR Size",
+                "PR Churn Risk",
+                "PR Merge Readiness",
+                "PR Freshness",
                 "Signal Quality",
                 "Signal Quality Score",
                 "Vision Fit",
@@ -41,6 +45,9 @@ internal static class ProjectViewCatalog {
             new[] {
                 "Title",
                 "Status",
+                "PR Size",
+                "PR Merge Readiness",
+                "PR Freshness",
                 "Signal Quality",
                 "Vision Fit",
                 "IX Suggested Decision",
@@ -57,6 +64,8 @@ internal static class ProjectViewCatalog {
                 "Title",
                 "Status",
                 "Vision Fit",
+                "PR Size",
+                "PR Merge Readiness",
                 "Signal Quality",
                 "IX Suggested Decision",
                 "Category"
@@ -71,6 +80,8 @@ internal static class ProjectViewCatalog {
                 "Status",
                 "Duplicate Cluster",
                 "Canonical Item",
+                "PR Size",
+                "PR Churn Risk",
                 "Signal Quality",
                 "Triage Score",
                 "Category"

--- a/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
+++ b/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
@@ -189,6 +189,13 @@ internal static class TriageIndexRunner {
         IReadOnlyList<string> Reasons
     );
 
+    internal sealed record PullRequestOperationalSignals(
+        string SizeBand,
+        string ChurnRisk,
+        string MergeReadiness,
+        string Freshness
+    );
+
     private sealed record IssueReferenceHint(
         int Number,
         double Confidence,
@@ -790,6 +797,59 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                 : "low";
 
         return new SignalQualityAssessment(level, score, reasons);
+    }
+
+    internal static PullRequestOperationalSignals? AssessPullRequestOperationalSignals(
+        TriageIndexItem item,
+        DateTimeOffset nowUtc) {
+        if (item.PullRequest is null ||
+            !item.Kind.Equals("pull_request", StringComparison.OrdinalIgnoreCase)) {
+            return null;
+        }
+
+        var signals = item.PullRequest;
+        var changedFiles = Math.Max(0, signals.ChangedFiles);
+        var changeVolume = Math.Max(0, signals.Additions) + Math.Max(0, signals.Deletions);
+        var ageDays = Math.Max(0, (nowUtc - item.UpdatedAtUtc).TotalDays);
+
+        var sizeBand = (changedFiles, changeVolume) switch {
+            (<= 3, <= 80) => "xsmall",
+            (<= 10, <= 300) => "small",
+            (<= 30, <= 900) => "medium",
+            (<= 80, <= 2500) => "large",
+            _ => "xlarge"
+        };
+
+        var blocked = signals.IsDraft ||
+                      signals.Mergeable.Equals("CONFLICTING", StringComparison.OrdinalIgnoreCase) ||
+                      signals.Mergeable.Equals("UNKNOWN", StringComparison.OrdinalIgnoreCase) ||
+                      signals.ReviewDecision.Equals("CHANGES_REQUESTED", StringComparison.OrdinalIgnoreCase) ||
+                      signals.StatusCheckState.Equals("FAILURE", StringComparison.OrdinalIgnoreCase) ||
+                      signals.StatusCheckState.Equals("ERROR", StringComparison.OrdinalIgnoreCase) ||
+                      signals.StatusCheckState.Equals("PENDING", StringComparison.OrdinalIgnoreCase);
+
+        var mergeReadiness = blocked
+            ? "blocked"
+            : signals.Mergeable.Equals("MERGEABLE", StringComparison.OrdinalIgnoreCase) &&
+              signals.ReviewDecision.Equals("APPROVED", StringComparison.OrdinalIgnoreCase) &&
+              signals.StatusCheckState.Equals("SUCCESS", StringComparison.OrdinalIgnoreCase)
+                ? "ready"
+                : "needs-review";
+
+        var churnRisk = blocked || changedFiles > 120 || changeVolume > 3500
+            ? "high"
+            : changedFiles > 40 || changeVolume > 1200 || signals.Comments > 20 || signals.Commits > 20
+                ? "medium"
+                : "low";
+
+        var freshness = ageDays switch {
+            <= 1 => "fresh",
+            <= 7 => "recent",
+            <= 30 => "aging",
+            _ => "stale"
+        };
+
+        return new PullRequestOperationalSignals(sizeBand, churnRisk, mergeReadiness, freshness);
     }
 
     internal static CategoryTagInference InferCategoryAndTagsWithConfidence(TriageIndexItem item) {
@@ -1673,9 +1733,18 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                 item => item.Item.Id,
                 item => AssessSignalQuality(item.Item, enrichments.TryGetValue(item.Item.Id, out var enrichment) ? enrichment : null),
                 StringComparer.OrdinalIgnoreCase);
+        var pullRequestOperationalSignalsById = scoredItems
+            .ToDictionary(
+                item => item.Item.Id,
+                item => AssessPullRequestOperationalSignals(item.Item, nowUtc),
+                StringComparer.OrdinalIgnoreCase);
         var highSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "high");
         var mediumSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "medium");
         var lowSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "low");
+        var pullRequestSignalValues = pullRequestOperationalSignalsById.Values
+            .Where(value => value is not null)
+            .Select(value => value!)
+            .ToList();
 
         var items = scoredItems
             .OrderByDescending(item => item.Item.UpdatedAtUtc)
@@ -1684,6 +1753,7 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
             .Select(item => {
                 enrichments.TryGetValue(item.Item.Id, out var enrichment);
                 signalAssessmentsById.TryGetValue(item.Item.Id, out var signalQuality);
+                pullRequestOperationalSignalsById.TryGetValue(item.Item.Id, out var operationalSignals);
                 return new {
                     id = item.Item.Id,
                     kind = item.Item.Kind,
@@ -1723,6 +1793,10 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                     signalQuality = signalQuality?.Level ?? "low",
                     signalQualityScore = signalQuality?.Score ?? 0,
                     signalQualityReasons = signalQuality?.Reasons ?? Array.Empty<string>(),
+                    prSizeBand = operationalSignals?.SizeBand,
+                    prChurnRisk = operationalSignals?.ChurnRisk,
+                    prMergeReadiness = operationalSignals?.MergeReadiness,
+                    prFreshness = operationalSignals?.Freshness,
                     score = item.Score,
                     scoreReasons = item.ScoreReasons,
                     signals = new {
@@ -1774,6 +1848,31 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                     high = highSignalCount,
                     medium = mediumSignalCount,
                     low = lowSignalCount
+                },
+                pullRequestSignals = new {
+                    size = new {
+                        xsmall = pullRequestSignalValues.Count(value => value.SizeBand.Equals("xsmall", StringComparison.OrdinalIgnoreCase)),
+                        small = pullRequestSignalValues.Count(value => value.SizeBand.Equals("small", StringComparison.OrdinalIgnoreCase)),
+                        medium = pullRequestSignalValues.Count(value => value.SizeBand.Equals("medium", StringComparison.OrdinalIgnoreCase)),
+                        large = pullRequestSignalValues.Count(value => value.SizeBand.Equals("large", StringComparison.OrdinalIgnoreCase)),
+                        xlarge = pullRequestSignalValues.Count(value => value.SizeBand.Equals("xlarge", StringComparison.OrdinalIgnoreCase))
+                    },
+                    churnRisk = new {
+                        low = pullRequestSignalValues.Count(value => value.ChurnRisk.Equals("low", StringComparison.OrdinalIgnoreCase)),
+                        medium = pullRequestSignalValues.Count(value => value.ChurnRisk.Equals("medium", StringComparison.OrdinalIgnoreCase)),
+                        high = pullRequestSignalValues.Count(value => value.ChurnRisk.Equals("high", StringComparison.OrdinalIgnoreCase))
+                    },
+                    mergeReadiness = new {
+                        ready = pullRequestSignalValues.Count(value => value.MergeReadiness.Equals("ready", StringComparison.OrdinalIgnoreCase)),
+                        needsReview = pullRequestSignalValues.Count(value => value.MergeReadiness.Equals("needs-review", StringComparison.OrdinalIgnoreCase)),
+                        blocked = pullRequestSignalValues.Count(value => value.MergeReadiness.Equals("blocked", StringComparison.OrdinalIgnoreCase))
+                    },
+                    freshness = new {
+                        fresh = pullRequestSignalValues.Count(value => value.Freshness.Equals("fresh", StringComparison.OrdinalIgnoreCase)),
+                        recent = pullRequestSignalValues.Count(value => value.Freshness.Equals("recent", StringComparison.OrdinalIgnoreCase)),
+                        aging = pullRequestSignalValues.Count(value => value.Freshness.Equals("aging", StringComparison.OrdinalIgnoreCase)),
+                        stale = pullRequestSignalValues.Count(value => value.Freshness.Equals("stale", StringComparison.OrdinalIgnoreCase))
+                    }
                 }
             },
             bestPullRequests = best,
@@ -1798,9 +1897,18 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                 item => item.Item.Id,
                 item => AssessSignalQuality(item.Item, enrichments.TryGetValue(item.Item.Id, out var enrichment) ? enrichment : null),
                 StringComparer.OrdinalIgnoreCase);
+        var pullRequestOperationalSignalsById = scoredItems
+            .ToDictionary(
+                item => item.Item.Id,
+                item => AssessPullRequestOperationalSignals(item.Item, nowUtc),
+                StringComparer.OrdinalIgnoreCase);
         var highSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "high");
         var mediumSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "medium");
         var lowSignalCount = signalAssessmentsById.Values.Count(value => value.Level == "low");
+        var pullRequestSignalValues = pullRequestOperationalSignalsById.Values
+            .Where(value => value is not null)
+            .Select(value => value!)
+            .ToList();
 
         var sb = new StringBuilder();
         sb.AppendLine("# IntelligenceX Triage Index");
@@ -1820,6 +1928,18 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
         sb.AppendLine($"- PRs with matched issue: {enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedIssueUrl))}");
         sb.AppendLine($"- Issues with matched PR: {enrichments.Values.Count(value => !string.IsNullOrWhiteSpace(value.MatchedPullRequestUrl))}");
         sb.AppendLine($"- Signal quality (high/medium/low): {highSignalCount}/{mediumSignalCount}/{lowSignalCount}");
+        sb.AppendLine(
+            $"- PR size (xsmall/small/medium/large/xlarge): " +
+            $"{pullRequestSignalValues.Count(value => value.SizeBand.Equals("xsmall", StringComparison.OrdinalIgnoreCase))}/" +
+            $"{pullRequestSignalValues.Count(value => value.SizeBand.Equals("small", StringComparison.OrdinalIgnoreCase))}/" +
+            $"{pullRequestSignalValues.Count(value => value.SizeBand.Equals("medium", StringComparison.OrdinalIgnoreCase))}/" +
+            $"{pullRequestSignalValues.Count(value => value.SizeBand.Equals("large", StringComparison.OrdinalIgnoreCase))}/" +
+            $"{pullRequestSignalValues.Count(value => value.SizeBand.Equals("xlarge", StringComparison.OrdinalIgnoreCase))}");
+        sb.AppendLine(
+            $"- PR merge readiness (ready/needs-review/blocked): " +
+            $"{pullRequestSignalValues.Count(value => value.MergeReadiness.Equals("ready", StringComparison.OrdinalIgnoreCase))}/" +
+            $"{pullRequestSignalValues.Count(value => value.MergeReadiness.Equals("needs-review", StringComparison.OrdinalIgnoreCase))}/" +
+            $"{pullRequestSignalValues.Count(value => value.MergeReadiness.Equals("blocked", StringComparison.OrdinalIgnoreCase))}");
         sb.AppendLine();
         sb.AppendLine("## Best PR Candidates");
         sb.AppendLine();

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -17,6 +17,10 @@ internal static partial class Program {
         AssertEqual(true, names.Contains("Signal Quality", StringComparer.OrdinalIgnoreCase), "has Signal Quality");
         AssertEqual(true, names.Contains("Signal Quality Score", StringComparer.OrdinalIgnoreCase), "has Signal Quality Score");
         AssertEqual(true, names.Contains("Signal Quality Notes", StringComparer.OrdinalIgnoreCase), "has Signal Quality Notes");
+        AssertEqual(true, names.Contains("PR Size", StringComparer.OrdinalIgnoreCase), "has PR Size");
+        AssertEqual(true, names.Contains("PR Churn Risk", StringComparer.OrdinalIgnoreCase), "has PR Churn Risk");
+        AssertEqual(true, names.Contains("PR Merge Readiness", StringComparer.OrdinalIgnoreCase), "has PR Merge Readiness");
+        AssertEqual(true, names.Contains("PR Freshness", StringComparer.OrdinalIgnoreCase), "has PR Freshness");
         AssertEqual(true, names.Contains("Tags", StringComparer.OrdinalIgnoreCase), "has Tags");
         AssertEqual(true, names.Contains("Tag Confidence Summary", StringComparer.OrdinalIgnoreCase), "has Tag Confidence Summary");
         AssertEqual(true, names.Contains("Matched Issue", StringComparer.OrdinalIgnoreCase), "has Matched Issue");
@@ -160,6 +164,10 @@ internal static partial class Program {
         "Description/context is sparse.",
         "No labels present."
       ],
+      "prSizeBand": "xsmall",
+      "prChurnRisk": "low",
+      "prMergeReadiness": "ready",
+      "prFreshness": "fresh",
       "tags": [ "security", "api" ],
       "tagConfidences": {
         "security": 0.91,
@@ -188,6 +196,10 @@ internal static partial class Program {
         AssertEqual(true, entry.SignalQualityScore.HasValue, "signal quality score parsed");
         AssertEqual(42.5, entry.SignalQualityScore!.Value, "signal quality score value");
         AssertEqual(true, (entry.SignalQualityReasons?.Count ?? 0) == 2, "signal quality reasons parsed");
+        AssertEqual("xsmall", entry.PullRequestSize, "pull request size parsed");
+        AssertEqual("low", entry.PullRequestChurnRisk, "pull request churn risk parsed");
+        AssertEqual("ready", entry.PullRequestMergeReadiness, "pull request merge readiness parsed");
+        AssertEqual("fresh", entry.PullRequestFreshness, "pull request freshness parsed");
     }
 
     private static void TestProjectSyncBuildEntriesSuggestsMergeCandidateForBestReadyPr() {

--- a/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
+++ b/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
@@ -352,5 +352,51 @@ internal static partial class Program {
         AssertEqual("high", strongQuality.Level, "strong signal quality level");
         AssertEqual("low", weakQuality.Level, "weak signal quality level");
     }
+
+    private static void TestTriageIndexAssessPullRequestOperationalSignalsClassifiesSizeRiskAndReadiness() {
+        var now = DateTimeOffset.UtcNow;
+        var xsmallReady = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "pr#801",
+            "pull_request",
+            801,
+            "Fix typo in docs",
+            "https://example/pr/801",
+            now,
+            Array.Empty<string>(),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Fix typo in docs"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Fix typo in docs"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Fix typo in docs and markdown style"),
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.PullRequestSignals(false, "MERGEABLE", "APPROVED", "SUCCESS", 2, 20, 5, 0, 1, "dev"),
+            null
+        );
+        var blockedHighRisk = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "pr#802",
+            "pull_request",
+            802,
+            "Massive refactor",
+            "https://example/pr/802",
+            now.AddDays(-45),
+            Array.Empty<string>(),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Massive refactor"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Massive refactor"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Massive refactor with broad subsystem changes"),
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.PullRequestSignals(true, "CONFLICTING", "CHANGES_REQUESTED", "FAILURE", 240, 7000, 2000, 35, 55, "dev"),
+            null
+        );
+
+        var readySignals = IntelligenceX.Cli.Todo.TriageIndexRunner.AssessPullRequestOperationalSignals(xsmallReady, now);
+        var blockedSignals = IntelligenceX.Cli.Todo.TriageIndexRunner.AssessPullRequestOperationalSignals(blockedHighRisk, now);
+
+        AssertNotNull(readySignals, "ready signals not null");
+        AssertNotNull(blockedSignals, "blocked signals not null");
+        AssertEqual("xsmall", readySignals!.SizeBand, "xsmall size");
+        AssertEqual("low", readySignals.ChurnRisk, "low churn risk");
+        AssertEqual("ready", readySignals.MergeReadiness, "ready merge readiness");
+        AssertEqual("fresh", readySignals.Freshness, "freshness classification");
+        AssertEqual("xlarge", blockedSignals!.SizeBand, "xlarge size");
+        AssertEqual("high", blockedSignals.ChurnRisk, "high churn risk");
+        AssertEqual("blocked", blockedSignals.MergeReadiness, "blocked merge readiness");
+        AssertEqual("stale", blockedSignals.Freshness, "stale freshness");
+    }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -462,6 +462,7 @@ internal static partial class Program {
         failed += Run("Todo triage index category/tag inference", TestTriageIndexInferCategoryAndTagsDetectsSecurity);
         failed += Run("Todo triage index category/tag confidence inference", TestTriageIndexInferCategoryAndTagsWithConfidenceUsesEvidenceStrength);
         failed += Run("Todo triage index signal-quality inference", TestTriageIndexAssessSignalQualityDistinguishesStrongAndWeakContext);
+        failed += Run("Todo triage index operational signals", TestTriageIndexAssessPullRequestOperationalSignalsClassifiesSizeRiskAndReadiness);
         failed += Run("Todo vision check out-of-scope classification", TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate);
         failed += Run("Todo vision check aligned classification", TestVisionCheckClassifiesAlignedWhenInTokensMatch);
         failed += Run("Todo vision check explicit reject policy precedence", TestVisionCheckExplicitRejectPolicyTakesPrecedence);


### PR DESCRIPTION
## Summary
- add PR operational signals in triage index output (`prSizeBand`, `prChurnRisk`, `prMergeReadiness`, `prFreshness`)
- expose aggregate PR signal distributions in triage summary and markdown
- sync new PR signal fields into GitHub Project items (`PR Size`, `PR Churn Risk`, `PR Merge Readiness`, `PR Freshness`)
- surface these fields in suggested project views and document the new signals
- extend tests for triage classification and project sync parsing

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet .\\IntelligenceX.Tests\\bin\\Release\\net8.0\\IntelligenceX.Tests.dll`
- `dotnet .\\IntelligenceX.Tests\\bin\\Release\\net10.0\\IntelligenceX.Tests.dll`
