### PR TITLE
feat(project-views): add default Issue Ops view

### DIFF
--- a/Docs/reviewer/project-views-and-ops.md
+++ b/Docs/reviewer/project-views-and-ops.md
@@ -44,6 +44,7 @@ Useful options:
 
 Both checklist and apply-plan outputs include recommended columns per view. Use those column sets, otherwise triage quality signals stay hidden and the board appears weak.
 Recommended columns now include operational PR signals such as `PR Size`, `PR Churn Risk`, `PR Merge Readiness`, `PR Freshness`, `PR Check Health`, `PR Review Latency`, and `PR Merge Conflict Risk`.
+Default view guidance now also includes `Issue Ops`, which highlights issue applicability fields (`Issue Review Action`, `Issue Review Action Confidence`) for infra-blocker triage.
 
 ## Sync bot feedback into TODO.md
 

--- a/IntelligenceX.Cli/Todo/ProjectViewCatalog.cs
+++ b/IntelligenceX.Cli/Todo/ProjectViewCatalog.cs
@@ -79,6 +79,26 @@ internal static class ProjectViewCatalog {
                 "Category"
             }),
         new ProjectViewDefinition(
+            "Issue Ops",
+            "TABLE",
+            "Issue-first operations queue for stale infra blockers and applicability review signals.",
+            "is:open \"Triage Kind\":\"issue\"",
+            new[] {
+                "Title",
+                "Status",
+                "Triage Kind",
+                "Issue Review Action",
+                "Issue Review Action Confidence",
+                "Matched Pull Request",
+                "Matched Pull Request Confidence",
+                "Related Pull Requests",
+                "Signal Quality",
+                "Signal Quality Score",
+                "Triage Score",
+                "Category",
+                "Duplicate Cluster"
+            }),
+        new ProjectViewDefinition(
             "Duplicate Clusters",
             "TABLE",
             "Items that belong to duplicate clusters and need consolidation.",

--- a/IntelligenceX.Tests/Program.Todo.ProjectViewApply.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectViewApply.cs
@@ -25,8 +25,9 @@ internal static partial class Program {
             new DateTimeOffset(2026, 02, 15, 23, 10, 00, TimeSpan.Zero));
 
         AssertContainsText(markdown, "intelligencex:project-view-apply", "apply marker present");
-        AssertContainsText(markdown, "Default view coverage: 1/4", "coverage reflects missing defaults");
+        AssertContainsText(markdown, "Default view coverage: 1/5", "coverage reflects missing defaults");
         AssertContainsText(markdown, "- [ ] **Merge Candidates** (`TABLE`)", "missing default view listed");
+        AssertContainsText(markdown, "- [ ] **Issue Ops** (`TABLE`)", "missing issue ops view listed");
         AssertContainsText(markdown, "Suggested columns:", "suggested columns guidance included");
         AssertContainsText(markdown, "Select `+ New view` in GitHub Projects.", "manual apply step present");
         AssertContainsText(markdown, "public API surface does not expose direct project view creation", "platform note present");
@@ -52,7 +53,7 @@ internal static partial class Program {
             directCreateSupported: true,
             new DateTimeOffset(2026, 02, 15, 23, 15, 00, TimeSpan.Zero));
 
-        AssertContainsText(markdown, "Default view coverage: 4/4", "coverage reflects all defaults present");
+        AssertContainsText(markdown, "Default view coverage: 5/5", "coverage reflects all defaults present");
         AssertContainsText(markdown, "Missing default views: 0", "missing count is zero");
         AssertContainsText(markdown, "- [x] All recommended IX default views are present.", "completed checklist message");
         AssertContainsText(markdown, "Direct API view-create support: available", "capability line included");

--- a/IntelligenceX.Tests/Program.Todo.ProjectViewChecklist.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectViewChecklist.cs
@@ -23,9 +23,10 @@ internal static partial class Program {
             new DateTimeOffset(2026, 02, 15, 22, 00, 00, TimeSpan.Zero));
 
         AssertContainsText(markdown, "intelligencex:project-view-checklist", "checklist marker present");
-        AssertContainsText(markdown, "Default view coverage: 1/4", "coverage reflects missing defaults");
+        AssertContainsText(markdown, "Default view coverage: 1/5", "coverage reflects missing defaults");
         AssertContainsText(markdown, "- [x] **IX Queue** (`TABLE`) - present", "existing default view checked");
         AssertContainsText(markdown, "- [ ] **Merge Candidates** (`TABLE`) - missing", "missing default view unchecked");
+        AssertContainsText(markdown, "- [ ] **Issue Ops** (`TABLE`) - missing", "issue ops default view unchecked");
         AssertContainsText(markdown, "Suggested columns:", "suggested columns guidance included");
         AssertContainsText(markdown, "https://github.com/orgs/EvotecIT/projects/123/views/1", "existing view link included");
     }

--- a/IntelligenceX.Tests/Program.Todo.ProjectViews.cs
+++ b/IntelligenceX.Tests/Program.Todo.ProjectViews.cs
@@ -14,6 +14,7 @@ internal static partial class Program {
         AssertEqual(true, names.Contains("IX Queue", StringComparer.OrdinalIgnoreCase), "default queue view present");
         AssertEqual(true, names.Contains("Merge Candidates", StringComparer.OrdinalIgnoreCase), "merge candidates view present");
         AssertEqual(true, names.Contains("Vision Review", StringComparer.OrdinalIgnoreCase), "vision review view present");
+        AssertEqual(true, names.Contains("Issue Ops", StringComparer.OrdinalIgnoreCase), "issue ops view present");
         AssertEqual(true, names.Contains("Duplicate Clusters", StringComparer.OrdinalIgnoreCase), "duplicate clusters view present");
         AssertEqual(true,
             IntelligenceX.Cli.Todo.ProjectViewCatalog.DefaultViews.All(view => view.SuggestedColumns.Count > 0),
@@ -31,6 +32,7 @@ internal static partial class Program {
             .ToList();
 
         AssertEqual(true, missing.Contains("Merge Candidates", StringComparer.OrdinalIgnoreCase), "missing merge candidates detected");
+        AssertEqual(true, missing.Contains("Issue Ops", StringComparer.OrdinalIgnoreCase), "missing issue ops detected");
         AssertEqual(true, missing.Contains("Duplicate Clusters", StringComparer.OrdinalIgnoreCase), "missing duplicate clusters detected");
         AssertEqual(false, missing.Contains("IX Queue", StringComparer.OrdinalIgnoreCase), "existing queue view not flagged");
     }


### PR DESCRIPTION
## Summary
- add a new default project view: `Issue Ops`
- focus this view on issue-side applicability triage (`Issue Review Action`, `Issue Review Action Confidence`)
- include issue linkage and signal columns for maintainer workflow (`Matched Pull Request*`, `Related Pull Requests`, `Signal Quality*`, `Triage Score`, `Category`, `Duplicate Cluster`)
- update project-view catalog/checklist/apply tests for 5 default views
- refresh reviewer docs to call out the new view and issue-review columns

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
