### PR TITLE
Deduplicate AD projected detail filtering paths

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -192,6 +192,58 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     }
 
     /// <summary>
+    /// Builds a projected key set from row values using case-insensitive matching.
+    /// </summary>
+    protected static HashSet<string> BuildProjectedSet<TRow>(
+        IReadOnlyList<TRow> rows,
+        Func<TRow, string?> keySelector) {
+        if (rows is null) {
+            throw new ArgumentNullException(nameof(rows));
+        }
+        if (keySelector is null) {
+            throw new ArgumentNullException(nameof(keySelector));
+        }
+
+        var projected = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in rows) {
+            var key = keySelector(row);
+            if (!string.IsNullOrWhiteSpace(key)) {
+                projected.Add(key);
+            }
+        }
+
+        return projected;
+    }
+
+    /// <summary>
+    /// Filters details by a projected key set.
+    /// </summary>
+    protected static IReadOnlyList<TDetail> FilterByProjectedSet<TDetail>(
+        IReadOnlyList<TDetail> details,
+        IReadOnlySet<string> projectedKeys,
+        Func<TDetail, string?> keySelector) {
+        if (details is null) {
+            throw new ArgumentNullException(nameof(details));
+        }
+        if (projectedKeys is null) {
+            throw new ArgumentNullException(nameof(projectedKeys));
+        }
+        if (keySelector is null) {
+            throw new ArgumentNullException(nameof(keySelector));
+        }
+        if (details.Count == 0 || projectedKeys.Count == 0) {
+            return Array.Empty<TDetail>();
+        }
+
+        return details
+            .Where(detail => {
+                var key = keySelector(detail);
+                return !string.IsNullOrWhiteSpace(key) && projectedKeys.Contains(key);
+            })
+            .ToArray();
+    }
+
+    /// <summary>
     /// Builds filtered + capped policy-attribution rows using consistent configured-value semantics.
     /// </summary>
     protected static IReadOnlyList<PolicyAttribution> PreparePolicyAttributionRows(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
@@ -119,17 +119,9 @@ public sealed class AdAzureAdSsoTool : ActiveDirectoryToolBase, ITool {
             .Where(row => !riskyOnly || row.RiskyConfiguration)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<AzureAdSsoRow> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var projectedDetails = details
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(details, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdAzureAdSsoResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
@@ -110,17 +110,9 @@ public sealed class AdDangerousExtendedRightsTool : ActiveDirectoryToolBase, ITo
             errors: errors,
             cancellationToken: cancellationToken);
 
-        var scanned = summaries.Count;
-        IReadOnlyList<DangerousExtendedRightsSummaryRow> projectedRows = scanned > maxResults
-            ? summaries.Take(maxResults).ToArray()
-            : summaries;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var projectedDetails = details
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(summaries, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(details, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdDangerousExtendedRightsResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
@@ -123,18 +123,9 @@ public sealed class AdDcFleetPostureTool : ActiveDirectoryToolBase, ITool {
             errors: errors,
             cancellationToken: cancellationToken);
 
-        var scanned = summaryRows.Count;
-        IReadOnlyList<DcFleetPostureRow> projectedRows = scanned > maxResults
-            ? summaryRows.Take(maxResults).ToArray()
-            : summaryRows;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        var projectedDetails = detailRows
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(summaryRows, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(detailRows, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdDcFleetPostureResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
@@ -101,17 +101,9 @@ public sealed class AdDcShadowIndicatorsTool : ActiveDirectoryToolBase, ITool {
             errors: errors,
             cancellationToken: cancellationToken);
 
-        var scanned = summaries.Count;
-        IReadOnlyList<DcShadowIndicatorsSummaryRow> projectedRows = scanned > maxResults
-            ? summaries.Take(maxResults).ToArray()
-            : summaries;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var projectedDetails = details
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(summaries, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(details, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdDcShadowIndicatorsResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
@@ -157,22 +157,14 @@ public sealed class AdDnsZoneSecurityTool : ActiveDirectoryToolBase, ITool {
             .Where(row => row.BroadWriteAceCount >= broadWriteMin)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<DnsZoneSecurityRow> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var projectedZones = projectedRows
-            .Select(static row => $"{row.DomainName}|{row.ZoneName}")
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var projectedOffending = offendingRows
-            .Where(row => projectedDomains.Contains(row.DomainName))
-            .Where(row => projectedZones.Contains($"{row.DomainName}|{row.ZoneName}"))
-            .ToArray();
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedZones = BuildProjectedSet(projectedRows, static row => $"{row.DomainName}|{row.ZoneName}");
+        var projectedOffending = FilterByProjectedSet(
+            FilterByProjectedSet(offendingRows, projectedDomains, static row => row.DomainName),
+            projectedZones,
+            static row => $"{row.DomainName}|{row.ZoneName}");
 
         var result = new AdDnsZoneSecurityResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
@@ -108,14 +108,8 @@ public sealed class AdDomainStatisticsTool : ActiveDirectoryToolBase, ITool {
             errors: errors,
             cancellationToken: cancellationToken);
 
-        var scanned = summaries.Count;
-        IReadOnlyList<DomainStatisticsSummaryRow> projectedRows = scanned > maxResults
-            ? summaries.Take(maxResults).ToArray()
-            : summaries;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var projectedRows = CapRows(summaries, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
 
         var projectedSnapshots = snapshots
             .Where(snapshot => projectedDomains.Contains(snapshot.DomainName))

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
@@ -143,21 +143,10 @@ public sealed class AdDuplicateAccountsTool : ActiveDirectoryToolBase, ITool {
             .Where(row => !duplicatesOnly || row.DuplicateSamCount > 0)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<DuplicateAccountsRow> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        var projectedConflictDetails = conflictDetails
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
-        var projectedDuplicateDetails = duplicateDetails
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedConflictDetails = FilterByProjectedSet(conflictDetails, projectedDomains, static detail => detail.DomainName);
+        var projectedDuplicateDetails = FilterByProjectedSet(duplicateDetails, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdDuplicateAccountsResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
@@ -147,12 +147,8 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
 
         var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var projectedDetails = details
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(details, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdLapsCoverageResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
@@ -139,18 +139,9 @@ public sealed class AdLapsSchemaPostureTool : ActiveDirectoryToolBase, ITool {
             .Where(row => !onlyFindings || row.AnyFinding)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<LapsSchemaPostureRow> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        var projectedDetails = details
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(details, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdLapsSchemaPostureResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
@@ -131,18 +131,9 @@ public sealed class AdOuProtectionTool : ActiveDirectoryToolBase, ITool {
             .Where(row => !unprotectedOnly || row.UnprotectedCount > 0)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<OuProtectionRow> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        var projectedDetails = details
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(details, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdOuProtectionResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
@@ -118,17 +118,9 @@ public sealed class AdPasswordPolicyRollupTool : ActiveDirectoryToolBase, ITool 
             errors: errors,
             cancellationToken: cancellationToken);
 
-        var scanned = summaries.Count;
-        IReadOnlyList<PasswordPolicyRollupSummaryRow> projectedRows = scanned > maxResults
-            ? summaries.Take(maxResults).ToArray()
-            : summaries;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var projectedDetails = details
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(summaries, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(details, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdPasswordPolicyRollupResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
@@ -141,18 +141,9 @@ public sealed class AdRegistrationPostureTool : ActiveDirectoryToolBase, ITool {
             .Where(row => !missingSubnetOnly || row.MissingSubnetCount > 0)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<RegistrationPostureRow> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
-
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var projectedDetails = details
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(details, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdRegistrationPostureResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
@@ -101,17 +101,9 @@ public sealed class AdShadowCredentialsRiskTool : ActiveDirectoryToolBase, ITool
             errors: errors,
             cancellationToken: cancellationToken);
 
-        var scanned = summaries.Count;
-        IReadOnlyList<ShadowCredentialsRiskSummaryRow> projectedRows = scanned > maxResults
-            ? summaries.Take(maxResults).ToArray()
-            : summaries;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var projectedDetails = details
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(summaries, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(details, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdShadowCredentialsRiskResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
@@ -120,17 +120,9 @@ public sealed class AdSmartCardPostureTool : ActiveDirectoryToolBase, ITool {
             errors: errors,
             cancellationToken: cancellationToken);
 
-        var scanned = summaries.Count;
-        IReadOnlyList<SmartCardPostureSummaryRow> projectedRows = scanned > maxResults
-            ? summaries.Take(maxResults).ToArray()
-            : summaries;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var projectedDetails = details
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(summaries, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(details, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdSmartCardPostureResult(
             DomainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
@@ -144,17 +144,9 @@ public sealed class AdSpnHygieneTool : ActiveDirectoryToolBase, ITool {
             errors: errors,
             cancellationToken: cancellationToken);
 
-        var scanned = summaries.Count;
-        IReadOnlyList<SpnHygieneSummaryRow> projectedRows = scanned > maxResults
-            ? summaries.Take(maxResults).ToArray()
-            : summaries;
-        var truncated = scanned > projectedRows.Count;
-        var projectedDomains = projectedRows
-            .Select(static row => row.DomainName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var projectedDetails = details
-            .Where(detail => projectedDomains.Contains(detail.DomainName))
-            .ToArray();
+        var projectedRows = CapRows(summaries, maxResults, out var scanned, out var truncated);
+        var projectedDomains = BuildProjectedSet(projectedRows, static row => row.DomainName);
+        var projectedDetails = FilterByProjectedSet(details, projectedDomains, static detail => detail.DomainName);
 
         var result = new AdSpnHygieneResult(
             DomainName: domainName,


### PR DESCRIPTION
## Summary
- add shared AD projection helpers in `ActiveDirectoryToolBase` for projected-key building and detail filtering
- migrate repeated per-tool projected domain/detail filtering to helper calls across AD tools
- standardize row capping in those paths via `CapRows(...)`

## Why
Many AD tools repeated the same 6-10 line blocks for:
- building projected domain sets from capped rows
- filtering detail payloads by projected domains
- ad-hoc scanned/truncated capping

Centralizing this reduces code size, keeps behavior consistent, and lowers drift risk when we adjust projection semantics later.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release` (pass)
- touched-file LOC check: all modified files remain below 700 lines
- AD tool scan confirms previous manual projected-domain/detail pattern is removed in migrated files