### PR TITLE
Chat startup: add WebView budgeted fail-open and profiling telemetry

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
@@ -45,6 +45,22 @@ public sealed class MainWindowStartupConnectTimeoutPolicyTests {
     }
 
     /// <summary>
+    /// Ensures startup webview wait budget is enabled only during startup flow telemetry capture.
+    /// </summary>
+    [Theory]
+    [InlineData(false, null)]
+    [InlineData(true, 4000)]
+    public void ResolveStartupWebViewBudget_ReturnsExpectedBudget(
+        bool captureStartupPhaseTelemetry,
+        int? expectedTimeoutMs) {
+        var timeout = MainWindow.ResolveStartupWebViewBudget(captureStartupPhaseTelemetry);
+        var expected = expectedTimeoutMs.HasValue
+            ? TimeSpan.FromMilliseconds(expectedTimeoutMs.Value)
+            : (TimeSpan?)null;
+        Assert.Equal(expected, timeout);
+    }
+
+    /// <summary>
     /// Ensures connect attempt timeout is capped by remaining startup budget, including exhaustion behavior.
     /// </summary>
     [Theory]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -69,6 +69,7 @@ public sealed partial class MainWindow : Window {
     private static readonly TimeSpan StartupConnectBudget = TimeSpan.FromSeconds(4);
     private static readonly TimeSpan StartupConnectMinAttemptTimeout = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan StartupConnectRetryDelay = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan StartupWebViewBudget = TimeSpan.FromSeconds(4);
     private static readonly TimeSpan[] StartupConnectRetryTimeouts = {
         TimeSpan.FromSeconds(6),
         TimeSpan.FromSeconds(10),
@@ -491,8 +492,15 @@ public sealed partial class MainWindow : Window {
         try {
             StartupLog.Write("MainWindow.StartupFlow begin");
             StartupLog.Write("StartupPhase.WebView begin");
-            await EnsureWebViewInitializedAsync().ConfigureAwait(false);
-            StartupLog.Write("StartupPhase.WebView done");
+            var startupWebViewBudget = ResolveStartupWebViewBudget(Volatile.Read(ref _startupFlowState) == 1);
+            var webViewInitializationTask = EnsureWebViewInitializedAsync();
+            if (await TryAwaitStartupWebViewWithinBudgetAsync(webViewInitializationTask, startupWebViewBudget).ConfigureAwait(false)) {
+                StartupLog.Write("StartupPhase.WebView done");
+            } else {
+                StartupLog.Write("StartupPhase.WebView budget_exhausted");
+                StartupLog.Write("StartupPhase.WebView deferred");
+                ObserveDeferredStartupWebViewInitialization(webViewInitializationTask);
+            }
             StartupLog.Write("StartupPhase.AppState begin");
             await EnsureAppStateLoadedAsync().ConfigureAwait(false);
             StartupLog.Write("StartupPhase.AppState done");
@@ -509,6 +517,47 @@ public sealed partial class MainWindow : Window {
             Interlocked.Exchange(ref _startupFlowState, 0);
             StartupLog.Write("MainWindow.StartupFlow failed: " + ex);
         }
+    }
+
+    internal static TimeSpan? ResolveStartupWebViewBudget(bool captureStartupPhaseTelemetry) {
+        return captureStartupPhaseTelemetry ? StartupWebViewBudget : null;
+    }
+
+    private static async Task<bool> TryAwaitStartupWebViewWithinBudgetAsync(Task webViewInitializationTask, TimeSpan? startupWebViewBudget) {
+        if (webViewInitializationTask.IsCompleted) {
+            await webViewInitializationTask.ConfigureAwait(false);
+            return true;
+        }
+
+        if (!startupWebViewBudget.HasValue || startupWebViewBudget.Value <= TimeSpan.Zero) {
+            await webViewInitializationTask.ConfigureAwait(false);
+            return true;
+        }
+
+        var completed = await Task.WhenAny(webViewInitializationTask, Task.Delay(startupWebViewBudget.Value)).ConfigureAwait(false);
+        if (ReferenceEquals(completed, webViewInitializationTask)) {
+            await webViewInitializationTask.ConfigureAwait(false);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void ObserveDeferredStartupWebViewInitialization(Task webViewInitializationTask) {
+        _ = webViewInitializationTask.ContinueWith(task => {
+            if (task.IsCanceled) {
+                StartupLog.Write("StartupPhase.WebView eventual_canceled");
+                return;
+            }
+
+            if (task.IsFaulted) {
+                var root = task.Exception?.GetBaseException();
+                StartupLog.Write("StartupPhase.WebView eventual_failed: " + (root?.Message ?? "unknown"));
+                return;
+            }
+
+            StartupLog.Write("StartupPhase.WebView eventual_done");
+        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
     }
 
     private void QueueDeferredStartupOnboarding() {
@@ -715,7 +764,9 @@ public sealed partial class MainWindow : Window {
                 StartupLog.Write("EnsureWebViewInitializedAsync begin");
                 InstallWindowMessageHook();
                 RefreshGlobalWheelHookPolicy();
+                StartupLog.Write("EnsureWebViewInitializedAsync.ensure_core begin");
                 await _webView.EnsureCoreWebView2Async().AsTask().ConfigureAwait(false);
+                StartupLog.Write("EnsureWebViewInitializedAsync.ensure_core done");
                 _webView.CoreWebView2.WebMessageReceived -= OnWebMessageReceived;
                 _webView.CoreWebView2.WebMessageReceived += OnWebMessageReceived;
                 _webView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
@@ -740,6 +791,7 @@ public sealed partial class MainWindow : Window {
                     navTcs.TrySetResult(null);
                 }
                 _webView.NavigationCompleted += OnNavigationCompleted;
+                StartupLog.Write("EnsureWebViewInitializedAsync.navigate begin");
                 _webView.NavigateToString(BuildShellHtml());
                 navReadyTask = navTcs.Task;
                 _webViewReady = true;
@@ -747,7 +799,10 @@ public sealed partial class MainWindow : Window {
                 RequestTitleBarMetricsRefresh();
             }).ConfigureAwait(false);
 
-            await Task.WhenAny(navReadyTask, Task.Delay(TimeSpan.FromSeconds(2))).ConfigureAwait(false);
+            var navReadyCompleted = ReferenceEquals(await Task.WhenAny(navReadyTask, Task.Delay(TimeSpan.FromSeconds(2))).ConfigureAwait(false), navReadyTask);
+            StartupLog.Write(navReadyCompleted
+                ? "EnsureWebViewInitializedAsync.navigate done"
+                : "EnsureWebViewInitializedAsync.navigate timeout");
             await RunOnUiThreadAsync(() => {
                 InstallWindowMessageHook();
                 EnsureNativeTitleBarEventSubscriptions();

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -42,6 +42,7 @@ pwsh .\scripts\profile-chat-startup.ps1 -Runs 5 -OutFile .\artifacts\chat-startu
 
 Add `-PostStartupGraceSeconds 2` if you want to include deferred post-startup warmup phases in the report.
 Add `-ArchiveLogsDirectory .\artifacts\chat-startup-logs` to retain each run's raw startup log for hotspot/outlier investigation.
+The report includes startup WebView metrics (`startup_webview_ms`, `ensure_webview_ms`) plus budget/defer markers to track fail-open behavior.
 
 Markdown renderer dependency resolution is automatic:
 - Dev: if sibling local source exists (`..\OfficeIMO`), Chat builds against that local project.

--- a/scripts/profile-chat-startup.ps1
+++ b/scripts/profile-chat-startup.ps1
@@ -124,17 +124,22 @@ for ($i = 1; $i -le $Runs; $i++) {
         state            = $state
         startup_log_path = $archivedStartupLogPath
         total_ms         = Get-DurationMs (Get-MarkerTimestamp $lines 'Program.Main enter') (Get-MarkerTimestamp $lines 'MainWindow.StartupFlow done')
+        startup_webview_ms = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupPhase.WebView begin') (Get-MarkerTimestamp $lines 'StartupPhase.WebView done')
+        ensure_webview_ms  = Get-DurationMs (Get-MarkerTimestamp $lines 'EnsureWebViewInitializedAsync begin') (Get-MarkerTimestamp $lines 'EnsureWebViewInitializedAsync ok')
         connect_ms       = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupPhase.Connect begin') (Get-MarkerTimestamp $lines 'StartupPhase.Connect done')
         hello_ms         = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupConnect.hello begin') (Get-MarkerTimestamp $lines 'StartupConnect.hello done')
         list_tools_ms    = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupConnect.list_tools begin') (Get-MarkerTimestamp $lines 'StartupConnect.list_tools done')
         auth_refresh_ms  = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupConnect.auth_refresh begin') (Get-MarkerTimestamp $lines 'StartupConnect.auth_refresh done')
         model_sync_ms    = Get-DurationMs (Get-MarkerTimestamp $lines 'StartupConnect.model_profile_sync begin') (Get-MarkerTimestamp $lines 'StartupConnect.model_profile_sync done')
+        startup_webview_budget_exhausted = [bool]($lines | Where-Object { $_ -match 'StartupPhase.WebView budget_exhausted' } | Select-Object -First 1)
+        startup_webview_deferred = [bool]($lines | Where-Object { $_ -match 'StartupPhase.WebView deferred' } | Select-Object -First 1)
+        startup_webview_eventual_done = [bool]($lines | Where-Object { $_ -match 'StartupPhase.WebView eventual_done' } | Select-Object -First 1)
         hello_deferred   = [bool]($lines | Where-Object { $_ -match 'StartupConnect.hello deferred' } | Select-Object -First 1)
         model_deferred   = [bool]($lines | Where-Object { $_ -match 'StartupConnect.model_profile_sync deferred' } | Select-Object -First 1)
     }
 
     $runResults.Add([pscustomobject]$run)
-    Write-Host ("Run {0}/{1}: state={2}, total={3}ms, connect={4}ms, hello={5}ms" -f $i, $Runs, $run.state, $run.total_ms, $run.connect_ms, $run.hello_ms)
+    Write-Host ("Run {0}/{1}: state={2}, total={3}ms, startup_webview={4}ms, connect={5}ms, hello={6}ms" -f $i, $Runs, $run.state, $run.total_ms, $run.startup_webview_ms, $run.connect_ms, $run.hello_ms)
 }
 
 $completedRuns = @($runResults | Where-Object { $_.state -eq 'done' })
@@ -148,14 +153,21 @@ $summary = [pscustomobject]@{
     runs_requested       = $Runs
     runs_completed       = $completedRuns.Count
     avg_total_ms         = Get-Average ($completedRuns | ForEach-Object { $_.total_ms })
+    avg_startup_webview_ms = Get-Average ($completedRuns | ForEach-Object { $_.startup_webview_ms })
+    avg_ensure_webview_ms  = Get-Average ($completedRuns | ForEach-Object { $_.ensure_webview_ms })
     avg_connect_ms       = Get-Average ($completedRuns | ForEach-Object { $_.connect_ms })
     avg_hello_ms         = Get-Average ($completedRuns | ForEach-Object { $_.hello_ms })
     avg_list_tools_ms    = Get-Average ($completedRuns | ForEach-Object { $_.list_tools_ms })
     avg_auth_refresh_ms  = Get-Average ($completedRuns | ForEach-Object { $_.auth_refresh_ms })
     avg_model_sync_ms    = Get-Average ($completedRuns | ForEach-Object { $_.model_sync_ms })
     avg_warm_total_ms    = Get-Average ($warmRuns | ForEach-Object { $_.total_ms })
+    avg_warm_startup_webview_ms = Get-Average ($warmRuns | ForEach-Object { $_.startup_webview_ms })
+    avg_warm_ensure_webview_ms  = Get-Average ($warmRuns | ForEach-Object { $_.ensure_webview_ms })
     avg_warm_connect_ms  = Get-Average ($warmRuns | ForEach-Object { $_.connect_ms })
     avg_warm_hello_ms    = Get-Average ($warmRuns | ForEach-Object { $_.hello_ms })
+    startup_webview_budget_exhausted_runs = @($completedRuns | Where-Object { $_.startup_webview_budget_exhausted }).Count
+    startup_webview_deferred_runs = @($completedRuns | Where-Object { $_.startup_webview_deferred }).Count
+    startup_webview_eventual_done_runs = @($completedRuns | Where-Object { $_.startup_webview_eventual_done }).Count
     hello_deferred_runs  = @($completedRuns | Where-Object { $_.hello_deferred }).Count
     model_deferred_runs  = @($completedRuns | Where-Object { $_.model_deferred }).Count
 }


### PR DESCRIPTION
## Summary
- add a startup WebView budget (`4s`) with fail-open behavior in `MainWindow.StartupFlow`
- when WebView init exceeds budget, startup continues (`AppState` + `Connect`) and WebView completion is observed/logged in background
- add detailed WebView startup telemetry markers:
  - `EnsureWebViewInitializedAsync.ensure_core begin|done`
  - `EnsureWebViewInitializedAsync.navigate begin|done|timeout`
  - `StartupPhase.WebView budget_exhausted|deferred|eventual_done|eventual_failed`
- extend startup profiler output with WebView metrics and defer/budget counters
- add tests for startup WebView budget policy selection

## Why
WebView initialization is still the largest startup hotspot and can keep startup flow blocked for multiple seconds. This change introduces a bounded startup wait and keeps startup progressing safely, while preserving eventual WebView initialization and adding telemetry to measure real behavior.

## Validation
### Tests
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release -p:SkipChatServiceSidecarBuild=true -p:ChatServiceBin=Z:\\ix-missing\\` (pass, 212)

### Startup profiling (same script, 8 runs)
- baseline (`artifacts/chat-startup-profile-webview-budget-baseline.json`):
  - `avg_total_ms=6569.52`
  - `median_total_ms=7053.86`
  - `avg_connect_ms=983.60`
- after (`artifacts/chat-startup-profile-webview-budget-after.json`):
  - `avg_total_ms=4525.94`
  - `median_total_ms=4930.35`
  - `avg_connect_ms=477.24`
  - `startup_webview_budget_exhausted_runs=7`

### Rebased sanity run (5 runs)
- `artifacts/chat-startup-profile-webview-budget-after-rebased.json`
- `avg_total_ms=4023.53`, `avg_warm_total_ms=4343.53`
- `startup_webview_budget_exhausted_runs=3`