### PR TITLE
docs(project-ops): add demo capture runbook for screenshot generation

### DIFF
--- a/Docs/_index.md
+++ b/Docs/_index.md
@@ -29,6 +29,7 @@ Welcome to the IntelligenceX documentation.
 ## Project Ops
 
 - [Project Ops Overview](/docs/project-ops/overview/)
+- [Project Ops Demo Capture Runbook](/docs/project-ops/demo-capture-runbook/)
 - [Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
 - [Project Views and Operations](/docs/reviewer/project-views-and-ops/)
 

--- a/Docs/project-ops/demo-capture-runbook.md
+++ b/Docs/project-ops/demo-capture-runbook.md
@@ -1,0 +1,102 @@
+---
+title: Project Ops Demo Capture Runbook
+slug: demo-capture-runbook
+---
+
+# Project Ops Demo Capture Runbook
+
+Use this runbook to produce reliable, real screenshots for `Issue Ops` and Project triage docs.
+
+All logic should come from built-in `intelligencex todo ...` commands. Do not use external scripts for decision logic.
+
+## Important disclaimer
+
+Project Ops is assistive automation, not autonomous production governance.
+
+- Treat suggested actions and confidence as recommendations.
+- Keep close and keep-open decisions human-owned.
+- Use proposal-only and dry-run modes before mutating operations.
+
+## Demo goals
+
+Capture screenshots that prove three things:
+
+1. `Issue Review Action` is populated by real IX runs.
+2. `Issue Review Action Confidence` and linked PR context are visible in the project table.
+3. Maintainers can review recommendations before any close action is applied.
+
+## Prerequisites
+
+- A repository with active issues and pull requests.
+- GitHub Project access (`project` scope).
+- IX CLI authentication completed.
+- Existing or bootstrap-ready project configuration.
+
+## End-to-end demo flow
+
+Run these commands from the target repository root.
+
+```bash
+# 1) Bootstrap project fields and local config artifacts
+intelligencex todo project-bootstrap --repo owner/repo --owner owner
+
+# 2) Build triage index for PR and issue context
+intelligencex todo build-triage-index --repo owner/repo
+
+# 3) Run issue applicability review (non-mutating)
+intelligencex todo issue-review --repo owner/repo --proposal-only --min-consecutive-candidates 2 --min-auto-close-confidence 80 --state-path artifacts/triage/ix-issue-review-state.json
+
+# 4) Optional: align backlog with VISION.md
+intelligencex todo vision-check --repo owner/repo --vision VISION.md
+
+# 5) Sync signals into project fields in dry-run first
+intelligencex todo project-sync --config artifacts/triage/ix-project-config.json --issue-review artifacts/triage/ix-issue-review.json --dry-run
+
+# 6) Apply after maintainer approval
+intelligencex todo project-sync --config artifacts/triage/ix-project-config.json --issue-review artifacts/triage/ix-issue-review.json
+```
+
+## Screenshot shot list
+
+Capture these in one session so filters and state are consistent:
+
+1. Project board overview with open issues and triage columns visible.
+2. Table focused on `Issue Review Action` and `Issue Review Action Confidence`.
+3. Row example showing linked PR context (`Matched Pull Request` or related PR fields).
+4. Markdown summary from `artifacts/triage/ix-issue-review.md`.
+
+## Capture quality checklist
+
+- Resolution: `>= 1920x1080`.
+- Keep the same theme and zoom level across all captures.
+- Do not crop out key columns used in the narrative.
+- Avoid screenshots with hidden filters that cannot be explained.
+- Remove unrelated personal or sensitive data before publishing.
+
+## Naming convention
+
+Use deterministic names for website assets:
+
+- `ix-issue-ops-01-board-overview.png`
+- `ix-issue-ops-02-review-columns.png`
+- `ix-issue-ops-03-linked-pr-context.png`
+- `ix-issue-ops-04-issue-review-summary.png`
+
+Place them in:
+
+`Website/static/assets/screenshots/ix-issue-ops/`
+
+## Publish checklist
+
+1. Replace placeholder references in docs or blog pages.
+2. Verify each image has explicit width, height, loading, and decoding hints.
+3. Run website validation:
+   - `Website/build.ps1 -Dev`
+   - `Website/build.ps1 -CI`
+4. Open PR with before/after screenshots in the description.
+
+## Related docs
+
+- [Project Ops Overview](/docs/project-ops/overview/)
+- [Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
+- [Project Views and Operations](/docs/reviewer/project-views-and-ops/)

--- a/Docs/project-ops/overview.md
+++ b/Docs/project-ops/overview.md
@@ -57,6 +57,7 @@ intelligencex todo project-sync --config artifacts/triage/ix-project-config.json
 
 ## Related docs
 
+- [Project Ops Demo Capture Runbook](/docs/project-ops/demo-capture-runbook/)
 - [Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
 - [Project Bootstrap and Sync](/docs/reviewer/project-bootstrap-sync/)
 - [Project Views and Operations](/docs/reviewer/project-views-and-ops/)

--- a/Docs/toc.json
+++ b/Docs/toc.json
@@ -24,7 +24,8 @@
   {
     "title": "Project Ops",
     "items": [
-      { "title": "Overview", "href": "/docs/project-ops/overview/" }
+      { "title": "Overview", "href": "/docs/project-ops/overview/" },
+      { "title": "Demo Capture Runbook", "href": "/docs/project-ops/demo-capture-runbook/" }
     ]
   },
   {

--- a/Website/content/blog/ix-issue-ops-in-action.md
+++ b/Website/content/blog/ix-issue-ops-in-action.md
@@ -61,5 +61,6 @@ intelligencex todo project-sync --config artifacts/triage/ix-project-config.json
 ## Related Docs
 
 - [Project Ops Overview](/docs/project-ops/overview/)
+- [Project Ops Demo Capture Runbook](/docs/project-ops/demo-capture-runbook/)
 - [Projects + PR Monitoring](/docs/reviewer/projects-pr-monitoring/)
 - [Project Views and Operations](/docs/reviewer/project-views-and-ops/)

--- a/Website/data/sitemap.entries.json
+++ b/Website/data/sitemap.entries.json
@@ -43,6 +43,13 @@
       "changefreq": "weekly"
     },
     {
+      "path": "/docs/project-ops/demo-capture-runbook/",
+      "title": "Project Ops Demo Capture Runbook",
+      "section": "Docs",
+      "priority": "0.8",
+      "changefreq": "monthly"
+    },
+    {
       "path": "/docs/cli/overview/",
       "title": "CLI Overview",
       "section": "Docs",


### PR DESCRIPTION
## Summary\n- add a public Project Ops demo capture runbook focused on built-in intelligencex todo commands\n- document deterministic command flow, shot list, naming convention, and publish checklist\n- wire runbook into docs navigation and project-ops overview related links\n- add website discoverability via docs index, blog related links, and sitemap entry\n\n## Validation\n- Website/build.ps1 -Dev\n- Website/build.ps1 -CI *(fails locally on existing verify best-practice baseline warning: PFWEB.BESTPRACTICE for blog list layout, unrelated to runbook content)*\n