### PR TITLE
Chat startup: overlap connect with WebView initialization

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -511,6 +511,9 @@ public sealed partial class MainWindow : Window {
         try {
             Interlocked.Exchange(ref _startupWebViewBudgetExceededThisRun, 0);
             StartupLog.Write("MainWindow.StartupFlow begin");
+            StartupLog.Write("StartupPhase.AppState begin");
+            await EnsureAppStateLoadedAsync().ConfigureAwait(false);
+            StartupLog.Write("StartupPhase.AppState done");
             StartupLog.Write("StartupPhase.WebView begin");
             var startupWebViewBudgetCache = SnapshotStartupWebViewBudgetCache();
             var startupWebViewBudget = ResolveStartupWebViewBudget(
@@ -532,7 +535,11 @@ public sealed partial class MainWindow : Window {
                     + startupWebViewBudgetCache.AdaptiveCooldownRunsRemaining.ToString(CultureInfo.InvariantCulture));
             }
             var webViewInitializationTask = EnsureWebViewInitializedAsync();
-            if (await TryAwaitStartupWebViewWithinBudgetAsync(webViewInitializationTask, startupWebViewBudget).ConfigureAwait(false)) {
+            var startupWebViewBudgetWaitTask = TryAwaitStartupWebViewWithinBudgetAsync(webViewInitializationTask, startupWebViewBudget);
+            StartupLog.Write("StartupPhase.Connect begin");
+            await EnsureStartupConnectedAsync().ConfigureAwait(false);
+            StartupLog.Write("StartupPhase.Connect done");
+            if (await startupWebViewBudgetWaitTask.ConfigureAwait(false)) {
                 StartupLog.Write("StartupPhase.WebView done");
             } else {
                 StartupLog.Write("StartupPhase.WebView budget_exhausted");
@@ -540,12 +547,6 @@ public sealed partial class MainWindow : Window {
                 MarkStartupWebViewBudgetExhausted();
                 ObserveDeferredStartupWebViewInitialization(webViewInitializationTask);
             }
-            StartupLog.Write("StartupPhase.AppState begin");
-            await EnsureAppStateLoadedAsync().ConfigureAwait(false);
-            StartupLog.Write("StartupPhase.AppState done");
-            StartupLog.Write("StartupPhase.Connect begin");
-            await EnsureStartupConnectedAsync().ConfigureAwait(false);
-            StartupLog.Write("StartupPhase.Connect done");
             StartupLog.Write("StartupPhase.Auth deferred");
             QueueDeferredStartupAuthentication();
             StartupLog.Write("StartupPhase.Onboarding deferred");
@@ -1069,7 +1070,7 @@ public sealed partial class MainWindow : Window {
                 RefreshGlobalWheelHookPolicy();
                 return Task.CompletedTask;
             }).ConfigureAwait(false);
-            await SetStatusAsync(SessionStatus.Disconnected()).ConfigureAwait(false);
+            await SetStatusAsync(_statusText, _statusTone, _usageLimitSwitchRecommended).ConfigureAwait(false);
             await RenderTranscriptAsync().ConfigureAwait(false);
             await PublishOptionsStateAsync().ConfigureAwait(false);
             RecordStartupWebViewEnsureCompletion(


### PR DESCRIPTION
## Summary
- overlap startup `Connect` with startup WebView initialization after app state load
- keep startup ordering hardware-safe: app state remains first, WebView budget/fail-open behavior remains unchanged
- prevent status regression from parallel completion by replaying current in-memory status during WebView hydration (instead of forcing disconnected)

## Why
Startup logs showed warm startup was dominated by WebView init (`~2.7-2.8s`) plus connect (`~0.5-0.6s`) serialized. Running connect in parallel with WebView reduces total startup wall-clock without increasing dependency risk.

## Profiling (same machine, 8 runs, `-PostStartupGraceSeconds 2`)
Baseline (`artifacts/chat-startup-profile-followup-baseline.json`):
- `avg_total_ms`: `4201.43`
- `avg_warm_total_ms`: `3902.71`
- `avg_warm_startup_webview_ms`: `2764.89`
- `avg_warm_connect_ms`: `572.05`
- `startup_webview_budget_exhausted_runs`: `0`

After (`artifacts/chat-startup-profile-followup-after-overlap.json`):
- `avg_total_ms`: `3661.65` (`-539.78ms`)
- `avg_warm_total_ms`: `3658.28` (`-244.43ms`)
- `avg_warm_startup_webview_ms`: `2771.81` (`+6.92ms`, essentially unchanged)
- `avg_warm_connect_ms`: `474.93` (`-97.12ms`)
- `startup_webview_budget_exhausted_runs`: `1` (single outlier run; eventual completion logged)

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release -p:SkipChatServiceSidecarBuild=true -p:ChatServiceBin=Z:\ix-missing\` (Passed: 221)
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release` (Passed: 443)
