### PR TITLE
chore: bump OfficeIMO fallback package versions

### DIFF
--- a/IntelligenceX.Chat/Directory.Build.props
+++ b/IntelligenceX.Chat/Directory.Build.props
@@ -29,6 +29,6 @@
     <DbaClientXRepoRoot Condition="'$(DbaClientXRepoRoot)' == '' and Exists('$(DbaClientXRepoRootCandidate2)DbaClientX.SQLite\\DbaClientX.SQLite.csproj')">$(DbaClientXRepoRootCandidate2)</DbaClientXRepoRoot>
     <DbaClientXRepoRoot Condition="'$(DbaClientXRepoRoot)' == ''">$(DbaClientXRepoRootCandidate1)</DbaClientXRepoRoot>
 
-    <OfficeImoMarkdownRendererNuGetVersion Condition="'$(OfficeImoMarkdownRendererNuGetVersion)' == ''">0.1.5</OfficeImoMarkdownRendererNuGetVersion>
+    <OfficeImoMarkdownRendererNuGetVersion Condition="'$(OfficeImoMarkdownRendererNuGetVersion)' == ''">0.1.7</OfficeImoMarkdownRendererNuGetVersion>
   </PropertyGroup>
 </Project>

--- a/IntelligenceX.Tools/Directory.Build.props
+++ b/IntelligenceX.Tools/Directory.Build.props
@@ -36,7 +36,7 @@
     <!-- Public package fallbacks for CI/consumers when local engine sources are unavailable. -->
     <MailozaurrNuGetVersion Condition="'$(MailozaurrNuGetVersion)'==''">2.0.5</MailozaurrNuGetVersion>
     <EventViewerXNuGetVersion Condition="'$(EventViewerXNuGetVersion)'==''">3.3.0</EventViewerXNuGetVersion>
-    <OfficeImoReaderNuGetVersion Condition="'$(OfficeImoReaderNuGetVersion)'==''">0.1.3</OfficeImoReaderNuGetVersion>
+    <OfficeImoReaderNuGetVersion Condition="'$(OfficeImoReaderNuGetVersion)'==''">0.1.5</OfficeImoReaderNuGetVersion>
   </PropertyGroup>
 
   <!-- Normalize caller-provided roots first. -->


### PR DESCRIPTION
## Summary
- bump `OfficeImoReaderNuGetVersion` from `0.1.3` to `0.1.5` in `IntelligenceX.Tools/Directory.Build.props`
- bump `OfficeImoMarkdownRendererNuGetVersion` from `0.1.5` to `0.1.7` in `IntelligenceX.Chat/Directory.Build.props`
- keep local sibling-project override behavior unchanged; this only updates NuGet fallback versions so IX picks up the latest published OfficeIMO fixes when local OfficeIMO source is not wired in

## Why
- OfficeIMO packages were just published with markdown rendering/normalization fixes
- this lets IntelligenceX consume those fixes in package-based environments

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
