### PR TITLE
feat(todo): harden issue-review auto-close workflow

### DIFF
--- a/.github/workflows/issue-review.yml
+++ b/.github/workflows/issue-review.yml
@@ -1,0 +1,191 @@
+name: Issue Review Sweep
+
+on:
+  schedule:
+    - cron: "37 2 * * *"
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Max open issues to scan"
+        required: false
+        default: "500"
+      stale_days:
+        description: "Stale threshold (days) when no linked PR exists"
+        required: false
+        default: "14"
+      min_consecutive_candidates:
+        description: "Consecutive no-longer-applicable runs required before auto-close"
+        required: false
+        default: "2"
+      apply_close:
+        description: "Apply auto-close to eligible candidates"
+        required: false
+        default: false
+        type: boolean
+      confirm_apply_close:
+        description: "Set to CLOSE_ISSUES to confirm apply_close"
+        required: false
+        default: ""
+      close_reason:
+        description: "Close reason when apply_close=true"
+        required: false
+        type: choice
+        options:
+          - completed
+          - not-planned
+        default: completed
+      allow_labels:
+        description: "Comma-separated labels required for auto-close eligibility (optional)"
+        required: false
+        default: ""
+      deny_labels:
+        description: "Comma-separated labels to block auto-close (optional)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+env:
+  ISSUE_REVIEW_STATE_PATH: artifacts/triage/ix-issue-review-state.json
+  ISSUE_REVIEW_STATE_CACHE_PREFIX: ix-issue-review-state-${{ github.repository }}-${{ github.ref_name }}
+  ISSUE_REVIEW_STATE_CACHE_KEY: ix-issue-review-state-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_id }}
+
+jobs:
+  issue-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore issue-review state cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.ISSUE_REVIEW_STATE_PATH }}
+          key: ${{ env.ISSUE_REVIEW_STATE_CACHE_KEY }}
+          restore-keys: |
+            ${{ env.ISSUE_REVIEW_STATE_CACHE_PREFIX }}-
+
+      - name: Run issue review
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MAX_ISSUES="${{ github.event.inputs.max_issues }}"
+          STALE_DAYS="${{ github.event.inputs.stale_days }}"
+          MIN_CONSECUTIVE="${{ github.event.inputs.min_consecutive_candidates }}"
+          APPLY_CLOSE="${{ github.event.inputs.apply_close }}"
+          CONFIRM_APPLY_CLOSE="${{ github.event.inputs.confirm_apply_close }}"
+          CLOSE_REASON="${{ github.event.inputs.close_reason }}"
+          ALLOW_LABELS="${{ github.event.inputs.allow_labels }}"
+          DENY_LABELS="${{ github.event.inputs.deny_labels }}"
+
+          if [ -z "$MAX_ISSUES" ]; then MAX_ISSUES="500"; fi
+          if [ -z "$STALE_DAYS" ]; then STALE_DAYS="14"; fi
+          if [ -z "$MIN_CONSECUTIVE" ]; then MIN_CONSECUTIVE="2"; fi
+          if [ -z "$CLOSE_REASON" ]; then CLOSE_REASON="completed"; fi
+          if [ -z "$APPLY_CLOSE" ]; then APPLY_CLOSE="false"; fi
+
+          ARGS=(
+            "todo" "issue-review"
+            "--repo" "${{ github.repository }}"
+            "--max-issues" "$MAX_ISSUES"
+            "--stale-days" "$STALE_DAYS"
+            "--min-consecutive-candidates" "$MIN_CONSECUTIVE"
+            "--state-path" "${ISSUE_REVIEW_STATE_PATH}"
+            "--out" "artifacts/triage/ix-issue-review.json"
+            "--summary" "artifacts/triage/ix-issue-review.md"
+          )
+
+          if [ -n "$ALLOW_LABELS" ]; then
+            IFS=',' read -ra ALLOW_PARTS <<< "$ALLOW_LABELS"
+            for raw in "${ALLOW_PARTS[@]}"; do
+              label="$(echo "$raw" | xargs)"
+              if [ -n "$label" ]; then
+                ARGS+=("--allow-label" "$label")
+              fi
+            done
+          fi
+
+          if [ -n "$DENY_LABELS" ]; then
+            IFS=',' read -ra DENY_PARTS <<< "$DENY_LABELS"
+            for raw in "${DENY_PARTS[@]}"; do
+              label="$(echo "$raw" | xargs)"
+              if [ -n "$label" ]; then
+                ARGS+=("--deny-label" "$label")
+              fi
+            done
+          fi
+
+          if [ "$APPLY_CLOSE" = "true" ]; then
+            if [ "$CONFIRM_APPLY_CLOSE" != "CLOSE_ISSUES" ]; then
+              echo "apply_close=true requires confirm_apply_close=CLOSE_ISSUES"
+              exit 1
+            fi
+            ARGS+=("--apply-close" "--close-reason" "$CLOSE_REASON")
+          fi
+
+          dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- "${ARGS[@]}"
+
+      - name: Upload issue-review artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ix-issue-review
+          path: artifacts/triage
+
+      - name: Save issue-review state cache
+        if: ${{ always() && hashFiles('artifacts/triage/ix-issue-review-state.json') != '' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.ISSUE_REVIEW_STATE_PATH }}
+          key: ${{ env.ISSUE_REVIEW_STATE_CACHE_KEY }}
+
+      - name: Comment summary on control issue (optional)
+        if: ${{ vars.IX_TRIAGE_CONTROL_ISSUE != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MARKER="<!-- intelligencex:issue-review-summary -->"
+          ISSUE="${{ vars.IX_TRIAGE_CONTROL_ISSUE }}"
+          SUMMARY_FILE="artifacts/triage/ix-issue-review-control-summary.md"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          GENERATED_AT="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+
+          {
+            echo "$MARKER"
+            echo "# IX Issue Review Sweep"
+            echo
+            echo "- Generated: $GENERATED_AT"
+            echo "- Repo: \`${{ github.repository }}\`"
+            echo "- Workflow run: $RUN_URL"
+            echo
+            if [ -f artifacts/triage/ix-issue-review.md ]; then
+              cat artifacts/triage/ix-issue-review.md
+            else
+              echo "_No issue-review summary file found at artifacts/triage/ix-issue-review.md._"
+            fi
+          } > "$SUMMARY_FILE"
+
+          EXISTING_ID="$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+            --jq '.[] | select(.body | contains("<!-- intelligencex:issue-review-summary -->")) | .id' \
+            | tail -n 1)"
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/$EXISTING_ID" \
+              -F "body=@$SUMMARY_FILE" > /dev/null
+          else
+            gh api \
+              --method POST \
+              "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+              -F "body=@$SUMMARY_FILE" > /dev/null
+          fi

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -40,8 +40,8 @@ intelligencex todo sync-bot-feedback --repo EvotecIT/IntelligenceX
 # 2) Build triage index artifacts
 intelligencex todo build-triage-index --repo EvotecIT/IntelligenceX
 
-# 3) Review infra blocker issue applicability (dry-run)
-intelligencex todo issue-review --repo EvotecIT/IntelligenceX
+# 3) Review infra blocker issue applicability (dry-run, with streak state)
+intelligencex todo issue-review --repo EvotecIT/IntelligenceX --min-consecutive-candidates 2 --state-path artifacts/triage/ix-issue-review-state.json
 
 # 4) Check backlog against VISION.md
 intelligencex todo vision-check --repo EvotecIT/IntelligenceX --vision VISION.md
@@ -69,6 +69,15 @@ intelligencex todo project-view-checklist --config artifacts/triage/ix-project-c
 | `project-bootstrap` | First-run bootstrap for project + workflow + vision scaffold | Project config + workflow + `VISION.md` scaffold |
 | `project-view-checklist` | Build checklist of recommended project views | `artifacts/triage/ix-project-view-checklist.md` |
 | `project-view-apply` | Build deterministic plan to apply missing views | `artifacts/triage/ix-project-view-apply.md` |
+
+## Automation workflow
+
+- Workflow: `.github/workflows/issue-review.yml`
+- Schedule: nightly dry-run (no auto-close by default)
+- Manual auto-close: use `workflow_dispatch` with:
+  - `apply_close=true`
+  - `confirm_apply_close=CLOSE_ISSUES`
+  - optional label policy (`allow_labels`, `deny_labels`)
 
 ## Permissions and safety
 

--- a/IntelligenceX.Cli/Todo/IssueReviewRunner.cs
+++ b/IntelligenceX.Cli/Todo/IssueReviewRunner.cs
@@ -67,6 +67,7 @@ internal static class IssueReviewRunner {
         bool IsInfraBlocker,
         string Classification,
         bool EligibleForAutoClose,
+        int CandidateStreak,
         double AgeDays,
         IReadOnlyList<int> LinkedPullRequests,
         IReadOnlyList<string> LinkedPullRequestStates,
@@ -74,10 +75,26 @@ internal static class IssueReviewRunner {
         IReadOnlyList<string> Labels
     );
 
+    internal sealed record IssueReviewPolicy(
+        IReadOnlySet<string> AutoCloseAllowLabels,
+        IReadOnlySet<string> AutoCloseDenyLabels
+    );
+
+    private sealed class IssueReviewState {
+        public string Schema { get; set; } = "intelligencex.issue-review.state.v1";
+        public string Repo { get; set; } = string.Empty;
+        public DateTimeOffset UpdatedAtUtc { get; set; } = DateTimeOffset.UtcNow;
+        public Dictionary<int, int> CandidateStreaks { get; set; } = new();
+    }
+
     private sealed class Options {
         public string Repo { get; set; } = DefaultRepo;
         public int MaxIssues { get; set; } = 300;
         public int StaleDays { get; set; } = 14;
+        public int MinConsecutiveCandidatesForClose { get; set; } = 1;
+        public string? StatePath { get; set; } = Path.Combine("artifacts", "triage", "ix-issue-review-state.json");
+        public List<string> AutoCloseAllowLabels { get; } = new();
+        public List<string> AutoCloseDenyLabels { get; } = new();
         public bool ApplyClose { get; set; }
         public string CloseReason { get; set; } = "completed";
         public bool CommentOnClose { get; set; } = true;
@@ -117,6 +134,54 @@ internal static class IssueReviewRunner {
                     if (i + 1 < args.Length &&
                         int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var staleDays)) {
                         options.StaleDays = Math.Max(1, Math.Min(staleDays, 365));
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--min-consecutive-candidates":
+                    if (i + 1 < args.Length &&
+                        int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var minConsecutiveCandidates)) {
+                        options.MinConsecutiveCandidatesForClose = Math.Max(1, Math.Min(minConsecutiveCandidates, 20));
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--state-path":
+                    if (i + 1 < args.Length) {
+                        options.StatePath = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--no-state":
+                    options.StatePath = null;
+                    break;
+                case "--allow-label":
+                    if (i + 1 < args.Length) {
+                        var value = args[++i].Trim();
+                        if (string.IsNullOrWhiteSpace(value)) {
+                            options.ParseFailed = true;
+                            options.ShowHelp = true;
+                        } else {
+                            options.AutoCloseAllowLabels.Add(value);
+                        }
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--deny-label":
+                    if (i + 1 < args.Length) {
+                        var value = args[++i].Trim();
+                        if (string.IsNullOrWhiteSpace(value)) {
+                            options.ParseFailed = true;
+                            options.ShowHelp = true;
+                        } else {
+                            options.AutoCloseDenyLabels.Add(value);
+                        }
                     } else {
                         options.ParseFailed = true;
                         options.ShowHelp = true;
@@ -195,6 +260,11 @@ internal static class IssueReviewRunner {
         Console.WriteLine("  --repo <owner/name>         Repository to scan (default: EvotecIT/IntelligenceX)");
         Console.WriteLine("  --max-issues <n>            Open issues to scan (1-2000, default: 300)");
         Console.WriteLine("  --stale-days <n>            Age threshold for stale infra issues without PR links (default: 14)");
+        Console.WriteLine("  --min-consecutive-candidates <n>  Consecutive no-longer-applicable runs required for auto-close (default: 1)");
+        Console.WriteLine("  --state-path <path>         Candidate state path for consecutive tracking (default: artifacts/triage/ix-issue-review-state.json)");
+        Console.WriteLine("  --no-state                  Disable candidate streak persistence");
+        Console.WriteLine("  --allow-label <label>       Require at least one of these labels for auto-close (repeatable)");
+        Console.WriteLine("  --deny-label <label>        Never auto-close issues with these labels (repeatable)");
         Console.WriteLine("  --apply-close               Close no-longer-applicable issues (default: dry-run)");
         Console.WriteLine("  --close-reason <completed|not-planned>  Reason used when closing issues (default: completed)");
         Console.WriteLine("  --no-comment                Do not post a managed IX close note");
@@ -246,14 +316,33 @@ internal static class IssueReviewRunner {
             }
         }
 
+        var priorState = LoadState(options.StatePath, options.Repo);
+        var policy = BuildPolicy(options.AutoCloseAllowLabels, options.AutoCloseDenyLabels);
         var nowUtc = DateTimeOffset.UtcNow;
-        var assessments = issues
-            .Select(issue => AssessIssueForApplicability(issue, options.Repo, pullRequestsByNumber, nowUtc, options.StaleDays))
+        var assessments = new List<IssueReviewAssessment>(issues.Count);
+        foreach (var issue in issues) {
+            priorState.CandidateStreaks.TryGetValue(issue.Number, out var previousCandidateStreak);
+            var assessment = AssessIssueForApplicability(
+                issue,
+                options.Repo,
+                pullRequestsByNumber,
+                nowUtc,
+                options.StaleDays,
+                policy,
+                previousCandidateStreak,
+                options.MinConsecutiveCandidatesForClose);
+            assessments.Add(assessment);
+        }
+        assessments = assessments
             .OrderBy(value => ClassificationRank(value.Classification))
+            .ThenByDescending(value => value.CandidateStreak)
             .ThenByDescending(value => value.AgeDays)
             .ThenBy(value => value.Number)
             .ToList();
 
+        var noLongerApplicableCandidates = assessments
+            .Where(value => value.Classification.Equals("no-longer-applicable", StringComparison.OrdinalIgnoreCase))
+            .ToList();
         var autoCloseCandidates = assessments
             .Where(value => value.EligibleForAutoClose)
             .ToList();
@@ -273,6 +362,8 @@ internal static class IssueReviewRunner {
             }
         }
 
+        var updatedState = BuildUpdatedState(options.Repo, nowUtc, assessments);
+        SaveState(options.StatePath, updatedState);
         var report = BuildReport(options, nowUtc, assessments, closedIssueNumbers);
         var summary = BuildMarkdownSummary(options, nowUtc, assessments, closedIssueNumbers);
         WriteText(options.OutputPath, JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
@@ -282,7 +373,12 @@ internal static class IssueReviewRunner {
         Console.WriteLine($"Generated issue review summary: {options.SummaryPath}");
         Console.WriteLine($"Open issues scanned: {assessments.Count}");
         Console.WriteLine($"Infra blockers detected: {assessments.Count(value => value.IsInfraBlocker)}");
-        Console.WriteLine($"No-longer-applicable candidates: {autoCloseCandidates.Count}");
+        Console.WriteLine($"No-longer-applicable candidates: {noLongerApplicableCandidates.Count}");
+        Console.WriteLine($"Auto-close eligible this run: {autoCloseCandidates.Count}");
+        Console.WriteLine($"Min consecutive candidates required: {options.MinConsecutiveCandidatesForClose}");
+        Console.WriteLine(options.StatePath is null
+            ? "State persistence: disabled."
+            : $"State persistence: {options.StatePath}");
         Console.WriteLine(options.ApplyClose
             ? $"Closed by automation: {closedIssueNumbers.Count}"
             : "Dry-run mode: no issues were closed (use --apply-close to close candidates).");
@@ -405,6 +501,27 @@ internal static class IssueReviewRunner {
         IReadOnlyDictionary<int, PullRequestReference> pullRequestsByNumber,
         DateTimeOffset nowUtc,
         int staleDays) {
+        var defaultPolicy = BuildPolicy(Array.Empty<string>(), Array.Empty<string>());
+        return AssessIssueForApplicability(
+            issue,
+            repo,
+            pullRequestsByNumber,
+            nowUtc,
+            staleDays,
+            defaultPolicy,
+            previousCandidateStreak: 0,
+            minConsecutiveCandidatesForClose: 1);
+    }
+
+    internal static IssueReviewAssessment AssessIssueForApplicability(
+        IssueReviewCandidateIssue issue,
+        string repo,
+        IReadOnlyDictionary<int, PullRequestReference> pullRequestsByNumber,
+        DateTimeOffset nowUtc,
+        int staleDays,
+        IssueReviewPolicy policy,
+        int previousCandidateStreak,
+        int minConsecutiveCandidatesForClose) {
         var linkedPullRequests = ExtractPullRequestReferences(repo, $"{issue.Title}\n{issue.Body}");
         var linkedStates = new List<string>();
         foreach (var number in linkedPullRequests) {
@@ -427,6 +544,7 @@ internal static class IssueReviewRunner {
                 false,
                 "out-of-scope",
                 false,
+                0,
                 ageDays,
                 linkedPullRequests,
                 linkedStates,
@@ -434,7 +552,7 @@ internal static class IssueReviewRunner {
                 issue.Labels);
         }
 
-        if (issue.Labels.Any(label => ProtectedLabels.Contains(label))) {
+        if (issue.Labels.Any(label => policy.AutoCloseDenyLabels.Contains(label))) {
             return new IssueReviewAssessment(
                 issue.Number,
                 issue.Title,
@@ -442,10 +560,11 @@ internal static class IssueReviewRunner {
                 true,
                 "needs-review",
                 false,
+                0,
                 ageDays,
                 linkedPullRequests,
                 linkedStates,
-                "Protected label present (keep-open/do-not-close); leaving for maintainer review.",
+                "Denied/protected label present; leaving for maintainer review.",
                 issue.Labels);
         }
 
@@ -458,6 +577,7 @@ internal static class IssueReviewRunner {
                     true,
                     "needs-review",
                     false,
+                    0,
                     ageDays,
                     linkedPullRequests,
                     linkedStates,
@@ -472,6 +592,7 @@ internal static class IssueReviewRunner {
                 true,
                 "active",
                 false,
+                0,
                 ageDays,
                 linkedPullRequests,
                 linkedStates,
@@ -490,6 +611,7 @@ internal static class IssueReviewRunner {
                 true,
                 "needs-review",
                 false,
+                0,
                 ageDays,
                 linkedPullRequests,
                 linkedStates,
@@ -510,6 +632,7 @@ internal static class IssueReviewRunner {
                 true,
                 "active",
                 false,
+                0,
                 ageDays,
                 linkedPullRequests,
                 linkedStates,
@@ -522,17 +645,31 @@ internal static class IssueReviewRunner {
             return state is "merged" or "closed";
         });
         if (allResolved) {
+            var candidateStreak = Math.Max(0, previousCandidateStreak) + 1;
+            var reason = "All linked PRs are resolved (merged/closed).";
+            var eligibleForAutoClose = true;
+            if (policy.AutoCloseAllowLabels.Count > 0 &&
+                !issue.Labels.Any(label => policy.AutoCloseAllowLabels.Contains(label))) {
+                eligibleForAutoClose = false;
+                reason += $" Missing allow label for auto-close ({string.Join(", ", policy.AutoCloseAllowLabels.OrderBy(value => value, StringComparer.OrdinalIgnoreCase))}).";
+            }
+            if (candidateStreak < minConsecutiveCandidatesForClose) {
+                eligibleForAutoClose = false;
+                reason += $" Candidate streak {candidateStreak}/{minConsecutiveCandidatesForClose}.";
+            }
+
             return new IssueReviewAssessment(
                 issue.Number,
                 issue.Title,
                 issue.Url,
                 true,
                 "no-longer-applicable",
-                true,
+                eligibleForAutoClose,
+                candidateStreak,
                 ageDays,
                 linkedPullRequests,
                 linkedStates,
-                "All linked PRs are resolved (merged/closed).",
+                reason,
                 issue.Labels);
         }
 
@@ -543,6 +680,7 @@ internal static class IssueReviewRunner {
             true,
             "needs-review",
             false,
+            0,
             ageDays,
             linkedPullRequests,
             linkedStates,
@@ -604,6 +742,10 @@ internal static class IssueReviewRunner {
             settings = new {
                 maxIssues = options.MaxIssues,
                 staleDays = options.StaleDays,
+                minConsecutiveCandidatesForClose = options.MinConsecutiveCandidatesForClose,
+                statePath = options.StatePath,
+                autoCloseAllowLabels = options.AutoCloseAllowLabels,
+                autoCloseDenyLabels = options.AutoCloseDenyLabels,
                 applyClose = options.ApplyClose,
                 closeReason = options.CloseReason
             },
@@ -611,6 +753,7 @@ internal static class IssueReviewRunner {
                 openIssuesScanned = assessments.Count,
                 infraBlockers = infra.Count,
                 noLongerApplicable = infra.Count(value => value.Classification.Equals("no-longer-applicable", StringComparison.OrdinalIgnoreCase)),
+                autoCloseEligible = infra.Count(value => value.EligibleForAutoClose),
                 needsReview = infra.Count(value => value.Classification.Equals("needs-review", StringComparison.OrdinalIgnoreCase)),
                 active = infra.Count(value => value.Classification.Equals("active", StringComparison.OrdinalIgnoreCase)),
                 closedByAutomation = closedIssueNumbers.Count
@@ -623,6 +766,7 @@ internal static class IssueReviewRunner {
                 isInfraBlocker = value.IsInfraBlocker,
                 classification = value.Classification,
                 eligibleForAutoClose = value.EligibleForAutoClose,
+                candidateStreak = value.CandidateStreak,
                 ageDays = value.AgeDays,
                 linkedPullRequests = value.LinkedPullRequests,
                 linkedPullRequestStates = value.LinkedPullRequestStates,
@@ -656,8 +800,19 @@ internal static class IssueReviewRunner {
         builder.AppendLine($"- Open issues scanned: {assessments.Count}");
         builder.AppendLine($"- Infra blockers detected: {infra.Count}");
         builder.AppendLine($"- No-longer-applicable: {noLongerApplicable.Count}");
+        builder.AppendLine($"- Auto-close eligible: {noLongerApplicable.Count(value => value.EligibleForAutoClose)}");
         builder.AppendLine($"- Needs review: {needsReview.Count}");
         builder.AppendLine($"- Active infra blockers: {active.Count}");
+        builder.AppendLine($"- Min consecutive candidates for close: {options.MinConsecutiveCandidatesForClose}");
+        builder.AppendLine(options.StatePath is null
+            ? "- State path: disabled"
+            : $"- State path: `{options.StatePath}`");
+        if (options.AutoCloseAllowLabels.Count > 0) {
+            builder.AppendLine($"- Auto-close allow labels: `{string.Join("`, `", options.AutoCloseAllowLabels)}`");
+        }
+        if (options.AutoCloseDenyLabels.Count > 0) {
+            builder.AppendLine($"- Auto-close deny labels: `{string.Join("`, `", options.AutoCloseDenyLabels)}`");
+        }
         builder.AppendLine(options.ApplyClose
             ? $"- Closed by automation: {closedIssueNumbers.Count}"
             : "- Dry-run mode: no issues were closed.");
@@ -681,8 +836,14 @@ internal static class IssueReviewRunner {
             var linked = item.LinkedPullRequestStates.Count == 0
                 ? "none"
                 : string.Join(", ", item.LinkedPullRequestStates);
+            var streak = item.CandidateStreak > 0
+                ? $" | streak {item.CandidateStreak}"
+                : string.Empty;
+            var eligibility = item.EligibleForAutoClose
+                ? " | eligible auto-close"
+                : string.Empty;
             builder.AppendLine(
-                $"- #{item.Number} [{item.Title}]({item.Url}) | age {item.AgeDays.ToString("0.0", CultureInfo.InvariantCulture)}d | linked PRs: {linked} | {item.Reason}");
+                $"- #{item.Number} [{item.Title}]({item.Url}) | age {item.AgeDays.ToString("0.0", CultureInfo.InvariantCulture)}d{streak}{eligibility} | linked PRs: {linked} | {item.Reason}");
         }
         builder.AppendLine();
     }
@@ -694,6 +855,89 @@ internal static class IssueReviewRunner {
             "active" => 2,
             _ => 3
         };
+    }
+
+    internal static IssueReviewPolicy BuildPolicy(
+        IReadOnlyCollection<string> autoCloseAllowLabels,
+        IReadOnlyCollection<string> autoCloseDenyLabels) {
+        var allow = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in autoCloseAllowLabels) {
+            if (!string.IsNullOrWhiteSpace(value)) {
+                allow.Add(value.Trim());
+            }
+        }
+
+        var deny = new HashSet<string>(ProtectedLabels, StringComparer.OrdinalIgnoreCase);
+        foreach (var value in autoCloseDenyLabels) {
+            if (!string.IsNullOrWhiteSpace(value)) {
+                deny.Add(value.Trim());
+            }
+        }
+
+        return new IssueReviewPolicy(allow, deny);
+    }
+
+    private static IssueReviewState LoadState(string? path, string repo) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return new IssueReviewState { Repo = repo };
+        }
+
+        var fullPath = Path.GetFullPath(path);
+        if (!File.Exists(fullPath)) {
+            return new IssueReviewState { Repo = repo };
+        }
+
+        try {
+            var content = File.ReadAllText(fullPath);
+            var state = JsonSerializer.Deserialize<IssueReviewState>(content);
+            if (state is null) {
+                return new IssueReviewState { Repo = repo };
+            }
+
+            if (!string.IsNullOrWhiteSpace(state.Repo) &&
+                !state.Repo.Equals(repo, StringComparison.OrdinalIgnoreCase)) {
+                return new IssueReviewState { Repo = repo };
+            }
+
+            state.Repo = repo;
+            state.CandidateStreaks ??= new Dictionary<int, int>();
+            return state;
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Warning: failed to load issue-review state from '{path}': {ex.Message}");
+            return new IssueReviewState { Repo = repo };
+        }
+    }
+
+    private static IssueReviewState BuildUpdatedState(
+        string repo,
+        DateTimeOffset updatedAtUtc,
+        IReadOnlyList<IssueReviewAssessment> assessments) {
+        var state = new IssueReviewState {
+            Repo = repo,
+            UpdatedAtUtc = updatedAtUtc
+        };
+
+        foreach (var assessment in assessments) {
+            if (!assessment.Classification.Equals("no-longer-applicable", StringComparison.OrdinalIgnoreCase) ||
+                assessment.CandidateStreak <= 0) {
+                continue;
+            }
+            state.CandidateStreaks[assessment.Number] = assessment.CandidateStreak;
+        }
+
+        return state;
+    }
+
+    private static void SaveState(string? path, IssueReviewState state) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return;
+        }
+
+        try {
+            WriteText(path, JsonSerializer.Serialize(state, new JsonSerializerOptions { WriteIndented = true }));
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Warning: failed to write issue-review state to '{path}': {ex.Message}");
+        }
     }
 
     private static bool IsInfraBlocker(IssueReviewCandidateIssue issue) {

--- a/IntelligenceX.Tests/Program.Todo.IssueReview.cs
+++ b/IntelligenceX.Tests/Program.Todo.IssueReview.cs
@@ -43,5 +43,106 @@ internal static partial class Program {
         AssertEqual(true, assessment.EligibleForAutoClose, "eligible for auto close");
         AssertEqual(true, assessment.Reason.Contains("resolved", StringComparison.OrdinalIgnoreCase), "resolved reason text");
     }
+
+    private static void TestIssueReviewAssessIssueForApplicabilityRequiresConsecutiveCandidatesForAutoClose() {
+        var now = DateTimeOffset.UtcNow;
+        var issue = new IntelligenceX.Cli.Todo.IssueReviewRunner.IssueReviewCandidateIssue(
+            Number: 362,
+            Title: "Infra blocker: PR #359 checks failing with no space left on device",
+            Body: "Tracking infra incident.",
+            Url: "https://github.com/EvotecIT/IntelligenceX/issues/362",
+            UpdatedAtUtc: now.AddDays(-1),
+            Labels: new[] { "infra-blocker" });
+        var pullRequests = new Dictionary<int, IntelligenceX.Cli.Todo.IssueReviewRunner.PullRequestReference> {
+            [359] = new(
+                Number: 359,
+                Title: "Runner disk cleanup",
+                Url: "https://github.com/EvotecIT/IntelligenceX/pull/359",
+                State: "MERGED",
+                MergedAtUtc: now.AddDays(-1),
+                ClosedAtUtc: now.AddDays(-1))
+        };
+        var policy = IntelligenceX.Cli.Todo.IssueReviewRunner.BuildPolicy(Array.Empty<string>(), Array.Empty<string>());
+
+        var firstAssessment = IntelligenceX.Cli.Todo.IssueReviewRunner.AssessIssueForApplicability(
+            issue,
+            "EvotecIT/IntelligenceX",
+            pullRequests,
+            now,
+            staleDays: 14,
+            policy,
+            previousCandidateStreak: 0,
+            minConsecutiveCandidatesForClose: 2);
+        var secondAssessment = IntelligenceX.Cli.Todo.IssueReviewRunner.AssessIssueForApplicability(
+            issue,
+            "EvotecIT/IntelligenceX",
+            pullRequests,
+            now,
+            staleDays: 14,
+            policy,
+            previousCandidateStreak: 1,
+            minConsecutiveCandidatesForClose: 2);
+
+        AssertEqual("no-longer-applicable", firstAssessment.Classification, "first classification");
+        AssertEqual(false, firstAssessment.EligibleForAutoClose, "first eligibility");
+        AssertEqual(1, firstAssessment.CandidateStreak, "first streak");
+        AssertEqual(true, firstAssessment.Reason.Contains("1/2", StringComparison.OrdinalIgnoreCase), "first streak reason");
+        AssertEqual(true, secondAssessment.EligibleForAutoClose, "second eligibility");
+        AssertEqual(2, secondAssessment.CandidateStreak, "second streak");
+    }
+
+    private static void TestIssueReviewAssessIssueForApplicabilityRespectsAllowAndDenyLabelPolicy() {
+        var now = DateTimeOffset.UtcNow;
+        var issueMissingAllow = new IntelligenceX.Cli.Todo.IssueReviewRunner.IssueReviewCandidateIssue(
+            Number: 440,
+            Title: "Infra blocker: PR #438 checks stuck in Setup .NET",
+            Body: "Tracking after retries.",
+            Url: "https://github.com/EvotecIT/IntelligenceX/issues/440",
+            UpdatedAtUtc: now.AddDays(-2),
+            Labels: new[] { "infra-blocker" });
+        var issueDenied = issueMissingAllow with {
+            Number = 441,
+            Url = "https://github.com/EvotecIT/IntelligenceX/issues/441",
+            Labels = new[] { "infra-blocker", "ops-hold" }
+        };
+        var pullRequests = new Dictionary<int, IntelligenceX.Cli.Todo.IssueReviewRunner.PullRequestReference> {
+            [438] = new(
+                Number: 438,
+                Title: "Fix setup checks",
+                Url: "https://github.com/EvotecIT/IntelligenceX/pull/438",
+                State: "MERGED",
+                MergedAtUtc: now.AddDays(-1),
+                ClosedAtUtc: now.AddDays(-1))
+        };
+        var policy = IntelligenceX.Cli.Todo.IssueReviewRunner.BuildPolicy(
+            new[] { "close-approved" },
+            new[] { "ops-hold" });
+
+        var missingAllowAssessment = IntelligenceX.Cli.Todo.IssueReviewRunner.AssessIssueForApplicability(
+            issueMissingAllow,
+            "EvotecIT/IntelligenceX",
+            pullRequests,
+            now,
+            staleDays: 14,
+            policy,
+            previousCandidateStreak: 3,
+            minConsecutiveCandidatesForClose: 2);
+        var deniedAssessment = IntelligenceX.Cli.Todo.IssueReviewRunner.AssessIssueForApplicability(
+            issueDenied,
+            "EvotecIT/IntelligenceX",
+            pullRequests,
+            now,
+            staleDays: 14,
+            policy,
+            previousCandidateStreak: 3,
+            minConsecutiveCandidatesForClose: 2);
+
+        AssertEqual("no-longer-applicable", missingAllowAssessment.Classification, "missing allow classification");
+        AssertEqual(false, missingAllowAssessment.EligibleForAutoClose, "missing allow eligibility");
+        AssertEqual(true, missingAllowAssessment.Reason.Contains("Missing allow label", StringComparison.OrdinalIgnoreCase), "missing allow reason");
+        AssertEqual("needs-review", deniedAssessment.Classification, "denied classification");
+        AssertEqual(false, deniedAssessment.EligibleForAutoClose, "denied eligibility");
+        AssertEqual(true, deniedAssessment.Reason.Contains("Denied/protected", StringComparison.OrdinalIgnoreCase), "denied reason");
+    }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -467,6 +467,8 @@ internal static partial class Program {
         failed += Run("Todo PR signal backtest bucket stats", TestPullRequestSignalBacktestBuildBucketStatsCalculatesMergeRates);
         failed += Run("Todo issue review pull-request reference parsing", TestIssueReviewExtractPullRequestReferencesParsesMultipleForms);
         failed += Run("Todo issue review no-longer-applicable classification", TestIssueReviewAssessIssueForApplicabilityMarksResolvedInfraBlockerAsNoLongerApplicable);
+        failed += Run("Todo issue review consecutive candidate gate", TestIssueReviewAssessIssueForApplicabilityRequiresConsecutiveCandidatesForAutoClose);
+        failed += Run("Todo issue review allow/deny label policy", TestIssueReviewAssessIssueForApplicabilityRespectsAllowAndDenyLabelPolicy);
         failed += Run("Todo vision check out-of-scope classification", TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate);
         failed += Run("Todo vision check aligned classification", TestVisionCheckClassifiesAlignedWhenInTokensMatch);
         failed += Run("Todo vision check explicit reject policy precedence", TestVisionCheckExplicitRejectPolicyTakesPrecedence);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -69,6 +69,11 @@ intelligencex todo issue-review --repo EvotecIT/IntelligenceX
 Options:
 - `--max-issues <n>` (1-2000, default `300`)
 - `--stale-days <n>` (default `14`)
+- `--min-consecutive-candidates <n>` (default `1`; use `2+` for safer auto-close)
+- `--state-path <path>` (default `artifacts/triage/ix-issue-review-state.json`)
+- `--no-state` (disable streak persistence)
+- `--allow-label <label>` (repeatable; require at least one for auto-close eligibility)
+- `--deny-label <label>` (repeatable; never auto-close when present)
 - `--apply-close` (opt-in mutating mode; closes no-longer-applicable candidates)
 - `--close-reason <completed|not-planned>` (default `completed`)
 - `--no-comment` (skip managed close note comment)
@@ -79,6 +84,13 @@ Safety defaults:
 - Dry-run by default (no issue mutation unless `--apply-close` is set).
 - Issues with protected labels (`do-not-close`, `keep-open`, `pinned`, `ix/decision:accept`) are never auto-closed.
 - Auto-close scope is currently conservative: infra blockers with linked PR references where all linked PRs are resolved.
+- For production-like automation, prefer `--min-consecutive-candidates 2` (or higher) with a persisted `--state-path`.
+
+Workflow automation:
+- `.github/workflows/issue-review.yml` runs nightly in dry-run mode.
+- Manual close runs require explicit confirmation in workflow dispatch:
+  - `apply_close=true`
+  - `confirm_apply_close=CLOSE_ISSUES`
 
 ## Vision Check (Assistive)
 


### PR DESCRIPTION
## Summary
- harden `todo issue-review` with engine-native safety controls for auto-close
- add consecutive-candidate gating with persisted state (`--min-consecutive-candidates`, `--state-path`, `--no-state`)
- add label policy gates (`--allow-label`, `--deny-label`) merged with protected labels
- enrich issue-review JSON/markdown output with candidate streak and auto-close eligibility details
- add first-party workflow `.github/workflows/issue-review.yml` for scheduled dry-runs and guarded manual close runs
- update docs for projects/PR monitoring and internal CLI command reference
- add tests for consecutive-run gating and allow/deny label policy behavior

## Why
This keeps issue auto-management conservative and deterministic without external scripts, while making issue triage automation practical for stale/invalid infra blockers.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
