### PR TITLE
Deduplicate AD row-capping and table response patterns

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -162,6 +162,24 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     }
 
     /// <summary>
+    /// Caps a row collection by max-results and returns standard scanned/truncated counters.
+    /// </summary>
+    protected static IReadOnlyList<TRow> CapRows<TRow>(
+        IReadOnlyList<TRow> allRows,
+        int maxResults,
+        out int scanned,
+        out bool truncated) {
+        scanned = allRows.Count;
+        if (scanned <= maxResults) {
+            truncated = false;
+            return allRows;
+        }
+
+        truncated = true;
+        return allRows.Take(maxResults).ToArray();
+    }
+
+    /// <summary>
     /// Builds filtered + capped policy-attribution rows using consistent configured-value semantics.
     /// </summary>
     protected static IReadOnlyList<PolicyAttribution> PreparePolicyAttributionRows(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDelegationAuditTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDelegationAuditTool.cs
@@ -79,7 +79,7 @@ public sealed class AdDelegationAuditTool : ActiveDirectoryToolBase, ITool {
         }
 
         var result = queryResult!;
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        return Task.FromResult(BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Results,
@@ -87,7 +87,6 @@ public sealed class AdDelegationAuditTool : ActiveDirectoryToolBase, ITool {
             title: "Active Directory: Delegation Audit (preview)",
             maxTop: MaxViewTop,
             baseTruncated: result.IsTruncated,
-            response: out var response);
-        return Task.FromResult(response);
+            scanned: result.Results.Count));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
@@ -163,11 +163,7 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
             .Where(row => !insecureOnly || row.AnyFinding)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<DomainControllerSecurityRow> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new AdDomainControllerSecurityResult(
             DomainName: domainName,
@@ -180,7 +176,7 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
             Errors: errors,
             Rows: projectedRows);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        return BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: projectedRows,
@@ -188,7 +184,6 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
             title: "Active Directory: Domain Controller Security (preview)",
             maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("insecure_only", insecureOnly);
@@ -204,6 +199,5 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
                     meta.Add("domain_controller", domainController);
                 }
             });
-        return response;
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
@@ -98,11 +98,7 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
             }
         }
 
-        var scanned = rows.Count;
-        IReadOnlyList<KerberosCryptoPostureRow> projectedRows = scanned > maxResults
-            ? rows.Take(maxResults).ToArray()
-            : rows;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(rows, maxResults, out var scanned, out var truncated);
 
         var result = new AdKerberosCryptoPostureResult(
             DomainName: domainName,
@@ -113,7 +109,7 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
             Errors: errors,
             Domains: projectedRows);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        return BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: projectedRows,
@@ -121,7 +117,6 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
             title: "Active Directory: Kerberos Crypto Posture (preview)",
             maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("max_results", maxResults);
@@ -133,6 +128,5 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
                     meta.Add("forest_name", forestName);
                 }
             });
-        return response;
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
@@ -144,11 +144,7 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
             .Where(row => !legacyNtlmOnly || row.LegacyNtlmAllowed)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<LanManagerSettingsRow> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new AdLanManagerSettingsResult(
             DomainName: domainName,
@@ -161,7 +157,7 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
             Errors: errors,
             Rows: projectedRows);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        return BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: projectedRows,
@@ -169,7 +165,6 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
             title: "Active Directory: LAN Manager Settings (preview)",
             maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("allow_lm_hash_only", allowLmHashOnly);
@@ -187,6 +182,5 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
                     meta.Add("explicit_domain_controllers", explicitDomainControllers.Count);
                 }
             });
-        return response;
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
@@ -149,11 +149,7 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
             .Where(row => !expiredOnly || row.EitherLapsExpiredCount > 0)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<LapsCoverageRow> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var projectedDomains = projectedRows
             .Select(static row => row.DomainName)
@@ -176,7 +172,7 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
             Rows: projectedRows,
             Details: projectedDetails);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        return BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: projectedRows,
@@ -184,7 +180,6 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
             title: "Active Directory: LAPS Coverage (preview)",
             maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: scanned,
             metaMutate: meta => {
                 if (coverageBelowPercent.HasValue) {
@@ -202,6 +197,5 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
                     meta.Add("forest_name", forestName);
                 }
             });
-        return response;
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapDiagnosticsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapDiagnosticsTool.cs
@@ -84,7 +84,7 @@ public sealed class AdLdapDiagnosticsTool : ActiveDirectoryToolBase, ITool {
                 cancellationToken)
             .ConfigureAwait(false);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        return BuildAutoTableResponse(
             arguments: arguments,
             model: report,
             sourceRows: report.Servers,
@@ -92,7 +92,6 @@ public sealed class AdLdapDiagnosticsTool : ActiveDirectoryToolBase, ITool {
             title: "Active Directory: LDAP Diagnostics (preview)",
             maxTop: MaxViewTop,
             baseTruncated: false,
-            response: out var response);
-        return response;
+            scanned: report.Servers.Count);
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteCoverageTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteCoverageTool.cs
@@ -74,9 +74,7 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
                 return Task.FromResult(errorResponse!);
             }
 
-            var scanned = allSummary.Count;
-            var rows = scanned > maxResults ? allSummary.Take(maxResults).ToArray() : allSummary;
-            var truncated = scanned > rows.Count;
+            var rows = CapRows(allSummary, maxResults, out var scanned, out var truncated);
 
             var result = new AdSiteCoverageSummaryResult(
                 ForestName: forestName,
@@ -85,7 +83,7 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
                 Truncated: truncated,
                 Summary: rows);
 
-            ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+            return Task.FromResult(BuildAutoTableResponse(
                 arguments: arguments,
                 model: result,
                 sourceRows: rows,
@@ -93,7 +91,6 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
                 title: "Active Directory: Site Coverage (preview)",
                 maxTop: MaxViewTop,
                 baseTruncated: truncated,
-                response: out var summaryResponse,
                 scanned: scanned,
                 metaMutate: meta => {
                     meta.Add("mode", "summary");
@@ -102,8 +99,7 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
                     if (!string.IsNullOrWhiteSpace(forestName)) {
                         meta.Add("forest_name", forestName);
                     }
-                });
-            return Task.FromResult(summaryResponse);
+                }));
         }
 
         if (!TryExecute(
@@ -115,17 +111,9 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(rawErrorResponse!);
         }
 
-        var summaryScanned = report.Summary.Count;
-        var sitesScanned = report.Sites.Count;
-        var subnetsScanned = report.Subnets.Count;
-
-        var summaryRows = summaryScanned > maxResults ? report.Summary.Take(maxResults).ToArray() : report.Summary;
-        var siteRows = sitesScanned > maxResults ? report.Sites.Take(maxResults).ToArray() : report.Sites;
-        var subnetRows = subnetsScanned > maxResults ? report.Subnets.Take(maxResults).ToArray() : report.Subnets;
-
-        var summaryTruncated = summaryScanned > summaryRows.Count;
-        var sitesTruncated = sitesScanned > siteRows.Count;
-        var subnetsTruncated = subnetsScanned > subnetRows.Count;
+        var summaryRows = CapRows(report.Summary, maxResults, out var summaryScanned, out var summaryTruncated);
+        var siteRows = CapRows(report.Sites, maxResults, out var sitesScanned, out var sitesTruncated);
+        var subnetRows = CapRows(report.Subnets, maxResults, out var subnetsScanned, out var subnetsTruncated);
 
         var rawResult = new AdSiteCoverageRawResult(
             ForestName: forestName,
@@ -140,7 +128,7 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
             Sites: siteRows,
             Subnets: subnetRows);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        return Task.FromResult(BuildAutoTableResponse(
             arguments: arguments,
             model: rawResult,
             sourceRows: summaryRows,
@@ -148,7 +136,6 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
             title: "Active Directory: Site Coverage (raw preview)",
             maxTop: MaxViewTop,
             baseTruncated: summaryTruncated || sitesTruncated || subnetsTruncated,
-            response: out var rawResponse,
             scanned: summaryScanned,
             metaMutate: meta => {
                 meta.Add("mode", "raw");
@@ -161,8 +148,6 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
                 if (!string.IsNullOrWhiteSpace(forestName)) {
                     meta.Add("forest_name", forestName);
                 }
-            });
-        return Task.FromResult(rawResponse);
+            }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteLinksTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteLinksTool.cs
@@ -134,7 +134,7 @@ public sealed class AdSiteLinksTool : ActiveDirectoryToolBase, ITool {
                 SiteLinks: links,
                 ScheduleRows: scheduleRows);
 
-            ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+            return Task.FromResult(BuildAutoTableResponse(
                 arguments: arguments,
                 model: scheduleResult,
                 sourceRows: scheduleRows,
@@ -142,7 +142,6 @@ public sealed class AdSiteLinksTool : ActiveDirectoryToolBase, ITool {
                 title: "Active Directory: Site Link Schedules (preview)",
                 maxTop: MaxViewTop,
                 baseTruncated: truncatedScheduleRows,
-                response: out var scheduleResponse,
                 scanned: scannedScheduleRows,
                 metaMutate: meta => {
                     meta.Add("mode", "schedule");
@@ -153,13 +152,10 @@ public sealed class AdSiteLinksTool : ActiveDirectoryToolBase, ITool {
                     if (!string.IsNullOrWhiteSpace(forestName)) {
                         meta.Add("forest_name", forestName);
                     }
-                });
-            return Task.FromResult(scheduleResponse);
+                }));
         }
 
-        var scanned = links.Count;
-        var rows = scanned > maxResults ? links.Take(maxResults).ToArray() : links;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(links, maxResults, out var scanned, out var truncated);
 
         var result = new AdSiteLinksResult(
             ForestName: forestName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnStatsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnStatsTool.cs
@@ -88,7 +88,7 @@ public sealed class AdSpnStatsTool : ActiveDirectoryToolBase, ITool {
 
         var stats = await SpnStatsService.QueryAsync(query, cancellationToken).ConfigureAwait(false);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        return BuildAutoTableResponse(
             arguments: arguments,
             model: stats,
             sourceRows: stats.ServiceClasses,
@@ -96,8 +96,6 @@ public sealed class AdSpnStatsTool : ActiveDirectoryToolBase, ITool {
             title: "Active Directory: SPN Stats (preview)",
             maxTop: MaxViewTop,
             baseTruncated: stats.Truncated,
-            response: out var response,
             scanned: stats.ScannedObjects);
-        return response;
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTrustTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTrustTool.cs
@@ -312,21 +312,6 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
             });
     }
 
-    private static IReadOnlyList<TRow> CapRows<TRow>(
-        IReadOnlyList<TRow> allRows,
-        int maxResults,
-        out int scanned,
-        out bool truncated) {
-        scanned = allRows.Count;
-        if (scanned <= maxResults) {
-            truncated = false;
-            return allRows;
-        }
-
-        truncated = true;
-        return allRows.Take(maxResults).ToArray();
-    }
-
     private static AdTrustResult CreateResult(
         string Mode,
         TrustRequestContext context,
@@ -376,7 +361,7 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
         bool truncated,
         int scanned,
         Action<JsonObject> metaMutate) {
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        return BuildAutoTableResponse(
             arguments: arguments,
             model: model,
             sourceRows: sourceRows,
@@ -384,10 +369,8 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
             title: title,
             maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: scanned,
             metaMutate: metaMutate);
-        return response;
     }
 
     private static bool IsOneOf(string value, params string[] allowed) {


### PR DESCRIPTION
## Summary
- add shared `CapRows` helper to `ActiveDirectoryToolBase` for standard scanned/truncated/max-results handling
- migrate remaining AD tools off direct `ToolTableViewEnvelope.TryBuildModelResponseAutoColumns` usage to shared base helper paths
- remove duplicated row-capping implementation from `ad_trust` and reuse base helper

## Why
This continues the consistency pass by removing repeated capping + table-envelope plumbing and lowering drift risk across AD tools.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
- verified touched files remain below 700 LOC
