### PR TITLE
Deduplicate TestimoX selection and error handling

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRuleSelectionHelper.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRuleSelectionHelper.cs
@@ -136,6 +136,68 @@ internal static class TestimoXRuleSelectionHelper {
         return !string.IsNullOrWhiteSpace(value) && value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
+    internal static IEnumerable<Rule> ApplyVisibilityFilters(
+        IEnumerable<Rule> rules,
+        bool includeDisabled,
+        bool includeHidden,
+        bool includeDeprecated) {
+        var filtered = rules;
+        if (!includeDisabled) {
+            filtered = filtered.Where(static x => x.Enable);
+        }
+        if (!includeHidden) {
+            filtered = filtered.Where(static x => x.Visibility != RuleVisibility.Hidden);
+        }
+        if (!includeDeprecated) {
+            filtered = filtered.Where(static x => !x.IsDeprecated);
+        }
+
+        return filtered;
+    }
+
+    internal static IEnumerable<Rule> ApplySharedFilters(
+        IEnumerable<Rule> rules,
+        string? searchText,
+        IReadOnlyList<string> requestedCategories,
+        IReadOnlyList<string> requestedTags,
+        HashSet<string>? sourceTypeFilter,
+        string ruleOrigin,
+        bool usingExternalDirectory,
+        HashSet<string>? builtinRuleNames) {
+        var filtered = rules;
+        if (!string.IsNullOrWhiteSpace(searchText)) {
+            var term = searchText.Trim();
+            filtered = filtered.Where(rule =>
+                ContainsIgnoreCase(rule.Name, term) ||
+                ContainsIgnoreCase(rule.DisplayName, term) ||
+                ContainsIgnoreCase(rule.Description, term));
+        }
+
+        if (requestedCategories.Count > 0) {
+            var requested = new HashSet<string>(requestedCategories, StringComparer.OrdinalIgnoreCase);
+            filtered = filtered.Where(rule => rule.Category.Any(cat => requested.Contains(cat.ToString())));
+        }
+
+        if (requestedTags.Count > 0) {
+            var requested = new HashSet<string>(requestedTags, StringComparer.OrdinalIgnoreCase);
+            filtered = filtered.Where(rule => rule.Tags.Any(tag => requested.Contains(tag)));
+        }
+
+        if (sourceTypeFilter is { Count: > 0 }) {
+            filtered = filtered.Where(rule => MatchesSourceType(rule, sourceTypeFilter));
+        }
+
+        if (!string.Equals(ruleOrigin, RuleOriginAny, StringComparison.OrdinalIgnoreCase)) {
+            filtered = filtered.Where(rule =>
+                string.Equals(
+                    ResolveRuleOrigin(rule, usingExternalDirectory, builtinRuleNames),
+                    ruleOrigin,
+                    StringComparison.OrdinalIgnoreCase));
+        }
+
+        return filtered;
+    }
+
     private static string NormalizeSourceType(string? value) {
         var canonical = Canonicalize(value);
         return canonical switch {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesListTool.cs
@@ -79,62 +79,35 @@ public sealed class TestimoXRulesListTool : TestimoXToolBase, ITool {
         List<Rule> discovered;
         var usingExternalDirectory = !string.IsNullOrWhiteSpace(powerShellRulesDirectory);
         HashSet<string>? builtinRuleNames = null;
-        try {
-            var runner = new TestimoRunner();
-            discovered = await runner.DiscoverRulesAsync(
-                includeDisabled: true,
-                ct: cancellationToken,
-                powerShellRulesDirectory: powerShellRulesDirectory).ConfigureAwait(false);
-
-            if (usingExternalDirectory) {
-                builtinRuleNames = await TestimoXRuleSelectionHelper.DiscoverBuiltinRuleNamesAsync(cancellationToken).ConfigureAwait(false);
-            }
-        } catch (OperationCanceledException) {
-            throw;
-        } catch (Exception ex) {
-            return ToolResponse.Error("query_failed", $"TestimoX rule discovery failed: {ex.Message}");
+        var runner = new TestimoRunner();
+        var discovery = await TryDiscoverRulesAsync(
+            runner,
+            powerShellRulesDirectory,
+            cancellationToken,
+            defaultErrorMessage: "TestimoX rule discovery failed.").ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(discovery.ErrorResponse)) {
+            return discovery.ErrorResponse!;
         }
 
-        IEnumerable<Rule> filtered = discovered;
-        if (!includeDisabled) {
-            filtered = filtered.Where(static x => x.Enable);
-        }
-        if (!includeHidden) {
-            filtered = filtered.Where(static x => x.Visibility != RuleVisibility.Hidden);
-        }
-        if (!includeDeprecated) {
-            filtered = filtered.Where(static x => !x.IsDeprecated);
+        discovered = discovery.Rules ?? new List<Rule>();
+        if (usingExternalDirectory) {
+            builtinRuleNames = await TestimoXRuleSelectionHelper.DiscoverBuiltinRuleNamesAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        if (!string.IsNullOrWhiteSpace(searchText)) {
-            var term = searchText.Trim();
-            filtered = filtered.Where(rule =>
-                TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.Name, term) ||
-                TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.DisplayName, term) ||
-                TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.Description, term));
-        }
-
-        if (sourceTypeFilter is { Count: > 0 }) {
-            filtered = filtered.Where(rule => TestimoXRuleSelectionHelper.MatchesSourceType(rule, sourceTypeFilter));
-        }
-
-        if (requestedCategories.Count > 0) {
-            var requested = new HashSet<string>(requestedCategories, StringComparer.OrdinalIgnoreCase);
-            filtered = filtered.Where(rule => rule.Category.Any(cat => requested.Contains(cat.ToString())));
-        }
-
-        if (requestedTags.Count > 0) {
-            var requested = new HashSet<string>(requestedTags, StringComparer.OrdinalIgnoreCase);
-            filtered = filtered.Where(rule => rule.Tags.Any(tag => requested.Contains(tag)));
-        }
-
-        if (!string.Equals(ruleOrigin, TestimoXRuleSelectionHelper.RuleOriginAny, StringComparison.OrdinalIgnoreCase)) {
-            filtered = filtered.Where(rule =>
-                string.Equals(
-                    TestimoXRuleSelectionHelper.ResolveRuleOrigin(rule, usingExternalDirectory, builtinRuleNames),
-                    ruleOrigin,
-                    StringComparison.OrdinalIgnoreCase));
-        }
+        IEnumerable<Rule> filtered = TestimoXRuleSelectionHelper.ApplyVisibilityFilters(
+            discovered,
+            includeDisabled: includeDisabled,
+            includeHidden: includeHidden,
+            includeDeprecated: includeDeprecated);
+        filtered = TestimoXRuleSelectionHelper.ApplySharedFilters(
+            filtered,
+            searchText,
+            requestedCategories,
+            requestedTags,
+            sourceTypeFilter,
+            ruleOrigin,
+            usingExternalDirectory,
+            builtinRuleNames);
 
         var matchedRows = filtered
             .OrderBy(static x => x.Name, StringComparer.OrdinalIgnoreCase)

--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesRunTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesRunTool.cs
@@ -187,19 +187,19 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
         List<Rule> discoveredRules;
         var usingExternalDirectory = !string.IsNullOrWhiteSpace(powerShellRulesDirectory);
         HashSet<string>? builtinRuleNames = null;
-        try {
-            runner = new TestimoRunner();
-            discoveredRules = await runner.DiscoverRulesAsync(
-                includeDisabled: true,
-                ct: cancellationToken,
-                powerShellRulesDirectory: powerShellRulesDirectory).ConfigureAwait(false);
-            if (usingExternalDirectory) {
-                builtinRuleNames = await TestimoXRuleSelectionHelper.DiscoverBuiltinRuleNamesAsync(cancellationToken).ConfigureAwait(false);
-            }
-        } catch (OperationCanceledException) {
-            throw;
-        } catch (Exception ex) {
-            return ToolResponse.Error("query_failed", $"TestimoX rule discovery failed: {ex.Message}");
+        runner = new TestimoRunner();
+        var discovery = await TryDiscoverRulesAsync(
+            runner,
+            powerShellRulesDirectory,
+            cancellationToken,
+            defaultErrorMessage: "TestimoX rule discovery failed.").ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(discovery.ErrorResponse)) {
+            return discovery.ErrorResponse!;
+        }
+
+        discoveredRules = discovery.Rules ?? new List<Rule>();
+        if (usingExternalDirectory) {
+            builtinRuleNames = await TestimoXRuleSelectionHelper.DiscoverBuiltinRuleNamesAsync(cancellationToken).ConfigureAwait(false);
         }
 
         var availableByName = discoveredRules
@@ -224,51 +224,25 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
         }
 
         if (hasSelectorFilters || runAllEnabledWhenNoSelection) {
-            IEnumerable<Rule> candidates = discoveredRules;
-
-            if (!includeDisabledForSelection) {
-                candidates = candidates.Where(static x => x.Enable);
-            }
-            if (!includeHiddenForSelection) {
-                candidates = candidates.Where(static x => x.Visibility != RuleVisibility.Hidden);
-            }
-            if (!includeDeprecatedForSelection) {
-                candidates = candidates.Where(static x => !x.IsDeprecated);
-            }
+            IEnumerable<Rule> candidates = TestimoXRuleSelectionHelper.ApplyVisibilityFilters(
+                discoveredRules,
+                includeDisabled: includeDisabledForSelection,
+                includeHidden: includeHiddenForSelection,
+                includeDeprecated: includeDeprecatedForSelection);
 
             if (ruleNamePatterns.Count > 0) {
                 candidates = candidates.Where(rule => TestimoXRuleSelectionHelper.MatchesAnyPattern(rule, ruleNamePatterns));
             }
 
-            if (!string.IsNullOrWhiteSpace(searchText)) {
-                var term = searchText.Trim();
-                candidates = candidates.Where(rule =>
-                    TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.Name, term) ||
-                    TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.DisplayName, term) ||
-                    TestimoXRuleSelectionHelper.ContainsIgnoreCase(rule.Description, term));
-            }
-
-            if (requestedCategories.Count > 0) {
-                var requested = new HashSet<string>(requestedCategories, StringComparer.OrdinalIgnoreCase);
-                candidates = candidates.Where(rule => rule.Category.Any(cat => requested.Contains(cat.ToString())));
-            }
-
-            if (requestedTags.Count > 0) {
-                var requested = new HashSet<string>(requestedTags, StringComparer.OrdinalIgnoreCase);
-                candidates = candidates.Where(rule => rule.Tags.Any(tag => requested.Contains(tag)));
-            }
-
-            if (sourceTypeFilter is { Count: > 0 }) {
-                candidates = candidates.Where(rule => TestimoXRuleSelectionHelper.MatchesSourceType(rule, sourceTypeFilter));
-            }
-
-            if (!string.Equals(ruleOrigin, TestimoXRuleSelectionHelper.RuleOriginAny, StringComparison.OrdinalIgnoreCase)) {
-                candidates = candidates.Where(rule =>
-                    string.Equals(
-                        TestimoXRuleSelectionHelper.ResolveRuleOrigin(rule, usingExternalDirectory, builtinRuleNames),
-                        ruleOrigin,
-                        StringComparison.OrdinalIgnoreCase));
-            }
+            candidates = TestimoXRuleSelectionHelper.ApplySharedFilters(
+                candidates,
+                searchText,
+                requestedCategories,
+                requestedTags,
+                sourceTypeFilter,
+                ruleOrigin,
+                usingExternalDirectory,
+                builtinRuleNames);
 
             foreach (var rule in candidates.OrderBy(static x => x.Name, StringComparer.OrdinalIgnoreCase)) {
                 if (!string.IsNullOrWhiteSpace(rule.Name)) {
@@ -332,7 +306,7 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
         } catch (OperationCanceledException) {
             throw;
         } catch (Exception ex) {
-            return ToolResponse.Error("execution_failed", $"TestimoX execution failed: {ex.Message}");
+            return ErrorFromException(ex, defaultMessage: "TestimoX execution failed.", fallbackErrorCode: "execution_failed");
         }
 
         var completed = (run.Engine.RulesCompleted ?? new List<RuleComplete>())

--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXToolBase.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using IntelligenceX.Tools.Common;
+using TestimoX.Definitions;
+using TestimoX.Execution;
 
 namespace IntelligenceX.Tools.TestimoX;
 
@@ -18,5 +23,46 @@ public abstract class TestimoXToolBase : ToolBase {
     protected TestimoXToolBase(TestimoXToolOptions options) {
         Options = options ?? throw new ArgumentNullException(nameof(options));
         Options.Validate();
+    }
+
+    /// <summary>
+    /// Maps common runtime exceptions for TestimoX tools to stable tool error envelopes.
+    /// </summary>
+    protected static string ErrorFromException(
+        Exception exception,
+        string defaultMessage = "TestimoX operation failed.",
+        string fallbackErrorCode = "query_failed") {
+        return ToolExceptionMapper.ErrorFromException(
+            exception,
+            defaultMessage: defaultMessage,
+            unauthorizedMessage: "Access denied while executing TestimoX operations.",
+            timeoutMessage: "TestimoX operation timed out.",
+            fallbackErrorCode: fallbackErrorCode,
+            invalidOperationErrorCode: "invalid_argument");
+    }
+
+    /// <summary>
+    /// Discovers TestimoX rules with consistent cancellation and error-envelope behavior.
+    /// </summary>
+    protected static async Task<(List<Rule>? Rules, string? ErrorResponse)> TryDiscoverRulesAsync(
+        TestimoRunner runner,
+        string? powerShellRulesDirectory,
+        CancellationToken cancellationToken,
+        string defaultErrorMessage = "TestimoX rule discovery failed.") {
+        if (runner is null) {
+            throw new ArgumentNullException(nameof(runner));
+        }
+
+        try {
+            var discovered = await runner.DiscoverRulesAsync(
+                includeDisabled: true,
+                ct: cancellationToken,
+                powerShellRulesDirectory: powerShellRulesDirectory).ConfigureAwait(false);
+            return (discovered, null);
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception ex) {
+            return (null, ErrorFromException(ex, defaultErrorMessage, fallbackErrorCode: "query_failed"));
+        }
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/TestimoXToolBaseErrorMappingTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/TestimoXToolBaseErrorMappingTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+using IntelligenceX.Tools.TestimoX;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public class TestimoXToolBaseErrorMappingTests {
+    [Fact]
+    public void ErrorFromException_ShouldMapInvalidOperationToInvalidArgument() {
+        var tool = new HarnessTool();
+
+        var json = tool.Map(new InvalidOperationException("Bad input\r\nline2"), "Fallback.");
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        Assert.Equal("Bad input line2", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void ErrorFromException_ShouldHideUnhandledExceptionDetails() {
+        var tool = new HarnessTool();
+
+        var json = tool.Map(new Exception("secret-token=abc123"), "TestimoX execution failed.");
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("query_failed", root.GetProperty("error_code").GetString());
+        Assert.Equal("TestimoX execution failed.", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void ErrorFromException_ShouldAllowFallbackCodeOverride() {
+        var tool = new HarnessTool();
+
+        var json = tool.Map(new Exception("details"), "TestimoX execution failed.", fallbackErrorCode: "execution_failed");
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("execution_failed", root.GetProperty("error_code").GetString());
+        Assert.Equal("TestimoX execution failed.", root.GetProperty("error").GetString());
+    }
+
+    private sealed class HarnessTool : TestimoXToolBase {
+        private static readonly ToolDefinition DefinitionValue = new(
+            "testimox_test_harness",
+            "Test harness tool.",
+            ToolSchema.Object().NoAdditionalProperties());
+
+        public HarnessTool() : base(new TestimoXToolOptions()) { }
+
+        public override ToolDefinition Definition => DefinitionValue;
+
+        public string Map(
+            Exception ex,
+            string defaultMessage,
+            string fallbackErrorCode = "query_failed") {
+            return ErrorFromException(ex, defaultMessage, fallbackErrorCode);
+        }
+
+        protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+            return Task.FromResult(ToolResponse.OkModel(new { ok = true }));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add shared TestimoX base helpers for exception-envelope mapping and rule discovery (`TestimoXToolBase`)
- deduplicate shared rule filtering logic into `TestimoXRuleSelectionHelper` and reuse it from both `testimox_rules_list` and `testimox_rules_run`
- normalize `testimox_rules_run` execution failures to stable/sanitized tool error envelopes
- add `TestimoXToolBaseErrorMappingTests` coverage for mapped/sanitized TestimoX error contracts

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo`
