### PR TITLE
Deduplicate shared patch-tool parsing and metadata plumbing

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchComplianceTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchComplianceTool.cs
@@ -17,13 +17,6 @@ namespace IntelligenceX.Tools.System;
 public sealed class SystemPatchComplianceTool : SystemToolBase, ITool {
     private const int MaxViewTop = 5000;
 
-    private static readonly string[] AllowedSeverities = {
-        "Critical",
-        "Important",
-        "Moderate",
-        "Low"
-    };
-
     private static readonly ToolDefinition DefinitionValue = new(
         "system_patch_compliance",
         "Correlate monthly MSRC patch details with installed updates to estimate host patch compliance for KB-backed vulnerabilities.",
@@ -112,43 +105,20 @@ public sealed class SystemPatchComplianceTool : SystemToolBase, ITool {
         var includePendingLocal = ToolArgs.GetBoolean(arguments, "include_pending_local", defaultValue: false);
         var missingOnly = ToolArgs.GetBoolean(arguments, "missing_only", defaultValue: false);
 
-        var nowUtc = DateTime.UtcNow;
-        var year = nowUtc.Year;
-        var month = nowUtc.Month;
-
-        var yearRaw = arguments?.GetInt64("year");
-        var monthRaw = arguments?.GetInt64("month");
-        if (yearRaw.HasValue) {
-            if (yearRaw.Value < 2000 || yearRaw.Value > 2100) {
-                return ToolResponse.Error("invalid_argument", "year must be between 2000 and 2100.");
-            }
-            year = (int)yearRaw.Value;
+        if (!TryResolvePatchReleaseWindow(arguments, out var year, out var month, out var releaseError)) {
+            return releaseError!;
         }
-        if (monthRaw.HasValue) {
-            if (monthRaw.Value < 1 || monthRaw.Value > 12) {
-                return ToolResponse.Error("invalid_argument", "month must be between 1 and 12.");
-            }
-            month = (int)monthRaw.Value;
+        if (!TryResolvePatchProductFilter(
+                arguments,
+                out var productFamily,
+                out var productVersion,
+                out var productBuild,
+                out var productEdition,
+                out var productError)) {
+            return productError!;
         }
-
-        var productFamily = ToolArgs.GetOptionalTrimmed(arguments, "product_family");
-        var productVersion = ToolArgs.GetOptionalTrimmed(arguments, "product_version");
-        var productBuild = ToolArgs.GetOptionalTrimmed(arguments, "product_build");
-        var productEdition = ToolArgs.GetOptionalTrimmed(arguments, "product_edition");
-        if (string.IsNullOrWhiteSpace(productFamily)
-            && (!string.IsNullOrWhiteSpace(productVersion)
-                || !string.IsNullOrWhiteSpace(productBuild)
-                || !string.IsNullOrWhiteSpace(productEdition))) {
-            return ToolResponse.Error("invalid_argument", "product_family is required when product_version/product_build/product_edition is provided.");
-        }
-
-        var severityRaw = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("severity"));
-        var severity = new List<string>(severityRaw.Count);
-        foreach (var item in severityRaw) {
-            if (!TryNormalizeSeverity(item, out var normalized)) {
-                return ToolResponse.Error("invalid_argument", "severity contains unsupported value. Allowed: Critical, Important, Moderate, Low.");
-            }
-            severity.Add(normalized);
+        if (!TryResolvePatchSeverityAllowlist(arguments, out var severity, out var severityError)) {
+            return severityError!;
         }
 
         var exploitedOnly = ToolArgs.GetBoolean(arguments, "exploited_only", defaultValue: false);
@@ -157,24 +127,16 @@ public sealed class SystemPatchComplianceTool : SystemToolBase, ITool {
         var kbContains = ToolArgs.GetOptionalTrimmed(arguments, "kb_contains");
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        IReadOnlyList<PatchDetailsInfo> monthly;
-        try {
-            if (!string.IsNullOrWhiteSpace(productFamily)) {
-                var descriptor = new ProductDescriptor {
-                    Family = productFamily!,
-                    Version = productVersion ?? string.Empty,
-                    Build = productBuild,
-                    Edition = productEdition
-                };
-                monthly = await PatchDetails.GetForProductsAsync(
-                    products: new[] { descriptor },
-                    since: new DateTime(year, month, 1),
-                    ct: cancellationToken).ConfigureAwait(false);
-            } else {
-                monthly = await PatchDetails.GetMonthlyAsync(year, month, cancellationToken).ConfigureAwait(false);
-            }
-        } catch (Exception ex) {
-            return ErrorFromException(ex, defaultMessage: "Patch details query failed.");
+        var (monthly, patchError) = await TryGetMonthlyPatchDetailsAsync(
+            year: year,
+            month: month,
+            productFamily: productFamily,
+            productVersion: productVersion,
+            productBuild: productBuild,
+            productEdition: productEdition,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (patchError is not null) {
+            return patchError;
         }
 
         if (!TryGetInstalledAndPendingUpdates(
@@ -291,59 +253,28 @@ public sealed class SystemPatchComplianceTool : SystemToolBase, ITool {
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("computer_name", target);
-                meta.Add("year", year);
-                meta.Add("month", month);
-                meta.Add("release", release);
                 meta.Add("max_results", maxResults);
                 meta.Add("include_pending_local", includePendingLocal);
                 meta.Add("pending_included", pendingIncluded);
+                AddPatchFilterMeta(
+                    meta: meta,
+                    year: year,
+                    month: month,
+                    release: release,
+                    productFamily: productFamily,
+                    productVersion: productVersion,
+                    productBuild: productBuild,
+                    productEdition: productEdition,
+                    severity: severity,
+                    exploitedOnly: exploitedOnly,
+                    publiclyDisclosedOnly: publiclyDisclosedOnly,
+                    cveContains: cveContains,
+                    kbContains: kbContains);
                 if (missingOnly) {
                     meta.Add("missing_only", true);
                 }
-                if (!string.IsNullOrWhiteSpace(productFamily)) {
-                    meta.Add("product_family", productFamily);
-                }
-                if (!string.IsNullOrWhiteSpace(productVersion)) {
-                    meta.Add("product_version", productVersion);
-                }
-                if (!string.IsNullOrWhiteSpace(productBuild)) {
-                    meta.Add("product_build", productBuild);
-                }
-                if (!string.IsNullOrWhiteSpace(productEdition)) {
-                    meta.Add("product_edition", productEdition);
-                }
-                if (severity.Count > 0) {
-                    meta.Add("severity", string.Join(", ", severity));
-                }
-                if (exploitedOnly) {
-                    meta.Add("exploited_only", true);
-                }
-                if (publiclyDisclosedOnly) {
-                    meta.Add("publicly_disclosed_only", true);
-                }
-                if (!string.IsNullOrWhiteSpace(cveContains)) {
-                    meta.Add("cve_contains", cveContains);
-                }
-                if (!string.IsNullOrWhiteSpace(kbContains)) {
-                    meta.Add("kb_contains", kbContains);
-                }
             });
         return response;
-    }
-
-    private static bool TryNormalizeSeverity(string input, out string normalized) {
-        normalized = string.Empty;
-        if (string.IsNullOrWhiteSpace(input)) {
-            return false;
-        }
-
-        foreach (var allowed in AllowedSeverities) {
-            if (allowed.Equals(input.Trim(), StringComparison.OrdinalIgnoreCase)) {
-                normalized = allowed;
-                return true;
-            }
-        }
-        return false;
     }
 
     private static PatchComplianceSummary BuildSummary(IReadOnlyList<ComplianceRow> rows) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchDetailsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchDetailsTool.cs
@@ -16,13 +16,6 @@ namespace IntelligenceX.Tools.System;
 public sealed class SystemPatchDetailsTool : SystemToolBase, ITool {
     private const int MaxViewTop = 5000;
 
-    private static readonly string[] AllowedSeverities = {
-        "Critical",
-        "Important",
-        "Moderate",
-        "Low"
-    };
-
     private static readonly ToolDefinition DefinitionValue = new(
         "system_patch_details",
         "Return MSRC patch details for a month (default current UTC month), including CVE/KB/product metadata and summary counters.",
@@ -75,48 +68,25 @@ public sealed class SystemPatchDetailsTool : SystemToolBase, ITool {
     protected override async Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var nowUtc = DateTime.UtcNow;
-        var year = nowUtc.Year;
-        var month = nowUtc.Month;
-
-        var yearRaw = arguments?.GetInt64("year");
-        var monthRaw = arguments?.GetInt64("month");
-        if (yearRaw.HasValue) {
-            if (yearRaw.Value < 2000 || yearRaw.Value > 2100) {
-                return ToolResponse.Error("invalid_argument", "year must be between 2000 and 2100.");
-            }
-            year = (int)yearRaw.Value;
+        if (!TryResolvePatchReleaseWindow(arguments, out var year, out var month, out var releaseError)) {
+            return releaseError!;
         }
-        if (monthRaw.HasValue) {
-            if (monthRaw.Value < 1 || monthRaw.Value > 12) {
-                return ToolResponse.Error("invalid_argument", "month must be between 1 and 12.");
-            }
-            month = (int)monthRaw.Value;
-        }
-
-        var productFamily = ToolArgs.GetOptionalTrimmed(arguments, "product_family");
-        var productVersion = ToolArgs.GetOptionalTrimmed(arguments, "product_version");
-        var productBuild = ToolArgs.GetOptionalTrimmed(arguments, "product_build");
-        var productEdition = ToolArgs.GetOptionalTrimmed(arguments, "product_edition");
-        if (string.IsNullOrWhiteSpace(productFamily)
-            && (!string.IsNullOrWhiteSpace(productVersion)
-                || !string.IsNullOrWhiteSpace(productBuild)
-                || !string.IsNullOrWhiteSpace(productEdition))) {
-            return ToolResponse.Error("invalid_argument", "product_family is required when product_version/product_build/product_edition is provided.");
+        if (!TryResolvePatchProductFilter(
+                arguments,
+                out var productFamily,
+                out var productVersion,
+                out var productBuild,
+                out var productEdition,
+                out var productError)) {
+            return productError!;
         }
 
         var productNameContains = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("product_name_contains"));
         if (productNameContains.Count > 20) {
             productNameContains = productNameContains.Take(20).ToList();
         }
-
-        var severityRaw = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("severity"));
-        var severity = new List<string>(severityRaw.Count);
-        foreach (var item in severityRaw) {
-            if (!TryNormalizeSeverity(item, out var normalized)) {
-                return ToolResponse.Error("invalid_argument", "severity contains unsupported value. Allowed: Critical, Important, Moderate, Low.");
-            }
-            severity.Add(normalized);
+        if (!TryResolvePatchSeverityAllowlist(arguments, out var severity, out var severityError)) {
+            return severityError!;
         }
 
         var exploitedOnly = ToolArgs.GetBoolean(arguments, "exploited_only", defaultValue: false);
@@ -125,24 +95,16 @@ public sealed class SystemPatchDetailsTool : SystemToolBase, ITool {
         var kbContains = ToolArgs.GetOptionalTrimmed(arguments, "kb_contains");
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        IReadOnlyList<PatchDetailsInfo> monthly;
-        try {
-            if (!string.IsNullOrWhiteSpace(productFamily)) {
-                var descriptor = new ProductDescriptor {
-                    Family = productFamily!,
-                    Version = productVersion ?? string.Empty,
-                    Build = productBuild,
-                    Edition = productEdition
-                };
-                monthly = await PatchDetails.GetForProductsAsync(
-                    products: new[] { descriptor },
-                    since: new DateTime(year, month, 1),
-                    ct: cancellationToken).ConfigureAwait(false);
-            } else {
-                monthly = await PatchDetails.GetMonthlyAsync(year, month, cancellationToken).ConfigureAwait(false);
-            }
-        } catch (Exception ex) {
-            return ToolResponse.Error("query_failed", $"Patch details query failed: {ex.Message}");
+        var (monthly, patchError) = await TryGetMonthlyPatchDetailsAsync(
+            year: year,
+            month: month,
+            productFamily: productFamily,
+            productVersion: productVersion,
+            productBuild: productBuild,
+            productEdition: productEdition,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (patchError is not null) {
+            return patchError;
         }
 
         var severitySet = severity.Count == 0
@@ -203,59 +165,27 @@ public sealed class SystemPatchDetailsTool : SystemToolBase, ITool {
             response: out var response,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("year", year);
-                meta.Add("month", month);
-                meta.Add("release", release);
                 meta.Add("max_results", maxResults);
-                meta.Add("product_mapped_filter_applied", !string.IsNullOrWhiteSpace(productFamily));
-                if (!string.IsNullOrWhiteSpace(productFamily)) {
-                    meta.Add("product_family", productFamily);
-                }
-                if (!string.IsNullOrWhiteSpace(productVersion)) {
-                    meta.Add("product_version", productVersion);
-                }
-                if (!string.IsNullOrWhiteSpace(productBuild)) {
-                    meta.Add("product_build", productBuild);
-                }
-                if (!string.IsNullOrWhiteSpace(productEdition)) {
-                    meta.Add("product_edition", productEdition);
-                }
+                AddPatchFilterMeta(
+                    meta: meta,
+                    year: year,
+                    month: month,
+                    release: release,
+                    productFamily: productFamily,
+                    productVersion: productVersion,
+                    productBuild: productBuild,
+                    productEdition: productEdition,
+                    severity: severity,
+                    exploitedOnly: exploitedOnly,
+                    publiclyDisclosedOnly: publiclyDisclosedOnly,
+                    cveContains: cveContains,
+                    kbContains: kbContains);
                 if (productNameContains.Count > 0) {
                     meta.Add("product_name_contains", string.Join(", ", productNameContains));
-                }
-                if (severity.Count > 0) {
-                    meta.Add("severity", string.Join(", ", severity));
-                }
-                if (exploitedOnly) {
-                    meta.Add("exploited_only", true);
-                }
-                if (publiclyDisclosedOnly) {
-                    meta.Add("publicly_disclosed_only", true);
-                }
-                if (!string.IsNullOrWhiteSpace(cveContains)) {
-                    meta.Add("cve_contains", cveContains);
-                }
-                if (!string.IsNullOrWhiteSpace(kbContains)) {
-                    meta.Add("kb_contains", kbContains);
                 }
             });
 
         return response;
-    }
-
-    private static bool TryNormalizeSeverity(string input, out string normalized) {
-        normalized = string.Empty;
-        if (string.IsNullOrWhiteSpace(input)) {
-            return false;
-        }
-
-        foreach (var allowed in AllowedSeverities) {
-            if (allowed.Equals(input.Trim(), StringComparison.OrdinalIgnoreCase)) {
-                normalized = allowed;
-                return true;
-            }
-        }
-        return false;
     }
 
     private static PatchDetailsSummary BuildSummary(IReadOnlyList<PatchDetailsInfo> rows) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemToolBase.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ComputerX.PatchDetails;
 using ComputerX.Updates;
+using IntelligenceX.Json;
 using IntelligenceX.Tools.Common;
 
 namespace IntelligenceX.Tools.System;
@@ -10,6 +14,12 @@ namespace IntelligenceX.Tools.System;
 /// </summary>
 public abstract class SystemToolBase : ToolBase {
     private const int MaxErrorMessageLength = 300;
+    private static readonly string[] AllowedPatchSeverities = {
+        "Critical",
+        "Important",
+        "Moderate",
+        "Low"
+    };
 
     /// <summary>
     /// Shared options for system tools.
@@ -107,6 +117,195 @@ public abstract class SystemToolBase : ToolBase {
         updates = rows;
         errorResponse = null;
         return true;
+    }
+
+    /// <summary>
+    /// Resolves patch release year/month from arguments with defaults and validation.
+    /// </summary>
+    protected static bool TryResolvePatchReleaseWindow(
+        JsonObject? arguments,
+        out int year,
+        out int month,
+        out string? errorResponse) {
+        var nowUtc = DateTime.UtcNow;
+        year = nowUtc.Year;
+        month = nowUtc.Month;
+        errorResponse = null;
+
+        var yearRaw = arguments?.GetInt64("year");
+        var monthRaw = arguments?.GetInt64("month");
+        if (yearRaw.HasValue) {
+            if (yearRaw.Value < 2000 || yearRaw.Value > 2100) {
+                errorResponse = ToolResponse.Error("invalid_argument", "year must be between 2000 and 2100.");
+                return false;
+            }
+            year = (int)yearRaw.Value;
+        }
+
+        if (monthRaw.HasValue) {
+            if (monthRaw.Value < 1 || monthRaw.Value > 12) {
+                errorResponse = ToolResponse.Error("invalid_argument", "month must be between 1 and 12.");
+                return false;
+            }
+            month = (int)monthRaw.Value;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves optional mapped product filter arguments used by patch tools.
+    /// </summary>
+    protected static bool TryResolvePatchProductFilter(
+        JsonObject? arguments,
+        out string? productFamily,
+        out string? productVersion,
+        out string? productBuild,
+        out string? productEdition,
+        out string? errorResponse) {
+        productFamily = ToolArgs.GetOptionalTrimmed(arguments, "product_family");
+        productVersion = ToolArgs.GetOptionalTrimmed(arguments, "product_version");
+        productBuild = ToolArgs.GetOptionalTrimmed(arguments, "product_build");
+        productEdition = ToolArgs.GetOptionalTrimmed(arguments, "product_edition");
+        errorResponse = null;
+
+        if (string.IsNullOrWhiteSpace(productFamily)
+            && (!string.IsNullOrWhiteSpace(productVersion)
+                || !string.IsNullOrWhiteSpace(productBuild)
+                || !string.IsNullOrWhiteSpace(productEdition))) {
+            errorResponse = ToolResponse.Error(
+                "invalid_argument",
+                "product_family is required when product_version/product_build/product_edition is provided.");
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves optional severity allowlist for patch tools.
+    /// </summary>
+    protected static bool TryResolvePatchSeverityAllowlist(
+        JsonObject? arguments,
+        out IReadOnlyList<string> severity,
+        out string? errorResponse) {
+        var severityRaw = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("severity"));
+        var normalized = new List<string>(severityRaw.Count);
+        foreach (var item in severityRaw) {
+            if (!TryNormalizePatchSeverity(item, out var allowedSeverity)) {
+                severity = Array.Empty<string>();
+                errorResponse = ToolResponse.Error(
+                    "invalid_argument",
+                    "severity contains unsupported value. Allowed: Critical, Important, Moderate, Low.");
+                return false;
+            }
+
+            normalized.Add(allowedSeverity);
+        }
+
+        severity = normalized;
+        errorResponse = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Loads monthly patch details with optional mapped product filtering.
+    /// </summary>
+    protected static async Task<(IReadOnlyList<PatchDetailsInfo> Data, string? ErrorResponse)> TryGetMonthlyPatchDetailsAsync(
+        int year,
+        int month,
+        string? productFamily,
+        string? productVersion,
+        string? productBuild,
+        string? productEdition,
+        CancellationToken cancellationToken) {
+        try {
+            if (!string.IsNullOrWhiteSpace(productFamily)) {
+                var descriptor = new ProductDescriptor {
+                    Family = productFamily,
+                    Version = productVersion ?? string.Empty,
+                    Build = productBuild,
+                    Edition = productEdition
+                };
+
+                var filtered = await PatchDetails.GetForProductsAsync(
+                    products: new[] { descriptor },
+                    since: new DateTime(year, month, 1),
+                    ct: cancellationToken).ConfigureAwait(false);
+                return (filtered, null);
+            }
+
+            var monthly = await PatchDetails.GetMonthlyAsync(year, month, cancellationToken).ConfigureAwait(false);
+            return (monthly, null);
+        } catch (Exception ex) {
+            return (Array.Empty<PatchDetailsInfo>(), ErrorFromException(ex, defaultMessage: "Patch details query failed."));
+        }
+    }
+
+    /// <summary>
+    /// Adds standard patch filter metadata fields shared by patch tools.
+    /// </summary>
+    protected static void AddPatchFilterMeta(
+        JsonObject meta,
+        int year,
+        int month,
+        string release,
+        string? productFamily,
+        string? productVersion,
+        string? productBuild,
+        string? productEdition,
+        IReadOnlyList<string> severity,
+        bool exploitedOnly,
+        bool publiclyDisclosedOnly,
+        string? cveContains,
+        string? kbContains) {
+        meta.Add("year", year);
+        meta.Add("month", month);
+        meta.Add("release", release);
+        meta.Add("product_mapped_filter_applied", !string.IsNullOrWhiteSpace(productFamily));
+        if (!string.IsNullOrWhiteSpace(productFamily)) {
+            meta.Add("product_family", productFamily);
+        }
+        if (!string.IsNullOrWhiteSpace(productVersion)) {
+            meta.Add("product_version", productVersion);
+        }
+        if (!string.IsNullOrWhiteSpace(productBuild)) {
+            meta.Add("product_build", productBuild);
+        }
+        if (!string.IsNullOrWhiteSpace(productEdition)) {
+            meta.Add("product_edition", productEdition);
+        }
+        if (severity.Count > 0) {
+            meta.Add("severity", string.Join(", ", severity));
+        }
+        if (exploitedOnly) {
+            meta.Add("exploited_only", true);
+        }
+        if (publiclyDisclosedOnly) {
+            meta.Add("publicly_disclosed_only", true);
+        }
+        if (!string.IsNullOrWhiteSpace(cveContains)) {
+            meta.Add("cve_contains", cveContains);
+        }
+        if (!string.IsNullOrWhiteSpace(kbContains)) {
+            meta.Add("kb_contains", kbContains);
+        }
+    }
+
+    private static bool TryNormalizePatchSeverity(string input, out string normalized) {
+        normalized = string.Empty;
+        if (string.IsNullOrWhiteSpace(input)) {
+            return false;
+        }
+
+        foreach (var allowed in AllowedPatchSeverities) {
+            if (allowed.Equals(input.Trim(), StringComparison.OrdinalIgnoreCase)) {
+                normalized = allowed;
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsLocalTarget(string? computerName, string target) {


### PR DESCRIPTION
## Summary
- centralize shared patch-tool parsing/validation in `SystemToolBase`:
  - year/month release window parsing
  - mapped product filter parsing
  - severity allowlist normalization
- centralize monthly patch-details retrieval with mapped/unmapped modes in one helper
- centralize common patch filter metadata emission
- refactor `system_patch_details` and `system_patch_compliance` to use shared helpers

## Why
This removes duplicated parsing/fetch/meta logic across both patch tools and keeps behavior consistent as we evolve patch filtering.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
