### PR TITLE
perf(chat): avoid blocking startup on staging cleanup

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
@@ -970,7 +970,7 @@ public sealed partial class MainWindow : Window {
 
             _stagedServiceDir = stagedDir;
             TouchDirectory(stagedDir);
-            CleanupStaleServiceStaging(runtimeRoot, stagedDir);
+            QueueStaleServiceStagingCleanup(runtimeRoot, stagedDir);
             return stagedDir;
         } catch (Exception ex) {
             AppendSystem(SystemNotice.ServiceStagingError(ex.Message));
@@ -1050,6 +1050,20 @@ public sealed partial class MainWindow : Window {
         } catch {
             // Ignore.
         }
+    }
+
+    private void QueueStaleServiceStagingCleanup(string runtimeRoot, string keepDir) {
+        if (Interlocked.CompareExchange(ref _serviceStagingCleanupInFlight, 1, 0) != 0) {
+            return;
+        }
+
+        _ = Task.Run(() => {
+            try {
+                CleanupStaleServiceStaging(runtimeRoot, keepDir);
+            } finally {
+                Interlocked.Exchange(ref _serviceStagingCleanupInFlight, 0);
+            }
+        });
     }
 
     private static void CleanupStaleServiceStaging(string runtimeRoot, string keepDir) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -223,6 +223,7 @@ public sealed partial class MainWindow : Window {
     private readonly object _startupWebViewBudgetCacheSync = new();
     private StartupWebViewBudgetCacheEntry _startupWebViewBudgetCache = StartupWebViewBudgetCacheEntry.Default;
     private int _startupWebViewBudgetExceededThisRun;
+    private int _serviceStagingCleanupInFlight;
 
     private ChatServiceClient? _client;
     private string? _threadId;


### PR DESCRIPTION
## Summary
- move stale sidecar staging cleanup off the startup critical path
- keep startup staging behavior unchanged (same staging key/payload checks)
- queue stale cleanup as a single in-flight background task to avoid repeated startup blocking work

## Why
- startup connect can be delayed when %TEMP%\\IntelligenceX.Chat\\service-runtime contains many stale staging directories
- cleanup work is maintenance; it does not need to block sidecar ensure/start

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release -p:SkipChatServiceSidecarBuild=true -p:ChatServiceBin=C:\_ix_chat_service_missing\\ (passed, 255)

Synthetic stale-dir stress profiling (300 stale stage dirs under isolated TEMP root):
- baseline report: rtifacts/stale-cleanup-sim-20260218-211031/baseline.json
- patched report: rtifacts/stale-cleanup-sim-20260218-211236/patched.json

Observed deltas from those reports:
- avg total startup: 3426.69ms -> 2963.66ms (-463.03ms)
- avg connect: 1024.16ms -> 765.18ms (-258.98ms)
- first-run connect (worst stale-cleanup impact): 2240.04ms -> 1462.41ms (-777.63ms)

## Notes
- Local dotnet build still ends with existing MSB3030 sidecar copy issues in this environment (missing *.psd1 files), but app executable is emitted and used for profiling.