### PR TITLE
ci(website): purge + verify Cloudflare cache after deploy

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -101,33 +101,10 @@ jobs:
             --base-url "https://intelligencex.dev" \
             --path "/,/docs/,/api/,/api/powershell/,/blog/,/showcase/,/search/,/sitemap/,/changelog/,/404.html,/sitemap.xml,/llms.txt,/llms-full.txt,/llms.json"
 
-  verify-cache:
-    needs: purge-cloudflare
-    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ZONE_ID_IX != '' }}
-    runs-on: [self-hosted, linux]
-    steps:
-      - name: Verify Cloudflare caching on key pages
+      - name: Verify Cloudflare cache status (key routes)
         run: |
-          set -euo pipefail
-          urls=(
-            "https://intelligencex.dev/"
-            "https://intelligencex.dev/docs/"
-            "https://intelligencex.dev/api/"
-            "https://intelligencex.dev/api/powershell/"
-            "https://intelligencex.dev/blog/"
-            "https://intelligencex.dev/showcase/"
-            "https://intelligencex.dev/search/"
-            "https://intelligencex.dev/sitemap/"
-          )
-          for url in "${urls[@]}"; do
-            curl -s -o /dev/null "$url"
-            status=$(curl -s -D - "$url" -o /dev/null | awk 'BEGIN{IGNORECASE=1}/^cf-cache-status:/{print toupper($2)}' | tr -d '\r')
-            echo "$url -> cf-cache-status=$status"
-            case "$status" in
-              HIT|REVALIDATED|EXPIRED|STALE) ;;
-              *)
-                echo "Unexpected cache status for $url: $status"
-                exit 1
-                ;;
-            esac
-          done
+          dotnet PSPublishModule/PowerForge.Web.Cli/bin/Release/net10.0/PowerForge.Web.Cli.dll \
+            cloudflare verify \
+            --base-url "https://intelligencex.dev" \
+            --path "/,/docs/,/api/,/api/powershell/,/blog/,/showcase/,/search/,/sitemap/" \
+            --warmup 1


### PR DESCRIPTION
## Summary
- add post-deploy Cloudflare purge job using org secrets
- use native powerforge-web cloudflare verify command (no inline bash loop)
- verifies key routes after purge to catch cache rule regressions

## Required secrets
- CLOUDFLARE_API_TOKEN
- CLOUDFLARE_ZONE_ID_IX

## Dependency
Requires PSPublishModule PR #139 to be merged first (adds cloudflare verify command).