### PR TITLE
Reduce AD policy tool duplication via shared attribution helpers

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
+using ADPlayground.Gpo;
 using ADPlayground.Helpers;
 using IntelligenceX.Json;
 using IntelligenceX.Tools.Common;
@@ -157,6 +159,56 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
                 metaMutate?.Invoke(meta);
             });
         return response;
+    }
+
+    /// <summary>
+    /// Builds filtered + capped policy-attribution rows using consistent configured-value semantics.
+    /// </summary>
+    protected static IReadOnlyList<PolicyAttribution> PreparePolicyAttributionRows(
+        IReadOnlyList<PolicyAttribution> attribution,
+        bool includeAttribution,
+        bool configuredAttributionOnly,
+        int maxResults,
+        out int scanned,
+        out bool truncated) {
+        var filtered = includeAttribution
+            ? attribution
+                .Where(static row => row is not null)
+                .Where(row => !configuredAttributionOnly || IsConfiguredAttributionValue(row.Effective))
+                .ToArray()
+            : Array.Empty<PolicyAttribution>();
+
+        scanned = filtered.Length;
+        if (scanned <= maxResults) {
+            truncated = false;
+            return filtered;
+        }
+
+        truncated = true;
+        return filtered.Take(maxResults).ToArray();
+    }
+
+    /// <summary>
+    /// Adds standard policy-attribution query metadata keys.
+    /// </summary>
+    protected static void AddStandardPolicyAttributionMeta(
+        JsonObject meta,
+        string domainName,
+        bool includeAttribution,
+        bool configuredAttributionOnly,
+        int maxResults) {
+        meta.Add("domain_name", domainName);
+        meta.Add("include_attribution", includeAttribution);
+        meta.Add("configured_attribution_only", configuredAttributionOnly);
+        meta.Add("max_results", maxResults);
+    }
+
+    /// <summary>
+    /// Determines whether policy-attribution effective value is configured.
+    /// </summary>
+    protected static bool IsConfiguredAttributionValue(string? effectiveValue) {
+        return !string.IsNullOrWhiteSpace(effectiveValue)
+               && !effectiveValue.TrimStart().StartsWith("Not configured", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDefenderAsrPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDefenderAsrPolicyTool.cs
@@ -79,17 +79,13 @@ public sealed class AdDefenderAsrPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(errorResponse!);
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase) && !string.Equals(row.Effective, "Off", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdDefenderAsrPolicyResult(
             DomainName: domainName,
@@ -122,10 +118,7 @@ public sealed class AdDefenderAsrPolicyTool : ActiveDirectoryToolBase, ITool {
             scanned: scanned,
             maxTop: MaxViewTop,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             });
         return Task.FromResult(response);
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDenyLogonRightsPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDenyLogonRightsPolicyTool.cs
@@ -68,17 +68,13 @@ public sealed class AdDenyLogonRightsPolicyTool : ActiveDirectoryToolBase, ITool
             return Task.FromResult(errorResponse!);
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdDenyLogonRightsPolicyResult(
             DomainName: domainName,
@@ -100,10 +96,7 @@ public sealed class AdDenyLogonRightsPolicyTool : ActiveDirectoryToolBase, ITool
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdEnableDelegationPrivilegePolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdEnableDelegationPrivilegePolicyTool.cs
@@ -68,17 +68,13 @@ public sealed class AdEnableDelegationPrivilegePolicyTool : ActiveDirectoryToolB
             return Task.FromResult(errorResponse!);
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdEnableDelegationPrivilegePolicyResult(
             DomainName: domainName,
@@ -100,10 +96,7 @@ public sealed class AdEnableDelegationPrivilegePolicyTool : ActiveDirectoryToolB
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdEveryoneIncludesAnonymousPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdEveryoneIncludesAnonymousPolicyTool.cs
@@ -69,17 +69,13 @@ public sealed class AdEveryoneIncludesAnonymousPolicyTool : ActiveDirectoryToolB
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdEveryoneIncludesAnonymousPolicyResult(
             DomainName: domainName,
@@ -103,10 +99,7 @@ public sealed class AdEveryoneIncludesAnonymousPolicyTool : ActiveDirectoryToolB
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdHardenedPathsPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdHardenedPathsPolicyTool.cs
@@ -69,17 +69,13 @@ public sealed class AdHardenedPathsPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdHardenedPathsPolicyResult(
             DomainName: domainName,
@@ -103,10 +99,7 @@ public sealed class AdHardenedPathsPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKdcProxyPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKdcProxyPolicyTool.cs
@@ -69,17 +69,13 @@ public sealed class AdKdcProxyPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdKdcProxyPolicyResult(
             DomainName: domainName,
@@ -103,10 +99,7 @@ public sealed class AdKdcProxyPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosPacPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosPacPolicyTool.cs
@@ -68,17 +68,13 @@ public sealed class AdKerberosPacPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdKerberosPacPolicyResult(
             DomainName: domainName,
@@ -101,10 +97,7 @@ public sealed class AdKerberosPacPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLimitBlankPasswordUsePolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLimitBlankPasswordUsePolicyTool.cs
@@ -67,17 +67,13 @@ public sealed class AdLimitBlankPasswordUsePolicyTool : ActiveDirectoryToolBase,
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdLimitBlankPasswordUsePolicyResult(
             DomainName: domainName,
@@ -99,10 +95,7 @@ public sealed class AdLimitBlankPasswordUsePolicyTool : ActiveDirectoryToolBase,
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLlmnrPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLlmnrPolicyTool.cs
@@ -68,17 +68,13 @@ public sealed class AdLlmnrPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(errorResponse!);
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdLlmnrPolicyResult(
             DomainName: domainName,
@@ -100,10 +96,7 @@ public sealed class AdLlmnrPolicyTool : ActiveDirectoryToolBase, ITool {
             scanned: scanned,
             maxTop: MaxViewTop,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLogonUxUacPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLogonUxUacPolicyTool.cs
@@ -69,17 +69,13 @@ public sealed class AdLogonUxUacPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdLogonUxUacPolicyResult(
             DomainName: domainName,
@@ -103,10 +99,7 @@ public sealed class AdLogonUxUacPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLsaProtectionPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLsaProtectionPolicyTool.cs
@@ -66,17 +66,13 @@ public sealed class AdLsaProtectionPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdLsaProtectionPolicyResult(
             DomainName: domainName,
@@ -97,10 +93,7 @@ public sealed class AdLsaProtectionPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNameResolutionPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNameResolutionPolicyTool.cs
@@ -67,17 +67,13 @@ public sealed class AdNameResolutionPolicyTool : ActiveDirectoryToolBase, ITool 
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdNameResolutionPolicyResult(
             DomainName: domainName,
@@ -99,10 +95,7 @@ public sealed class AdNameResolutionPolicyTool : ActiveDirectoryToolBase, ITool 
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNetSessionHardeningPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNetSessionHardeningPolicyTool.cs
@@ -66,17 +66,13 @@ public sealed class AdNetSessionHardeningPolicyTool : ActiveDirectoryToolBase, I
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdNetSessionHardeningPolicyResult(
             DomainName: domainName,
@@ -97,10 +93,7 @@ public sealed class AdNetSessionHardeningPolicyTool : ActiveDirectoryToolBase, I
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNoLmHashPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNoLmHashPolicyTool.cs
@@ -68,17 +68,13 @@ public sealed class AdNoLmHashPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdNoLmHashPolicyResult(
             DomainName: domainName,
@@ -101,10 +97,7 @@ public sealed class AdNoLmHashPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNtlmRestrictionsPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNtlmRestrictionsPolicyTool.cs
@@ -69,17 +69,13 @@ public sealed class AdNtlmRestrictionsPolicyTool : ActiveDirectoryToolBase, IToo
             return Task.FromResult(errorResponse!);
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdNtlmRestrictionsPolicyResult(
             DomainName: domainName,
@@ -102,10 +98,7 @@ public sealed class AdNtlmRestrictionsPolicyTool : ActiveDirectoryToolBase, IToo
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPku2uPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPku2uPolicyTool.cs
@@ -67,17 +67,13 @@ public sealed class AdPku2uPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !row.Effective.StartsWith("Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdPku2uPolicyResult(
             DomainName: domainName,
@@ -99,10 +95,7 @@ public sealed class AdPku2uPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPowerShellLoggingPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPowerShellLoggingPolicyTool.cs
@@ -70,17 +70,13 @@ public sealed class AdPowerShellLoggingPolicyTool : ActiveDirectoryToolBase, ITo
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdPowerShellLoggingPolicyResult(
             DomainName: domainName,
@@ -105,10 +101,7 @@ public sealed class AdPowerShellLoggingPolicyTool : ActiveDirectoryToolBase, ITo
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdProxyPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdProxyPolicyTool.cs
@@ -72,17 +72,13 @@ public sealed class AdProxyPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(errorResponse!);
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdProxyPolicyResult(
             DomainName: domainName,
@@ -108,10 +104,7 @@ public sealed class AdProxyPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSchannelPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSchannelPolicyTool.cs
@@ -73,17 +73,13 @@ public sealed class AdSchannelPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdSchannelPolicyResult(
             DomainName: domainName,
@@ -111,10 +107,7 @@ public sealed class AdSchannelPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTerminalServicesRedirectionPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTerminalServicesRedirectionPolicyTool.cs
@@ -67,17 +67,13 @@ public sealed class AdTerminalServicesRedirectionPolicyTool : ActiveDirectoryToo
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdTerminalServicesRedirectionPolicyResult(
             DomainName: domainName,
@@ -99,10 +95,7 @@ public sealed class AdTerminalServicesRedirectionPolicyTool : ActiveDirectoryToo
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTerminalServicesTimeoutPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTerminalServicesTimeoutPolicyTool.cs
@@ -70,17 +70,13 @@ public sealed class AdTerminalServicesTimeoutPolicyTool : ActiveDirectoryToolBas
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdTerminalServicesTimeoutPolicyResult(
             DomainName: domainName,
@@ -105,10 +101,7 @@ public sealed class AdTerminalServicesTimeoutPolicyTool : ActiveDirectoryToolBas
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdWdigestPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdWdigestPolicyTool.cs
@@ -68,17 +68,13 @@ public sealed class AdWdigestPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(errorResponse!);
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !row.Effective.StartsWith("Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdWdigestPolicyResult(
             DomainName: domainName,
@@ -100,10 +96,7 @@ public sealed class AdWdigestPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdWinRmPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdWinRmPolicyTool.cs
@@ -68,17 +68,13 @@ public sealed class AdWinRmPolicyTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("query_failed", message));
         }
 
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
+        var rows = PreparePolicyAttributionRows(
+            attribution: view.Attribution,
+            includeAttribution: includeAttribution,
+            configuredAttributionOnly: configuredAttributionOnly,
+            maxResults: maxResults,
+            scanned: out var scanned,
+            truncated: out var truncated);
 
         var result = new AdWinRmPolicyResult(
             DomainName: domainName,
@@ -101,10 +97,7 @@ public sealed class AdWinRmPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
+                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
             }));
     }
 }


### PR DESCRIPTION
## Summary
- add shared policy-attribution helpers in `ActiveDirectoryToolBase`
- centralize filtering/capping of attribution rows and configured-value detection
- centralize standard attribution query metadata emission
- migrate AD policy tools to use the shared helpers

## Why
This removes repeated filtering/capping/meta code across policy tools, keeps behavior consistent, and lowers drift risk when policy-attribution rules change.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
