### PR TITLE
Deduplicate AD policy-attribution execution pipeline

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using ADPlayground.Gpo;
 using ADPlayground.Helpers;
 using IntelligenceX.Json;
@@ -14,6 +15,16 @@ namespace IntelligenceX.Tools.ADPlayground;
 /// </summary>
 public abstract class ActiveDirectoryToolBase : ToolBase {
     private const int MaxErrorMessageLength = 300;
+    private const int DefaultPolicyAttributionMaxTop = 5000;
+
+    /// <summary>
+    /// Standard argument set used by AD policy-attribution tools.
+    /// </summary>
+    protected readonly record struct PolicyAttributionToolRequest(
+        string DomainName,
+        bool IncludeAttribution,
+        bool ConfiguredAttributionOnly,
+        int MaxResults);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ActiveDirectoryToolBase"/> class.
@@ -338,5 +349,96 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     /// </summary>
     protected static string ToCollectorErrorMessage(Exception? exception, string fallback = "Active Directory query failed.") {
         return SanitizeErrorMessage(exception?.Message, fallback);
+    }
+
+    /// <summary>
+    /// Executes a standard AD policy-attribution query tool pipeline:
+    /// parse args, run query, shape attribution rows, and build the table response.
+    /// </summary>
+    protected Task<string> ExecutePolicyAttributionTool<TView, TResult>(
+        JsonObject? arguments,
+        CancellationToken cancellationToken,
+        string title,
+        string defaultErrorMessage,
+        Func<string, TView> query,
+        Func<TView, IReadOnlyList<PolicyAttribution>> attributionSelector,
+        Func<PolicyAttributionToolRequest, TView, int, bool, IReadOnlyList<PolicyAttribution>, TResult> resultFactory,
+        IReadOnlyList<string>? additionalUnconfiguredValues = null,
+        string invalidOperationErrorCode = "query_failed",
+        int maxTop = DefaultPolicyAttributionMaxTop) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (query is null) {
+            throw new ArgumentNullException(nameof(query));
+        }
+        if (attributionSelector is null) {
+            throw new ArgumentNullException(nameof(attributionSelector));
+        }
+        if (resultFactory is null) {
+            throw new ArgumentNullException(nameof(resultFactory));
+        }
+
+        if (!TryReadPolicyAttributionToolRequest(arguments, out var request, out var requestError)) {
+            return Task.FromResult(requestError!);
+        }
+
+        if (!TryExecute(
+                action: () => query(request.DomainName),
+                result: out TView view,
+                errorResponse: out var errorResponse,
+                defaultErrorMessage: defaultErrorMessage,
+                invalidOperationErrorCode: invalidOperationErrorCode)) {
+            return Task.FromResult(errorResponse!);
+        }
+
+        var rows = PreparePolicyAttributionRows(
+            attribution: attributionSelector(view),
+            includeAttribution: request.IncludeAttribution,
+            configuredAttributionOnly: request.ConfiguredAttributionOnly,
+            maxResults: request.MaxResults,
+            additionalUnconfiguredValues: additionalUnconfiguredValues,
+            scanned: out var scanned,
+            truncated: out var truncated);
+
+        var result = resultFactory(request, view, scanned, truncated, rows);
+
+        return Task.FromResult(BuildAutoTableResponse(
+            arguments: arguments,
+            model: result,
+            sourceRows: rows,
+            viewRowsPath: "attribution_view",
+            title: title,
+            maxTop: maxTop,
+            baseTruncated: truncated,
+            scanned: scanned,
+            metaMutate: meta => AddStandardPolicyAttributionMeta(
+                meta,
+                request.DomainName,
+                request.IncludeAttribution,
+                request.ConfiguredAttributionOnly,
+                request.MaxResults)));
+    }
+
+    /// <summary>
+    /// Parses standard AD policy-attribution arguments.
+    /// </summary>
+    protected bool TryReadPolicyAttributionToolRequest(
+        JsonObject? arguments,
+        out PolicyAttributionToolRequest request,
+        out string? errorResponse) {
+        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
+        if (string.IsNullOrWhiteSpace(domainName)) {
+            request = default;
+            errorResponse = ToolResponse.Error("invalid_argument", "domain_name is required.");
+            return false;
+        }
+
+        request = new PolicyAttributionToolRequest(
+            DomainName: domainName,
+            IncludeAttribution: ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true),
+            ConfiguredAttributionOnly: ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false),
+            MaxResults: ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults));
+        errorResponse = null;
+        return true;
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDefenderAsrPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDefenderAsrPolicyTool.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ADPlayground.Gpo;
@@ -14,7 +13,6 @@ namespace IntelligenceX.Tools.ADPlayground;
 /// Returns Defender ASR and cloud policy posture for Domain Controllers OU in one domain (read-only).
 /// </summary>
 public sealed class AdDefenderAsrPolicyTool : ActiveDirectoryToolBase, ITool {
-    private const int MaxViewTop = 5000;
     private static readonly IReadOnlyList<string> AdditionalUnconfiguredAttributionValues = new[] { "Off" };
 
     private static readonly ToolDefinition DefinitionValue = new(
@@ -60,69 +58,33 @@ public sealed class AdDefenderAsrPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        if (!TryExecute(
-                action: () => DefenderAsrPolicyService.Get(domainName),
-                result: out DefenderAsrPolicyService.View view,
-                errorResponse: out var errorResponse,
-                defaultErrorMessage: "Defender ASR policy query failed.",
-                invalidOperationErrorCode: "query_failed")) {
-            return Task.FromResult(errorResponse!);
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            additionalUnconfiguredValues: AdditionalUnconfiguredAttributionValues,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdDefenderAsrPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            Asr: view.Asr,
-            Cloud: view.Cloud,
-            AsrEntriesFriendly: view.AsrEntriesFriendly,
-            CloudFriendly: view.CloudFriendly,
-            AttributionTopWriters: view.AttributionTopWriters,
-            NetworkProtectionMode: view.NetworkProtectionMode,
-            NetworkProtectionNotOff: view.NetworkProtectionNotOff,
-            PuaProtectionMode: view.PuaProtectionMode,
-            PuaNotDisabled: view.PuaNotDisabled,
-            RtpRealtimeEnabled: view.RtpRealtimeEnabled,
-            RtpBehaviorEnabled: view.RtpBehaviorEnabled,
-            RtpIoavEnabled: view.RtpIoavEnabled,
-            RtpScriptEnabled: view.RtpScriptEnabled,
-            Attribution: rows);
-
-        var response = BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool<DefenderAsrPolicyService.View, AdDefenderAsrPolicyResult>(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Defender ASR Policy (preview)",
-            baseTruncated: truncated,
-            scanned: scanned,
-            maxTop: MaxViewTop,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            });
-        return Task.FromResult(response);
+            defaultErrorMessage: "Defender ASR policy query failed.",
+            query: static domainName => DefenderAsrPolicyService.Get(domainName),
+            attributionSelector: static view => view.Attribution,
+            additionalUnconfiguredValues: AdditionalUnconfiguredAttributionValues,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdDefenderAsrPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                Asr: view.Asr,
+                Cloud: view.Cloud,
+                AsrEntriesFriendly: view.AsrEntriesFriendly,
+                CloudFriendly: view.CloudFriendly,
+                AttributionTopWriters: view.AttributionTopWriters,
+                NetworkProtectionMode: view.NetworkProtectionMode,
+                NetworkProtectionNotOff: view.NetworkProtectionNotOff,
+                PuaProtectionMode: view.PuaProtectionMode,
+                PuaNotDisabled: view.PuaNotDisabled,
+                RtpRealtimeEnabled: view.RtpRealtimeEnabled,
+                RtpBehaviorEnabled: view.RtpBehaviorEnabled,
+                RtpIoavEnabled: view.RtpIoavEnabled,
+                RtpScriptEnabled: view.RtpScriptEnabled,
+                Attribution: rows));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDenyLogonRightsPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDenyLogonRightsPolicyTool.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ADPlayground.Gpo;
@@ -14,8 +13,6 @@ namespace IntelligenceX.Tools.ADPlayground;
 /// Returns deny-logon-rights posture for Domain Controllers OU in one domain (read-only).
 /// </summary>
 public sealed class AdDenyLogonRightsPolicyTool : ActiveDirectoryToolBase, ITool {
-    private const int MaxViewTop = 5000;
-
     private static readonly ToolDefinition DefinitionValue = new(
         "ad_deny_logon_rights_policy",
         "Assess deny-logon-rights assignments and attribution for Domain Controllers OU (read-only).",
@@ -48,57 +45,22 @@ public sealed class AdDenyLogonRightsPolicyTool : ActiveDirectoryToolBase, ITool
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        if (!TryExecute(
-                action: () => DenyLogonRightsPolicyService.Get(domainName),
-                result: out DenyLogonRightsPolicyService.View view,
-                errorResponse: out var errorResponse,
-                defaultErrorMessage: "Deny-logon-rights policy query failed.",
-                invalidOperationErrorCode: "query_failed")) {
-            return Task.FromResult(errorResponse!);
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdDenyLogonRightsPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            AssignmentCount: view.Assignments.Count,
-            Scanned: scanned,
-            Truncated: truncated,
-            Assignments: view.Assignments,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool<DenyLogonRightsPolicyService.View, AdDenyLogonRightsPolicyResult>(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Deny Logon Rights Policy (preview)",
-            maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            defaultErrorMessage: "Deny-logon-rights policy query failed.",
+            query: static domainName => DenyLogonRightsPolicyService.Get(domainName),
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdDenyLogonRightsPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                AssignmentCount: view.Assignments.Count,
+                Scanned: scanned,
+                Truncated: truncated,
+                Assignments: view.Assignments,
+                Attribution: rows));
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdEnableDelegationPrivilegePolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdEnableDelegationPrivilegePolicyTool.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ADPlayground.Gpo;
@@ -14,8 +13,6 @@ namespace IntelligenceX.Tools.ADPlayground;
 /// Returns SeEnableDelegationPrivilege policy posture for Domain Controllers OU in one domain (read-only).
 /// </summary>
 public sealed class AdEnableDelegationPrivilegePolicyTool : ActiveDirectoryToolBase, ITool {
-    private const int MaxViewTop = 5000;
-
     private static readonly ToolDefinition DefinitionValue = new(
         "ad_enable_delegation_privilege_policy",
         "Assess SeEnableDelegationPrivilege assignment and attribution for Domain Controllers OU (read-only).",
@@ -48,57 +45,22 @@ public sealed class AdEnableDelegationPrivilegePolicyTool : ActiveDirectoryToolB
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        if (!TryExecute(
-                action: () => EnableDelegationPrivilegePolicyService.Get(domainName),
-                result: out EnableDelegationPrivilegePolicyService.View view,
-                errorResponse: out var errorResponse,
-                defaultErrorMessage: "Enable-delegation-privilege policy query failed.",
-                invalidOperationErrorCode: "query_failed")) {
-            return Task.FromResult(errorResponse!);
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdEnableDelegationPrivilegePolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            AssignedCount: view.Assigned.Count,
-            Scanned: scanned,
-            Truncated: truncated,
-            Assigned: view.Assigned,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool<EnableDelegationPrivilegePolicyService.View, AdEnableDelegationPrivilegePolicyResult>(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Enable Delegation Privilege Policy (preview)",
-            maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            defaultErrorMessage: "Enable-delegation-privilege policy query failed.",
+            query: static domainName => EnableDelegationPrivilegePolicyService.Get(domainName),
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdEnableDelegationPrivilegePolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                AssignedCount: view.Assigned.Count,
+                Scanned: scanned,
+                Truncated: truncated,
+                Assigned: view.Assigned,
+                Attribution: rows));
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLlmnrPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLlmnrPolicyTool.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ADPlayground.Gpo;
@@ -14,8 +13,6 @@ namespace IntelligenceX.Tools.ADPlayground;
 /// Returns LLMNR policy posture for Domain Controllers OU in one domain (read-only).
 /// </summary>
 public sealed class AdLlmnrPolicyTool : ActiveDirectoryToolBase, ITool {
-    private const int MaxViewTop = 5000;
-
     private static readonly ToolDefinition DefinitionValue = new(
         "ad_llmnr_policy",
         "Assess LLMNR policy posture (EnableMulticast) for Domain Controllers OU (read-only).",
@@ -48,57 +45,22 @@ public sealed class AdLlmnrPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        if (!TryExecute(
-                action: () => LlmnrPolicyService.Get(domainName),
-                result: out LlmnrPolicyService.View view,
-                errorResponse: out var errorResponse,
-                defaultErrorMessage: "LLMNR policy query failed.",
-                invalidOperationErrorCode: "query_failed")) {
-            return Task.FromResult(errorResponse!);
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdLlmnrPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            EffectiveValue: view.EffectiveValue,
-            LlmnrDisabled: view.LlmnrDisabled,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool<LlmnrPolicyService.View, AdLlmnrPolicyResult>(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: LLMNR Policy (preview)",
-            baseTruncated: truncated,
-            scanned: scanned,
-            maxTop: MaxViewTop,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            defaultErrorMessage: "LLMNR policy query failed.",
+            query: static domainName => LlmnrPolicyService.Get(domainName),
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdLlmnrPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                EffectiveValue: view.EffectiveValue,
+                LlmnrDisabled: view.LlmnrDisabled,
+                Attribution: rows));
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNtlmRestrictionsPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNtlmRestrictionsPolicyTool.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ADPlayground.Gpo;
@@ -14,8 +13,6 @@ namespace IntelligenceX.Tools.ADPlayground;
 /// Returns Restrict NTLM policy values for Domain Controllers OU in one domain (read-only).
 /// </summary>
 public sealed class AdNtlmRestrictionsPolicyTool : ActiveDirectoryToolBase, ITool {
-    private const int MaxViewTop = 5000;
-
     private static readonly ToolDefinition DefinitionValue = new(
         "ad_ntlm_restrictions_policy",
         "Assess Restrict NTLM policy values (incoming/outgoing traffic controls) for Domain Controllers OU (read-only).",
@@ -49,58 +46,23 @@ public sealed class AdNtlmRestrictionsPolicyTool : ActiveDirectoryToolBase, IToo
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        if (!TryExecute(
-                action: () => NtlmRestrictionsPolicyService.Get(domainName),
-                result: out NtlmRestrictionsPolicyService.View view,
-                errorResponse: out var errorResponse,
-                defaultErrorMessage: "NTLM restrictions policy query failed.",
-                invalidOperationErrorCode: "query_failed")) {
-            return Task.FromResult(errorResponse!);
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdNtlmRestrictionsPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            TargetDn: view.TargetDn,
-            RestrictSending: view.RestrictSending,
-            RestrictReceiving: view.RestrictReceiving,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool<NtlmRestrictionsPolicyService.View, AdNtlmRestrictionsPolicyResult>(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: NTLM Restrictions Policy (preview)",
-            maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            defaultErrorMessage: "NTLM restrictions policy query failed.",
+            query: static domainName => NtlmRestrictionsPolicyService.Get(domainName),
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdNtlmRestrictionsPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                TargetDn: view.TargetDn,
+                RestrictSending: view.RestrictSending,
+                RestrictReceiving: view.RestrictReceiving,
+                Attribution: rows));
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdProxyPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdProxyPolicyTool.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ADPlayground.Gpo;
@@ -14,8 +13,6 @@ namespace IntelligenceX.Tools.ADPlayground;
 /// Returns proxy/WPAD policy posture for Domain Controllers OU in one domain (read-only).
 /// </summary>
 public sealed class AdProxyPolicyTool : ActiveDirectoryToolBase, ITool {
-    private const int MaxViewTop = 5000;
-
     private static readonly ToolDefinition DefinitionValue = new(
         "ad_proxy_policy",
         "Assess proxy/WPAD policy posture (machine-wide proxy, auto-proxy cache, WinHttpAutoProxySvc) for Domain Controllers OU (read-only).",
@@ -52,61 +49,26 @@ public sealed class AdProxyPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        if (!TryExecute(
-                action: () => ProxyPolicyService.Get(domainName),
-                result: out ProxyPolicyService.View view,
-                errorResponse: out var errorResponse,
-                defaultErrorMessage: "Proxy policy query failed.",
-                invalidOperationErrorCode: "query_failed")) {
-            return Task.FromResult(errorResponse!);
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdProxyPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            ProxySettingsPerUser: view.ProxySettingsPerUser,
-            EnableAutoProxyResultCache: view.EnableAutoProxyResultCache,
-            WinHttpAutoProxySvcStart: view.WinHttpAutoProxySvcStart,
-            ExampleMachineWideProxy: view.Example_MachineWideProxy,
-            ExampleAutoProxyCacheDisabled: view.Example_AutoProxyCacheDisabled,
-            ExampleWinHttpAutoProxySvcDisabled: view.Example_WinHttpAutoProxySvcDisabled,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool<ProxyPolicyService.View, AdProxyPolicyResult>(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Proxy Policy (preview)",
-            maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            defaultErrorMessage: "Proxy policy query failed.",
+            query: static domainName => ProxyPolicyService.Get(domainName),
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdProxyPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                ProxySettingsPerUser: view.ProxySettingsPerUser,
+                EnableAutoProxyResultCache: view.EnableAutoProxyResultCache,
+                WinHttpAutoProxySvcStart: view.WinHttpAutoProxySvcStart,
+                ExampleMachineWideProxy: view.Example_MachineWideProxy,
+                ExampleAutoProxyCacheDisabled: view.Example_AutoProxyCacheDisabled,
+                ExampleWinHttpAutoProxySvcDisabled: view.Example_WinHttpAutoProxySvcDisabled,
+                Attribution: rows));
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdWdigestPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdWdigestPolicyTool.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ADPlayground.Gpo;
@@ -14,8 +13,6 @@ namespace IntelligenceX.Tools.ADPlayground;
 /// Returns WDigest policy posture for Domain Controllers OU in one domain (read-only).
 /// </summary>
 public sealed class AdWdigestPolicyTool : ActiveDirectoryToolBase, ITool {
-    private const int MaxViewTop = 5000;
-
     private static readonly ToolDefinition DefinitionValue = new(
         "ad_wdigest_policy",
         "Assess WDigest UseLogonCredential posture for Domain Controllers OU (read-only).",
@@ -48,57 +45,22 @@ public sealed class AdWdigestPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        if (!TryExecute(
-                action: () => WdigestPolicyService.Get(domainName),
-                result: out WdigestPolicyService.View view,
-                errorResponse: out var errorResponse,
-                defaultErrorMessage: "WDigest policy query failed.",
-                invalidOperationErrorCode: "query_failed")) {
-            return Task.FromResult(errorResponse!);
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdWdigestPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            EffectiveValue: view.EffectiveValue,
-            Disabled: view.Disabled,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool<WdigestPolicyService.View, AdWdigestPolicyResult>(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: WDigest Policy (preview)",
-            maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            defaultErrorMessage: "WDigest policy query failed.",
+            query: static domainName => WdigestPolicyService.Get(domainName),
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdWdigestPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                EffectiveValue: view.EffectiveValue,
+                Disabled: view.Disabled,
+                Attribution: rows));
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using ADPlayground.Gpo;
 using IntelligenceX.Json;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.ADPlayground;
@@ -85,6 +86,70 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
         Assert.Equal("Domain query failed.", fallback);
     }
 
+    [Fact]
+    public void TryReadPolicyAttributionToolRequest_ShouldRequireDomainName() {
+        var tool = new HarnessTool();
+
+        var ok = tool.TryReadPolicyRequest(
+            arguments: new JsonObject(),
+            out _,
+            out _,
+            out _,
+            out _,
+            out var errorResponse);
+
+        Assert.False(ok);
+        Assert.NotNull(errorResponse);
+        using var doc = JsonDocument.Parse(errorResponse!);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+    }
+
+    [Fact]
+    public async Task ExecutePolicyAttributionTool_ShouldFilterRowsAndAddStandardMeta() {
+        var tool = new HarnessTool();
+        var arguments = new JsonObject()
+            .Add("domain_name", "contoso.local")
+            .Add("configured_attribution_only", true)
+            .Add("max_results", 10);
+
+        var json = await tool.ExecutePolicyToolAsync(
+            arguments,
+            _ => new HarnessTool.MockPolicyView(new[] {
+                new PolicyAttribution("s1", "k", "v", "Off", null, Array.Empty<GpoRef>()),
+                new PolicyAttribution("s2", "k", "v", "Enabled", null, Array.Empty<GpoRef>()),
+                new PolicyAttribution("s3", "k", "v", "Not configured", null, Array.Empty<GpoRef>())
+            }, "ok"),
+            additionalUnconfiguredValues: new[] { "Off" });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(1, root.GetProperty("attribution_view").GetArrayLength());
+        Assert.Equal(1, root.GetProperty("scanned").GetInt32());
+        Assert.Equal("contoso.local", root.GetProperty("meta").GetProperty("domain_name").GetString());
+        Assert.True(root.GetProperty("meta").GetProperty("configured_attribution_only").GetBoolean());
+        Assert.Equal(1, root.GetProperty("meta").GetProperty("scanned").GetInt32());
+    }
+
+    [Fact]
+    public async Task ExecutePolicyAttributionTool_ShouldMapInvalidOperationToQueryFailed() {
+        var tool = new HarnessTool();
+        var arguments = new JsonObject().Add("domain_name", "contoso.local");
+
+        var json = await tool.ExecutePolicyToolAsync(
+            arguments,
+            _ => throw new InvalidOperationException("Policy service unavailable"));
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("query_failed", root.GetProperty("error_code").GetString());
+        Assert.Equal("Policy service unavailable", root.GetProperty("error").GetString());
+    }
+
     private sealed class HarnessTool : ActiveDirectoryToolBase {
         private static readonly ToolDefinition DefinitionValue = new(
             "ad_test_harness",
@@ -115,8 +180,56 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
             return ToCollectorErrorMessage(exception, fallback);
         }
 
+        public bool TryReadPolicyRequest(
+            JsonObject? arguments,
+            out string? domainName,
+            out bool includeAttribution,
+            out bool configuredAttributionOnly,
+            out int maxResults,
+            out string? errorResponse) {
+            var ok = TryReadPolicyAttributionToolRequest(arguments, out var request, out errorResponse);
+            domainName = ok ? request.DomainName : null;
+            includeAttribution = ok && request.IncludeAttribution;
+            configuredAttributionOnly = ok && request.ConfiguredAttributionOnly;
+            maxResults = ok ? request.MaxResults : 0;
+            return ok;
+        }
+
+        public Task<string> ExecutePolicyToolAsync(
+            JsonObject? arguments,
+            Func<string, MockPolicyView> query,
+            IReadOnlyList<string>? additionalUnconfiguredValues = null) {
+            return ExecutePolicyAttributionTool<MockPolicyView, MockPolicyResult>(
+                arguments: arguments,
+                cancellationToken: CancellationToken.None,
+                title: "Active Directory: Test Policy (preview)",
+                defaultErrorMessage: "Policy query failed.",
+                query: query,
+                attributionSelector: static view => view.Attribution,
+                additionalUnconfiguredValues: additionalUnconfiguredValues,
+                resultFactory: static (request, view, scanned, truncated, rows) => new MockPolicyResult(
+                    request.DomainName,
+                    request.IncludeAttribution,
+                    request.ConfiguredAttributionOnly,
+                    scanned,
+                    truncated,
+                    view.Marker,
+                    rows));
+        }
+
         protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
             return Task.FromResult(ToolResponse.OkModel(new { ok = true }));
         }
+
+        internal sealed record MockPolicyView(IReadOnlyList<PolicyAttribution> Attribution, string Marker);
+
+        private sealed record MockPolicyResult(
+            string DomainName,
+            bool IncludeAttribution,
+            bool ConfiguredAttributionOnly,
+            int Scanned,
+            bool Truncated,
+            string Marker,
+            IReadOnlyList<PolicyAttribution> Attribution);
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable `ExecutePolicyAttributionTool<TView, TResult>` helper to `ActiveDirectoryToolBase`
  - parses standard policy args (`domain_name`, `include_attribution`, `configured_attribution_only`, `max_results`)
  - runs typed query via existing error mapping
  - applies attribution filtering/capping (including optional additional unconfigured values)
  - emits standard `attribution_view` + metadata envelope
- migrate 7 policy tools to the shared runner:
  - `ad_defender_asr_policy`
  - `ad_deny_logon_rights_policy`
  - `ad_enable_delegation_privilege_policy`
  - `ad_llmnr_policy`
  - `ad_ntlm_restrictions_policy`
  - `ad_proxy_policy`
  - `ad_wdigest_policy`
- extend tests in `ActiveDirectoryToolBaseErrorMappingTests` for:
  - policy request parsing error path
  - shared runner row filtering + meta behavior
  - shared runner invalid-operation error mapping

## Why
This removes repeated per-tool plumbing and makes new policy-attribution tools mostly about service + model mapping, not boilerplate.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
  - Passed: 241, Failed: 0

## Guardrail
- touched files remain below 700 LOC.