### PR TITLE
feat(todo,website): add issue-review confidence signals + Project Ops area

### DIFF
--- a/.github/workflows/issue-review.yml
+++ b/.github/workflows/issue-review.yml
@@ -17,6 +17,10 @@ on:
         description: "Consecutive no-longer-applicable runs required before auto-close"
         required: false
         default: "2"
+      min_auto_close_confidence:
+        description: "Minimum confidence (0-100) required before auto-close"
+        required: false
+        default: "80"
       apply_close:
         description: "Apply auto-close to eligible candidates"
         required: false
@@ -81,6 +85,7 @@ jobs:
           MAX_ISSUES="${{ github.event.inputs.max_issues }}"
           STALE_DAYS="${{ github.event.inputs.stale_days }}"
           MIN_CONSECUTIVE="${{ github.event.inputs.min_consecutive_candidates }}"
+          MIN_CONFIDENCE="${{ github.event.inputs.min_auto_close_confidence }}"
           APPLY_CLOSE="${{ github.event.inputs.apply_close }}"
           CONFIRM_APPLY_CLOSE="${{ github.event.inputs.confirm_apply_close }}"
           CLOSE_REASON="${{ github.event.inputs.close_reason }}"
@@ -90,6 +95,7 @@ jobs:
           if [ -z "$MAX_ISSUES" ]; then MAX_ISSUES="500"; fi
           if [ -z "$STALE_DAYS" ]; then STALE_DAYS="14"; fi
           if [ -z "$MIN_CONSECUTIVE" ]; then MIN_CONSECUTIVE="2"; fi
+          if [ -z "$MIN_CONFIDENCE" ]; then MIN_CONFIDENCE="80"; fi
           if [ -z "$CLOSE_REASON" ]; then CLOSE_REASON="completed"; fi
           if [ -z "$APPLY_CLOSE" ]; then APPLY_CLOSE="false"; fi
 
@@ -99,6 +105,7 @@ jobs:
             "--max-issues" "$MAX_ISSUES"
             "--stale-days" "$STALE_DAYS"
             "--min-consecutive-candidates" "$MIN_CONSECUTIVE"
+            "--min-auto-close-confidence" "$MIN_CONFIDENCE"
             "--state-path" "${ISSUE_REVIEW_STATE_PATH}"
             "--out" "artifacts/triage/ix-issue-review.json"
             "--summary" "artifacts/triage/ix-issue-review.md"

--- a/Docs/_index.md
+++ b/Docs/_index.md
@@ -26,6 +26,12 @@ Welcome to the IntelligenceX documentation.
 - [Reviewer Project Bootstrap and Sync](/docs/reviewer/project-bootstrap-sync/)
 - [Reviewer Project Views and Operations](/docs/reviewer/project-views-and-ops/)
 
+## Project Ops
+
+- [Project Ops Overview](/docs/project-ops/overview/)
+- [Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
+- [Project Views and Operations](/docs/reviewer/project-views-and-ops/)
+
 ## CLI Tools
 
 - [CLI Overview](/docs/cli/overview/)

--- a/Docs/project-ops/overview.md
+++ b/Docs/project-ops/overview.md
@@ -1,0 +1,37 @@
+---
+title: Project Ops Overview
+slug: overview
+---
+
+# Project Ops
+
+Project Ops is the maintainer-first control plane for backlog triage in GitHub Projects.
+
+It combines:
+
+- `issue-review` for stale or no-longer-applicable infra blockers
+- `build-triage-index` for duplicate clustering and ranking
+- `vision-check` for scope alignment against `VISION.md`
+- `project-sync` for pushing signals into Project fields
+
+## Important disclaimer
+
+Project Ops is assistive automation, not autonomous production governance.
+
+- Treat proposed actions and confidence as recommendations.
+- Keep close/defer/accept decisions human-owned.
+- Use dry-run and proposal-only modes before any mutating workflow.
+
+## Recommended start
+
+```bash
+intelligencex todo project-bootstrap --repo EvotecIT/IntelligenceX --owner EvotecIT
+intelligencex todo issue-review --repo EvotecIT/IntelligenceX --proposal-only --min-consecutive-candidates 2 --min-auto-close-confidence 80
+intelligencex todo project-sync --config artifacts/triage/ix-project-config.json --dry-run
+```
+
+## Related docs
+
+- [Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
+- [Project Bootstrap and Sync](/docs/reviewer/project-bootstrap-sync/)
+- [Project Views and Operations](/docs/reviewer/project-views-and-ops/)

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -16,6 +16,7 @@ These commands are assistive. They are not an autonomous production decision sys
 - Backlog indexing and duplicate clustering across open PRs/issues (`build-triage-index`).
 - Scope alignment checks against `VISION.md` (`vision-check`).
 - Issue applicability review for stale/no-longer-applicable infra blockers (`issue-review`).
+- Issue applicability proposed actions (`close`, `keep-open`, `needs-human-review`) with confidence scoring and safety signals.
 - GitHub Project field sync for triage at scale (`project-init`, `project-sync`, `project-bootstrap`).
 - Maintainer-assist view checklist and apply plan generation (`project-view-checklist`, `project-view-apply`).
 - Signal quality grading (`high`/`medium`/`low`) to separate strong recommendations from weak-context items.
@@ -41,7 +42,7 @@ intelligencex todo sync-bot-feedback --repo EvotecIT/IntelligenceX
 intelligencex todo build-triage-index --repo EvotecIT/IntelligenceX
 
 # 3) Review infra blocker issue applicability (dry-run, with streak state)
-intelligencex todo issue-review --repo EvotecIT/IntelligenceX --min-consecutive-candidates 2 --state-path artifacts/triage/ix-issue-review-state.json
+intelligencex todo issue-review --repo EvotecIT/IntelligenceX --proposal-only --min-consecutive-candidates 2 --min-auto-close-confidence 80 --state-path artifacts/triage/ix-issue-review-state.json
 
 # 4) Check backlog against VISION.md
 intelligencex todo vision-check --repo EvotecIT/IntelligenceX --vision VISION.md
@@ -77,7 +78,22 @@ intelligencex todo project-view-checklist --config artifacts/triage/ix-project-c
 - Manual auto-close: use `workflow_dispatch` with:
   - `apply_close=true`
   - `confirm_apply_close=CLOSE_ISSUES`
+  - `min_auto_close_confidence` (default `80`)
   - optional label policy (`allow_labels`, `deny_labels`)
+
+### Issue-review confidence signals
+
+`issue-review` now emits a proposed action and confidence score for each issue:
+
+- `proposedAction`: `close`, `keep-open`, `needs-human-review`, `ignore`
+- `actionConfidence`: `0-100` with level hints (`high`/`medium`/`low`)
+- `confidenceSignals`: explainable signal list (for example stale bucket, recent activity, linked PR age, reopened count)
+
+Safety behavior:
+
+- Auto-close requires both policy eligibility and confidence threshold (`--min-auto-close-confidence`).
+- Recently active issues and reopened issues are downgraded to `needs-human-review`.
+- Use `--proposal-only` for calibration runs where any close operation must be blocked.
 
 ## Permissions and safety
 

--- a/Docs/toc.json
+++ b/Docs/toc.json
@@ -21,6 +21,12 @@
     ]
   },
   {
+    "title": "Project Ops",
+    "items": [
+      { "title": "Overview", "href": "/docs/project-ops/overview/" }
+    ]
+  },
+  {
     "title": "IX Chat",
     "items": [
       { "title": "Overview", "href": "/docs/chat/overview/" },

--- a/IntelligenceX.Cli/Program.Help.cs
+++ b/IntelligenceX.Cli/Program.Help.cs
@@ -66,7 +66,7 @@ internal static partial class Program {
         Console.WriteLine("  todo sync-bot-feedback   Sync bot checklist items into TODO.md (optional issue creation)");
         Console.WriteLine("  todo build-triage-index  Build PR/Issue triage index with duplicate clusters and best PR ranking");
         Console.WriteLine("  todo backtest-pr-signals Backtest PR operational signal calibration on closed/merged historical PRs");
-        Console.WriteLine("  todo issue-review        Review open issues for no-longer-applicable infra blockers and optional auto-close");
+        Console.WriteLine("  todo issue-review        Review open issues for infra applicability with proposed actions/confidence and optional auto-close");
         Console.WriteLine("  todo vision-check        Compare PR backlog against VISION.md and flag likely out-of-scope work");
         Console.WriteLine("  todo project-init        Create or initialize a GitHub Project with IX triage/vision fields");
         Console.WriteLine("  todo project-sync        Sync triage/vision artifacts into GitHub Project items and fields");

--- a/IntelligenceX.Cli/Todo/IssueReviewRunner.cs
+++ b/IntelligenceX.Cli/Todo/IssueReviewRunner.cs
@@ -72,7 +72,11 @@ internal static class IssueReviewRunner {
         IReadOnlyList<int> LinkedPullRequests,
         IReadOnlyList<string> LinkedPullRequestStates,
         string Reason,
-        IReadOnlyList<string> Labels
+        IReadOnlyList<string> Labels,
+        string ProposedAction = "needs-human-review",
+        int ActionConfidence = 0,
+        IReadOnlyList<string>? ConfidenceSignals = null,
+        int ReopenedCount = 0
     );
 
     internal sealed record IssueReviewPolicy(
@@ -92,9 +96,11 @@ internal static class IssueReviewRunner {
         public int MaxIssues { get; set; } = 300;
         public int StaleDays { get; set; } = 14;
         public int MinConsecutiveCandidatesForClose { get; set; } = 1;
+        public int MinAutoCloseConfidence { get; set; } = 80;
         public string? StatePath { get; set; } = Path.Combine("artifacts", "triage", "ix-issue-review-state.json");
         public List<string> AutoCloseAllowLabels { get; } = new();
         public List<string> AutoCloseDenyLabels { get; } = new();
+        public bool ProposalOnly { get; set; }
         public bool ApplyClose { get; set; }
         public string CloseReason { get; set; } = "completed";
         public bool CommentOnClose { get; set; } = true;
@@ -148,6 +154,15 @@ internal static class IssueReviewRunner {
                         options.ShowHelp = true;
                     }
                     break;
+                case "--min-auto-close-confidence":
+                    if (i + 1 < args.Length &&
+                        int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var minAutoCloseConfidence)) {
+                        options.MinAutoCloseConfidence = Math.Max(0, Math.Min(minAutoCloseConfidence, 100));
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
                 case "--state-path":
                     if (i + 1 < args.Length) {
                         options.StatePath = args[++i];
@@ -189,6 +204,9 @@ internal static class IssueReviewRunner {
                     break;
                 case "--apply-close":
                     options.ApplyClose = true;
+                    break;
+                case "--proposal-only":
+                    options.ProposalOnly = true;
                     break;
                 case "--close-reason":
                     if (i + 1 < args.Length) {
@@ -235,6 +253,11 @@ internal static class IssueReviewRunner {
             options.ParseFailed = true;
             options.ShowHelp = true;
         }
+        if (options.ApplyClose && options.ProposalOnly) {
+            Console.Error.WriteLine("`--apply-close` and `--proposal-only` cannot be used together.");
+            options.ParseFailed = true;
+            options.ShowHelp = true;
+        }
 
         return options;
     }
@@ -261,10 +284,12 @@ internal static class IssueReviewRunner {
         Console.WriteLine("  --max-issues <n>            Open issues to scan (1-2000, default: 300)");
         Console.WriteLine("  --stale-days <n>            Age threshold for stale infra issues without PR links (default: 14)");
         Console.WriteLine("  --min-consecutive-candidates <n>  Consecutive no-longer-applicable runs required for auto-close (default: 1)");
+        Console.WriteLine("  --min-auto-close-confidence <0-100>  Minimum confidence required for auto-close (default: 80)");
         Console.WriteLine("  --state-path <path>         Candidate state path for consecutive tracking (default: artifacts/triage/ix-issue-review-state.json)");
         Console.WriteLine("  --no-state                  Disable candidate streak persistence");
         Console.WriteLine("  --allow-label <label>       Require at least one of these labels for auto-close (repeatable)");
         Console.WriteLine("  --deny-label <label>        Never auto-close issues with these labels (repeatable)");
+        Console.WriteLine("  --proposal-only             Force advisory output mode (never close issues)");
         Console.WriteLine("  --apply-close               Close no-longer-applicable issues (default: dry-run)");
         Console.WriteLine("  --close-reason <completed|not-planned>  Reason used when closing issues (default: completed)");
         Console.WriteLine("  --no-comment                Do not post a managed IX close note");
@@ -333,8 +358,36 @@ internal static class IssueReviewRunner {
                 options.MinConsecutiveCandidatesForClose);
             assessments.Add(assessment);
         }
+        var issueByNumber = issues.ToDictionary(value => value.Number);
+        var enrichedAssessments = new List<IssueReviewAssessment>(assessments.Count);
+        foreach (var assessment in assessments) {
+            if (!issueByNumber.TryGetValue(assessment.Number, out var issue)) {
+                enrichedAssessments.Add(assessment);
+                continue;
+            }
+
+            int? reopenedCount = null;
+            if (assessment.IsInfraBlocker &&
+                (assessment.Classification.Equals("no-longer-applicable", StringComparison.OrdinalIgnoreCase) ||
+                 assessment.Classification.Equals("needs-review", StringComparison.OrdinalIgnoreCase))) {
+                reopenedCount = await TryFetchReopenedCountAsync(options.Repo, assessment.Number).ConfigureAwait(false);
+            }
+
+            var enriched = EnrichWithActionSignals(
+                assessment,
+                issue,
+                pullRequestsByNumber,
+                nowUtc,
+                options.MinAutoCloseConfidence,
+                reopenedCount);
+            enrichedAssessments.Add(enriched);
+        }
+        assessments = enrichedAssessments;
+
         assessments = assessments
             .OrderBy(value => ClassificationRank(value.Classification))
+            .ThenBy(value => ProposedActionRank(value.ProposedAction))
+            .ThenByDescending(value => value.ActionConfidence)
             .ThenByDescending(value => value.CandidateStreak)
             .ThenByDescending(value => value.AgeDays)
             .ThenBy(value => value.Number)
@@ -344,7 +397,10 @@ internal static class IssueReviewRunner {
             .Where(value => value.Classification.Equals("no-longer-applicable", StringComparison.OrdinalIgnoreCase))
             .ToList();
         var autoCloseCandidates = assessments
-            .Where(value => value.EligibleForAutoClose)
+            .Where(value =>
+                value.EligibleForAutoClose &&
+                value.ProposedAction.Equals("close", StringComparison.OrdinalIgnoreCase) &&
+                value.ActionConfidence >= options.MinAutoCloseConfidence)
             .ToList();
 
         var closedIssueNumbers = new List<int>();
@@ -376,10 +432,13 @@ internal static class IssueReviewRunner {
         Console.WriteLine($"No-longer-applicable candidates: {noLongerApplicableCandidates.Count}");
         Console.WriteLine($"Auto-close eligible this run: {autoCloseCandidates.Count}");
         Console.WriteLine($"Min consecutive candidates required: {options.MinConsecutiveCandidatesForClose}");
+        Console.WriteLine($"Min auto-close confidence: {options.MinAutoCloseConfidence}");
         Console.WriteLine(options.StatePath is null
             ? "State persistence: disabled."
             : $"State persistence: {options.StatePath}");
-        Console.WriteLine(options.ApplyClose
+        Console.WriteLine(options.ProposalOnly
+            ? "Proposal-only mode: close operations disabled."
+            : options.ApplyClose
             ? $"Closed by automation: {closedIssueNumbers.Count}"
             : "Dry-run mode: no issues were closed (use --apply-close to close candidates).");
         return 0;
@@ -705,6 +764,137 @@ internal static class IssueReviewRunner {
         return false;
     }
 
+    private static async Task<int?> TryFetchReopenedCountAsync(string repo, int issueNumber) {
+        var (code, stdout, stderr) = await GhCli.RunAsync(
+            TimeSpan.FromSeconds(45),
+            "api",
+            $"repos/{repo}/issues/{issueNumber.ToString(CultureInfo.InvariantCulture)}/events?per_page=100").ConfigureAwait(false);
+        if (code != 0) {
+            Console.Error.WriteLine(
+                $"Warning: failed to query issue events for #{issueNumber}: {(string.IsNullOrWhiteSpace(stderr) ? "unknown error" : stderr.Trim())}");
+            return null;
+        }
+
+        try {
+            using var doc = JsonDocument.Parse(stdout);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) {
+                return 0;
+            }
+
+            var count = 0;
+            foreach (var entry in doc.RootElement.EnumerateArray()) {
+                var kind = ReadString(entry, "event");
+                if (kind.Equals("reopened", StringComparison.OrdinalIgnoreCase)) {
+                    count++;
+                }
+            }
+            return count;
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Warning: failed to parse issue events for #{issueNumber}: {ex.Message}");
+            return null;
+        }
+    }
+
+    internal static IssueReviewAssessment EnrichWithActionSignals(
+        IssueReviewAssessment assessment,
+        IssueReviewCandidateIssue issue,
+        IReadOnlyDictionary<int, PullRequestReference> pullRequestsByNumber,
+        DateTimeOffset nowUtc,
+        int minAutoCloseConfidence,
+        int? reopenedCount) {
+        var signals = new List<string>();
+        var proposedAction = assessment.Classification.ToLowerInvariant() switch {
+            "no-longer-applicable" when assessment.EligibleForAutoClose => "close",
+            "active" => "keep-open",
+            "out-of-scope" => "ignore",
+            _ => "needs-human-review"
+        };
+        var confidence = assessment.Classification.ToLowerInvariant() switch {
+            "no-longer-applicable" => 72,
+            "active" => 78,
+            "out-of-scope" => 82,
+            _ => 58
+        };
+
+        if (assessment.AgeDays >= 30) {
+            confidence += 10;
+            signals.Add("stale_days_bucket:>=30d(+10)");
+        } else if (assessment.AgeDays >= 14) {
+            confidence += 6;
+            signals.Add("stale_days_bucket:14-29d(+6)");
+        } else if (assessment.AgeDays <= 2) {
+            confidence -= 16;
+            signals.Add("stale_days_bucket:<=2d(-16)");
+        }
+
+        if (assessment.AgeDays <= 2) {
+            confidence -= 15;
+            signals.Add("recent_issue_activity:high(-15)");
+        } else if (assessment.AgeDays <= 7) {
+            confidence -= 8;
+            signals.Add("recent_issue_activity:medium(-8)");
+        } else {
+            confidence += 4;
+            signals.Add("recent_issue_activity:low(+4)");
+        }
+
+        if (issue.Labels.Any(label => label.Equals("ix/decision:accept", StringComparison.OrdinalIgnoreCase))) {
+            confidence -= 25;
+            signals.Add("maintainer_decision_accept(-25)");
+            proposedAction = "needs-human-review";
+        }
+
+        var linkedResolvedAges = new List<double>();
+        foreach (var number in assessment.LinkedPullRequests) {
+            if (!pullRequestsByNumber.TryGetValue(number, out var reference)) {
+                continue;
+            }
+            var resolvedAt = reference.MergedAtUtc ?? reference.ClosedAtUtc;
+            if (!resolvedAt.HasValue) {
+                continue;
+            }
+            linkedResolvedAges.Add(Math.Max(0, (nowUtc - resolvedAt.Value).TotalDays));
+        }
+        if (linkedResolvedAges.Count > 0) {
+            var minLinkedPrAge = linkedResolvedAges.Min();
+            if (minLinkedPrAge < 3) {
+                confidence -= 12;
+                signals.Add("linked_pr_age:<3d(-12)");
+            } else if (minLinkedPrAge >= 14) {
+                confidence += 8;
+                signals.Add("linked_pr_age:>=14d(+8)");
+            } else {
+                signals.Add("linked_pr_age:3-13d(+0)");
+            }
+        }
+
+        var reopenSignalCount = Math.Max(0, reopenedCount ?? 0);
+        if (reopenedCount.HasValue) {
+            if (reopenSignalCount > 0) {
+                var penalty = Math.Min(35, reopenSignalCount * 12);
+                confidence -= penalty;
+                signals.Add($"reopened_count:{reopenSignalCount}(-{penalty})");
+            } else {
+                confidence += 4;
+                signals.Add("reopened_count:0(+4)");
+            }
+        }
+
+        confidence = Math.Clamp(confidence, 0, 100);
+        if (proposedAction.Equals("close", StringComparison.OrdinalIgnoreCase)) {
+            if (reopenSignalCount > 0 || assessment.AgeDays <= 2 || confidence < minAutoCloseConfidence) {
+                proposedAction = "needs-human-review";
+            }
+        }
+
+        return assessment with {
+            ProposedAction = proposedAction,
+            ActionConfidence = confidence,
+            ConfidenceSignals = signals,
+            ReopenedCount = reopenSignalCount
+        };
+    }
+
     private static async Task TryCommentOnClosedIssueAsync(string repo, IssueReviewAssessment assessment, string closeReason) {
         var body = new StringBuilder();
         body.AppendLine(ManagedCommentMarker);
@@ -712,6 +902,7 @@ internal static class IssueReviewRunner {
         body.AppendLine();
         body.AppendLine($"- Classification: `{assessment.Classification}`");
         body.AppendLine($"- Reason: {assessment.Reason}");
+        body.AppendLine($"- Proposed action: `{assessment.ProposedAction}` ({assessment.ActionConfidence}/100)");
         body.AppendLine($"- Close reason: `{closeReason}`");
         if (assessment.LinkedPullRequestStates.Count > 0) {
             body.AppendLine($"- Linked PR states: {string.Join(", ", assessment.LinkedPullRequestStates)}");
@@ -743,9 +934,11 @@ internal static class IssueReviewRunner {
                 maxIssues = options.MaxIssues,
                 staleDays = options.StaleDays,
                 minConsecutiveCandidatesForClose = options.MinConsecutiveCandidatesForClose,
+                minAutoCloseConfidence = options.MinAutoCloseConfidence,
                 statePath = options.StatePath,
                 autoCloseAllowLabels = options.AutoCloseAllowLabels,
                 autoCloseDenyLabels = options.AutoCloseDenyLabels,
+                proposalOnly = options.ProposalOnly,
                 applyClose = options.ApplyClose,
                 closeReason = options.CloseReason
             },
@@ -753,7 +946,14 @@ internal static class IssueReviewRunner {
                 openIssuesScanned = assessments.Count,
                 infraBlockers = infra.Count,
                 noLongerApplicable = infra.Count(value => value.Classification.Equals("no-longer-applicable", StringComparison.OrdinalIgnoreCase)),
-                autoCloseEligible = infra.Count(value => value.EligibleForAutoClose),
+                autoCloseEligible = infra.Count(value =>
+                    value.EligibleForAutoClose &&
+                    value.ProposedAction.Equals("close", StringComparison.OrdinalIgnoreCase) &&
+                    value.ActionConfidence >= options.MinAutoCloseConfidence),
+                proposedClose = assessments.Count(value => value.ProposedAction.Equals("close", StringComparison.OrdinalIgnoreCase)),
+                proposedKeepOpen = assessments.Count(value => value.ProposedAction.Equals("keep-open", StringComparison.OrdinalIgnoreCase)),
+                proposedNeedsHumanReview = assessments.Count(value => value.ProposedAction.Equals("needs-human-review", StringComparison.OrdinalIgnoreCase)),
+                proposedIgnore = assessments.Count(value => value.ProposedAction.Equals("ignore", StringComparison.OrdinalIgnoreCase)),
                 needsReview = infra.Count(value => value.Classification.Equals("needs-review", StringComparison.OrdinalIgnoreCase)),
                 active = infra.Count(value => value.Classification.Equals("active", StringComparison.OrdinalIgnoreCase)),
                 closedByAutomation = closedIssueNumbers.Count
@@ -767,6 +967,11 @@ internal static class IssueReviewRunner {
                 classification = value.Classification,
                 eligibleForAutoClose = value.EligibleForAutoClose,
                 candidateStreak = value.CandidateStreak,
+                proposedAction = value.ProposedAction,
+                actionConfidence = value.ActionConfidence,
+                actionConfidenceLevel = ConfidenceLevel(value.ActionConfidence),
+                confidenceSignals = value.ConfidenceSignals ?? Array.Empty<string>(),
+                reopenedCount = value.ReopenedCount,
                 ageDays = value.AgeDays,
                 linkedPullRequests = value.LinkedPullRequests,
                 linkedPullRequestStates = value.LinkedPullRequestStates,
@@ -800,10 +1005,14 @@ internal static class IssueReviewRunner {
         builder.AppendLine($"- Open issues scanned: {assessments.Count}");
         builder.AppendLine($"- Infra blockers detected: {infra.Count}");
         builder.AppendLine($"- No-longer-applicable: {noLongerApplicable.Count}");
-        builder.AppendLine($"- Auto-close eligible: {noLongerApplicable.Count(value => value.EligibleForAutoClose)}");
+        builder.AppendLine($"- Auto-close eligible: {noLongerApplicable.Count(value => value.EligibleForAutoClose && value.ProposedAction.Equals("close", StringComparison.OrdinalIgnoreCase) && value.ActionConfidence >= options.MinAutoCloseConfidence)}");
         builder.AppendLine($"- Needs review: {needsReview.Count}");
         builder.AppendLine($"- Active infra blockers: {active.Count}");
         builder.AppendLine($"- Min consecutive candidates for close: {options.MinConsecutiveCandidatesForClose}");
+        builder.AppendLine($"- Min auto-close confidence: {options.MinAutoCloseConfidence}");
+        builder.AppendLine($"- Proposed action `close`: {assessments.Count(value => value.ProposedAction.Equals("close", StringComparison.OrdinalIgnoreCase))}");
+        builder.AppendLine($"- Proposed action `keep-open`: {assessments.Count(value => value.ProposedAction.Equals("keep-open", StringComparison.OrdinalIgnoreCase))}");
+        builder.AppendLine($"- Proposed action `needs-human-review`: {assessments.Count(value => value.ProposedAction.Equals("needs-human-review", StringComparison.OrdinalIgnoreCase))}");
         builder.AppendLine(options.StatePath is null
             ? "- State path: disabled"
             : $"- State path: `{options.StatePath}`");
@@ -813,7 +1022,9 @@ internal static class IssueReviewRunner {
         if (options.AutoCloseDenyLabels.Count > 0) {
             builder.AppendLine($"- Auto-close deny labels: `{string.Join("`, `", options.AutoCloseDenyLabels)}`");
         }
-        builder.AppendLine(options.ApplyClose
+        builder.AppendLine(options.ProposalOnly
+            ? "- Proposal-only mode: close operations disabled."
+            : options.ApplyClose
             ? $"- Closed by automation: {closedIssueNumbers.Count}"
             : "- Dry-run mode: no issues were closed.");
         builder.AppendLine();
@@ -842,8 +1053,9 @@ internal static class IssueReviewRunner {
             var eligibility = item.EligibleForAutoClose
                 ? " | eligible auto-close"
                 : string.Empty;
+            var action = $" | action {item.ProposedAction} ({item.ActionConfidence}/100,{ConfidenceLevel(item.ActionConfidence)})";
             builder.AppendLine(
-                $"- #{item.Number} [{item.Title}]({item.Url}) | age {item.AgeDays.ToString("0.0", CultureInfo.InvariantCulture)}d{streak}{eligibility} | linked PRs: {linked} | {item.Reason}");
+                $"- #{item.Number} [{item.Title}]({item.Url}) | age {item.AgeDays.ToString("0.0", CultureInfo.InvariantCulture)}d{streak}{eligibility}{action} | linked PRs: {linked} | {item.Reason}");
         }
         builder.AppendLine();
     }
@@ -854,6 +1066,24 @@ internal static class IssueReviewRunner {
             "needs-review" => 1,
             "active" => 2,
             _ => 3
+        };
+    }
+
+    private static int ProposedActionRank(string proposedAction) {
+        return proposedAction.ToLowerInvariant() switch {
+            "close" => 0,
+            "needs-human-review" => 1,
+            "keep-open" => 2,
+            "ignore" => 3,
+            _ => 4
+        };
+    }
+
+    private static string ConfidenceLevel(int confidence) {
+        return confidence switch {
+            >= 80 => "high",
+            >= 60 => "medium",
+            _ => "low"
         };
     }
 

--- a/IntelligenceX.Tests/Program.Todo.IssueReview.cs
+++ b/IntelligenceX.Tests/Program.Todo.IssueReview.cs
@@ -144,5 +144,89 @@ internal static partial class Program {
         AssertEqual(false, deniedAssessment.EligibleForAutoClose, "denied eligibility");
         AssertEqual(true, deniedAssessment.Reason.Contains("Denied/protected", StringComparison.OrdinalIgnoreCase), "denied reason");
     }
+
+    private static void TestIssueReviewActionSignalsDowngradeCloseProposalWhenReopenedOrTooFresh() {
+        var now = DateTimeOffset.UtcNow;
+        var issue = new IntelligenceX.Cli.Todo.IssueReviewRunner.IssueReviewCandidateIssue(
+            Number: 440,
+            Title: "Infra blocker: PR #438 checks stuck in Setup .NET",
+            Body: "Tracking after retries.",
+            Url: "https://github.com/EvotecIT/IntelligenceX/issues/440",
+            UpdatedAtUtc: now.AddDays(-1),
+            Labels: new[] { "infra-blocker" });
+        var pullRequests = new Dictionary<int, IntelligenceX.Cli.Todo.IssueReviewRunner.PullRequestReference> {
+            [438] = new(
+                Number: 438,
+                Title: "Fix setup checks",
+                Url: "https://github.com/EvotecIT/IntelligenceX/pull/438",
+                State: "MERGED",
+                MergedAtUtc: now.AddDays(-1),
+                ClosedAtUtc: now.AddDays(-1))
+        };
+
+        var baseline = IntelligenceX.Cli.Todo.IssueReviewRunner.AssessIssueForApplicability(
+            issue,
+            "EvotecIT/IntelligenceX",
+            pullRequests,
+            now,
+            staleDays: 14);
+        var signaled = IntelligenceX.Cli.Todo.IssueReviewRunner.EnrichWithActionSignals(
+            baseline,
+            issue,
+            pullRequests,
+            now,
+            minAutoCloseConfidence: 80,
+            reopenedCount: 1);
+
+        AssertEqual("no-longer-applicable", baseline.Classification, "baseline classification");
+        AssertEqual(true, baseline.EligibleForAutoClose, "baseline eligibility");
+        AssertEqual("needs-human-review", signaled.ProposedAction, "proposal downgraded");
+        AssertEqual(true, signaled.ActionConfidence < 80, "confidence below threshold");
+        AssertEqual(1, signaled.ReopenedCount, "reopened count persisted");
+    }
+
+    private static void TestIssueReviewActionSignalsKeepCloseProposalWhenSignalsStrong() {
+        var now = DateTimeOffset.UtcNow;
+        var issue = new IntelligenceX.Cli.Todo.IssueReviewRunner.IssueReviewCandidateIssue(
+            Number: 362,
+            Title: "Infra blocker: PR #359 checks failing with no space left on device",
+            Body: "Tracking infra incident.",
+            Url: "https://github.com/EvotecIT/IntelligenceX/issues/362",
+            UpdatedAtUtc: now.AddDays(-28),
+            Labels: new[] { "infra-blocker", "close-approved" });
+        var pullRequests = new Dictionary<int, IntelligenceX.Cli.Todo.IssueReviewRunner.PullRequestReference> {
+            [359] = new(
+                Number: 359,
+                Title: "Runner disk cleanup",
+                Url: "https://github.com/EvotecIT/IntelligenceX/pull/359",
+                State: "MERGED",
+                MergedAtUtc: now.AddDays(-21),
+                ClosedAtUtc: now.AddDays(-21))
+        };
+        var policy = IntelligenceX.Cli.Todo.IssueReviewRunner.BuildPolicy(
+            new[] { "close-approved" },
+            Array.Empty<string>());
+        var baseline = IntelligenceX.Cli.Todo.IssueReviewRunner.AssessIssueForApplicability(
+            issue,
+            "EvotecIT/IntelligenceX",
+            pullRequests,
+            now,
+            staleDays: 14,
+            policy,
+            previousCandidateStreak: 2,
+            minConsecutiveCandidatesForClose: 2);
+        var signaled = IntelligenceX.Cli.Todo.IssueReviewRunner.EnrichWithActionSignals(
+            baseline,
+            issue,
+            pullRequests,
+            now,
+            minAutoCloseConfidence: 80,
+            reopenedCount: 0);
+
+        AssertEqual(true, baseline.EligibleForAutoClose, "baseline eligibility");
+        AssertEqual("close", signaled.ProposedAction, "proposal close");
+        AssertEqual(true, signaled.ActionConfidence >= 80, "confidence threshold");
+        AssertEqual(true, signaled.ConfidenceSignals is { Count: > 0 }, "signals present");
+    }
 #endif
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -469,6 +469,8 @@ internal static partial class Program {
         failed += Run("Todo issue review no-longer-applicable classification", TestIssueReviewAssessIssueForApplicabilityMarksResolvedInfraBlockerAsNoLongerApplicable);
         failed += Run("Todo issue review consecutive candidate gate", TestIssueReviewAssessIssueForApplicabilityRequiresConsecutiveCandidatesForAutoClose);
         failed += Run("Todo issue review allow/deny label policy", TestIssueReviewAssessIssueForApplicabilityRespectsAllowAndDenyLabelPolicy);
+        failed += Run("Todo issue review action signals downgrade close proposal", TestIssueReviewActionSignalsDowngradeCloseProposalWhenReopenedOrTooFresh);
+        failed += Run("Todo issue review action signals keep close proposal", TestIssueReviewActionSignalsKeepCloseProposalWhenSignalsStrong);
         failed += Run("Todo vision check out-of-scope classification", TestVisionCheckClassifiesOutOfScopeWhenOutTokensDominate);
         failed += Run("Todo vision check aligned classification", TestVisionCheckClassifiesAlignedWhenInTokensMatch);
         failed += Run("Todo vision check explicit reject policy precedence", TestVisionCheckExplicitRejectPolicyTakesPrecedence);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -70,10 +70,12 @@ Options:
 - `--max-issues <n>` (1-2000, default `300`)
 - `--stale-days <n>` (default `14`)
 - `--min-consecutive-candidates <n>` (default `1`; use `2+` for safer auto-close)
+- `--min-auto-close-confidence <0-100>` (default `80`; auto-close requires meeting threshold)
 - `--state-path <path>` (default `artifacts/triage/ix-issue-review-state.json`)
 - `--no-state` (disable streak persistence)
 - `--allow-label <label>` (repeatable; require at least one for auto-close eligibility)
 - `--deny-label <label>` (repeatable; never auto-close when present)
+- `--proposal-only` (force advisory mode; block close operations)
 - `--apply-close` (opt-in mutating mode; closes no-longer-applicable candidates)
 - `--close-reason <completed|not-planned>` (default `completed`)
 - `--no-comment` (skip managed close note comment)
@@ -85,12 +87,16 @@ Safety defaults:
 - Issues with protected labels (`do-not-close`, `keep-open`, `pinned`, `ix/decision:accept`) are never auto-closed.
 - Auto-close scope is currently conservative: infra blockers with linked PR references where all linked PRs are resolved.
 - For production-like automation, prefer `--min-consecutive-candidates 2` (or higher) with a persisted `--state-path`.
+- Proposed actions and confidence are generated for every scanned issue (`close`, `keep-open`, `needs-human-review`, `ignore`).
+- Confidence is explainable via `confidenceSignals` (stale bucket, recent issue activity, linked PR age, reopened count).
+- Reopened/too-fresh issues are intentionally downgraded to `needs-human-review`.
 
 Workflow automation:
 - `.github/workflows/issue-review.yml` runs nightly in dry-run mode.
 - Manual close runs require explicit confirmation in workflow dispatch:
   - `apply_close=true`
   - `confirm_apply_close=CLOSE_ISSUES`
+  - `min_auto_close_confidence` tune threshold for mutation runs
 
 ## Vision Check (Assistive)
 

--- a/Website/data/products.json
+++ b/Website/data/products.json
@@ -61,5 +61,16 @@
     "featured": false,
     "install": "Install-Module IntelligenceX",
     "screenshot": "/assets/screenshots/product-powershell.svg"
+  },
+  {
+    "title": "Project Ops",
+    "description": "GitHub Project triage control plane with issue-review, backlog signal scoring, and maintainer-first operations for stale or invalid work.",
+    "icon": "project-ops",
+    "link": "/docs/project-ops/overview/",
+    "tag": "Operations",
+    "badge": "First Party",
+    "featured": false,
+    "install": "intelligencex todo project-bootstrap --repo EvotecIT/IntelligenceX --owner EvotecIT",
+    "screenshot": "/assets/screenshots/product-project-ops.svg"
   }
 ]

--- a/Website/site.json
+++ b/Website/site.json
@@ -160,6 +160,7 @@
         "Name": "footer-docs",
         "Items": [
           { "Title": "Reviewer", "Url": "/docs/reviewer/overview/" },
+          { "Title": "Project Ops", "Url": "/docs/project-ops/overview/" },
           { "Title": "IX Chat", "Url": "/docs/chat/overview/" },
           { "Title": "IX Tools", "Url": "/docs/tools/overview/" },
           { "Title": "CLI Tools", "Url": "/docs/cli/overview/" },

--- a/Website/static/assets/screenshots/product-project-ops.svg
+++ b/Website/static/assets/screenshots/product-project-ops.svg
@@ -1,0 +1,47 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Project Ops dashboard screenshot">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1280" y2="720" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#071525"/>
+      <stop offset="1" stop-color="#0F2A44"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="140" y1="120" x2="1140" y2="610" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#11253A"/>
+      <stop offset="1" stop-color="#0B1D31"/>
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#bg)"/>
+  <rect x="64" y="48" width="1152" height="624" rx="20" fill="#081424" stroke="#1A3958"/>
+  <rect x="64" y="48" width="1152" height="72" rx="20" fill="#0E2236"/>
+  <circle cx="102" cy="84" r="9" fill="#2F5B84"/>
+  <circle cx="132" cy="84" r="9" fill="#2F5B84"/>
+  <circle cx="162" cy="84" r="9" fill="#2F5B84"/>
+  <rect x="214" y="66" width="340" height="36" rx="8" fill="#102A43"/>
+  <text x="244" y="90" fill="#9EC7EE" font-family="Segoe UI, Arial, sans-serif" font-size="16" font-weight="600">Project Ops • Issue Review</text>
+
+  <rect x="106" y="148" width="1068" height="498" rx="14" fill="url(#panel)" stroke="#1A3958"/>
+  <rect x="142" y="186" width="992" height="52" rx="10" fill="#0D2237"/>
+  <text x="172" y="219" fill="#7FAED8" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="600">Infra blockers with suggested action and confidence</text>
+
+  <rect x="142" y="258" width="992" height="66" rx="8" fill="#0A1D31"/>
+  <text x="168" y="288" fill="#D8EBFF" font-family="Segoe UI, Arial, sans-serif" font-size="17">#362 Infra blocker: PR checks failing with no space left on device</text>
+  <text x="168" y="309" fill="#78A9D2" font-family="Segoe UI, Arial, sans-serif" font-size="14">Action: close • Confidence: 91/high • Signals: stale + linked PR age + no reopen</text>
+  <rect x="1008" y="275" width="110" height="30" rx="15" fill="#133E2B" stroke="#2F8D5C"/>
+  <text x="1043" y="295" fill="#9EF0C1" font-family="Segoe UI, Arial, sans-serif" font-size="13" font-weight="700">CLOSE</text>
+
+  <rect x="142" y="338" width="992" height="66" rx="8" fill="#0A1D31"/>
+  <text x="168" y="368" fill="#D8EBFF" font-family="Segoe UI, Arial, sans-serif" font-size="17">#440 Infra blocker: PR checks stuck in Setup .NET</text>
+  <text x="168" y="389" fill="#78A9D2" font-family="Segoe UI, Arial, sans-serif" font-size="14">Action: needs-human-review • Confidence: 63/medium • Signals: fresh activity + reopened</text>
+  <rect x="916" y="355" width="202" height="30" rx="15" fill="#3B2F10" stroke="#A88933"/>
+  <text x="946" y="375" fill="#F6DCA4" font-family="Segoe UI, Arial, sans-serif" font-size="13" font-weight="700">NEEDS HUMAN REVIEW</text>
+
+  <rect x="142" y="418" width="992" height="66" rx="8" fill="#0A1D31"/>
+  <text x="168" y="448" fill="#D8EBFF" font-family="Segoe UI, Arial, sans-serif" font-size="17">#345 CI infra: website build runner dependencies unavailable</text>
+  <text x="168" y="469" fill="#78A9D2" font-family="Segoe UI, Arial, sans-serif" font-size="14">Action: keep-open • Confidence: 86/high • Signals: open linked PR + active updates</text>
+  <rect x="980" y="435" width="138" height="30" rx="15" fill="#102F49" stroke="#2C6B9A"/>
+  <text x="1014" y="455" fill="#9FD3FF" font-family="Segoe UI, Arial, sans-serif" font-size="13" font-weight="700">KEEP OPEN</text>
+
+  <rect x="142" y="510" width="300" height="100" rx="10" fill="#0D2237"/>
+  <text x="168" y="545" fill="#7FAED8" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="600">Run summary</text>
+  <text x="168" y="568" fill="#D8EBFF" font-family="Segoe UI, Arial, sans-serif" font-size="14">Proposed close: 4</text>
+  <text x="168" y="590" fill="#D8EBFF" font-family="Segoe UI, Arial, sans-serif" font-size="14">Needs review: 3</text>
+</svg>

--- a/Website/themes/intelligencex/partials/sections/products.html
+++ b/Website/themes/intelligencex/partials/sections/products.html
@@ -2,7 +2,7 @@
 <section class="products">
     <div class="section-header">
         <span class="section-label">The Platform</span>
-        <h2>Six Product Areas</h2>
+        <h2>{{ data.products.size }} Product Areas</h2>
         <p>Everything you need for AI-powered development workflows.</p>
     </div>
 


### PR DESCRIPTION
## Summary
- extend `todo issue-review` with built-in proposed actions and confidence scoring (`close`, `keep-open`, `needs-human-review`, `ignore`)
- add explainable confidence signals in engine output: stale-age bucket, recent issue activity, linked PR age, and reopened-count signal
- add safety gate `--min-auto-close-confidence` (default `80`) and `--proposal-only` advisory mode
- keep auto-close conservative: now requires policy eligibility + proposed action `close` + confidence threshold
- add tests for action-signal downgrade/upgrade behavior
- add first-party `Project Ops` product area to website/docs and wire navigation/home card/screenshot
- update issue-review workflow input to pass confidence threshold and update docs for safe usage

## Why
We wanted IX to manage stale/invalid issues more reliably without over-closing active work, and to surface this capability clearly as a first-party product area.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
