### PR TITLE
feat(todo): calibrate PR operational signal thresholds

### DIFF
--- a/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
+++ b/IntelligenceX.Cli/Todo/TriageIndexRunner.cs
@@ -199,6 +199,22 @@ internal static class TriageIndexRunner {
         string MergeConflictRisk
     );
 
+    private const int ChurnHighChangedFilesThreshold = 120;
+    private const int ChurnHighChangeVolumeThreshold = 3500;
+    private const int ChurnHighCommentsThreshold = 35;
+    private const int ChurnHighCommitsThreshold = 35;
+    private const int ChurnMediumChangedFilesThreshold = 40;
+    private const int ChurnMediumChangeVolumeThreshold = 1200;
+    private const int ChurnMediumCommentsThreshold = 12;
+    private const int ChurnMediumCommitsThreshold = 15;
+    private const int ReviewLatencyLowAgeDaysThreshold = 2;
+    private const int ReviewLatencyMediumAgeDaysThreshold = 10;
+    private const int ReadyReviewLatencyLowAgeDaysThreshold = 1;
+    private const int ReadyReviewLatencyMediumAgeDaysThreshold = 4;
+    private const int PendingReviewLatencyHighAgeDaysThreshold = 4;
+    private const int ConflictRiskMediumAgeDaysThreshold = 14;
+    private const int ConflictRiskHighAgeDaysThreshold = 21;
+
     private sealed record IssueReferenceHint(
         int Number,
         double Confidence,
@@ -828,8 +844,7 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                       signals.Mergeable.Equals("UNKNOWN", StringComparison.OrdinalIgnoreCase) ||
                       signals.ReviewDecision.Equals("CHANGES_REQUESTED", StringComparison.OrdinalIgnoreCase) ||
                       signals.StatusCheckState.Equals("FAILURE", StringComparison.OrdinalIgnoreCase) ||
-                      signals.StatusCheckState.Equals("ERROR", StringComparison.OrdinalIgnoreCase) ||
-                      signals.StatusCheckState.Equals("PENDING", StringComparison.OrdinalIgnoreCase);
+                      signals.StatusCheckState.Equals("ERROR", StringComparison.OrdinalIgnoreCase);
 
         var mergeReadiness = blocked
             ? "blocked"
@@ -839,11 +854,22 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
                 ? "ready"
                 : "needs-review";
 
-        var churnRisk = blocked || changedFiles > 120 || changeVolume > 3500
+        var churnRisk = changedFiles >= ChurnHighChangedFilesThreshold ||
+                        changeVolume >= ChurnHighChangeVolumeThreshold ||
+                        signals.Comments >= ChurnHighCommentsThreshold ||
+                        signals.Commits >= ChurnHighCommitsThreshold
             ? "high"
-            : changedFiles > 40 || changeVolume > 1200 || signals.Comments > 20 || signals.Commits > 20
+            : changedFiles >= ChurnMediumChangedFilesThreshold ||
+              changeVolume >= ChurnMediumChangeVolumeThreshold ||
+              signals.Comments >= ChurnMediumCommentsThreshold ||
+              signals.Commits >= ChurnMediumCommitsThreshold
                 ? "medium"
                 : "low";
+        if ((signals.Mergeable.Equals("CONFLICTING", StringComparison.OrdinalIgnoreCase) ||
+             signals.Mergeable.Equals("UNKNOWN", StringComparison.OrdinalIgnoreCase)) &&
+            churnRisk.Equals("low", StringComparison.OrdinalIgnoreCase)) {
+            churnRisk = "medium";
+        }
 
         var freshness = ageDays switch {
             <= 1 => "fresh",
@@ -854,35 +880,75 @@ query($owner: String!, $name: String!, $n: Int!, $cursor: String) {
 
         var checkHealth = signals.StatusCheckState.Trim().ToUpperInvariant() switch {
             "SUCCESS" => "healthy",
+            "NEUTRAL" => "healthy",
+            "SKIPPED" => "healthy",
             "PENDING" => "pending",
             "EXPECTED" => "pending",
+            "IN_PROGRESS" => "pending",
+            "QUEUED" => "pending",
             "FAILURE" => "failing",
             "ERROR" => "failing",
+            "CANCELLED" => "failing",
+            "TIMED_OUT" => "failing",
+            "ACTION_REQUIRED" => "failing",
+            "STARTUP_FAILURE" => "failing",
             _ => "unknown"
         };
 
         var reviewLatency = ageDays switch {
-            <= 2 => "low",
-            <= 7 => "medium",
+            <= ReviewLatencyLowAgeDaysThreshold => "low",
+            <= ReviewLatencyMediumAgeDaysThreshold => "medium",
             _ => "high"
         };
-        if (mergeReadiness.Equals("ready", StringComparison.OrdinalIgnoreCase) && ageDays > 3) {
-            reviewLatency = "high";
-        } else if (mergeReadiness.Equals("ready", StringComparison.OrdinalIgnoreCase) && ageDays > 1 &&
-                   reviewLatency.Equals("low", StringComparison.OrdinalIgnoreCase)) {
+        if (mergeReadiness.Equals("ready", StringComparison.OrdinalIgnoreCase)) {
+            reviewLatency = ageDays switch {
+                <= ReadyReviewLatencyLowAgeDaysThreshold => "low",
+                <= ReadyReviewLatencyMediumAgeDaysThreshold => "medium",
+                _ => "high"
+            };
+        } else if (mergeReadiness.Equals("blocked", StringComparison.OrdinalIgnoreCase) &&
+                   reviewLatency.Equals("low", StringComparison.OrdinalIgnoreCase) &&
+                   ageDays > 2) {
             reviewLatency = "medium";
         }
-        if (checkHealth.Equals("pending", StringComparison.OrdinalIgnoreCase) && ageDays > 5) {
+        if (checkHealth.Equals("pending", StringComparison.OrdinalIgnoreCase) &&
+            ageDays > PendingReviewLatencyHighAgeDaysThreshold) {
             reviewLatency = "high";
+        }
+        if ((signals.Comments >= ChurnHighCommentsThreshold || signals.Commits >= ChurnHighCommitsThreshold) &&
+            !reviewLatency.Equals("high", StringComparison.OrdinalIgnoreCase)) {
+            reviewLatency = "high";
+        } else if ((signals.Comments >= ChurnMediumCommentsThreshold || signals.Commits >= ChurnMediumCommitsThreshold) &&
+                   reviewLatency.Equals("low", StringComparison.OrdinalIgnoreCase)) {
+            reviewLatency = "medium";
         }
 
         var mergeConflictRisk = signals.Mergeable.Trim().ToUpperInvariant() switch {
             "CONFLICTING" => "high",
-            "UNKNOWN" => sizeBand is "large" or "xlarge" || ageDays > 10 ? "high" : "medium",
-            "MERGEABLE" => sizeBand is "xlarge" || churnRisk.Equals("high", StringComparison.OrdinalIgnoreCase) || ageDays > 21
-                ? "medium"
-                : "low",
-            _ => sizeBand is "large" or "xlarge" ? "high" : "medium"
+            "UNKNOWN" => sizeBand is "xlarge" ||
+                         churnRisk.Equals("high", StringComparison.OrdinalIgnoreCase) ||
+                         ageDays > ConflictRiskHighAgeDaysThreshold
+                ? "high"
+                : sizeBand is "large" ||
+                  ageDays > 7 ||
+                  checkHealth is "pending" or "failing"
+                    ? "medium"
+                    : "low",
+            "MERGEABLE" => sizeBand is "xlarge" &&
+                           churnRisk.Equals("high", StringComparison.OrdinalIgnoreCase) &&
+                           ageDays > ConflictRiskHighAgeDaysThreshold
+                ? "high"
+                : sizeBand is "large" or "xlarge" ||
+                  churnRisk is "medium" or "high" ||
+                  ageDays > ConflictRiskMediumAgeDaysThreshold ||
+                  checkHealth is "pending" or "failing"
+                    ? "medium"
+                    : "low",
+            _ => sizeBand is "xlarge" || churnRisk.Equals("high", StringComparison.OrdinalIgnoreCase)
+                ? "high"
+                : sizeBand is "large" || ageDays > 10
+                    ? "medium"
+                    : "low"
         };
 
         return new PullRequestOperationalSignals(sizeBand, churnRisk, mergeReadiness, freshness, checkHealth, reviewLatency,

--- a/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
+++ b/IntelligenceX.Tests/Program.Todo.TriageIndex.cs
@@ -404,5 +404,71 @@ internal static partial class Program {
         AssertEqual("high", blockedSignals.ReviewLatency, "high review latency classification");
         AssertEqual("high", blockedSignals.MergeConflictRisk, "high merge conflict risk classification");
     }
+
+    private static void TestTriageIndexAssessPullRequestOperationalSignalsCalibrationBoundaries() {
+        var now = DateTimeOffset.UtcNow;
+        var pendingChecks = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "pr#803",
+            "pull_request",
+            803,
+            "Feature rollout with checks pending",
+            "https://example/pr/803",
+            now.AddDays(-6),
+            Array.Empty<string>(),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Feature rollout with checks pending"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Feature rollout with checks pending"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Feature rollout with checks still running"),
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.PullRequestSignals(
+                false,
+                "MERGEABLE",
+                "APPROVED",
+                "PENDING",
+                12,
+                260,
+                40,
+                4,
+                7,
+                "dev"),
+            null
+        );
+        var unknownSmallFresh = new IntelligenceX.Cli.Todo.TriageIndexRunner.TriageIndexItem(
+            "pr#804",
+            "pull_request",
+            804,
+            "Small cleanup PR",
+            "https://example/pr/804",
+            now.AddHours(-10),
+            Array.Empty<string>(),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.NormalizeText("Small cleanup PR"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Small cleanup PR"),
+            IntelligenceX.Cli.Todo.TriageIndexRunner.Tokenize("Small cleanup PR for docs and comments"),
+            new IntelligenceX.Cli.Todo.TriageIndexRunner.PullRequestSignals(
+                false,
+                "UNKNOWN",
+                "REVIEW_REQUIRED",
+                string.Empty,
+                2,
+                35,
+                6,
+                1,
+                1,
+                "dev"),
+            null
+        );
+
+        var pendingSignals = IntelligenceX.Cli.Todo.TriageIndexRunner.AssessPullRequestOperationalSignals(pendingChecks, now);
+        var unknownSignals = IntelligenceX.Cli.Todo.TriageIndexRunner.AssessPullRequestOperationalSignals(unknownSmallFresh, now);
+
+        AssertNotNull(pendingSignals, "pending signals not null");
+        AssertNotNull(unknownSignals, "unknown signals not null");
+        AssertEqual("needs-review", pendingSignals!.MergeReadiness, "pending checks should not classify as blocked");
+        AssertEqual("pending", pendingSignals.CheckHealth, "pending checks classification");
+        AssertEqual("high", pendingSignals.ReviewLatency, "pending checks aging should elevate latency");
+        AssertEqual("medium", pendingSignals.MergeConflictRisk, "pending checks risk medium when mergeable");
+        AssertEqual("blocked", unknownSignals!.MergeReadiness, "unknown mergeability remains blocked");
+        AssertEqual("unknown", unknownSignals.CheckHealth, "unknown check health classification");
+        AssertEqual("medium", unknownSignals.ChurnRisk, "unknown mergeability raises low churn to medium");
+        AssertEqual("low", unknownSignals.MergeConflictRisk, "small fresh unknown should not be high conflict risk");
+    }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -463,6 +463,7 @@ internal static partial class Program {
         failed += Run("Todo triage index category/tag confidence inference", TestTriageIndexInferCategoryAndTagsWithConfidenceUsesEvidenceStrength);
         failed += Run("Todo triage index signal-quality inference", TestTriageIndexAssessSignalQualityDistinguishesStrongAndWeakContext);
         failed += Run("Todo triage index operational signals", TestTriageIndexAssessPullRequestOperationalSignalsClassifiesSizeRiskAndReadiness);
+        failed += Run("Todo triage index operational signal calibration boundaries", TestTriageIndexAssessPullRequestOperationalSignalsCalibrationBoundaries);
         failed += Run("Todo vision check out-of-scope classification", TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate);
         failed += Run("Todo vision check aligned classification", TestVisionCheckClassifiesAlignedWhenInTokensMatch);
         failed += Run("Todo vision check explicit reject policy precedence", TestVisionCheckExplicitRejectPolicyTakesPrecedence);


### PR DESCRIPTION
## Summary
- calibrate PR operational signal thresholds to reduce false-positive blocking/risk on active PRs
- treat `PENDING` checks as `needs-review` (not hard blocked) while preserving blocked states for conflicts/review-requested/failing checks
- expand check-health mapping (`healthy`, `pending`, `failing`, `unknown`) for additional status variants
- tune review-latency and merge-conflict-risk heuristics using explicit named thresholds
- add regression tests for calibration boundaries (pending-check PRs and small/fresh unknown-mergeability PRs)

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet .\\IntelligenceX.Tests\\bin\\Release\\net8.0\\IntelligenceX.Tests.dll`
- `dotnet .\\IntelligenceX.Tests\\bin\\Release\\net10.0\\IntelligenceX.Tests.dll`
