### PR TITLE
feat(todo): sync issue-review action/confidence into project fields

### DIFF
--- a/Docs/project-ops/overview.md
+++ b/Docs/project-ops/overview.md
@@ -27,7 +27,7 @@ Project Ops is assistive automation, not autonomous production governance.
 ```bash
 intelligencex todo project-bootstrap --repo EvotecIT/IntelligenceX --owner EvotecIT
 intelligencex todo issue-review --repo EvotecIT/IntelligenceX --proposal-only --min-consecutive-candidates 2 --min-auto-close-confidence 80
-intelligencex todo project-sync --config artifacts/triage/ix-project-config.json --dry-run
+intelligencex todo project-sync --config artifacts/triage/ix-project-config.json --issue-review artifacts/triage/ix-issue-review.json --dry-run
 ```
 
 ## Related docs

--- a/Docs/reviewer/project-bootstrap-sync.md
+++ b/Docs/reviewer/project-bootstrap-sync.md
@@ -52,14 +52,15 @@ Useful options:
 - `--ensure-default-views` to validate recommended view coverage.
 - `--no-ensure-labels` to skip taxonomy setup when labels are managed elsewhere.
 
-## Sync triage and vision into project fields
+## Sync triage, issue-review, and vision into project fields
 
-After generating triage artifacts, run `project-sync`:
+After generating triage artifacts (including `ix-issue-review.json`), run `project-sync`:
 
 ```bash
 intelligencex todo project-sync \
   --config artifacts/triage/ix-project-config.json \
   --triage artifacts/triage/ix-triage-index.json \
+  --issue-review artifacts/triage/ix-issue-review.json \
   --vision artifacts/triage/ix-vision-check.json \
   --max-items 500
 ```
@@ -87,6 +88,7 @@ intelligencex todo project-sync \
 ## What sync updates
 
 - Project item fields for triage and vision fit.
+- Issue-review fields for stale infra blockers (`Issue Review Action`, `Issue Review Action Confidence`).
 - Signal-quality fields (`Signal Quality`, `Signal Quality Score`, `Signal Quality Notes`).
 - Operational PR fields (`PR Size`, `PR Churn Risk`, `PR Merge Readiness`, `PR Freshness`, `PR Check Health`, `PR Review Latency`, `PR Merge Conflict Risk`).
 - Suggested maintainership decision signal (`IX Suggested Decision`).
@@ -102,7 +104,11 @@ Template files:
 - `IntelligenceX.Cli/Templates/triage-index-scheduled.yml`
 - `IntelligenceX.Cli/Templates/triage-project-sync.yml`
 
-The project-sync workflow template also emits `artifacts/triage/ix-project-view-apply.md` so maintainers can continuously see missing view coverage and recommended columns.
+The project-sync workflow template runs `issue-review` in proposal mode before sync, and emits:
+
+- `artifacts/triage/ix-issue-review.json`
+- `artifacts/triage/ix-issue-review.md`
+- `artifacts/triage/ix-project-view-apply.md`
 
 Recommended rollout:
 

--- a/Docs/reviewer/project-views-and-ops.md
+++ b/Docs/reviewer/project-views-and-ops.md
@@ -69,7 +69,7 @@ Behavior notes:
 - Preserves existing checkbox state in `TODO.md` where possible.
 - Uses stable markers for issue deduplication when `--create-issues` is enabled.
 
-## Build triage and vision artifacts
+## Build triage, issue-review, and vision artifacts
 
 ### Build triage index
 
@@ -86,6 +86,22 @@ Outputs:
 
 - `artifacts/triage/ix-triage-index.json`
 - `artifacts/triage/ix-triage-index.md`
+
+### Build issue-review signals
+
+```bash
+intelligencex todo issue-review \
+  --repo EvotecIT/IntelligenceX \
+  --proposal-only \
+  --state-path artifacts/triage/ix-issue-review-state.json \
+  --out artifacts/triage/ix-issue-review.json \
+  --summary artifacts/triage/ix-issue-review.md
+```
+
+Outputs:
+
+- `artifacts/triage/ix-issue-review.json`
+- `artifacts/triage/ix-issue-review.md`
 
 ### Run vision check
 
@@ -106,7 +122,7 @@ Outputs:
 ## Suggested maintainer cadence
 
 1. Run `sync-bot-feedback` during PR-review sweeps.
-2. Refresh triage/vision artifacts daily or per release train.
+2. Refresh triage/issue-review/vision artifacts daily or per release train.
 3. Sync project fields before backlog grooming.
 4. Triage `Signal Quality = low` items first and request better PR/issue context before acting on recommendations.
 5. Regenerate view checklist/apply plan when project layout drifts.

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -29,7 +29,7 @@ These commands are assistive. They are not an autonomous production decision sys
 3. Run issue applicability review.
 4. Run vision alignment check.
 5. Bootstrap or initialize GitHub Project.
-6. Sync triage + vision into project fields.
+6. Sync triage + issue-review + vision into project fields.
 7. Generate project view checklist and apply plan for maintainers.
 
 ## End-to-end example
@@ -50,8 +50,8 @@ intelligencex todo vision-check --repo EvotecIT/IntelligenceX --vision VISION.md
 # 5) Bootstrap project + workflow + vision scaffold
 intelligencex todo project-bootstrap --repo EvotecIT/IntelligenceX --owner EvotecIT
 
-# 6) Sync triage + vision into project fields
-intelligencex todo project-sync --config artifacts/triage/ix-project-config.json --max-items 500
+# 6) Sync triage + issue-review + vision into project fields
+intelligencex todo project-sync --config artifacts/triage/ix-project-config.json --issue-review artifacts/triage/ix-issue-review.json --max-items 500
 
 # 7) Generate a maintainer view checklist
 intelligencex todo project-view-checklist --config artifacts/triage/ix-project-config.json --create-issue
@@ -66,7 +66,7 @@ intelligencex todo project-view-checklist --config artifacts/triage/ix-project-c
 | `issue-review` | Detect stale/no-longer-applicable infra blocker issues and optionally auto-close | `artifacts/triage/ix-issue-review.json`, `.md` |
 | `vision-check` | Compare backlog against `VISION.md` scope | `artifacts/triage/ix-vision-check.json`, `.md` |
 | `project-init` | Create/initialize GitHub Project fields + metadata | `artifacts/triage/ix-project-config.json` |
-| `project-sync` | Push triage/vision signals to project items and optional labels/comments | Project field updates, optional comment/label updates |
+| `project-sync` | Push triage/issue-review/vision signals to project items and optional labels/comments | Project field updates, optional comment/label updates |
 | `project-bootstrap` | First-run bootstrap for project + workflow + vision scaffold | Project config + workflow + `VISION.md` scaffold |
 | `project-view-checklist` | Build checklist of recommended project views | `artifacts/triage/ix-project-view-checklist.md` |
 | `project-view-apply` | Build deterministic plan to apply missing views | `artifacts/triage/ix-project-view-apply.md` |
@@ -88,6 +88,7 @@ intelligencex todo project-view-checklist --config artifacts/triage/ix-project-c
 - `proposedAction`: `close`, `keep-open`, `needs-human-review`, `ignore`
 - `actionConfidence`: `0-100` with level hints (`high`/`medium`/`low`)
 - `confidenceSignals`: explainable signal list (for example stale bucket, recent activity, linked PR age, reopened count)
+- `project-sync` maps these into project fields: `Issue Review Action`, `Issue Review Action Confidence`
 
 Safety behavior:
 

--- a/IntelligenceX.Cli/Templates/triage-project-sync.yml
+++ b/IntelligenceX.Cli/Templates/triage-project-sync.yml
@@ -72,6 +72,18 @@ jobs:
             --out artifacts/triage/ix-vision-check.json \
             --summary artifacts/triage/ix-vision-check.md
 
+      - name: Run issue review signals
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- \
+            todo issue-review \
+            --repo "${{ github.repository }}" \
+            --proposal-only \
+            --state-path artifacts/triage/ix-issue-review-state.json \
+            --out artifacts/triage/ix-issue-review.json \
+            --summary artifacts/triage/ix-issue-review.md
+
       - name: Sync into GitHub Project
         env:
           GH_TOKEN: ${{ secrets.IX_PROJECT_TOKEN != '' && secrets.IX_PROJECT_TOKEN || github.token }}
@@ -91,6 +103,7 @@ jobs:
             --project "$PROJECT_NUMBER" \
             --triage artifacts/triage/ix-triage-index.json \
             --vision artifacts/triage/ix-vision-check.json \
+            --issue-review artifacts/triage/ix-issue-review.json \
             --max-items "$MAX_ITEMS" \
             --apply-labels \
             --apply-link-comments
@@ -151,6 +164,13 @@ jobs:
               echo "## Vision Check"
               echo
               cat artifacts/triage/ix-vision-check.md
+              echo
+            fi
+
+            if [ -f artifacts/triage/ix-issue-review.md ]; then
+              echo "## Issue Review"
+              echo
+              cat artifacts/triage/ix-issue-review.md
               echo
             fi
 

--- a/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectFieldCatalog.cs
@@ -84,6 +84,13 @@ internal static class ProjectFieldCatalog {
         new ProjectFieldDefinition("Matched Pull Request Confidence", "NUMBER", Array.Empty<string>()),
         new ProjectFieldDefinition("Matched Pull Request Reason", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Related Pull Requests", "TEXT", Array.Empty<string>()),
+        new ProjectFieldDefinition("Issue Review Action", "SINGLE_SELECT", new[] {
+            "close",
+            "keep-open",
+            "needs-human-review",
+            "ignore"
+        }),
+        new ProjectFieldDefinition("Issue Review Action Confidence", "NUMBER", Array.Empty<string>()),
         new ProjectFieldDefinition("Triage Score", "NUMBER", Array.Empty<string>()),
         new ProjectFieldDefinition("Duplicate Cluster", "TEXT", Array.Empty<string>()),
         new ProjectFieldDefinition("Canonical Item", "TEXT", Array.Empty<string>()),

--- a/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
+++ b/IntelligenceX.Cli/Todo/ProjectSyncRunner.cs
@@ -73,7 +73,9 @@ internal static class ProjectSyncRunner {
         string? PullRequestFreshness = null,
         string? PullRequestCheckHealth = null,
         string? PullRequestReviewLatency = null,
-        string? PullRequestMergeConflictRisk = null
+        string? PullRequestMergeConflictRisk = null,
+        string? IssueReviewAction = null,
+        double? IssueReviewActionConfidence = null
     );
 
     private sealed class Options {
@@ -83,6 +85,7 @@ internal static class ProjectSyncRunner {
         public string ConfigPath { get; set; } = Path.Combine("artifacts", "triage", "ix-project-config.json");
         public string TriagePath { get; set; } = Path.Combine("artifacts", "triage", "ix-triage-index.json");
         public string VisionPath { get; set; } = Path.Combine("artifacts", "triage", "ix-vision-check.json");
+        public string IssueReviewPath { get; set; } = Path.Combine("artifacts", "triage", "ix-issue-review.json");
         public int MaxItems { get; set; } = 500;
         public int ProjectItemScanLimit { get; set; } = 5000;
         public bool EnsureFields { get; set; } = true;
@@ -123,7 +126,7 @@ internal static class ProjectSyncRunner {
 
         List<ProjectSyncEntry> entries;
         try {
-            entries = LoadEntries(options.TriagePath, options.VisionPath, options.MaxItems);
+            entries = LoadEntries(options.TriagePath, options.VisionPath, options.IssueReviewPath, options.MaxItems);
         } catch (Exception ex) {
             Console.Error.WriteLine(ex.Message);
             return 1;
@@ -376,6 +379,11 @@ internal static class ProjectSyncRunner {
                         options.VisionPath = args[++i];
                     }
                     break;
+                case "--issue-review":
+                    if (i + 1 < args.Length) {
+                        options.IssueReviewPath = args[++i];
+                    }
+                    break;
                 case "--max-items":
                     if (i + 1 < args.Length &&
                         int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var maxItems)) {
@@ -445,6 +453,7 @@ internal static class ProjectSyncRunner {
         Console.WriteLine("  --config <path>          Project config JSON from project-init (default: artifacts/triage/ix-project-config.json)");
         Console.WriteLine("  --triage <path>          Triage index JSON (default: artifacts/triage/ix-triage-index.json)");
         Console.WriteLine("  --vision <path>          Vision check JSON (default: artifacts/triage/ix-vision-check.json)");
+        Console.WriteLine("  --issue-review <path>    Issue review JSON (default: artifacts/triage/ix-issue-review.json)");
         Console.WriteLine("  --max-items <n>          Max entries to sync (1-5000, default: 500)");
         Console.WriteLine("  --project-item-scan-limit <n>  Existing project item scan limit (100-10000, default: 5000)");
         Console.WriteLine("  --ensure-fields          Ensure IX fields exist before sync (default)");
@@ -497,19 +506,32 @@ internal static class ProjectSyncRunner {
         return true;
     }
 
-    private static List<ProjectSyncEntry> LoadEntries(string triagePath, string visionPath, int maxItems) {
+    private static List<ProjectSyncEntry> LoadEntries(string triagePath, string visionPath, string issueReviewPath, int maxItems) {
         using var triageDoc = JsonDocument.Parse(File.ReadAllText(triagePath));
         JsonDocument? visionDoc = null;
+        JsonDocument? issueReviewDoc = null;
         if (File.Exists(visionPath)) {
             visionDoc = JsonDocument.Parse(File.ReadAllText(visionPath));
         }
+        if (File.Exists(issueReviewPath)) {
+            issueReviewDoc = JsonDocument.Parse(File.ReadAllText(issueReviewPath));
+        }
 
-        var entries = BuildEntriesFromDocuments(triageDoc.RootElement, visionDoc?.RootElement, maxItems);
+        var entries = BuildEntriesFromDocuments(
+            triageDoc.RootElement,
+            visionDoc?.RootElement,
+            maxItems,
+            issueReviewDoc?.RootElement);
         visionDoc?.Dispose();
+        issueReviewDoc?.Dispose();
         return entries;
     }
 
-    internal static List<ProjectSyncEntry> BuildEntriesFromDocuments(JsonElement triageRoot, JsonElement? visionRoot, int maxItems) {
+    internal static List<ProjectSyncEntry> BuildEntriesFromDocuments(
+        JsonElement triageRoot,
+        JsonElement? visionRoot,
+        int maxItems,
+        JsonElement? issueReviewRoot = null) {
         var entriesByUrl = new Dictionary<string, ProjectSyncEntry>(StringComparer.OrdinalIgnoreCase);
         var idToUrl = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var clusterToCanonicalId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -700,6 +722,10 @@ internal static class ProjectSyncRunner {
                     );
                 }
             }
+        }
+
+        if (issueReviewRoot.HasValue) {
+            MergeIssueReviewAssessments(entriesByUrl, issueReviewRoot.Value);
         }
 
         foreach (var pair in entriesByUrl.ToList()) {
@@ -1079,6 +1105,102 @@ internal static class ProjectSyncRunner {
         );
     }
 
+    private static void MergeIssueReviewAssessments(
+        IDictionary<string, ProjectSyncEntry> entriesByUrl,
+        JsonElement issueReviewRoot) {
+        if (!TryGetProperty(issueReviewRoot, "items", out var items) || items.ValueKind != JsonValueKind.Array) {
+            return;
+        }
+
+        var issueEntriesByNumber = entriesByUrl.Values
+            .Where(entry => entry.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase) && entry.Number > 0)
+            .GroupBy(entry => entry.Number)
+            .ToDictionary(group => group.Key, group => group.First());
+
+        foreach (var item in items.EnumerateArray()) {
+            var proposedAction = NormalizeIssueReviewAction(ReadNullableStringCaseInsensitive(item, "proposedAction"));
+            var actionConfidenceRaw = ReadNullableDoubleCaseInsensitive(item, "actionConfidence");
+            var actionConfidence = actionConfidenceRaw.HasValue
+                ? Math.Round(Math.Clamp(actionConfidenceRaw.Value, 0.0, 100.0), 2, MidpointRounding.AwayFromZero)
+                : (double?)null;
+            if (string.IsNullOrWhiteSpace(proposedAction) && !actionConfidence.HasValue) {
+                continue;
+            }
+
+            var url = ReadNullableStringCaseInsensitive(item, "url") ?? string.Empty;
+            var number = ReadInt(item, "number");
+            if (string.IsNullOrWhiteSpace(url) &&
+                number > 0 &&
+                issueEntriesByNumber.TryGetValue(number, out var byNumberMatch)) {
+                url = byNumberMatch.Url;
+            }
+
+            ProjectSyncEntry existing;
+            if (!string.IsNullOrWhiteSpace(url) && entriesByUrl.TryGetValue(url, out var byUrlExisting)) {
+                existing = byUrlExisting;
+            } else if (number > 0 && issueEntriesByNumber.TryGetValue(number, out var byNumberExisting)) {
+                existing = byNumberExisting;
+                url = existing.Url;
+            } else {
+                if (string.IsNullOrWhiteSpace(url)) {
+                    continue;
+                }
+
+                var (_, parsedNumber) = ParseKindAndNumberFromUrl(url);
+                existing = new ProjectSyncEntry(
+                    Number: number > 0 ? number : parsedNumber,
+                    Url: url,
+                    Kind: "issue",
+                    TriageScore: null,
+                    DuplicateCluster: null,
+                    CanonicalItem: null,
+                    Category: null,
+                    Tags: Array.Empty<string>(),
+                    MatchedIssueUrl: null,
+                    MatchedIssueConfidence: null,
+                    VisionFit: null,
+                    VisionConfidence: null,
+                    RelatedIssues: Array.Empty<RelatedIssueCandidate>(),
+                    SuggestedDecision: null,
+                    RelatedPullRequests: Array.Empty<RelatedPullRequestCandidate>(),
+                    ExistingLabels: Array.Empty<string>(),
+                    SignalQualityReasons: Array.Empty<string>()
+                );
+            }
+
+            if (!existing.Kind.Equals("issue", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            var updated = existing with {
+                IssueReviewAction = proposedAction ?? existing.IssueReviewAction,
+                IssueReviewActionConfidence = actionConfidence ?? existing.IssueReviewActionConfidence
+            };
+            entriesByUrl[updated.Url] = updated;
+            if (!string.IsNullOrWhiteSpace(url) &&
+                !updated.Url.Equals(url, StringComparison.OrdinalIgnoreCase)) {
+                entriesByUrl[url] = updated;
+            }
+            if (updated.Number > 0) {
+                issueEntriesByNumber[updated.Number] = updated;
+            }
+        }
+    }
+
+    private static string? NormalizeIssueReviewAction(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        return value.Trim().ToLowerInvariant() switch {
+            "close" => "close",
+            "keep-open" => "keep-open",
+            "needs-human-review" => "needs-human-review",
+            "ignore" => "ignore",
+            _ => null
+        };
+    }
+
     private static async Task<IReadOnlyDictionary<string, ProjectV2Client.ProjectField>> EnsureFieldsAsync(
         ProjectV2Client client,
         string owner,
@@ -1301,6 +1423,26 @@ internal static class ProjectSyncRunner {
                 await client.SetTextFieldAsync(projectId, itemId, relatedIssuesField.Id, relatedIssuesValue).ConfigureAwait(false);
             } else {
                 await client.ClearFieldAsync(projectId, itemId, relatedIssuesField.Id).ConfigureAwait(false);
+            }
+            updated++;
+        }
+
+        if (fields.TryGetValue("Issue Review Action", out var issueReviewActionField)) {
+            if (isIssue &&
+                !string.IsNullOrWhiteSpace(entry.IssueReviewAction) &&
+                TryResolveOptionId(issueReviewActionField, entry.IssueReviewAction, out var issueReviewActionOptionId)) {
+                await client.SetSingleSelectFieldAsync(projectId, itemId, issueReviewActionField.Id, issueReviewActionOptionId).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, issueReviewActionField.Id).ConfigureAwait(false);
+            }
+            updated++;
+        }
+
+        if (fields.TryGetValue("Issue Review Action Confidence", out var issueReviewActionConfidenceField)) {
+            if (isIssue && entry.IssueReviewActionConfidence.HasValue) {
+                await client.SetNumberFieldAsync(projectId, itemId, issueReviewActionConfidenceField.Id, entry.IssueReviewActionConfidence.Value).ConfigureAwait(false);
+            } else {
+                await client.ClearFieldAsync(projectId, itemId, issueReviewActionConfidenceField.Id).ConfigureAwait(false);
             }
             updated++;
         }
@@ -2103,6 +2245,19 @@ internal static class ProjectSyncRunner {
             return null;
         }
         return prop.GetBoolean();
+    }
+
+    private static double? ReadNullableDoubleCaseInsensitive(JsonElement obj, string name) {
+        if (!TryGetPropertyCaseInsensitive(obj, name, out var prop)) {
+            return null;
+        }
+        if (prop.ValueKind == JsonValueKind.Null) {
+            return null;
+        }
+        if (prop.ValueKind != JsonValueKind.Number || !prop.TryGetDouble(out var value)) {
+            return null;
+        }
+        return value;
     }
 
     private static string? ReadNullableString(JsonElement obj, string name) {

--- a/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectBootstrap.cs
@@ -84,6 +84,8 @@ project={{ProjectNumber}}
             0.70);
 
         AssertContainsText(rendered, "todo project-sync", "workflow contains project sync step");
+        AssertContainsText(rendered, "todo issue-review", "workflow contains issue review step");
+        AssertContainsText(rendered, "--issue-review artifacts/triage/ix-issue-review.json", "workflow passes issue review artifact to project sync");
         AssertContainsText(rendered, "--apply-labels", "workflow enables label application");
         AssertContainsText(rendered, "--apply-link-comments", "workflow enables PR issue suggestion comments");
         AssertContainsText(rendered, "--enforce-contract", "workflow enforces vision contract");

--- a/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectSync.cs
@@ -34,6 +34,8 @@ internal static partial class Program {
         AssertEqual(true, names.Contains("Matched Pull Request Confidence", StringComparer.OrdinalIgnoreCase), "has Matched Pull Request Confidence");
         AssertEqual(true, names.Contains("Matched Pull Request Reason", StringComparer.OrdinalIgnoreCase), "has Matched Pull Request Reason");
         AssertEqual(true, names.Contains("Related Pull Requests", StringComparer.OrdinalIgnoreCase), "has Related Pull Requests");
+        AssertEqual(true, names.Contains("Issue Review Action", StringComparer.OrdinalIgnoreCase), "has Issue Review Action");
+        AssertEqual(true, names.Contains("Issue Review Action Confidence", StringComparer.OrdinalIgnoreCase), "has Issue Review Action Confidence");
         AssertEqual(true, names.Contains("Triage Score", StringComparer.OrdinalIgnoreCase), "has Triage Score");
         AssertEqual(true, names.Contains("IX Suggested Decision", StringComparer.OrdinalIgnoreCase), "has IX Suggested Decision");
         AssertEqual(true, names.Contains("Maintainer Decision", StringComparer.OrdinalIgnoreCase), "has Maintainer Decision");
@@ -209,6 +211,61 @@ internal static partial class Program {
         AssertEqual("healthy", entry.PullRequestCheckHealth, "pull request check health parsed");
         AssertEqual("low", entry.PullRequestReviewLatency, "pull request review latency parsed");
         AssertEqual("low", entry.PullRequestMergeConflictRisk, "pull request merge conflict risk parsed");
+    }
+
+    private static void TestProjectSyncBuildEntriesMergesIssueReviewSignals() {
+        const string triageJson = """
+{
+  "items": [
+    {
+      "id": "issue#362",
+      "kind": "issue",
+      "number": 362,
+      "url": "https://github.com/EvotecIT/IntelligenceX/issues/362",
+      "score": 17.0
+    }
+  ]
+}
+""";
+
+        const string issueReviewJson = """
+{
+  "items": [
+    {
+      "number": 362,
+      "url": "https://github.com/EvotecIT/IntelligenceX/issues/362",
+      "proposedAction": "close",
+      "actionConfidence": 92
+    },
+    {
+      "number": 440,
+      "url": "https://github.com/EvotecIT/IntelligenceX/issues/440",
+      "proposedAction": "needs-human-review",
+      "actionConfidence": 64
+    }
+  ]
+}
+""";
+
+        using var triageDoc = System.Text.Json.JsonDocument.Parse(triageJson);
+        using var issueReviewDoc = System.Text.Json.JsonDocument.Parse(issueReviewJson);
+        var entries = IntelligenceX.Cli.Todo.ProjectSyncRunner.BuildEntriesFromDocuments(
+            triageDoc.RootElement,
+            null,
+            100,
+            issueReviewDoc.RootElement);
+
+        var issue362 = entries.Single(item => item.Url.EndsWith("/issues/362", StringComparison.OrdinalIgnoreCase));
+        AssertEqual("issue", issue362.Kind, "issue kind preserved");
+        AssertEqual("close", issue362.IssueReviewAction, "issue action merged");
+        AssertEqual(true, issue362.IssueReviewActionConfidence.HasValue, "issue confidence merged");
+        AssertEqual(92.0, issue362.IssueReviewActionConfidence!.Value, "issue confidence value merged");
+
+        var issue440 = entries.Single(item => item.Url.EndsWith("/issues/440", StringComparison.OrdinalIgnoreCase));
+        AssertEqual("issue", issue440.Kind, "issue-only review entry created");
+        AssertEqual("needs-human-review", issue440.IssueReviewAction, "issue-only action merged");
+        AssertEqual(true, issue440.IssueReviewActionConfidence.HasValue, "issue-only confidence merged");
+        AssertEqual(64.0, issue440.IssueReviewActionConfidence!.Value, "issue-only confidence value merged");
     }
 
     private static void TestProjectSyncBuildEntriesSuggestsMergeCandidateForBestReadyPr() {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -496,6 +496,7 @@ internal static partial class Program {
         failed += Run("Todo project view apply markdown all views present shows completed checklist", TestProjectViewApplyMarkdownAllViewsPresentShowsCompletedChecklist);
         failed += Run("Todo project sync merges vision and canonical", TestProjectSyncBuildEntriesMergesVisionAndCanonical);
         failed += Run("Todo project sync parses category/tag confidence fields", TestProjectSyncBuildEntriesParsesCategoryAndTagConfidences);
+        failed += Run("Todo project sync merges issue review action signals", TestProjectSyncBuildEntriesMergesIssueReviewSignals);
         failed += Run("Todo project sync labels include tags and high-confidence match", TestProjectSyncBuildLabelsIncludesTagsAndHighConfidenceIssueMatch);
         failed += Run("Todo project sync labels normalize dynamic category and tags", TestProjectSyncBuildLabelsNormalizesDynamicCategoryAndTags);
         failed += Run("Todo project sync labels skip low-confidence category/tags", TestProjectSyncBuildLabelsSkipsLowConfidenceCategoryAndTags);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -153,6 +153,8 @@ Expected fields:
 - `Tags` (text)
 - `Matched Issue` (text)
 - `Matched Issue Confidence` (number)
+- `Issue Review Action` (single-select)
+- `Issue Review Action Confidence` (number)
 - `Triage Score` (number)
 - `Duplicate Cluster` (text)
 - `Canonical Item` (text)
@@ -161,7 +163,7 @@ Expected fields:
 
 ## Project Sync
 
-Sync triage and vision artifacts into project items:
+Sync triage, issue-review, and vision artifacts into project items:
 
 ```bash
 intelligencex todo project-sync --owner EvotecIT --project 123
@@ -169,7 +171,7 @@ intelligencex todo project-sync --owner EvotecIT --project 123
 
 Options:
 - `--config <path>` resolve owner/project from `project-init` output
-- `--triage <path>` and `--vision <path>`
+- `--triage <path>`, `--issue-review <path>`, and `--vision <path>`
 - `--max-items <n>` (default `500`)
 - `--project-item-scan-limit <n>` (default `5000`)
 - `--ensure-fields` / `--no-ensure-fields`
@@ -177,6 +179,9 @@ Options:
 - `--ensure-labels` / `--no-ensure-labels`
 - `--apply-link-comments`
 - `--dry-run`
+
+Behavior:
+- `Issue Review Action` and `Issue Review Action Confidence` are synced on issue items when `ix-issue-review.json` is available.
 
 ## Project Bootstrap (Project + Workflow in one command)
 
@@ -255,7 +260,7 @@ Behavior:
 - Generates triage index artifacts.
 - Optional control-issue summary comment upsert when repo variable `IX_TRIAGE_CONTROL_ISSUE` is configured.
 - `triage-index-scheduled.yml` upserts a single marker comment with the latest triage index summary on the control issue.
-- `triage-project-sync.yml` upserts a single marker comment with the latest combined triage + vision markdown summary on the control issue.
+- `triage-project-sync.yml` upserts a single marker comment with the latest combined triage + issue-review + vision markdown summary on the control issue.
 - Both workflows also upsert a shared `intelligencex:triage-control-dashboard` comment linking to the latest summary comments.
 - The shared dashboard comment includes quick links: control issue, `VISION.md`, project board (when `artifacts/triage/ix-project-config.json` is available), project-view apply issue (`IX_PROJECT_VIEW_APPLY_ISSUE`), and bootstrap links comment.
 - `todo project-bootstrap --create-control-issue` can configure the control issue variable automatically.

--- a/InternalDocs/operations/cli-todo-backlog-sync.md
+++ b/InternalDocs/operations/cli-todo-backlog-sync.md
@@ -113,7 +113,7 @@ intelligencex todo project-init \
 Notes:
 - Creates a project (or initializes an existing one with `--project <n>`).
 - Can copy from a prepared template project with `--view-template-project <n>` to preserve saved GitHub views.
-- Ensures required custom fields such as `Vision Fit`, `Category`, `Category Confidence`, `Tags`, `Tag Confidence Summary`, `Matched Issue`, `Matched Issue Reason`, `Matched Pull Request`, `Matched Pull Request Reason`, `Triage Score`, `Duplicate Cluster`, and `IX Suggested Decision`.
+- Ensures required custom fields such as `Vision Fit`, `Category`, `Category Confidence`, `Tags`, `Tag Confidence Summary`, `Matched Issue`, `Matched Issue Reason`, `Matched Pull Request`, `Matched Pull Request Reason`, `Issue Review Action`, `Issue Review Action Confidence`, `Triage Score`, `Duplicate Cluster`, and `IX Suggested Decision`.
 - Ensures IX label taxonomy in the repo by default (`--no-ensure-labels` to skip).
 - Validates default IX view coverage by default (`--no-ensure-default-views` to skip).
 - Writes a reusable config file containing owner/project/field metadata.
@@ -122,15 +122,16 @@ Notes:
 Important:
 - GitHub API currently does not provide a `createProjectV2View` mutation, so IX can validate/report default view coverage but cannot create views from scratch without a template copy.
 
-## Sync triage + vision into GitHub Project
+## Sync triage + issue-review + vision into GitHub Project
 
-Push triage and vision outputs into project item fields so maintainers can triage in GitHub only.
+Push triage, issue-review, and vision outputs into project item fields so maintainers can triage in GitHub only.
 
 ```bash
 intelligencex todo project-sync \
   --owner EvotecIT \
   --project 123 \
   --triage artifacts/triage/ix-triage-index.json \
+  --issue-review artifacts/triage/ix-issue-review.json \
   --vision artifacts/triage/ix-vision-check.json \
   --max-items 500
 ```
@@ -147,6 +148,7 @@ Useful options:
 Behavior:
 - `IX Suggested Decision` is populated automatically (`accept`, `defer`, `reject`, `merge-candidate`) from combined triage + vision signals.
 - `Maintainer Decision` remains human-owned for final triage decisions.
+- Issue applicability actions from `issue-review` are synced into `Issue Review Action` and `Issue Review Action Confidence`.
 - Unknown categories/tags are normalized into dynamic labels (for example `ML Ops` -> `ix/category:ml-ops`, `Release Candidate` -> `ix/tag:release-candidate`) and are auto-created when `--apply-labels --ensure-labels` is used.
 - Category/tag labels are confidence-gated for reliability: category labels require `categoryConfidence >= 0.62` and tag labels require `tagConfidences[tag] >= 0.60` when those confidence fields are present in triage output.
 - Category confidence and per-tag confidence summaries are synced into project fields (`Category Confidence`, `Tag Confidence Summary`) when triage confidence data is available.
@@ -235,7 +237,7 @@ A reusable scheduled workflow template is available at:
 It runs `build-triage-index`, uploads artifacts, and can optionally upsert a control-issue summary comment
 when repository variable `IX_TRIAGE_CONTROL_ISSUE` is set.
 For `triage-index-scheduled.yml`, IX upserts a single marker comment (latest only) with the triage index summary.
-For `triage-project-sync.yml`, IX upserts a single marker comment (latest only) that includes both triage and vision markdown summaries.
+For `triage-project-sync.yml`, IX upserts a single marker comment (latest only) that includes triage, issue-review, and vision markdown summaries.
 Both workflows also upsert a shared `intelligencex:triage-control-dashboard` comment linking to the latest summary comments.
 The dashboard comment also includes quick links for maintainers (control issue, vision file, project board when config is available, project-view apply issue variable, and bootstrap links comment).
 `todo project-bootstrap --create-control-issue` can set this variable for you automatically.


### PR DESCRIPTION
## Summary
- add `project-sync --issue-review` support (default `artifacts/triage/ix-issue-review.json`)
- merge `issue-review` signals (`proposedAction`, `actionConfidence`) into issue entries and sync to project fields
- add default project fields: `Issue Review Action` and `Issue Review Action Confidence`
- update triage project-sync workflow template to run `todo issue-review` and pass artifact into `todo project-sync`
- refresh reviewer/internal docs and tests for the new issue-review wiring

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
