### PR TITLE
Restore classic reviewer visuals while keeping concise reusable flow

### DIFF
--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -25,9 +25,7 @@ jobs:
     uses: evotecit/github-actions/.github/workflows/review-intelligencex.yml@master
     with:
       runs_on: '["self-hosted","ubuntu"]'
-      reviewer_source: release
-      reviewer_release_repo: EvotecIT/github-actions
-      reviewer_release_tag: latest
+      reviewer_source: source
       
       
       repo: ${{ github.event.pull_request.number && github.repository || inputs.repo }}
@@ -35,6 +33,10 @@ jobs:
       provider: openai
       model: gpt-5.3-codex
       openai_transport: native
+      review_config_path: .intelligencex/reviewer.json
+      mode: hybrid
+      length: medium
+      style: direct
       include_issue_comments: true
       include_review_comments: true
       include_related_prs: true


### PR DESCRIPTION
## Summary
- keep the single reusable IntelligenceX Review workflow job
- switch reviewer execution from external release bundle to repo source (eviewer_source: source) so visuals follow in-repo templates
- explicitly set reviewer presentation inputs for concise structured output:
  - eview_config_path: .intelligencex/reviewer.json
  - mode: hybrid
  - length: medium
  - style: direct

## Why
Recent migration to reusable workflow + release binary changed the rendered review style. This restores the familiar sectioned visuals while retaining the newer concise behavior.

## Notes
- no code/runtime changes outside workflow config
- small workflow-only diff
