### PR TITLE
Refactor shared tool exception mapping

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -15,7 +15,6 @@ namespace IntelligenceX.Tools.ADPlayground;
 /// Base class for Active Directory tools.
 /// </summary>
 public abstract class ActiveDirectoryToolBase : ToolBase {
-    private const int MaxErrorMessageLength = 300;
     private const int DefaultPolicyAttributionMaxTop = 5000;
 
     /// <summary>
@@ -301,56 +300,20 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         string defaultMessage = "Active Directory query failed.",
         string fallbackErrorCode = "query_failed",
         string invalidOperationErrorCode = "invalid_argument") {
-        if (exception is null) {
-            throw new ArgumentNullException(nameof(exception));
-        }
-
-        var safeDefault = string.IsNullOrWhiteSpace(defaultMessage)
-            ? "Active Directory query failed."
-            : defaultMessage.Trim();
-
-        return exception switch {
-            OperationCanceledException => Error("cancelled", "Operation was cancelled.", isTransient: true),
-            ArgumentException => Error("invalid_argument", SanitizeErrorMessage(exception.Message, safeDefault)),
-            InvalidOperationException => Error(
-                string.IsNullOrWhiteSpace(invalidOperationErrorCode) ? "invalid_argument" : invalidOperationErrorCode,
-                SanitizeErrorMessage(exception.Message, safeDefault)),
-            FormatException => Error("invalid_argument", SanitizeErrorMessage(exception.Message, safeDefault)),
-            UnauthorizedAccessException => Error("access_denied", SanitizeErrorMessage(exception.Message, "Access denied while querying Active Directory.")),
-            TimeoutException => Error("timeout", SanitizeErrorMessage(exception.Message, "Active Directory query timed out."), isTransient: true),
-            NotSupportedException => Error("not_supported", SanitizeErrorMessage(exception.Message, safeDefault)),
-            _ => Error(
-                string.IsNullOrWhiteSpace(fallbackErrorCode) ? "query_failed" : fallbackErrorCode,
-                safeDefault)
-        };
+        return ToolExceptionMapper.ErrorFromException(
+            exception,
+            defaultMessage: string.IsNullOrWhiteSpace(defaultMessage) ? "Active Directory query failed." : defaultMessage,
+            unauthorizedMessage: "Access denied while querying Active Directory.",
+            timeoutMessage: "Active Directory query timed out.",
+            fallbackErrorCode: fallbackErrorCode,
+            invalidOperationErrorCode: invalidOperationErrorCode);
     }
 
     /// <summary>
     /// Compacts and bounds an error message to keep tool envelopes stable/safe.
     /// </summary>
     protected static string SanitizeErrorMessage(string? message, string fallback) {
-        var safeFallback = string.IsNullOrWhiteSpace(fallback) ? "Operation failed." : fallback.Trim();
-        if (string.IsNullOrWhiteSpace(message)) {
-            return safeFallback;
-        }
-
-        var compact = message
-            .Replace('\r', ' ')
-            .Replace('\n', ' ')
-            .Replace('\t', ' ')
-            .Trim();
-
-        while (compact.Contains("  ", StringComparison.Ordinal)) {
-            compact = compact.Replace("  ", " ", StringComparison.Ordinal);
-        }
-
-        if (compact.Length == 0) {
-            return safeFallback;
-        }
-
-        return compact.Length <= MaxErrorMessageLength
-            ? compact
-            : compact.Substring(0, MaxErrorMessageLength).TrimEnd() + "...";
+        return ToolExceptionMapper.SanitizeErrorMessage(message, fallback);
     }
 
     /// <summary>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolExceptionMapper.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolExceptionMapper.cs
@@ -1,0 +1,77 @@
+using System;
+
+namespace IntelligenceX.Tools.Common;
+
+/// <summary>
+/// Maps runtime exceptions to stable tool error envelopes and sanitizes user-facing messages.
+/// </summary>
+public static class ToolExceptionMapper {
+    private const int MaxErrorMessageLength = 300;
+
+    /// <summary>
+    /// Maps common runtime exceptions to stable tool error envelopes.
+    /// </summary>
+    public static string ErrorFromException(
+        Exception exception,
+        string defaultMessage,
+        string unauthorizedMessage,
+        string timeoutMessage,
+        string fallbackErrorCode = "query_failed",
+        string invalidOperationErrorCode = "invalid_argument") {
+        if (exception is null) {
+            throw new ArgumentNullException(nameof(exception));
+        }
+
+        var safeDefault = string.IsNullOrWhiteSpace(defaultMessage)
+            ? "Operation failed."
+            : defaultMessage.Trim();
+
+        return exception switch {
+            OperationCanceledException => ToolResponse.Error("cancelled", "Operation was cancelled.", isTransient: true),
+            ArgumentException => ToolResponse.Error("invalid_argument", SanitizeErrorMessage(exception.Message, safeDefault)),
+            InvalidOperationException => ToolResponse.Error(
+                string.IsNullOrWhiteSpace(invalidOperationErrorCode) ? "invalid_argument" : invalidOperationErrorCode,
+                SanitizeErrorMessage(exception.Message, safeDefault)),
+            FormatException => ToolResponse.Error("invalid_argument", SanitizeErrorMessage(exception.Message, safeDefault)),
+            UnauthorizedAccessException => ToolResponse.Error(
+                "access_denied",
+                SanitizeErrorMessage(exception.Message, string.IsNullOrWhiteSpace(unauthorizedMessage) ? "Access denied." : unauthorizedMessage)),
+            TimeoutException => ToolResponse.Error(
+                "timeout",
+                SanitizeErrorMessage(exception.Message, string.IsNullOrWhiteSpace(timeoutMessage) ? "Operation timed out." : timeoutMessage),
+                isTransient: true),
+            NotSupportedException => ToolResponse.Error("not_supported", SanitizeErrorMessage(exception.Message, safeDefault)),
+            _ => ToolResponse.Error(
+                string.IsNullOrWhiteSpace(fallbackErrorCode) ? "query_failed" : fallbackErrorCode,
+                safeDefault)
+        };
+    }
+
+    /// <summary>
+    /// Compacts and bounds an error message to keep tool envelopes stable/safe.
+    /// </summary>
+    public static string SanitizeErrorMessage(string? message, string fallback) {
+        var safeFallback = string.IsNullOrWhiteSpace(fallback) ? "Operation failed." : fallback.Trim();
+        if (string.IsNullOrWhiteSpace(message)) {
+            return safeFallback;
+        }
+
+        var compact = message
+            .Replace('\r', ' ')
+            .Replace('\n', ' ')
+            .Replace('\t', ' ')
+            .Trim();
+
+        while (compact.Contains("  ", StringComparison.Ordinal)) {
+            compact = compact.Replace("  ", " ", StringComparison.Ordinal);
+        }
+
+        if (compact.Length == 0) {
+            return safeFallback;
+        }
+
+        return compact.Length <= MaxErrorMessageLength
+            ? compact
+            : compact.Substring(0, MaxErrorMessageLength).TrimEnd() + "...";
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemToolBase.cs
@@ -13,7 +13,6 @@ namespace IntelligenceX.Tools.System;
 /// Base class for system tools with shared option validation.
 /// </summary>
 public abstract class SystemToolBase : ToolBase {
-    private const int MaxErrorMessageLength = 300;
     private static readonly string[] AllowedPatchSeverities = {
         "Critical",
         "Important",
@@ -61,28 +60,13 @@ public abstract class SystemToolBase : ToolBase {
         string defaultMessage = "System query failed.",
         string fallbackErrorCode = "query_failed",
         string invalidOperationErrorCode = "invalid_argument") {
-        if (exception is null) {
-            throw new ArgumentNullException(nameof(exception));
-        }
-
-        var safeDefault = string.IsNullOrWhiteSpace(defaultMessage)
-            ? "System query failed."
-            : defaultMessage.Trim();
-
-        return exception switch {
-            OperationCanceledException => ToolResponse.Error("cancelled", "Operation was cancelled.", isTransient: true),
-            ArgumentException => ToolResponse.Error("invalid_argument", SanitizeErrorMessage(exception.Message, safeDefault)),
-            InvalidOperationException => ToolResponse.Error(
-                string.IsNullOrWhiteSpace(invalidOperationErrorCode) ? "invalid_argument" : invalidOperationErrorCode,
-                SanitizeErrorMessage(exception.Message, safeDefault)),
-            FormatException => ToolResponse.Error("invalid_argument", SanitizeErrorMessage(exception.Message, safeDefault)),
-            UnauthorizedAccessException => ToolResponse.Error("access_denied", SanitizeErrorMessage(exception.Message, "Access denied while querying system data.")),
-            TimeoutException => ToolResponse.Error("timeout", SanitizeErrorMessage(exception.Message, "System query timed out."), isTransient: true),
-            NotSupportedException => ToolResponse.Error("not_supported", SanitizeErrorMessage(exception.Message, safeDefault)),
-            _ => ToolResponse.Error(
-                string.IsNullOrWhiteSpace(fallbackErrorCode) ? "query_failed" : fallbackErrorCode,
-                safeDefault)
-        };
+        return ToolExceptionMapper.ErrorFromException(
+            exception,
+            defaultMessage: string.IsNullOrWhiteSpace(defaultMessage) ? "System query failed." : defaultMessage,
+            unauthorizedMessage: "Access denied while querying system data.",
+            timeoutMessage: "System query timed out.",
+            fallbackErrorCode: fallbackErrorCode,
+            invalidOperationErrorCode: invalidOperationErrorCode);
     }
 
     /// <summary>
@@ -348,30 +332,5 @@ public abstract class SystemToolBase : ToolBase {
         return string.IsNullOrWhiteSpace(computerName)
                || string.Equals(computerName, ".", StringComparison.Ordinal)
                || string.Equals(target, Environment.MachineName, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string SanitizeErrorMessage(string? message, string fallback) {
-        var safeFallback = string.IsNullOrWhiteSpace(fallback) ? "Operation failed." : fallback.Trim();
-        if (string.IsNullOrWhiteSpace(message)) {
-            return safeFallback;
-        }
-
-        var compact = message
-            .Replace('\r', ' ')
-            .Replace('\n', ' ')
-            .Replace('\t', ' ')
-            .Trim();
-
-        while (compact.Contains("  ", StringComparison.Ordinal)) {
-            compact = compact.Replace("  ", " ", StringComparison.Ordinal);
-        }
-
-        if (compact.Length == 0) {
-            return safeFallback;
-        }
-
-        return compact.Length <= MaxErrorMessageLength
-            ? compact
-            : compact.Substring(0, MaxErrorMessageLength).TrimEnd() + "...";
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolExceptionMapperTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolExceptionMapperTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Text.Json;
+using IntelligenceX.Tools.Common;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public class ToolExceptionMapperTests {
+    [Fact]
+    public void ErrorFromException_ShouldMapInvalidOperation_WithOverrideCode() {
+        var json = ToolExceptionMapper.ErrorFromException(
+            new InvalidOperationException("Bad input\r\nline2"),
+            defaultMessage: "Fallback.",
+            unauthorizedMessage: "Access denied.",
+            timeoutMessage: "Timed out.",
+            invalidOperationErrorCode: "query_failed");
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("query_failed", root.GetProperty("error_code").GetString());
+        Assert.Equal("Bad input line2", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void ErrorFromException_ShouldMapTimeout_AsTransient() {
+        var json = ToolExceptionMapper.ErrorFromException(
+            new TimeoutException("timed out"),
+            defaultMessage: "Fallback.",
+            unauthorizedMessage: "Access denied.",
+            timeoutMessage: "Timed out.");
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("timeout", root.GetProperty("error_code").GetString());
+        Assert.True(root.GetProperty("is_transient").GetBoolean());
+    }
+
+    [Fact]
+    public void ErrorFromException_ShouldHideUnhandledExceptionDetails() {
+        var json = ToolExceptionMapper.ErrorFromException(
+            new Exception("secret-token=abc123"),
+            defaultMessage: "Patch details query failed.",
+            unauthorizedMessage: "Access denied.",
+            timeoutMessage: "Timed out.");
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("query_failed", root.GetProperty("error_code").GetString());
+        Assert.Equal("Patch details query failed.", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void SanitizeErrorMessage_ShouldCompactWhitespace_AndFallbackWhenEmpty() {
+        var compact = ToolExceptionMapper.SanitizeErrorMessage("server:\r\nline2\tfailure", "fallback");
+        Assert.Equal("server: line2 failure", compact);
+
+        var fallback = ToolExceptionMapper.SanitizeErrorMessage("   ", "fallback");
+        Assert.Equal("fallback", fallback);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ToolExceptionMapper` in `IntelligenceX.Tools.Common` to centralize exception-to-error-envelope mapping and message sanitization
- refactor AD and System base tools to delegate to the shared mapper while preserving existing method signatures
- add unit tests for the shared mapper behavior

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo`
