### PR TITLE
ci(website): purge + verify Cloudflare cache after deploy

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -67,3 +67,67 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  purge-cloudflare:
+    needs: deploy
+    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ZONE_ID_IX != '' }}
+    runs-on: [self-hosted, linux]
+    permissions:
+      contents: read
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Checkout PSPublishModule
+        uses: actions/checkout@v4
+        with:
+          repository: EvotecIT/PSPublishModule
+          ref: main
+          path: PSPublishModule
+
+      - name: Build PowerForge.Web.Cli
+        run: dotnet build PSPublishModule/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -c Release
+
+      - name: Purge Cloudflare cache (key routes)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          dotnet PSPublishModule/PowerForge.Web.Cli/bin/Release/net10.0/PowerForge.Web.Cli.dll \
+            cloudflare purge \
+            --zone-id "${{ secrets.CLOUDFLARE_ZONE_ID_IX }}" \
+            --token-env CLOUDFLARE_API_TOKEN \
+            --base-url "https://intelligencex.dev" \
+            --path "/,/docs/,/api/,/api/powershell/,/blog/,/showcase/,/search/,/sitemap/,/changelog/,/404.html,/sitemap.xml,/llms.txt,/llms-full.txt,/llms.json"
+
+  verify-cache:
+    needs: purge-cloudflare
+    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ZONE_ID_IX != '' }}
+    runs-on: [self-hosted, linux]
+    steps:
+      - name: Verify Cloudflare caching on key pages
+        run: |
+          set -euo pipefail
+          urls=(
+            "https://intelligencex.dev/"
+            "https://intelligencex.dev/docs/"
+            "https://intelligencex.dev/api/"
+            "https://intelligencex.dev/api/powershell/"
+            "https://intelligencex.dev/blog/"
+            "https://intelligencex.dev/showcase/"
+            "https://intelligencex.dev/search/"
+            "https://intelligencex.dev/sitemap/"
+          )
+          for url in "${urls[@]}"; do
+            curl -s -o /dev/null "$url"
+            status=$(curl -s -D - "$url" -o /dev/null | awk 'BEGIN{IGNORECASE=1}/^cf-cache-status:/{print toupper($2)}' | tr -d '\r')
+            echo "$url -> cf-cache-status=$status"
+            case "$status" in
+              HIT|REVALIDATED|EXPIRED|STALE) ;;
+              *)
+                echo "Unexpected cache status for $url: $status"
+                exit 1
+                ;;
+            esac
+          done


### PR DESCRIPTION
## Summary
- add post-deploy Cloudflare purge job using org secrets
- add cache verification job to assert key routes resolve to cacheable statuses (HIT/REVALIDATED/EXPIRED/STALE)
- keeps cache behavior deterministic after GitHub Pages deployments

## Required secrets
- CLOUDFLARE_API_TOKEN
- CLOUDFLARE_ZONE_ID_IX