### PR TITLE
Refactor AD trust shaping and unify ComputerX patch/update helpers

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTrustTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTrustTool.cs
@@ -190,13 +190,13 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
                 invalidOperationErrorCode: "query_failed");
         }
 
-        var scanned = allIssues.Count;
-        var rows = scanned > context.MaxResults ? allIssues.Take(context.MaxResults).ToArray() : allIssues;
-        var truncated = scanned > rows.Count;
-
-        var result = new AdTrustResult(
+        var rows = CapRows(allIssues, context.MaxResults, out var scanned, out var truncated);
+        var result = CreateResult(
             Mode: "communication_issues",
-            ForestName: context.ForestName,
+            context: context,
+            Scanned: scanned,
+            Truncated: truncated,
+            TotalFiltered: scanned,
             Recursive: false,
             SkipValidation: true,
             Status: "any",
@@ -205,13 +205,6 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
             Impermeability: false,
             TrustType: "any",
             Direction: "any",
-            SummaryBy: "direction",
-            Scanned: scanned,
-            Truncated: truncated,
-            TotalFiltered: scanned,
-            Items: Array.Empty<TrustExplorer.Assessment>(),
-            SummaryRows: Array.Empty<TrustSummaryRow>(),
-            MatrixRows: Array.Empty<TrustSummaryMatrixRow>(),
             CommunicationIssues: rows);
 
         return BuildViewResponse(
@@ -235,29 +228,14 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
         JsonObject? arguments,
         TrustRequestContext context,
         IReadOnlyList<TrustExplorer.Assessment> filtered) {
-        var scanned = filtered.Count;
-        var rows = scanned > context.MaxResults ? filtered.Take(context.MaxResults).ToArray() : filtered;
-        var truncated = scanned > rows.Count;
-
-        var result = new AdTrustResult(
+        var rows = CapRows(filtered, context.MaxResults, out var scanned, out var truncated);
+        var result = CreateResult(
             Mode: "raw",
-            ForestName: context.ForestName,
-            Recursive: context.Recursive,
-            SkipValidation: context.SkipValidation,
-            Status: context.Status,
-            InactiveDays: context.InactiveDays,
-            OldProtocol: context.OldProtocol,
-            Impermeability: context.Impermeability,
-            TrustType: context.TrustType,
-            Direction: context.Direction,
-            SummaryBy: "direction",
+            context: context,
             Scanned: scanned,
             Truncated: truncated,
             TotalFiltered: scanned,
-            Items: rows,
-            SummaryRows: Array.Empty<TrustSummaryRow>(),
-            MatrixRows: Array.Empty<TrustSummaryMatrixRow>(),
-            CommunicationIssues: Array.Empty<TrustCommunicationIssue>());
+            Items: rows);
 
         return BuildViewResponse(
             arguments: arguments,
@@ -279,29 +257,15 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
         string summaryBy,
         IReadOnlyList<TrustExplorer.Assessment> filtered) {
         var allRows = TrustExplorerFilter.GetSummaryBy(filtered, summaryBy.Equals("type", StringComparison.OrdinalIgnoreCase) ? "Type" : "Direction");
-        var scanned = allRows.Count;
-        var rows = scanned > context.MaxResults ? allRows.Take(context.MaxResults).ToArray() : allRows;
-        var truncated = scanned > rows.Count;
-
-        var result = new AdTrustResult(
+        var rows = CapRows(allRows, context.MaxResults, out var scanned, out var truncated);
+        var result = CreateResult(
             Mode: "summary",
-            ForestName: context.ForestName,
-            Recursive: context.Recursive,
-            SkipValidation: context.SkipValidation,
-            Status: context.Status,
-            InactiveDays: context.InactiveDays,
-            OldProtocol: context.OldProtocol,
-            Impermeability: context.Impermeability,
-            TrustType: context.TrustType,
-            Direction: context.Direction,
+            context: context,
             SummaryBy: summaryBy,
             Scanned: scanned,
             Truncated: truncated,
             TotalFiltered: filtered.Count,
-            Items: Array.Empty<TrustExplorer.Assessment>(),
-            SummaryRows: rows,
-            MatrixRows: Array.Empty<TrustSummaryMatrixRow>(),
-            CommunicationIssues: Array.Empty<TrustCommunicationIssue>());
+            SummaryRows: rows);
 
         return BuildViewResponse(
             arguments: arguments,
@@ -324,29 +288,14 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
         TrustRequestContext context,
         IReadOnlyList<TrustExplorer.Assessment> filtered) {
         var allRows = TrustExplorerFilter.GetSummaryMatrix(filtered);
-        var scanned = allRows.Count;
-        var rows = scanned > context.MaxResults ? allRows.Take(context.MaxResults).ToArray() : allRows;
-        var truncated = scanned > rows.Count;
-
-        var result = new AdTrustResult(
+        var rows = CapRows(allRows, context.MaxResults, out var scanned, out var truncated);
+        var result = CreateResult(
             Mode: "summary_matrix",
-            ForestName: context.ForestName,
-            Recursive: context.Recursive,
-            SkipValidation: context.SkipValidation,
-            Status: context.Status,
-            InactiveDays: context.InactiveDays,
-            OldProtocol: context.OldProtocol,
-            Impermeability: context.Impermeability,
-            TrustType: context.TrustType,
-            Direction: context.Direction,
-            SummaryBy: "direction",
+            context: context,
             Scanned: scanned,
             Truncated: truncated,
             TotalFiltered: filtered.Count,
-            Items: Array.Empty<TrustExplorer.Assessment>(),
-            SummaryRows: Array.Empty<TrustSummaryRow>(),
-            MatrixRows: rows,
-            CommunicationIssues: Array.Empty<TrustCommunicationIssue>());
+            MatrixRows: rows);
 
         return BuildViewResponse(
             arguments: arguments,
@@ -361,6 +310,61 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("total_filtered", filtered.Count);
                 meta.Add("max_results", context.MaxResults);
             });
+    }
+
+    private static IReadOnlyList<TRow> CapRows<TRow>(
+        IReadOnlyList<TRow> allRows,
+        int maxResults,
+        out int scanned,
+        out bool truncated) {
+        scanned = allRows.Count;
+        if (scanned <= maxResults) {
+            truncated = false;
+            return allRows;
+        }
+
+        truncated = true;
+        return allRows.Take(maxResults).ToArray();
+    }
+
+    private static AdTrustResult CreateResult(
+        string Mode,
+        TrustRequestContext context,
+        int Scanned,
+        bool Truncated,
+        int TotalFiltered,
+        bool? Recursive = null,
+        bool? SkipValidation = null,
+        string? Status = null,
+        int? InactiveDays = null,
+        bool? OldProtocol = null,
+        bool? Impermeability = null,
+        string? TrustType = null,
+        string? Direction = null,
+        string? SummaryBy = null,
+        IReadOnlyList<TrustExplorer.Assessment>? Items = null,
+        IReadOnlyList<TrustSummaryRow>? SummaryRows = null,
+        IReadOnlyList<TrustSummaryMatrixRow>? MatrixRows = null,
+        IReadOnlyList<TrustCommunicationIssue>? CommunicationIssues = null) {
+        return new AdTrustResult(
+            Mode: Mode,
+            ForestName: context.ForestName,
+            Recursive: Recursive ?? context.Recursive,
+            SkipValidation: SkipValidation ?? context.SkipValidation,
+            Status: Status ?? context.Status,
+            InactiveDays: InactiveDays ?? context.InactiveDays,
+            OldProtocol: OldProtocol ?? context.OldProtocol,
+            Impermeability: Impermeability ?? context.Impermeability,
+            TrustType: TrustType ?? context.TrustType,
+            Direction: Direction ?? context.Direction,
+            SummaryBy: SummaryBy ?? "direction",
+            Scanned: Scanned,
+            Truncated: Truncated,
+            TotalFiltered: TotalFiltered,
+            Items: Items ?? Array.Empty<TrustExplorer.Assessment>(),
+            SummaryRows: SummaryRows ?? Array.Empty<TrustSummaryRow>(),
+            MatrixRows: MatrixRows ?? Array.Empty<TrustSummaryMatrixRow>(),
+            CommunicationIssues: CommunicationIssues ?? Array.Empty<TrustCommunicationIssue>());
     }
 
     private static string BuildViewResponse<TRow>(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchComplianceTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchComplianceTool.cs
@@ -174,27 +174,17 @@ public sealed class SystemPatchComplianceTool : SystemToolBase, ITool {
                 monthly = await PatchDetails.GetMonthlyAsync(year, month, cancellationToken).ConfigureAwait(false);
             }
         } catch (Exception ex) {
-            return ToolResponse.Error("query_failed", $"Patch details query failed: {ex.Message}");
+            return ErrorFromException(ex, defaultMessage: "Patch details query failed.");
         }
 
-        IEnumerable<UpdateInfo> updates;
-        try {
-            updates = Updates.GetInstalled(computerName);
-        } catch (Exception ex) {
-            return ToolResponse.Error("query_failed", $"Installed updates query failed: {ex.Message}");
-        }
-
-        var isLocalTarget = string.IsNullOrWhiteSpace(computerName)
-            || string.Equals(computerName, ".", StringComparison.Ordinal)
-            || string.Equals(target, Environment.MachineName, StringComparison.OrdinalIgnoreCase);
-        var pendingIncluded = false;
-        if (includePendingLocal && isLocalTarget) {
-            try {
-                updates = updates.Concat(Updates.GetPending());
-                pendingIncluded = true;
-            } catch {
-                pendingIncluded = false;
-            }
+        if (!TryGetInstalledAndPendingUpdates(
+                computerName: computerName,
+                target: target,
+                includePendingLocal: includePendingLocal,
+                updates: out var updates,
+                pendingIncluded: out var pendingIncluded,
+                errorResponse: out var updateError)) {
+            return updateError!;
         }
 
         var installedKbSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchKbNormalization.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchKbNormalization.cs
@@ -11,7 +11,7 @@ internal static class SystemPatchKbNormalization {
     /// <summary>
     /// Normalizes KB-like values into distinct canonical tokens (for example: KB5034441).
     /// </summary>
-    internal static IReadOnlyList<string> NormalizeDistinct(IEnumerable<string>? values) {
+    internal static IReadOnlyList<string> NormalizeDistinct(IEnumerable<string?>? values) {
         if (values is null) {
             return Array.Empty<string>();
         }
@@ -31,7 +31,7 @@ internal static class SystemPatchKbNormalization {
     /// <summary>
     /// Returns true when any candidate KB matches a case-insensitive contains filter.
     /// </summary>
-    internal static bool MatchesContainsFilter(IEnumerable<string>? values, string? filter) {
+    internal static bool MatchesContainsFilter(IEnumerable<string?>? values, string? filter) {
         if (string.IsNullOrWhiteSpace(filter)) {
             return true;
         }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemToolBase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using ComputerX.Updates;
 using IntelligenceX.Tools.Common;
 
 namespace IntelligenceX.Tools.System;
@@ -7,6 +9,8 @@ namespace IntelligenceX.Tools.System;
 /// Base class for system tools with shared option validation.
 /// </summary>
 public abstract class SystemToolBase : ToolBase {
+    private const int MaxErrorMessageLength = 300;
+
     /// <summary>
     /// Shared options for system tools.
     /// </summary>
@@ -37,5 +41,102 @@ public abstract class SystemToolBase : ToolBase {
             messageSelector,
             defaultMessage,
             fallbackErrorCode);
+    }
+
+    /// <summary>
+    /// Maps common runtime exceptions to stable tool error envelopes.
+    /// </summary>
+    protected static string ErrorFromException(
+        Exception exception,
+        string defaultMessage = "System query failed.",
+        string fallbackErrorCode = "query_failed",
+        string invalidOperationErrorCode = "invalid_argument") {
+        if (exception is null) {
+            throw new ArgumentNullException(nameof(exception));
+        }
+
+        var safeDefault = string.IsNullOrWhiteSpace(defaultMessage)
+            ? "System query failed."
+            : defaultMessage.Trim();
+
+        return exception switch {
+            OperationCanceledException => ToolResponse.Error("cancelled", "Operation was cancelled.", isTransient: true),
+            ArgumentException => ToolResponse.Error("invalid_argument", SanitizeErrorMessage(exception.Message, safeDefault)),
+            InvalidOperationException => ToolResponse.Error(
+                string.IsNullOrWhiteSpace(invalidOperationErrorCode) ? "invalid_argument" : invalidOperationErrorCode,
+                SanitizeErrorMessage(exception.Message, safeDefault)),
+            FormatException => ToolResponse.Error("invalid_argument", SanitizeErrorMessage(exception.Message, safeDefault)),
+            UnauthorizedAccessException => ToolResponse.Error("access_denied", SanitizeErrorMessage(exception.Message, "Access denied while querying system data.")),
+            TimeoutException => ToolResponse.Error("timeout", SanitizeErrorMessage(exception.Message, "System query timed out."), isTransient: true),
+            NotSupportedException => ToolResponse.Error("not_supported", SanitizeErrorMessage(exception.Message, safeDefault)),
+            _ => ToolResponse.Error(
+                string.IsNullOrWhiteSpace(fallbackErrorCode) ? "query_failed" : fallbackErrorCode,
+                safeDefault)
+        };
+    }
+
+    /// <summary>
+    /// Gets installed updates and optionally augments with pending local updates.
+    /// </summary>
+    protected static bool TryGetInstalledAndPendingUpdates(
+        string? computerName,
+        string target,
+        bool includePendingLocal,
+        out IReadOnlyList<UpdateInfo> updates,
+        out bool pendingIncluded,
+        out string? errorResponse) {
+        pendingIncluded = false;
+        var rows = new List<UpdateInfo>();
+        try {
+            rows.AddRange(Updates.GetInstalled(computerName));
+        } catch (Exception ex) {
+            updates = Array.Empty<UpdateInfo>();
+            errorResponse = ErrorFromException(ex, defaultMessage: "Installed updates query failed.");
+            return false;
+        }
+
+        if (includePendingLocal && IsLocalTarget(computerName, target)) {
+            try {
+                rows.AddRange(Updates.GetPending());
+                pendingIncluded = true;
+            } catch {
+                pendingIncluded = false;
+            }
+        }
+
+        updates = rows;
+        errorResponse = null;
+        return true;
+    }
+
+    private static bool IsLocalTarget(string? computerName, string target) {
+        return string.IsNullOrWhiteSpace(computerName)
+               || string.Equals(computerName, ".", StringComparison.Ordinal)
+               || string.Equals(target, Environment.MachineName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string SanitizeErrorMessage(string? message, string fallback) {
+        var safeFallback = string.IsNullOrWhiteSpace(fallback) ? "Operation failed." : fallback.Trim();
+        if (string.IsNullOrWhiteSpace(message)) {
+            return safeFallback;
+        }
+
+        var compact = message
+            .Replace('\r', ' ')
+            .Replace('\n', ' ')
+            .Replace('\t', ' ')
+            .Trim();
+
+        while (compact.Contains("  ", StringComparison.Ordinal)) {
+            compact = compact.Replace("  ", " ", StringComparison.Ordinal);
+        }
+
+        if (compact.Length == 0) {
+            return safeFallback;
+        }
+
+        return compact.Length <= MaxErrorMessageLength
+            ? compact
+            : compact.Substring(0, MaxErrorMessageLength).TrimEnd() + "...";
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemUpdatesInstalledTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemUpdatesInstalledTool.cs
@@ -72,31 +72,21 @@ public sealed class SystemUpdatesInstalledTool : SystemToolBase, ITool {
             installedAfterUtc = parsed.Kind == DateTimeKind.Utc ? parsed : parsed.ToUniversalTime();
         }
 
-        var rows = new List<UpdateInfo>();
-        try {
-            rows.AddRange(Updates.GetInstalled(computerName));
-        } catch (Exception ex) {
-            return Task.FromResult(ToolResponse.Error("query_failed", $"Installed updates query failed: {ex.Message}"));
-        }
-
-        var isLocalTarget = string.IsNullOrWhiteSpace(computerName)
-            || string.Equals(computerName, ".", StringComparison.Ordinal)
-            || string.Equals(target, Environment.MachineName, StringComparison.OrdinalIgnoreCase);
-        var pendingIncluded = false;
-        if (includePendingLocal && isLocalTarget) {
-            try {
-                rows.AddRange(Updates.GetPending());
-                pendingIncluded = true;
-            } catch {
-                pendingIncluded = false;
-            }
+        if (!TryGetInstalledAndPendingUpdates(
+                computerName: computerName,
+                target: target,
+                includePendingLocal: includePendingLocal,
+                updates: out var rows,
+                pendingIncluded: out var pendingIncluded,
+                errorResponse: out var updateError)) {
+            return Task.FromResult(updateError!);
         }
 
         var filtered = rows
             .Where(x => string.IsNullOrWhiteSpace(titleContains)
                 || x.Title.Contains(titleContains, StringComparison.OrdinalIgnoreCase))
             .Where(x => string.IsNullOrWhiteSpace(kbContains)
-                || (x.Kb?.Contains(kbContains, StringComparison.OrdinalIgnoreCase) ?? false))
+                || SystemPatchKbNormalization.MatchesContainsFilter(new[] { x.Kb, x.Title }, kbContains))
             .Where(x => !installedAfterUtc.HasValue
                 || (x.InstalledOn.HasValue && x.InstalledOn.Value.ToUniversalTime() >= installedAfterUtc.Value))
             .ToArray();
@@ -146,4 +136,3 @@ public sealed class SystemUpdatesInstalledTool : SystemToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-


### PR DESCRIPTION
## Summary
- reduce response-construction duplication in `ad_trust` by introducing shared row capping and result-model builders
- add shared system helpers in `SystemToolBase` for:
  - stable/sanitized exception-to-error mapping
  - consistent installed + optional pending update retrieval for ComputerX-backed tools
- migrate `system_patch_compliance` and `system_updates_installed` to shared update retrieval helper
- align `system_updates_installed` KB filtering with shared normalization (`SystemPatchKbNormalization`) so title/KB variants match consistently

## Why
- keeps AD trust modes consistent while reducing repeated boilerplate
- removes duplicated ComputerX update-collection logic across system tools
- avoids leaking low-level exception text directly in tool envelopes
- improves KB matching consistency between monthly compliance/details and installed updates filtering

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
