### PR TITLE
Refactor ADPlayground tools to shared collector helpers

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ADPlayground;
 using ADPlayground.Gpo;
 using ADPlayground.Helpers;
 using IntelligenceX.Json;
@@ -440,5 +441,99 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
             MaxResults: ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults));
         errorResponse = null;
         return true;
+    }
+
+    /// <summary>
+    /// Resolves target domains from an explicit domain name or forest discovery.
+    /// </summary>
+    protected static bool TryResolveTargetDomains(
+        string? domainName,
+        string? forestName,
+        CancellationToken cancellationToken,
+        string queryName,
+        out string[] targetDomains,
+        out string? errorResponse) {
+        targetDomains = string.IsNullOrWhiteSpace(domainName)
+            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
+                .Where(static x => !string.IsNullOrWhiteSpace(x))
+                .Select(static x => x.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray()
+            : new[] { domainName! };
+
+        if (targetDomains.Length > 0) {
+            errorResponse = null;
+            return true;
+        }
+
+        var name = string.IsNullOrWhiteSpace(queryName) ? "query" : queryName.Trim();
+        errorResponse = ToolResponse.Error(
+            "query_failed",
+            $"No domains resolved for {name} query. Provide domain_name or ensure forest discovery is available.");
+        return false;
+    }
+
+    /// <summary>
+    /// Executes per-target collection action with per-target exception mapping.
+    /// </summary>
+    protected static void RunPerTargetCollection<TTarget, TError>(
+        IEnumerable<TTarget> targets,
+        Action<TTarget> collect,
+        Func<TTarget, Exception, TError> errorFactory,
+        ICollection<TError> errors,
+        CancellationToken cancellationToken) {
+        if (targets is null) {
+            throw new ArgumentNullException(nameof(targets));
+        }
+        if (collect is null) {
+            throw new ArgumentNullException(nameof(collect));
+        }
+        if (errorFactory is null) {
+            throw new ArgumentNullException(nameof(errorFactory));
+        }
+        if (errors is null) {
+            throw new ArgumentNullException(nameof(errors));
+        }
+
+        foreach (var target in targets) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                collect(target);
+            } catch (Exception ex) {
+                errors.Add(errorFactory(target, ex));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Executes per-target asynchronous collection action with per-target exception mapping.
+    /// </summary>
+    protected static async Task RunPerTargetCollectionAsync<TTarget, TError>(
+        IEnumerable<TTarget> targets,
+        Func<TTarget, Task> collectAsync,
+        Func<TTarget, Exception, TError> errorFactory,
+        ICollection<TError> errors,
+        CancellationToken cancellationToken) {
+        if (targets is null) {
+            throw new ArgumentNullException(nameof(targets));
+        }
+        if (collectAsync is null) {
+            throw new ArgumentNullException(nameof(collectAsync));
+        }
+        if (errorFactory is null) {
+            throw new ArgumentNullException(nameof(errorFactory));
+        }
+        if (errors is null) {
+            throw new ArgumentNullException(nameof(errors));
+        }
+
+        foreach (var target in targets) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                await collectAsync(target).ConfigureAwait(false);
+            } catch (Exception ex) {
+                errors.Add(errorFactory(target, ex));
+            }
+        }
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
@@ -79,27 +79,22 @@ public sealed class AdAzureAdSsoTool : ActiveDirectoryToolBase, ITool {
         var includeSpns = ToolArgs.GetBoolean(arguments, "include_spns", defaultValue: false);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for Azure AD SSO posture query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "Azure AD SSO posture",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<AzureAdSsoRow>(targetDomains.Length);
         var details = new List<AzureAdSsoDetail>(targetDomains.Length);
         var errors = new List<AzureAdSsoError>();
-
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var snapshot = AzureAdSsoService.GetSnapshot(domain);
                 var risky = snapshot.Present && snapshot.UnconstrainedDelegation == true;
                 rows.Add(new AzureAdSsoRow(
@@ -114,10 +109,10 @@ public sealed class AdAzureAdSsoTool : ActiveDirectoryToolBase, ITool {
                     DomainName: domain,
                     AccountDn: snapshot.AccountDn,
                     Spns: includeSpns ? snapshot.Spns : Array.Empty<string>()));
-            } catch (Exception ex) {
-                errors.Add(new AzureAdSsoError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new AzureAdSsoError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var filtered = rows
             .Where(row => !onlyPresent || row.SeamlessSsoPresent)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
@@ -74,27 +74,23 @@ public sealed class AdDangerousExtendedRightsTool : ActiveDirectoryToolBase, ITo
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 200, 1, Options.MaxResults);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for dangerous extended-rights query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "dangerous extended-rights",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var summaries = new List<DangerousExtendedRightsSummaryRow>(targetDomains.Length);
         var details = new List<DangerousExtendedRightsDetail>(targetDomains.Length);
         var errors = new List<DangerousExtendedRightsError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var domainDn = DomainHelper.DomainNameToDistinguishedName(domain);
                 var view = DangerousExtendedRightsService.Evaluate(domain, domainDn);
                 summaries.Add(new DangerousExtendedRightsSummaryRow(
@@ -109,10 +105,10 @@ public sealed class AdDangerousExtendedRightsTool : ActiveDirectoryToolBase, ITo
                     Findings: includeFindings
                         ? view.Items.Take(maxFindingsPerDomain).ToArray()
                         : Array.Empty<DangerousExtendedRightsService.Finding>()));
-            } catch (Exception ex) {
-                errors.Add(new DangerousExtendedRightsError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new DangerousExtendedRightsError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var scanned = summaries.Count;
         IReadOnlyList<DangerousExtendedRightsSummaryRow> projectedRows = scanned > maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
@@ -81,27 +81,23 @@ public sealed class AdDcFleetPostureTool : ActiveDirectoryToolBase, ITool {
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 2000);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for DC fleet posture query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "DC fleet posture",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var summaryRows = new List<DcFleetPostureRow>(targetDomains.Length);
         var detailRows = new List<DcFleetPostureDomainDetails>(targetDomains.Length);
         var errors = new List<DcFleetPostureError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var view = FleetPostureService.Evaluate(domain, cancellationToken: cancellationToken);
                 summaryRows.Add(new DcFleetPostureRow(
                     DomainName: view.DomainName,
@@ -122,10 +118,10 @@ public sealed class AdDcFleetPostureTool : ActiveDirectoryToolBase, ITool {
                         ManagedBySet: view.ManagedBySet.Take(maxDetailRowsPerDomain).ToArray(),
                         NonAdministrativeOwners: view.NonAdministrativeOwners.Take(maxDetailRowsPerDomain).ToArray()));
                 }
-            } catch (Exception ex) {
-                errors.Add(new DcFleetPostureError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new DcFleetPostureError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var scanned = summaryRows.Count;
         IReadOnlyList<DcFleetPostureRow> projectedRows = scanned > maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
@@ -70,27 +70,23 @@ public sealed class AdDcShadowIndicatorsTool : ActiveDirectoryToolBase, ITool {
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 100, 1, Options.MaxResults);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for DC-shadow indicators query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "DC-shadow indicators",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var summaries = new List<DcShadowIndicatorsSummaryRow>(targetDomains.Length);
         var details = new List<DcShadowIndicatorsDetail>(targetDomains.Length);
         var errors = new List<DcShadowIndicatorsError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var view = DcShadowIndicatorService.Evaluate(domain);
                 summaries.Add(new DcShadowIndicatorsSummaryRow(
                     DomainName: view.DomainName,
@@ -100,10 +96,10 @@ public sealed class AdDcShadowIndicatorsTool : ActiveDirectoryToolBase, ITool {
                     Findings: includeFindings
                         ? view.Findings.Take(maxFindingsPerDomain).ToArray()
                         : Array.Empty<DcShadowIndicatorService.Finding>()));
-            } catch (Exception ex) {
-                errors.Add(new DcShadowIndicatorsError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new DcShadowIndicatorsError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var scanned = summaries.Count;
         IReadOnlyList<DcShadowIndicatorsSummaryRow> projectedRows = scanned > maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsDelegationTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsDelegationTool.cs
@@ -70,26 +70,22 @@ public sealed class AdDnsDelegationTool : ActiveDirectoryToolBase, ITool {
         var identityContains = ToolArgs.GetOptionalTrimmed(arguments, "identity_contains");
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for DNS delegation query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "DNS delegation",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<DnsDelegationRow>(targetDomains.Length * 20);
         var errors = new List<DnsDelegationError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var snapshot = DnsDelegationService.GetSnapshot(domain);
                 foreach (var record in snapshot.Delegations) {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -110,10 +106,10 @@ public sealed class AdDnsDelegationTool : ActiveDirectoryToolBase, ITool {
                         Sid: record.Sid,
                         Rights: record.Rights.ToString()));
                 }
-            } catch (Exception ex) {
-                errors.Add(new DnsDelegationError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new DnsDelegationError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var scanned = rows.Count;
         IReadOnlyList<DnsDelegationRow> projectedRows = scanned > maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsServerConfigTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsServerConfigTool.cs
@@ -73,34 +73,42 @@ public sealed class AdDnsServerConfigTool : ActiveDirectoryToolBase, ITool {
         var missingForwardersOnly = ToolArgs.GetBoolean(arguments, "missing_forwarders_only", defaultValue: false);
         var maxServers = ToolArgs.GetCappedInt32(arguments, "max_servers", 200, 1, 5000);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var errors = new List<DnsServerConfigError>();
 
         var servers = new List<string>(maxServers);
         if (explicitServers.Count > 0) {
             servers.AddRange(explicitServers.Take(maxServers));
         } else {
-            var targetDomains = string.IsNullOrWhiteSpace(domainName)
-                ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                    .Where(static x => !string.IsNullOrWhiteSpace(x))
-                    .Select(static x => x.Trim())
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToArray()
-                : new[] { domainName! };
-
-            foreach (var domain in targetDomains) {
-                cancellationToken.ThrowIfCancellationRequested();
-                foreach (var dc in DomainHelper.EnumerateDomainControllers(domain, cancellationToken: cancellationToken)) {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    if (!servers.Contains(dc, StringComparer.OrdinalIgnoreCase)) {
-                        servers.Add(dc);
-                    }
-                    if (servers.Count >= maxServers) {
-                        break;
-                    }
-                }
-                if (servers.Count >= maxServers) {
-                    break;
-                }
+            if (!TryResolveTargetDomains(
+                    domainName: domainName,
+                    forestName: forestName,
+                    cancellationToken: cancellationToken,
+                    queryName: "DNS server configuration discovery",
+                    targetDomains: out var targetDomains,
+                    errorResponse: out _)) {
+                targetDomains = Array.Empty<string>();
             }
+
+            RunPerTargetCollection(
+                targets: targetDomains,
+                collect: domain => {
+                    if (servers.Count >= maxServers) {
+                        return;
+                    }
+
+                    foreach (var dc in DomainHelper.EnumerateDomainControllers(domain, cancellationToken: cancellationToken)) {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (!servers.Contains(dc, StringComparer.OrdinalIgnoreCase)) {
+                            servers.Add(dc);
+                        }
+                        if (servers.Count >= maxServers) {
+                            break;
+                        }
+                    }
+                },
+                errorFactory: (domain, ex) => new DnsServerConfigError(domain, ToCollectorErrorMessage(ex)),
+                errors: errors,
+                cancellationToken: cancellationToken);
         }
 
         if (servers.Count == 0) {
@@ -110,11 +118,9 @@ public sealed class AdDnsServerConfigTool : ActiveDirectoryToolBase, ITool {
         }
 
         var rows = new List<DnsServerConfigRow>(servers.Count);
-        var errors = new List<DnsServerConfigError>();
-
-        foreach (var server in servers) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: servers,
+            collect: server => {
                 var cfg = DnsServerConfigService.GetConfig(server);
                 var forwarders = cfg.Forwarders ?? Array.Empty<string>();
                 rows.Add(new DnsServerConfigRow(
@@ -123,10 +129,10 @@ public sealed class AdDnsServerConfigTool : ActiveDirectoryToolBase, ITool {
                     ForwarderCount: forwarders.Length,
                     Forwarders: forwarders,
                     MissingForwarders: forwarders.Length == 0));
-            } catch (Exception ex) {
-                errors.Add(new DnsServerConfigError(server, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (server, ex) => new DnsServerConfigError(server, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var filtered = rows
             .Where(row => !recursionDisabledOnly || row.RecursionEnabled == false)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
@@ -92,27 +92,23 @@ public sealed class AdDnsZoneSecurityTool : ActiveDirectoryToolBase, ITool {
         var maxOffendingRows = ToolArgs.GetCappedInt32(arguments, "max_offending_rows", 500, 1, 50000);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for DNS zone security query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "DNS zone security",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<DnsZoneSecurityRow>(targetDomains.Length * 10);
         var offendingRows = new List<DnsZoneSecurityOffendingRow>(maxOffendingRows);
         var errors = new List<DnsZoneSecurityError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var snapshot = DnsZoneSecurityService.GetSnapshot(domain);
                 foreach (var zone in snapshot.Zones) {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -151,10 +147,10 @@ public sealed class AdDnsZoneSecurityTool : ActiveDirectoryToolBase, ITool {
                         }
                     }
                 }
-            } catch (Exception ex) {
-                errors.Add(new DnsZoneSecurityError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new DnsZoneSecurityError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var filtered = rows
             .Where(row => !exposedOnly || row.AnyExposure)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainContainerDefaultsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainContainerDefaultsTool.cs
@@ -67,25 +67,21 @@ public sealed class AdDomainContainerDefaultsTool : ActiveDirectoryToolBase, ITo
         var changedOnly = ToolArgs.GetBoolean(arguments, "changed_only", defaultValue: false);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for domain-container-defaults query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "domain-container-defaults",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<DomainContainerDefaultsRow>(targetDomains.Length);
         var errors = new List<DomainContainerDefaultsError>();
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var snapshot = DomainContainerDefaultsService.GetSnapshot(domain);
                 var anyChanged = snapshot.ComputerContainerChanged || snapshot.UserContainerChanged;
                 rows.Add(new DomainContainerDefaultsRow(
@@ -95,10 +91,10 @@ public sealed class AdDomainContainerDefaultsTool : ActiveDirectoryToolBase, ITo
                     ComputerContainerChanged: snapshot.ComputerContainerChanged,
                     UserContainerChanged: snapshot.UserContainerChanged,
                     AnyChanged: anyChanged));
-            } catch (Exception ex) {
-                errors.Add(new DomainContainerDefaultsError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new DomainContainerDefaultsError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var filtered = rows
             .Where(row => !changedOnly || row.AnyChanged)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerFactsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerFactsTool.cs
@@ -81,26 +81,22 @@ public sealed class AdDomainControllerFactsTool : ActiveDirectoryToolBase, ITool
         var timeoutMs = ToolArgs.GetCappedInt32(arguments, "timeout_ms", 3000, 300, 60000);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for domain-controller-facts query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "domain-controller-facts",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<DomainControllerFactRow>(targetDomains.Length * 8);
         var errors = new List<DomainControllerFactsError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var facts = DomainControllerFactsService.GetFacts(domain, timeoutMs, additionalAttributes);
                 foreach (var fact in facts.Values.OrderBy(static x => x.Server, StringComparer.OrdinalIgnoreCase)) {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -129,10 +125,10 @@ public sealed class AdDomainControllerFactsTool : ActiveDirectoryToolBase, ITool
                         AdditionalAttributeCount: fact.Attributes.Count,
                         Attributes: attributes));
                 }
-            } catch (Exception ex) {
-                errors.Add(new DomainControllerFactsError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new DomainControllerFactsError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var scanned = rows.Count;
         IReadOnlyList<DomainControllerFactRow> projectedRows = scanned > maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
@@ -84,26 +84,22 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
                 "domain_controller requires domain_name so audit and policy context can be resolved.");
         }
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for domain-controller-security query. Provide domain_name or ensure forest discovery is available.");
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "domain-controller-security",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return targetDomainError!;
         }
 
         var rows = new List<DomainControllerSecurityRow>(targetDomains.Length * 8);
         var errors = new List<DomainControllerSecurityError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        await RunPerTargetCollectionAsync(
+                targets: targetDomains,
+                collectAsync: async domain => {
                 var snapshot = string.IsNullOrWhiteSpace(domainController)
                     ? await DomainControllerSecurityService.GetSnapshotAsync(domain, cancellationToken).ConfigureAwait(false)
                     : await DomainControllerSecurityService.GetSnapshotForControllerAsync(domain, domainController!, cancellationToken).ConfigureAwait(false);
@@ -154,10 +150,10 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
                         MissingAdvancedAuditPolicy: missingAdvanced,
                         AnyFinding: anyFinding));
                 }
-            } catch (Exception ex) {
-                errors.Add(new DomainControllerSecurityError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new DomainControllerSecurityError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var filtered = rows
             .Where(row => !insecureOnly || row.AnyFinding)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
@@ -73,27 +73,23 @@ public sealed class AdDomainStatisticsTool : ActiveDirectoryToolBase, ITool {
         var includeDomainControllers = ToolArgs.GetBoolean(arguments, "include_domain_controllers", defaultValue: false);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for domain statistics query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "domain statistics",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var snapshots = new List<DomainStatisticsSnapshot>(targetDomains.Length);
         var summaries = new List<DomainStatisticsSummaryRow>(targetDomains.Length);
         var errors = new List<DomainStatisticsError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var snapshot = DomainStatisticsService.GetSnapshot(domain);
                 snapshots.Add(snapshot);
                 summaries.Add(new DomainStatisticsSummaryRow(
@@ -107,10 +103,10 @@ public sealed class AdDomainStatisticsTool : ActiveDirectoryToolBase, ITool {
                     IsComplete: snapshot.IsComplete,
                     RecommendedFunctionalLevelLabel: snapshot.RecommendedFunctionalLevelLabel,
                     FunctionalLevelGap: snapshot.FunctionalLevelGap));
-            } catch (Exception ex) {
-                errors.Add(new DomainStatisticsError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new DomainStatisticsError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var scanned = summaries.Count;
         IReadOnlyList<DomainStatisticsSummaryRow> projectedRows = scanned > maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
@@ -90,18 +90,14 @@ public sealed class AdDuplicateAccountsTool : ActiveDirectoryToolBase, ITool {
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 5000);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for duplicate-account query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "duplicate-account",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<DuplicateAccountsRow>(targetDomains.Length);
@@ -109,9 +105,9 @@ public sealed class AdDuplicateAccountsTool : ActiveDirectoryToolBase, ITool {
         var duplicateDetails = new List<DuplicateAccountsDuplicateDetailRow>(targetDomains.Length * 4);
         var errors = new List<DuplicateAccountsError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var view = DuplicateAccountService.Evaluate(domain);
                 rows.Add(new DuplicateAccountsRow(
                     DomainName: view.DomainName,
@@ -137,10 +133,10 @@ public sealed class AdDuplicateAccountsTool : ActiveDirectoryToolBase, ITool {
                             ObjectClasses: duplicate.ObjectClasses));
                     }
                 }
-            } catch (Exception ex) {
-                errors.Add(new DuplicateAccountsError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new DuplicateAccountsError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var filtered = rows
             .Where(row => !conflictsOnly || row.ConflictObjectCount > 0)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
@@ -65,25 +65,21 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for Kerberos crypto posture query. Provide domain_name or ensure forest discovery is available.");
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "Kerberos crypto posture",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return targetDomainError!;
         }
 
         var rows = new List<KerberosCryptoPostureRow>(targetDomains.Length);
         var errors = new List<KerberosCryptoPostureError>();
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        await RunPerTargetCollectionAsync(
+                targets: targetDomains,
+                collectAsync: async domain => {
                 var view = await KerberosCryptoPostureService.EvaluateAsync(domain).ConfigureAwait(false);
                 rows.Add(new KerberosCryptoPostureRow(
                     DomainName: view.DomainName,
@@ -93,10 +89,10 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
                     ComputersAesDisabled: view.ComputersAesDisabled,
                     UsersPreAuthDisabled: view.UsersPreAuthDisabled,
                     TotalSignals: view.UsersRc4Only + view.ComputersRc4Only + view.UsersAesDisabled + view.ComputersAesDisabled + view.UsersPreAuthDisabled));
-            } catch (Exception ex) {
-                errors.Add(new KerberosCryptoPostureError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new KerberosCryptoPostureError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var projectedRows = CapRows(rows, maxResults, out var scanned, out var truncated);
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKrbtgtHealthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKrbtgtHealthTool.cs
@@ -59,30 +59,26 @@ public sealed class AdKrbtgtHealthTool : ActiveDirectoryToolBase, ITool {
         var ageThresholdDays = ToolArgs.GetCappedInt32(arguments, "age_threshold_days", 180, 1, 3650);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for KRBTGT health query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "KRBTGT health",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<KrbtgtHealthSnapshot>(targetDomains.Length);
         var errors = new List<KrbtgtHealthError>();
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 rows.Add(KrbtgtHealthService.GetSnapshot(domain, ageThresholdDays));
-            } catch (Exception ex) {
-                errors.Add(new KrbtgtHealthError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new KrbtgtHealthError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var scanned = rows.Count;
         IReadOnlyList<KrbtgtHealthSnapshot> projectedRows = scanned > maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
@@ -78,13 +78,13 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
         var errors = new List<LanManagerSettingsError>();
 
         if (explicitDomainControllers.Count > 0) {
-            foreach (var dc in explicitDomainControllers.Take(maxDomainControllers)) {
-                cancellationToken.ThrowIfCancellationRequested();
-                try {
+            await RunPerTargetCollectionAsync(
+                    targets: explicitDomainControllers.Take(maxDomainControllers),
+                    collectAsync: async dc => {
                     var status = await LanManagerSettingsService.GetStatusForControllerAsync(dc, cancellationToken).ConfigureAwait(false);
                     if (status is null) {
                         errors.Add(new LanManagerSettingsError(dc, "Controller status was unavailable."));
-                        continue;
+                        return;
                     }
 
                     rows.Add(new LanManagerSettingsRow(
@@ -94,28 +94,28 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
                         LmCompatibilityLevel: status.LmCompatibilityLevel,
                         AllowsLmHash: !status.NoLmHash,
                         LegacyNtlmAllowed: status.LmCompatibilityLevel.GetValueOrDefault() < 5));
-                } catch (Exception ex) {
-                    errors.Add(new LanManagerSettingsError(dc, ToCollectorErrorMessage(ex)));
-                }
-            }
+                },
+                errorFactory: (dc, ex) => new LanManagerSettingsError(dc, ToCollectorErrorMessage(ex)),
+                errors: errors,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
         } else {
-            var targetDomains = string.IsNullOrWhiteSpace(domainName)
-                ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                    .Where(static x => !string.IsNullOrWhiteSpace(x))
-                    .Select(static x => x.Trim())
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToArray()
-                : new[] { domainName! };
-
-            if (targetDomains.Length == 0) {
-                return ToolResponse.Error(
-                    "query_failed",
-                    "No domains resolved for LAN Manager settings query. Provide domain_name/domain_controllers or ensure forest discovery is available.");
+            if (!TryResolveTargetDomains(
+                    domainName: domainName,
+                    forestName: forestName,
+                    cancellationToken: cancellationToken,
+                    queryName: "LAN Manager settings",
+                    targetDomains: out var targetDomains,
+                    errorResponse: out var targetDomainError)) {
+                return targetDomainError!;
             }
 
-            foreach (var domain in targetDomains) {
-                cancellationToken.ThrowIfCancellationRequested();
-                try {
+            await RunPerTargetCollectionAsync(
+                    targets: targetDomains,
+                    collectAsync: async domain => {
+                    if (rows.Count >= maxDomainControllers) {
+                        return;
+                    }
+
                     var snapshot = await LanManagerSettingsService.GetSnapshotAsync(domain, cancellationToken).ConfigureAwait(false);
                     foreach (var status in snapshot.DomainControllers) {
                         cancellationToken.ThrowIfCancellationRequested();
@@ -130,13 +130,10 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
                             break;
                         }
                     }
-                    if (rows.Count >= maxDomainControllers) {
-                        break;
-                    }
-                } catch (Exception ex) {
-                    errors.Add(new LanManagerSettingsError(domain, ToCollectorErrorMessage(ex)));
-                }
-            }
+                },
+                errorFactory: (domain, ex) => new LanManagerSettingsError(domain, ToCollectorErrorMessage(ex)),
+                errors: errors,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         var filtered = rows

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
@@ -94,27 +94,23 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
         var maxSampleRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_sample_rows_per_domain", 50, 1, 1000);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for LAPS coverage query. Provide domain_name or ensure forest discovery is available.");
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "LAPS coverage",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return targetDomainError!;
         }
 
         var rows = new List<LapsCoverageRow>(targetDomains.Length);
         var details = new List<LapsCoverageDetail>(targetDomains.Length);
         var errors = new List<LapsCoverageError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        await RunPerTargetCollectionAsync(
+                targets: targetDomains,
+                collectAsync: async domain => {
                 var view = await LapsCoverageService.EvaluateAsync(domain).ConfigureAwait(false);
                 rows.Add(new LapsCoverageRow(
                     DomainName: view.DomainName,
@@ -139,10 +135,10 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
                         MissingDsrmLaps: view.MissingDsrmLaps.Take(maxSampleRowsPerDomain).ToArray(),
                         ExpiredDsrmLaps: view.ExpiredDsrmLaps.Take(maxSampleRowsPerDomain).ToArray()));
                 }
-            } catch (Exception ex) {
-                errors.Add(new LapsCoverageError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new LapsCoverageError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var filtered = rows
             .Where(row => !coverageBelowPercent.HasValue || row.EitherLapsCoveragePercent < coverageBelowPercent.Value)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
@@ -82,27 +82,23 @@ public sealed class AdLapsSchemaPostureTool : ActiveDirectoryToolBase, ITool {
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: false);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for LAPS schema posture query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "LAPS schema posture",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<LapsSchemaPostureRow>(targetDomains.Length);
         var details = new List<LapsSchemaPostureDetail>(targetDomains.Length);
         var errors = new List<LapsSchemaPostureError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var legacy = LapsLegacySearchFlagsService.Evaluate(domain);
                 var modern = LapsModernSchemaService.Evaluate(domain);
 
@@ -134,10 +130,10 @@ public sealed class AdLapsSchemaPostureTool : ActiveDirectoryToolBase, ITool {
                         LegacyAttributeDn: legacy.AttributeDn,
                         ModernSchemaDn: modern.SchemaDn));
                 }
-            } catch (Exception ex) {
-                errors.Add(new LapsSchemaPostureError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new LapsSchemaPostureError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var filtered = rows
             .Where(row => !onlyFindings || row.AnyFinding)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdMachineAccountQuotaTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdMachineAccountQuotaTool.cs
@@ -69,25 +69,21 @@ public sealed class AdMachineAccountQuotaTool : ActiveDirectoryToolBase, ITool {
         var riskyOnly = ToolArgs.GetBoolean(arguments, "risky_only", defaultValue: false);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for machine-account-quota query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "machine-account-quota",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<MachineAccountQuotaRow>(targetDomains.Length);
         var errors = new List<MachineAccountQuotaError>();
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var view = MachineAccountQuotaEvaluator.Evaluate(domain);
                 var isKnown = view.MachineAccountQuota >= 0;
                 var exceedsThreshold = isKnown && view.MachineAccountQuota > threshold;
@@ -97,10 +93,10 @@ public sealed class AdMachineAccountQuotaTool : ActiveDirectoryToolBase, ITool {
                     IsKnown: isKnown,
                     ExceedsThreshold: exceedsThreshold,
                     Threshold: threshold));
-            } catch (Exception ex) {
-                errors.Add(new MachineAccountQuotaError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new MachineAccountQuotaError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var filtered = rows
             .Where(row => !riskyOnly || row.ExceedsThreshold)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
@@ -79,27 +79,23 @@ public sealed class AdOuProtectionTool : ActiveDirectoryToolBase, ITool {
         var maxOuRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_ou_rows_per_domain", 100, 1, 5000);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for OU protection query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "OU protection",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<OuProtectionRow>(targetDomains.Length);
         var details = new List<OuProtectionDetailRow>(targetDomains.Length * 4);
         var errors = new List<OuProtectionError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var snapshot = OuProtectionService.GetSnapshot(domain);
                 var total = snapshot.Ous.Count;
                 var unprotected = snapshot.Ous
@@ -126,10 +122,10 @@ public sealed class AdOuProtectionTool : ActiveDirectoryToolBase, ITool {
                             DistinguishedName: ou.DistinguishedName));
                     }
                 }
-            } catch (Exception ex) {
-                errors.Add(new OuProtectionError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new OuProtectionError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var filtered = rows
             .Where(row => !unprotectedOnly || row.UnprotectedCount > 0)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyLengthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyLengthTool.cs
@@ -62,34 +62,30 @@ public sealed class AdPasswordPolicyLengthTool : ActiveDirectoryToolBase, ITool 
         var belowRecommendedOnly = ToolArgs.GetBoolean(arguments, "below_recommended_only", defaultValue: false);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for password-policy-length query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "password-policy-length",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<PasswordPolicyLengthSnapshot>(targetDomains.Length);
         var errors = new List<PasswordPolicyLengthError>();
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 rows.Add(PasswordPolicyLengthService.GetSnapshot(
                     domainName: domain,
                     options: new PasswordPolicyLengthOptions {
                         RecommendedMinimumLength = recommendedMinimumLength
                     }));
-            } catch (Exception ex) {
-                errors.Add(new PasswordPolicyLengthError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new PasswordPolicyLengthError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var filtered = rows
             .Where(row => !belowRecommendedOnly || !row.MeetsRecommendation)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
@@ -81,27 +81,23 @@ public sealed class AdPasswordPolicyRollupTool : ActiveDirectoryToolBase, ITool 
         var maxPsoRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_pso_rows_per_domain", 100, 1, Options.MaxResults);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for password policy rollup query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "password policy rollup",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var summaries = new List<PasswordPolicyRollupSummaryRow>(targetDomains.Length);
         var details = new List<PasswordPolicyRollupDetail>(targetDomains.Length);
         var errors = new List<PasswordPolicyRollupError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var rollup = PasswordPolicyRollupService.Evaluate(domain, psoMinLength, psoHistoryMin);
                 summaries.Add(new PasswordPolicyRollupSummaryRow(
                     DomainName: rollup.DomainName,
@@ -117,10 +113,10 @@ public sealed class AdPasswordPolicyRollupTool : ActiveDirectoryToolBase, ITool 
                     Psos: includePsoDetails
                         ? rollup.Psos.Take(maxPsoRowsPerDomain).ToArray()
                         : Array.Empty<PasswordPolicyInfo>()));
-            } catch (Exception ex) {
-                errors.Add(new PasswordPolicyRollupError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new PasswordPolicyRollupError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var scanned = summaries.Count;
         IReadOnlyList<PasswordPolicyRollupSummaryRow> projectedRows = scanned > maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
@@ -91,27 +91,23 @@ public sealed class AdRegistrationPostureTool : ActiveDirectoryToolBase, ITool {
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 5000);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for registration posture query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "registration posture",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<RegistrationPostureRow>(targetDomains.Length);
         var details = new List<RegistrationPostureDetailRow>(targetDomains.Length * 3);
         var errors = new List<RegistrationPostureError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var domainDn = DomainHelper.DomainNameToDistinguishedName(domain);
                 var view = RegistrationPostureService.Evaluate(domain, domainDn);
 
@@ -134,10 +130,10 @@ public sealed class AdRegistrationPostureTool : ActiveDirectoryToolBase, ITool {
                         details.Add(MapDetail(view.DomainName, "missing_subnet", item));
                     }
                 }
-            } catch (Exception ex) {
-                errors.Add(new RegistrationPostureError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new RegistrationPostureError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var filtered = rows
             .Where(row => !dnsFailedOnly || row.DnsResolveFailedCount > 0)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
@@ -70,27 +70,23 @@ public sealed class AdShadowCredentialsRiskTool : ActiveDirectoryToolBase, ITool
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 100, 1, Options.MaxResults);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for shadow credentials risk query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "shadow credentials risk",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var summaries = new List<ShadowCredentialsRiskSummaryRow>(targetDomains.Length);
         var details = new List<ShadowCredentialsRiskDetail>(targetDomains.Length);
         var errors = new List<ShadowCredentialsRiskError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var view = ShadowCredentialsRiskService.Evaluate(domain);
                 summaries.Add(new ShadowCredentialsRiskSummaryRow(
                     DomainName: view.DomainName,
@@ -100,10 +96,10 @@ public sealed class AdShadowCredentialsRiskTool : ActiveDirectoryToolBase, ITool
                     Findings: includeFindings
                         ? view.Findings.Take(maxFindingsPerDomain).ToArray()
                         : Array.Empty<ShadowCredentialsRiskService.Finding>()));
-            } catch (Exception ex) {
-                errors.Add(new ShadowCredentialsRiskError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new ShadowCredentialsRiskError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var scanned = summaries.Count;
         IReadOnlyList<ShadowCredentialsRiskSummaryRow> projectedRows = scanned > maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
@@ -78,27 +78,23 @@ public sealed class AdSmartCardPostureTool : ActiveDirectoryToolBase, ITool {
         var maxFindingRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_finding_rows_per_domain", 100, 1, Options.MaxResults);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for smart-card posture query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "smart-card posture",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var summaries = new List<SmartCardPostureSummaryRow>(targetDomains.Length);
         var details = new List<SmartCardPostureDetail>(targetDomains.Length);
         var errors = new List<SmartCardPostureError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var domainDn = DomainHelper.DomainNameToDistinguishedName(domain);
                 var view = SmartCardPostureService.Evaluate(domain, domainDn);
                 summaries.Add(new SmartCardPostureSummaryRow(
@@ -119,10 +115,10 @@ public sealed class AdSmartCardPostureTool : ActiveDirectoryToolBase, ITool {
                     SmartCardPwdOld: includeDetails
                         ? view.SmartCardPwdOld.Take(maxFindingRowsPerDomain).ToArray()
                         : Array.Empty<SmartCardPostureService.Finding>()));
-            } catch (Exception ex) {
-                errors.Add(new SmartCardPostureError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new SmartCardPostureError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var scanned = summaries.Count;
         IReadOnlyList<SmartCardPostureSummaryRow> projectedRows = scanned > maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
@@ -90,27 +90,23 @@ public sealed class AdSpnHygieneTool : ActiveDirectoryToolBase, ITool {
         var maxInvalidSpnSample = ToolArgs.GetCappedInt32(arguments, "max_invalid_spn_sample", 25, 1, 200);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for SPN hygiene query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "SPN hygiene",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var summaries = new List<SpnHygieneSummaryRow>(targetDomains.Length);
         var details = new List<SpnHygieneDetail>(targetDomains.Length);
         var errors = new List<SpnHygieneError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var snapshot = SpnHygieneService.Evaluate(
                     domainName: domain,
                     allowlist: allowlist,
@@ -143,10 +139,10 @@ public sealed class AdSpnHygieneTool : ActiveDirectoryToolBase, ITool {
                     UnresolvableTargets: includeInvalidSpnSample
                         ? snapshot.UnresolvableTargets.Take(maxInvalidSpnSample).ToArray()
                         : Array.Empty<SpnHygieneService.SpnInvalidEntry>()));
-            } catch (Exception ex) {
-                errors.Add(new SpnHygieneError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new SpnHygieneError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var scanned = summaries.Count;
         IReadOnlyList<SpnHygieneSummaryRow> projectedRows = scanned > maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSystemStateBackupTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSystemStateBackupTool.cs
@@ -74,26 +74,22 @@ public sealed class AdSystemStateBackupTool : ActiveDirectoryToolBase, ITool {
         var staleOnly = ToolArgs.GetBoolean(arguments, "stale_only", defaultValue: false);
         var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
 
-        var targetDomains = string.IsNullOrWhiteSpace(domainName)
-            ? DomainHelper.EnumerateForestDomainNames(forestName, cancellationToken)
-                .Where(static x => !string.IsNullOrWhiteSpace(x))
-                .Select(static x => x.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray()
-            : new[] { domainName! };
-
-        if (targetDomains.Length == 0) {
-            return Task.FromResult(ToolResponse.Error(
-                "query_failed",
-                "No domains resolved for System State backup query. Provide domain_name or ensure forest discovery is available."));
+        if (!TryResolveTargetDomains(
+                domainName: domainName,
+                forestName: forestName,
+                cancellationToken: cancellationToken,
+                queryName: "System State backup",
+                targetDomains: out var targetDomains,
+                errorResponse: out var targetDomainError)) {
+            return Task.FromResult(targetDomainError!);
         }
 
         var rows = new List<SystemStateBackupRow>(targetDomains.Length * 8);
         var errors = new List<SystemStateBackupError>();
 
-        foreach (var domain in targetDomains) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
+        RunPerTargetCollection(
+            targets: targetDomains,
+            collect: domain => {
                 var checker = new SystemStateBackupChecker(
                     thresholdDays: thresholdDays,
                     enumerateDcs: () => DomainHelper.EnumerateDomainControllers(domain, cancellationToken: cancellationToken));
@@ -112,10 +108,10 @@ public sealed class AdSystemStateBackupTool : ActiveDirectoryToolBase, ITool {
                         IsStale: isStale,
                         ThresholdDays: thresholdDays));
                 }
-            } catch (Exception ex) {
-                errors.Add(new SystemStateBackupError(domain, ToCollectorErrorMessage(ex)));
-            }
-        }
+            },
+            errorFactory: (domain, ex) => new SystemStateBackupError(domain, ToCollectorErrorMessage(ex)),
+            errors: errors,
+            cancellationToken: cancellationToken);
 
         var filtered = rows
             .Where(row => !missingOnly || row.IsMissing)


### PR DESCRIPTION
## Summary
- add shared AD base helpers for domain-target resolution and per-target collection (sync + async)
- migrate ADPlayground tools to the shared collector pipeline to remove repeated domain-loop boilerplate
- preserve per-tool filtering/table/meta behavior while standardizing cancellation + per-target error mapping

## What Changed
- added to `ActiveDirectoryToolBase`:
  - `TryResolveTargetDomains(...)`
  - `RunPerTargetCollection<TTarget, TError>(...)`
  - `RunPerTargetCollectionAsync<TTarget, TError>(...)`
- migrated all AD tools that previously used manual `targetDomains` + per-domain `try/catch` loops to these helpers

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release` (pass)
- touched-file LOC check confirms all touched files are under 700 lines
- `rg` check confirms no remaining manual `foreach (var domain in targetDomains)` patterns in ADPlayground tools