### PR TITLE
feat(website): add first-party Issue Ops product area and screenshots

### DIFF
--- a/Docs/project-ops/overview.md
+++ b/Docs/project-ops/overview.md
@@ -22,6 +22,31 @@ Project Ops is assistive automation, not autonomous production governance.
 - Keep close/defer/accept decisions human-owned.
 - Use dry-run and proposal-only modes before any mutating workflow.
 
+## What this looks like in practice
+
+Issue Ops creates a maintainer-focused board view for stale/no-longer-applicable blockers:
+
+<img src="/assets/screenshots/ix-issue-ops/ix-issue-ops-01-board-overview.svg"
+     alt="Issue Ops project board overview with issue review action and confidence fields visible for infra blocker triage"
+     width="1600"
+     height="900"
+     loading="lazy"
+     decoding="async" />
+
+Key decision fields are synced directly to project rows:
+
+- `Issue Review Action`
+- `Issue Review Action Confidence`
+- `Matched Pull Request`
+- `Signal Quality`
+
+<img src="/assets/screenshots/ix-issue-ops/ix-issue-ops-02-review-columns.svg"
+     alt="Issue Ops table detail with action confidence and matched pull request columns used during issue applicability review"
+     width="1600"
+     height="900"
+     loading="lazy"
+     decoding="async" />
+
 ## Recommended start
 
 ```bash

--- a/Website/content/blog/_index.md
+++ b/Website/content/blog/_index.md
@@ -8,6 +8,7 @@ layout: page
 
 ## Latest Posts
 
+- [IX Issue Ops in Action](/blog/ix-issue-ops-in-action/)
 - [Reviewer Config Playbook (YAML vs JSON)](/blog/reviewer-yaml-vs-json-playbook/)
 - [Multilanguage Support in Action](/blog/multilanguage-support-in-action/)
 - [IX Reviewer in Action](/blog/ix-reviewer-in-action/)

--- a/Website/content/blog/ix-issue-ops-in-action.md
+++ b/Website/content/blog/ix-issue-ops-in-action.md
@@ -1,0 +1,65 @@
+---
+title: IX Issue Ops in Action
+description: First-party GitHub Project triage with issue applicability review, confidence signals, and maintainer-owned close or keep-open decisions.
+slug: ix-issue-ops-in-action
+collection: blog
+layout: page
+---
+
+Issue Ops extends reviewer workflows into backlog operations.
+It helps maintainers spot stale or no-longer-applicable infra blockers, but keeps final decisions human-owned.
+
+## Why This Exists
+
+Issue lists decay fast: old infra blockers stay open, linked PR context drifts, and teams lose confidence in the backlog.
+Issue Ops gives maintainers one triage surface where every recommendation includes a confidence score and explainable signals.
+
+## Board Overview
+
+The project view below is optimized for issue triage at scale.
+You can quickly separate likely-invalid blockers from items that still need active ownership.
+
+<img src="/assets/screenshots/ix-issue-ops/ix-issue-ops-01-board-overview.svg"
+     alt="Issue Ops project board view with open infra blocker issues, status, linked pull request columns, and quick filtering for maintainer triage"
+     width="1600"
+     height="900"
+     loading="lazy"
+     decoding="async" />
+
+## Signals That Matter
+
+Each issue recommendation includes:
+
+- `Issue Review Action` (`close`, `keep-open`, `needs-human-review`)
+- `Issue Review Action Confidence` (`0-100`, with high/medium/low levels)
+- linked PR context (`Matched Pull Request`, related PRs)
+- supporting confidence signals (stale age, reopen history, activity recency)
+
+<img src="/assets/screenshots/ix-issue-ops/ix-issue-ops-02-review-columns.svg"
+     alt="Issue Ops table columns showing Issue Review Action, confidence score, and linked pull request matching used for stale infra blocker triage"
+     width="1600"
+     height="900"
+     loading="lazy"
+     decoding="async" />
+
+## Safety First
+
+Issue Ops is assistive, not autonomous governance.
+
+- Do not run unattended close/merge decisions in production.
+- Use dry-run and proposal-only passes first.
+- Require a maintainer-owned approval step for mutating actions.
+
+## Start Here
+
+```bash
+intelligencex todo project-bootstrap --repo owner/repo --owner owner
+intelligencex todo issue-review --repo owner/repo --proposal-only --min-consecutive-candidates 2
+intelligencex todo project-sync --config artifacts/triage/ix-project-config.json --issue-review artifacts/triage/ix-issue-review.json --dry-run
+```
+
+## Related Docs
+
+- [Project Ops Overview](/docs/project-ops/overview/)
+- [Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
+- [Project Views and Operations](/docs/reviewer/project-views-and-ops/)

--- a/Website/data/products.json
+++ b/Website/data/products.json
@@ -63,14 +63,14 @@
     "screenshot": "/assets/screenshots/product-powershell.svg"
   },
   {
-    "title": "Project Ops",
-    "description": "GitHub Project triage control plane with issue-review, backlog signal scoring, and maintainer-first operations for stale or invalid work.",
+    "title": "Issue Ops + Project Control",
+    "description": "First-party GitHub Project control plane for PR and issue triage. Built-in issue-review flags stale or invalid infra blockers, proposes actions, and syncs confidence to project fields.",
     "icon": "project-ops",
     "link": "/docs/project-ops/overview/",
-    "tag": "Operations",
-    "badge": "First Party",
+    "tag": "First-Party Ops",
+    "badge": "Issue Ops",
     "featured": false,
-    "install": "intelligencex todo project-bootstrap --repo EvotecIT/IntelligenceX --owner EvotecIT",
-    "screenshot": "/assets/screenshots/product-project-ops.svg"
+    "install": "intelligencex todo project-bootstrap --repo owner/repo --owner owner",
+    "screenshot": "/assets/screenshots/ix-issue-ops/ix-issue-ops-01-board-overview.svg"
   }
 ]

--- a/Website/data/showcase.json
+++ b/Website/data/showcase.json
@@ -7,6 +7,12 @@
       "screenshot": "/assets/screenshots/showcase-pr-inline.svg"
     },
     {
+      "title": "Issue Ops Project View",
+      "summary": "GitHub Project view for issue applicability triage with suggested action, confidence, and linked PR context for stale infra blockers.",
+      "tags": ["Issue Ops", "Project Control"],
+      "screenshot": "/assets/screenshots/ix-issue-ops/ix-issue-ops-02-review-columns.svg"
+    },
+    {
       "title": "CLI Setup Wizard",
       "summary": "Interactive wizard guides you through authentication, repo selection, and workflow generation in under a minute.",
       "tags": ["CLI", "Onboarding"],

--- a/Website/data/sitemap.entries.json
+++ b/Website/data/sitemap.entries.json
@@ -36,6 +36,13 @@
       "changefreq": "weekly"
     },
     {
+      "path": "/docs/project-ops/overview/",
+      "title": "Project Ops Overview",
+      "section": "Docs",
+      "priority": "0.9",
+      "changefreq": "weekly"
+    },
+    {
       "path": "/docs/cli/overview/",
       "title": "CLI Overview",
       "section": "Docs",
@@ -94,6 +101,13 @@
     {
       "path": "/blog/chat-flow-and-options/",
       "title": "Chat Flow and Options",
+      "section": "Resources",
+      "priority": "0.7",
+      "changefreq": "monthly"
+    },
+    {
+      "path": "/blog/ix-issue-ops-in-action/",
+      "title": "IX Issue Ops in Action",
       "section": "Resources",
       "priority": "0.7",
       "changefreq": "monthly"

--- a/Website/static/assets/screenshots/ix-issue-ops/ix-issue-ops-01-board-overview.svg
+++ b/Website/static/assets/screenshots/ix-issue-ops/ix-issue-ops-01-board-overview.svg
@@ -1,0 +1,80 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Issue Ops project board overview">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1600" y2="900" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#020817"/>
+      <stop offset="1" stop-color="#0B1D3A"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="64" y1="112" x2="1536" y2="852" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0B1222"/>
+      <stop offset="1" stop-color="#081225"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <rect x="36" y="28" width="1528" height="844" rx="20" fill="url(#panel)" stroke="#1E3A64"/>
+
+  <rect x="36" y="28" width="1528" height="68" rx="20" fill="#08162C"/>
+  <circle cx="74" cy="62" r="8" fill="#334E76"/>
+  <circle cx="102" cy="62" r="8" fill="#334E76"/>
+  <circle cx="130" cy="62" r="8" fill="#334E76"/>
+  <rect x="170" y="44" width="410" height="36" rx="10" fill="#102647"/>
+  <text x="194" y="67" fill="#A5C8F1" font-family="Segoe UI, Arial, sans-serif" font-size="16" font-weight="600">EvotecIT / Projects / IX Issue Ops Control</text>
+  <rect x="1268" y="44" width="264" height="36" rx="10" fill="#0C2B24" stroke="#1D7A63"/>
+  <text x="1292" y="67" fill="#97F3CD" font-family="Segoe UI, Arial, sans-serif" font-size="14" font-weight="700">Issue Ops view</text>
+
+  <rect x="72" y="126" width="1456" height="66" rx="12" fill="#0D1C34" stroke="#1A335A"/>
+  <text x="96" y="166" fill="#CFE4FF" font-family="Segoe UI, Arial, sans-serif" font-size="20" font-weight="700">Filter by keyword or field</text>
+
+  <rect x="72" y="212" width="1456" height="620" rx="14" fill="#08172B" stroke="#1A335A"/>
+  <rect x="72" y="212" width="1456" height="56" rx="14" fill="#0D223E"/>
+  <text x="108" y="246" fill="#A3C6EF" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700">Title</text>
+  <text x="818" y="246" fill="#A3C6EF" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700">Status</text>
+  <text x="1008" y="246" fill="#A3C6EF" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700">Issue Review Action</text>
+  <text x="1240" y="246" fill="#A3C6EF" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700">Confidence</text>
+  <text x="1380" y="246" fill="#A3C6EF" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700">Matched PR</text>
+
+  <line x1="794" y1="212" x2="794" y2="832" stroke="#173154"/>
+  <line x1="984" y1="212" x2="984" y2="832" stroke="#173154"/>
+  <line x1="1230" y1="212" x2="1230" y2="832" stroke="#173154"/>
+  <line x1="1368" y1="212" x2="1368" y2="832" stroke="#173154"/>
+
+  <g font-family="Segoe UI, Arial, sans-serif" font-size="14">
+    <text x="96" y="305" fill="#E2ECFF">#362 Infra blocker: PR checks failing with no space left on device</text>
+    <text x="822" y="305" fill="#D8E6FC">Open</text>
+    <rect x="1002" y="282" width="120" height="30" rx="14" fill="#123E2E" stroke="#2E8861"/>
+    <text x="1041" y="301" fill="#A0F2CE" font-size="13" font-weight="700">close</text>
+    <text x="1251" y="304" fill="#A8EED4" font-size="13" font-weight="700">91 / high</text>
+    <text x="1390" y="305" fill="#D8E6FC">#359</text>
+
+    <text x="96" y="371" fill="#E2ECFF">#440 Infra blocker: PR checks stuck in Setup .NET</text>
+    <text x="822" y="371" fill="#D8E6FC">Open</text>
+    <rect x="1002" y="348" width="206" height="30" rx="14" fill="#3A2F14" stroke="#B98B31"/>
+    <text x="1028" y="367" fill="#FBE3A2" font-size="13" font-weight="700">needs-human-review</text>
+    <text x="1246" y="370" fill="#F8DFA1" font-size="13" font-weight="700">63 / medium</text>
+    <text x="1390" y="371" fill="#D8E6FC">#438</text>
+
+    <text x="96" y="437" fill="#E2ECFF">#345 CI infra: Website Build fails when browser deps unavailable</text>
+    <text x="822" y="437" fill="#D8E6FC">Open</text>
+    <rect x="1002" y="414" width="146" height="30" rx="14" fill="#133151" stroke="#3178B2"/>
+    <text x="1037" y="433" fill="#A9D8FF" font-size="13" font-weight="700">keep-open</text>
+    <text x="1251" y="436" fill="#A7D7FF" font-size="13" font-weight="700">86 / high</text>
+    <text x="1390" y="437" fill="#D8E6FC">#355</text>
+
+    <text x="96" y="503" fill="#E2ECFF">#259 Improve documentation</text>
+    <text x="822" y="503" fill="#D8E6FC">Open</text>
+    <rect x="1002" y="480" width="146" height="30" rx="14" fill="#133151" stroke="#3178B2"/>
+    <text x="1037" y="499" fill="#A9D8FF" font-size="13" font-weight="700">keep-open</text>
+    <text x="1246" y="502" fill="#F8DFA1" font-size="13" font-weight="700">58 / medium</text>
+    <text x="1390" y="503" fill="#D8E6FC">#531</text>
+  </g>
+
+  <line x1="72" y1="334" x2="1528" y2="334" stroke="#173154"/>
+  <line x1="72" y1="400" x2="1528" y2="400" stroke="#173154"/>
+  <line x1="72" y1="466" x2="1528" y2="466" stroke="#173154"/>
+  <line x1="72" y1="532" x2="1528" y2="532" stroke="#173154"/>
+
+  <rect x="92" y="734" width="440" height="78" rx="10" fill="#0D223E" stroke="#1A335A"/>
+  <text x="116" y="763" fill="#9FC3EE" font-family="Segoe UI, Arial, sans-serif" font-size="14" font-weight="700">Run summary</text>
+  <text x="116" y="788" fill="#D9E8FF" font-family="Segoe UI, Arial, sans-serif" font-size="13">close: 4  keep-open: 7  needs-human-review: 3</text>
+  <text x="116" y="806" fill="#7EAED9" font-family="Segoe UI, Arial, sans-serif" font-size="12">mode: proposal-only  threshold: 80  state streak: 2</text>
+</svg>

--- a/Website/static/assets/screenshots/ix-issue-ops/ix-issue-ops-02-review-columns.svg
+++ b/Website/static/assets/screenshots/ix-issue-ops/ix-issue-ops-02-review-columns.svg
@@ -1,0 +1,58 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Issue review action and confidence columns">
+  <defs>
+    <linearGradient id="bg2" x1="0" y1="0" x2="1600" y2="900" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#040B1A"/>
+      <stop offset="1" stop-color="#11284B"/>
+    </linearGradient>
+    <linearGradient id="card2" x1="120" y1="110" x2="1480" y2="800" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D1B30"/>
+      <stop offset="1" stop-color="#0A1628"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg2)"/>
+  <rect x="84" y="62" width="1432" height="776" rx="22" fill="url(#card2)" stroke="#1B3A61"/>
+
+  <text x="120" y="124" fill="#CFE6FF" font-family="Segoe UI, Arial, sans-serif" font-size="26" font-weight="700">Issue Ops Signals in Project Fields</text>
+  <text x="120" y="154" fill="#8EB5DE" font-family="Segoe UI, Arial, sans-serif" font-size="15">Use action + confidence + linked PR context to keep backlog hygiene high without unattended decisions.</text>
+
+  <rect x="120" y="190" width="1360" height="84" rx="12" fill="#0A1A31" stroke="#1B3A61"/>
+  <text x="154" y="239" fill="#A7CBF1" font-family="Segoe UI, Arial, sans-serif" font-size="17" font-weight="700">Issue Review Action</text>
+  <text x="484" y="239" fill="#A7CBF1" font-family="Segoe UI, Arial, sans-serif" font-size="17" font-weight="700">Issue Review Action Confidence</text>
+  <text x="890" y="239" fill="#A7CBF1" font-family="Segoe UI, Arial, sans-serif" font-size="17" font-weight="700">Matched Pull Request</text>
+  <text x="1210" y="239" fill="#A7CBF1" font-family="Segoe UI, Arial, sans-serif" font-size="17" font-weight="700">Signal Quality</text>
+
+  <g font-family="Segoe UI, Arial, sans-serif">
+    <rect x="120" y="292" width="1360" height="96" rx="12" fill="#0A1628" stroke="#1B3152"/>
+    <rect x="154" y="322" width="104" height="36" rx="18" fill="#123D2D" stroke="#2F8A63"/>
+    <text x="186" y="345" fill="#A7F4D2" font-size="15" font-weight="700">close</text>
+    <text x="488" y="346" fill="#9DEFD3" font-size="15" font-weight="700">91 / high</text>
+    <text x="894" y="346" fill="#DDEBFF" font-size="15">#359</text>
+    <rect x="1214" y="322" width="84" height="34" rx="17" fill="#123D2D" stroke="#2F8A63"/>
+    <text x="1238" y="343" fill="#A7F4D2" font-size="14" font-weight="700">high</text>
+    <text x="154" y="373" fill="#82ADD8" font-size="13">stale bucket: very old | linked PR closed long ago | no reopen</text>
+
+    <rect x="120" y="408" width="1360" height="96" rx="12" fill="#0A1628" stroke="#1B3152"/>
+    <rect x="154" y="438" width="196" height="36" rx="18" fill="#3A2E14" stroke="#B88A30"/>
+    <text x="178" y="461" fill="#FCE3A7" font-size="15" font-weight="700">needs-human-review</text>
+    <text x="488" y="462" fill="#F8DFA2" font-size="15" font-weight="700">63 / medium</text>
+    <text x="894" y="462" fill="#DDEBFF" font-size="15">#438</text>
+    <rect x="1214" y="438" width="102" height="34" rx="17" fill="#3A2E14" stroke="#B88A30"/>
+    <text x="1244" y="459" fill="#FCE3A7" font-size="14" font-weight="700">medium</text>
+    <text x="154" y="489" fill="#82ADD8" font-size="13">recent updates detected | reopen history present | confidence reduced</text>
+
+    <rect x="120" y="524" width="1360" height="96" rx="12" fill="#0A1628" stroke="#1B3152"/>
+    <rect x="154" y="554" width="130" height="36" rx="18" fill="#133252" stroke="#347AB3"/>
+    <text x="184" y="577" fill="#ACD9FF" font-size="15" font-weight="700">keep-open</text>
+    <text x="488" y="578" fill="#ACD9FF" font-size="15" font-weight="700">86 / high</text>
+    <text x="894" y="578" fill="#DDEBFF" font-size="15">#355</text>
+    <rect x="1214" y="554" width="84" height="34" rx="17" fill="#123D2D" stroke="#2F8A63"/>
+    <text x="1238" y="575" fill="#A7F4D2" font-size="14" font-weight="700">high</text>
+    <text x="154" y="605" fill="#82ADD8" font-size="13">active linked PR context | recent activity | not eligible for close</text>
+  </g>
+
+  <rect x="120" y="662" width="1360" height="146" rx="14" fill="#0A1A31" stroke="#1B3A61"/>
+  <text x="154" y="700" fill="#A7CBF1" font-family="Segoe UI, Arial, sans-serif" font-size="17" font-weight="700">Maintainer decision rule</text>
+  <text x="154" y="730" fill="#DCEBFF" font-family="Segoe UI, Arial, sans-serif" font-size="15">Use these fields as decision support, not autonomous execution.</text>
+  <text x="154" y="756" fill="#88B2DE" font-family="Segoe UI, Arial, sans-serif" font-size="14">Recommended: proposal-only + dry-run sync + explicit maintainer approval for any close action.</text>
+</svg>

--- a/Website/static/css/home.css
+++ b/Website/static/css/home.css
@@ -47,6 +47,8 @@
 
 /* ===== Products Grid ===== */
 .products { padding: 4rem 1.5rem; max-width: var(--pf-max-width); margin: 0 auto; }
+.products-safety-note { margin: 0 auto 1.75rem; max-width: 980px; border: 1px solid rgba(245, 158, 11, 0.35); background: linear-gradient(135deg, rgba(245, 158, 11, 0.12), rgba(251, 191, 36, 0.06)); border-radius: var(--pf-radius-sm); color: #FDE68A; padding: 0.85rem 1rem; font-size: 0.88rem; line-height: 1.55; }
+[data-theme="light"] .products-safety-note { background: linear-gradient(135deg, rgba(180, 83, 9, 0.1), rgba(202, 138, 4, 0.08)); border-color: rgba(146, 64, 14, 0.28); color: #7C2D12; }
 .products-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
 .product-card { background: var(--pf-card-bg); border: 1px solid var(--pf-border); border-radius: var(--pf-radius); overflow: hidden; transition: all 0.3s; display: flex; flex-direction: column; }
 .product-card:hover { border-color: var(--pf-accent); box-shadow: 0 0 30px var(--pf-glow-primary); transform: translateY(-4px); }

--- a/Website/themes/intelligencex/partials/sections/products.html
+++ b/Website/themes/intelligencex/partials/sections/products.html
@@ -6,6 +6,10 @@
         <p>Everything you need for AI-powered development workflows.</p>
     </div>
 
+    <div class="products-safety-note" role="note" aria-label="Operational safety note">
+        <strong>Operational safety:</strong> IX Reviewer, IX Chat, and Issue Ops are assistive systems. Do not use them as unattended production decision engines without explicit human approval gates.
+    </div>
+
     <div class="products-grid">
         {{ for item in data.products }}
         <div class="product-card{{ if item.featured }} featured{{ end }}">


### PR DESCRIPTION
## Summary\n- promote Issue Ops on the front page as a first-party product area\n- add a homepage operational safety note for Reviewer/Chat/Issue Ops\n- add an Issue Ops showcase card and a new blog walkthrough with screenshots\n- add two Issue Ops screenshot assets and wire them into docs/blog\n- update sitemap entries for Project Ops and the new blog page\n\n## Validation\n- Website/build.ps1 -Dev\n- Website/build.ps1 -CI\n