### PR TITLE
Address remaining tool review gaps: KB-only matching + AD attribution/error sanitization

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -189,10 +189,31 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         int maxResults,
         out int scanned,
         out bool truncated) {
+        return PreparePolicyAttributionRows(
+            attribution,
+            includeAttribution,
+            configuredAttributionOnly,
+            maxResults,
+            additionalUnconfiguredValues: null,
+            out scanned,
+            out truncated);
+    }
+
+    /// <summary>
+    /// Builds filtered + capped policy-attribution rows using consistent configured-value semantics.
+    /// </summary>
+    protected static IReadOnlyList<PolicyAttribution> PreparePolicyAttributionRows(
+        IReadOnlyList<PolicyAttribution> attribution,
+        bool includeAttribution,
+        bool configuredAttributionOnly,
+        int maxResults,
+        IReadOnlyList<string>? additionalUnconfiguredValues,
+        out int scanned,
+        out bool truncated) {
         var filtered = includeAttribution
             ? attribution
                 .Where(static row => row is not null)
-                .Where(row => !configuredAttributionOnly || IsConfiguredAttributionValue(row.Effective))
+                .Where(row => !configuredAttributionOnly || IsConfiguredAttributionValue(row.Effective, additionalUnconfiguredValues))
                 .ToArray()
             : Array.Empty<PolicyAttribution>();
 
@@ -224,9 +245,32 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     /// <summary>
     /// Determines whether policy-attribution effective value is configured.
     /// </summary>
-    protected static bool IsConfiguredAttributionValue(string? effectiveValue) {
-        return !string.IsNullOrWhiteSpace(effectiveValue)
-               && !effectiveValue.TrimStart().StartsWith("Not configured", StringComparison.OrdinalIgnoreCase);
+    protected static bool IsConfiguredAttributionValue(string? effectiveValue, IReadOnlyList<string>? additionalUnconfiguredValues = null) {
+        if (string.IsNullOrWhiteSpace(effectiveValue)) {
+            return false;
+        }
+
+        var trimmed = effectiveValue.Trim();
+        if (trimmed.StartsWith("Not configured", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        if (additionalUnconfiguredValues is null || additionalUnconfiguredValues.Count == 0) {
+            return true;
+        }
+
+        for (var i = 0; i < additionalUnconfiguredValues.Count; i++) {
+            var candidate = additionalUnconfiguredValues[i];
+            if (string.IsNullOrWhiteSpace(candidate)) {
+                continue;
+            }
+
+            if (string.Equals(trimmed, candidate.Trim(), StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -287,5 +331,12 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         return compact.Length <= MaxErrorMessageLength
             ? compact
             : compact.Substring(0, MaxErrorMessageLength).TrimEnd() + "...";
+    }
+
+    /// <summary>
+    /// Normalizes a collector exception message before adding it to per-domain/per-target error rows.
+    /// </summary>
+    protected static string ToCollectorErrorMessage(Exception? exception, string fallback = "Active Directory query failed.") {
+        return SanitizeErrorMessage(exception?.Message, fallback);
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
@@ -115,7 +115,7 @@ public sealed class AdAzureAdSsoTool : ActiveDirectoryToolBase, ITool {
                     AccountDn: snapshot.AccountDn,
                     Spns: includeSpns ? snapshot.Spns : Array.Empty<string>()));
             } catch (Exception ex) {
-                errors.Add(new AzureAdSsoError(domain, ex.Message));
+                errors.Add(new AzureAdSsoError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
@@ -110,7 +110,7 @@ public sealed class AdDangerousExtendedRightsTool : ActiveDirectoryToolBase, ITo
                         ? view.Items.Take(maxFindingsPerDomain).ToArray()
                         : Array.Empty<DangerousExtendedRightsService.Finding>()));
             } catch (Exception ex) {
-                errors.Add(new DangerousExtendedRightsError(domain, ex.Message));
+                errors.Add(new DangerousExtendedRightsError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
@@ -123,7 +123,7 @@ public sealed class AdDcFleetPostureTool : ActiveDirectoryToolBase, ITool {
                         NonAdministrativeOwners: view.NonAdministrativeOwners.Take(maxDetailRowsPerDomain).ToArray()));
                 }
             } catch (Exception ex) {
-                errors.Add(new DcFleetPostureError(domain, ex.Message));
+                errors.Add(new DcFleetPostureError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
@@ -101,7 +101,7 @@ public sealed class AdDcShadowIndicatorsTool : ActiveDirectoryToolBase, ITool {
                         ? view.Findings.Take(maxFindingsPerDomain).ToArray()
                         : Array.Empty<DcShadowIndicatorService.Finding>()));
             } catch (Exception ex) {
-                errors.Add(new DcShadowIndicatorsError(domain, ex.Message));
+                errors.Add(new DcShadowIndicatorsError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDefenderAsrPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDefenderAsrPolicyTool.cs
@@ -15,6 +15,7 @@ namespace IntelligenceX.Tools.ADPlayground;
 /// </summary>
 public sealed class AdDefenderAsrPolicyTool : ActiveDirectoryToolBase, ITool {
     private const int MaxViewTop = 5000;
+    private static readonly IReadOnlyList<string> AdditionalUnconfiguredAttributionValues = new[] { "Off" };
 
     private static readonly ToolDefinition DefinitionValue = new(
         "ad_defender_asr_policy",
@@ -84,6 +85,7 @@ public sealed class AdDefenderAsrPolicyTool : ActiveDirectoryToolBase, ITool {
             includeAttribution: includeAttribution,
             configuredAttributionOnly: configuredAttributionOnly,
             maxResults: maxResults,
+            additionalUnconfiguredValues: AdditionalUnconfiguredAttributionValues,
             scanned: out var scanned,
             truncated: out var truncated);
 
@@ -123,5 +125,4 @@ public sealed class AdDefenderAsrPolicyTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsDelegationTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsDelegationTool.cs
@@ -111,7 +111,7 @@ public sealed class AdDnsDelegationTool : ActiveDirectoryToolBase, ITool {
                         Rights: record.Rights.ToString()));
                 }
             } catch (Exception ex) {
-                errors.Add(new DnsDelegationError(domain, ex.Message));
+                errors.Add(new DnsDelegationError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsServerConfigTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsServerConfigTool.cs
@@ -124,7 +124,7 @@ public sealed class AdDnsServerConfigTool : ActiveDirectoryToolBase, ITool {
                     Forwarders: forwarders,
                     MissingForwarders: forwarders.Length == 0));
             } catch (Exception ex) {
-                errors.Add(new DnsServerConfigError(server, ex.Message));
+                errors.Add(new DnsServerConfigError(server, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
@@ -152,7 +152,7 @@ public sealed class AdDnsZoneSecurityTool : ActiveDirectoryToolBase, ITool {
                     }
                 }
             } catch (Exception ex) {
-                errors.Add(new DnsZoneSecurityError(domain, ex.Message));
+                errors.Add(new DnsZoneSecurityError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainContainerDefaultsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainContainerDefaultsTool.cs
@@ -96,7 +96,7 @@ public sealed class AdDomainContainerDefaultsTool : ActiveDirectoryToolBase, ITo
                     UserContainerChanged: snapshot.UserContainerChanged,
                     AnyChanged: anyChanged));
             } catch (Exception ex) {
-                errors.Add(new DomainContainerDefaultsError(domain, ex.Message));
+                errors.Add(new DomainContainerDefaultsError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerFactsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerFactsTool.cs
@@ -130,7 +130,7 @@ public sealed class AdDomainControllerFactsTool : ActiveDirectoryToolBase, ITool
                         Attributes: attributes));
                 }
             } catch (Exception ex) {
-                errors.Add(new DomainControllerFactsError(domain, ex.Message));
+                errors.Add(new DomainControllerFactsError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
@@ -155,7 +155,7 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
                         AnyFinding: anyFinding));
                 }
             } catch (Exception ex) {
-                errors.Add(new DomainControllerSecurityError(domain, ex.Message));
+                errors.Add(new DomainControllerSecurityError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
@@ -108,7 +108,7 @@ public sealed class AdDomainStatisticsTool : ActiveDirectoryToolBase, ITool {
                     RecommendedFunctionalLevelLabel: snapshot.RecommendedFunctionalLevelLabel,
                     FunctionalLevelGap: snapshot.FunctionalLevelGap));
             } catch (Exception ex) {
-                errors.Add(new DomainStatisticsError(domain, ex.Message));
+                errors.Add(new DomainStatisticsError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
@@ -138,7 +138,7 @@ public sealed class AdDuplicateAccountsTool : ActiveDirectoryToolBase, ITool {
                     }
                 }
             } catch (Exception ex) {
-                errors.Add(new DuplicateAccountsError(domain, ex.Message));
+                errors.Add(new DuplicateAccountsError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
@@ -94,7 +94,7 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
                     UsersPreAuthDisabled: view.UsersPreAuthDisabled,
                     TotalSignals: view.UsersRc4Only + view.ComputersRc4Only + view.UsersAesDisabled + view.ComputersAesDisabled + view.UsersPreAuthDisabled));
             } catch (Exception ex) {
-                errors.Add(new KerberosCryptoPostureError(domain, ex.Message));
+                errors.Add(new KerberosCryptoPostureError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKrbtgtHealthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKrbtgtHealthTool.cs
@@ -80,7 +80,7 @@ public sealed class AdKrbtgtHealthTool : ActiveDirectoryToolBase, ITool {
             try {
                 rows.Add(KrbtgtHealthService.GetSnapshot(domain, ageThresholdDays));
             } catch (Exception ex) {
-                errors.Add(new KrbtgtHealthError(domain, ex.Message));
+                errors.Add(new KrbtgtHealthError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
@@ -95,7 +95,7 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
                         AllowsLmHash: !status.NoLmHash,
                         LegacyNtlmAllowed: status.LmCompatibilityLevel.GetValueOrDefault() < 5));
                 } catch (Exception ex) {
-                    errors.Add(new LanManagerSettingsError(dc, ex.Message));
+                    errors.Add(new LanManagerSettingsError(dc, ToCollectorErrorMessage(ex)));
                 }
             }
         } else {
@@ -134,7 +134,7 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
                         break;
                     }
                 } catch (Exception ex) {
-                    errors.Add(new LanManagerSettingsError(domain, ex.Message));
+                    errors.Add(new LanManagerSettingsError(domain, ToCollectorErrorMessage(ex)));
                 }
             }
         }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
@@ -140,7 +140,7 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
                         ExpiredDsrmLaps: view.ExpiredDsrmLaps.Take(maxSampleRowsPerDomain).ToArray()));
                 }
             } catch (Exception ex) {
-                errors.Add(new LapsCoverageError(domain, ex.Message));
+                errors.Add(new LapsCoverageError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
@@ -135,7 +135,7 @@ public sealed class AdLapsSchemaPostureTool : ActiveDirectoryToolBase, ITool {
                         ModernSchemaDn: modern.SchemaDn));
                 }
             } catch (Exception ex) {
-                errors.Add(new LapsSchemaPostureError(domain, ex.Message));
+                errors.Add(new LapsSchemaPostureError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdMachineAccountQuotaTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdMachineAccountQuotaTool.cs
@@ -98,7 +98,7 @@ public sealed class AdMachineAccountQuotaTool : ActiveDirectoryToolBase, ITool {
                     ExceedsThreshold: exceedsThreshold,
                     Threshold: threshold));
             } catch (Exception ex) {
-                errors.Add(new MachineAccountQuotaError(domain, ex.Message));
+                errors.Add(new MachineAccountQuotaError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNullSessionPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNullSessionPostureTool.cs
@@ -125,7 +125,7 @@ public sealed class AdNullSessionPostureTool : ActiveDirectoryToolBase, ITool {
                     NullSessionAllowed: nullSessionAllowed,
                     AnyInsecure: anonymousSamAllowed || nullSessionAllowed));
             } catch (Exception ex) {
-                errors.Add(new NullSessionPostureError(dc, ex.Message));
+                errors.Add(new NullSessionPostureError(dc, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
@@ -127,7 +127,7 @@ public sealed class AdOuProtectionTool : ActiveDirectoryToolBase, ITool {
                     }
                 }
             } catch (Exception ex) {
-                errors.Add(new OuProtectionError(domain, ex.Message));
+                errors.Add(new OuProtectionError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyLengthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyLengthTool.cs
@@ -87,7 +87,7 @@ public sealed class AdPasswordPolicyLengthTool : ActiveDirectoryToolBase, ITool 
                         RecommendedMinimumLength = recommendedMinimumLength
                     }));
             } catch (Exception ex) {
-                errors.Add(new PasswordPolicyLengthError(domain, ex.Message));
+                errors.Add(new PasswordPolicyLengthError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
@@ -118,7 +118,7 @@ public sealed class AdPasswordPolicyRollupTool : ActiveDirectoryToolBase, ITool 
                         ? rollup.Psos.Take(maxPsoRowsPerDomain).ToArray()
                         : Array.Empty<PasswordPolicyInfo>()));
             } catch (Exception ex) {
-                errors.Add(new PasswordPolicyRollupError(domain, ex.Message));
+                errors.Add(new PasswordPolicyRollupError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
@@ -135,7 +135,7 @@ public sealed class AdRegistrationPostureTool : ActiveDirectoryToolBase, ITool {
                     }
                 }
             } catch (Exception ex) {
-                errors.Add(new RegistrationPostureError(domain, ex.Message));
+                errors.Add(new RegistrationPostureError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
@@ -101,7 +101,7 @@ public sealed class AdShadowCredentialsRiskTool : ActiveDirectoryToolBase, ITool
                         ? view.Findings.Take(maxFindingsPerDomain).ToArray()
                         : Array.Empty<ShadowCredentialsRiskService.Finding>()));
             } catch (Exception ex) {
-                errors.Add(new ShadowCredentialsRiskError(domain, ex.Message));
+                errors.Add(new ShadowCredentialsRiskError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
@@ -120,7 +120,7 @@ public sealed class AdSmartCardPostureTool : ActiveDirectoryToolBase, ITool {
                         ? view.SmartCardPwdOld.Take(maxFindingRowsPerDomain).ToArray()
                         : Array.Empty<SmartCardPostureService.Finding>()));
             } catch (Exception ex) {
-                errors.Add(new SmartCardPostureError(domain, ex.Message));
+                errors.Add(new SmartCardPostureError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
@@ -144,7 +144,7 @@ public sealed class AdSpnHygieneTool : ActiveDirectoryToolBase, ITool {
                         ? snapshot.UnresolvableTargets.Take(maxInvalidSpnSample).ToArray()
                         : Array.Empty<SpnHygieneService.SpnInvalidEntry>()));
             } catch (Exception ex) {
-                errors.Add(new SpnHygieneError(domain, ex.Message));
+                errors.Add(new SpnHygieneError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSystemStateBackupTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSystemStateBackupTool.cs
@@ -113,7 +113,7 @@ public sealed class AdSystemStateBackupTool : ActiveDirectoryToolBase, ITool {
                         ThresholdDays: thresholdDays));
                 }
             } catch (Exception ex) {
-                errors.Add(new SystemStateBackupError(domain, ex.Message));
+                errors.Add(new SystemStateBackupError(domain, ToCollectorErrorMessage(ex)));
             }
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemUpdatesInstalledTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemUpdatesInstalledTool.cs
@@ -86,7 +86,9 @@ public sealed class SystemUpdatesInstalledTool : SystemToolBase, ITool {
             .Where(x => string.IsNullOrWhiteSpace(titleContains)
                 || x.Title.Contains(titleContains, StringComparison.OrdinalIgnoreCase))
             .Where(x => string.IsNullOrWhiteSpace(kbContains)
-                || SystemPatchKbNormalization.MatchesContainsFilter(new[] { x.Kb, x.Title }, kbContains))
+                || SystemPatchKbNormalization.MatchesContainsFilter(
+                    SystemPatchKbNormalization.NormalizeDistinct(new[] { x.Kb, x.Title }),
+                    kbContains))
             .Where(x => !installedAfterUtc.HasValue
                 || (x.InstalledOn.HasValue && x.InstalledOn.Value.ToUniversalTime() >= installedAfterUtc.Value))
             .ToArray();

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,6 +64,27 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
         Assert.Equal("GPO list query failed.", root.GetProperty("error").GetString());
     }
 
+    [Fact]
+    public void IsConfiguredAttributionValue_ShouldTreatOffAsUnconfiguredWhenConfiguredAliasProvided() {
+        var tool = new HarnessTool();
+
+        Assert.False(tool.IsConfigured("Off", new[] { "off" }));
+        Assert.False(tool.IsConfigured("  OFF  ", new[] { "Off" }));
+        Assert.True(tool.IsConfigured("Off", additionalUnconfiguredValues: null));
+        Assert.True(tool.IsConfigured("Enabled", new[] { "Off" }));
+    }
+
+    [Fact]
+    public void ToCollectorErrorMessage_ShouldSanitizeAndFallback() {
+        var tool = new HarnessTool();
+
+        var sanitized = tool.CollectorError(new Exception("server:\r\nline2\tfailure"), "Domain query failed.");
+        Assert.Equal("server: line2 failure", sanitized);
+
+        var fallback = tool.CollectorError(new Exception("   "), "Domain query failed.");
+        Assert.Equal("Domain query failed.", fallback);
+    }
+
     private sealed class HarnessTool : ActiveDirectoryToolBase {
         private static readonly ToolDefinition DefinitionValue = new(
             "ad_test_harness",
@@ -83,6 +105,14 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
                 defaultMessage,
                 fallbackErrorCode,
                 invalidOperationErrorCode);
+        }
+
+        public bool IsConfigured(string? effectiveValue, IReadOnlyList<string>? additionalUnconfiguredValues = null) {
+            return IsConfiguredAttributionValue(effectiveValue, additionalUnconfiguredValues);
+        }
+
+        public string CollectorError(Exception? exception, string fallback) {
+            return ToCollectorErrorMessage(exception, fallback);
         }
 
         protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/SystemPatchKbNormalizationTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/SystemPatchKbNormalizationTests.cs
@@ -42,4 +42,30 @@ public class SystemPatchKbNormalizationTests {
 
         Assert.False(matched);
     }
+
+    [Fact]
+    public void MatchesContainsFilter_WithNormalizedKbCandidates_ShouldIgnoreTitleKeywords() {
+        var kbCandidates = SystemPatchKbNormalization.NormalizeDistinct(new[] {
+            "Security cumulative update for Windows (KB5034441)"
+        });
+
+        var matched = SystemPatchKbNormalization.MatchesContainsFilter(
+            values: kbCandidates,
+            filter: "security");
+
+        Assert.False(matched);
+    }
+
+    [Fact]
+    public void MatchesContainsFilter_WithNormalizedKbCandidates_ShouldMatchKbFragments() {
+        var kbCandidates = SystemPatchKbNormalization.NormalizeDistinct(new[] {
+            "Security cumulative update for Windows (KB5034441)"
+        });
+
+        var matched = SystemPatchKbNormalization.MatchesContainsFilter(
+            values: kbCandidates,
+            filter: "5034441");
+
+        Assert.True(matched);
+    }
 }


### PR DESCRIPTION
## Summary
- fix `system_updates_installed` `kb_contains` matching to operate on normalized KB identifiers (prevents title-keyword matches)
- restore expected `configured_attribution_only` semantics for `ad_defender_asr_policy` by treating `Off` as unconfigured in attribution filtering
- add shared `ActiveDirectoryToolBase.ToCollectorErrorMessage(...)` helper and apply it across per-domain/per-target AD collector tools to avoid returning raw exception messages
- add regression tests for:
  - ASR configured attribution handling + collector message sanitization
  - normalized KB matching behavior (no title-keyword false positives)

## Why
This closes the remaining actionable reviewer feedback from the recent tool PR wave (`#488`, `#491`) and improves consistency/safety in AD collector error payloads.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
  - Passed: 238, Failed: 0

## Guardrails
- touched files stay below the 700 LOC cap