### PR TITLE
perf(chat-app): defer startup metadata/auth warmup and add profiler scripts

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
@@ -37,4 +37,43 @@ public sealed class MainWindowStartupConnectTimeoutPolicyTests {
         var shouldDefer = MainWindow.ShouldDeferStartupModelProfileSync(captureStartupPhaseTelemetry);
         Assert.Equal(expected, shouldDefer);
     }
+
+    /// <summary>
+    /// Ensures startup hello probe is deferred only during startup flow telemetry capture.
+    /// </summary>
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void ShouldDeferStartupHelloProbe_ReturnsExpectedValue(
+        bool captureStartupPhaseTelemetry,
+        bool expected) {
+        var shouldDefer = MainWindow.ShouldDeferStartupHelloProbe(captureStartupPhaseTelemetry);
+        Assert.Equal(expected, shouldDefer);
+    }
+
+    /// <summary>
+    /// Ensures startup tool-catalog sync is deferred only during startup flow telemetry capture.
+    /// </summary>
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void ShouldDeferStartupToolCatalogSync_ReturnsExpectedValue(
+        bool captureStartupPhaseTelemetry,
+        bool expected) {
+        var shouldDefer = MainWindow.ShouldDeferStartupToolCatalogSync(captureStartupPhaseTelemetry);
+        Assert.Equal(expected, shouldDefer);
+    }
+
+    /// <summary>
+    /// Ensures startup auth refresh is deferred only during startup flow telemetry capture.
+    /// </summary>
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void ShouldDeferStartupAuthRefresh_ReturnsExpectedValue(
+        bool captureStartupPhaseTelemetry,
+        bool expected) {
+        var shouldDefer = MainWindow.ShouldDeferStartupAuthRefresh(captureStartupPhaseTelemetry);
+        Assert.Equal(expected, shouldDefer);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
@@ -38,6 +38,18 @@ public sealed partial class MainWindow : Window {
         return captureStartupPhaseTelemetry;
     }
 
+    internal static bool ShouldDeferStartupHelloProbe(bool captureStartupPhaseTelemetry) {
+        return captureStartupPhaseTelemetry;
+    }
+
+    internal static bool ShouldDeferStartupToolCatalogSync(bool captureStartupPhaseTelemetry) {
+        return captureStartupPhaseTelemetry;
+    }
+
+    internal static bool ShouldDeferStartupAuthRefresh(bool captureStartupPhaseTelemetry) {
+        return captureStartupPhaseTelemetry;
+    }
+
     private async Task ConnectAsync(bool fromUserAction = false) {
         await _connectGate.WaitAsync().ConfigureAwait(false);
         try {
@@ -137,41 +149,56 @@ public sealed partial class MainWindow : Window {
             StopAutoReconnectLoop();
             await SetStatusAsync(SessionStatus.Connected()).ConfigureAwait(false);
 
-            try {
-                LogStartupConnectPhase("hello", "begin");
-                var hello = await _client.RequestAsync<HelloMessage>(new HelloRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
-                _sessionPolicy = hello.Policy;
-                LogStartupConnectPhase("hello", "done");
-            } catch (Exception ex) {
-                LogStartupConnectPhase("hello", "failed");
+            var deferStartupMetadataSync = ShouldDeferStartupHelloProbe(captureStartupPhaseTelemetry)
+                                           || ShouldDeferStartupToolCatalogSync(captureStartupPhaseTelemetry);
+            if (deferStartupMetadataSync) {
                 _sessionPolicy = null;
-                if (VerboseServiceLogs || _debugMode) {
-                    AppendSystem(SystemNotice.HelloFailed(ex.Message));
+                LogStartupConnectPhase("hello", "deferred");
+                LogStartupConnectPhase("list_tools", "deferred");
+                QueueDeferredStartupConnectMetadataSync();
+            } else {
+                try {
+                    LogStartupConnectPhase("hello", "begin");
+                    var hello = await _client.RequestAsync<HelloMessage>(new HelloRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
+                    _sessionPolicy = hello.Policy;
+                    LogStartupConnectPhase("hello", "done");
+                } catch (Exception ex) {
+                    LogStartupConnectPhase("hello", "failed");
+                    _sessionPolicy = null;
+                    if (VerboseServiceLogs || _debugMode) {
+                        AppendSystem(SystemNotice.HelloFailed(ex.Message));
+                    }
                 }
             }
 
-            try {
-                LogStartupConnectPhase("list_tools", "begin");
-                var toolList = await _client.RequestAsync<ToolListMessage>(new ListToolsRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
-                UpdateToolCatalog(toolList.Tools);
-                LogStartupConnectPhase("list_tools", "done");
-            } catch (Exception ex) {
-                LogStartupConnectPhase("list_tools", "failed");
-                if (VerboseServiceLogs || _debugMode) {
-                    AppendSystem(SystemNotice.ListToolsFailed(ex.Message));
+            if (!deferStartupMetadataSync) {
+                try {
+                    LogStartupConnectPhase("list_tools", "begin");
+                    var toolList = await _client.RequestAsync<ToolListMessage>(new ListToolsRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
+                    UpdateToolCatalog(toolList.Tools);
+                    LogStartupConnectPhase("list_tools", "done");
+                } catch (Exception ex) {
+                    LogStartupConnectPhase("list_tools", "failed");
+                    if (VerboseServiceLogs || _debugMode) {
+                        AppendSystem(SystemNotice.ListToolsFailed(ex.Message));
+                    }
                 }
             }
 
             AppendStartupToolHealthWarningsFromPolicy();
             AppendUnavailablePacksFromPolicy();
 
-            LogStartupConnectPhase("auth_refresh", "begin");
-            try {
-                _ = await RefreshAuthenticationStateAsync(updateStatus: true).ConfigureAwait(false);
-                LogStartupConnectPhase("auth_refresh", "done");
-            } catch {
-                LogStartupConnectPhase("auth_refresh", "failed");
-                throw;
+            if (ShouldDeferStartupAuthRefresh(captureStartupPhaseTelemetry)) {
+                LogStartupConnectPhase("auth_refresh", "deferred");
+            } else {
+                LogStartupConnectPhase("auth_refresh", "begin");
+                try {
+                    _ = await RefreshAuthenticationStateAsync(updateStatus: true).ConfigureAwait(false);
+                    LogStartupConnectPhase("auth_refresh", "done");
+                } catch {
+                    LogStartupConnectPhase("auth_refresh", "failed");
+                    throw;
+                }
             }
             if (ShouldDeferStartupModelProfileSync(captureStartupPhaseTelemetry)) {
                 LogStartupConnectPhase("model_profile_sync", "deferred");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -280,7 +280,9 @@ public sealed partial class MainWindow : Window {
     private bool _modelKickoffAttempted;
     private bool _modelKickoffInProgress;
     private bool _autoSignInAttempted;
+    private int _startupAuthDeferredQueued;
     private int _startupOnboardingDeferredQueued;
+    private int _startupConnectMetadataDeferredQueued;
     private int _startupModelProfileSyncDeferredQueued;
     private string _themePreset = "default";
     private string? _sessionUserNameOverride;
@@ -495,9 +497,8 @@ public sealed partial class MainWindow : Window {
             StartupLog.Write("StartupPhase.Connect begin");
             await EnsureStartupConnectedAsync().ConfigureAwait(false);
             StartupLog.Write("StartupPhase.Connect done");
-            StartupLog.Write("StartupPhase.Auth begin");
-            await EnsureFirstRunAuthenticatedAsync().ConfigureAwait(false);
-            StartupLog.Write("StartupPhase.Auth done");
+            StartupLog.Write("StartupPhase.Auth deferred");
+            QueueDeferredStartupAuthentication();
             StartupLog.Write("StartupPhase.Onboarding deferred");
             QueueDeferredStartupOnboarding();
             Interlocked.Exchange(ref _startupFlowState, 2);
@@ -532,6 +533,31 @@ public sealed partial class MainWindow : Window {
         });
     }
 
+    private void QueueDeferredStartupAuthentication() {
+        if (_shutdownRequested) {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _startupAuthDeferredQueued, 1, 0) != 0) {
+            return;
+        }
+
+        _ = Task.Run(async () => {
+            try {
+                await Task.Delay(200).ConfigureAwait(false);
+                if (_shutdownRequested) {
+                    return;
+                }
+
+                StartupLog.Write("StartupPhase.Auth begin");
+                await EnsureFirstRunAuthenticatedAsync().ConfigureAwait(false);
+                StartupLog.Write("StartupPhase.Auth done");
+            } catch (Exception ex) {
+                StartupLog.Write("StartupPhase.Auth failed: " + ex.Message);
+            }
+        });
+    }
+
     private void QueueDeferredStartupModelProfileSync() {
         if (_shutdownRequested) {
             return;
@@ -559,6 +585,72 @@ public sealed partial class MainWindow : Window {
                 if (VerboseServiceLogs || _debugMode) {
                     AppendSystem("Model/profile sync failed: " + ex.Message);
                 }
+            }
+        });
+    }
+
+    private void QueueDeferredStartupConnectMetadataSync() {
+        if (_shutdownRequested) {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _startupConnectMetadataDeferredQueued, 1, 0) != 0) {
+            return;
+        }
+
+        _ = Task.Run(async () => {
+            try {
+                await Task.Delay(100).ConfigureAwait(false);
+                if (_shutdownRequested) {
+                    return;
+                }
+
+                var client = _client;
+                if (client is null) {
+                    return;
+                }
+
+                try {
+                    StartupLog.Write("StartupConnect.hello begin");
+                    var hello = await client.RequestAsync<HelloMessage>(new HelloRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
+                    _sessionPolicy = hello.Policy;
+                    StartupLog.Write("StartupConnect.hello done");
+                    AppendStartupToolHealthWarningsFromPolicy();
+                    AppendUnavailablePacksFromPolicy();
+                } catch (Exception ex) {
+                    _sessionPolicy = null;
+                    StartupLog.Write("StartupConnect.hello failed");
+                    if (VerboseServiceLogs || _debugMode) {
+                        AppendSystem(SystemNotice.HelloFailed(ex.Message));
+                    }
+                }
+
+                try {
+                    StartupLog.Write("StartupConnect.list_tools begin");
+                    var toolList = await client.RequestAsync<ToolListMessage>(new ListToolsRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
+                    UpdateToolCatalog(toolList.Tools);
+                    StartupLog.Write("StartupConnect.list_tools done");
+                } catch (Exception ex) {
+                    StartupLog.Write("StartupConnect.list_tools failed");
+                    if (VerboseServiceLogs || _debugMode) {
+                        AppendSystem(SystemNotice.ListToolsFailed(ex.Message));
+                    }
+                }
+
+                try {
+                    StartupLog.Write("StartupConnect.auth_refresh begin");
+                    _ = await RefreshAuthenticationStateAsync(updateStatus: true).ConfigureAwait(false);
+                    StartupLog.Write("StartupConnect.auth_refresh done");
+                } catch (Exception ex) {
+                    StartupLog.Write("StartupConnect.auth_refresh failed");
+                    if (VerboseServiceLogs || _debugMode) {
+                        AppendSystem(SystemNotice.EnsureLoginFailed(ex.Message));
+                    }
+                }
+
+                await PublishOptionsStateSafeAsync().ConfigureAwait(false);
+            } catch (Exception ex) {
+                StartupLog.Write("StartupConnect.metadata_sync failed: " + ex.Message);
             }
         });
     }

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -30,6 +30,18 @@ WinUI app:
 pwsh .\Build\Run-ChatApp.ps1 -Configuration Release
 ```
 
+Startup profiling (phase timing from `StartupLog`):
+
+```powershell
+pwsh .\scripts\profile-chat-startup.ps1 -Runs 5 -OutFile .\artifacts\chat-startup-profile.json
+```
+
+```bash
+./scripts/profile-chat-startup.sh -Runs 5 -OutFile ./artifacts/chat-startup-profile.json
+```
+
+Add `-PostStartupGraceSeconds 2` if you want to include deferred post-startup warmup phases in the report.
+
 Markdown renderer dependency resolution is automatic:
 - Dev: if sibling local source exists (`..\OfficeIMO`), Chat builds against that local project.
 - Fallback: if local source is not present (CI/clean OSS checkout), Chat uses the NuGet package.

--- a/scripts/profile-chat-startup.ps1
+++ b/scripts/profile-chat-startup.ps1
@@ -1,0 +1,170 @@
+[CmdletBinding()]
+param(
+    [string] $ExePath,
+    [ValidateRange(1, 50)]
+    [int] $Runs = 5,
+    [ValidateRange(5, 300)]
+    [int] $TimeoutSeconds = 75,
+    [ValidateRange(0, 120)]
+    [int] $PostStartupGraceSeconds = 0,
+    [string] $OutFile
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows) {
+    throw "This profiler targets the WinUI chat app and currently requires Windows."
+}
+
+$repoRoot = (Get-Item (Join-Path $PSScriptRoot '..')).FullName
+if ([string]::IsNullOrWhiteSpace($ExePath)) {
+    $ExePath = Join-Path $repoRoot 'IntelligenceX.Chat\IntelligenceX.Chat.App\bin\Release\net8.0-windows10.0.26100.0\win-x64\IntelligenceX.Chat.App.exe'
+}
+
+if (-not (Test-Path $ExePath)) {
+    throw "Chat app executable not found: $ExePath"
+}
+
+$startupLogPath = Join-Path $env:TEMP 'IntelligenceX.Chat\app-startup.log'
+
+function Stop-ChatProcesses {
+    Get-Process -Name 'IntelligenceX.Chat.App', 'IntelligenceX.Chat.Service' -ErrorAction SilentlyContinue |
+        Stop-Process -Force -ErrorAction SilentlyContinue
+}
+
+function Parse-Timestamp([string] $line) {
+    if ([string]::IsNullOrWhiteSpace($line)) {
+        return $null
+    }
+
+    if ($line -match '^\[(?<ts>[^\]]+)\]') {
+        return [datetime]::Parse($Matches['ts'])
+    }
+
+    return $null
+}
+
+function Get-MarkerTimestamp([string[]] $lines, [string] $marker) {
+    $line = $lines | Where-Object { $_ -match [regex]::Escape($marker) } | Select-Object -First 1
+    return Parse-Timestamp $line
+}
+
+function Get-DurationMs($start, $end) {
+    if ($null -eq $start -or $null -eq $end) {
+        return $null
+    }
+
+    return [math]::Round(($end - $start).TotalMilliseconds, 2)
+}
+
+function Get-Average([object[]] $values) {
+    $usable = @($values | Where-Object { $null -ne $_ })
+    if ($usable.Count -eq 0) {
+        return $null
+    }
+
+    return [math]::Round((($usable | Measure-Object -Average).Average), 2)
+}
+
+$runResults = New-Object System.Collections.Generic.List[object]
+
+for ($i = 1; $i -le $Runs; $i++) {
+    Stop-ChatProcesses
+    if (Test-Path $startupLogPath) {
+        Remove-Item $startupLogPath -Force
+    }
+
+    $process = Start-Process -FilePath $ExePath -PassThru
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $state = 'timeout'
+
+    while ((Get-Date) -lt $deadline) {
+        if (Test-Path $startupLogPath) {
+            $raw = Get-Content $startupLogPath -Raw -ErrorAction SilentlyContinue
+            if ($raw -match 'MainWindow.StartupFlow done') {
+                $state = 'done'
+                break
+            }
+
+            if ($raw -match 'MainWindow.StartupFlow failed') {
+                $state = 'failed'
+                break
+            }
+        }
+
+        if ($process.HasExited) {
+            $state = 'exited'
+            break
+        }
+
+        Start-Sleep -Milliseconds 200
+    }
+
+    if ($state -eq 'done' -and $PostStartupGraceSeconds -gt 0) {
+        Start-Sleep -Seconds $PostStartupGraceSeconds
+    }
+
+    Stop-ChatProcesses
+    $lines = if (Test-Path $startupLogPath) { Get-Content $startupLogPath -ErrorAction SilentlyContinue } else { @() }
+
+    $run = [ordered]@{
+        run              = $i
+        state            = $state
+        total_ms         = Get-DurationMs (Get-MarkerTimestamp $lines 'Program.Main enter') (Get-MarkerTimestamp $lines 'MainWindow.StartupFlow done')
+        connect_ms       = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupPhase.Connect begin') (Get-MarkerTimestamp $lines 'StartupPhase.Connect done')
+        hello_ms         = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupConnect.hello begin') (Get-MarkerTimestamp $lines 'StartupConnect.hello done')
+        list_tools_ms    = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupConnect.list_tools begin') (Get-MarkerTimestamp $lines 'StartupConnect.list_tools done')
+        auth_refresh_ms  = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupConnect.auth_refresh begin') (Get-MarkerTimestamp $lines 'StartupConnect.auth_refresh done')
+        model_sync_ms    = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupConnect.model_profile_sync begin') (Get-MarkerTimestamp $lines 'StartupConnect.model_profile_sync done')
+        hello_deferred   = [bool]($lines | Where-Object { $_ -match 'StartupConnect.hello deferred' } | Select-Object -First 1)
+        model_deferred   = [bool]($lines | Where-Object { $_ -match 'StartupConnect.model_profile_sync deferred' } | Select-Object -First 1)
+    }
+
+    $runResults.Add([pscustomobject]$run)
+    Write-Host ("Run {0}/{1}: state={2}, total={3}ms, connect={4}ms, hello={5}ms" -f $i, $Runs, $run.state, $run.total_ms, $run.connect_ms, $run.hello_ms)
+}
+
+$completedRuns = @($runResults | Where-Object { $_.state -eq 'done' })
+if ($completedRuns.Count -eq 0) {
+    throw "No successful startup runs completed."
+}
+
+$warmRuns = @($completedRuns | Where-Object { $_.run -gt 1 })
+
+$summary = [pscustomobject]@{
+    runs_requested       = $Runs
+    runs_completed       = $completedRuns.Count
+    avg_total_ms         = Get-Average ($completedRuns | ForEach-Object { $_.total_ms })
+    avg_connect_ms       = Get-Average ($completedRuns | ForEach-Object { $_.connect_ms })
+    avg_hello_ms         = Get-Average ($completedRuns | ForEach-Object { $_.hello_ms })
+    avg_list_tools_ms    = Get-Average ($completedRuns | ForEach-Object { $_.list_tools_ms })
+    avg_auth_refresh_ms  = Get-Average ($completedRuns | ForEach-Object { $_.auth_refresh_ms })
+    avg_model_sync_ms    = Get-Average ($completedRuns | ForEach-Object { $_.model_sync_ms })
+    avg_warm_total_ms    = Get-Average ($warmRuns | ForEach-Object { $_.total_ms })
+    avg_warm_connect_ms  = Get-Average ($warmRuns | ForEach-Object { $_.connect_ms })
+    avg_warm_hello_ms    = Get-Average ($warmRuns | ForEach-Object { $_.hello_ms })
+    hello_deferred_runs  = @($completedRuns | Where-Object { $_.hello_deferred }).Count
+    model_deferred_runs  = @($completedRuns | Where-Object { $_.model_deferred }).Count
+}
+
+$report = [pscustomobject]@{
+    generated_utc = [datetime]::UtcNow.ToString('O')
+    exe_path      = $ExePath
+    startup_log   = $startupLogPath
+    summary       = $summary
+    runs          = $runResults
+}
+
+$json = $report | ConvertTo-Json -Depth 6
+if (-not [string]::IsNullOrWhiteSpace($OutFile)) {
+    $outDir = Split-Path -Parent $OutFile
+    if (-not [string]::IsNullOrWhiteSpace($outDir)) {
+        New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+    }
+
+    Set-Content -Path $OutFile -Value $json
+    Write-Host "Saved report to $OutFile"
+}
+
+$json

--- a/scripts/profile-chat-startup.sh
+++ b/scripts/profile-chat-startup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ps_script="$script_dir/profile-chat-startup.ps1"
+
+if command -v pwsh >/dev/null 2>&1; then
+  exec pwsh -NoLogo -NoProfile -File "$ps_script" "$@"
+fi
+
+if command -v powershell >/dev/null 2>&1; then
+  exec powershell -NoLogo -NoProfile -File "$ps_script" "$@"
+fi
+
+echo "PowerShell is required. Install pwsh to run startup profiling." >&2
+exit 1


### PR DESCRIPTION
## Summary
- defer startup connect metadata/auth warmup (`hello`, `list_tools`, `auth_refresh`) out of the blocking startup connect path and run it in a single queued background pass
- keep non-startup reconnect behavior unchanged (still eager)
- defer startup first-run auth bootstrap (`StartupPhase.Auth`) so startup flow is no longer blocked by auth probes/login bootstrap work
- add reusable cross-platform startup profiler scripts (`scripts/profile-chat-startup.ps1` + `.sh`) and document usage

## Why
Startup connect logs showed warm startup was dominated by startup metadata/auth requests while UI startup waited on connect completion. We now keep startup responsive and let metadata/auth warm after the initial startup-ready state.

## Code changes
- `IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs`
  - added startup defer policy helpers:
    - `ShouldDeferStartupHelloProbe(...)`
    - `ShouldDeferStartupToolCatalogSync(...)`
    - `ShouldDeferStartupAuthRefresh(...)`
  - startup `ConnectAsync` now logs deferred phases and queues a single deferred metadata/auth warmup pass during startup telemetry capture
  - non-startup path keeps eager behavior
- `IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs`
  - added `QueueDeferredStartupConnectMetadataSync()` (one-shot queue) to run:
    - `hello` policy fetch
    - `list_tools` catalog refresh
    - `auth_refresh`
  - added `QueueDeferredStartupAuthentication()` and switched startup flow auth phase to deferred
- `IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs`
  - added tests for new defer policy helpers
- `scripts/profile-chat-startup.ps1`
  - new startup profiler (run loop, phase timing extraction from `StartupLog`, JSON summary output)
  - supports optional `-PostStartupGraceSeconds` for deferred phase capture
- `scripts/profile-chat-startup.sh`
  - cross-platform wrapper that invokes the PowerShell profiler
- `IntelligenceX.Chat/README.md`
  - added startup profiler usage examples

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
  - Passed: 200, Failed: 0

## Startup profile data (5 runs each)
Method: `scripts/profile-chat-startup.ps1` (default mode; startup completion measured by `Program.Main enter` -> `MainWindow.StartupFlow done`).

Baseline (`origin/master` @ `052ab24`, rerun):
- warm avg total: `6689.59 ms`
- warm avg connect: `2213.68 ms`
- all-runs avg total: `6484.16 ms`

This branch:
- warm avg total: `6683.48 ms`
- warm avg connect: `786.42 ms`
- all-runs avg total: `5974.40 ms`

Delta:
- warm avg total: `-6.11 ms` (`-0.09%`)
- warm avg connect: `-1427.26 ms` (`-64.47%`)
- all-runs avg total: `-509.76 ms` (`-7.86%`)
