### PR TITLE
Map builtin rule discovery failures in TestimoX tools

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesListTool.cs
@@ -91,7 +91,14 @@ public sealed class TestimoXRulesListTool : TestimoXToolBase, ITool {
 
         discovered = discovery.Rules ?? new List<Rule>();
         if (usingExternalDirectory) {
-            builtinRuleNames = await TestimoXRuleSelectionHelper.DiscoverBuiltinRuleNamesAsync(cancellationToken).ConfigureAwait(false);
+            var builtinDiscovery = await TryDiscoverBuiltinRuleNamesAsync(
+                cancellationToken,
+                defaultErrorMessage: "TestimoX builtin rule discovery failed.").ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(builtinDiscovery.ErrorResponse)) {
+                return builtinDiscovery.ErrorResponse!;
+            }
+
+            builtinRuleNames = builtinDiscovery.RuleNames ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         IEnumerable<Rule> filtered = TestimoXRuleSelectionHelper.ApplyVisibilityFilters(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesRunTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXRulesRunTool.cs
@@ -199,7 +199,14 @@ public sealed class TestimoXRulesRunTool : TestimoXToolBase, ITool {
 
         discoveredRules = discovery.Rules ?? new List<Rule>();
         if (usingExternalDirectory) {
-            builtinRuleNames = await TestimoXRuleSelectionHelper.DiscoverBuiltinRuleNamesAsync(cancellationToken).ConfigureAwait(false);
+            var builtinDiscovery = await TryDiscoverBuiltinRuleNamesAsync(
+                cancellationToken,
+                defaultErrorMessage: "TestimoX builtin rule discovery failed.").ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(builtinDiscovery.ErrorResponse)) {
+                return builtinDiscovery.ErrorResponse!;
+            }
+
+            builtinRuleNames = builtinDiscovery.RuleNames ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         var availableByName = discoveredRules

--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/TestimoXToolBase.cs
@@ -65,4 +65,22 @@ public abstract class TestimoXToolBase : ToolBase {
             return (null, ErrorFromException(ex, defaultErrorMessage, fallbackErrorCode: "query_failed"));
         }
     }
+
+    /// <summary>
+    /// Discovers builtin TestimoX rule names with consistent cancellation and error-envelope behavior.
+    /// </summary>
+    protected static async Task<(HashSet<string>? RuleNames, string? ErrorResponse)> TryDiscoverBuiltinRuleNamesAsync(
+        CancellationToken cancellationToken,
+        string defaultErrorMessage = "TestimoX builtin rule discovery failed.",
+        Func<CancellationToken, Task<HashSet<string>>>? discoverFunc = null) {
+        var discover = discoverFunc ?? TestimoXRuleSelectionHelper.DiscoverBuiltinRuleNamesAsync;
+        try {
+            var names = await discover(cancellationToken).ConfigureAwait(false);
+            return (names, null);
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception ex) {
+            return (null, ErrorFromException(ex, defaultErrorMessage, fallbackErrorCode: "query_failed"));
+        }
+    }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/TestimoXToolBaseErrorMappingTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/TestimoXToolBaseErrorMappingTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -50,6 +51,24 @@ public class TestimoXToolBaseErrorMappingTests {
         Assert.Equal("TestimoX execution failed.", root.GetProperty("error").GetString());
     }
 
+    [Fact]
+    public async Task TryDiscoverBuiltinRuleNamesAsync_ShouldReturnMappedError_WhenDiscoveryThrows() {
+        var tool = new HarnessTool();
+
+        var (names, error) = await tool.TryDiscoverBuiltinAsync(
+            CancellationToken.None,
+            _ => throw new InvalidOperationException("loader crash"));
+
+        Assert.Null(names);
+        Assert.NotNull(error);
+        using var doc = JsonDocument.Parse(error!);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        Assert.Equal("loader crash", root.GetProperty("error").GetString());
+    }
+
     private sealed class HarnessTool : TestimoXToolBase {
         private static readonly ToolDefinition DefinitionValue = new(
             "testimox_test_harness",
@@ -65,6 +84,15 @@ public class TestimoXToolBaseErrorMappingTests {
             string defaultMessage,
             string fallbackErrorCode = "query_failed") {
             return ErrorFromException(ex, defaultMessage, fallbackErrorCode);
+        }
+
+        public Task<(HashSet<string>? RuleNames, string? ErrorResponse)> TryDiscoverBuiltinAsync(
+            CancellationToken cancellationToken,
+            Func<CancellationToken, Task<HashSet<string>>> discoverFunc) {
+            return TryDiscoverBuiltinRuleNamesAsync(
+                cancellationToken,
+                defaultErrorMessage: "TestimoX builtin rule discovery failed.",
+                discoverFunc: discoverFunc);
         }
 
         protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {


### PR DESCRIPTION
## Summary
- wrap builtin-rule baseline discovery in mapped/sanitized error handling for both `testimox_rules_list` and `testimox_rules_run`
- add shared helper in `TestimoXToolBase` to ensure consistent envelope behavior for builtin discovery failures
- extend `TestimoXToolBaseErrorMappingTests` with explicit coverage for builtin-discovery exception mapping

## Why
Codex review correctly flagged that baseline builtin-rule discovery could throw outside the mapped catch path, leading to `error_code=exception` and raw message leakage. This restores stable `query_failed`/mapped envelopes.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo`
