### PR TITLE
Centralize shared query helpers across AD and System tools

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -157,7 +157,7 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         int scanned,
         int maxTop,
         Action<JsonObject>? metaMutate = null) {
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        return ToolQueryHelpers.BuildAutoTableResponse(
             arguments: arguments,
             model: model,
             sourceRows: sourceRows,
@@ -165,12 +165,8 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
             title: title,
             maxTop: maxTop,
             baseTruncated: baseTruncated,
-            response: out var response,
             scanned: scanned,
-            metaMutate: meta => {
-                metaMutate?.Invoke(meta);
-            });
-        return response;
+            metaMutate: metaMutate);
     }
 
     /// <summary>
@@ -181,14 +177,7 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         int maxResults,
         out int scanned,
         out bool truncated) {
-        scanned = allRows.Count;
-        if (scanned <= maxResults) {
-            truncated = false;
-            return allRows;
-        }
-
-        truncated = true;
-        return allRows.Take(maxResults).ToArray();
+        return ToolQueryHelpers.CapRows(allRows, maxResults, out scanned, out truncated);
     }
 
     /// <summary>
@@ -197,22 +186,7 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     protected static HashSet<string> BuildProjectedSet<TRow>(
         IReadOnlyList<TRow> rows,
         Func<TRow, string?> keySelector) {
-        if (rows is null) {
-            throw new ArgumentNullException(nameof(rows));
-        }
-        if (keySelector is null) {
-            throw new ArgumentNullException(nameof(keySelector));
-        }
-
-        var projected = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var row in rows) {
-            var key = keySelector(row);
-            if (!string.IsNullOrWhiteSpace(key)) {
-                projected.Add(key);
-            }
-        }
-
-        return projected;
+        return ToolQueryHelpers.BuildProjectedSet(rows, keySelector);
     }
 
     /// <summary>
@@ -222,25 +196,7 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         IReadOnlyList<TDetail> details,
         IReadOnlySet<string> projectedKeys,
         Func<TDetail, string?> keySelector) {
-        if (details is null) {
-            throw new ArgumentNullException(nameof(details));
-        }
-        if (projectedKeys is null) {
-            throw new ArgumentNullException(nameof(projectedKeys));
-        }
-        if (keySelector is null) {
-            throw new ArgumentNullException(nameof(keySelector));
-        }
-        if (details.Count == 0 || projectedKeys.Count == 0) {
-            return Array.Empty<TDetail>();
-        }
-
-        return details
-            .Where(detail => {
-                var key = keySelector(detail);
-                return !string.IsNullOrWhiteSpace(key) && projectedKeys.Contains(key);
-            })
-            .ToArray();
+        return ToolQueryHelpers.FilterByProjectedSet(details, projectedKeys, keySelector);
     }
 
     /// <summary>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolQueryHelpers.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolQueryHelpers.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using IntelligenceX.Json;
+
+namespace IntelligenceX.Tools.Common;
+
+/// <summary>
+/// Shared row/query helper primitives used by multiple tool packs.
+/// </summary>
+public static class ToolQueryHelpers {
+    /// <summary>
+    /// Caps a row collection by max-results and returns standard scanned/truncated counters.
+    /// </summary>
+    public static IReadOnlyList<TRow> CapRows<TRow>(
+        IReadOnlyList<TRow> allRows,
+        int maxResults,
+        out int scanned,
+        out bool truncated) {
+        scanned = allRows.Count;
+        if (scanned <= maxResults) {
+            truncated = false;
+            return allRows;
+        }
+
+        truncated = true;
+        return allRows.Take(maxResults).ToArray();
+    }
+
+    /// <summary>
+    /// Builds the standard auto-column table envelope.
+    /// </summary>
+    public static string BuildAutoTableResponse<TModel, TRow>(
+        JsonObject? arguments,
+        TModel model,
+        IReadOnlyList<TRow> sourceRows,
+        string viewRowsPath,
+        string title,
+        bool baseTruncated,
+        int scanned,
+        int maxTop,
+        Action<JsonObject>? metaMutate = null) {
+        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+            arguments: arguments,
+            model: model,
+            sourceRows: sourceRows,
+            viewRowsPath: viewRowsPath,
+            title: title,
+            maxTop: maxTop,
+            baseTruncated: baseTruncated,
+            response: out var response,
+            scanned: scanned,
+            metaMutate: meta => {
+                metaMutate?.Invoke(meta);
+            });
+        return response;
+    }
+
+    /// <summary>
+    /// Builds a projected key set from row values using case-insensitive matching.
+    /// </summary>
+    public static HashSet<string> BuildProjectedSet<TRow>(
+        IReadOnlyList<TRow> rows,
+        Func<TRow, string?> keySelector) {
+        if (rows is null) {
+            throw new ArgumentNullException(nameof(rows));
+        }
+        if (keySelector is null) {
+            throw new ArgumentNullException(nameof(keySelector));
+        }
+
+        var projected = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in rows) {
+            var key = keySelector(row);
+            if (!string.IsNullOrWhiteSpace(key)) {
+                projected.Add(key);
+            }
+        }
+
+        return projected;
+    }
+
+    /// <summary>
+    /// Filters details by a projected key set.
+    /// </summary>
+    public static IReadOnlyList<TDetail> FilterByProjectedSet<TDetail>(
+        IReadOnlyList<TDetail> details,
+        IReadOnlySet<string> projectedKeys,
+        Func<TDetail, string?> keySelector) {
+        if (details is null) {
+            throw new ArgumentNullException(nameof(details));
+        }
+        if (projectedKeys is null) {
+            throw new ArgumentNullException(nameof(projectedKeys));
+        }
+        if (keySelector is null) {
+            throw new ArgumentNullException(nameof(keySelector));
+        }
+        if (details.Count == 0 || projectedKeys.Count == 0) {
+            return Array.Empty<TDetail>();
+        }
+
+        return details
+            .Where(detail => {
+                var key = keySelector(detail);
+                return !string.IsNullOrWhiteSpace(key) && projectedKeys.Contains(key);
+            })
+            .ToArray();
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemBitlockerStatusTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemBitlockerStatusTool.cs
@@ -61,7 +61,7 @@ public sealed class SystemBitlockerStatusTool : SystemToolBase, ITool {
         try {
             query = BitLocker.Get(computerName);
         } catch (Exception ex) {
-            return Task.FromResult(ToolResponse.Error("query_failed", $"BitLocker status query failed: {ex.Message}"));
+            return Task.FromResult(ErrorFromException(ex, defaultMessage: "BitLocker status query failed."));
         }
 
         var filtered = query
@@ -69,11 +69,7 @@ public sealed class SystemBitlockerStatusTool : SystemToolBase, ITool {
             .Where(x => !encryptedOnly || x.EncryptionPercentage > 0)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<BitLockerVolumeInfo> rows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new SystemBitlockerStatusResult(
             ComputerName: target,
@@ -83,7 +79,7 @@ public sealed class SystemBitlockerStatusTool : SystemToolBase, ITool {
             Truncated: truncated,
             Volumes: rows);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: rows,
@@ -91,7 +87,6 @@ public sealed class SystemBitlockerStatusTool : SystemToolBase, ITool {
             title: "BitLocker status (preview)",
             maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("computer_name", target);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemInstalledApplicationsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemInstalledApplicationsTool.cs
@@ -61,7 +61,7 @@ public sealed class SystemInstalledApplicationsTool : SystemToolBase, ITool {
         try {
             query = InstalledApplications.Query(computerName);
         } catch (Exception ex) {
-            return Task.FromResult(ToolResponse.Error("query_failed", $"Installed applications query failed: {ex.Message}"));
+            return Task.FromResult(ErrorFromException(ex, defaultMessage: "Installed applications query failed."));
         }
 
         var filtered = query
@@ -71,11 +71,7 @@ public sealed class SystemInstalledApplicationsTool : SystemToolBase, ITool {
                 || x.Publisher?.Contains(publisherContains, StringComparison.OrdinalIgnoreCase) == true)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<InstalledApplicationInfo> rows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new SystemInstalledApplicationsResult(
             ComputerName: target,
@@ -85,7 +81,7 @@ public sealed class SystemInstalledApplicationsTool : SystemToolBase, ITool {
             Truncated: truncated,
             Applications: rows);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: rows,
@@ -93,7 +89,6 @@ public sealed class SystemInstalledApplicationsTool : SystemToolBase, ITool {
             title: "Installed applications (preview)",
             maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("computer_name", target);
@@ -108,4 +103,3 @@ public sealed class SystemInstalledApplicationsTool : SystemToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchComplianceTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchComplianceTool.cs
@@ -210,11 +210,7 @@ public sealed class SystemPatchComplianceTool : SystemToolBase, ITool {
                 ComplianceState: state));
         }
 
-        var scanned = complianceRows.Count;
-        IReadOnlyList<ComplianceRow> rows = scanned > maxResults
-            ? complianceRows.Take(maxResults).ToArray()
-            : complianceRows;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(complianceRows, maxResults, out var scanned, out var truncated);
         var summary = BuildSummary(complianceRows);
         var release = new DateTime(year, month, 1).ToString("yyyy-MM");
 
@@ -241,7 +237,7 @@ public sealed class SystemPatchComplianceTool : SystemToolBase, ITool {
             Summary: summary,
             Compliance: rows);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: rows,
@@ -249,7 +245,6 @@ public sealed class SystemPatchComplianceTool : SystemToolBase, ITool {
             title: "Patch compliance (preview)",
             maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("computer_name", target);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchDetailsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchDetailsTool.cs
@@ -126,11 +126,7 @@ public sealed class SystemPatchDetailsTool : SystemToolBase, ITool {
             .ThenBy(static x => x.CveId, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<PatchDetailsInfo> rows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(filtered, maxResults, out var scanned, out var truncated);
         var summary = BuildSummary(filtered);
         var release = new DateTime(year, month, 1).ToString("yyyy-MM");
 
@@ -154,7 +150,7 @@ public sealed class SystemPatchDetailsTool : SystemToolBase, ITool {
             Summary: summary,
             Patches: rows);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: rows,
@@ -162,7 +158,6 @@ public sealed class SystemPatchDetailsTool : SystemToolBase, ITool {
             title: "System patch details (preview)",
             maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("max_results", maxResults);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemToolBase.cs
@@ -292,6 +292,42 @@ public abstract class SystemToolBase : ToolBase {
         }
     }
 
+    /// <summary>
+    /// Caps a row collection by max-results and returns standard scanned/truncated counters.
+    /// </summary>
+    protected static IReadOnlyList<TRow> CapRows<TRow>(
+        IReadOnlyList<TRow> allRows,
+        int maxResults,
+        out int scanned,
+        out bool truncated) {
+        return ToolQueryHelpers.CapRows(allRows, maxResults, out scanned, out truncated);
+    }
+
+    /// <summary>
+    /// Builds the standard auto-column table envelope used by System read tools.
+    /// </summary>
+    protected static string BuildAutoTableResponse<TModel, TRow>(
+        JsonObject? arguments,
+        TModel model,
+        IReadOnlyList<TRow> sourceRows,
+        string viewRowsPath,
+        string title,
+        bool baseTruncated,
+        int scanned,
+        int maxTop,
+        Action<JsonObject>? metaMutate = null) {
+        return ToolQueryHelpers.BuildAutoTableResponse(
+            arguments: arguments,
+            model: model,
+            sourceRows: sourceRows,
+            viewRowsPath: viewRowsPath,
+            title: title,
+            maxTop: maxTop,
+            baseTruncated: baseTruncated,
+            scanned: scanned,
+            metaMutate: metaMutate);
+    }
+
     private static bool TryNormalizePatchSeverity(string input, out string normalized) {
         normalized = string.Empty;
         if (string.IsNullOrWhiteSpace(input)) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemUpdatesInstalledTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemUpdatesInstalledTool.cs
@@ -93,11 +93,7 @@ public sealed class SystemUpdatesInstalledTool : SystemToolBase, ITool {
                 || (x.InstalledOn.HasValue && x.InstalledOn.Value.ToUniversalTime() >= installedAfterUtc.Value))
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<UpdateInfo> viewRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > viewRows.Count;
+        var viewRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new SystemUpdatesInstalledResult(
             ComputerName: target,
@@ -110,7 +106,7 @@ public sealed class SystemUpdatesInstalledTool : SystemToolBase, ITool {
             Truncated: truncated,
             Updates: viewRows);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: viewRows,
@@ -118,7 +114,6 @@ public sealed class SystemUpdatesInstalledTool : SystemToolBase, ITool {
             title: "System updates (preview)",
             maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("computer_name", target);


### PR DESCRIPTION
## Summary
- add a shared cross-pack query helper in `IntelligenceX.Tools.Common`:
  - `CapRows(...)`
  - `BuildAutoTableResponse(...)`
  - `BuildProjectedSet(...)`
  - `FilterByProjectedSet(...)`
- rewire `ActiveDirectoryToolBase` and `SystemToolBase` to delegate to the shared helper
- migrate key ComputerX-backed System tools to the shared base helpers and standardized exception envelope mapping:
  - `system_bitlocker_status`
  - `system_installed_applications`
  - `system_updates_installed`
  - `system_patch_details`
  - `system_patch_compliance`

## Why
This removes duplicated query mechanics across AD/System packs and makes future tool additions thinner and more consistent.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release` (pass)
- touched-file LOC check confirms all modified files are under 700 lines