### PR TITLE
Chat startup: cap connect budget and archive profiler logs

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
@@ -26,6 +26,51 @@ public sealed class MainWindowStartupConnectTimeoutPolicyTests {
     }
 
     /// <summary>
+    /// Ensures startup-only connect budget is enabled exclusively for non-user startup flow connects.
+    /// </summary>
+    [Theory]
+    [InlineData(true, true, null)]
+    [InlineData(true, false, null)]
+    [InlineData(false, false, null)]
+    [InlineData(false, true, 4000)]
+    public void ResolveStartupConnectBudget_ReturnsExpectedBudget(
+        bool fromUserAction,
+        bool captureStartupPhaseTelemetry,
+        int? expectedTimeoutMs) {
+        var timeout = MainWindow.ResolveStartupConnectBudget(fromUserAction, captureStartupPhaseTelemetry);
+        var expected = expectedTimeoutMs.HasValue
+            ? TimeSpan.FromMilliseconds(expectedTimeoutMs.Value)
+            : (TimeSpan?)null;
+        Assert.Equal(expected, timeout);
+    }
+
+    /// <summary>
+    /// Ensures connect attempt timeout is capped by remaining startup budget, including exhaustion behavior.
+    /// </summary>
+    [Theory]
+    [InlineData(2000, null, 0, true, 2000)]
+    [InlineData(2000, 4000, 1000, true, 2000)]
+    [InlineData(6000, 4000, 1000, true, 3000)]
+    [InlineData(2000, 4000, 3900, true, 100)]
+    [InlineData(2000, 4000, 3950, false, 0)]
+    [InlineData(2000, 4000, 4000, false, 0)]
+    public void TryResolveStartupConnectAttemptTimeout_UsesBudgetCap(
+        int requestedTimeoutMs,
+        int? budgetMs,
+        int elapsedMs,
+        bool expectedResolved,
+        int expectedTimeoutMs) {
+        var resolved = MainWindow.TryResolveStartupConnectAttemptTimeout(
+            requestedTimeout: TimeSpan.FromMilliseconds(requestedTimeoutMs),
+            startupConnectBudget: budgetMs.HasValue ? TimeSpan.FromMilliseconds(budgetMs.Value) : null,
+            startupConnectElapsed: TimeSpan.FromMilliseconds(elapsedMs),
+            timeout: out var timeout);
+
+        Assert.Equal(expectedResolved, resolved);
+        Assert.Equal(TimeSpan.FromMilliseconds(expectedTimeoutMs), timeout);
+    }
+
+    /// <summary>
     /// Ensures model/profile sync is deferred only during startup flow telemetry capture.
     /// </summary>
     [Theory]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
@@ -34,6 +34,49 @@ public sealed partial class MainWindow : Window {
         return StartupInitialPipeConnectColdStartTimeout;
     }
 
+    internal static TimeSpan? ResolveStartupConnectBudget(bool fromUserAction, bool captureStartupPhaseTelemetry) {
+        if (fromUserAction || !captureStartupPhaseTelemetry) {
+            return null;
+        }
+
+        return StartupConnectBudget;
+    }
+
+    internal static bool TryResolveStartupConnectAttemptTimeout(
+        TimeSpan requestedTimeout,
+        TimeSpan? startupConnectBudget,
+        TimeSpan startupConnectElapsed,
+        out TimeSpan timeout) {
+        timeout = TimeSpan.Zero;
+        if (requestedTimeout <= TimeSpan.Zero) {
+            return false;
+        }
+
+        if (!startupConnectBudget.HasValue) {
+            timeout = requestedTimeout;
+            return true;
+        }
+
+        var remaining = startupConnectBudget.Value - startupConnectElapsed;
+        if (remaining <= TimeSpan.Zero) {
+            return false;
+        }
+
+        timeout = remaining < requestedTimeout ? remaining : requestedTimeout;
+        if (timeout < StartupConnectMinAttemptTimeout) {
+            timeout = TimeSpan.Zero;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static TimeoutException CreateStartupConnectBudgetExceededException(TimeSpan budget, TimeSpan elapsed) {
+        var budgetMs = Math.Round(Math.Max(0, budget.TotalMilliseconds));
+        var elapsedMs = Math.Round(Math.Max(0, elapsed.TotalMilliseconds));
+        return new TimeoutException($"Startup connect budget exhausted after {elapsedMs.ToString(CultureInfo.InvariantCulture)}ms (budget: {budgetMs.ToString(CultureInfo.InvariantCulture)}ms).");
+    }
+
     internal static bool ShouldDeferStartupModelProfileSync(bool captureStartupPhaseTelemetry) {
         return captureStartupPhaseTelemetry;
     }
@@ -58,6 +101,41 @@ public sealed partial class MainWindow : Window {
                 if (captureStartupPhaseTelemetry) {
                     StartupLog.Write("StartupConnect." + phase + " " + state);
                 }
+            }
+            var startupConnectBudget = ResolveStartupConnectBudget(fromUserAction, captureStartupPhaseTelemetry);
+            var startupConnectStopwatch = startupConnectBudget.HasValue ? Stopwatch.StartNew() : null;
+            var startupBudgetExhaustedLogged = false;
+
+            void LogStartupConnectBudgetExhausted(TimeSpan elapsed) {
+                if (startupBudgetExhaustedLogged || !startupConnectBudget.HasValue) {
+                    return;
+                }
+
+                startupBudgetExhaustedLogged = true;
+                LogStartupConnectPhase("budget", "exhausted");
+                StartupLog.Write(
+                    "StartupConnect.budget exhausted after "
+                    + Math.Round(elapsed.TotalMilliseconds).ToString(CultureInfo.InvariantCulture)
+                    + "ms (budget "
+                    + Math.Round(startupConnectBudget.Value.TotalMilliseconds).ToString(CultureInfo.InvariantCulture)
+                    + "ms).");
+            }
+
+            bool TryResolveConnectTimeout(TimeSpan requestedTimeout, out TimeSpan timeout) {
+                var elapsed = startupConnectStopwatch?.Elapsed ?? TimeSpan.Zero;
+                if (TryResolveStartupConnectAttemptTimeout(requestedTimeout, startupConnectBudget, elapsed, out timeout)) {
+                    return true;
+                }
+
+                LogStartupConnectBudgetExhausted(elapsed);
+                timeout = TimeSpan.Zero;
+                return false;
+            }
+
+            Exception CreateBudgetExceededException() {
+                var budget = startupConnectBudget.GetValueOrDefault(TimeSpan.Zero);
+                var elapsed = startupConnectStopwatch?.Elapsed ?? TimeSpan.Zero;
+                return CreateStartupConnectBudgetExceededException(budget, elapsed);
             }
 
             if (_client is not null && await IsClientAliveAsync(_client).ConfigureAwait(false)) {
@@ -84,61 +162,92 @@ public sealed partial class MainWindow : Window {
             Exception? initialConnectException = null;
             var hasTrackedRunningServiceProcess = _serviceProcess is not null && !_serviceProcess.HasExited;
             var initialPipeConnectTimeout = ResolveStartupInitialPipeConnectTimeout(fromUserAction, hasTrackedRunningServiceProcess);
+            var connected = false;
 
             try {
                 LogStartupConnectPhase("pipe_connect.initial", "begin");
-                await ConnectClientWithTimeoutAsync(client, pipeName, initialPipeConnectTimeout).ConfigureAwait(false);
+                if (!TryResolveConnectTimeout(initialPipeConnectTimeout, out var initialAttemptTimeout)) {
+                    throw CreateBudgetExceededException();
+                }
+
+                await ConnectClientWithTimeoutAsync(client, pipeName, initialAttemptTimeout).ConfigureAwait(false);
                 LogStartupConnectPhase("pipe_connect.initial", "done");
+                connected = true;
             } catch (Exception ex) {
                 LogStartupConnectPhase("pipe_connect.initial", "failed");
                 initialConnectException = ex;
+            }
 
-                LogStartupConnectPhase("ensure_sidecar", "begin");
-                if (await EnsureServiceRunningAsync(pipeName).ConfigureAwait(false)) {
-                    LogStartupConnectPhase("ensure_sidecar", "done");
-                    Exception? sidecarConnectException = null;
-                    LogStartupConnectPhase("pipe_connect.retry", "begin");
-                    for (var attempt = 0; attempt < StartupConnectRetryTimeouts.Length; attempt++) {
-                        try {
-                            await ConnectClientWithTimeoutAsync(client, pipeName, StartupConnectRetryTimeouts[attempt]).ConfigureAwait(false);
-                            sidecarConnectException = null;
-                            break;
-                        } catch (Exception ex2) {
-                            sidecarConnectException = ex2;
-                            if (_serviceProcess is { HasExited: true }) {
+            if (!connected) {
+                Exception? sidecarConnectException = null;
+                if (startupConnectBudget.HasValue
+                    && startupConnectStopwatch is not null
+                    && startupConnectStopwatch.Elapsed >= startupConnectBudget.Value) {
+                    LogStartupConnectBudgetExhausted(startupConnectStopwatch.Elapsed);
+                    LogStartupConnectPhase("ensure_sidecar", "skipped_budget");
+                    sidecarConnectException = CreateBudgetExceededException();
+                } else {
+                    LogStartupConnectPhase("ensure_sidecar", "begin");
+                    if (await EnsureServiceRunningAsync(pipeName).ConfigureAwait(false)) {
+                        LogStartupConnectPhase("ensure_sidecar", "done");
+                        LogStartupConnectPhase("pipe_connect.retry", "begin");
+                        for (var attempt = 0; attempt < StartupConnectRetryTimeouts.Length; attempt++) {
+                            if (!TryResolveConnectTimeout(StartupConnectRetryTimeouts[attempt], out var retryTimeout)) {
+                                sidecarConnectException = CreateBudgetExceededException();
                                 break;
                             }
 
-                            if (attempt + 1 < StartupConnectRetryTimeouts.Length) {
-                                await Task.Delay(StartupConnectRetryDelay).ConfigureAwait(false);
+                            try {
+                                await ConnectClientWithTimeoutAsync(client, pipeName, retryTimeout).ConfigureAwait(false);
+                                sidecarConnectException = null;
+                                connected = true;
+                                break;
+                            } catch (Exception ex2) {
+                                sidecarConnectException = ex2;
+                                if (_serviceProcess is { HasExited: true }) {
+                                    break;
+                                }
+
+                                if (attempt + 1 < StartupConnectRetryTimeouts.Length) {
+                                    if (!TryResolveConnectTimeout(StartupConnectRetryDelay, out var retryDelay)) {
+                                        sidecarConnectException = CreateBudgetExceededException();
+                                        break;
+                                    }
+
+                                    await Task.Delay(retryDelay).ConfigureAwait(false);
+                                }
                             }
                         }
-                    }
 
-                    if (sidecarConnectException is not null) {
-                        LogStartupConnectPhase("pipe_connect.retry", "failed");
+                        if (sidecarConnectException is not null) {
+                            LogStartupConnectPhase("pipe_connect.retry", "failed");
+                        } else {
+                            LogStartupConnectPhase("pipe_connect.retry", "done");
+                        }
+                    } else {
+                        LogStartupConnectPhase("ensure_sidecar", "failed");
                         await client.DisposeAsync().ConfigureAwait(false);
                         _isConnected = false;
                         await SetStatusAsync(SessionStatus.ConnectFailed()).ConfigureAwait(false);
                         EnsureAutoReconnectLoop();
-                        if (VerboseServiceLogs || _debugMode) {
-                            AppendSystem(SystemNotice.ConnectProbeFailed(FormatConnectError(initialConnectException)));
-                        }
                         if (fromUserAction || _debugMode) {
-                            AppendSystem(SystemNotice.ConnectFailedAfterSidecarStart(FormatConnectError(sidecarConnectException)));
+                            AppendSystem(SystemNotice.ConnectFailed(FormatConnectError(initialConnectException ?? CreateBudgetExceededException())));
+                            AppendSystem(SystemNotice.ServiceSidecarUnavailable());
                         }
                         return;
                     }
-                    LogStartupConnectPhase("pipe_connect.retry", "done");
-                } else {
-                    LogStartupConnectPhase("ensure_sidecar", "failed");
+                }
+
+                if (!connected) {
                     await client.DisposeAsync().ConfigureAwait(false);
                     _isConnected = false;
                     await SetStatusAsync(SessionStatus.ConnectFailed()).ConfigureAwait(false);
                     EnsureAutoReconnectLoop();
+                    if (VerboseServiceLogs || _debugMode) {
+                        AppendSystem(SystemNotice.ConnectProbeFailed(FormatConnectError(initialConnectException ?? CreateBudgetExceededException())));
+                    }
                     if (fromUserAction || _debugMode) {
-                        AppendSystem(SystemNotice.ConnectFailed(FormatConnectError(initialConnectException)));
-                        AppendSystem(SystemNotice.ServiceSidecarUnavailable());
+                        AppendSystem(SystemNotice.ConnectFailedAfterSidecarStart(FormatConnectError(sidecarConnectException ?? CreateBudgetExceededException())));
                     }
                     return;
                 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -66,6 +66,8 @@ public sealed partial class MainWindow : Window {
     private static readonly TimeSpan DragMoveWatchdogInterval = TimeSpan.FromMilliseconds(1200);
     private static readonly TimeSpan StartupInitialPipeConnectTimeout = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan StartupInitialPipeConnectColdStartTimeout = TimeSpan.FromMilliseconds(350);
+    private static readonly TimeSpan StartupConnectBudget = TimeSpan.FromSeconds(4);
+    private static readonly TimeSpan StartupConnectMinAttemptTimeout = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan StartupConnectRetryDelay = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan[] StartupConnectRetryTimeouts = {
         TimeSpan.FromSeconds(6),

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -41,6 +41,7 @@ pwsh .\scripts\profile-chat-startup.ps1 -Runs 5 -OutFile .\artifacts\chat-startu
 ```
 
 Add `-PostStartupGraceSeconds 2` if you want to include deferred post-startup warmup phases in the report.
+Add `-ArchiveLogsDirectory .\artifacts\chat-startup-logs` to retain each run's raw startup log for hotspot/outlier investigation.
 
 Markdown renderer dependency resolution is automatic:
 - Dev: if sibling local source exists (`..\OfficeIMO`), Chat builds against that local project.

--- a/scripts/profile-chat-startup.ps1
+++ b/scripts/profile-chat-startup.ps1
@@ -7,6 +7,7 @@ param(
     [int] $TimeoutSeconds = 75,
     [ValidateRange(0, 120)]
     [int] $PostStartupGraceSeconds = 0,
+    [string] $ArchiveLogsDirectory,
     [string] $OutFile
 )
 
@@ -27,6 +28,10 @@ if (-not (Test-Path $ExePath)) {
 }
 
 $startupLogPath = Join-Path $env:TEMP 'IntelligenceX.Chat\app-startup.log'
+$resolvedArchiveLogsDirectory = $null
+if (-not [string]::IsNullOrWhiteSpace($ArchiveLogsDirectory)) {
+    $resolvedArchiveLogsDirectory = [System.IO.Path]::GetFullPath($ArchiveLogsDirectory)
+}
 
 function Stop-ChatProcesses {
     Get-Process -Name 'IntelligenceX.Chat.App', 'IntelligenceX.Chat.Service' -ErrorAction SilentlyContinue |
@@ -107,10 +112,17 @@ for ($i = 1; $i -le $Runs; $i++) {
 
     Stop-ChatProcesses
     $lines = if (Test-Path $startupLogPath) { Get-Content $startupLogPath -ErrorAction SilentlyContinue } else { @() }
+    $archivedStartupLogPath = $null
+    if (-not [string]::IsNullOrWhiteSpace($resolvedArchiveLogsDirectory) -and (Test-Path $startupLogPath)) {
+        New-Item -ItemType Directory -Path $resolvedArchiveLogsDirectory -Force | Out-Null
+        $archivedStartupLogPath = Join-Path $resolvedArchiveLogsDirectory ("run-{0:D2}-{1}.log" -f $i, $state)
+        Copy-Item -Path $startupLogPath -Destination $archivedStartupLogPath -Force
+    }
 
     $run = [ordered]@{
         run              = $i
         state            = $state
+        startup_log_path = $archivedStartupLogPath
         total_ms         = Get-DurationMs (Get-MarkerTimestamp $lines 'Program.Main enter') (Get-MarkerTimestamp $lines 'MainWindow.StartupFlow done')
         connect_ms       = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupPhase.Connect begin') (Get-MarkerTimestamp $lines 'StartupPhase.Connect done')
         hello_ms         = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupConnect.hello begin') (Get-MarkerTimestamp $lines 'StartupConnect.hello done')
@@ -152,6 +164,7 @@ $report = [pscustomobject]@{
     generated_utc = [datetime]::UtcNow.ToString('O')
     exe_path      = $ExePath
     startup_log   = $startupLogPath
+    archive_logs_directory = $resolvedArchiveLogsDirectory
     summary       = $summary
     runs          = $runResults
 }


### PR DESCRIPTION
## Summary
- add a startup-only connect budget (4s) so startup no longer waits through long sidecar retry windows
- cap each startup connect attempt by remaining budget and fail-open into disconnected state with auto-reconnect loop still active
- add startup connect budget telemetry markers/log lines when the budget is exhausted
- extend startup profiler script with `-ArchiveLogsDirectory` and per-run `startup_log_path` in output JSON
- document the new profiler archival flag in chat README

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release -p:SkipChatServiceSidecarBuild=true -p:ChatServiceBin=Z:\ix-missing\
- pwsh -NoLogo -NoProfile -File scripts/profile-chat-startup.ps1 -Runs 1 -TimeoutSeconds 60 -ArchiveLogsDirectory artifacts/chat-startup-logs-smoke -OutFile artifacts/chat-startup-profile-smoke.json

## Notes
- In this environment, running App tests without the sidecar-copy override intermittently failed on missing sidecar runtime module copy artifacts; code changes are independent of that packaging race.