### PR TITLE
Chat startup: trim cold initial pipe probe timeout

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
@@ -16,7 +16,7 @@ public sealed class MainWindowStartupConnectTimeoutPolicyTests {
     [InlineData(true, true, 2000)]
     [InlineData(true, false, 2000)]
     [InlineData(false, true, 2000)]
-    [InlineData(false, false, 350)]
+    [InlineData(false, false, 150)]
     public void ResolveStartupInitialPipeConnectTimeout_ReturnsExpectedTimeout(
         bool fromUserAction,
         bool hasTrackedRunningServiceProcess,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -65,7 +65,7 @@ public sealed partial class MainWindow : Window {
     private static readonly TimeSpan WheelForwardCoalesceInterval = TimeSpan.FromMilliseconds(12);
     private static readonly TimeSpan DragMoveWatchdogInterval = TimeSpan.FromMilliseconds(1200);
     private static readonly TimeSpan StartupInitialPipeConnectTimeout = TimeSpan.FromSeconds(2);
-    private static readonly TimeSpan StartupInitialPipeConnectColdStartTimeout = TimeSpan.FromMilliseconds(350);
+    private static readonly TimeSpan StartupInitialPipeConnectColdStartTimeout = TimeSpan.FromMilliseconds(150);
     private static readonly TimeSpan StartupConnectBudget = TimeSpan.FromSeconds(4);
     private static readonly TimeSpan StartupConnectMinAttemptTimeout = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan StartupConnectRetryDelay = TimeSpan.FromMilliseconds(250);


### PR DESCRIPTION
## Summary
- reduce startup cold initial pipe probe timeout from `350ms` to `150ms`
- keep user-initiated/tracked-service probe timeout unchanged (`2s`)
- update startup timeout policy test expectations accordingly

## Why
Cold startup was still paying avoidable connect probe latency before sidecar bootstrap. This narrows the cold probe window while preserving existing behavior for user actions and tracked-running sidecars.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release -p:SkipChatServiceSidecarBuild=true -p:ChatServiceBin=Z:\\ix-missing\\` (pass, 210)
- startup profiling (`scripts/profile-chat-startup.ps1`):
  - baseline (8 runs): `avg_connect_ms=1545.34`, `median_connect_ms=789.13`
  - after change (8 runs): `avg_connect_ms=582.14`, `median_connect_ms=592.46`
  - rebased sanity pass (5 runs): warm `connect_ms` clustered around `~587-591ms`