### PR TITLE
feat(todo): add issue reviewer for stale infra blockers

### DIFF
--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -15,6 +15,7 @@ These commands are assistive. They are not an autonomous production decision sys
 - Bot-review checklist sync into `TODO.md` (`sync-bot-feedback`).
 - Backlog indexing and duplicate clustering across open PRs/issues (`build-triage-index`).
 - Scope alignment checks against `VISION.md` (`vision-check`).
+- Issue applicability review for stale/no-longer-applicable infra blockers (`issue-review`).
 - GitHub Project field sync for triage at scale (`project-init`, `project-sync`, `project-bootstrap`).
 - Maintainer-assist view checklist and apply plan generation (`project-view-checklist`, `project-view-apply`).
 - Signal quality grading (`high`/`medium`/`low`) to separate strong recommendations from weak-context items.
@@ -24,10 +25,11 @@ These commands are assistive. They are not an autonomous production decision sys
 
 1. Pull explicit bot checklist items into `TODO.md`.
 2. Build triage index artifacts.
-3. Run vision alignment check.
-4. Bootstrap or initialize GitHub Project.
-5. Sync triage + vision into project fields.
-6. Generate project view checklist and apply plan for maintainers.
+3. Run issue applicability review.
+4. Run vision alignment check.
+5. Bootstrap or initialize GitHub Project.
+6. Sync triage + vision into project fields.
+7. Generate project view checklist and apply plan for maintainers.
 
 ## End-to-end example
 
@@ -38,16 +40,19 @@ intelligencex todo sync-bot-feedback --repo EvotecIT/IntelligenceX
 # 2) Build triage index artifacts
 intelligencex todo build-triage-index --repo EvotecIT/IntelligenceX
 
-# 3) Check backlog against VISION.md
+# 3) Review infra blocker issue applicability (dry-run)
+intelligencex todo issue-review --repo EvotecIT/IntelligenceX
+
+# 4) Check backlog against VISION.md
 intelligencex todo vision-check --repo EvotecIT/IntelligenceX --vision VISION.md
 
-# 4) Bootstrap project + workflow + vision scaffold
+# 5) Bootstrap project + workflow + vision scaffold
 intelligencex todo project-bootstrap --repo EvotecIT/IntelligenceX --owner EvotecIT
 
-# 5) Sync triage + vision into project fields
+# 6) Sync triage + vision into project fields
 intelligencex todo project-sync --config artifacts/triage/ix-project-config.json --max-items 500
 
-# 6) Generate a maintainer view checklist
+# 7) Generate a maintainer view checklist
 intelligencex todo project-view-checklist --config artifacts/triage/ix-project-config.json --create-issue
 ```
 
@@ -57,6 +62,7 @@ intelligencex todo project-view-checklist --config artifacts/triage/ix-project-c
 | --- | --- | --- |
 | `sync-bot-feedback` | Extract explicit bot checklist tasks and keep them tracked in `TODO.md` | Updated `TODO.md` (optional GitHub issues) |
 | `build-triage-index` | Build PR/issue inventory, duplicate clusters, and best PR ranking | `artifacts/triage/ix-triage-index.json`, `.md` |
+| `issue-review` | Detect stale/no-longer-applicable infra blocker issues and optionally auto-close | `artifacts/triage/ix-issue-review.json`, `.md` |
 | `vision-check` | Compare backlog against `VISION.md` scope | `artifacts/triage/ix-vision-check.json`, `.md` |
 | `project-init` | Create/initialize GitHub Project fields + metadata | `artifacts/triage/ix-project-config.json` |
 | `project-sync` | Push triage/vision signals to project items and optional labels/comments | Project field updates, optional comment/label updates |

--- a/IntelligenceX.Cli/Program.Help.cs
+++ b/IntelligenceX.Cli/Program.Help.cs
@@ -66,6 +66,7 @@ internal static partial class Program {
         Console.WriteLine("  todo sync-bot-feedback   Sync bot checklist items into TODO.md (optional issue creation)");
         Console.WriteLine("  todo build-triage-index  Build PR/Issue triage index with duplicate clusters and best PR ranking");
         Console.WriteLine("  todo backtest-pr-signals Backtest PR operational signal calibration on closed/merged historical PRs");
+        Console.WriteLine("  todo issue-review        Review open issues for no-longer-applicable infra blockers and optional auto-close");
         Console.WriteLine("  todo vision-check        Compare PR backlog against VISION.md and flag likely out-of-scope work");
         Console.WriteLine("  todo project-init        Create or initialize a GitHub Project with IX triage/vision fields");
         Console.WriteLine("  todo project-sync        Sync triage/vision artifacts into GitHub Project items and fields");

--- a/IntelligenceX.Cli/Todo/IssueReviewRunner.cs
+++ b/IntelligenceX.Cli/Todo/IssueReviewRunner.cs
@@ -1,0 +1,825 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using IntelligenceX.Cli.GitHub;
+
+namespace IntelligenceX.Cli.Todo;
+
+internal static class IssueReviewRunner {
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+    private static readonly Regex PullRequestUrlRef = new(
+        @"(?i)\bhttps?://github\.com/(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)/pull/(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly Regex PullRequestRef = new(
+        @"(?i)\b(?:pr|pull\s*request|pull)\s*#(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly Regex RepoPullRequestRef = new(
+        @"(?i)\b(?:pr|pull\s*request|pull)\s+(?<owner>[A-Za-z0-9_.-]+)/(?<repo>[A-Za-z0-9_.-]+)#(?<num>\d+)\b",
+        RegexOptions.Compiled
+    );
+    private static readonly HashSet<string> ProtectedLabels = new(StringComparer.OrdinalIgnoreCase) {
+        "do-not-close",
+        "keep-open",
+        "pinned",
+        "ix/decision:accept"
+    };
+    private static readonly string[] InfraKeywords = {
+        "infra blocker",
+        "infrastructure blocker",
+        "ci blocker",
+        "build blocker",
+        "runner blocker"
+    };
+
+    internal const string ManagedCommentMarker = "<!-- intelligencex:issue-review -->";
+    private const string DefaultRepo = "EvotecIT/IntelligenceX";
+
+    internal sealed record IssueReviewCandidateIssue(
+        int Number,
+        string Title,
+        string Body,
+        string Url,
+        DateTimeOffset UpdatedAtUtc,
+        IReadOnlyList<string> Labels
+    );
+
+    internal sealed record PullRequestReference(
+        int Number,
+        string Title,
+        string Url,
+        string State,
+        DateTimeOffset? MergedAtUtc,
+        DateTimeOffset? ClosedAtUtc
+    );
+
+    internal sealed record IssueReviewAssessment(
+        int Number,
+        string Title,
+        string Url,
+        bool IsInfraBlocker,
+        string Classification,
+        bool EligibleForAutoClose,
+        double AgeDays,
+        IReadOnlyList<int> LinkedPullRequests,
+        IReadOnlyList<string> LinkedPullRequestStates,
+        string Reason,
+        IReadOnlyList<string> Labels
+    );
+
+    private sealed class Options {
+        public string Repo { get; set; } = DefaultRepo;
+        public int MaxIssues { get; set; } = 300;
+        public int StaleDays { get; set; } = 14;
+        public bool ApplyClose { get; set; }
+        public string CloseReason { get; set; } = "completed";
+        public bool CommentOnClose { get; set; } = true;
+        public string OutputPath { get; set; } = Path.Combine("artifacts", "triage", "ix-issue-review.json");
+        public string SummaryPath { get; set; } = Path.Combine("artifacts", "triage", "ix-issue-review.md");
+        public bool ShowHelp { get; set; }
+        public bool ParseFailed { get; set; }
+    }
+
+    private static Options ParseOptions(string[] args) {
+        var options = new Options();
+        for (var i = 0; i < args.Length; i++) {
+            var arg = args[i];
+            switch (arg) {
+                case "-h":
+                case "--help":
+                    options.ShowHelp = true;
+                    break;
+                case "--repo":
+                    if (i + 1 < args.Length) {
+                        options.Repo = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--max-issues":
+                    if (i + 1 < args.Length &&
+                        int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var maxIssues)) {
+                        options.MaxIssues = Math.Max(1, Math.Min(maxIssues, 2000));
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--stale-days":
+                    if (i + 1 < args.Length &&
+                        int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var staleDays)) {
+                        options.StaleDays = Math.Max(1, Math.Min(staleDays, 365));
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--apply-close":
+                    options.ApplyClose = true;
+                    break;
+                case "--close-reason":
+                    if (i + 1 < args.Length) {
+                        var reason = NormalizeCloseReason(args[++i]);
+                        if (reason is null) {
+                            options.ParseFailed = true;
+                            options.ShowHelp = true;
+                        } else {
+                            options.CloseReason = reason;
+                        }
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--no-comment":
+                    options.CommentOnClose = false;
+                    break;
+                case "--out":
+                    if (i + 1 < args.Length) {
+                        options.OutputPath = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--summary":
+                    if (i + 1 < args.Length) {
+                        options.SummaryPath = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                default:
+                    Console.Error.WriteLine($"Unknown option: {arg}");
+                    options.ParseFailed = true;
+                    options.ShowHelp = true;
+                    break;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Repo) || !options.Repo.Contains('/', StringComparison.Ordinal)) {
+            options.ParseFailed = true;
+            options.ShowHelp = true;
+        }
+
+        return options;
+    }
+
+    private static string? NormalizeCloseReason(string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        return value.Trim().ToLowerInvariant() switch {
+            "completed" => "completed",
+            "not-planned" => "not_planned",
+            "not_planned" => "not_planned",
+            _ => null
+        };
+    }
+
+    private static void PrintHelp() {
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  intelligencex todo issue-review [options]");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --repo <owner/name>         Repository to scan (default: EvotecIT/IntelligenceX)");
+        Console.WriteLine("  --max-issues <n>            Open issues to scan (1-2000, default: 300)");
+        Console.WriteLine("  --stale-days <n>            Age threshold for stale infra issues without PR links (default: 14)");
+        Console.WriteLine("  --apply-close               Close no-longer-applicable issues (default: dry-run)");
+        Console.WriteLine("  --close-reason <completed|not-planned>  Reason used when closing issues (default: completed)");
+        Console.WriteLine("  --no-comment                Do not post a managed IX close note");
+        Console.WriteLine("  --out <path>                JSON output path (default: artifacts/triage/ix-issue-review.json)");
+        Console.WriteLine("  --summary <path>            Markdown summary path (default: artifacts/triage/ix-issue-review.md)");
+    }
+
+    public static async Task<int> RunAsync(string[] args) {
+        var options = ParseOptions(args);
+        if (options.ShowHelp) {
+            PrintHelp();
+            return options.ParseFailed ? 1 : 0;
+        }
+
+        var (authCode, _, authErr) = await GhCli.RunAsync("auth", "status").ConfigureAwait(false);
+        if (authCode != 0) {
+            Console.Error.WriteLine("gh is not authenticated. Run `gh auth login`.");
+            if (!string.IsNullOrWhiteSpace(authErr)) {
+                Console.Error.WriteLine(authErr.Trim());
+            }
+            return 1;
+        }
+
+        List<IssueReviewCandidateIssue> issues;
+        try {
+            issues = await FetchOpenIssuesAsync(options.Repo, options.MaxIssues).ConfigureAwait(false);
+        } catch (Exception ex) {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+
+        var pullRequestNumbers = new HashSet<int>();
+        foreach (var issue in issues) {
+            if (!IsInfraBlocker(issue)) {
+                continue;
+            }
+
+            var refs = ExtractPullRequestReferences(options.Repo, $"{issue.Title}\n{issue.Body}");
+            foreach (var value in refs) {
+                pullRequestNumbers.Add(value);
+            }
+        }
+
+        var pullRequestsByNumber = new Dictionary<int, PullRequestReference>();
+        foreach (var number in pullRequestNumbers.OrderBy(value => value)) {
+            var reference = await TryFetchPullRequestReferenceAsync(options.Repo, number).ConfigureAwait(false);
+            if (reference is not null) {
+                pullRequestsByNumber[number] = reference;
+            }
+        }
+
+        var nowUtc = DateTimeOffset.UtcNow;
+        var assessments = issues
+            .Select(issue => AssessIssueForApplicability(issue, options.Repo, pullRequestsByNumber, nowUtc, options.StaleDays))
+            .OrderBy(value => ClassificationRank(value.Classification))
+            .ThenByDescending(value => value.AgeDays)
+            .ThenBy(value => value.Number)
+            .ToList();
+
+        var autoCloseCandidates = assessments
+            .Where(value => value.EligibleForAutoClose)
+            .ToList();
+
+        var closedIssueNumbers = new List<int>();
+        if (options.ApplyClose) {
+            foreach (var assessment in autoCloseCandidates) {
+                var closeSuccess = await TryCloseIssueAsync(options.Repo, assessment.Number, options.CloseReason).ConfigureAwait(false);
+                if (!closeSuccess) {
+                    continue;
+                }
+
+                closedIssueNumbers.Add(assessment.Number);
+                if (options.CommentOnClose) {
+                    await TryCommentOnClosedIssueAsync(options.Repo, assessment, options.CloseReason).ConfigureAwait(false);
+                }
+            }
+        }
+
+        var report = BuildReport(options, nowUtc, assessments, closedIssueNumbers);
+        var summary = BuildMarkdownSummary(options, nowUtc, assessments, closedIssueNumbers);
+        WriteText(options.OutputPath, JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
+        WriteText(options.SummaryPath, summary);
+
+        Console.WriteLine($"Generated issue review report: {options.OutputPath}");
+        Console.WriteLine($"Generated issue review summary: {options.SummaryPath}");
+        Console.WriteLine($"Open issues scanned: {assessments.Count}");
+        Console.WriteLine($"Infra blockers detected: {assessments.Count(value => value.IsInfraBlocker)}");
+        Console.WriteLine($"No-longer-applicable candidates: {autoCloseCandidates.Count}");
+        Console.WriteLine(options.ApplyClose
+            ? $"Closed by automation: {closedIssueNumbers.Count}"
+            : "Dry-run mode: no issues were closed (use --apply-close to close candidates).");
+        return 0;
+    }
+
+    private static async Task<List<IssueReviewCandidateIssue>> FetchOpenIssuesAsync(string repo, int maxIssues) {
+        var (code, stdout, stderr) = await GhCli.RunAsync(
+            TimeSpan.FromSeconds(90),
+            "issue", "list",
+            "--repo", repo,
+            "--state", "open",
+            "--limit", maxIssues.ToString(CultureInfo.InvariantCulture),
+            "--json", "number,title,body,url,updatedAt,labels").ConfigureAwait(false);
+        if (code != 0) {
+            throw new InvalidOperationException(
+                string.IsNullOrWhiteSpace(stderr)
+                    ? "Failed to query open issues with gh issue list."
+                    : stderr.Trim());
+        }
+
+        using var doc = JsonDocument.Parse(stdout);
+        var values = new List<IssueReviewCandidateIssue>();
+        if (doc.RootElement.ValueKind != JsonValueKind.Array) {
+            return values;
+        }
+
+        foreach (var issue in doc.RootElement.EnumerateArray()) {
+            var number = ReadInt(issue, "number");
+            if (number <= 0) {
+                continue;
+            }
+            var title = ReadString(issue, "title");
+            var body = ReadString(issue, "body");
+            var url = ReadString(issue, "url");
+            var updatedAt = ReadDate(issue, "updatedAt");
+            var labels = ReadLabels(issue);
+            values.Add(new IssueReviewCandidateIssue(number, title, body, url, updatedAt, labels));
+        }
+        return values;
+    }
+
+    private static async Task<PullRequestReference?> TryFetchPullRequestReferenceAsync(string repo, int number) {
+        var (code, stdout, stderr) = await GhCli.RunAsync(
+            TimeSpan.FromSeconds(60),
+            "pr", "view",
+            number.ToString(CultureInfo.InvariantCulture),
+            "--repo", repo,
+            "--json", "number,title,url,state,mergedAt,closedAt").ConfigureAwait(false);
+        if (code != 0) {
+            if (!string.IsNullOrWhiteSpace(stderr) &&
+                stderr.IndexOf("Not Found", StringComparison.OrdinalIgnoreCase) >= 0) {
+                return null;
+            }
+            Console.Error.WriteLine(
+                $"Warning: failed to fetch PR #{number} for {repo}: {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
+            return null;
+        }
+
+        using var doc = JsonDocument.Parse(stdout);
+        var root = doc.RootElement;
+        var parsedNumber = ReadInt(root, "number");
+        if (parsedNumber <= 0) {
+            return null;
+        }
+
+        var title = ReadString(root, "title");
+        var url = ReadString(root, "url");
+        var state = ReadString(root, "state");
+        var mergedAt = ReadNullableDate(root, "mergedAt");
+        var closedAt = ReadNullableDate(root, "closedAt");
+        return new PullRequestReference(parsedNumber, title, url, state, mergedAt, closedAt);
+    }
+
+    internal static IReadOnlyList<int> ExtractPullRequestReferences(string repo, string text) {
+        if (string.IsNullOrWhiteSpace(text)) {
+            return Array.Empty<int>();
+        }
+
+        var numbers = new HashSet<int>();
+        var (owner, name) = SplitRepo(repo);
+        foreach (Match match in PullRequestRef.Matches(text)) {
+            if (TryExtractNumber(match, "num", out var value)) {
+                numbers.Add(value);
+            }
+        }
+
+        foreach (Match match in RepoPullRequestRef.Matches(text)) {
+            var refOwner = match.Groups["owner"].Value;
+            var refName = match.Groups["repo"].Value;
+            if (!refOwner.Equals(owner, StringComparison.OrdinalIgnoreCase) ||
+                !refName.Equals(name, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (TryExtractNumber(match, "num", out var value)) {
+                numbers.Add(value);
+            }
+        }
+
+        foreach (Match match in PullRequestUrlRef.Matches(text)) {
+            var refOwner = match.Groups["owner"].Value;
+            var refName = match.Groups["repo"].Value;
+            if (!refOwner.Equals(owner, StringComparison.OrdinalIgnoreCase) ||
+                !refName.Equals(name, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (TryExtractNumber(match, "num", out var value)) {
+                numbers.Add(value);
+            }
+        }
+
+        return numbers
+            .OrderBy(value => value)
+            .ToList();
+    }
+
+    internal static IssueReviewAssessment AssessIssueForApplicability(
+        IssueReviewCandidateIssue issue,
+        string repo,
+        IReadOnlyDictionary<int, PullRequestReference> pullRequestsByNumber,
+        DateTimeOffset nowUtc,
+        int staleDays) {
+        var linkedPullRequests = ExtractPullRequestReferences(repo, $"{issue.Title}\n{issue.Body}");
+        var linkedStates = new List<string>();
+        foreach (var number in linkedPullRequests) {
+            if (pullRequestsByNumber.TryGetValue(number, out var pullRequest)) {
+                var state = NormalizePullRequestState(pullRequest);
+                linkedStates.Add($"#{number}:{state}");
+            } else {
+                linkedStates.Add($"#{number}:unknown");
+            }
+        }
+
+        var ageDays = Math.Round(Math.Max(0, (nowUtc - issue.UpdatedAtUtc).TotalDays), 1, MidpointRounding.AwayFromZero);
+        var isInfra = IsInfraBlocker(issue);
+
+        if (!isInfra) {
+            return new IssueReviewAssessment(
+                issue.Number,
+                issue.Title,
+                issue.Url,
+                false,
+                "out-of-scope",
+                false,
+                ageDays,
+                linkedPullRequests,
+                linkedStates,
+                "Issue is not classified as infra blocker.",
+                issue.Labels);
+        }
+
+        if (issue.Labels.Any(label => ProtectedLabels.Contains(label))) {
+            return new IssueReviewAssessment(
+                issue.Number,
+                issue.Title,
+                issue.Url,
+                true,
+                "needs-review",
+                false,
+                ageDays,
+                linkedPullRequests,
+                linkedStates,
+                "Protected label present (keep-open/do-not-close); leaving for maintainer review.",
+                issue.Labels);
+        }
+
+        if (linkedPullRequests.Count == 0) {
+            if (ageDays >= staleDays) {
+                return new IssueReviewAssessment(
+                    issue.Number,
+                    issue.Title,
+                    issue.Url,
+                    true,
+                    "needs-review",
+                    false,
+                    ageDays,
+                    linkedPullRequests,
+                    linkedStates,
+                    $"Infra blocker is stale ({ageDays.ToString("0.0", CultureInfo.InvariantCulture)}d) with no linked PR reference.",
+                    issue.Labels);
+            }
+
+            return new IssueReviewAssessment(
+                issue.Number,
+                issue.Title,
+                issue.Url,
+                true,
+                "active",
+                false,
+                ageDays,
+                linkedPullRequests,
+                linkedStates,
+                "Infra blocker has no linked PR reference yet.",
+                issue.Labels);
+        }
+
+        var missingReferences = linkedPullRequests
+            .Where(number => !pullRequestsByNumber.ContainsKey(number))
+            .ToList();
+        if (missingReferences.Count > 0) {
+            return new IssueReviewAssessment(
+                issue.Number,
+                issue.Title,
+                issue.Url,
+                true,
+                "needs-review",
+                false,
+                ageDays,
+                linkedPullRequests,
+                linkedStates,
+                $"Linked PR references could not be resolved: {string.Join(", ", missingReferences.Select(value => $"#{value}"))}.",
+                issue.Labels);
+        }
+
+        var linkedReferences = linkedPullRequests
+            .Select(number => pullRequestsByNumber[number])
+            .ToList();
+        var hasOpenPr = linkedReferences.Any(reference =>
+            NormalizePullRequestState(reference).Equals("open", StringComparison.OrdinalIgnoreCase));
+        if (hasOpenPr) {
+            return new IssueReviewAssessment(
+                issue.Number,
+                issue.Title,
+                issue.Url,
+                true,
+                "active",
+                false,
+                ageDays,
+                linkedPullRequests,
+                linkedStates,
+                "At least one linked PR is still open.",
+                issue.Labels);
+        }
+
+        var allResolved = linkedReferences.All(reference => {
+            var state = NormalizePullRequestState(reference);
+            return state is "merged" or "closed";
+        });
+        if (allResolved) {
+            return new IssueReviewAssessment(
+                issue.Number,
+                issue.Title,
+                issue.Url,
+                true,
+                "no-longer-applicable",
+                true,
+                ageDays,
+                linkedPullRequests,
+                linkedStates,
+                "All linked PRs are resolved (merged/closed).",
+                issue.Labels);
+        }
+
+        return new IssueReviewAssessment(
+            issue.Number,
+            issue.Title,
+            issue.Url,
+            true,
+            "needs-review",
+            false,
+            ageDays,
+            linkedPullRequests,
+            linkedStates,
+            "Linked PR states are inconclusive.",
+            issue.Labels);
+    }
+
+    private static async Task<bool> TryCloseIssueAsync(string repo, int issueNumber, string closeReason) {
+        var (code, _, err) = await GhCli.RunAsync(
+            TimeSpan.FromSeconds(45),
+            "api",
+            "--method", "PATCH",
+            $"repos/{repo}/issues/{issueNumber.ToString(CultureInfo.InvariantCulture)}",
+            "-f", "state=closed",
+            "-f", $"state_reason={closeReason}").ConfigureAwait(false);
+        if (code == 0) {
+            return true;
+        }
+
+        Console.Error.WriteLine(
+            $"Warning: failed to close issue #{issueNumber} ({repo}): {(string.IsNullOrWhiteSpace(err) ? "unknown error" : err.Trim())}");
+        return false;
+    }
+
+    private static async Task TryCommentOnClosedIssueAsync(string repo, IssueReviewAssessment assessment, string closeReason) {
+        var body = new StringBuilder();
+        body.AppendLine(ManagedCommentMarker);
+        body.AppendLine("Closed by IntelligenceX issue-review automation.");
+        body.AppendLine();
+        body.AppendLine($"- Classification: `{assessment.Classification}`");
+        body.AppendLine($"- Reason: {assessment.Reason}");
+        body.AppendLine($"- Close reason: `{closeReason}`");
+        if (assessment.LinkedPullRequestStates.Count > 0) {
+            body.AppendLine($"- Linked PR states: {string.Join(", ", assessment.LinkedPullRequestStates)}");
+        }
+
+        var (code, _, err) = await GhCli.RunAsync(
+            TimeSpan.FromSeconds(45),
+            "api",
+            "--method", "POST",
+            $"repos/{repo}/issues/{assessment.Number.ToString(CultureInfo.InvariantCulture)}/comments",
+            "-f", $"body={body.ToString().TrimEnd()}").ConfigureAwait(false);
+        if (code != 0) {
+            Console.Error.WriteLine(
+                $"Warning: failed to add managed close note to issue #{assessment.Number}: {(string.IsNullOrWhiteSpace(err) ? "unknown error" : err.Trim())}");
+        }
+    }
+
+    private static object BuildReport(
+        Options options,
+        DateTimeOffset generatedAtUtc,
+        IReadOnlyList<IssueReviewAssessment> assessments,
+        IReadOnlyList<int> closedIssueNumbers) {
+        var infra = assessments.Where(value => value.IsInfraBlocker).ToList();
+        return new {
+            schema = "intelligencex.issue-review.v1",
+            generatedAtUtc = generatedAtUtc.UtcDateTime.ToString("o", CultureInfo.InvariantCulture),
+            repo = options.Repo,
+            settings = new {
+                maxIssues = options.MaxIssues,
+                staleDays = options.StaleDays,
+                applyClose = options.ApplyClose,
+                closeReason = options.CloseReason
+            },
+            summary = new {
+                openIssuesScanned = assessments.Count,
+                infraBlockers = infra.Count,
+                noLongerApplicable = infra.Count(value => value.Classification.Equals("no-longer-applicable", StringComparison.OrdinalIgnoreCase)),
+                needsReview = infra.Count(value => value.Classification.Equals("needs-review", StringComparison.OrdinalIgnoreCase)),
+                active = infra.Count(value => value.Classification.Equals("active", StringComparison.OrdinalIgnoreCase)),
+                closedByAutomation = closedIssueNumbers.Count
+            },
+            closedIssueNumbers = closedIssueNumbers,
+            items = assessments.Select(value => new {
+                number = value.Number,
+                title = value.Title,
+                url = value.Url,
+                isInfraBlocker = value.IsInfraBlocker,
+                classification = value.Classification,
+                eligibleForAutoClose = value.EligibleForAutoClose,
+                ageDays = value.AgeDays,
+                linkedPullRequests = value.LinkedPullRequests,
+                linkedPullRequestStates = value.LinkedPullRequestStates,
+                labels = value.Labels,
+                reason = value.Reason
+            }).ToList()
+        };
+    }
+
+    private static string BuildMarkdownSummary(
+        Options options,
+        DateTimeOffset generatedAtUtc,
+        IReadOnlyList<IssueReviewAssessment> assessments,
+        IReadOnlyList<int> closedIssueNumbers) {
+        var infra = assessments.Where(value => value.IsInfraBlocker).ToList();
+        var noLongerApplicable = infra
+            .Where(value => value.Classification.Equals("no-longer-applicable", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var needsReview = infra
+            .Where(value => value.Classification.Equals("needs-review", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var active = infra
+            .Where(value => value.Classification.Equals("active", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var builder = new StringBuilder();
+        builder.AppendLine("# Issue Review");
+        builder.AppendLine();
+        builder.AppendLine($"- Generated: {generatedAtUtc.UtcDateTime:yyyy-MM-dd HH:mm:ss} UTC");
+        builder.AppendLine($"- Repo: `{options.Repo}`");
+        builder.AppendLine($"- Open issues scanned: {assessments.Count}");
+        builder.AppendLine($"- Infra blockers detected: {infra.Count}");
+        builder.AppendLine($"- No-longer-applicable: {noLongerApplicable.Count}");
+        builder.AppendLine($"- Needs review: {needsReview.Count}");
+        builder.AppendLine($"- Active infra blockers: {active.Count}");
+        builder.AppendLine(options.ApplyClose
+            ? $"- Closed by automation: {closedIssueNumbers.Count}"
+            : "- Dry-run mode: no issues were closed.");
+        builder.AppendLine();
+        AppendSection(builder, "No-Longer-Applicable Candidates", noLongerApplicable);
+        AppendSection(builder, "Needs Review", needsReview);
+        AppendSection(builder, "Active Infra Blockers", active);
+        return builder.ToString().TrimEnd() + Environment.NewLine;
+    }
+
+    private static void AppendSection(StringBuilder builder, string title, IReadOnlyList<IssueReviewAssessment> items) {
+        builder.AppendLine($"## {title}");
+        builder.AppendLine();
+        if (items.Count == 0) {
+            builder.AppendLine("None.");
+            builder.AppendLine();
+            return;
+        }
+
+        foreach (var item in items) {
+            var linked = item.LinkedPullRequestStates.Count == 0
+                ? "none"
+                : string.Join(", ", item.LinkedPullRequestStates);
+            builder.AppendLine(
+                $"- #{item.Number} [{item.Title}]({item.Url}) | age {item.AgeDays.ToString("0.0", CultureInfo.InvariantCulture)}d | linked PRs: {linked} | {item.Reason}");
+        }
+        builder.AppendLine();
+    }
+
+    private static int ClassificationRank(string classification) {
+        return classification.ToLowerInvariant() switch {
+            "no-longer-applicable" => 0,
+            "needs-review" => 1,
+            "active" => 2,
+            _ => 3
+        };
+    }
+
+    private static bool IsInfraBlocker(IssueReviewCandidateIssue issue) {
+        foreach (var label in issue.Labels) {
+            if (label.Equals("infra", StringComparison.OrdinalIgnoreCase) ||
+                label.Equals("infra-blocker", StringComparison.OrdinalIgnoreCase) ||
+                label.Equals("infrastructure", StringComparison.OrdinalIgnoreCase) ||
+                label.Equals("blocker", StringComparison.OrdinalIgnoreCase) ||
+                label.Equals("ci", StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        var text = $"{issue.Title}\n{issue.Body}";
+        foreach (var keyword in InfraKeywords) {
+            if (text.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) >= 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string NormalizePullRequestState(PullRequestReference reference) {
+        if (reference.MergedAtUtc.HasValue) {
+            return "merged";
+        }
+
+        return reference.State.Trim().ToUpperInvariant() switch {
+            "OPEN" => "open",
+            "CLOSED" => "closed",
+            "MERGED" => "merged",
+            _ => "unknown"
+        };
+    }
+
+    private static bool TryExtractNumber(Match match, string groupName, out int value) {
+        value = 0;
+        var raw = match.Groups[groupName].Value;
+        return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value) && value > 0;
+    }
+
+    private static (string Owner, string Name) SplitRepo(string repo) {
+        var parts = repo.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 2) {
+            throw new InvalidOperationException($"Invalid repo value: '{repo}'. Expected owner/name.");
+        }
+        return (parts[0], parts[1]);
+    }
+
+    private static int ReadInt(JsonElement element, string name) {
+        if (!element.TryGetProperty(name, out var value)) {
+            return 0;
+        }
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var number)) {
+            return number;
+        }
+        return value.ValueKind == JsonValueKind.String &&
+               int.TryParse(value.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : 0;
+    }
+
+    private static string ReadString(JsonElement element, string name) {
+        return element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? string.Empty
+            : string.Empty;
+    }
+
+    private static DateTimeOffset ReadDate(JsonElement element, string name) {
+        if (!element.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.String) {
+            return DateTimeOffset.UtcNow;
+        }
+        return DateTimeOffset.TryParse(value.GetString(), CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed)
+            ? parsed
+            : DateTimeOffset.UtcNow;
+    }
+
+    private static DateTimeOffset? ReadNullableDate(JsonElement element, string name) {
+        if (!element.TryGetProperty(name, out var value) || value.ValueKind == JsonValueKind.Null) {
+            return null;
+        }
+        if (value.ValueKind != JsonValueKind.String) {
+            return null;
+        }
+        return DateTimeOffset.TryParse(value.GetString(), CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static IReadOnlyList<string> ReadLabels(JsonElement issue) {
+        if (!issue.TryGetProperty("labels", out var labelsElement) || labelsElement.ValueKind != JsonValueKind.Array) {
+            return Array.Empty<string>();
+        }
+
+        var labels = new List<string>();
+        foreach (var label in labelsElement.EnumerateArray()) {
+            if (label.ValueKind == JsonValueKind.Object &&
+                label.TryGetProperty("name", out var nameProp) &&
+                nameProp.ValueKind == JsonValueKind.String) {
+                var value = nameProp.GetString();
+                if (!string.IsNullOrWhiteSpace(value)) {
+                    labels.Add(value.Trim());
+                }
+                continue;
+            }
+
+            if (label.ValueKind == JsonValueKind.String) {
+                var value = label.GetString();
+                if (!string.IsNullOrWhiteSpace(value)) {
+                    labels.Add(value.Trim());
+                }
+            }
+        }
+
+        return labels;
+    }
+
+    private static void WriteText(string path, string content) {
+        var fullPath = Path.GetFullPath(path);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrWhiteSpace(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+        File.WriteAllText(fullPath, content, Utf8NoBom);
+    }
+}

--- a/IntelligenceX.Cli/Todo/TodoRunner.cs
+++ b/IntelligenceX.Cli/Todo/TodoRunner.cs
@@ -18,6 +18,8 @@ internal static class TodoRunner {
             "triage-index" => TriageIndexRunner.RunAsync(rest),
             "backtest-pr-signals" => PullRequestSignalBacktestRunner.RunAsync(rest),
             "pr-signal-backtest" => PullRequestSignalBacktestRunner.RunAsync(rest),
+            "issue-review" => IssueReviewRunner.RunAsync(rest),
+            "review-issues" => IssueReviewRunner.RunAsync(rest),
             "vision-check" => VisionCheckRunner.RunAsync(rest),
             "project-init" => ProjectInitRunner.RunAsync(rest),
             "project-sync" => ProjectSyncRunner.RunAsync(rest),
@@ -47,6 +49,7 @@ internal static class TodoRunner {
         Console.WriteLine("  intelligencex todo sync-bot-feedback [options]");
         Console.WriteLine("  intelligencex todo build-triage-index [options]");
         Console.WriteLine("  intelligencex todo backtest-pr-signals [options]");
+        Console.WriteLine("  intelligencex todo issue-review [options]");
         Console.WriteLine("  intelligencex todo vision-check [options]");
         Console.WriteLine("  intelligencex todo project-init [options]");
         Console.WriteLine("  intelligencex todo project-sync [options]");
@@ -57,6 +60,7 @@ internal static class TodoRunner {
         Console.WriteLine("Use `intelligencex todo sync-bot-feedback --help` for options.");
         Console.WriteLine("Use `intelligencex todo build-triage-index --help` for options.");
         Console.WriteLine("Use `intelligencex todo backtest-pr-signals --help` for options.");
+        Console.WriteLine("Use `intelligencex todo issue-review --help` for options.");
         Console.WriteLine("Use `intelligencex todo vision-check --help` for options.");
         Console.WriteLine("Use `intelligencex todo project-init --help` for options.");
         Console.WriteLine("Use `intelligencex todo project-sync --help` for options.");

--- a/IntelligenceX.Tests/Program.Todo.IssueReview.cs
+++ b/IntelligenceX.Tests/Program.Todo.IssueReview.cs
@@ -1,0 +1,47 @@
+namespace IntelligenceX.Tests;
+
+internal static partial class Program {
+#if !NET472
+    private static void TestIssueReviewExtractPullRequestReferencesParsesMultipleForms() {
+        var refs = IntelligenceX.Cli.Todo.IssueReviewRunner.ExtractPullRequestReferences(
+            "EvotecIT/IntelligenceX",
+            "Infra blocker: PR #438 checks stuck. Also see https://github.com/EvotecIT/IntelligenceX/pull/359 and PR EvotecIT/IntelligenceX#438.");
+
+        AssertEqual(2, refs.Count, "unique refs count");
+        AssertEqual(359, refs[0], "first ref number");
+        AssertEqual(438, refs[1], "second ref number");
+    }
+
+    private static void TestIssueReviewAssessIssueForApplicabilityMarksResolvedInfraBlockerAsNoLongerApplicable() {
+        var now = DateTimeOffset.UtcNow;
+        var issue = new IntelligenceX.Cli.Todo.IssueReviewRunner.IssueReviewCandidateIssue(
+            Number: 440,
+            Title: "Infra blocker: PR #438 checks stuck in Setup .NET",
+            Body: "Tracking after retries.",
+            Url: "https://github.com/EvotecIT/IntelligenceX/issues/440",
+            UpdatedAtUtc: now.AddDays(-2),
+            Labels: new[] { "infra-blocker" });
+        var pullRequests = new Dictionary<int, IntelligenceX.Cli.Todo.IssueReviewRunner.PullRequestReference> {
+            [438] = new(
+                Number: 438,
+                Title: "Fix setup checks",
+                Url: "https://github.com/EvotecIT/IntelligenceX/pull/438",
+                State: "MERGED",
+                MergedAtUtc: now.AddDays(-1),
+                ClosedAtUtc: now.AddDays(-1))
+        };
+
+        var assessment = IntelligenceX.Cli.Todo.IssueReviewRunner.AssessIssueForApplicability(
+            issue,
+            "EvotecIT/IntelligenceX",
+            pullRequests,
+            now,
+            staleDays: 14);
+
+        AssertEqual(true, assessment.IsInfraBlocker, "infra blocker detection");
+        AssertEqual("no-longer-applicable", assessment.Classification, "classification");
+        AssertEqual(true, assessment.EligibleForAutoClose, "eligible for auto close");
+        AssertEqual(true, assessment.Reason.Contains("resolved", StringComparison.OrdinalIgnoreCase), "resolved reason text");
+    }
+#endif
+}

--- a/IntelligenceX.Tests/Program.Todo.cs
+++ b/IntelligenceX.Tests/Program.Todo.cs
@@ -19,6 +19,7 @@ internal static partial class Program {
             AssertContainsText(output, "sync-bot-feedback", "todo help includes command");
             AssertContainsText(output, "build-triage-index", "todo help includes triage command");
             AssertContainsText(output, "backtest-pr-signals", "todo help includes backtest command");
+            AssertContainsText(output, "issue-review", "todo help includes issue review command");
             AssertContainsText(output, "vision-check", "todo help includes vision command");
             AssertContainsText(output, "project-init", "todo help includes project init command");
             AssertContainsText(output, "project-sync", "todo help includes project sync command");

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -465,6 +465,8 @@ internal static partial class Program {
         failed += Run("Todo triage index operational signals", TestTriageIndexAssessPullRequestOperationalSignalsClassifiesSizeRiskAndReadiness);
         failed += Run("Todo triage index operational signal calibration boundaries", TestTriageIndexAssessPullRequestOperationalSignalsCalibrationBoundaries);
         failed += Run("Todo PR signal backtest bucket stats", TestPullRequestSignalBacktestBuildBucketStatsCalculatesMergeRates);
+        failed += Run("Todo issue review pull-request reference parsing", TestIssueReviewExtractPullRequestReferencesParsesMultipleForms);
+        failed += Run("Todo issue review no-longer-applicable classification", TestIssueReviewAssessIssueForApplicabilityMarksResolvedInfraBlockerAsNoLongerApplicable);
         failed += Run("Todo vision check out-of-scope classification", TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate);
         failed += Run("Todo vision check aligned classification", TestVisionCheckClassifiesAlignedWhenInTokensMatch);
         failed += Run("Todo vision check explicit reject policy precedence", TestVisionCheckExplicitRejectPolicyTakesPrecedence);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -58,6 +58,28 @@ Important:
 - PR ranking includes status-check signals (when available) in addition to mergeability/review/churn/recency.
 - Item output includes assistive `category` + `tags` and PR `relatedIssues`/`matchedIssueUrl` fields for downstream automation.
 
+## Issue Review (Infra Applicability + Auto-Manage)
+
+Review open issues and detect infra blockers that are likely no longer applicable (for example linked PRs are already merged/closed):
+
+```bash
+intelligencex todo issue-review --repo EvotecIT/IntelligenceX
+```
+
+Options:
+- `--max-issues <n>` (1-2000, default `300`)
+- `--stale-days <n>` (default `14`)
+- `--apply-close` (opt-in mutating mode; closes no-longer-applicable candidates)
+- `--close-reason <completed|not-planned>` (default `completed`)
+- `--no-comment` (skip managed close note comment)
+- `--out <path>` (default `artifacts/triage/ix-issue-review.json`)
+- `--summary <path>` (default `artifacts/triage/ix-issue-review.md`)
+
+Safety defaults:
+- Dry-run by default (no issue mutation unless `--apply-close` is set).
+- Issues with protected labels (`do-not-close`, `keep-open`, `pinned`, `ix/decision:accept`) are never auto-closed.
+- Auto-close scope is currently conservative: infra blockers with linked PR references where all linked PRs are resolved.
+
 ## Vision Check (Assistive)
 
 Evaluate PR backlog alignment against `VISION.md`:


### PR DESCRIPTION
## Summary
- add a new `intelligencex todo issue-review` command (alias: `review-issues`) to review open issues and detect no-longer-applicable infra blockers
- classify issues into `no-longer-applicable`, `needs-review`, `active`, and `out-of-scope` using infra heuristics + linked PR state resolution
- add opt-in automation with safety guards:
  - dry-run by default
  - `--apply-close` to close only no-longer-applicable candidates
  - protected labels (`do-not-close`, `keep-open`, `pinned`, `ix/decision:accept`) block auto-close
  - optional managed close-note comment marker (`<!-- intelligencex:issue-review -->`)
- generate machine + human artifacts:
  - `artifacts/triage/ix-issue-review.json`
  - `artifacts/triage/ix-issue-review.md`
- wire command into todo routing/help and top-level CLI help
- add tests for PR reference parsing + no-longer-applicable classification
- update reviewer/docs pages with issue-review workflow and safety guidance

## Examples
```bash
# dry-run (recommended first pass)
intelligencex todo issue-review --repo EvotecIT/IntelligenceX

# apply close for no-longer-applicable candidates
intelligencex todo issue-review --repo EvotecIT/IntelligenceX --apply-close --close-reason completed
```

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- todo issue-review --help`
- `dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- todo issue-review --repo EvotecIT/IntelligenceX --max-issues 10 --out artifacts/triage/ix-issue-review.sample.json --summary artifacts/triage/ix-issue-review.sample.md`
