### PR TITLE
Refactor tool helper reuse and add tool authoring playbook/skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -8,6 +8,7 @@ Repo-local skills that make agents more consistent across onboarding, setup, ana
 - `intelligencex-pr-unblock-loop`: Use for PR triage, CI failure classification, and merge-blocker closure loops.
 - `intelligencex-reviewer-bootstrap`: Use for reviewer bootstrap (`reviewer.json` + workflow YAML) dry-runs, precedence checks, and managed-block validation.
 - `intelligencex-first-pr-rollout`: Use to verify first post-onboarding PR rollout signals (workflow, checks, sticky summary, analysis sections).
+- `intelligencex-tools-authoring`: Use for tool creation/refactors focused on helper reuse, stable contracts, and low-maintenance patterns.
 
 ## Shared Rules
 - Always use a dedicated `codex/*` branch and worktree.

--- a/.agents/skills/intelligencex-tools-authoring/SKILL.md
+++ b/.agents/skills/intelligencex-tools-authoring/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: intelligencex-tools-authoring
+description: Use when creating or refactoring IntelligenceX tools to maximize helper reuse, reduce duplication, and keep stable tool contracts.
+---
+
+# Skill: intelligencex-tools-authoring
+
+Use this skill when changing files in `IntelligenceX.Tools/**`, especially when adding new tools or consolidating helper logic.
+
+## Trigger Phrases
+- "new tool"
+- "tooling refactor"
+- "reduce duplication in tools"
+- "centralize tool helpers"
+- "tool contract cleanup"
+
+## Strict Execution Order
+1. Identify target package and existing base helpers.
+2. Reuse shared helper paths first (`ToolBase`, `ToolQueryHelpers`, package base helpers).
+3. Implement tool/refactor changes with no output contract drift.
+4. Add or update tests for helper behavior and edge cases.
+5. Run targeted build/tests for changed tool packages.
+6. Summarize reusable pattern changes for future tools.
+
+## Commands
+- Targeted build:
+  - `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/IntelligenceX.Tools.ADPlayground.csproj -c Release`
+  - `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.EventLog/IntelligenceX.Tools.EventLog.csproj -c Release`
+  - `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.System/IntelligenceX.Tools.System.csproj -c Release`
+- Targeted tests:
+  - `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
+- Full tool solution gate:
+  - `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`
+
+## Fail-Fast Rules
+- Do not add package-specific duplicate helpers when a shared helper exists.
+- Do not change `error_code`/metadata/table view contracts without explicit intent.
+- Keep mass normalization (for example line endings) in a dedicated cleanup PR, not mixed with behavior changes.
+
+## References
+- `InternalDocs/agent-playbooks/tool-authoring-playbook.md`
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -25,6 +25,10 @@
 .gitattributes text eol=lf
 .editorconfig text eol=lf
 
+# Keep active AD/tooling development paths explicitly normalized to LF.
+IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/*.cs text eol=lf
+IntelligenceX.Tools/IntelligenceX.Tools.Tests/*.cs text eol=lf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,4 +118,5 @@ When an agent is assigned a PR to improve or unblock, it must iterate until merg
   - First PR rollout verification: `/.agents/skills/intelligencex-first-pr-rollout/SKILL.md`
   - Analysis/catalog/gate work: `/.agents/skills/intelligencex-analysis-gate/SKILL.md`
   - PR unblock/merge loop: `/.agents/skills/intelligencex-pr-unblock-loop/SKILL.md`
+  - Tool creation/refactor reuse loops: `/.agents/skills/intelligencex-tools-authoring/SKILL.md`
 - Follow each skill's strict execution order and helper scripts before posting PR updates.

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -60,6 +60,52 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     }
 
     /// <summary>
+    /// Resolves a positive max-results argument capped by pack options.
+    /// </summary>
+    /// <param name="arguments">Tool arguments.</param>
+    /// <param name="argumentName">Argument name (defaults to <c>max_results</c>).</param>
+    /// <returns>Normalized max-results value.</returns>
+    protected int ResolveMaxResults(JsonObject? arguments, string argumentName = "max_results") {
+        return ToolArgs.GetPositiveOptionBoundedInt32OrDefault(
+            arguments,
+            argumentName,
+            Options.MaxResults,
+            Options.MaxResults);
+    }
+
+    /// <summary>
+    /// Resolves a max-results argument with strict lower-bound clamping (minimum 1).
+    /// </summary>
+    /// <param name="arguments">Tool arguments.</param>
+    /// <param name="argumentName">Argument name (defaults to <c>max_results</c>).</param>
+    /// <returns>Normalized max-results value.</returns>
+    protected int ResolveBoundedMaxResults(JsonObject? arguments, string argumentName = "max_results") {
+        return ToolArgs.GetOptionBoundedInt32(
+            arguments,
+            argumentName,
+            Options.MaxResults);
+    }
+
+    /// <summary>
+    /// Reads a required trimmed domain argument and returns a standard invalid-argument envelope on failure.
+    /// </summary>
+    protected static bool TryReadRequiredDomainName(
+        JsonObject? arguments,
+        out string domainName,
+        out string? errorResponse,
+        string argumentName = "domain_name") {
+        var key = string.IsNullOrWhiteSpace(argumentName) ? "domain_name" : argumentName.Trim();
+        domainName = ToolArgs.GetOptionalTrimmed(arguments, key) ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(domainName)) {
+            errorResponse = ToolResponse.Error("invalid_argument", $"{key} is required.");
+            return false;
+        }
+
+        errorResponse = null;
+        return true;
+    }
+
+    /// <summary>
     /// Resolves tool-requested AD attribute list via ADPlayground policy helper.
     /// </summary>
     protected static List<string> ResolveAttributes(
@@ -119,6 +165,157 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     }
 
     /// <summary>
+    /// Maps AD collection-view success/error fields to a standardized query_failed envelope.
+    /// </summary>
+    protected static bool TryMapCollectionFailure(
+        bool collectionSucceeded,
+        string? collectionError,
+        string defaultErrorMessage,
+        out string? errorResponse) {
+        if (collectionSucceeded) {
+            errorResponse = null;
+            return true;
+        }
+
+        var message = string.IsNullOrWhiteSpace(collectionError)
+            ? defaultErrorMessage
+            : collectionError!;
+        errorResponse = ToolResponse.Error("query_failed", message);
+        return false;
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException"/> when collection did not succeed.
+    /// </summary>
+    protected static void ThrowIfCollectionFailed(
+        bool collectionSucceeded,
+        string? collectionError,
+        string defaultErrorMessage) {
+        if (collectionSucceeded) {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            string.IsNullOrWhiteSpace(collectionError)
+                ? defaultErrorMessage
+                : collectionError!);
+    }
+
+    /// <summary>
+    /// Executes a query that returns a conventional AD collection view and maps failures consistently.
+    /// </summary>
+    protected static bool TryExecuteCollectionQuery<T>(
+        Func<T> query,
+        out T result,
+        out string? errorResponse,
+        string defaultErrorMessage,
+        string fallbackErrorCode = "query_failed",
+        string invalidOperationErrorCode = "query_failed") {
+        if (!TryExecute(
+                action: query,
+                result: out result,
+                errorResponse: out errorResponse,
+                defaultErrorMessage: defaultErrorMessage,
+                fallbackErrorCode: fallbackErrorCode,
+                invalidOperationErrorCode: invalidOperationErrorCode)) {
+            return false;
+        }
+
+        return TryMapCollectionFailureByConvention(result, defaultErrorMessage, out errorResponse);
+    }
+
+    /// <summary>
+    /// Executes a query that returns an AD collection view and maps failures using typed selectors.
+    /// </summary>
+    protected static bool TryExecuteCollectionQuery<T>(
+        Func<T> query,
+        Func<T, bool> collectionSucceededSelector,
+        Func<T, string?> collectionErrorSelector,
+        out T result,
+        out string? errorResponse,
+        string defaultErrorMessage,
+        string fallbackErrorCode = "query_failed",
+        string invalidOperationErrorCode = "query_failed") {
+        if (collectionSucceededSelector is null) {
+            throw new ArgumentNullException(nameof(collectionSucceededSelector));
+        }
+        if (collectionErrorSelector is null) {
+            throw new ArgumentNullException(nameof(collectionErrorSelector));
+        }
+
+        if (!TryExecute(
+                action: query,
+                result: out result,
+                errorResponse: out errorResponse,
+                defaultErrorMessage: defaultErrorMessage,
+                fallbackErrorCode: fallbackErrorCode,
+                invalidOperationErrorCode: invalidOperationErrorCode)) {
+            return false;
+        }
+
+        bool collectionSucceeded;
+        string? collectionError;
+        try {
+            collectionSucceeded = collectionSucceededSelector(result);
+            collectionError = collectionErrorSelector(result);
+        } catch (Exception ex) {
+            errorResponse = ErrorFromException(ex, defaultErrorMessage, fallbackErrorCode, invalidOperationErrorCode);
+            return false;
+        }
+
+        return TryMapCollectionFailure(collectionSucceeded, collectionError, defaultErrorMessage, out errorResponse);
+    }
+
+    /// <summary>
+    /// Maps failures from views exposing <c>CollectionSucceeded</c>/<c>CollectionError</c> members.
+    /// </summary>
+    protected static bool TryMapCollectionFailureByConvention<T>(
+        T view,
+        string defaultErrorMessage,
+        out string? errorResponse) {
+        if (!TryReadCollectionViewState(view, out var collectionSucceeded, out var collectionError)) {
+            errorResponse = ToolResponse.Error("query_failed", "Collection view contract is invalid.");
+            return false;
+        }
+
+        return TryMapCollectionFailure(
+            collectionSucceeded,
+            collectionError,
+            defaultErrorMessage,
+            out errorResponse);
+    }
+
+    private static bool TryReadCollectionViewState<T>(
+        T view,
+        out bool collectionSucceeded,
+        out string? collectionError) {
+        collectionSucceeded = false;
+        collectionError = null;
+        if (view is null) {
+            return false;
+        }
+
+        var type = view.GetType();
+        var collectionSucceededProperty = type.GetProperty("CollectionSucceeded");
+        var collectionErrorProperty = type.GetProperty("CollectionError");
+        if (collectionSucceededProperty is null ||
+            collectionSucceededProperty.PropertyType != typeof(bool) ||
+            collectionErrorProperty is null ||
+            collectionErrorProperty.PropertyType != typeof(string)) {
+            return false;
+        }
+
+        var succeededValue = collectionSucceededProperty.GetValue(view);
+        if (succeededValue is not bool succeeded) {
+            return false;
+        }
+
+        collectionSucceeded = succeeded;
+        collectionError = collectionErrorProperty.GetValue(view) as string;
+        return true;
+    }
+
+    /// <summary>
     /// Executes a query delegate and maps exceptions into a stable error envelope.
     /// </summary>
     protected static bool TryExecute<T>(
@@ -144,28 +341,75 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     }
 
     /// <summary>
-    /// Builds the standard auto-column table envelope used by AD read tools.
+    /// Executes the common AD rows-view pipeline:
+    /// parse required domain, run typed collection query, cap rows, build result, and emit table response.
     /// </summary>
-    protected static string BuildAutoTableResponse<TModel, TRow>(
+    protected Task<string> ExecuteDomainRowsViewTool<TView, TRow, TResult>(
         JsonObject? arguments,
-        TModel model,
-        IReadOnlyList<TRow> sourceRows,
-        string viewRowsPath,
+        CancellationToken cancellationToken,
         string title,
-        bool baseTruncated,
-        int scanned,
-        int maxTop,
-        Action<JsonObject>? metaMutate = null) {
-        return ToolQueryHelpers.BuildAutoTableResponse(
+        string defaultErrorMessage,
+        Func<string, TView> query,
+        Func<TView, bool> collectionSucceededSelector,
+        Func<TView, string?> collectionErrorSelector,
+        Func<TView, IReadOnlyList<TRow>> allRowsSelector,
+        Func<string, TView, IReadOnlyList<TRow>, IReadOnlyList<TRow>, int, bool, TResult> resultFactory,
+        Action<JsonObject, string, int, TView>? additionalMetaMutate = null,
+        int maxTop = DefaultPolicyAttributionMaxTop,
+        string viewRowsPath = "rows_view",
+        string invalidOperationErrorCode = "query_failed") {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (query is null) {
+            throw new ArgumentNullException(nameof(query));
+        }
+        if (collectionSucceededSelector is null) {
+            throw new ArgumentNullException(nameof(collectionSucceededSelector));
+        }
+        if (collectionErrorSelector is null) {
+            throw new ArgumentNullException(nameof(collectionErrorSelector));
+        }
+        if (allRowsSelector is null) {
+            throw new ArgumentNullException(nameof(allRowsSelector));
+        }
+        if (resultFactory is null) {
+            throw new ArgumentNullException(nameof(resultFactory));
+        }
+
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+            return Task.FromResult(argumentError!);
+        }
+
+        var maxResults = ResolveBoundedMaxResults(arguments);
+
+        if (!TryExecuteCollectionQuery(
+                query: () => query(domainName),
+                collectionSucceededSelector: collectionSucceededSelector,
+                collectionErrorSelector: collectionErrorSelector,
+                result: out TView view,
+                errorResponse: out var errorResponse,
+                defaultErrorMessage: defaultErrorMessage,
+                invalidOperationErrorCode: invalidOperationErrorCode)) {
+            return Task.FromResult(errorResponse!);
+        }
+
+        var allRows = allRowsSelector(view) ?? Array.Empty<TRow>();
+        var rows = CapRows(allRows, maxResults, out var scanned, out var truncated);
+        var result = resultFactory(domainName, view, allRows, rows, scanned, truncated);
+
+        return Task.FromResult(BuildAutoTableResponse(
             arguments: arguments,
-            model: model,
-            sourceRows: sourceRows,
+            model: result,
+            sourceRows: rows,
             viewRowsPath: viewRowsPath,
             title: title,
             maxTop: maxTop,
-            baseTruncated: baseTruncated,
+            baseTruncated: truncated,
             scanned: scanned,
-            metaMutate: metaMutate);
+            metaMutate: meta => {
+                AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
+                additionalMetaMutate?.Invoke(meta, domainName, maxResults, view);
+            }));
     }
 
     /// <summary>
@@ -258,7 +502,34 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         meta.Add("domain_name", domainName);
         meta.Add("include_attribution", includeAttribution);
         meta.Add("configured_attribution_only", configuredAttributionOnly);
-        meta.Add("max_results", maxResults);
+        AddMaxResultsMeta(meta, maxResults);
+    }
+
+    /// <summary>
+    /// Adds optional <c>domain_name</c> and <c>forest_name</c> metadata keys when values are present.
+    /// </summary>
+    protected static void AddDomainAndForestMeta(JsonObject meta, string? domainName, string? forestName) {
+        AddOptionalStringMeta(meta, "domain_name", domainName);
+        AddOptionalStringMeta(meta, "forest_name", forestName);
+    }
+
+    /// <summary>
+    /// Adds standard <c>domain_name</c> and <c>max_results</c> metadata keys.
+    /// </summary>
+    protected static void AddDomainAndMaxResultsMeta(JsonObject meta, string domainName, int maxResults) {
+        AddOptionalStringMeta(meta, "domain_name", domainName);
+        AddMaxResultsMeta(meta, maxResults);
+    }
+
+    /// <summary>
+    /// Adds an optional string metadata key when value is non-empty.
+    /// </summary>
+    protected static void AddOptionalStringMeta(JsonObject meta, string key, string? value) {
+        if (string.IsNullOrWhiteSpace(value) || string.IsNullOrWhiteSpace(key)) {
+            return;
+        }
+
+        meta.Add(key, value);
     }
 
     /// <summary>
@@ -335,6 +606,7 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         Func<string, TView> query,
         Func<TView, IReadOnlyList<PolicyAttribution>> attributionSelector,
         Func<PolicyAttributionToolRequest, TView, int, bool, IReadOnlyList<PolicyAttribution>, TResult> resultFactory,
+        Action<JsonObject, PolicyAttributionToolRequest, TView, TResult>? additionalMetaMutate = null,
         IReadOnlyList<string>? additionalUnconfiguredValues = null,
         string invalidOperationErrorCode = "query_failed",
         int maxTop = DefaultPolicyAttributionMaxTop) {
@@ -383,12 +655,15 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
             maxTop: maxTop,
             baseTruncated: truncated,
             scanned: scanned,
-            metaMutate: meta => AddStandardPolicyAttributionMeta(
-                meta,
-                request.DomainName,
-                request.IncludeAttribution,
-                request.ConfiguredAttributionOnly,
-                request.MaxResults)));
+            metaMutate: meta => {
+                AddStandardPolicyAttributionMeta(
+                    meta,
+                    request.DomainName,
+                    request.IncludeAttribution,
+                    request.ConfiguredAttributionOnly,
+                    request.MaxResults);
+                additionalMetaMutate?.Invoke(meta, request, view, result);
+            }));
     }
 
     /// <summary>
@@ -409,7 +684,7 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
             DomainName: domainName,
             IncludeAttribution: ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true),
             ConfiguredAttributionOnly: ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false),
-            MaxResults: ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults));
+            MaxResults: ResolveBoundedMaxResults(arguments));
         errorResponse = null;
         return true;
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
@@ -77,7 +77,7 @@ public sealed class AdAzureAdSsoTool : ActiveDirectoryToolBase, ITool {
         var onlyPresent = ToolArgs.GetBoolean(arguments, "only_present", defaultValue: false);
         var riskyOnly = ToolArgs.GetBoolean(arguments, "risky_only", defaultValue: false);
         var includeSpns = ToolArgs.GetBoolean(arguments, "include_spns", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -149,14 +149,10 @@ public sealed class AdAzureAdSsoTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("only_present", onlyPresent);
                 meta.Add("risky_only", riskyOnly);
                 meta.Add("include_spns", includeSpns);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdClientServerAuthPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdClientServerAuthPostureTool.cs
@@ -61,76 +61,48 @@ public sealed class AdClientServerAuthPostureTool : ActiveDirectoryToolBase, ITo
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var posture = ClientServerAuthPostureService.EvaluateForDomainControllers(domainName);
-        if (!posture.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(posture.CollectionError)
-                ? "Client/server authentication posture query failed."
-                : posture.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var attributionRows = includeAttribution
-            ? posture.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> projectedRows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > projectedRows.Count;
-
-        var result = new AdClientServerAuthPostureResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            LdapSigningRequired: posture.LdapSigningRequired,
-            LdapChannelBindingEnabled: posture.LdapChannelBindingEnabled,
-            SmbSigningServerRequired: posture.SmbSigningServerRequired,
-            SmbSigningClientRequired: posture.SmbSigningClientRequired,
-            LmCompatibilityLevel: posture.LmCompatibilityLevel,
-            NoLmHash: posture.NoLmHash,
-            NtlmSmb: posture.NtlmSmb,
-            RestrictNtlmSummary: posture.RestrictNtlmSummary,
-            LdapSigning: posture.LdapSigning,
-            LdapChannelBinding: posture.LdapChannelBinding,
-            Netlogon: posture.Netlogon,
-            RestrictAnonymous: posture.RestrictAnonymous,
-            NullSessionFallback: posture.NullSessionFallback,
-            NullSession: posture.NullSession,
-            SmbNtlmDetails: posture.SmbNtlmDetails,
-            Attribution: projectedRows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: projectedRows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Client/Server Auth Posture (preview)",
+            defaultErrorMessage: "Client/server authentication posture query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("ldap_signing_required", posture.LdapSigningRequired);
-                meta.Add("ldap_channel_binding_enabled", posture.LdapChannelBindingEnabled);
-                meta.Add("max_results", maxResults);
-            }));
+            query: domainName => {
+                var view = ClientServerAuthPostureService.EvaluateForDomainControllers(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "Client/server authentication posture query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdClientServerAuthPostureResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                LdapSigningRequired: view.LdapSigningRequired,
+                LdapChannelBindingEnabled: view.LdapChannelBindingEnabled,
+                SmbSigningServerRequired: view.SmbSigningServerRequired,
+                SmbSigningClientRequired: view.SmbSigningClientRequired,
+                LmCompatibilityLevel: view.LmCompatibilityLevel,
+                NoLmHash: view.NoLmHash,
+                NtlmSmb: view.NtlmSmb,
+                RestrictNtlmSummary: view.RestrictNtlmSummary,
+                LdapSigning: view.LdapSigning,
+                LdapChannelBinding: view.LdapChannelBinding,
+                Netlogon: view.Netlogon,
+                RestrictAnonymous: view.RestrictAnonymous,
+                NullSessionFallback: view.NullSessionFallback,
+                NullSession: view.NullSession,
+                SmbNtlmDetails: view.SmbNtlmDetails,
+                Attribution: rows),
+            additionalMetaMutate: static (meta, _, view, _) => {
+                meta.Add("ldap_signing_required", view.LdapSigningRequired);
+                meta.Add("ldap_channel_binding_enabled", view.LdapChannelBindingEnabled);
+            }
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
@@ -72,7 +72,7 @@ public sealed class AdDangerousExtendedRightsTool : ActiveDirectoryToolBase, ITo
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeFindings = ToolArgs.GetBoolean(arguments, "include_findings", defaultValue: true);
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 200, 1, Options.MaxResults);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -137,14 +137,10 @@ public sealed class AdDangerousExtendedRightsTool : ActiveDirectoryToolBase, ITo
             metaMutate: meta => {
                 meta.Add("include_findings", includeFindings);
                 meta.Add("max_findings_per_domain", maxFindingsPerDomain);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
@@ -79,7 +79,7 @@ public sealed class AdDcFleetPostureTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: false);
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 2000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -151,14 +151,10 @@ public sealed class AdDcFleetPostureTool : ActiveDirectoryToolBase, ITool {
             metaMutate: meta => {
                 meta.Add("include_details", includeDetails);
                 meta.Add("max_detail_rows_per_domain", maxDetailRowsPerDomain);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
@@ -68,7 +68,7 @@ public sealed class AdDcShadowIndicatorsTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeFindings = ToolArgs.GetBoolean(arguments, "include_findings", defaultValue: true);
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -128,14 +128,10 @@ public sealed class AdDcShadowIndicatorsTool : ActiveDirectoryToolBase, ITool {
             metaMutate: meta => {
                 meta.Add("include_findings", includeFindings);
                 meta.Add("max_findings_per_domain", maxFindingsPerDomain);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDelegationAuditTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDelegationAuditTool.cs
@@ -54,10 +54,7 @@ public sealed class AdDelegationAuditTool : ActiveDirectoryToolBase, ITool {
             ? (int)Math.Min(requestedMaxValues.Value, MaxValuesPerAttributeCap)
             : 50;
 
-        var requestedMax = arguments?.GetInt64("max_results");
-        var maxResults = requestedMax.HasValue && requestedMax.Value > 0
-            ? (int)Math.Min(requestedMax.Value, Options.MaxResults)
-            : Options.MaxResults;
+        var maxResults = ResolveMaxResults(arguments);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDirectoryDiscoveryDiagnosticsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDirectoryDiscoveryDiagnosticsTool.cs
@@ -55,7 +55,7 @@ public sealed class AdDirectoryDiscoveryDiagnosticsTool : ActiveDirectoryToolBas
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var domains = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("domains"));
         var asIssue = ToolArgs.GetBoolean(arguments, "as_issue", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         var maxIssues = ToolArgs.GetCappedInt32(arguments, "max_issues", 5000, 1, 100_000);
         var dnsResolveTimeoutMs = ToolArgs.GetCappedInt32(arguments, "dns_resolve_timeout_ms", 1500, 200, 120_000);
@@ -108,7 +108,7 @@ public sealed class AdDirectoryDiscoveryDiagnosticsTool : ActiveDirectoryToolBas
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("mode", asIssue ? "issues" : "snapshot");
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("max_issues", maxIssues);
                 meta.Add("include_dns_srv_comparison", includeDnsSrvComparison);
                 meta.Add("include_host_resolution", includeHostResolution);
@@ -122,5 +122,4 @@ public sealed class AdDirectoryDiscoveryDiagnosticsTool : ActiveDirectoryToolBas
             }));
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsDelegationTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsDelegationTool.cs
@@ -68,7 +68,7 @@ public sealed class AdDnsDelegationTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var zoneNameContains = ToolArgs.GetOptionalTrimmed(arguments, "zone_name_contains");
         var identityContains = ToolArgs.GetOptionalTrimmed(arguments, "identity_contains");
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -111,11 +111,7 @@ public sealed class AdDnsDelegationTool : ActiveDirectoryToolBase, ITool {
             errors: errors,
             cancellationToken: cancellationToken);
 
-        var scanned = rows.Count;
-        IReadOnlyList<DnsDelegationRow> projectedRows = scanned > maxResults
-            ? rows.Take(maxResults).ToArray()
-            : rows;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(rows, maxResults, out var scanned, out var truncated);
 
         var result = new AdDnsDelegationResult(
             DomainName: domainName,
@@ -138,7 +134,7 @@ public sealed class AdDnsDelegationTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
                 if (!string.IsNullOrWhiteSpace(zoneNameContains)) {
                     meta.Add("zone_name_contains", zoneNameContains);
@@ -146,12 +142,8 @@ public sealed class AdDnsDelegationTool : ActiveDirectoryToolBase, ITool {
                 if (!string.IsNullOrWhiteSpace(identityContains)) {
                     meta.Add("identity_contains", identityContains);
                 }
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsScavengingTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsScavengingTool.cs
@@ -61,7 +61,7 @@ public sealed class AdDnsScavengingTool : ActiveDirectoryToolBase, ITool {
         var mismatchedOnly = ToolArgs.GetBoolean(arguments, "mismatched_only", defaultValue: false);
         var staleOnly = ToolArgs.GetBoolean(arguments, "stale_only", defaultValue: false);
         var scavengingEnabledOnly = ToolArgs.GetBoolean(arguments, "scavenging_enabled_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryExecute(
                 action: () => new DnsScavengingAnalyzer()
@@ -109,12 +109,11 @@ public sealed class AdDnsScavengingTool : ActiveDirectoryToolBase, ITool {
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("dns_server", dnsServer);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("mismatched_only", mismatchedOnly);
                 meta.Add("stale_only", staleOnly);
                 meta.Add("scavenging_enabled_only", scavengingEnabledOnly);
             }));
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsServerConfigTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsServerConfigTool.cs
@@ -72,7 +72,7 @@ public sealed class AdDnsServerConfigTool : ActiveDirectoryToolBase, ITool {
         var recursionDisabledOnly = ToolArgs.GetBoolean(arguments, "recursion_disabled_only", defaultValue: false);
         var missingForwardersOnly = ToolArgs.GetBoolean(arguments, "missing_forwarders_only", defaultValue: false);
         var maxServers = ToolArgs.GetCappedInt32(arguments, "max_servers", 200, 1, 5000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
         var errors = new List<DnsServerConfigError>();
 
         var servers = new List<string>(maxServers);
@@ -170,17 +170,13 @@ public sealed class AdDnsServerConfigTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("max_servers", maxServers);
                 meta.Add("recursion_disabled_only", recursionDisabledOnly);
                 meta.Add("missing_forwarders_only", missingForwardersOnly);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
                 if (explicitServers.Count > 0) {
                     meta.Add("explicit_dns_servers", explicitServers.Count);
                 }
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneConfigTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneConfigTool.cs
@@ -71,7 +71,7 @@ public sealed class AdDnsZoneConfigTool : ActiveDirectoryToolBase, ITool {
         var zoneNameContains = ToolArgs.GetOptionalTrimmed(arguments, "zone_name_contains");
         var dynamicUpdatesOnly = ToolArgs.GetBoolean(arguments, "dynamic_updates_only", defaultValue: false);
         var insecureUpdatesOnly = ToolArgs.GetBoolean(arguments, "insecure_updates_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryExecute(
                 action: () => DnsZoneConfigService.GetZonesResult(dnsServer),
@@ -129,7 +129,7 @@ public sealed class AdDnsZoneConfigTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("query_succeeded", query.QuerySucceeded);
                 meta.Add("dynamic_updates_only", dynamicUpdatesOnly);
                 meta.Add("insecure_updates_only", insecureUpdatesOnly);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 if (!string.IsNullOrWhiteSpace(zoneNameContains)) {
                     meta.Add("zone_name_contains", zoneNameContains);
                 }
@@ -140,5 +140,4 @@ public sealed class AdDnsZoneConfigTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
@@ -90,7 +90,7 @@ public sealed class AdDnsZoneSecurityTool : ActiveDirectoryToolBase, ITool {
         var broadWriteMin = ToolArgs.GetCappedInt32(arguments, "broad_write_min", 0, 0, 100000);
         var includeOffendingPrincipals = ToolArgs.GetBoolean(arguments, "include_offending_principals", defaultValue: false);
         var maxOffendingRows = ToolArgs.GetCappedInt32(arguments, "max_offending_rows", 500, 1, 50000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -194,14 +194,10 @@ public sealed class AdDnsZoneSecurityTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("broad_write_min", broadWriteMin);
                 meta.Add("include_offending_principals", includeOffendingPrincipals);
                 meta.Add("max_offending_rows", maxOffendingRows);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainAdminsSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainAdminsSummaryTool.cs
@@ -47,10 +47,7 @@ public sealed class AdDomainAdminsSummaryTool : ActiveDirectoryToolBase, ITool {
 
         var includeMembers = arguments?.GetBoolean("include_members") ?? true;
 
-        var requestedMax = arguments?.GetInt64("max_results");
-        var maxResults = requestedMax.HasValue && requestedMax.Value > 0
-            ? (int)Math.Min(requestedMax.Value, Options.MaxResults)
-            : Options.MaxResults;
+        var maxResults = ResolveMaxResults(arguments);
 
         try {
             var summary = await DomainAdminsSummaryService

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainContainerDefaultsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainContainerDefaultsTool.cs
@@ -65,7 +65,7 @@ public sealed class AdDomainContainerDefaultsTool : ActiveDirectoryToolBase, ITo
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var changedOnly = ToolArgs.GetBoolean(arguments, "changed_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -127,14 +127,10 @@ public sealed class AdDomainContainerDefaultsTool : ActiveDirectoryToolBase, ITo
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("changed_only", changedOnly);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerFactsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerFactsTool.cs
@@ -79,7 +79,7 @@ public sealed class AdDomainControllerFactsTool : ActiveDirectoryToolBase, ITool
         var onlyGlobalCatalog = ToolArgs.GetBoolean(arguments, "only_global_catalog", defaultValue: false);
         var onlyRodc = ToolArgs.GetBoolean(arguments, "only_rodc", defaultValue: false);
         var timeoutMs = ToolArgs.GetCappedInt32(arguments, "timeout_ms", 3000, 300, 60000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -130,11 +130,7 @@ public sealed class AdDomainControllerFactsTool : ActiveDirectoryToolBase, ITool
             errors: errors,
             cancellationToken: cancellationToken);
 
-        var scanned = rows.Count;
-        IReadOnlyList<DomainControllerFactRow> projectedRows = scanned > maxResults
-            ? rows.Take(maxResults).ToArray()
-            : rows;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(rows, maxResults, out var scanned, out var truncated);
 
         var result = new AdDomainControllerFactsResult(
             DomainName: domainName,
@@ -164,14 +160,10 @@ public sealed class AdDomainControllerFactsTool : ActiveDirectoryToolBase, ITool
                 meta.Add("only_global_catalog", onlyGlobalCatalog);
                 meta.Add("only_rodc", onlyRodc);
                 meta.Add("additional_attributes_count", additionalAttributes.Count);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
@@ -76,7 +76,7 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var domainController = ToolArgs.GetOptionalTrimmed(arguments, "domain_controller");
         var insecureOnly = ToolArgs.GetBoolean(arguments, "insecure_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!string.IsNullOrWhiteSpace(domainController) && string.IsNullOrWhiteSpace(domainName)) {
             return ToolResponse.Error(
@@ -183,17 +183,13 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("insecure_only", insecureOnly);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
                 if (!string.IsNullOrWhiteSpace(domainController)) {
                     meta.Add("domain_controller", domainController);
                 }
             });
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllersTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllersTool.cs
@@ -33,7 +33,7 @@ public sealed class AdDomainControllersTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var max = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var max = ResolveBoundedMaxResults(arguments);
 
         var (dc, defaultNc) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
         if (string.IsNullOrWhiteSpace(defaultNc)) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
@@ -71,7 +71,7 @@ public sealed class AdDomainStatisticsTool : ActiveDirectoryToolBase, ITool {
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeDomainControllers = ToolArgs.GetBoolean(arguments, "include_domain_controllers", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -160,15 +160,11 @@ public sealed class AdDomainStatisticsTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("include_domain_controllers", includeDomainControllers);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
@@ -88,7 +88,7 @@ public sealed class AdDuplicateAccountsTool : ActiveDirectoryToolBase, ITool {
         var conflictsOnly = ToolArgs.GetBoolean(arguments, "conflicts_only", defaultValue: false);
         var duplicatesOnly = ToolArgs.GetBoolean(arguments, "duplicates_only", defaultValue: false);
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 5000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -179,14 +179,10 @@ public sealed class AdDuplicateAccountsTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("conflicts_only", conflictsOnly);
                 meta.Add("duplicates_only", duplicatesOnly);
                 meta.Add("max_detail_rows_per_domain", maxDetailRowsPerDomain);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdEveryoneIncludesAnonymousPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdEveryoneIncludesAnonymousPolicyTool.cs
@@ -50,56 +50,33 @@ public sealed class AdEveryoneIncludesAnonymousPolicyTool : ActiveDirectoryToolB
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = EveryoneIncludesAnonymousPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "EveryoneIncludesAnonymous policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdEveryoneIncludesAnonymousPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            TargetDn: view.TargetDn,
-            EffectiveValue: view.EffectiveValue,
-            Enabled: view.Enabled,
-            Disabled: view.Disabled,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: EveryoneIncludesAnonymous Policy (preview)",
+            defaultErrorMessage: "EveryoneIncludesAnonymous policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = EveryoneIncludesAnonymousPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "EveryoneIncludesAnonymous policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdEveryoneIncludesAnonymousPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                TargetDn: view.TargetDn,
+                EffectiveValue: view.EffectiveValue,
+                Enabled: view.Enabled,
+                Disabled: view.Disabled,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdFirewallProfilesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdFirewallProfilesTool.cs
@@ -64,77 +64,47 @@ public sealed class AdFirewallProfilesTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = FirewallProfilesService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "Firewall profile query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> projectedRows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > projectedRows.Count;
-
-        var result = new AdFirewallProfilesResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            DomainEnabled: view.DomainEnabled,
-            PrivateEnabled: view.PrivateEnabled,
-            PublicEnabled: view.PublicEnabled,
-            DomainDefaultInbound: view.DomainDefaultInbound,
-            DomainDefaultOutbound: view.DomainDefaultOutbound,
-            PrivateDefaultInbound: view.PrivateDefaultInbound,
-            PrivateDefaultOutbound: view.PrivateDefaultOutbound,
-            PublicDefaultInbound: view.PublicDefaultInbound,
-            PublicDefaultOutbound: view.PublicDefaultOutbound,
-            DomainNotificationsDisabled: view.DomainNotificationsDisabled,
-            PrivateNotificationsDisabled: view.PrivateNotificationsDisabled,
-            PublicNotificationsDisabled: view.PublicNotificationsDisabled,
-            DomainLogDroppedPackets: view.DomainLogDroppedPackets,
-            PrivateLogDroppedPackets: view.PrivateLogDroppedPackets,
-            PublicLogDroppedPackets: view.PublicLogDroppedPackets,
-            DomainLogSuccessfulConnections: view.DomainLogSuccessfulConnections,
-            PrivateLogSuccessfulConnections: view.PrivateLogSuccessfulConnections,
-            PublicLogSuccessfulConnections: view.PublicLogSuccessfulConnections,
-            Attribution: projectedRows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: projectedRows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Firewall Profiles (preview)",
+            defaultErrorMessage: "Firewall profile query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
-            }));
+            query: domainName => {
+                var view = FirewallProfilesService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "Firewall profile query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdFirewallProfilesResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                DomainEnabled: view.DomainEnabled,
+                PrivateEnabled: view.PrivateEnabled,
+                PublicEnabled: view.PublicEnabled,
+                DomainDefaultInbound: view.DomainDefaultInbound,
+                DomainDefaultOutbound: view.DomainDefaultOutbound,
+                PrivateDefaultInbound: view.PrivateDefaultInbound,
+                PrivateDefaultOutbound: view.PrivateDefaultOutbound,
+                PublicDefaultInbound: view.PublicDefaultInbound,
+                PublicDefaultOutbound: view.PublicDefaultOutbound,
+                DomainNotificationsDisabled: view.DomainNotificationsDisabled,
+                PrivateNotificationsDisabled: view.PrivateNotificationsDisabled,
+                PublicNotificationsDisabled: view.PublicNotificationsDisabled,
+                DomainLogDroppedPackets: view.DomainLogDroppedPackets,
+                PrivateLogDroppedPackets: view.PrivateLogDroppedPackets,
+                PublicLogDroppedPackets: view.PublicLogDroppedPackets,
+                DomainLogSuccessfulConnections: view.DomainLogSuccessfulConnections,
+                PrivateLogSuccessfulConnections: view.PrivateLogSuccessfulConnections,
+                PublicLogSuccessfulConnections: view.PublicLogSuccessfulConnections,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoBlockedInheritanceTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoBlockedInheritanceTool.cs
@@ -47,54 +47,30 @@ public sealed class AdGpoBlockedInheritanceTool : ActiveDirectoryToolBase, ITool
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
         var onlyBlocked = ToolArgs.GetBoolean(arguments, "only_blocked", defaultValue: true);
         var maxRows = ToolArgs.GetCappedInt32(arguments, "max_rows", 200000, 1, 500000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = GpoBlockedInheritanceService.Get(domainName, onlyBlocked: onlyBlocked, maxRows: maxRows);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO blocked-inheritance query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var scanned = view.Items.Count;
-        IReadOnlyList<GpoBlockedInheritanceRow> rows = scanned > maxResults
-            ? view.Items.Take(maxResults).ToArray()
-            : view.Items;
-        var truncated = scanned > rows.Count;
-
-        var result = new AdGpoBlockedInheritanceResult(
-            DomainName: domainName,
-            OnlyBlocked: onlyBlocked,
-            MaxRows: maxRows,
-            Scanned: scanned,
-            Truncated: truncated,
-            BlockedCount: view.Items.Count(static row => row.BlockedInheritance),
-            Rows: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecuteDomainRowsViewTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "rows_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: GPO Blocked Inheritance (preview)",
+            defaultErrorMessage: "GPO blocked-inheritance query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+            query: domainName => GpoBlockedInheritanceService.Get(domainName, onlyBlocked: onlyBlocked, maxRows: maxRows),
+            collectionSucceededSelector: static view => view.CollectionSucceeded,
+            collectionErrorSelector: static view => view.CollectionError,
+            allRowsSelector: static view => view.Items,
+            resultFactory: (domainName, view, _, rows, scanned, truncated) => new AdGpoBlockedInheritanceResult(
+                DomainName: domainName,
+                OnlyBlocked: onlyBlocked,
+                MaxRows: maxRows,
+                Scanned: scanned,
+                Truncated: truncated,
+                BlockedCount: view.Items.Count(static row => row.BlockedInheritance),
+                Rows: rows),
+            additionalMetaMutate: (meta, _, _, _) => {
                 meta.Add("only_blocked", onlyBlocked);
                 meta.Add("max_rows", maxRows);
-                meta.Add("max_results", maxResults);
-            }));
+            });
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoChangesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoChangesTool.cs
@@ -45,16 +45,15 @@ public sealed class AdGpoChangesTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name") ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+            return Task.FromResult(argumentError!);
         }
 
         if (!ToolTime.TryParseUtcOptional(ToolArgs.GetOptionalTrimmed(arguments, "since_utc"), out var sinceUtc, out var sinceError)) {
             return Task.FromResult(ToolResponse.Error("invalid_argument", $"since_utc: {sinceError}"));
         }
 
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
         var items = new List<GpoListItem>(Math.Min(maxResults, 512));
         var scanned = 0;
         var truncated = false;
@@ -95,8 +94,7 @@ public sealed class AdGpoChangesTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("max_results", maxResults);
+                AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
                 if (sinceUtc.HasValue) {
                     meta.Add("since_utc", ToolTime.FormatUtc(sinceUtc));
                 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoDuplicatesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoDuplicatesTool.cs
@@ -42,47 +42,21 @@ public sealed class AdGpoDuplicatesTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = GpoDuplicateService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO duplicate query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var scanned = view.Items.Count;
-        IReadOnlyList<GpoDuplicateObject> rows = scanned > maxResults
-            ? view.Items.Take(maxResults).ToArray()
-            : view.Items;
-        var truncated = scanned > rows.Count;
-
-        var result = new AdGpoDuplicatesResult(
-            DomainName: domainName,
-            Scanned: scanned,
-            Truncated: truncated,
-            Rows: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecuteDomainRowsViewTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "rows_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: GPO Duplicates (preview)",
+            defaultErrorMessage: "GPO duplicate query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("max_results", maxResults);
-            }));
+            query: static domainName => GpoDuplicateService.Get(domainName),
+            collectionSucceededSelector: static view => view.CollectionSucceeded,
+            collectionErrorSelector: static view => view.CollectionError,
+            allRowsSelector: static view => view.Items,
+            resultFactory: static (domainName, _, _, rows, scanned, truncated) => new AdGpoDuplicatesResult(
+                DomainName: domainName,
+                Scanned: scanned,
+                Truncated: truncated,
+                Rows: rows));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoHealthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoHealthTool.cs
@@ -62,7 +62,7 @@ public sealed class AdGpoHealthTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", "gpo_ids must contain at least one GUID."));
         }
 
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
         var requestedCount = rawIds.Count;
         var truncated = requestedCount > maxResults;
         if (rawIds.Count > maxResults) {
@@ -100,10 +100,9 @@ public sealed class AdGpoHealthTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: rows.Count,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+                AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
                 meta.Add("requested_count", requestedCount);
                 meta.Add("processed_count", rows.Count);
-                meta.Add("max_results", maxResults);
             }));
     }
 
@@ -118,3 +117,4 @@ public sealed class AdGpoHealthTool : ActiveDirectoryToolBase, ITool {
             : null;
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoIntegrityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoIntegrityTool.cs
@@ -53,22 +53,23 @@ public sealed class AdGpoIntegrityTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+            return Task.FromResult(argumentError!);
         }
 
         var sysvolMissingOnly = ToolArgs.GetBoolean(arguments, "sysvol_missing_only", defaultValue: false);
         var adMissingOnly = ToolArgs.GetBoolean(arguments, "ad_missing_only", defaultValue: false);
         var errorsOnly = ToolArgs.GetBoolean(arguments, "errors_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
-        var view = GpoIntegrityService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO integrity query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
+        if (!TryExecuteCollectionQuery(
+                query: () => GpoIntegrityService.Get(domainName),
+                collectionSucceededSelector: static view => view.CollectionSucceeded,
+                collectionErrorSelector: static view => view.CollectionError,
+                result: out var view,
+                errorResponse: out var errorResponse,
+                defaultErrorMessage: "GPO integrity query failed.")) {
+            return Task.FromResult(errorResponse!);
         }
 
         var filtered = view.Items
@@ -77,11 +78,7 @@ public sealed class AdGpoIntegrityTool : ActiveDirectoryToolBase, ITool {
             .Where(row => !errorsOnly || !string.IsNullOrWhiteSpace(row.Error))
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<GpoIntegrityService.GpoBrokenItem> rows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new AdGpoIntegrityResult(
             DomainName: domainName,
@@ -105,11 +102,10 @@ public sealed class AdGpoIntegrityTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+                AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
                 meta.Add("sysvol_missing_only", sysvolMissingOnly);
                 meta.Add("ad_missing_only", adMissingOnly);
                 meta.Add("errors_only", errorsOnly);
-                meta.Add("max_results", maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoInventoryHealthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoInventoryHealthTool.cs
@@ -49,69 +49,45 @@ public sealed class AdGpoInventoryHealthTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
         var slice = (ToolArgs.GetOptionalTrimmed(arguments, "slice") ?? "all").ToLowerInvariant();
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = GpoInventoryHealthService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO inventory health query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        IReadOnlyList<GpoInventoryHealthService.GpoHealthItem> selectedRows = slice switch {
-            "all" => view.All,
-            "disabled" => view.Disabled,
-            "empty" => view.Empty,
-            "unlinked" => view.Unlinked,
-            "all_settings_disabled" => view.AllSettingsDisabled,
-            _ => Array.Empty<GpoInventoryHealthService.GpoHealthItem>()
-        };
-
         if (slice is not ("all" or "disabled" or "empty" or "unlinked" or "all_settings_disabled")) {
             return Task.FromResult(ToolResponse.Error(
                 "invalid_argument",
                 "slice must be one of: all, disabled, empty, unlinked, all_settings_disabled."));
         }
 
-        var scanned = selectedRows.Count;
-        var rows = scanned > maxResults ? selectedRows.Take(maxResults).ToArray() : selectedRows;
-        var truncated = scanned > rows.Count;
-
-        var result = new AdGpoInventoryHealthResult(
-            DomainName: domainName,
-            Slice: slice,
-            GposEnumerated: view.GposEnumerated,
-            Scanned: scanned,
-            Truncated: truncated,
-            DisabledCount: view.Disabled.Count,
-            EmptyCount: view.Empty.Count,
-            UnlinkedCount: view.Unlinked.Count,
-            AllSettingsDisabledCount: view.AllSettingsDisabled.Count,
-            Rows: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecuteDomainRowsViewTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "rows_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: GPO Inventory Health (preview)",
+            defaultErrorMessage: "GPO inventory health query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+            query: static domainName => GpoInventoryHealthService.Get(domainName),
+            collectionSucceededSelector: static view => view.CollectionSucceeded,
+            collectionErrorSelector: static view => view.CollectionError,
+            allRowsSelector: view => slice switch {
+                "all" => view.All,
+                "disabled" => view.Disabled,
+                "empty" => view.Empty,
+                "unlinked" => view.Unlinked,
+                "all_settings_disabled" => view.AllSettingsDisabled,
+                _ => Array.Empty<GpoInventoryHealthService.GpoHealthItem>()
+            },
+            resultFactory: (domainName, view, _, rows, scanned, truncated) => new AdGpoInventoryHealthResult(
+                DomainName: domainName,
+                Slice: slice,
+                GposEnumerated: view.GposEnumerated,
+                Scanned: scanned,
+                Truncated: truncated,
+                DisabledCount: view.Disabled.Count,
+                EmptyCount: view.Empty.Count,
+                UnlinkedCount: view.Unlinked.Count,
+                AllSettingsDisabledCount: view.AllSettingsDisabled.Count,
+                Rows: rows),
+            additionalMetaMutate: (meta, _, _, view) => {
                 meta.Add("slice", slice);
                 meta.Add("gpos_enumerated", view.GposEnumerated);
-                meta.Add("max_results", maxResults);
-            }));
+            });
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoListTool.cs
@@ -104,7 +104,7 @@ public sealed class AdGpoListTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", $"modified_since_utc: {modifiedSinceError}"));
         }
 
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
         var items = new List<GpoListItem>(Math.Min(maxResults, 512));
         var scanned = 0;
         var truncated = false;
@@ -149,13 +149,8 @@ public sealed class AdGpoListTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("max_results", maxResults);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddMaxResultsMeta(meta, maxResults);
+                AddDomainAndForestMeta(meta, domainName, forestName);
                 if (!string.IsNullOrWhiteSpace(nameContains)) {
                     meta.Add("name_contains", nameContains);
                 }
@@ -197,3 +192,4 @@ public sealed class AdGpoListTool : ActiveDirectoryToolBase, ITool {
         return true;
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoOuLinkSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoOuLinkSummaryTool.cs
@@ -52,66 +52,40 @@ public sealed class AdGpoOuLinkSummaryTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
         var linkCountAtLeast = ToolArgs.GetCappedInt32(arguments, "link_count_at_least", 0, 0, 100000);
         var brokenOnly = ToolArgs.GetBoolean(arguments, "broken_only", defaultValue: false);
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 25000, 1, 250000);
         var maxOus = ToolArgs.GetCappedInt32(arguments, "max_ous", 50000, 1, 250000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = GpoOuLinkSummaryService.Get(domainName, maxGpos: maxGpos, maxOus: maxOus);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO OU link summary query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var filtered = view.Items
-            .Where(row => row.LinkCount >= linkCountAtLeast)
-            .Where(row => !brokenOnly || row.BrokenCount > 0)
-            .ToArray();
-
-        var scanned = filtered.Length;
-        IReadOnlyList<GpoOuLinkSummaryService.Row> rows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > rows.Count;
-
-        var result = new AdGpoOuLinkSummaryResult(
-            DomainName: domainName,
-            LinkCountAtLeast: linkCountAtLeast,
-            BrokenOnly: brokenOnly,
-            MaxGpos: maxGpos,
-            MaxOus: maxOus,
-            Scanned: scanned,
-            Truncated: truncated,
-            WithBlockedInheritanceCount: filtered.Count(static row => row.BlockedInheritance),
-            WithBrokenLinksCount: filtered.Count(static row => row.BrokenCount > 0),
-            Rows: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecuteDomainRowsViewTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "rows_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: GPO OU Link Summary (preview)",
+            defaultErrorMessage: "GPO OU link summary query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+            query: domainName => GpoOuLinkSummaryService.Get(domainName, maxGpos: maxGpos, maxOus: maxOus),
+            collectionSucceededSelector: static view => view.CollectionSucceeded,
+            collectionErrorSelector: static view => view.CollectionError,
+            allRowsSelector: view => view.Items
+                .Where(row => row.LinkCount >= linkCountAtLeast)
+                .Where(row => !brokenOnly || row.BrokenCount > 0)
+                .ToArray(),
+            resultFactory: (domainName, _, allRows, rows, scanned, truncated) => new AdGpoOuLinkSummaryResult(
+                DomainName: domainName,
+                LinkCountAtLeast: linkCountAtLeast,
+                BrokenOnly: brokenOnly,
+                MaxGpos: maxGpos,
+                MaxOus: maxOus,
+                Scanned: scanned,
+                Truncated: truncated,
+                WithBlockedInheritanceCount: allRows.Count(static row => row.BlockedInheritance),
+                WithBrokenLinksCount: allRows.Count(static row => row.BrokenCount > 0),
+                Rows: rows),
+            additionalMetaMutate: (meta, _, _, _) => {
                 meta.Add("link_count_at_least", linkCountAtLeast);
                 meta.Add("broken_only", brokenOnly);
                 meta.Add("max_gpos", maxGpos);
                 meta.Add("max_ous", maxOus);
-                meta.Add("max_results", maxResults);
-            }));
+            });
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionAdministrativeTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionAdministrativeTool.cs
@@ -52,33 +52,30 @@ public sealed class AdGpoPermissionAdministrativeTool : ActiveDirectoryToolBase,
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+            return Task.FromResult(argumentError!);
         }
 
         var includeCompliant = ToolArgs.GetBoolean(arguments, "include_compliant", defaultValue: false);
         var errorsOnly = ToolArgs.GetBoolean(arguments, "errors_only", defaultValue: false);
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
-        var view = GpoPermissionAdministrativeService.Get(domainName, includeCompliant: includeCompliant, maxGpos: maxGpos);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO administrative-permission baseline query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
+        if (!TryExecuteCollectionQuery(
+                query: () => GpoPermissionAdministrativeService.Get(domainName, includeCompliant: includeCompliant, maxGpos: maxGpos),
+                collectionSucceededSelector: static view => view.CollectionSucceeded,
+                collectionErrorSelector: static view => view.CollectionError,
+                result: out var view,
+                errorResponse: out var errorResponse,
+                defaultErrorMessage: "GPO administrative-permission baseline query failed.")) {
+            return Task.FromResult(errorResponse!);
         }
 
         var filtered = view.Items
             .Where(row => !errorsOnly || !string.IsNullOrWhiteSpace(row.Error))
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<GpoPermissionAdministrativeRow> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new AdGpoPermissionAdministrativeResult(
             DomainName: domainName,
@@ -101,11 +98,10 @@ public sealed class AdGpoPermissionAdministrativeTool : ActiveDirectoryToolBase,
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+                AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
                 meta.Add("include_compliant", includeCompliant);
                 meta.Add("errors_only", errorsOnly);
                 meta.Add("max_gpos", maxGpos);
-                meta.Add("max_results", maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionConsistencyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionConsistencyTool.cs
@@ -59,9 +59,8 @@ public sealed class AdGpoPermissionConsistencyTool : ActiveDirectoryToolBase, IT
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+            return Task.FromResult(argumentError!);
         }
 
         var verifyInheritance = ToolArgs.GetBoolean(arguments, "verify_inheritance", defaultValue: false);
@@ -76,19 +75,16 @@ public sealed class AdGpoPermissionConsistencyTool : ActiveDirectoryToolBase, IT
 
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
         var sysvolScanCap = ToolArgs.GetCappedInt32(arguments, "sysvol_scan_cap", 2000, 1, 500000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
-        var view = GpoPermissionConsistencyService.Get(
-            domainName,
-            verifyInheritance: verifyInheritance,
-            includeConsistent: includeConsistent,
-            maxGpos: maxGpos,
-            sysvolScanCap: sysvolScanCap);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO permission consistency query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
+        if (!TryExecuteCollectionQuery(
+                query: () => GpoPermissionConsistencyService.Get(domainName, verifyInheritance: verifyInheritance, includeConsistent: includeConsistent, maxGpos: maxGpos, sysvolScanCap: sysvolScanCap),
+                collectionSucceededSelector: static view => view.CollectionSucceeded,
+                collectionErrorSelector: static view => view.CollectionError,
+                result: out var view,
+                errorResponse: out var errorResponse,
+                defaultErrorMessage: "GPO permission consistency query failed.")) {
+            return Task.FromResult(errorResponse!);
         }
 
         var filtered = view.Items
@@ -96,11 +92,7 @@ public sealed class AdGpoPermissionConsistencyTool : ActiveDirectoryToolBase, IT
             .Where(row => !insideInconsistentOnly || row.AclConsistentInside == false)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<GpoPermissionConsistency> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new AdGpoPermissionConsistencyResult(
             DomainName: domainName,
@@ -127,14 +119,13 @@ public sealed class AdGpoPermissionConsistencyTool : ActiveDirectoryToolBase, IT
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+                AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
                 meta.Add("verify_inheritance", verifyInheritance);
                 meta.Add("include_consistent", includeConsistent);
                 meta.Add("top_level_inconsistent_only", topLevelInconsistentOnly);
                 meta.Add("inside_inconsistent_only", insideInconsistentOnly);
                 meta.Add("max_gpos", maxGpos);
                 meta.Add("sysvol_scan_cap", sysvolScanCap);
-                meta.Add("max_results", maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReadTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReadTool.cs
@@ -53,33 +53,30 @@ public sealed class AdGpoPermissionReadTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+            return Task.FromResult(argumentError!);
         }
 
         var includeCompliant = ToolArgs.GetBoolean(arguments, "include_compliant", defaultValue: false);
         var denyOnly = ToolArgs.GetBoolean(arguments, "deny_only", defaultValue: false);
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
-        var view = GpoPermissionReadService.Get(domainName, includeCompliant: includeCompliant, maxGpos: maxGpos);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO read-permission baseline query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
+        if (!TryExecuteCollectionQuery(
+                query: () => GpoPermissionReadService.Get(domainName, includeCompliant: includeCompliant, maxGpos: maxGpos),
+                collectionSucceededSelector: static view => view.CollectionSucceeded,
+                collectionErrorSelector: static view => view.CollectionError,
+                result: out var view,
+                errorResponse: out var errorResponse,
+                defaultErrorMessage: "GPO read-permission baseline query failed.")) {
+            return Task.FromResult(errorResponse!);
         }
 
         var filtered = view.Items
             .Where(row => !denyOnly || row.HasAuthenticatedUsersDeny)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<GpoPermissionReadRow> projectedRows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new AdGpoPermissionReadResult(
             DomainName: domainName,
@@ -103,11 +100,10 @@ public sealed class AdGpoPermissionReadTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+                AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
                 meta.Add("include_compliant", includeCompliant);
                 meta.Add("deny_only", denyOnly);
                 meta.Add("max_gpos", maxGpos);
-                meta.Add("max_results", maxResults);
             }));
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReportTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReportTool.cs
@@ -59,9 +59,8 @@ public sealed class AdGpoPermissionReportTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+            return Task.FromResult(argumentError!);
         }
 
         var gpoIdRaw = ToolArgs.GetOptionalTrimmed(arguments, "gpo_id");
@@ -89,19 +88,16 @@ public sealed class AdGpoPermissionReportTool : ActiveDirectoryToolBase, ITool {
 
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
         var maxRows = ToolArgs.GetCappedInt32(arguments, "max_rows", 200000, 1, 2000000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
-        var view = GpoPermissionReportService.Get(
-            domainName,
-            gpoId: gpoId,
-            gpoName: gpoName,
-            maxGpos: maxGpos,
-            maxRows: maxRows);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO permission report query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
+        if (!TryExecuteCollectionQuery(
+                query: () => GpoPermissionReportService.Get(domainName, gpoId: gpoId, gpoName: gpoName, maxGpos: maxGpos, maxRows: maxRows),
+                collectionSucceededSelector: static view => view.CollectionSucceeded,
+                collectionErrorSelector: static view => view.CollectionError,
+                result: out var view,
+                errorResponse: out var errorResponse,
+                defaultErrorMessage: "GPO permission report query failed.")) {
+            return Task.FromResult(errorResponse!);
         }
 
         var filtered = view.Items
@@ -112,11 +108,7 @@ public sealed class AdGpoPermissionReportTool : ActiveDirectoryToolBase, ITool {
                 row.PrincipalSid.Contains(principalContains, StringComparison.OrdinalIgnoreCase))
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<GpoPermissionRow> rows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new AdGpoPermissionReportResult(
             DomainName: domainName,
@@ -143,10 +135,9 @@ public sealed class AdGpoPermissionReportTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+                AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
                 meta.Add("max_gpos", maxGpos);
                 meta.Add("max_rows", maxRows);
-                meta.Add("max_results", maxResults);
                 if (gpoId.HasValue) {
                     meta.Add("gpo_id", gpoId.Value.ToString());
                 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionRootTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionRootTool.cs
@@ -55,9 +55,8 @@ public sealed class AdGpoPermissionRootTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+            return Task.FromResult(argumentError!);
         }
 
         var permission = ToolArgs.GetOptionalTrimmed(arguments, "permission");
@@ -72,14 +71,16 @@ public sealed class AdGpoPermissionRootTool : ActiveDirectoryToolBase, ITool {
         var denyOnly = ToolArgs.GetBoolean(arguments, "deny_only", defaultValue: false);
         var inheritedOnly = ToolArgs.GetBoolean(arguments, "inherited_only", defaultValue: false);
         var maxRows = ToolArgs.GetCappedInt32(arguments, "max_rows", 100000, 1, 1000000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
-        var view = GpoPermissionRootService.Get(domainName, maxRows: maxRows);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO root-permission query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
+        if (!TryExecuteCollectionQuery(
+                query: () => GpoPermissionRootService.Get(domainName, maxRows: maxRows),
+                collectionSucceededSelector: static view => view.CollectionSucceeded,
+                collectionErrorSelector: static view => view.CollectionError,
+                result: out var view,
+                errorResponse: out var errorResponse,
+                defaultErrorMessage: "GPO root-permission query failed.")) {
+            return Task.FromResult(errorResponse!);
         }
 
         var filtered = view.Items
@@ -88,11 +89,7 @@ public sealed class AdGpoPermissionRootTool : ActiveDirectoryToolBase, ITool {
             .Where(row => !inheritedOnly || row.Inherited)
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<GpoPermissionRootRow> rows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new AdGpoPermissionRootResult(
             DomainName: domainName,
@@ -117,11 +114,10 @@ public sealed class AdGpoPermissionRootTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+                AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
                 meta.Add("deny_only", denyOnly);
                 meta.Add("inherited_only", inheritedOnly);
                 meta.Add("max_rows", maxRows);
-                meta.Add("max_results", maxResults);
                 if (!string.IsNullOrWhiteSpace(permission)) {
                     meta.Add("permission", permission);
                 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionUnknownTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionUnknownTool.cs
@@ -54,23 +54,24 @@ public sealed class AdGpoPermissionUnknownTool : ActiveDirectoryToolBase, ITool 
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+            return Task.FromResult(argumentError!);
         }
 
         var resolutionErrorContains = ToolArgs.GetOptionalTrimmed(arguments, "resolution_error_contains");
         var inheritedOnly = ToolArgs.GetBoolean(arguments, "inherited_only", defaultValue: false);
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
         var maxFindings = ToolArgs.GetCappedInt32(arguments, "max_findings", 200000, 1, 2000000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
-        var view = GpoPermissionUnknownService.Get(domainName, maxGpos: maxGpos, maxFindings: maxFindings);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO unknown-permission query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
+        if (!TryExecuteCollectionQuery(
+                query: () => GpoPermissionUnknownService.Get(domainName, maxGpos: maxGpos, maxFindings: maxFindings),
+                collectionSucceededSelector: static view => view.CollectionSucceeded,
+                collectionErrorSelector: static view => view.CollectionError,
+                result: out var view,
+                errorResponse: out var errorResponse,
+                defaultErrorMessage: "GPO unknown-permission query failed.")) {
+            return Task.FromResult(errorResponse!);
         }
 
         var filtered = view.Items
@@ -78,11 +79,7 @@ public sealed class AdGpoPermissionUnknownTool : ActiveDirectoryToolBase, ITool 
             .Where(row => string.IsNullOrWhiteSpace(resolutionErrorContains) || !string.IsNullOrWhiteSpace(row.ResolutionError) && row.ResolutionError.Contains(resolutionErrorContains, StringComparison.OrdinalIgnoreCase))
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<GpoPermissionUnknownRow> rows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new AdGpoPermissionUnknownResult(
             DomainName: domainName,
@@ -106,11 +103,10 @@ public sealed class AdGpoPermissionUnknownTool : ActiveDirectoryToolBase, ITool 
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+                AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
                 meta.Add("inherited_only", inheritedOnly);
                 meta.Add("max_gpos", maxGpos);
                 meta.Add("max_findings", maxFindings);
-                meta.Add("max_results", maxResults);
                 if (!string.IsNullOrWhiteSpace(resolutionErrorContains)) {
                     meta.Add("resolution_error_contains", resolutionErrorContains);
                 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoRedirectTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoRedirectTool.cs
@@ -50,9 +50,8 @@ public sealed class AdGpoRedirectTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+            return Task.FromResult(argumentError!);
         }
 
         var gpoIdsRaw = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("gpo_ids"));
@@ -66,28 +65,23 @@ public sealed class AdGpoRedirectTool : ActiveDirectoryToolBase, ITool {
 
         var gpoNames = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("gpo_names"));
         var actualPathContains = ToolArgs.GetOptionalTrimmed(arguments, "actual_path_contains");
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
-        var view = GpoRedirectAnalyzer.Get(
-            domainName,
-            ids: gpoIds.Count == 0 ? null : gpoIds.ToArray(),
-            names: gpoNames.Count == 0 ? null : gpoNames.ToArray());
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "GPO redirect query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
+        if (!TryExecuteCollectionQuery(
+                query: () => GpoRedirectAnalyzer.Get(domainName, ids: gpoIds.Count == 0 ? null : gpoIds.ToArray(), names: gpoNames.Count == 0 ? null : gpoNames.ToArray()),
+                collectionSucceededSelector: static view => view.CollectionSucceeded,
+                collectionErrorSelector: static view => view.CollectionError,
+                result: out var view,
+                errorResponse: out var errorResponse,
+                defaultErrorMessage: "GPO redirect query failed.")) {
+            return Task.FromResult(errorResponse!);
         }
 
         var filtered = view.Items
             .Where(row => string.IsNullOrWhiteSpace(actualPathContains) || row.ActualSysvolPath.Contains(actualPathContains, StringComparison.OrdinalIgnoreCase))
             .ToArray();
 
-        var scanned = filtered.Length;
-        IReadOnlyList<GpoRedirectFinding> rows = scanned > maxResults
-            ? filtered.Take(maxResults).ToArray()
-            : filtered;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(filtered, maxResults, out var scanned, out var truncated);
 
         var result = new AdGpoRedirectResult(
             DomainName: domainName,
@@ -108,10 +102,9 @@ public sealed class AdGpoRedirectTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("domain_name", domainName);
+                AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
                 meta.Add("gpo_ids_count", gpoIds.Count);
                 meta.Add("gpo_names_count", gpoNames.Count);
-                meta.Add("max_results", maxResults);
                 if (!string.IsNullOrWhiteSpace(actualPathContains)) {
                     meta.Add("actual_path_contains", actualPathContains);
                 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupMembersResolvedTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupMembersResolvedTool.cs
@@ -72,10 +72,7 @@ public sealed class AdGroupMembersResolvedTool : ActiveDirectoryToolBase, ITool 
             return Task.FromResult(Error("identity is required."));
         }
 
-        var requestedMax = arguments?.GetInt64("max_results");
-        var maxResults = requestedMax.HasValue && requestedMax.Value > 0
-            ? (int)Math.Min(requestedMax.Value, Options.MaxResults)
-            : Options.MaxResults;
+        var maxResults = ResolveMaxResults(arguments);
 
         var includeNested = ToolArgs.GetBoolean(arguments, "include_nested");
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupsListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupsListTool.cs
@@ -70,10 +70,7 @@ public sealed class AdGroupsListTool : ActiveDirectoryToolBase, ITool {
         var nameContains = ToolArgs.GetOptionalTrimmed(arguments, "name_contains");
         var namePrefix = ToolArgs.GetOptionalTrimmed(arguments, "name_prefix");
 
-        var requestedMax = arguments?.GetInt64("max_results");
-        var maxResults = requestedMax.HasValue && requestedMax.Value > 0
-            ? (int)Math.Min(requestedMax.Value, Options.MaxResults)
-            : Options.MaxResults;
+        var maxResults = ResolveMaxResults(arguments);
 
         var offset = Math.Max(arguments?.GetInt64("offset") ?? 0, 0);
         var requestedPageSize = arguments?.GetInt64("page_size");
@@ -135,4 +132,3 @@ public sealed class AdGroupsListTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdHardenedPathsPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdHardenedPathsPolicyTool.cs
@@ -50,56 +50,32 @@ public sealed class AdHardenedPathsPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = HardenedPathsPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "Hardened UNC paths policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdHardenedPathsPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            TargetDn: view.TargetDn,
-            SysvolValue: view.SysvolValue,
-            NetlogonValue: view.NetlogonValue,
-            MissingPaths: view.MissingPaths,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Hardened UNC Paths Policy (preview)",
+            defaultErrorMessage: "Hardened UNC paths policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = HardenedPathsPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "Hardened UNC paths policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdHardenedPathsPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                TargetDn: view.TargetDn,
+                SysvolValue: view.SysvolValue,
+                NetlogonValue: view.NetlogonValue,
+                MissingPaths: view.MissingPaths,
+                Attribution: rows));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKdcProxyPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKdcProxyPolicyTool.cs
@@ -50,56 +50,32 @@ public sealed class AdKdcProxyPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = KdcProxyPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "KDC proxy policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdKdcProxyPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            TargetDn: view.TargetDn,
-            EnabledPolicy: view.EnabledPolicy,
-            AttributionTopWriters: view.AttributionTopWriters,
-            Values: view.Values,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: KDC Proxy Policy (preview)",
+            defaultErrorMessage: "KDC proxy policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = KdcProxyPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "KDC proxy policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdKdcProxyPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                TargetDn: view.TargetDn,
+                EnabledPolicy: view.EnabledPolicy,
+                AttributionTopWriters: view.AttributionTopWriters,
+                Values: view.Values,
+                Attribution: rows));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
@@ -63,7 +63,7 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
 
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -115,14 +115,10 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             });
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosPacPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosPacPolicyTool.cs
@@ -49,55 +49,31 @@ public sealed class AdKerberosPacPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = KerberosPacPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "Kerberos PAC policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdKerberosPacPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            TargetDn: view.TargetDn,
-            PacRequestorEnforcement: view.PacRequestorEnforcement,
-            KrbtgtFullPacSignature: view.KrbtgtFullPacSignature,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Kerberos PAC Policy (preview)",
+            defaultErrorMessage: "Kerberos PAC policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = KerberosPacPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "Kerberos PAC policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdKerberosPacPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                TargetDn: view.TargetDn,
+                PacRequestorEnforcement: view.PacRequestorEnforcement,
+                KrbtgtFullPacSignature: view.KrbtgtFullPacSignature,
+                Attribution: rows));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKrbtgtHealthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKrbtgtHealthTool.cs
@@ -57,7 +57,7 @@ public sealed class AdKrbtgtHealthTool : ActiveDirectoryToolBase, ITool {
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var ageThresholdDays = ToolArgs.GetCappedInt32(arguments, "age_threshold_days", 180, 1, 3650);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -80,11 +80,7 @@ public sealed class AdKrbtgtHealthTool : ActiveDirectoryToolBase, ITool {
             errors: errors,
             cancellationToken: cancellationToken);
 
-        var scanned = rows.Count;
-        IReadOnlyList<KrbtgtHealthSnapshot> projectedRows = scanned > maxResults
-            ? rows.Take(maxResults).ToArray()
-            : rows;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(rows, maxResults, out var scanned, out var truncated);
 
         var result = new AdKrbtgtHealthResult(
             DomainName: domainName,
@@ -107,14 +103,10 @@ public sealed class AdKrbtgtHealthTool : ActiveDirectoryToolBase, ITool {
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("age_threshold_days", ageThresholdDays);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
@@ -72,7 +72,7 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
         var allowLmHashOnly = ToolArgs.GetBoolean(arguments, "allow_lm_hash_only", defaultValue: false);
         var legacyNtlmOnly = ToolArgs.GetBoolean(arguments, "legacy_ntlm_only", defaultValue: false);
         var maxDomainControllers = ToolArgs.GetCappedInt32(arguments, "max_domain_controllers", 200, 1, 2000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         var rows = new List<LanManagerSettingsRow>(maxDomainControllers);
         var errors = new List<LanManagerSettingsError>();
@@ -167,17 +167,13 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("allow_lm_hash_only", allowLmHashOnly);
                 meta.Add("legacy_ntlm_only", legacyNtlmOnly);
                 meta.Add("max_domain_controllers", maxDomainControllers);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
                 if (explicitDomainControllers.Count > 0) {
                     meta.Add("explicit_domain_controllers", explicitDomainControllers.Count);
                 }
             });
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
@@ -92,7 +92,7 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
         var expiredOnly = ToolArgs.GetBoolean(arguments, "expired_only", defaultValue: false);
         var includeSamples = ToolArgs.GetBoolean(arguments, "include_samples", defaultValue: false);
         var maxSampleRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_sample_rows_per_domain", 50, 1, 1000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -180,14 +180,10 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("expired_only", expiredOnly);
                 meta.Add("include_samples", includeSamples);
                 meta.Add("max_sample_rows_per_domain", maxSampleRowsPerDomain);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             });
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
@@ -80,7 +80,7 @@ public sealed class AdLapsSchemaPostureTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var onlyFindings = ToolArgs.GetBoolean(arguments, "only_findings", defaultValue: false);
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -167,14 +167,10 @@ public sealed class AdLapsSchemaPostureTool : ActiveDirectoryToolBase, ITool {
             metaMutate: meta => {
                 meta.Add("only_findings", onlyFindings);
                 meta.Add("include_details", includeDetails);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryPagedTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryPagedTool.cs
@@ -61,10 +61,7 @@ public sealed class AdLdapQueryPagedTool : ActiveDirectoryToolBase, ITool {
             ? (int)Math.Min(requestedMaxValues.Value, LdapQueryPolicy.MaxValuesPerAttributeCap)
             : LdapQueryPolicy.DefaultMaxValuesPerAttribute;
 
-        var requestedMax = arguments?.GetInt64("max_results");
-        var maxResults = requestedMax.HasValue && requestedMax.Value > 0
-            ? (int)Math.Min(requestedMax.Value, Options.MaxResults)
-            : Options.MaxResults;
+        var maxResults = ResolveMaxResults(arguments);
 
         var requestedPageSize = arguments?.GetInt64("page_size");
         var pageSize = requestedPageSize.HasValue && requestedPageSize.Value > 0
@@ -140,4 +137,3 @@ public sealed class AdLdapQueryPagedTool : ActiveDirectoryToolBase, ITool {
     }
 
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryTool.cs
@@ -56,10 +56,7 @@ public sealed class AdLdapQueryTool : ActiveDirectoryToolBase, ITool {
             ? (int)Math.Min(requestedMaxValues.Value, LdapQueryPolicy.MaxValuesPerAttributeCap)
             : LdapQueryPolicy.DefaultMaxValuesPerAttribute;
 
-        var requestedMax = arguments?.GetInt64("max_results");
-        var maxResults = requestedMax.HasValue && requestedMax.Value > 0
-            ? (int)Math.Min(requestedMax.Value, Options.MaxResults)
-            : Options.MaxResults;
+        var maxResults = ResolveMaxResults(arguments);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
 
@@ -108,4 +105,3 @@ public sealed class AdLdapQueryTool : ActiveDirectoryToolBase, ITool {
     }
 
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLegacyCveExposureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLegacyCveExposureTool.cs
@@ -53,59 +53,29 @@ public sealed class AdLegacyCveExposureTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = LegacyCveExposureService.Get(domainName);
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> projectedRows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > projectedRows.Count;
-
-        var result = new AdLegacyCveExposureResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            SmbSigningWeak: view.Smb.ServerSigningRequired != true || view.Smb.ClientSigningRequired != true,
-            Smb1Enabled: view.Smb.Smb1Disabled == false,
-            NetlogonMissingKeys: view.Netlogon.MissingKeys > 0,
-            NetlogonRefuseComputerPasswordChange: view.Netlogon.RefuseComputerPasswordChange,
-            Smb: view.Smb,
-            Netlogon: view.Netlogon,
-            Kerberos: view.Kerberos,
-            Attribution: projectedRows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: projectedRows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Legacy CVE Exposure Posture (preview)",
+            defaultErrorMessage: "Legacy CVE exposure query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
-            }));
+            query: static domainName => LegacyCveExposureService.Get(domainName),
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdLegacyCveExposureResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                SmbSigningWeak: view.Smb.ServerSigningRequired != true || view.Smb.ClientSigningRequired != true,
+                Smb1Enabled: view.Smb.Smb1Disabled == false,
+                NetlogonMissingKeys: view.Netlogon.MissingKeys > 0,
+                NetlogonRefuseComputerPasswordChange: view.Netlogon.RefuseComputerPasswordChange,
+                Smb: view.Smb,
+                Netlogon: view.Netlogon,
+                Kerberos: view.Kerberos,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLimitBlankPasswordUsePolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLimitBlankPasswordUsePolicyTool.cs
@@ -48,54 +48,31 @@ public sealed class AdLimitBlankPasswordUsePolicyTool : ActiveDirectoryToolBase,
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = LimitBlankPasswordUsePolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "LimitBlankPasswordUse policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdLimitBlankPasswordUsePolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            EffectiveValue: view.EffectiveValue,
-            Enabled: view.Enabled,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Limit Blank Password Use Policy (preview)",
+            defaultErrorMessage: "LimitBlankPasswordUse policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = LimitBlankPasswordUsePolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "LimitBlankPasswordUse policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdLimitBlankPasswordUsePolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                EffectiveValue: view.EffectiveValue,
+                Enabled: view.Enabled,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLogonUxUacPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLogonUxUacPolicyTool.cs
@@ -50,56 +50,33 @@ public sealed class AdLogonUxUacPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = LogonUxUacPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "Logon UX/UAC policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdLogonUxUacPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            TargetDn: view.TargetDn,
-            RequireCtrlAltDel: view.RequireCtrlAltDel,
-            HideLastUserName: view.HideLastUserName,
-            SecureDesktop: view.SecureDesktop,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Logon UX/UAC Policy (preview)",
+            defaultErrorMessage: "Logon UX/UAC policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = LogonUxUacPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "Logon UX/UAC policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdLogonUxUacPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                TargetDn: view.TargetDn,
+                RequireCtrlAltDel: view.RequireCtrlAltDel,
+                HideLastUserName: view.HideLastUserName,
+                SecureDesktop: view.SecureDesktop,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLsaProtectionPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLsaProtectionPolicyTool.cs
@@ -47,53 +47,30 @@ public sealed class AdLsaProtectionPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = LsaProtectionPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "LSA Protection policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdLsaProtectionPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            Enabled: view.Enabled,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: LSA Protection Policy (preview)",
+            defaultErrorMessage: "LSA Protection policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = LsaProtectionPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "LSA Protection policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdLsaProtectionPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                Enabled: view.Enabled,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdMachineAccountQuotaTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdMachineAccountQuotaTool.cs
@@ -67,7 +67,7 @@ public sealed class AdMachineAccountQuotaTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var threshold = ToolArgs.GetCappedInt32(arguments, "threshold", 0, -1, int.MaxValue);
         var riskyOnly = ToolArgs.GetBoolean(arguments, "risky_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -131,14 +131,10 @@ public sealed class AdMachineAccountQuotaTool : ActiveDirectoryToolBase, ITool {
             metaMutate: meta => {
                 meta.Add("threshold", threshold);
                 meta.Add("risky_only", riskyOnly);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNameResolutionPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNameResolutionPolicyTool.cs
@@ -48,54 +48,31 @@ public sealed class AdNameResolutionPolicyTool : ActiveDirectoryToolBase, ITool 
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = NameResolutionPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "Name-resolution policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdNameResolutionPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            EnableLmHostsLookup: view.EnableLmHostsLookup,
-            NetbtNodeType: view.NetbtNodeType,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Name Resolution Policy (preview)",
+            defaultErrorMessage: "Name-resolution policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = NameResolutionPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "Name-resolution policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdNameResolutionPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                EnableLmHostsLookup: view.EnableLmHostsLookup,
+                NetbtNodeType: view.NetbtNodeType,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNetSessionHardeningPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNetSessionHardeningPolicyTool.cs
@@ -47,53 +47,30 @@ public sealed class AdNetSessionHardeningPolicyTool : ActiveDirectoryToolBase, I
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = NetSessionHardeningPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "Net session hardening policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdNetSessionHardeningPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            SrvsvcSessionInfo: view.SrvsvcSessionInfo,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Net Session Hardening Policy (preview)",
+            defaultErrorMessage: "Net session hardening policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = NetSessionHardeningPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "Net session hardening policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdNetSessionHardeningPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                SrvsvcSessionInfo: view.SrvsvcSessionInfo,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNoLmHashPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNoLmHashPolicyTool.cs
@@ -49,55 +49,32 @@ public sealed class AdNoLmHashPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = NoLmHashPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "NoLMHash policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdNoLmHashPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            TargetDn: view.TargetDn,
-            EffectiveValue: view.EffectiveValue,
-            Disabled: view.Disabled,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: NoLMHash Policy (preview)",
+            defaultErrorMessage: "NoLMHash policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = NoLmHashPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "NoLMHash policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdNoLmHashPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                TargetDn: view.TargetDn,
+                EffectiveValue: view.EffectiveValue,
+                Disabled: view.Disabled,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNullSessionPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNullSessionPostureTool.cs
@@ -69,7 +69,7 @@ public sealed class AdNullSessionPostureTool : ActiveDirectoryToolBase, ITool {
         var anonymousSamOnly = ToolArgs.GetBoolean(arguments, "anonymous_sam_only", defaultValue: false);
         var nullSessionOnly = ToolArgs.GetBoolean(arguments, "null_session_only", defaultValue: false);
         var maxDomainControllers = ToolArgs.GetCappedInt32(arguments, "max_domain_controllers", 200, 1, 2000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         var dcRows = new List<(string DomainName, string DomainController)>();
         if (explicitDcs.Count > 0) {
@@ -159,20 +159,16 @@ public sealed class AdNullSessionPostureTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("max_domain_controllers", maxDomainControllers);
                 meta.Add("anonymous_sam_only", anonymousSamOnly);
                 meta.Add("null_session_only", nullSessionOnly);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
                 if (explicitDcs.Count > 0) {
                     meta.Add("explicit_domain_controllers", explicitDcs.Count);
                 }
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
@@ -77,7 +77,7 @@ public sealed class AdOuProtectionTool : ActiveDirectoryToolBase, ITool {
         var unprotectedOnly = ToolArgs.GetBoolean(arguments, "unprotected_only", defaultValue: false);
         var includeUnprotectedOus = ToolArgs.GetBoolean(arguments, "include_unprotected_ous", defaultValue: false);
         var maxOuRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_ou_rows_per_domain", 100, 1, 5000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -161,14 +161,10 @@ public sealed class AdOuProtectionTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("unprotected_only", unprotectedOnly);
                 meta.Add("include_unprotected_ous", includeUnprotectedOus);
                 meta.Add("max_ou_rows_per_domain", maxOuRowsPerDomain);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyLengthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyLengthTool.cs
@@ -60,7 +60,7 @@ public sealed class AdPasswordPolicyLengthTool : ActiveDirectoryToolBase, ITool 
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var recommendedMinimumLength = ToolArgs.GetCappedInt32(arguments, "recommended_minimum_length", 12, 1, 512);
         var belowRecommendedOnly = ToolArgs.GetBoolean(arguments, "below_recommended_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -120,14 +120,10 @@ public sealed class AdPasswordPolicyLengthTool : ActiveDirectoryToolBase, ITool 
             metaMutate: meta => {
                 meta.Add("recommended_minimum_length", recommendedMinimumLength);
                 meta.Add("below_recommended_only", belowRecommendedOnly);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
@@ -79,7 +79,7 @@ public sealed class AdPasswordPolicyRollupTool : ActiveDirectoryToolBase, ITool 
         var psoHistoryMin = ToolArgs.GetCappedInt32(arguments, "pso_history_min", 24, 0, 1024);
         var includePsoDetails = ToolArgs.GetBoolean(arguments, "include_pso_details", defaultValue: true);
         var maxPsoRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_pso_rows_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -149,14 +149,10 @@ public sealed class AdPasswordPolicyRollupTool : ActiveDirectoryToolBase, ITool 
                 meta.Add("pso_history_min", psoHistoryMin);
                 meta.Add("include_pso_details", includePsoDetails);
                 meta.Add("max_pso_rows_per_domain", maxPsoRowsPerDomain);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyTool.cs
@@ -59,7 +59,7 @@ public sealed class AdPasswordPolicyTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
         var includeFineGrained = ToolArgs.GetBoolean(arguments, "include_fine_grained", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         var domains = LdapQueryHelper.GetTargetDomains(domainName, forestName)
             .Where(static x => !string.IsNullOrWhiteSpace(x))
@@ -108,11 +108,7 @@ public sealed class AdPasswordPolicyTool : ActiveDirectoryToolBase, ITool {
             }
         }
 
-        var scanned = rows.Count;
-        IReadOnlyList<PasswordPolicyInfo> projectedRows = scanned > maxResults
-            ? rows.Take(maxResults).ToArray()
-            : rows;
-        var truncated = scanned > projectedRows.Count;
+        var projectedRows = CapRows(rows, maxResults, out var scanned, out var truncated);
 
         var result = new AdPasswordPolicyResult(
             ForestName: forestName,
@@ -135,16 +131,12 @@ public sealed class AdPasswordPolicyTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("include_fine_grained", includeFineGrained);
                 meta.Add("domains_count", domains.Count);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiTemplatesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiTemplatesTool.cs
@@ -58,8 +58,8 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
         var codeSigningRiskOnly = ToolArgs.GetBoolean(arguments, "code_signing_risk_only", defaultValue: false);
         var clientAuthRiskOnly = ToolArgs.GetBoolean(arguments, "client_auth_risk_only", defaultValue: false);
         var includeTakeoverRows = ToolArgs.GetBoolean(arguments, "include_takeover_rows", defaultValue: true);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-        var maxTakeoverRows = ToolArgs.GetCappedInt32(arguments, "max_takeover_rows", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxTakeoverRows = ResolveBoundedMaxResults(arguments, "max_takeover_rows");
 
         if (!TryExecute(
                 action: () => PkiApi.GetTemplates(forestName),
@@ -107,7 +107,7 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("forest_name", view.ForestName);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("max_takeover_rows", maxTakeoverRows);
                 meta.Add("weak_key_only", weakKeyOnly);
                 meta.Add("takeover_risk_only", takeoverRiskOnly);
@@ -117,5 +117,4 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPku2uPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPku2uPolicyTool.cs
@@ -48,54 +48,30 @@ public sealed class AdPku2uPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = Pku2uPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "PKU2U policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdPku2uPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            EffectiveValue: view.EffectiveValue,
-            Disabled: view.Disabled,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: PKU2U Policy (preview)",
+            defaultErrorMessage: "PKU2U policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = Pku2uPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "PKU2U policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdPku2uPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                EffectiveValue: view.EffectiveValue,
+                Disabled: view.Disabled,
+                Attribution: rows));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPowerShellLoggingPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPowerShellLoggingPolicyTool.cs
@@ -51,57 +51,34 @@ public sealed class AdPowerShellLoggingPolicyTool : ActiveDirectoryToolBase, ITo
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = PowerShellLoggingService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "PowerShell logging policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdPowerShellLoggingPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            TargetDn: view.TargetDn,
-            ScriptBlock: view.ScriptBlock,
-            Module: view.Module,
-            Transcription: view.Transcription,
-            AttributionTopWriters: view.AttributionTopWriters,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: PowerShell Logging Policy (preview)",
+            defaultErrorMessage: "PowerShell logging policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = PowerShellLoggingService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "PowerShell logging policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdPowerShellLoggingPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                TargetDn: view.TargetDn,
+                ScriptBlock: view.ScriptBlock,
+                Module: view.Module,
+                Transcription: view.Transcription,
+                AttributionTopWriters: view.AttributionTopWriters,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
@@ -89,7 +89,7 @@ public sealed class AdRegistrationPostureTool : ActiveDirectoryToolBase, ITool {
         var missingSubnetOnly = ToolArgs.GetBoolean(arguments, "missing_subnet_only", defaultValue: false);
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: false);
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 5000);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -175,14 +175,9 @@ public sealed class AdRegistrationPostureTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("missing_subnet_only", missingSubnetOnly);
                 meta.Add("include_details", includeDetails);
                 meta.Add("max_detail_rows_per_domain", maxDetailRowsPerDomain);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 
@@ -199,3 +194,4 @@ public sealed class AdRegistrationPostureTool : ActiveDirectoryToolBase, ITool {
             HasMatchingSubnet: item.HasMatchingSubnet);
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationConnectionsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationConnectionsTool.cs
@@ -64,7 +64,7 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
         var origin = NormalizeValue(ToolArgs.GetOptionalTrimmed(arguments, "origin"), "any");
         var summary = ToolArgs.GetBoolean(arguments, "summary", defaultValue: false);
         var summaryBy = NormalizeValue(ToolArgs.GetOptionalTrimmed(arguments, "summary_by"), "site");
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!IsOneOf(transport, "any", "rpc", "smtp")) {
             return Task.FromResult(ToolResponse.Error("invalid_argument", "transport must be one of: any, rpc, smtp."));
@@ -100,9 +100,7 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
 
         if (summary) {
             var allSummary = ConnectionsExplorer.GetSummaryBy(filtered, summaryBy);
-            var scanned = allSummary.Count;
-            var rows = scanned > maxResults ? allSummary.Take(maxResults).ToArray() : allSummary;
-            var truncated = scanned > rows.Count;
+            var rows = CapRows(allSummary, maxResults, out var scanned, out var truncated);
 
             var summaryResult = new AdReplicationConnectionsResult(
                 Mode: "summary",
@@ -129,7 +127,7 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
                     meta.Add("mode", "summary");
                     meta.Add("summary_by", summaryBy);
                     meta.Add("total_filtered", filtered.Count);
-                    meta.Add("max_results", maxResults);
+                    AddMaxResultsMeta(meta, maxResults);
                 }));
         }
 
@@ -160,7 +158,7 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
             scanned: scannedConnections,
             metaMutate: meta => {
                 meta.Add("mode", "raw");
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
             }));
     }
 
@@ -212,5 +210,4 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
         };
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationStatusTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationStatusTool.cs
@@ -48,7 +48,7 @@ public sealed class AdReplicationStatusTool : ActiveDirectoryToolBase, ITool {
 
         var requestedComputerNames = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("computer_names"));
         var healthOnly = ToolArgs.GetBoolean(arguments, "health_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         IReadOnlyList<string> targetServers = requestedComputerNames.Count == 0
             ? DomainHelper.EnumerateDomainControllers().Distinct(StringComparer.OrdinalIgnoreCase).ToArray()
@@ -63,9 +63,7 @@ public sealed class AdReplicationStatusTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(errorResponse!);
         }
 
-        var scanned = allRows.Count;
-        var rows = scanned > maxResults ? allRows.Take(maxResults).ToArray() : allRows;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(allRows, maxResults, out var scanned, out var truncated);
 
         var result = new AdReplicationStatusResult(
             HealthOnly: healthOnly,
@@ -84,11 +82,10 @@ public sealed class AdReplicationStatusTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("health_only", healthOnly);
                 meta.Add("target_server_count", targetServers.Count);
             }));
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRestrictNtlmConfigurationTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRestrictNtlmConfigurationTool.cs
@@ -47,53 +47,23 @@ public sealed class AdRestrictNtlmConfigurationTool : ActiveDirectoryToolBase, I
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = RestrictNtlmConfigurationService.Get(domainName);
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> rows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > rows.Count;
-
-        var result = new AdRestrictNtlmConfigurationResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            Restrict: view.Restrict,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Restrict NTLM Configuration (preview)",
+            defaultErrorMessage: "Restrict NTLM configuration query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
-                meta.Add("max_results", maxResults);
-            }));
+            query: static domainName => RestrictNtlmConfigurationService.Get(domainName),
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdRestrictNtlmConfigurationResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                Restrict: view.Restrict,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSchannelPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSchannelPolicyTool.cs
@@ -54,60 +54,37 @@ public sealed class AdSchannelPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = SchannelPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "Schannel policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdSchannelPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            Ssl3Enabled: view.Ssl3Enabled,
-            Tls10Enabled: view.Tls10Enabled,
-            Tls11Enabled: view.Tls11Enabled,
-            Tls12Enabled: view.Tls12Enabled,
-            Tls13Enabled: view.Tls13Enabled,
-            CipherSuiteOrderConfigured: view.CipherSuiteOrderConfigured,
-            DotNetStrongCrypto64: view.DotNetStrongCrypto64,
-            DotNetStrongCrypto32: view.DotNetStrongCrypto32,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Schannel Policy (preview)",
+            defaultErrorMessage: "Schannel policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = SchannelPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "Schannel policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdSchannelPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                Ssl3Enabled: view.Ssl3Enabled,
+                Tls10Enabled: view.Tls10Enabled,
+                Tls11Enabled: view.Tls11Enabled,
+                Tls12Enabled: view.Tls12Enabled,
+                Tls13Enabled: view.Tls13Enabled,
+                CipherSuiteOrderConfigured: view.CipherSuiteOrderConfigured,
+                DotNetStrongCrypto64: view.DotNetStrongCrypto64,
+                DotNetStrongCrypto32: view.DotNetStrongCrypto32,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSchemaVersionTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSchemaVersionTool.cs
@@ -47,7 +47,7 @@ public sealed class AdSchemaVersionTool : ActiveDirectoryToolBase, ITool {
         cancellationToken.ThrowIfCancellationRequested();
 
         var mismatchedOnly = ToolArgs.GetBoolean(arguments, "mismatched_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryExecute(
                 action: () => {
@@ -67,9 +67,7 @@ public sealed class AdSchemaVersionTool : ActiveDirectoryToolBase, ITool {
             : Array.Empty<SchemaVersionInfo>();
 
         IReadOnlyList<SchemaVersionInfo> selectedRows = mismatchedOnly ? mismatches : versions;
-        var scanned = selectedRows.Count;
-        var rows = scanned > maxResults ? selectedRows.Take(maxResults).ToArray() : selectedRows;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(selectedRows, maxResults, out var scanned, out var truncated);
 
         var result = new AdSchemaVersionResult(
             MismatchedOnly: mismatchedOnly,
@@ -90,7 +88,7 @@ public sealed class AdSchemaVersionTool : ActiveDirectoryToolBase, ITool {
             scanned: scanned,
             maxTop: MaxViewTop,
             metaMutate: meta => {
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("mismatched_only", mismatchedOnly);
                 meta.Add("mismatch_count", mismatches.Length);
                 if (referenceVersion.HasValue) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchFacetsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchFacetsTool.cs
@@ -100,10 +100,7 @@ public sealed class AdSearchFacetsTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var requestedMax = arguments?.GetInt64("max_results");
-        var maxResults = requestedMax.HasValue && requestedMax.Value > 0
-            ? (int)Math.Min(requestedMax.Value, Options.MaxResults)
-            : Options.MaxResults;
+        var maxResults = ResolveMaxResults(arguments);
 
         var requestedPageSize = arguments?.GetInt64("page_size");
         var pageSize = requestedPageSize.HasValue && requestedPageSize.Value > 0

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchTool.cs
@@ -53,10 +53,7 @@ public sealed class AdSearchTool : ActiveDirectoryToolBase, ITool {
         var kindArg = ToolArgs.GetOptionalTrimmed(arguments, "kind");
         var kind = string.IsNullOrWhiteSpace(kindArg) ? "any" : kindArg.Trim().ToLowerInvariant();
 
-        var requestedMax = arguments?.GetInt64("max_results");
-        var maxResults = requestedMax.HasValue && requestedMax.Value > 0
-            ? (int)Math.Min(requestedMax.Value, Options.MaxResults)
-            : Options.MaxResults;
+        var maxResults = ResolveMaxResults(arguments);
 
         var maxValuesPerAttribute = ToolArgs.GetCappedInt32(
             arguments,
@@ -110,4 +107,3 @@ public sealed class AdSearchTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
@@ -68,7 +68,7 @@ public sealed class AdShadowCredentialsRiskTool : ActiveDirectoryToolBase, ITool
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeFindings = ToolArgs.GetBoolean(arguments, "include_findings", defaultValue: true);
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -128,14 +128,10 @@ public sealed class AdShadowCredentialsRiskTool : ActiveDirectoryToolBase, ITool
             metaMutate: meta => {
                 meta.Add("include_findings", includeFindings);
                 meta.Add("max_findings_per_domain", maxFindingsPerDomain);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteCoverageTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteCoverageTool.cs
@@ -62,7 +62,7 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeRegistry = ToolArgs.GetBoolean(arguments, "include_registry", defaultValue: false);
         var raw = ToolArgs.GetBoolean(arguments, "raw", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!raw) {
             if (!TryExecute(
@@ -94,7 +94,7 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
                 scanned: scanned,
                 metaMutate: meta => {
                     meta.Add("mode", "summary");
-                    meta.Add("max_results", maxResults);
+                    AddMaxResultsMeta(meta, maxResults);
                     meta.Add("include_registry", includeRegistry);
                     if (!string.IsNullOrWhiteSpace(forestName)) {
                         meta.Add("forest_name", forestName);
@@ -139,7 +139,7 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
             scanned: summaryScanned,
             metaMutate: meta => {
                 meta.Add("mode", "raw");
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("include_registry", includeRegistry);
                 meta.Add("sites_scanned", sitesScanned);
                 meta.Add("subnets_scanned", subnetsScanned);
@@ -151,3 +151,4 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteLinksTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteLinksTool.cs
@@ -99,7 +99,7 @@ public sealed class AdSiteLinksTool : ActiveDirectoryToolBase, ITool {
 
         var hasSchedule = ToolArgs.GetBoolean(arguments, "has_schedule", defaultValue: false);
         var expandSchedule = ToolArgs.GetBoolean(arguments, "expand_schedule", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryParseRequiredOptions(arguments, out var requiredOptions, out var optionNames, out var optionError)) {
             return Task.FromResult(ToolResponse.Error("invalid_argument", optionError ?? "Invalid options_all value."));
@@ -145,7 +145,7 @@ public sealed class AdSiteLinksTool : ActiveDirectoryToolBase, ITool {
                 scanned: scannedScheduleRows,
                 metaMutate: meta => {
                     meta.Add("mode", "schedule");
-                    meta.Add("max_results", maxResults);
+                    AddMaxResultsMeta(meta, maxResults);
                     meta.Add("has_schedule", hasSchedule);
                     meta.Add("expand_schedule", true);
                     meta.Add("options_all", ToolJson.ToJsonArray(optionNames));
@@ -178,7 +178,7 @@ public sealed class AdSiteLinksTool : ActiveDirectoryToolBase, ITool {
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("mode", "raw");
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("has_schedule", hasSchedule);
                 meta.Add("expand_schedule", false);
                 meta.Add("options_all", ToolJson.ToJsonArray(optionNames));
@@ -287,3 +287,4 @@ public sealed class AdSiteLinksTool : ActiveDirectoryToolBase, ITool {
         };
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSitesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSitesTool.cs
@@ -53,7 +53,7 @@ public sealed class AdSitesTool : ActiveDirectoryToolBase, ITool {
         var includeSubnets = ToolArgs.GetBoolean(arguments, "include_subnets", defaultValue: false);
         var includeOptions = ToolArgs.GetBoolean(arguments, "include_options", defaultValue: false);
         var noDcOnly = ToolArgs.GetBoolean(arguments, "no_dc_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryExecute(
                 action: () => TopologyService.GetSites(
@@ -68,9 +68,7 @@ public sealed class AdSitesTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(errorResponse!);
         }
 
-        var scanned = allSites.Count;
-        var rows = scanned > maxResults ? allSites.Take(maxResults).ToArray() : allSites;
-        var truncated = scanned > rows.Count;
+        var rows = CapRows(allSites, maxResults, out var scanned, out var truncated);
 
         var result = new AdSitesResult(
             ForestName: forestName,
@@ -91,7 +89,7 @@ public sealed class AdSitesTool : ActiveDirectoryToolBase, ITool {
             scanned: scanned,
             maxTop: MaxViewTop,
             metaMutate: meta => {
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("include_subnets", includeSubnets);
                 meta.Add("include_options", includeOptions);
                 meta.Add("no_dc_only", noDcOnly);
@@ -102,5 +100,4 @@ public sealed class AdSitesTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
@@ -76,7 +76,7 @@ public sealed class AdSmartCardPostureTool : ActiveDirectoryToolBase, ITool {
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: true);
         var maxPrivilegedRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_privileged_rows_per_domain", 100, 1, Options.MaxResults);
         var maxFindingRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_finding_rows_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -148,14 +148,10 @@ public sealed class AdSmartCardPostureTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("include_details", includeDetails);
                 meta.Add("max_privileged_rows_per_domain", maxPrivilegedRowsPerDomain);
                 meta.Add("max_finding_rows_per_domain", maxFindingRowsPerDomain);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
@@ -88,7 +88,7 @@ public sealed class AdSpnHygieneTool : ActiveDirectoryToolBase, ITool {
         var topN = ToolArgs.GetCappedInt32(arguments, "top_n", 10, 1, 50);
         var includeInvalidSpnSample = ToolArgs.GetBoolean(arguments, "include_invalid_spn_sample", defaultValue: true);
         var maxInvalidSpnSample = ToolArgs.GetCappedInt32(arguments, "max_invalid_spn_sample", 25, 1, 200);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -170,16 +170,12 @@ public sealed class AdSpnHygieneTool : ActiveDirectoryToolBase, ITool {
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("top_n", topN);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("error_count", errors.Count);
                 meta.Add("allowlist_count", allowlist.Count);
                 meta.Add("blocklist_count", blocklist.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnSearchTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnSearchTool.cs
@@ -51,10 +51,7 @@ public sealed class AdSpnSearchTool : ActiveDirectoryToolBase, ITool {
         var kind = string.IsNullOrWhiteSpace(kindArg) ? "any" : kindArg.Trim().ToLowerInvariant();
         var enabledOnly = ToolArgs.GetBoolean(arguments, "enabled_only");
 
-        var requestedMax = arguments?.GetInt64("max_results");
-        var maxResults = requestedMax.HasValue && requestedMax.Value > 0
-            ? (int)Math.Min(requestedMax.Value, Options.MaxResults)
-            : Options.MaxResults;
+        var maxResults = ResolveMaxResults(arguments);
 
         var maxValuesPerAttribute = ToolArgs.GetCappedInt32(
             arguments,
@@ -112,4 +109,3 @@ public sealed class AdSpnSearchTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnStatsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnStatsTool.cs
@@ -54,10 +54,7 @@ public sealed class AdSpnStatsTool : ActiveDirectoryToolBase, ITool {
         var enabledOnly = ToolArgs.GetBoolean(arguments, "enabled_only");
         var includeExamples = ToolArgs.GetBoolean(arguments, "include_examples");
 
-        var requestedMax = arguments?.GetInt64("max_results");
-        var maxObjects = requestedMax.HasValue && requestedMax.Value > 0
-            ? (int)Math.Min(requestedMax.Value, Options.MaxResults)
-            : Options.MaxResults;
+        var maxObjects = ResolveMaxResults(arguments);
 
         var requestedServiceClasses = arguments?.GetInt64("max_service_classes");
         var maxServiceClasses = requestedServiceClasses.HasValue && requestedServiceClasses.Value > 0

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdStaleAccountsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdStaleAccountsTool.cs
@@ -53,10 +53,7 @@ public sealed class AdStaleAccountsTool : ActiveDirectoryToolBase, ITool {
 
         var match = ParseMatch(ToolArgs.GetOptionalTrimmed(arguments, "match"));
 
-        var requestedMax = arguments?.GetInt64("max_results");
-        var maxResults = requestedMax.HasValue && requestedMax.Value > 0
-            ? (int)Math.Min(requestedMax.Value, Options.MaxResults)
-            : Options.MaxResults;
+        var maxResults = ResolveMaxResults(arguments);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSubnetsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSubnetsTool.cs
@@ -55,7 +55,7 @@ public sealed class AdSubnetsTool : ActiveDirectoryToolBase, ITool {
 
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var summary = ToolArgs.GetBoolean(arguments, "summary", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (summary) {
             if (!TryExecute(
@@ -89,7 +89,7 @@ public sealed class AdSubnetsTool : ActiveDirectoryToolBase, ITool {
                 scanned: scanned,
                 metaMutate: meta => {
                     meta.Add("mode", "summary");
-                    meta.Add("max_results", maxResults);
+                    AddMaxResultsMeta(meta, maxResults);
                     if (!string.IsNullOrWhiteSpace(forestName)) {
                         meta.Add("forest_name", forestName);
                     }
@@ -128,12 +128,11 @@ public sealed class AdSubnetsTool : ActiveDirectoryToolBase, ITool {
             scanned: scannedSubnets,
             metaMutate: meta => {
                 meta.Add("mode", "raw");
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 if (!string.IsNullOrWhiteSpace(forestName)) {
                     meta.Add("forest_name", forestName);
                 }
             }));
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSystemStateBackupTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSystemStateBackupTool.cs
@@ -72,7 +72,7 @@ public sealed class AdSystemStateBackupTool : ActiveDirectoryToolBase, ITool {
         var thresholdDays = ToolArgs.GetCappedInt32(arguments, "threshold_days", 30, 1, 3650);
         var missingOnly = ToolArgs.GetBoolean(arguments, "missing_only", defaultValue: false);
         var staleOnly = ToolArgs.GetBoolean(arguments, "stale_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -147,16 +147,12 @@ public sealed class AdSystemStateBackupTool : ActiveDirectoryToolBase, ITool {
             scanned: scanned,
             metaMutate: meta => {
                 meta.Add("threshold_days", thresholdDays);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("missing_only", missingOnly);
                 meta.Add("stale_only", staleOnly);
                 meta.Add("error_count", errors.Count);
-                if (!string.IsNullOrWhiteSpace(domainName)) {
-                    meta.Add("domain_name", domainName);
-                }
-                if (!string.IsNullOrWhiteSpace(forestName)) {
-                    meta.Add("forest_name", forestName);
-                }
+                AddDomainAndForestMeta(meta, domainName, forestName);
             }));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTerminalServicesRedirectionPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTerminalServicesRedirectionPolicyTool.cs
@@ -48,54 +48,31 @@ public sealed class AdTerminalServicesRedirectionPolicyTool : ActiveDirectoryToo
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = TerminalServicesRedirectionPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "Terminal services redirection policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdTerminalServicesRedirectionPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            DisableDriveRedirect: view.DisableDriveRedirect,
-            DisableClipboardRedirect: view.DisableClipboardRedirect,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Terminal Services Redirection Policy (preview)",
+            defaultErrorMessage: "Terminal services redirection policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = TerminalServicesRedirectionPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "Terminal services redirection policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdTerminalServicesRedirectionPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                DisableDriveRedirect: view.DisableDriveRedirect,
+                DisableClipboardRedirect: view.DisableClipboardRedirect,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTerminalServicesTimeoutPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTerminalServicesTimeoutPolicyTool.cs
@@ -51,57 +51,34 @@ public sealed class AdTerminalServicesTimeoutPolicyTool : ActiveDirectoryToolBas
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = TerminalServicesTimeoutPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "Terminal services timeout policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdTerminalServicesTimeoutPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            MaxIdleTimeMs: view.MaxIdleTimeMs,
-            MaxDisconnectionTimeMs: view.MaxDisconnectionTimeMs,
-            MaxIdleTime: view.MaxIdleTime,
-            MaxDisconnectionTime: view.MaxDisconnectionTime,
-            ConfiguredCount: view.ConfiguredCount,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Terminal Services Timeout Policy (preview)",
+            defaultErrorMessage: "Terminal services timeout policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = TerminalServicesTimeoutPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "Terminal services timeout policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdTerminalServicesTimeoutPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                MaxIdleTimeMs: view.MaxIdleTimeMs,
+                MaxDisconnectionTimeMs: view.MaxDisconnectionTimeMs,
+                MaxIdleTime: view.MaxIdleTime,
+                MaxDisconnectionTime: view.MaxDisconnectionTime,
+                ConfiguredCount: view.ConfiguredCount,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTimeServiceConfigurationTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTimeServiceConfigurationTool.cs
@@ -50,65 +50,37 @@ public sealed class AdTimeServiceConfigurationTool : ActiveDirectoryToolBase, IT
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = TimeServiceConfigurationService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "Time service configuration query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var attributionRows = includeAttribution
-            ? view.Attribution
-                .Where(row => !configuredAttributionOnly || !string.IsNullOrWhiteSpace(row.Effective) && !string.Equals(row.Effective, "Not configured", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : Array.Empty<PolicyAttribution>();
-
-        var scanned = attributionRows.Length;
-        IReadOnlyList<PolicyAttribution> projectedRows = scanned > maxResults
-            ? attributionRows.Take(maxResults).ToArray()
-            : attributionRows;
-        var truncated = scanned > projectedRows.Count;
-
-        var result = new AdTimeServiceConfigurationResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            PdcAcceptable: view.PdcAcceptable,
-            NonPdcAcceptable: view.NonPdcAcceptable,
-            Pdc: view.Pdc,
-            NonPdc: view.NonPdc,
-            Attribution: projectedRows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: projectedRows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: Time Service Configuration (preview)",
+            defaultErrorMessage: "Time service configuration query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                meta.Add("domain_name", domainName);
-                meta.Add("include_attribution", includeAttribution);
-                meta.Add("configured_attribution_only", configuredAttributionOnly);
+            query: domainName => {
+                var view = TimeServiceConfigurationService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "Time service configuration query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdTimeServiceConfigurationResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                PdcAcceptable: view.PdcAcceptable,
+                NonPdcAcceptable: view.NonPdcAcceptable,
+                Pdc: view.Pdc,
+                NonPdc: view.NonPdc,
+                Attribution: rows),
+            additionalMetaMutate: static (meta, _, view, _) => {
                 meta.Add("pdc_acceptable", view.PdcAcceptable);
                 meta.Add("non_pdc_acceptable", view.NonPdcAcceptable);
-                meta.Add("max_results", maxResults);
-            }));
+            }
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTrustTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTrustTool.cs
@@ -88,7 +88,7 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
         var includeCommunicationIssues = ToolArgs.GetBoolean(arguments, "include_communication_issues", defaultValue: false);
         var summary = ToolArgs.GetBoolean(arguments, "summary", defaultValue: false);
         var summaryMatrix = ToolArgs.GetBoolean(arguments, "summary_matrix", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         var status = NormalizeEnumValue(ToolArgs.GetOptionalTrimmed(arguments, "status"), "any");
         var trustType = NormalizeEnumValue(ToolArgs.GetOptionalTrimmed(arguments, "trust_type"), "any");
@@ -419,3 +419,4 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
         };
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdUsersExpiredTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdUsersExpiredTool.cs
@@ -39,7 +39,7 @@ public sealed class AdUsersExpiredTool : ActiveDirectoryToolBase, ITool {
         }
         var referenceUtc = referenceUtcOpt ?? DateTime.UtcNow;
 
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveBoundedMaxResults(arguments);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
         if (string.IsNullOrWhiteSpace(baseDn)) {
@@ -58,3 +58,4 @@ public sealed class AdUsersExpiredTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(ToolResponse.OkModel(res));
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdWinRmPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdWinRmPolicyTool.cs
@@ -49,55 +49,32 @@ public sealed class AdWinRmPolicyTool : ActiveDirectoryToolBase, ITool {
 
     /// <inheritdoc />
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", "domain_name is required."));
-        }
-
-        var includeAttribution = ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true);
-        var configuredAttributionOnly = ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
-
-        var view = WinRmPolicyService.Get(domainName);
-        if (!view.CollectionSucceeded) {
-            var message = string.IsNullOrWhiteSpace(view.CollectionError)
-                ? "WinRM policy query failed."
-                : view.CollectionError!;
-            return Task.FromResult(ToolResponse.Error("query_failed", message));
-        }
-
-        var rows = PreparePolicyAttributionRows(
-            attribution: view.Attribution,
-            includeAttribution: includeAttribution,
-            configuredAttributionOnly: configuredAttributionOnly,
-            maxResults: maxResults,
-            scanned: out var scanned,
-            truncated: out var truncated);
-
-        var result = new AdWinRmPolicyResult(
-            DomainName: domainName,
-            IncludeAttribution: includeAttribution,
-            ConfiguredAttributionOnly: configuredAttributionOnly,
-            Scanned: scanned,
-            Truncated: truncated,
-            AllowUnencrypted: view.AllowUnencrypted,
-            BasicAuthEnabled: view.BasicAuthEnabled,
-            PotentiallyInsecure: view.AllowUnencrypted == true || view.BasicAuthEnabled == true,
-            Attribution: rows);
-
-        return Task.FromResult(BuildAutoTableResponse(
+        return ExecutePolicyAttributionTool(
             arguments: arguments,
-            model: result,
-            sourceRows: rows,
-            viewRowsPath: "attribution_view",
+            cancellationToken: cancellationToken,
             title: "Active Directory: WinRM Policy (preview)",
+            defaultErrorMessage: "WinRM policy query failed.",
             maxTop: MaxViewTop,
-            baseTruncated: truncated,
-            scanned: scanned,
-            metaMutate: meta => {
-                AddStandardPolicyAttributionMeta(meta, domainName, includeAttribution, configuredAttributionOnly, maxResults);
-            }));
+            query: domainName => {
+                var view = WinRmPolicyService.Get(domainName);
+                ThrowIfCollectionFailed(
+                    view.CollectionSucceeded,
+                    view.CollectionError,
+                    "WinRM policy query failed.");
+                return view;
+            },
+            attributionSelector: static view => view.Attribution,
+            resultFactory: static (request, view, scanned, truncated, rows) => new AdWinRmPolicyResult(
+                DomainName: request.DomainName,
+                IncludeAttribution: request.IncludeAttribution,
+                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                Scanned: scanned,
+                Truncated: truncated,
+                AllowUnencrypted: view.AllowUnencrypted,
+                BasicAuthEnabled: view.BasicAuthEnabled,
+                PotentiallyInsecure: view.AllowUnencrypted == true || view.BasicAuthEnabled == true,
+                Attribution: rows)
+            );
     }
 }
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ToolRegistryActiveDirectoryExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ToolRegistryActiveDirectoryExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
 
@@ -16,11 +14,7 @@ public static class ToolRegistryActiveDirectoryExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Ordered tool names for the pack.</returns>
     public static IReadOnlyList<string> GetRegisteredToolNames(ActiveDirectoryToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return CreateTools(options).Select(static tool => tool.Definition.Name).ToArray();
+        return ToolPackRegistry.GetRegisteredToolNames(options, CreateTools);
     }
 
     /// <summary>
@@ -29,11 +23,7 @@ public static class ToolRegistryActiveDirectoryExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Catalog entries derived from runtime definitions and input schemas.</returns>
     public static IReadOnlyList<ToolPackToolCatalogEntryModel> GetRegisteredToolCatalog(ActiveDirectoryToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return ToolPackGuidance.CatalogFromTools(CreateTools(options));
+        return ToolPackRegistry.GetRegisteredToolCatalog(options, CreateTools);
     }
 
     /// <summary>
@@ -43,17 +33,7 @@ public static class ToolRegistryActiveDirectoryExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>The same registry instance for chaining.</returns>
     public static ToolRegistry RegisterActiveDirectoryPack(this ToolRegistry registry, ActiveDirectoryToolOptions options) {
-        if (registry is null) {
-            throw new ArgumentNullException(nameof(registry));
-        }
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        foreach (var tool in CreateTools(options)) {
-            registry.Register(tool);
-        }
-        return registry;
+        return ToolPackRegistry.RegisterPack(registry, options, CreateTools);
     }
 
     private static IEnumerable<ITool> CreateTools(ActiveDirectoryToolOptions options) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolArgs.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolArgs.cs
@@ -280,6 +280,35 @@ public static class ToolArgs {
     }
 
     /// <summary>
+    /// Reads an optional integer argument bounded by a caller-provided option max value.
+    /// </summary>
+    /// <remarks>
+    /// Useful for pack/base helpers where many tools share the same configured max cap.
+    /// </remarks>
+    public static int GetOptionBoundedInt32(
+        JsonObject? arguments,
+        string key,
+        int optionMaxInclusive,
+        int minInclusive = 1) {
+        return GetCappedInt32(arguments, key, optionMaxInclusive, minInclusive, optionMaxInclusive);
+    }
+
+    /// <summary>
+    /// Reads an optional positive integer argument where non-positive values keep a default,
+    /// then caps to a caller-provided option max value.
+    /// </summary>
+    /// <remarks>
+    /// Useful for knobs where zero/negative should preserve default behavior instead of forcing the minimum.
+    /// </remarks>
+    public static int GetPositiveOptionBoundedInt32OrDefault(
+        JsonObject? arguments,
+        string key,
+        int defaultValue,
+        int optionMaxInclusive) {
+        return GetPositiveCappedInt32OrDefault(arguments, key, defaultValue, optionMaxInclusive);
+    }
+
+    /// <summary>
     /// Normalizes a nullable 64-bit value to a positive nullable 32-bit value.
     /// Returns <c>null</c> when value is null or non-positive.
     /// </summary>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolBase.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Json;
@@ -23,6 +25,62 @@ public abstract class ToolBase : ITool {
     }
 
     /// <summary>
+    /// Adds max_results metadata consistently across tool responses.
+    /// </summary>
+    protected static void AddMaxResultsMeta(JsonObject meta, int maxResults) {
+        meta.Add("max_results", maxResults);
+    }
+
+    /// <summary>
+    /// Builds the standard auto-column table envelope used by read-only list/query tools.
+    /// </summary>
+    protected static string BuildAutoTableResponse<TModel, TRow>(
+        JsonObject? arguments,
+        TModel model,
+        IReadOnlyList<TRow> sourceRows,
+        string viewRowsPath,
+        string title,
+        bool baseTruncated,
+        int scanned,
+        int maxTop,
+        Action<JsonObject>? metaMutate = null) {
+        return ToolQueryHelpers.BuildAutoTableResponse(
+            arguments: arguments,
+            model: model,
+            sourceRows: sourceRows,
+            viewRowsPath: viewRowsPath,
+            title: title,
+            maxTop: maxTop,
+            baseTruncated: baseTruncated,
+            scanned: scanned,
+            metaMutate: metaMutate);
+    }
+
+    /// <summary>
+    /// Builds a standard auto-column table envelope using source row count as scanned.
+    /// </summary>
+    protected static string BuildAutoTableResponse<TModel, TRow>(
+        JsonObject? arguments,
+        TModel model,
+        IReadOnlyList<TRow> sourceRows,
+        string viewRowsPath,
+        string title,
+        bool baseTruncated,
+        int maxTop,
+        Action<JsonObject>? metaMutate = null) {
+        return BuildAutoTableResponse(
+            arguments: arguments,
+            model: model,
+            sourceRows: sourceRows,
+            viewRowsPath: viewRowsPath,
+            title: title,
+            baseTruncated: baseTruncated,
+            scanned: sourceRows.Count,
+            maxTop: maxTop,
+            metaMutate: metaMutate);
+    }
+
+    /// <summary>
     /// Tool-specific implementation.
     /// </summary>
     /// <remarks>
@@ -31,4 +89,3 @@ public abstract class ToolBase : ITool {
     /// </remarks>
     protected abstract Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken);
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPackRegistry.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPackRegistry.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using IntelligenceX.Tools;
+
+namespace IntelligenceX.Tools.Common;
+
+/// <summary>
+/// Shared helpers for pack-level tool registration and catalog projection.
+/// </summary>
+public static class ToolPackRegistry {
+    /// <summary>
+    /// Returns tool names for tools created by the provided factory.
+    /// </summary>
+    public static IReadOnlyList<string> GetRegisteredToolNames<TOptions>(
+        TOptions options,
+        Func<TOptions, IEnumerable<ITool>> createTools,
+        string optionsParamName = "options")
+        where TOptions : class {
+        ArgumentNullException.ThrowIfNull(options, optionsParamName);
+        ArgumentNullException.ThrowIfNull(createTools);
+
+        return createTools(options).Select(static tool => tool.Definition.Name).ToArray();
+    }
+
+    /// <summary>
+    /// Returns tool-catalog entries for tools created by the provided factory.
+    /// </summary>
+    public static IReadOnlyList<ToolPackToolCatalogEntryModel> GetRegisteredToolCatalog<TOptions>(
+        TOptions options,
+        Func<TOptions, IEnumerable<ITool>> createTools,
+        string optionsParamName = "options")
+        where TOptions : class {
+        ArgumentNullException.ThrowIfNull(options, optionsParamName);
+        ArgumentNullException.ThrowIfNull(createTools);
+
+        return ToolPackGuidance.CatalogFromTools(createTools(options));
+    }
+
+    /// <summary>
+    /// Registers all tools produced by the provided factory into the target registry.
+    /// </summary>
+    public static ToolRegistry RegisterPack<TOptions>(
+        ToolRegistry registry,
+        TOptions options,
+        Func<TOptions, IEnumerable<ITool>> createTools,
+        string optionsParamName = "options")
+        where TOptions : class {
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(options, optionsParamName);
+        ArgumentNullException.ThrowIfNull(createTools);
+
+        foreach (var tool in createTools(options)) {
+            registry.Register(tool);
+        }
+
+        return registry;
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Email/ToolRegistryEmailExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Email/ToolRegistryEmailExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
 
@@ -16,11 +14,7 @@ public static class ToolRegistryEmailExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Ordered tool names for the pack.</returns>
     public static IReadOnlyList<string> GetRegisteredToolNames(EmailToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return CreateTools(options).Select(static tool => tool.Definition.Name).ToArray();
+        return ToolPackRegistry.GetRegisteredToolNames(options, CreateTools);
     }
 
     /// <summary>
@@ -29,11 +23,7 @@ public static class ToolRegistryEmailExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Catalog entries derived from runtime definitions and input schemas.</returns>
     public static IReadOnlyList<ToolPackToolCatalogEntryModel> GetRegisteredToolCatalog(EmailToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return ToolPackGuidance.CatalogFromTools(CreateTools(options));
+        return ToolPackRegistry.GetRegisteredToolCatalog(options, CreateTools);
     }
 
     /// <summary>
@@ -43,17 +33,7 @@ public static class ToolRegistryEmailExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>The same registry instance for chaining.</returns>
     public static ToolRegistry RegisterEmailPack(this ToolRegistry registry, EmailToolOptions options) {
-        if (registry is null) {
-            throw new ArgumentNullException(nameof(registry));
-        }
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        foreach (var tool in CreateTools(options)) {
-            registry.Register(tool);
-        }
-        return registry;
+        return ToolPackRegistry.RegisterPack(registry, options, CreateTools);
     }
 
     private static IEnumerable<ITool> CreateTools(EmailToolOptions options) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEvtxFindTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEvtxFindTool.cs
@@ -87,7 +87,7 @@ public sealed class EventLogEvtxFindTool : EventLogToolBase, ITool {
 
         var query = (arguments?.GetString("query") ?? string.Empty).Trim();
         var logHint = (arguments?.GetString("log_name") ?? string.Empty).Trim();
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", MaxDefaultResults, 1, MaxMaxResults);
+        var maxResults = ResolveMaxResults(arguments, MaxDefaultResults, maxInclusive: MaxMaxResults);
         var maxDepth = Options.EvtxFindMaxDepth;
         var maxDirsScanned = Options.EvtxFindMaxDirsScanned;
         var maxFilesScanned = Options.EvtxFindMaxFilesScanned;

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEvtxQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEvtxQueryTool.cs
@@ -60,7 +60,7 @@ public sealed class EventLogEvtxQueryTool : EventLogToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", timeErr ?? "Invalid time range."));
         }
 
-        var maxEvents = ToolArgs.GetCappedInt32(arguments, "max_events", Options.MaxResults, 1, Options.MaxResults);
+        var maxEvents = ResolveBoundedOptionLimit(arguments, "max_events");
 
         var eventIds = ToolArgs.TryReadPositiveInt32Array(arguments?.GetArray("event_ids"), "event_ids", out var eventIdsError);
         if (!string.IsNullOrWhiteSpace(eventIdsError)) {
@@ -87,16 +87,15 @@ public sealed class EventLogEvtxQueryTool : EventLogToolBase, ITool {
             return Task.FromResult(ErrorFromEvtxFailure(failure));
         }
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: root,
             sourceRows: root.Events,
             viewRowsPath: "events_view",
             title: "Events (preview)",
-            maxTop: MaxViewTop,
             baseTruncated: root.Truncated,
-            response: out var response);
+            scanned: root.Events.Count,
+            maxTop: MaxViewTop);
         return Task.FromResult(response);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEvtxSecurityReportHelper.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEvtxSecurityReportHelper.cs
@@ -45,7 +45,7 @@ internal static class EventLogEvtxSecurityReportHelper {
             : ToolJson.ToJsonObjectSnakeCase(model);
         output.Add("ad_correlation", ToolJson.ToJsonObjectSnakeCase(adCorrelation));
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        return ToolQueryHelpers.BuildAutoTableResponse(
             arguments: arguments,
             model: output,
             sourceRows: byTargetUser ?? Array.Empty<ReportTopRow>(),
@@ -53,12 +53,10 @@ internal static class EventLogEvtxSecurityReportHelper {
             title: title,
             maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: scannedEvents,
             metaMutate: meta => meta
                 .Add("matched_events", matchedEvents)
                 .Add("max_events_scanned", maxEventsScanned));
-        return response;
     }
 
     private static object BuildAdCorrelationHints(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEvtxStatsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEvtxStatsTool.cs
@@ -94,18 +94,16 @@ public sealed class EventLogEvtxStatsTool : EventLogToolBase, ITool {
             return Task.FromResult(ErrorFromEvtxFailure(failure));
         }
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.TopEventIds,
             viewRowsPath: "top_event_ids_view",
             title: "Top Event IDs (preview)",
-            maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.ScannedEvents,
+            maxTop: MaxViewTop,
             metaMutate: meta => meta.Add("max_events_scanned", result.MaxEventsScanned));
         return Task.FromResult(response);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogLiveQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogLiveQueryTool.cs
@@ -14,8 +14,6 @@ namespace IntelligenceX.Tools.EventLog;
 /// </summary>
 public sealed class EventLogLiveQueryTool : EventLogToolBase, ITool {
     private const int MaxViewTop = 5000;
-    private const int MinSessionTimeoutMs = 250;
-    private const int MaxSessionTimeoutMs = 300_000;
 
     private static readonly ToolDefinition DefinitionValue = new(
         "eventlog_live_query",
@@ -53,20 +51,14 @@ public sealed class EventLogLiveQueryTool : EventLogToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", "log_name is required."));
         }
 
-        var xpath = arguments?.GetString("xpath");
-        if (string.IsNullOrWhiteSpace(xpath)) {
-            xpath = "*";
-        }
+        var xpath = ResolveXPathOrDefault(arguments);
 
         var oldestFirst = arguments?.GetBoolean("oldest_first") ?? false;
         var includeMessage = arguments?.GetBoolean("include_message") ?? false;
         var machineName = ToolArgs.GetOptionalTrimmed(arguments, "machine_name");
-        var sessionTimeoutMs = ToolArgs.ToPositiveInt32OrNull(arguments?.GetInt64("session_timeout_ms"), maxInclusive: MaxSessionTimeoutMs);
-        if (sessionTimeoutMs.HasValue && sessionTimeoutMs.Value < MinSessionTimeoutMs) {
-            sessionTimeoutMs = MinSessionTimeoutMs;
-        }
+        var sessionTimeoutMs = ResolveSessionTimeoutMs(arguments, minInclusive: MinSessionTimeoutMs, maxInclusive: MaxSessionTimeoutMs);
 
-        var maxEvents = ToolArgs.GetCappedInt32(arguments, "max_events", Options.MaxResults, 1, Options.MaxResults);
+        var maxEvents = ResolveBoundedOptionLimit(arguments, "max_events");
 
         if (!LiveEventQueryExecutor.TryRead(
                 request: new LiveEventQueryRequest {
@@ -85,15 +77,15 @@ public sealed class EventLogLiveQueryTool : EventLogToolBase, ITool {
             return Task.FromResult(ErrorFromLiveQueryFailure(failure));
         }
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: root,
             sourceRows: root.Events,
             viewRowsPath: "events_view",
             title: "Live events (preview)",
-            maxTop: MaxViewTop,
             baseTruncated: root.Truncated,
-            response: out var response);
+            scanned: root.Events.Count,
+            maxTop: MaxViewTop);
         return Task.FromResult(response);
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogLiveStatsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogLiveStatsTool.cs
@@ -17,8 +17,6 @@ public sealed class EventLogLiveStatsTool : EventLogToolBase, ITool {
     private const int MaxTop = 50;
     private const int MaxScanCap = 5000;
     private const int MaxViewTop = 5000;
-    private const int MinSessionTimeoutMs = 250;
-    private const int MaxSessionTimeoutMs = 300_000;
 
     private static readonly ToolDefinition DefinitionValue = new(
         "eventlog_live_stats",
@@ -57,17 +55,11 @@ public sealed class EventLogLiveStatsTool : EventLogToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", "log_name is required."));
         }
 
-        var xpath = arguments?.GetString("xpath");
-        if (string.IsNullOrWhiteSpace(xpath)) {
-            xpath = "*";
-        }
+        var xpath = ResolveXPathOrDefault(arguments);
 
         var oldestFirst = arguments?.GetBoolean("oldest_first") ?? false;
         var machineName = ToolArgs.GetOptionalTrimmed(arguments, "machine_name");
-        var sessionTimeoutMs = ToolArgs.ToPositiveInt32OrNull(arguments?.GetInt64("session_timeout_ms"), maxInclusive: MaxSessionTimeoutMs);
-        if (sessionTimeoutMs.HasValue && sessionTimeoutMs.Value < MinSessionTimeoutMs) {
-            sessionTimeoutMs = MinSessionTimeoutMs;
-        }
+        var sessionTimeoutMs = ResolveSessionTimeoutMs(arguments, minInclusive: MinSessionTimeoutMs, maxInclusive: MaxSessionTimeoutMs);
 
         if (!ToolTime.TryParseUtcRange(arguments, "start_time_utc", "end_time_utc", out var startUtc, out var endUtc, out var timeErr)) {
             return Task.FromResult(ToolResponse.Error("invalid_argument", timeErr ?? "Invalid time range."));
@@ -103,16 +95,15 @@ public sealed class EventLogLiveStatsTool : EventLogToolBase, ITool {
             return Task.FromResult(ErrorFromLiveStatsFailure(failure));
         }
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.TopEventIds,
             viewRowsPath: "top_event_ids_view",
             title: "Live stats: top Event IDs (preview)",
-            maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.ScannedEvents,
+            maxTop: MaxViewTop,
             metaMutate: meta => meta
                 .Add("matched_events", result.MatchedEvents)
                 .Add("max_events_scanned", result.MaxEventsScanned));

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsCatalogTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsCatalogTool.cs
@@ -64,7 +64,7 @@ public sealed class EventLogNamedEventsCatalogTool : EventLogToolBase, ITool {
         var availableOnly = ToolArgs.GetBoolean(arguments, "available_only");
         var includeEventIds = arguments?.GetBoolean("include_event_ids") ?? true;
         var maxEventIdsPerRow = ToolArgs.GetCappedInt32(arguments, "max_event_ids_per_row", 32, 1, MaxEventIdsPerRowCap);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveMaxResults(arguments);
 
         var categoriesFilter = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("categories"));
         List<string>? categories = null;
@@ -114,20 +114,19 @@ public sealed class EventLogNamedEventsCatalogTool : EventLogToolBase, ITool {
             MaxEventIdsPerRow: maxEventIdsPerRow,
             Items: selectedRows);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: selectedRows,
             viewRowsPath: "items_view",
             title: "Named events catalog (preview)",
-            maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: selectedRows.Count,
+            maxTop: MaxViewTop,
             metaMutate: meta => {
                 meta.Add("total", all.Count);
                 meta.Add("matched", matchedRows.Count);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 meta.Add("available_only", availableOnly);
                 meta.Add("include_event_ids", includeEventIds);
                 if (includeEventIds) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryTool.cs
@@ -159,7 +159,7 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
         }
         var eventIdSet = eventIds is null ? null : new HashSet<int>(eventIds);
 
-        var maxEvents = ToolArgs.GetCappedInt32(arguments, "max_events", Options.MaxResults, 1, Options.MaxResults);
+        var maxEvents = ResolveBoundedOptionLimit(arguments, "max_events");
         var maxThreads = ToolArgs.GetCappedInt32(arguments, "max_threads", 4, 1, MaxThreadsCap);
         var maxEventsPerNamedEvent = ToolArgs.ToPositiveInt32OrNull(arguments?.GetInt64("max_events_per_named_event"), maxEvents);
         var includePayload = arguments?.GetBoolean("include_payload") ?? true;
@@ -219,10 +219,11 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
             }
         } catch (ArgumentException ex) {
             return ToolResponse.Error("invalid_argument", ex.Message);
-        } catch (InvalidOperationException ex) {
-            return ToolResponse.Error("query_failed", ex.Message);
         } catch (Exception ex) {
-            return ToolResponse.Error("query_failed", $"Named events query failed: {ex.Message}");
+            return ErrorFromException(
+                ex,
+                defaultMessage: "Named events query failed.",
+                invalidOperationErrorCode: "query_failed");
         }
 
         var result = new NamedEventsQueryResult(
@@ -235,16 +236,15 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
             Truncated: truncated,
             Events: rows);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: rows,
             viewRowsPath: "events_view",
             title: "Named events (preview)",
-            maxTop: MaxViewTop,
             baseTruncated: truncated,
-            response: out var response,
             scanned: rows.Count,
+            maxTop: MaxViewTop,
             metaMutate: meta => {
                 meta.Add("requested_named_events_count", namedEvents.Count);
                 meta.Add("max_events", maxEvents);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogToolBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using EventViewerX.Reports.Inventory;
 using EventViewerX.Reports.Evtx;
@@ -13,6 +14,21 @@ namespace IntelligenceX.Tools.EventLog;
 /// Base class for event log tools with safe-by-default path resolution.
 /// </summary>
 public abstract class EventLogToolBase : ToolBase {
+    /// <summary>
+    /// Shared default remote session timeout in milliseconds.
+    /// </summary>
+    protected const int DefaultRemoteSessionTimeoutMs = 30_000;
+
+    /// <summary>
+    /// Shared minimum session timeout in milliseconds.
+    /// </summary>
+    protected const int MinSessionTimeoutMs = 250;
+
+    /// <summary>
+    /// Shared maximum session timeout in milliseconds.
+    /// </summary>
+    protected const int MaxSessionTimeoutMs = 300_000;
+
     /// <summary>
     /// Shared options for event log tools.
     /// </summary>
@@ -91,6 +107,73 @@ public abstract class EventLogToolBase : ToolBase {
     }
 
     /// <summary>
+    /// Maps common runtime exceptions to stable event-log tool error envelopes.
+    /// </summary>
+    protected static string ErrorFromException(
+        Exception exception,
+        string defaultMessage = "Event log query failed.",
+        string fallbackErrorCode = "query_failed",
+        string invalidOperationErrorCode = "query_failed") {
+        return ToolExceptionMapper.ErrorFromException(
+            exception,
+            defaultMessage: string.IsNullOrWhiteSpace(defaultMessage) ? "Event log query failed." : defaultMessage,
+            unauthorizedMessage: "Access denied while querying event log data.",
+            timeoutMessage: "Event log query timed out.",
+            fallbackErrorCode: fallbackErrorCode,
+            invalidOperationErrorCode: invalidOperationErrorCode);
+    }
+
+    /// <summary>
+    /// Resolves a standard option-bounded limit argument (default + cap from <see cref="EventLogToolOptions.MaxResults"/>).
+    /// </summary>
+    protected int ResolveBoundedOptionLimit(JsonObject? arguments, string argumentName, int minInclusive = 1) {
+        return ToolArgs.GetOptionBoundedInt32(arguments, argumentName, Options.MaxResults, minInclusive);
+    }
+
+    /// <summary>
+    /// Resolves max_results with optional explicit defaults/caps.
+    /// </summary>
+    protected int ResolveMaxResults(JsonObject? arguments, int? defaultValue = null, int minInclusive = 1, int? maxInclusive = null) {
+        var normalizedDefault = defaultValue ?? Options.MaxResults;
+        var normalizedMax = maxInclusive ?? Options.MaxResults;
+        return ToolArgs.GetCappedInt32(arguments, "max_results", normalizedDefault, minInclusive, normalizedMax);
+    }
+
+    /// <summary>
+    /// Resolves optional session timeout values with shared positive/min/max clamping.
+    /// </summary>
+    protected static int? ResolveSessionTimeoutMs(long? timeoutRaw, int minInclusive = 250, int maxInclusive = 300_000) {
+        var sessionTimeoutMs = ToolArgs.ToPositiveInt32OrNull(timeoutRaw, maxInclusive: maxInclusive);
+        if (sessionTimeoutMs.HasValue && sessionTimeoutMs.Value < minInclusive) {
+            return minInclusive;
+        }
+
+        return sessionTimeoutMs;
+    }
+
+    /// <summary>
+    /// Resolves optional session timeout values from tool arguments with shared clamping.
+    /// </summary>
+    protected static int? ResolveSessionTimeoutMs(
+        JsonObject? arguments,
+        string argumentName = "session_timeout_ms",
+        int minInclusive = 250,
+        int maxInclusive = 300_000) {
+        return ResolveSessionTimeoutMs(arguments?.GetInt64(argumentName), minInclusive, maxInclusive);
+    }
+
+    /// <summary>
+    /// Resolves an optional XPath argument, defaulting to <c>*</c> when missing/blank.
+    /// </summary>
+    protected static string ResolveXPathOrDefault(
+        JsonObject? arguments,
+        string argumentName = "xpath",
+        string defaultXPath = "*") {
+        var xpath = arguments?.GetString(argumentName);
+        return string.IsNullOrWhiteSpace(xpath) ? defaultXPath : xpath;
+    }
+
+    /// <summary>
     /// Shared catalog listing flow for channel/provider list tools.
     /// </summary>
     protected string RunCatalogNameList(
@@ -105,7 +188,7 @@ public abstract class EventLogToolBase : ToolBase {
         cancellationToken.ThrowIfCancellationRequested();
 
         var nameContains = arguments?.GetString("name_contains");
-        var max = ToolArgs.GetCappedInt32(arguments, maxArgumentName, Options.MaxResults, 1, Options.MaxResults);
+        var max = ResolveBoundedOptionLimit(arguments, maxArgumentName);
 
         var machineNameNormalized = (arguments?.GetString("machine_name") ?? string.Empty).Trim();
         string? machineName = machineNameNormalized.Length == 0 ? null : machineNameNormalized;
@@ -113,15 +196,7 @@ public abstract class EventLogToolBase : ToolBase {
             machineName = machineName.Substring(0, 260);
         }
 
-        int? sessionTimeoutMs = null;
-        var timeoutRaw = arguments?.GetInt64("session_timeout_ms");
-        if (timeoutRaw.HasValue) {
-            var normalizedLong = Math.Clamp(timeoutRaw.Value, (long)int.MinValue, (long)int.MaxValue);
-            var normalized = (int)normalizedLong;
-            if (normalized > 0) {
-                sessionTimeoutMs = Math.Clamp(normalized, 1000, 600_000);
-            }
-        }
+        var sessionTimeoutMs = ResolveSessionTimeoutMs(arguments, minInclusive: 1000, maxInclusive: 600_000);
 
         var request = new EventCatalogQueryRequest {
             NameContains = nameContains,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogTopEventsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogTopEventsTool.cs
@@ -18,10 +18,6 @@ public sealed class EventLogTopEventsTool : EventLogToolBase, ITool {
     private const int MaxLogNameLength = 260;
     private static readonly SemaphoreSlim RemoteReadGate = new(initialCount: 4, maxCount: 4);
 
-    private const int DefaultRemoteSessionTimeoutMs = 30_000;
-    private const int MinSessionTimeoutMs = 250;
-    private const int MaxSessionTimeoutMs = 300_000;
-
     private static readonly ToolDefinition DefinitionValue = new(
         "eventlog_top_events",
         "Return the most recent N events from a Windows Event Log (local or remote machine). Designed for quick triage (example: \"top 5 events from AD0 System\").",
@@ -123,10 +119,10 @@ public sealed class EventLogTopEventsTool : EventLogToolBase, ITool {
             }
         }
 
-        var sessionTimeoutMs = ToolArgs.ToPositiveInt32OrNull(sessionTimeoutRaw, maxInclusive: MaxSessionTimeoutMs);
-        if (sessionTimeoutMs.HasValue && sessionTimeoutMs.Value < MinSessionTimeoutMs) {
-            sessionTimeoutMs = MinSessionTimeoutMs;
-        }
+        var sessionTimeoutMs = ResolveSessionTimeoutMs(
+            timeoutRaw: sessionTimeoutRaw,
+            minInclusive: MinSessionTimeoutMs,
+            maxInclusive: MaxSessionTimeoutMs);
 
         if (machineName is not null && !sessionTimeoutMs.HasValue) {
             sessionTimeoutMs = DefaultRemoteSessionTimeoutMs;
@@ -189,17 +185,15 @@ public sealed class EventLogTopEventsTool : EventLogToolBase, ITool {
             return ErrorFromLiveQueryFailure(failure);
         }
 
-        if (!ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: root!,
             sourceRows: root!.Events,
             viewRowsPath: "events_view",
             title: $"Top {maxEvents} recent events (preview)",
-            maxTop: MaxViewTop,
             baseTruncated: root!.Truncated,
-            response: out var response)) {
-            return response;
-        }
+            scanned: root.Events.Count,
+            maxTop: MaxViewTop);
         return response;
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/ToolRegistryEventLogExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/ToolRegistryEventLogExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
 
@@ -16,11 +14,7 @@ public static class ToolRegistryEventLogExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Ordered tool names for the pack.</returns>
     public static IReadOnlyList<string> GetRegisteredToolNames(EventLogToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return CreateTools(options).Select(static tool => tool.Definition.Name).ToArray();
+        return ToolPackRegistry.GetRegisteredToolNames(options, CreateTools);
     }
 
     /// <summary>
@@ -29,11 +23,7 @@ public static class ToolRegistryEventLogExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Catalog entries derived from runtime definitions and input schemas.</returns>
     public static IReadOnlyList<ToolPackToolCatalogEntryModel> GetRegisteredToolCatalog(EventLogToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return ToolPackGuidance.CatalogFromTools(CreateTools(options));
+        return ToolPackRegistry.GetRegisteredToolCatalog(options, CreateTools);
     }
 
     /// <summary>
@@ -43,17 +33,7 @@ public static class ToolRegistryEventLogExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>The same registry instance for chaining.</returns>
     public static ToolRegistry RegisterEventLogPack(this ToolRegistry registry, EventLogToolOptions options) {
-        if (registry is null) {
-            throw new ArgumentNullException(nameof(registry));
-        }
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        foreach (var tool in CreateTools(options)) {
-            registry.Register(tool);
-        }
-        return registry;
+        return ToolPackRegistry.RegisterPack(registry, options, CreateTools);
     }
 
     private static IEnumerable<ITool> CreateTools(EventLogToolOptions options) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.FileSystem/FileSystemToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.FileSystem/FileSystemToolBase.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using IntelligenceX.Json;
 using IntelligenceX.Tools.Common;
 
 namespace IntelligenceX.Tools.FileSystem;
@@ -103,4 +105,12 @@ public abstract class FileSystemToolBase : ToolBase {
     private static string ToPathError(string errorCode, string error, string[]? hints) {
         return ToolResponse.Error(errorCode, error, hints: hints, isTransient: false);
     }
+
+    /// <summary>
+    /// Resolves a standard option-bounded limit argument (default + cap from <see cref="FileSystemToolOptions.MaxResults"/>).
+    /// </summary>
+    protected int ResolveBoundedOptionLimit(JsonObject? arguments, string argumentName, int minInclusive = 1) {
+        return ToolArgs.GetOptionBoundedInt32(arguments, argumentName, Options.MaxResults, minInclusive);
+    }
+
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.FileSystem/FsListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.FileSystem/FsListTool.cs
@@ -65,15 +65,14 @@ public sealed class FsListTool : FileSystemToolBase, ITool {
             canDescendOrIncludePath: candidate => TryResolvePath(candidate, out _, out _),
             cancellationToken: cancellationToken);
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: root,
             sourceRows: root.Entries,
             viewRowsPath: "entries_view",
             title: "Directory entries (preview)",
             maxTop: MaxViewTop,
-            baseTruncated: root.Truncated,
-            response: out var response);
+            baseTruncated: root.Truncated);
         return Task.FromResult(response);
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.FileSystem/FsSearchTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.FileSystem/FsSearchTool.cs
@@ -56,7 +56,7 @@ public sealed class FsSearchTool : FileSystemToolBase, ITool {
         }
 
         var caseSensitive = arguments?.GetBoolean("case_sensitive") ?? false;
-        var maxMatches = ToolArgs.GetCappedInt32(arguments, "max_matches", Options.MaxResults, 1, Options.MaxResults);
+        var maxMatches = ResolveBoundedOptionLimit(arguments, "max_matches");
 
         FileTextSearchResult root;
         try {
@@ -74,15 +74,14 @@ public sealed class FsSearchTool : FileSystemToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", $"Invalid regex: {ex.Message}"));
         }
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: root,
             sourceRows: root.Matches,
             viewRowsPath: "matches_view",
             title: "Search matches (preview)",
             maxTop: MaxViewTop,
-            baseTruncated: root.Truncated,
-            response: out var response);
+            baseTruncated: root.Truncated);
         return Task.FromResult(response);
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.FileSystem/ToolRegistryFileSystemExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.FileSystem/ToolRegistryFileSystemExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
 
@@ -16,11 +14,7 @@ public static class ToolRegistryFileSystemExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Ordered tool names for the pack.</returns>
     public static IReadOnlyList<string> GetRegisteredToolNames(FileSystemToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return CreateTools(options).Select(static tool => tool.Definition.Name).ToArray();
+        return ToolPackRegistry.GetRegisteredToolNames(options, CreateTools);
     }
 
     /// <summary>
@@ -29,11 +23,7 @@ public static class ToolRegistryFileSystemExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Catalog entries derived from runtime definitions and input schemas.</returns>
     public static IReadOnlyList<ToolPackToolCatalogEntryModel> GetRegisteredToolCatalog(FileSystemToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return ToolPackGuidance.CatalogFromTools(CreateTools(options));
+        return ToolPackRegistry.GetRegisteredToolCatalog(options, CreateTools);
     }
 
     /// <summary>
@@ -43,17 +33,7 @@ public static class ToolRegistryFileSystemExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>The same registry instance for chaining.</returns>
     public static ToolRegistry RegisterFileSystemPack(this ToolRegistry registry, FileSystemToolOptions options) {
-        if (registry is null) {
-            throw new ArgumentNullException(nameof(registry));
-        }
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        foreach (var tool in CreateTools(options)) {
-            registry.Register(tool);
-        }
-        return registry;
+        return ToolPackRegistry.RegisterPack(registry, options, CreateTools);
     }
 
     private static IEnumerable<ITool> CreateTools(FileSystemToolOptions options) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/ToolRegistryOfficeImoExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/ToolRegistryOfficeImoExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
 
@@ -16,11 +14,7 @@ public static class ToolRegistryOfficeImoExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Ordered tool names for the pack.</returns>
     public static IReadOnlyList<string> GetRegisteredToolNames(OfficeImoToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return CreateTools(options).Select(static tool => tool.Definition.Name).ToArray();
+        return ToolPackRegistry.GetRegisteredToolNames(options, CreateTools);
     }
 
     /// <summary>
@@ -29,11 +23,7 @@ public static class ToolRegistryOfficeImoExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Catalog entries derived from runtime definitions and input schemas.</returns>
     public static IReadOnlyList<ToolPackToolCatalogEntryModel> GetRegisteredToolCatalog(OfficeImoToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return ToolPackGuidance.CatalogFromTools(CreateTools(options));
+        return ToolPackRegistry.GetRegisteredToolCatalog(options, CreateTools);
     }
 
     /// <summary>
@@ -43,17 +33,7 @@ public static class ToolRegistryOfficeImoExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>The same registry instance for chaining.</returns>
     public static ToolRegistry RegisterOfficeImoPack(this ToolRegistry registry, OfficeImoToolOptions options) {
-        if (registry is null) {
-            throw new ArgumentNullException(nameof(registry));
-        }
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        foreach (var tool in CreateTools(options)) {
-            registry.Register(tool);
-        }
-        return registry;
+        return ToolPackRegistry.RegisterPack(registry, options, CreateTools);
     }
 
     private static IEnumerable<ITool> CreateTools(OfficeImoToolOptions options) {
@@ -61,4 +41,3 @@ public static class ToolRegistryOfficeImoExtensions {
         yield return new OfficeImoReadTool(options);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/ToolRegistryPowerShellExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/ToolRegistryPowerShellExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
 
@@ -14,39 +12,21 @@ public static class ToolRegistryPowerShellExtensions {
     /// Returns the tool names registered by <see cref="RegisterPowerShellPack"/>.
     /// </summary>
     public static IReadOnlyList<string> GetRegisteredToolNames(PowerShellToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return CreateTools(options).Select(static tool => tool.Definition.Name).ToArray();
+        return ToolPackRegistry.GetRegisteredToolNames(options, CreateTools);
     }
 
     /// <summary>
     /// Returns tool catalog metadata for tools registered by <see cref="RegisterPowerShellPack"/>.
     /// </summary>
     public static IReadOnlyList<ToolPackToolCatalogEntryModel> GetRegisteredToolCatalog(PowerShellToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return ToolPackGuidance.CatalogFromTools(CreateTools(options));
+        return ToolPackRegistry.GetRegisteredToolCatalog(options, CreateTools);
     }
 
     /// <summary>
     /// Registers all IX.PowerShell tools into the provided registry.
     /// </summary>
     public static ToolRegistry RegisterPowerShellPack(this ToolRegistry registry, PowerShellToolOptions options) {
-        if (registry is null) {
-            throw new ArgumentNullException(nameof(registry));
-        }
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        foreach (var tool in CreateTools(options)) {
-            registry.Register(tool);
-        }
-        return registry;
+        return ToolPackRegistry.RegisterPack(registry, options, CreateTools);
     }
 
     private static IEnumerable<ITool> CreateTools(PowerShellToolOptions options) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ReviewerSetup/ToolRegistryReviewerSetupExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ReviewerSetup/ToolRegistryReviewerSetupExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
 
@@ -14,39 +12,21 @@ public static class ToolRegistryReviewerSetupExtensions {
     /// Returns the tool names registered by <see cref="RegisterReviewerSetupPack"/>.
     /// </summary>
     public static IReadOnlyList<string> GetRegisteredToolNames(ReviewerSetupToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return CreateTools(options).Select(static tool => tool.Definition.Name).ToArray();
+        return ToolPackRegistry.GetRegisteredToolNames(options, CreateTools);
     }
 
     /// <summary>
     /// Returns tool catalog metadata for tools registered by <see cref="RegisterReviewerSetupPack"/>.
     /// </summary>
     public static IReadOnlyList<ToolPackToolCatalogEntryModel> GetRegisteredToolCatalog(ReviewerSetupToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return ToolPackGuidance.CatalogFromTools(CreateTools(options));
+        return ToolPackRegistry.GetRegisteredToolCatalog(options, CreateTools);
     }
 
     /// <summary>
     /// Registers all reviewer setup tools into the provided registry.
     /// </summary>
     public static ToolRegistry RegisterReviewerSetupPack(this ToolRegistry registry, ReviewerSetupToolOptions options) {
-        if (registry is null) {
-            throw new ArgumentNullException(nameof(registry));
-        }
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        foreach (var tool in CreateTools(options)) {
-            registry.Register(tool);
-        }
-        return registry;
+        return ToolPackRegistry.RegisterPack(registry, options, CreateTools);
     }
 
     private static IEnumerable<ITool> CreateTools(ReviewerSetupToolOptions options) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemBiosSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemBiosSummaryTool.cs
@@ -40,14 +40,15 @@ public sealed class SystemBiosSummaryTool : SystemToolBase, ITool {
     protected override async Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!OperatingSystem.IsWindows()) {
-            return ToolResponse.Error("not_supported", "system_bios_summary is available only on Windows hosts.");
+        var windowsError = ValidateWindowsSupport("system_bios_summary");
+        if (windowsError is not null) {
+            return windowsError;
         }
 
         var computerName = ToolArgs.GetOptionalTrimmed(arguments, "computer_name");
         var includeBaseBoard = ToolArgs.GetBoolean(arguments, "include_baseboard", defaultValue: true);
-        var timeoutMs = ToolArgs.GetCappedInt32(arguments, "timeout_ms", 8000, 200, 120000);
-        var target = string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName!;
+        var timeoutMs = ResolveTimeoutMs(arguments, defaultValue: 8_000);
+        var target = ResolveTargetComputerName(computerName);
         var timeout = TimeSpan.FromMilliseconds(timeoutMs);
 
         try {
@@ -81,16 +82,19 @@ public sealed class SystemBiosSummaryTool : SystemToolBase, ITool {
                     ("BaseBoardManufacturer", baseBoard?.Manufacturer ?? string.Empty),
                     ("BaseBoardProduct", baseBoard?.Product ?? string.Empty)
                 },
-                meta: ToolOutputHints.Meta(count: 1, truncated: false)
-                    .Add("computer_name", target)
-                    .Add("include_baseboard", includeBaseBoard)
-                    .Add("timeout_ms", timeoutMs),
+                meta: BuildFactsMeta(
+                    count: 1,
+                    truncated: false,
+                    target: target,
+                    mutate: meta => meta
+                        .Add("include_baseboard", includeBaseBoard)
+                        .Add("timeout_ms", timeoutMs)),
                 keyHeader: "Field",
                 valueHeader: "Value",
                 truncated: false,
                 render: null);
         } catch (Exception ex) {
-            return ToolResponse.Error("query_failed", $"BIOS summary query failed: {ex.Message}");
+            return ErrorFromException(ex, defaultMessage: "BIOS summary query failed.");
         }
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemBitlockerStatusTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemBitlockerStatusTool.cs
@@ -47,15 +47,16 @@ public sealed class SystemBitlockerStatusTool : SystemToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!OperatingSystem.IsWindows()) {
-            return Task.FromResult(ToolResponse.Error("not_supported", "system_bitlocker_status is available only on Windows hosts."));
+        var windowsError = ValidateWindowsSupport("system_bitlocker_status");
+        if (windowsError is not null) {
+            return Task.FromResult(windowsError);
         }
 
         var computerName = ToolArgs.GetOptionalTrimmed(arguments, "computer_name");
-        var target = string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName!;
+        var target = ResolveTargetComputerName(computerName);
         var protectedOnly = ToolArgs.GetBoolean(arguments, "protected_only", defaultValue: false);
         var encryptedOnly = ToolArgs.GetBoolean(arguments, "encrypted_only", defaultValue: false);
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveMaxResults(arguments);
 
         IEnumerable<BitLockerVolumeInfo> query;
         try {
@@ -89,10 +90,10 @@ public sealed class SystemBitlockerStatusTool : SystemToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("computer_name", target);
+                AddComputerNameMeta(meta, target);
                 meta.Add("protected_only", protectedOnly);
                 meta.Add("encrypted_only", encryptedOnly);
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
             });
         return Task.FromResult(response);
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemBootConfigurationTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemBootConfigurationTool.cs
@@ -40,13 +40,14 @@ public sealed class SystemBootConfigurationTool : SystemToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!OperatingSystem.IsWindows()) {
-            return Task.FromResult(ToolResponse.Error("not_supported", "system_boot_configuration is available only on Windows hosts."));
+        var windowsError = ValidateWindowsSupport("system_boot_configuration");
+        if (windowsError is not null) {
+            return Task.FromResult(windowsError);
         }
 
         var computerName = ToolArgs.GetOptionalTrimmed(arguments, "computer_name");
         var includeRebootPending = ToolArgs.GetBoolean(arguments, "include_reboot_pending", defaultValue: true);
-        var target = string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName!;
+        var target = ResolveTargetComputerName(computerName);
 
         try {
             var boot = BootOptionsQuery.Query(computerName);
@@ -82,15 +83,17 @@ public sealed class SystemBootConfigurationTool : SystemToolBase, ITool {
                     ("RebootPending", rebootPending?.ToString() ?? string.Empty),
                     ("Warnings", warnings.Count.ToString())
                 },
-                meta: ToolOutputHints.Meta(count: warnings.Count, truncated: false)
-                    .Add("computer_name", target)
-                    .Add("include_reboot_pending", includeRebootPending),
+                meta: BuildFactsMeta(
+                    count: warnings.Count,
+                    truncated: false,
+                    target: target,
+                    mutate: meta => meta.Add("include_reboot_pending", includeRebootPending)),
                 keyHeader: "Field",
                 valueHeader: "Value",
                 truncated: false,
                 render: null));
         } catch (Exception ex) {
-            return Task.FromResult(ToolResponse.Error("query_failed", $"Boot configuration query failed: {ex.Message}"));
+            return Task.FromResult(ErrorFromException(ex, defaultMessage: "Boot configuration query failed."));
         }
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemDevicesSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemDevicesSummaryTool.cs
@@ -54,8 +54,8 @@ public sealed class SystemDevicesSummaryTool : SystemToolBase, ITool {
         var manufacturerContains = ToolArgs.GetOptionalTrimmed(arguments, "manufacturer_contains");
         var statusContains = ToolArgs.GetOptionalTrimmed(arguments, "status_contains");
         var problemOnly = arguments?.GetBoolean("problem_only", defaultValue: false) ?? false;
-        var max = ToolArgs.GetCappedInt32(arguments, "max_entries", Options.MaxResults, 1, Options.MaxResults);
-        var timeoutMs = ToolArgs.GetCappedInt32(arguments, "timeout_ms", 10_000, 200, 120_000);
+        var max = ResolveBoundedOptionLimit(arguments, "max_entries");
+        var timeoutMs = ResolveTimeoutMs(arguments);
 
         if (!DeviceInventoryQueryExecutor.TryExecute(
                 request: new DeviceInventoryQueryRequest {
@@ -76,7 +76,7 @@ public sealed class SystemDevicesSummaryTool : SystemToolBase, ITool {
         }
 
         var result = queryResult ?? new DeviceInventoryQueryResult();
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Devices,
@@ -84,7 +84,6 @@ public sealed class SystemDevicesSummaryTool : SystemToolBase, ITool {
             title: "Devices (preview)",
             maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.Scanned,
             metaMutate: meta => {
                 meta.Add("include_usb", includeUsb);
@@ -108,5 +107,3 @@ public sealed class SystemDevicesSummaryTool : SystemToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemDisksListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemDisksListTool.cs
@@ -42,7 +42,7 @@ public sealed class SystemDisksListTool : SystemToolBase, ITool {
         var modelContains = ToolArgs.GetOptionalTrimmed(arguments, "model_contains");
         var interfaceContains = ToolArgs.GetOptionalTrimmed(arguments, "interface_contains");
         var mediaContains = ToolArgs.GetOptionalTrimmed(arguments, "media_contains");
-        var max = ToolArgs.GetCappedInt32(arguments, "max_entries", Options.MaxResults, 1, Options.MaxResults);
+        var max = ResolveBoundedOptionLimit(arguments, "max_entries");
 
         var minSizeArg = arguments?.GetInt64("min_size_bytes");
         long? minSize = null;
@@ -68,7 +68,7 @@ public sealed class SystemDisksListTool : SystemToolBase, ITool {
         }
 
         var result = queryResult ?? new DiskInventoryQueryResult();
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Disks,
@@ -76,7 +76,6 @@ public sealed class SystemDisksListTool : SystemToolBase, ITool {
             title: "Physical disks (preview)",
             maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.Scanned,
             metaMutate: meta => {
                 if (!string.IsNullOrWhiteSpace(modelContains)) {
@@ -95,5 +94,4 @@ public sealed class SystemDisksListTool : SystemToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemFeaturesListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemFeaturesListTool.cs
@@ -94,8 +94,8 @@ public sealed class SystemFeaturesListTool : SystemToolBase, ITool {
             }
         }
 
-        var max = ToolArgs.GetCappedInt32(arguments, "max_entries", Options.MaxResults, 1, Options.MaxResults);
-        var timeoutMs = ToolArgs.GetCappedInt32(arguments, "timeout_ms", 10_000, 200, 120_000);
+        var max = ResolveBoundedOptionLimit(arguments, "max_entries");
+        var timeoutMs = ResolveTimeoutMs(arguments);
 
         if (!FeatureInventoryQueryExecutor.TryExecute(
                 request: new FeatureInventoryQueryRequest {
@@ -112,7 +112,7 @@ public sealed class SystemFeaturesListTool : SystemToolBase, ITool {
         }
 
         var result = queryResult ?? new FeatureInventoryQueryResult { Source = source };
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Features,
@@ -120,7 +120,6 @@ public sealed class SystemFeaturesListTool : SystemToolBase, ITool {
             title: "Features (preview)",
             maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.Scanned,
             metaMutate: meta => {
                 meta.Add("source", ToolEnumBinders.ToName(source, SourceNames));
@@ -135,5 +134,3 @@ public sealed class SystemFeaturesListTool : SystemToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemFirewallProfilesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemFirewallProfilesTool.cs
@@ -62,7 +62,7 @@ public sealed class SystemFirewallProfilesTool : SystemToolBase, ITool {
         }
 
         var enabled = arguments?.GetBoolean("enabled");
-        var max = ToolArgs.GetCappedInt32(arguments, "max_entries", Options.MaxResults, 1, Options.MaxResults);
+        var max = ResolveBoundedOptionLimit(arguments, "max_entries");
 
         if (!FirewallProfileListQueryExecutor.TryExecute(
                 request: new FirewallProfileListQueryRequest {
@@ -77,7 +77,7 @@ public sealed class SystemFirewallProfilesTool : SystemToolBase, ITool {
         }
 
         var result = queryResult ?? new FirewallProfileListQueryResult();
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Profiles,
@@ -85,7 +85,6 @@ public sealed class SystemFirewallProfilesTool : SystemToolBase, ITool {
             title: "Firewall profiles (preview)",
             maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.Scanned,
             metaMutate: meta => {
                 if (profile.HasValue) {
@@ -103,5 +102,4 @@ public sealed class SystemFirewallProfilesTool : SystemToolBase, ITool {
     }
 
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemFirewallRulesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemFirewallRulesTool.cs
@@ -96,7 +96,7 @@ public sealed class SystemFirewallRulesTool : SystemToolBase, ITool {
 
         var nameContains = ToolArgs.GetOptionalTrimmed(arguments, "name_contains");
         var applicationContains = ToolArgs.GetOptionalTrimmed(arguments, "application_contains");
-        var max = ToolArgs.GetCappedInt32(arguments, "max_entries", Options.MaxResults, 1, Options.MaxResults);
+        var max = ResolveBoundedOptionLimit(arguments, "max_entries");
 
         if (!ToolEnumBinders.TryParseOptional(
                 ToolArgs.GetOptionalTrimmed(arguments, "direction"),
@@ -148,7 +148,7 @@ public sealed class SystemFirewallRulesTool : SystemToolBase, ITool {
         }
 
         var result = queryResult ?? new FirewallRuleListQueryResult();
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Rules,
@@ -156,7 +156,6 @@ public sealed class SystemFirewallRulesTool : SystemToolBase, ITool {
             title: "Firewall rules (preview)",
             maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.Scanned,
             metaMutate: meta => {
                 if (!string.IsNullOrWhiteSpace(nameContains)) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemHardwareSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemHardwareSummaryTool.cs
@@ -44,7 +44,7 @@ public sealed class SystemHardwareSummaryTool : SystemToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", "At least one include_* section must be true."));
         }
 
-        var timeoutMs = ToolArgs.GetCappedInt32(arguments, "timeout_ms", 10_000, 200, 120_000);
+        var timeoutMs = ResolveTimeoutMs(arguments);
         var nameSampleArg = arguments?.GetInt64("name_sample_size");
         int? nameSampleSize = null;
         if (nameSampleArg.HasValue) {
@@ -100,4 +100,3 @@ public sealed class SystemHardwareSummaryTool : SystemToolBase, ITool {
             render: null));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemInstalledApplicationsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemInstalledApplicationsTool.cs
@@ -47,15 +47,16 @@ public sealed class SystemInstalledApplicationsTool : SystemToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!OperatingSystem.IsWindows()) {
-            return Task.FromResult(ToolResponse.Error("not_supported", "system_installed_applications is available only on Windows hosts."));
+        var windowsError = ValidateWindowsSupport("system_installed_applications");
+        if (windowsError is not null) {
+            return Task.FromResult(windowsError);
         }
 
         var computerName = ToolArgs.GetOptionalTrimmed(arguments, "computer_name");
-        var target = string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName!;
+        var target = ResolveTargetComputerName(computerName);
         var nameContains = ToolArgs.GetOptionalTrimmed(arguments, "name_contains");
         var publisherContains = ToolArgs.GetOptionalTrimmed(arguments, "publisher_contains");
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveMaxResults(arguments);
 
         IEnumerable<InstalledApplicationInfo> query;
         try {
@@ -91,8 +92,8 @@ public sealed class SystemInstalledApplicationsTool : SystemToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("computer_name", target);
-                meta.Add("max_results", maxResults);
+                AddComputerNameMeta(meta, target);
+                AddMaxResultsMeta(meta, maxResults);
                 if (!string.IsNullOrWhiteSpace(nameContains)) {
                     meta.Add("name_contains", nameContains);
                 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemLogicalDisksListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemLogicalDisksListTool.cs
@@ -65,7 +65,7 @@ public sealed class SystemLogicalDisksListTool : SystemToolBase, ITool {
 
         var nameContains = ToolArgs.GetOptionalTrimmed(arguments, "name_contains");
         var fileSystem = ToolArgs.GetOptionalTrimmed(arguments, "file_system");
-        var max = ToolArgs.GetCappedInt32(arguments, "max_entries", Options.MaxResults, 1, Options.MaxResults);
+        var max = ResolveBoundedOptionLimit(arguments, "max_entries");
 
         var minSizeArg = arguments?.GetInt64("min_size_bytes");
         long? minSize = null;
@@ -110,7 +110,7 @@ public sealed class SystemLogicalDisksListTool : SystemToolBase, ITool {
         }
 
         var result = queryResult ?? new LogicalDiskInventoryQueryResult();
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Disks,
@@ -118,7 +118,6 @@ public sealed class SystemLogicalDisksListTool : SystemToolBase, ITool {
             title: "Logical disks (preview)",
             maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.Scanned,
             metaMutate: meta => {
                 if (!string.IsNullOrWhiteSpace(nameContains)) {
@@ -140,5 +139,4 @@ public sealed class SystemLogicalDisksListTool : SystemToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemNetworkAdaptersTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemNetworkAdaptersTool.cs
@@ -38,8 +38,8 @@ public sealed class SystemNetworkAdaptersTool : SystemToolBase, ITool {
         cancellationToken.ThrowIfCancellationRequested();
 
         var nameContains = ToolArgs.GetOptionalTrimmed(arguments, "name_contains");
-        var max = ToolArgs.GetCappedInt32(arguments, "max_adapters", Options.MaxResults, 1, Options.MaxResults);
-        var timeoutMs = ToolArgs.GetCappedInt32(arguments, "timeout_ms", 10_000, 200, 120_000);
+        var max = ResolveBoundedOptionLimit(arguments, "max_adapters");
+        var timeoutMs = ResolveTimeoutMs(arguments);
 
         if (!NetworkAdapterInventoryQueryExecutor.TryExecute(
                 request: new NetworkAdapterInventoryQueryRequest {
@@ -54,7 +54,7 @@ public sealed class SystemNetworkAdaptersTool : SystemToolBase, ITool {
         }
 
         var result = queryResult ?? new NetworkAdapterInventoryQueryResult();
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Adapters,
@@ -62,7 +62,6 @@ public sealed class SystemNetworkAdaptersTool : SystemToolBase, ITool {
             title: "Network adapters (preview)",
             maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.Scanned,
             metaMutate: meta => {
                 meta.Add("timeout_ms", timeoutMs);
@@ -70,5 +69,3 @@ public sealed class SystemNetworkAdaptersTool : SystemToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchComplianceTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchComplianceTool.cs
@@ -96,12 +96,13 @@ public sealed class SystemPatchComplianceTool : SystemToolBase, ITool {
     protected override async Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!OperatingSystem.IsWindows()) {
-            return ToolResponse.Error("not_supported", "system_patch_compliance is available only on Windows hosts.");
+        var windowsError = ValidateWindowsSupport("system_patch_compliance");
+        if (windowsError is not null) {
+            return windowsError;
         }
 
         var computerName = ToolArgs.GetOptionalTrimmed(arguments, "computer_name");
-        var target = string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName!;
+        var target = ResolveTargetComputerName(computerName);
         var includePendingLocal = ToolArgs.GetBoolean(arguments, "include_pending_local", defaultValue: false);
         var missingOnly = ToolArgs.GetBoolean(arguments, "missing_only", defaultValue: false);
 
@@ -125,7 +126,7 @@ public sealed class SystemPatchComplianceTool : SystemToolBase, ITool {
         var publiclyDisclosedOnly = ToolArgs.GetBoolean(arguments, "publicly_disclosed_only", defaultValue: false);
         var cveContains = ToolArgs.GetOptionalTrimmed(arguments, "cve_contains");
         var kbContains = ToolArgs.GetOptionalTrimmed(arguments, "kb_contains");
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveMaxResults(arguments);
 
         var (monthly, patchError) = await TryGetMonthlyPatchDetailsAsync(
             year: year,
@@ -247,10 +248,9 @@ public sealed class SystemPatchComplianceTool : SystemToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("computer_name", target);
-                meta.Add("max_results", maxResults);
-                meta.Add("include_pending_local", includePendingLocal);
-                meta.Add("pending_included", pendingIncluded);
+                AddComputerNameMeta(meta, target);
+                AddMaxResultsMeta(meta, maxResults);
+                AddPendingLocalMeta(meta, includePendingLocal, pendingIncluded);
                 AddPatchFilterMeta(
                     meta: meta,
                     year: year,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchDetailsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPatchDetailsTool.cs
@@ -93,7 +93,7 @@ public sealed class SystemPatchDetailsTool : SystemToolBase, ITool {
         var publiclyDisclosedOnly = ToolArgs.GetBoolean(arguments, "publicly_disclosed_only", defaultValue: false);
         var cveContains = ToolArgs.GetOptionalTrimmed(arguments, "cve_contains");
         var kbContains = ToolArgs.GetOptionalTrimmed(arguments, "kb_contains");
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveMaxResults(arguments);
 
         var (monthly, patchError) = await TryGetMonthlyPatchDetailsAsync(
             year: year,
@@ -160,7 +160,7 @@ public sealed class SystemPatchDetailsTool : SystemToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("max_results", maxResults);
+                AddMaxResultsMeta(meta, maxResults);
                 AddPatchFilterMeta(
                     meta: meta,
                     year: year,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPortsListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemPortsListTool.cs
@@ -74,7 +74,7 @@ public sealed class SystemPortsListTool : SystemToolBase, ITool {
 
         var processNameContains = ToolArgs.GetOptionalTrimmed(arguments, "process_name_contains");
         var state = ToolArgs.GetOptionalTrimmed(arguments, "state");
-        var max = ToolArgs.GetCappedInt32(arguments, "max_entries", Options.MaxResults, 1, Options.MaxResults);
+        var max = ResolveBoundedOptionLimit(arguments, "max_entries");
 
         if (!PortInventoryQueryExecutor.TryExecute(
                 request: new PortInventoryQueryRequest {
@@ -91,7 +91,7 @@ public sealed class SystemPortsListTool : SystemToolBase, ITool {
         }
 
         var result = queryResult!;
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Rows,
@@ -99,7 +99,6 @@ public sealed class SystemPortsListTool : SystemToolBase, ITool {
             title: "Ports (preview)",
             maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.Scanned,
             metaMutate: meta => {
                 meta.Add("protocol", ProtocolToString(protocol));
@@ -120,5 +119,4 @@ public sealed class SystemPortsListTool : SystemToolBase, ITool {
         return ToolEnumBinders.ToName(protocol, ProtocolNames);
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemProcessListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemProcessListTool.cs
@@ -37,7 +37,7 @@ public sealed class SystemProcessListTool : SystemToolBase, ITool {
         cancellationToken.ThrowIfCancellationRequested();
 
         var nameContains = arguments?.GetString("name_contains");
-        var max = ToolArgs.GetCappedInt32(arguments, "max_processes", Options.MaxResults, 1, Options.MaxResults);
+        var max = ResolveBoundedOptionLimit(arguments, "max_processes");
 
         if (!ProcessListQueryExecutor.TryExecute(
                 request: new ProcessListQueryRequest {
@@ -52,7 +52,7 @@ public sealed class SystemProcessListTool : SystemToolBase, ITool {
         }
 
         var result = queryResult ?? new ProcessListQueryResult();
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Processes,
@@ -60,10 +60,8 @@ public sealed class SystemProcessListTool : SystemToolBase, ITool {
             title: "Processes (preview)",
             maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.Scanned);
         return Task.FromResult(response);
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemRdpPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemRdpPostureTool.cs
@@ -42,13 +42,14 @@ public sealed class SystemRdpPostureTool : SystemToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!OperatingSystem.IsWindows()) {
-            return Task.FromResult(ToolResponse.Error("not_supported", "system_rdp_posture is available only on Windows hosts."));
+        var windowsError = ValidateWindowsSupport("system_rdp_posture");
+        if (windowsError is not null) {
+            return Task.FromResult(windowsError);
         }
 
         var computerName = ToolArgs.GetOptionalTrimmed(arguments, "computer_name");
         var includePolicy = ToolArgs.GetBoolean(arguments, "include_policy", defaultValue: true);
-        var target = string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName!;
+        var target = ResolveTargetComputerName(computerName);
 
         try {
             var runtime = RdpQuery.Get(computerName);
@@ -99,15 +100,17 @@ public sealed class SystemRdpPostureTool : SystemToolBase, ITool {
                     ("TlsRequired", effectiveTlsRequired.ToString()),
                     ("Warnings", warnings.Count.ToString())
                 },
-                meta: ToolOutputHints.Meta(count: warnings.Count, truncated: false)
-                    .Add("computer_name", target)
-                    .Add("include_policy", includePolicy),
+                meta: BuildFactsMeta(
+                    count: warnings.Count,
+                    truncated: false,
+                    target: target,
+                    mutate: meta => meta.Add("include_policy", includePolicy)),
                 keyHeader: "Field",
                 valueHeader: "Value",
                 truncated: false,
                 render: null));
         } catch (Exception ex) {
-            return Task.FromResult(ToolResponse.Error("query_failed", $"RDP posture query failed: {ex.Message}"));
+            return Task.FromResult(ErrorFromException(ex, defaultMessage: "RDP posture query failed."));
         }
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemScheduledTasksListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemScheduledTasksListTool.cs
@@ -40,16 +40,13 @@ public sealed class SystemScheduledTasksListTool : SystemToolBase, ITool {
         return Task.Run(() => {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!OperatingSystem.IsWindows()) {
-                return ToolResponse.Error(
-                    errorCode: "unsupported_platform",
-                    error: "Scheduled tasks are only available on Windows.",
-                    hints: new[] { "Run this tool on Windows, or query scheduled tasks via a remote Windows host tool (future)." },
-                    isTransient: false);
+            var unsupported = ValidateWindowsSupport("The scheduled tasks tool");
+            if (!string.IsNullOrWhiteSpace(unsupported)) {
+                return unsupported;
             }
 
             var nameContains = arguments?.GetString("name_contains");
-            var max = ToolArgs.GetCappedInt32(arguments, "max_tasks", Options.MaxResults, 1, Options.MaxResults);
+            var max = ResolveBoundedOptionLimit(arguments, "max_tasks");
 
             var suspicious = arguments?.GetBoolean("suspicious") ?? false;
             var onlySuspicious = arguments?.GetBoolean("only_suspicious") ?? false;
@@ -68,7 +65,7 @@ public sealed class SystemScheduledTasksListTool : SystemToolBase, ITool {
             }
 
             var result = queryResult ?? new TaskSchedulerListQueryResult();
-            ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+            var response = BuildAutoTableResponse(
                 arguments: arguments,
                 model: result,
                 sourceRows: result.Tasks,
@@ -76,7 +73,6 @@ public sealed class SystemScheduledTasksListTool : SystemToolBase, ITool {
                 title: "Scheduled tasks (preview)",
                 maxTop: MaxViewTop,
                 baseTruncated: result.Truncated,
-                response: out var response,
                 scanned: result.Scanned,
                 metaMutate: meta => {
                     meta.Add("suspicious", suspicious);
@@ -86,5 +82,4 @@ public sealed class SystemScheduledTasksListTool : SystemToolBase, ITool {
         }, cancellationToken);
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemSecurityOptionsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemSecurityOptionsTool.cs
@@ -33,12 +33,13 @@ public sealed class SystemSecurityOptionsTool : SystemToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!OperatingSystem.IsWindows()) {
-            return Task.FromResult(ToolResponse.Error("not_supported", "system_security_options is available only on Windows hosts."));
+        var windowsError = ValidateWindowsSupport("system_security_options");
+        if (windowsError is not null) {
+            return Task.FromResult(windowsError);
         }
 
         var computerName = ToolArgs.GetOptionalTrimmed(arguments, "computer_name");
-        var target = string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName;
+        var target = ResolveTargetComputerName(computerName);
 
         try {
             var state = SecurityOptionsQuery.Get(computerName);
@@ -58,10 +59,8 @@ public sealed class SystemSecurityOptionsTool : SystemToolBase, ITool {
                 valueHeader: "Value",
                 truncated: false,
                 render: null));
-        } catch (ArgumentException ex) {
-            return Task.FromResult(ToolResponse.Error("invalid_argument", ex.Message));
         } catch (Exception ex) {
-            return Task.FromResult(ToolResponse.Error("query_failed", $"Security options query failed: {ex.Message}"));
+            return Task.FromResult(ErrorFromException(ex, defaultMessage: "Security options query failed."));
         }
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemServiceListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemServiceListTool.cs
@@ -58,7 +58,7 @@ public sealed class SystemServiceListTool : SystemToolBase, ITool {
         }
 
         var status = parsedStatus ?? ServiceListStatusFilter.Any;
-        var max = ToolArgs.GetCappedInt32(arguments, "max_services", Options.MaxResults, 1, Options.MaxResults);
+        var max = ResolveBoundedOptionLimit(arguments, "max_services");
 
         var attempt = await ServiceListQueryExecutor.TryExecuteAsync(
             request: new ServiceListQueryRequest {
@@ -73,7 +73,7 @@ public sealed class SystemServiceListTool : SystemToolBase, ITool {
         }
 
         var result = attempt.Result ?? new ServiceListQueryResult();
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Services,
@@ -81,10 +81,8 @@ public sealed class SystemServiceListTool : SystemToolBase, ITool {
             title: "Services (preview)",
             maxTop: MaxViewTop,
             baseTruncated: result.Truncated,
-            response: out var response,
             scanned: result.Scanned);
         return response;
     }
 }
-
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemSmbPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemSmbPostureTool.cs
@@ -45,13 +45,14 @@ public sealed class SystemSmbPostureTool : SystemToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!OperatingSystem.IsWindows()) {
-            return Task.FromResult(ToolResponse.Error("not_supported", "system_smb_posture is available only on Windows hosts."));
+        var windowsError = ValidateWindowsSupport("system_smb_posture");
+        if (windowsError is not null) {
+            return Task.FromResult(windowsError);
         }
 
         var computerName = ToolArgs.GetOptionalTrimmed(arguments, "computer_name");
         var includeNetbiosInterfaces = ToolArgs.GetBoolean(arguments, "include_netbios_interfaces", defaultValue: false);
-        var target = string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName!;
+        var target = ResolveTargetComputerName(computerName);
 
         try {
             var raw = SmbConfigQuery.Get(computerName);
@@ -133,15 +134,17 @@ public sealed class SystemSmbPostureTool : SystemToolBase, ITool {
                     ("NetbiosInterfacesNotDisabled", netbiosInterfacesNotDisabled.ToString()),
                     ("Warnings", warnings.Count.ToString())
                 },
-                meta: ToolOutputHints.Meta(count: warnings.Count, truncated: false)
-                    .Add("computer_name", target)
-                    .Add("include_netbios_interfaces", includeNetbiosInterfaces),
+                meta: BuildFactsMeta(
+                    count: warnings.Count,
+                    truncated: false,
+                    target: target,
+                    mutate: meta => meta.Add("include_netbios_interfaces", includeNetbiosInterfaces)),
                 keyHeader: "Field",
                 valueHeader: "Value",
                 truncated: false,
                 render: null));
         } catch (Exception ex) {
-            return Task.FromResult(ToolResponse.Error("query_failed", $"SMB posture query failed: {ex.Message}"));
+            return Task.FromResult(ErrorFromException(ex, defaultMessage: "SMB posture query failed."));
         }
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemTimeSyncTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemTimeSyncTool.cs
@@ -38,12 +38,13 @@ public sealed class SystemTimeSyncTool : SystemToolBase, ITool {
     protected override async Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!OperatingSystem.IsWindows()) {
-            return ToolResponse.Error("not_supported", "system_time_sync is available only on Windows hosts.");
+        var windowsError = ValidateWindowsSupport("system_time_sync");
+        if (windowsError is not null) {
+            return windowsError;
         }
 
         var computerName = ToolArgs.GetOptionalTrimmed(arguments, "computer_name");
-        var target = string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName!;
+        var target = ResolveTargetComputerName(computerName);
         var referenceRaw = ToolArgs.GetOptionalTrimmed(arguments, "reference_time_utc");
 
         DateTime referenceUtc;
@@ -57,16 +58,14 @@ public sealed class SystemTimeSyncTool : SystemToolBase, ITool {
 
         TimeSyncInfo status;
         try {
-            var isLocalTarget = string.IsNullOrWhiteSpace(computerName)
-                || string.Equals(computerName, ".", StringComparison.Ordinal)
-                || string.Equals(target, Environment.MachineName, StringComparison.OrdinalIgnoreCase);
+            var isLocalTarget = IsLocalTarget(computerName, target);
             if (isLocalTarget) {
                 status = TimeSync.GetLocalStatus(referenceUtc);
             } else {
                 status = await TimeSync.QueryRemoteStatusAsync(target, referenceUtc, cancellationToken).ConfigureAwait(false);
             }
         } catch (Exception ex) {
-            return ToolResponse.Error("query_failed", $"Time sync query failed: {ex.Message}");
+            return ErrorFromException(ex, defaultMessage: "Time sync query failed.");
         }
 
         var model = new SystemTimeSyncResult(
@@ -90,4 +89,3 @@ public sealed class SystemTimeSyncTool : SystemToolBase, ITool {
             render: null);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemToolBase.cs
@@ -288,28 +288,77 @@ public abstract class SystemToolBase : ToolBase {
     }
 
     /// <summary>
-    /// Builds the standard auto-column table envelope used by System read tools.
+    /// Resolves a standard option-bounded limit argument (default + cap from <see cref="SystemToolOptions.MaxResults"/>).
     /// </summary>
-    protected static string BuildAutoTableResponse<TModel, TRow>(
+    protected int ResolveBoundedOptionLimit(JsonObject? arguments, string argumentName, int minInclusive = 1) {
+        return ToolArgs.GetOptionBoundedInt32(arguments, argumentName, Options.MaxResults, minInclusive);
+    }
+
+    /// <summary>
+    /// Resolves max_results using the default option-bounded limit behavior.
+    /// </summary>
+    protected int ResolveMaxResults(JsonObject? arguments) {
+        return ResolveBoundedOptionLimit(arguments, "max_results");
+    }
+
+    /// <summary>
+    /// Adds computer_name metadata consistently across system tool responses.
+    /// </summary>
+    protected static void AddComputerNameMeta(JsonObject meta, string target) {
+        meta.Add("computer_name", target);
+    }
+
+    /// <summary>
+    /// Adds include/pending-local metadata consistently across system update responses.
+    /// </summary>
+    protected static void AddPendingLocalMeta(JsonObject meta, bool includePendingLocal, bool pendingIncluded) {
+        meta.Add("include_pending_local", includePendingLocal);
+        meta.Add("pending_included", pendingIncluded);
+    }
+
+    /// <summary>
+    /// Builds common facts-view metadata with computer_name and optional extra fields.
+    /// </summary>
+    protected static JsonObject BuildFactsMeta(
+        int count,
+        bool truncated,
+        string target,
+        Action<JsonObject>? mutate = null) {
+        var meta = ToolOutputHints.Meta(count: count, truncated: truncated);
+        AddComputerNameMeta(meta, target);
+        mutate?.Invoke(meta);
+        return meta;
+    }
+
+    /// <summary>
+    /// Returns a standardized not-supported error when a system tool is invoked on non-Windows hosts.
+    /// </summary>
+    protected static string? ValidateWindowsSupport(string toolName) {
+        if (OperatingSystem.IsWindows()) {
+            return null;
+        }
+
+        var safeToolName = string.IsNullOrWhiteSpace(toolName) ? "This tool" : toolName.Trim();
+        return ToolResponse.Error("not_supported", $"{safeToolName} is available only on Windows hosts.");
+    }
+
+    /// <summary>
+    /// Resolves local/remote target display name from optional computer_name argument.
+    /// </summary>
+    protected static string ResolveTargetComputerName(string? computerName) {
+        return string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName;
+    }
+
+    /// <summary>
+    /// Resolves timeout arguments with shared bounds used by system inventory tools.
+    /// </summary>
+    protected static int ResolveTimeoutMs(
         JsonObject? arguments,
-        TModel model,
-        IReadOnlyList<TRow> sourceRows,
-        string viewRowsPath,
-        string title,
-        bool baseTruncated,
-        int scanned,
-        int maxTop,
-        Action<JsonObject>? metaMutate = null) {
-        return ToolQueryHelpers.BuildAutoTableResponse(
-            arguments: arguments,
-            model: model,
-            sourceRows: sourceRows,
-            viewRowsPath: viewRowsPath,
-            title: title,
-            maxTop: maxTop,
-            baseTruncated: baseTruncated,
-            scanned: scanned,
-            metaMutate: metaMutate);
+        string argumentName = "timeout_ms",
+        int defaultValue = 10_000,
+        int minInclusive = 200,
+        int maxInclusive = 120_000) {
+        return ToolArgs.GetCappedInt32(arguments, argumentName, defaultValue, minInclusive, maxInclusive);
     }
 
     private static bool TryNormalizePatchSeverity(string input, out string normalized) {
@@ -328,7 +377,10 @@ public abstract class SystemToolBase : ToolBase {
         return false;
     }
 
-    private static bool IsLocalTarget(string? computerName, string target) {
+    /// <summary>
+    /// Determines whether the requested target should be treated as local machine execution.
+    /// </summary>
+    protected static bool IsLocalTarget(string? computerName, string target) {
         return string.IsNullOrWhiteSpace(computerName)
                || string.Equals(computerName, ".", StringComparison.Ordinal)
                || string.Equals(target, Environment.MachineName, StringComparison.OrdinalIgnoreCase);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemUpdatesInstalledTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/SystemUpdatesInstalledTool.cs
@@ -52,17 +52,18 @@ public sealed class SystemUpdatesInstalledTool : SystemToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!OperatingSystem.IsWindows()) {
-            return Task.FromResult(ToolResponse.Error("not_supported", "system_updates_installed is available only on Windows hosts."));
+        var windowsError = ValidateWindowsSupport("system_updates_installed");
+        if (windowsError is not null) {
+            return Task.FromResult(windowsError);
         }
 
         var computerName = ToolArgs.GetOptionalTrimmed(arguments, "computer_name");
-        var target = string.IsNullOrWhiteSpace(computerName) ? Environment.MachineName : computerName!;
+        var target = ResolveTargetComputerName(computerName);
         var includePendingLocal = ToolArgs.GetBoolean(arguments, "include_pending_local", defaultValue: false);
         var titleContains = ToolArgs.GetOptionalTrimmed(arguments, "title_contains");
         var kbContains = ToolArgs.GetOptionalTrimmed(arguments, "kb_contains");
         var installedAfterRaw = ToolArgs.GetOptionalTrimmed(arguments, "installed_after_utc");
-        var maxResults = ToolArgs.GetCappedInt32(arguments, "max_results", Options.MaxResults, 1, Options.MaxResults);
+        var maxResults = ResolveMaxResults(arguments);
 
         DateTime? installedAfterUtc = null;
         if (!string.IsNullOrWhiteSpace(installedAfterRaw)) {
@@ -116,10 +117,9 @@ public sealed class SystemUpdatesInstalledTool : SystemToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("computer_name", target);
-                meta.Add("include_pending_local", includePendingLocal);
-                meta.Add("pending_included", pendingIncluded);
-                meta.Add("max_results", maxResults);
+                AddComputerNameMeta(meta, target);
+                AddPendingLocalMeta(meta, includePendingLocal, pendingIncluded);
+                AddMaxResultsMeta(meta, maxResults);
                 if (!string.IsNullOrWhiteSpace(titleContains)) {
                     meta.Add("title_contains", titleContains);
                 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/ToolRegistrySystemExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/ToolRegistrySystemExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
 
@@ -16,11 +15,7 @@ public static class ToolRegistrySystemExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Ordered tool names for the pack.</returns>
     public static IReadOnlyList<string> GetRegisteredToolNames(SystemToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return CreateTools(options).Select(static tool => tool.Definition.Name).ToArray();
+        return ToolPackRegistry.GetRegisteredToolNames(options, CreateTools);
     }
 
     /// <summary>
@@ -29,11 +24,7 @@ public static class ToolRegistrySystemExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>Catalog entries derived from runtime definitions and input schemas.</returns>
     public static IReadOnlyList<ToolPackToolCatalogEntryModel> GetRegisteredToolCatalog(SystemToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return ToolPackGuidance.CatalogFromTools(CreateTools(options));
+        return ToolPackRegistry.GetRegisteredToolCatalog(options, CreateTools);
     }
 
     /// <summary>
@@ -43,17 +34,7 @@ public static class ToolRegistrySystemExtensions {
     /// <param name="options">Tool options.</param>
     /// <returns>The same registry instance for chaining.</returns>
     public static ToolRegistry RegisterSystemPack(this ToolRegistry registry, SystemToolOptions options) {
-        if (registry is null) {
-            throw new ArgumentNullException(nameof(registry));
-        }
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        foreach (var tool in CreateTools(options)) {
-            registry.Register(tool);
-        }
-        return registry;
+        return ToolPackRegistry.RegisterPack(registry, options, CreateTools);
     }
 
     private static IEnumerable<ITool> CreateTools(SystemToolOptions options) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.System/WslStatusTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.System/WslStatusTool.cs
@@ -61,7 +61,7 @@ public sealed class WslStatusTool : SystemToolBase, ITool {
                 render: ToolOutputHints.RenderCode(language: "text", contentPath: "raw_output")));
         }
 
-        ToolTableViewEnvelope.TryBuildModelResponseAutoColumns(
+        var response = BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: result.Distributions,
@@ -69,7 +69,7 @@ public sealed class WslStatusTool : SystemToolBase, ITool {
             title: "WSL distributions (preview)",
             maxTop: MaxViewTop,
             baseTruncated: false,
-            response: out var response);
+            scanned: result.Distributions.Count);
         return Task.FromResult(response);
     }
 
@@ -93,4 +93,3 @@ public sealed class WslStatusTool : SystemToolBase, ITool {
         };
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/ToolRegistryTestimoXExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.TestimoX/ToolRegistryTestimoXExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
 
@@ -14,39 +12,21 @@ public static class ToolRegistryTestimoXExtensions {
     /// Returns the tool names registered by <see cref="RegisterTestimoXPack"/>.
     /// </summary>
     public static IReadOnlyList<string> GetRegisteredToolNames(TestimoXToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return CreateTools(options).Select(static tool => tool.Definition.Name).ToArray();
+        return ToolPackRegistry.GetRegisteredToolNames(options, CreateTools);
     }
 
     /// <summary>
     /// Returns tool catalog metadata for tools registered by <see cref="RegisterTestimoXPack"/>.
     /// </summary>
     public static IReadOnlyList<ToolPackToolCatalogEntryModel> GetRegisteredToolCatalog(TestimoXToolOptions options) {
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        return ToolPackGuidance.CatalogFromTools(CreateTools(options));
+        return ToolPackRegistry.GetRegisteredToolCatalog(options, CreateTools);
     }
 
     /// <summary>
     /// Registers all IX.TestimoX tools into the provided registry.
     /// </summary>
     public static ToolRegistry RegisterTestimoXPack(this ToolRegistry registry, TestimoXToolOptions options) {
-        if (registry is null) {
-            throw new ArgumentNullException(nameof(registry));
-        }
-        if (options is null) {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        foreach (var tool in CreateTools(options)) {
-            registry.Register(tool);
-        }
-        return registry;
+        return ToolPackRegistry.RegisterPack(registry, options, CreateTools);
     }
 
     private static IEnumerable<ITool> CreateTools(TestimoXToolOptions options) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
@@ -107,6 +107,39 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
     }
 
     [Fact]
+    public void TryReadRequiredDomainName_ShouldReturnDomainWhenPresent() {
+        var tool = new HarnessTool();
+
+        var ok = tool.TryReadRequiredDomainNameArgument(
+            arguments: new JsonObject().Add("domain_name", "contoso.local"),
+            out var domainName,
+            out var errorResponse);
+
+        Assert.True(ok);
+        Assert.Equal("contoso.local", domainName);
+        Assert.Null(errorResponse);
+    }
+
+    [Fact]
+    public void TryReadRequiredDomainName_ShouldReturnInvalidArgumentWhenMissing() {
+        var tool = new HarnessTool();
+
+        var ok = tool.TryReadRequiredDomainNameArgument(
+            arguments: new JsonObject(),
+            out var domainName,
+            out var errorResponse);
+
+        Assert.False(ok);
+        Assert.Equal(string.Empty, domainName);
+        Assert.NotNull(errorResponse);
+        using var doc = JsonDocument.Parse(errorResponse!);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        Assert.Equal("domain_name is required.", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
     public async Task ExecutePolicyAttributionTool_ShouldFilterRowsAndAddStandardMeta() {
         var tool = new HarnessTool();
         var arguments = new JsonObject()
@@ -148,6 +181,171 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
         Assert.False(root.GetProperty("ok").GetBoolean());
         Assert.Equal("query_failed", root.GetProperty("error_code").GetString());
         Assert.Equal("Policy service unavailable", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task ExecutePolicyAttributionTool_ShouldAllowAdditionalMetaMutation() {
+        var tool = new HarnessTool();
+        var arguments = new JsonObject().Add("domain_name", "contoso.local");
+
+        var json = await tool.ExecutePolicyToolAsync(
+            arguments,
+            _ => new HarnessTool.MockPolicyView(Array.Empty<PolicyAttribution>(), "marker"),
+            additionalMetaMutate: static (meta, _, result) => {
+                meta.Add("marker", result.Marker);
+            });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("marker", root.GetProperty("meta").GetProperty("marker").GetString());
+    }
+
+    [Fact]
+    public void ResolveMaxResults_ShouldDefaultOnNonPositiveAndCapHighValues() {
+        var tool = new HarnessTool();
+
+        Assert.Equal(1000, tool.ResolveDefaultingMaxResults(new JsonObject().Add("max_results", 0)));
+        Assert.Equal(1000, tool.ResolveDefaultingMaxResults(new JsonObject().Add("max_results", -5)));
+        Assert.Equal(1000, tool.ResolveDefaultingMaxResults(new JsonObject().Add("max_results", 5000)));
+        Assert.Equal(50, tool.ResolveDefaultingMaxResults(new JsonObject().Add("max_results", 50)));
+    }
+
+    [Fact]
+    public void ResolveBoundedMaxResults_ShouldClampToOneAndCapHighValues() {
+        var tool = new HarnessTool();
+
+        Assert.Equal(1, tool.ResolveStrictlyBoundedMaxResults(new JsonObject().Add("max_results", 0)));
+        Assert.Equal(1, tool.ResolveStrictlyBoundedMaxResults(new JsonObject().Add("max_results", -5)));
+        Assert.Equal(1000, tool.ResolveStrictlyBoundedMaxResults(new JsonObject().Add("max_results", 5000)));
+        Assert.Equal(50, tool.ResolveStrictlyBoundedMaxResults(new JsonObject().Add("max_results", 50)));
+    }
+
+    [Fact]
+    public void AddDomainAndForestMeta_ShouldAddOnlyNonEmptyValues() {
+        var tool = new HarnessTool();
+
+        var withBoth = tool.CreateScopeMeta("contoso.local", "corp.contoso.local");
+        Assert.Equal("contoso.local", withBoth.GetString("domain_name"));
+        Assert.Equal("corp.contoso.local", withBoth.GetString("forest_name"));
+
+        var withDomainOnly = tool.CreateScopeMeta("contoso.local", " ");
+        Assert.Equal("contoso.local", withDomainOnly.GetString("domain_name"));
+        Assert.Null(withDomainOnly.GetString("forest_name"));
+
+        var withNone = tool.CreateScopeMeta(" ", null);
+        Assert.Null(withNone.GetString("domain_name"));
+        Assert.Null(withNone.GetString("forest_name"));
+    }
+
+    [Fact]
+    public void AddDomainAndMaxResultsMeta_ShouldAddBothKeys() {
+        var tool = new HarnessTool();
+
+        var meta = tool.CreateDomainAndMaxResultsMeta("contoso.local", 123);
+
+        Assert.Equal("contoso.local", meta.GetString("domain_name"));
+        Assert.Equal(123, meta.GetInt64("max_results"));
+    }
+
+    [Fact]
+    public void TryMapCollectionFailure_ShouldReturnFalseAndDefaultMessageWhenCollectionFailsWithoutError() {
+        var tool = new HarnessTool();
+
+        var ok = tool.MapCollectionFailure(
+            collectionSucceeded: false,
+            collectionError: null,
+            defaultErrorMessage: "Policy query failed.",
+            out var errorResponse);
+
+        Assert.False(ok);
+        Assert.NotNull(errorResponse);
+        using var doc = JsonDocument.Parse(errorResponse!);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("query_failed", root.GetProperty("error_code").GetString());
+        Assert.Equal("Policy query failed.", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void TryMapCollectionFailure_ShouldReturnTrueWhenCollectionSucceeds() {
+        var tool = new HarnessTool();
+
+        var ok = tool.MapCollectionFailure(
+            collectionSucceeded: true,
+            collectionError: "ignored",
+            defaultErrorMessage: "Policy query failed.",
+            out var errorResponse);
+
+        Assert.True(ok);
+        Assert.Null(errorResponse);
+    }
+
+    [Fact]
+    public void TryExecuteCollectionQuery_ShouldReturnResultWhenCollectionSucceeds() {
+        var tool = new HarnessTool();
+
+        var ok = tool.ExecuteCollectionQuerySuccess(out var marker, out var errorResponse);
+
+        Assert.True(ok);
+        Assert.Null(errorResponse);
+        Assert.Equal("ok", marker);
+    }
+
+    [Fact]
+    public void TryExecuteCollectionQuery_ShouldMapCollectionFailureToQueryFailed() {
+        var tool = new HarnessTool();
+
+        var ok = tool.ExecuteCollectionQueryFailure(out var errorResponse);
+
+        Assert.False(ok);
+        Assert.NotNull(errorResponse);
+        using var doc = JsonDocument.Parse(errorResponse!);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("query_failed", root.GetProperty("error_code").GetString());
+        Assert.Equal("Collection error.", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void TryExecuteCollectionQuery_ShouldReturnContractErrorWhenCollectionShapeIsMissing() {
+        var tool = new HarnessTool();
+
+        var ok = tool.ExecuteCollectionQueryInvalidContract(out var errorResponse);
+
+        Assert.False(ok);
+        Assert.NotNull(errorResponse);
+        using var doc = JsonDocument.Parse(errorResponse!);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("query_failed", root.GetProperty("error_code").GetString());
+        Assert.Equal("Collection view contract is invalid.", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void TryExecuteCollectionQuery_WithTypedSelectors_ShouldReturnResultWhenCollectionSucceeds() {
+        var tool = new HarnessTool();
+
+        var ok = tool.ExecuteTypedCollectionQuerySuccess(out var marker, out var errorResponse);
+
+        Assert.True(ok);
+        Assert.Null(errorResponse);
+        Assert.Equal("ok-typed", marker);
+    }
+
+    [Fact]
+    public void TryExecuteCollectionQuery_WithTypedSelectors_ShouldMapCollectionFailureToQueryFailed() {
+        var tool = new HarnessTool();
+
+        var ok = tool.ExecuteTypedCollectionQueryFailure(out var errorResponse);
+
+        Assert.False(ok);
+        Assert.NotNull(errorResponse);
+        using var doc = JsonDocument.Parse(errorResponse!);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("query_failed", root.GetProperty("error_code").GetString());
+        Assert.Equal("Typed collection error.", root.GetProperty("error").GetString());
     }
 
     private sealed class HarnessTool : ActiveDirectoryToolBase {
@@ -195,9 +393,17 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
             return ok;
         }
 
+        public bool TryReadRequiredDomainNameArgument(
+            JsonObject? arguments,
+            out string domainName,
+            out string? errorResponse) {
+            return TryReadRequiredDomainName(arguments, out domainName, out errorResponse);
+        }
+
         public Task<string> ExecutePolicyToolAsync(
             JsonObject? arguments,
             Func<string, MockPolicyView> query,
+            Action<JsonObject, MockPolicyView, MockPolicyResult>? additionalMetaMutate = null,
             IReadOnlyList<string>? additionalUnconfiguredValues = null) {
             return ExecutePolicyAttributionTool<MockPolicyView, MockPolicyResult>(
                 arguments: arguments,
@@ -206,6 +412,9 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
                 defaultErrorMessage: "Policy query failed.",
                 query: query,
                 attributionSelector: static view => view.Attribution,
+                additionalMetaMutate: additionalMetaMutate is null
+                    ? null
+                    : (meta, _, view, result) => additionalMetaMutate(meta, view, result),
                 additionalUnconfiguredValues: additionalUnconfiguredValues,
                 resultFactory: static (request, view, scanned, truncated, rows) => new MockPolicyResult(
                     request.DomainName,
@@ -217,13 +426,112 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
                     rows));
         }
 
+        public int ResolveDefaultingMaxResults(JsonObject? arguments) {
+            return ResolveMaxResults(arguments);
+        }
+
+        public int ResolveStrictlyBoundedMaxResults(JsonObject? arguments) {
+            return ResolveBoundedMaxResults(arguments);
+        }
+
+        public JsonObject CreateScopeMeta(string? domainName, string? forestName) {
+            var meta = new JsonObject();
+            AddDomainAndForestMeta(meta, domainName, forestName);
+            return meta;
+        }
+
+        public JsonObject CreateDomainAndMaxResultsMeta(string domainName, int maxResults) {
+            var meta = new JsonObject();
+            AddDomainAndMaxResultsMeta(meta, domainName, maxResults);
+            return meta;
+        }
+
+        public bool MapCollectionFailure(
+            bool collectionSucceeded,
+            string? collectionError,
+            string defaultErrorMessage,
+            out string? errorResponse) {
+            return TryMapCollectionFailure(
+                collectionSucceeded,
+                collectionError,
+                defaultErrorMessage,
+                out errorResponse);
+        }
+
+        public bool ExecuteCollectionQuerySuccess(out string? marker, out string? errorResponse) {
+            var ok = TryExecuteCollectionQuery(
+                query: static () => new MockCollectionContractView(
+                    CollectionSucceeded: true,
+                    CollectionError: null,
+                    Marker: "ok"),
+                result: out var view,
+                errorResponse: out errorResponse,
+                defaultErrorMessage: "Collection query failed.");
+            marker = ok ? view.Marker : null;
+            return ok;
+        }
+
+        public bool ExecuteCollectionQueryFailure(out string? errorResponse) {
+            return TryExecuteCollectionQuery(
+                query: static () => new MockCollectionContractView(
+                    CollectionSucceeded: false,
+                    CollectionError: "Collection error.",
+                    Marker: "failed"),
+                result: out _,
+                errorResponse: out errorResponse,
+                defaultErrorMessage: "Collection query failed.");
+        }
+
+        public bool ExecuteCollectionQueryInvalidContract(out string? errorResponse) {
+            return TryExecuteCollectionQuery(
+                query: static () => new MockInvalidCollectionContractView("invalid"),
+                result: out _,
+                errorResponse: out errorResponse,
+                defaultErrorMessage: "Collection query failed.");
+        }
+
+        public bool ExecuteTypedCollectionQuerySuccess(out string? marker, out string? errorResponse) {
+            var ok = TryExecuteCollectionQuery(
+                query: static () => new MockCollectionContractView(
+                    CollectionSucceeded: true,
+                    CollectionError: null,
+                    Marker: "ok-typed"),
+                collectionSucceededSelector: static view => view!.CollectionSucceeded,
+                collectionErrorSelector: static view => view!.CollectionError,
+                result: out var view,
+                errorResponse: out errorResponse,
+                defaultErrorMessage: "Collection query failed.");
+            marker = ok ? view.Marker : null;
+            return ok;
+        }
+
+        public bool ExecuteTypedCollectionQueryFailure(out string? errorResponse) {
+            return TryExecuteCollectionQuery(
+                query: static () => new MockCollectionContractView(
+                    CollectionSucceeded: false,
+                    CollectionError: "Typed collection error.",
+                    Marker: "typed-failed"),
+                collectionSucceededSelector: static view => view!.CollectionSucceeded,
+                collectionErrorSelector: static view => view!.CollectionError,
+                result: out _,
+                errorResponse: out errorResponse,
+                defaultErrorMessage: "Collection query failed.");
+        }
+
         protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
             return Task.FromResult(ToolResponse.OkModel(new { ok = true }));
         }
 
         internal sealed record MockPolicyView(IReadOnlyList<PolicyAttribution> Attribution, string Marker);
 
-        private sealed record MockPolicyResult(
+        internal sealed record MockCollectionContractView(
+            bool CollectionSucceeded,
+            string? CollectionError,
+            string Marker);
+
+        internal sealed record MockInvalidCollectionContractView(string Marker);
+
+        internal sealed record MockPolicyResult(
             string DomainName,
             bool IncludeAttribution,
             bool ConfiguredAttributionOnly,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogToolBaseHelperTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogToolBaseHelperTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.Json;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+using IntelligenceX.Tools.EventLog;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public class EventLogToolBaseHelperTests {
+    [Fact]
+    public void ResolveBoundedOptionLimit_ShouldClampToMinAndCapToOptionsMax() {
+        var tool = new HarnessTool(maxResults: 60);
+
+        Assert.Equal(60, tool.ResolveLimit("max_events", arguments: null));
+        Assert.Equal(1, tool.ResolveLimit("max_events", new JsonObject().Add("max_events", 0)));
+        Assert.Equal(1, tool.ResolveLimit("max_events", new JsonObject().Add("max_events", -2)));
+        Assert.Equal(60, tool.ResolveLimit("max_events", new JsonObject().Add("max_events", 900)));
+        Assert.Equal(15, tool.ResolveLimit("max_events", new JsonObject().Add("max_events", 15)));
+    }
+
+    [Fact]
+    public void ResolveMaxResults_ShouldHonorExplicitDefaultAndCap() {
+        var tool = new HarnessTool(maxResults: 200);
+
+        Assert.Equal(20, tool.ResolveMax(arguments: null, defaultValue: 20, maxInclusive: 80));
+        Assert.Equal(1, tool.ResolveMax(new JsonObject().Add("max_results", 0), defaultValue: 20, maxInclusive: 80));
+        Assert.Equal(80, tool.ResolveMax(new JsonObject().Add("max_results", 500), defaultValue: 20, maxInclusive: 80));
+        Assert.Equal(35, tool.ResolveMax(new JsonObject().Add("max_results", 35), defaultValue: 20, maxInclusive: 80));
+    }
+
+    [Fact]
+    public void AddMaxResultsMeta_ShouldPopulateMetaField() {
+        var meta = new JsonObject();
+        HarnessTool.AddMax(meta, 88);
+
+        Assert.Equal(88, meta.GetInt64("max_results"));
+    }
+
+    [Fact]
+    public void ResolveSessionTimeoutMs_FromArguments_ShouldClampToBounds() {
+        Assert.Null(HarnessTool.ResolveTimeoutFromArguments(arguments: null));
+        Assert.Null(HarnessTool.ResolveTimeoutFromArguments(new JsonObject().Add("session_timeout_ms", 0)));
+        Assert.Equal(250, HarnessTool.ResolveTimeoutFromArguments(new JsonObject().Add("session_timeout_ms", 10)));
+        Assert.Equal(300_000, HarnessTool.ResolveTimeoutFromArguments(new JsonObject().Add("session_timeout_ms", 999_999)));
+        Assert.Equal(1_000, HarnessTool.ResolveTimeoutFromArguments(
+            new JsonObject().Add("session_timeout_ms", 500),
+            minInclusive: 1_000,
+            maxInclusive: 600_000));
+    }
+
+    [Fact]
+    public void ResolveSessionTimeoutMs_FromRaw_ShouldClampToBounds() {
+        Assert.Null(HarnessTool.ResolveTimeoutFromRaw(null));
+        Assert.Null(HarnessTool.ResolveTimeoutFromRaw(0));
+        Assert.Equal(250, HarnessTool.ResolveTimeoutFromRaw(10));
+        Assert.Equal(300_000, HarnessTool.ResolveTimeoutFromRaw(999_999));
+        Assert.Equal(1_000, HarnessTool.ResolveTimeoutFromRaw(500, minInclusive: 1_000, maxInclusive: 600_000));
+    }
+
+    [Fact]
+    public void ResolveXPathOrDefault_ShouldReturnWildcardForMissingOrBlank() {
+        Assert.Equal("*", HarnessTool.ResolveXPath(arguments: null));
+        Assert.Equal("*", HarnessTool.ResolveXPath(new JsonObject()));
+        Assert.Equal("*", HarnessTool.ResolveXPath(new JsonObject().Add("xpath", " ")));
+        Assert.Equal("*[System]", HarnessTool.ResolveXPath(new JsonObject().Add("xpath", "*[System]")));
+    }
+
+    [Fact]
+    public void BuildAutoTableResponse_ShouldReturnInvalidArgumentEnvelopeForUnsupportedColumns() {
+        var rows = new[] { new AutoRow(1, "alpha") };
+        var model = new AutoModel { Items = rows };
+
+        var response = HarnessTool.BuildAutoResponse(
+            arguments: new JsonObject().Add("columns", new JsonArray().Add("missing_column")),
+            model: model,
+            rows: rows);
+
+        using var doc = JsonDocument.Parse(response);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+    }
+
+    [Fact]
+    public void ErrorFromException_ShouldMapUnauthorizedAccessToAccessDeniedEnvelope() {
+        var response = HarnessTool.MapException(new UnauthorizedAccessException("denied"));
+
+        using var doc = JsonDocument.Parse(response);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("access_denied", root.GetProperty("error_code").GetString());
+    }
+
+    private sealed record AutoRow(int Id, string DisplayName);
+
+    private sealed class AutoModel {
+        public IReadOnlyList<AutoRow> Items { get; init; } = Array.Empty<AutoRow>();
+    }
+
+    private sealed class HarnessTool : EventLogToolBase {
+        private static readonly ToolDefinition DefinitionValue = new(
+            "eventlog_test_harness",
+            "Event log helper harness.",
+            ToolSchema.Object().NoAdditionalProperties());
+
+        public HarnessTool(int maxResults) : base(new EventLogToolOptions { MaxResults = maxResults }) { }
+
+        public override ToolDefinition Definition => DefinitionValue;
+
+        public int ResolveLimit(string argumentName, JsonObject? arguments) {
+            return ResolveBoundedOptionLimit(arguments, argumentName);
+        }
+
+        public int ResolveMax(JsonObject? arguments, int? defaultValue = null, int? maxInclusive = null) {
+            return ResolveMaxResults(arguments, defaultValue, maxInclusive: maxInclusive);
+        }
+
+        public static void AddMax(JsonObject meta, int maxResults) {
+            AddMaxResultsMeta(meta, maxResults);
+        }
+
+        public static int? ResolveTimeoutFromArguments(
+            JsonObject? arguments,
+            int minInclusive = 250,
+            int maxInclusive = 300_000) {
+            return ResolveSessionTimeoutMs(arguments, minInclusive: minInclusive, maxInclusive: maxInclusive);
+        }
+
+        public static int? ResolveTimeoutFromRaw(
+            long? timeoutRaw,
+            int minInclusive = 250,
+            int maxInclusive = 300_000) {
+            return ResolveSessionTimeoutMs(timeoutRaw, minInclusive: minInclusive, maxInclusive: maxInclusive);
+        }
+
+        public static string ResolveXPath(JsonObject? arguments, string argumentName = "xpath", string defaultXPath = "*") {
+            return ResolveXPathOrDefault(arguments, argumentName, defaultXPath);
+        }
+
+        public static string BuildAutoResponse(JsonObject? arguments, AutoModel model, IReadOnlyList<AutoRow> rows) {
+            return BuildAutoTableResponse(
+                arguments: arguments,
+                model: model,
+                sourceRows: rows,
+                viewRowsPath: "items_view",
+                title: "Items",
+                baseTruncated: false,
+                scanned: rows.Count,
+                maxTop: 100);
+        }
+
+        public static string MapException(Exception ex) {
+            return ErrorFromException(ex);
+        }
+
+        protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+            return Task.FromResult(ToolResponse.OkModel(new { ok = true }));
+        }
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/FileSystemToolBaseHelperTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/FileSystemToolBaseHelperTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+using IntelligenceX.Tools.FileSystem;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public class FileSystemToolBaseHelperTests {
+    [Fact]
+    public void ResolveBoundedOptionLimit_ShouldClampToMinAndCapToOptionsMax() {
+        var tool = new HarnessTool(maxResults: 30);
+
+        Assert.Equal(30, tool.ResolveLimit("max_matches", arguments: null));
+        Assert.Equal(1, tool.ResolveLimit("max_matches", new JsonObject().Add("max_matches", 0)));
+        Assert.Equal(30, tool.ResolveLimit("max_matches", new JsonObject().Add("max_matches", 999)));
+        Assert.Equal(7, tool.ResolveLimit("max_matches", new JsonObject().Add("max_matches", 7)));
+    }
+
+    [Fact]
+    public void BuildAutoTableResponse_ShouldReturnInvalidArgumentEnvelopeForUnsupportedColumns() {
+        var rows = new[] { new AutoRow("file.txt") };
+        var model = new AutoModel { Items = rows };
+
+        var response = HarnessTool.BuildAutoResponse(
+            arguments: new JsonObject().Add("columns", new JsonArray().Add("missing_column")),
+            model: model,
+            rows: rows);
+
+        using var doc = JsonDocument.Parse(response);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+    }
+
+    private sealed record AutoRow(string Name);
+
+    private sealed class AutoModel {
+        public IReadOnlyList<AutoRow> Items { get; init; } = Array.Empty<AutoRow>();
+    }
+
+    private sealed class HarnessTool : FileSystemToolBase {
+        private static readonly ToolDefinition DefinitionValue = new(
+            "fs_test_harness",
+            "File system helper harness.",
+            ToolSchema.Object().NoAdditionalProperties());
+
+        public HarnessTool(int maxResults) : base(new FileSystemToolOptions { MaxResults = maxResults }) { }
+
+        public override ToolDefinition Definition => DefinitionValue;
+
+        public int ResolveLimit(string argumentName, JsonObject? arguments) {
+            return ResolveBoundedOptionLimit(arguments, argumentName);
+        }
+
+        public static string BuildAutoResponse(JsonObject? arguments, AutoModel model, IReadOnlyList<AutoRow> rows) {
+            return BuildAutoTableResponse(
+                arguments: arguments,
+                model: model,
+                sourceRows: rows,
+                viewRowsPath: "items_view",
+                title: "Items",
+                baseTruncated: false,
+                maxTop: 100);
+        }
+
+        protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+            return Task.FromResult(ToolResponse.OkModel(new { ok = true }));
+        }
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/SystemToolBaseHelperTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/SystemToolBaseHelperTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+using IntelligenceX.Tools.System;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public class SystemToolBaseHelperTests {
+    [Fact]
+    public void ResolveBoundedOptionLimit_ShouldClampToMinAndCapToOptionsMax() {
+        var tool = new HarnessTool(maxResults: 50);
+
+        Assert.Equal(50, tool.ResolveLimit("max_entries", arguments: null));
+        Assert.Equal(1, tool.ResolveLimit("max_entries", new JsonObject().Add("max_entries", 0)));
+        Assert.Equal(1, tool.ResolveLimit("max_entries", new JsonObject().Add("max_entries", -5)));
+        Assert.Equal(50, tool.ResolveLimit("max_entries", new JsonObject().Add("max_entries", 500)));
+        Assert.Equal(12, tool.ResolveLimit("max_entries", new JsonObject().Add("max_entries", 12)));
+    }
+
+    [Fact]
+    public void ResolveMaxResults_ShouldUseSharedOptionBoundedBehavior() {
+        var tool = new HarnessTool(maxResults: 40);
+
+        Assert.Equal(40, tool.ResolveMax(arguments: null));
+        Assert.Equal(1, tool.ResolveMax(new JsonObject().Add("max_results", 0)));
+        Assert.Equal(40, tool.ResolveMax(new JsonObject().Add("max_results", 999)));
+        Assert.Equal(22, tool.ResolveMax(new JsonObject().Add("max_results", 22)));
+    }
+
+    [Fact]
+    public void AddMaxResultsMeta_ShouldPopulateMetaField() {
+        var meta = new JsonObject();
+        HarnessTool.AddMax(meta, 77);
+
+        Assert.Equal(77, meta.GetInt64("max_results"));
+    }
+
+    [Fact]
+    public void ResolveTargetComputerName_ShouldFallbackToLocalMachineOnlyWhenMissing() {
+        Assert.Equal(Environment.MachineName, HarnessTool.ResolveTarget(computerName: null));
+        Assert.Equal(Environment.MachineName, HarnessTool.ResolveTarget("   "));
+        Assert.Equal(".", HarnessTool.ResolveTarget("."));
+        Assert.Equal("server01", HarnessTool.ResolveTarget("server01"));
+    }
+
+    [Fact]
+    public void IsLocalTarget_ShouldRecognizeDotAndMachineName() {
+        Assert.True(HarnessTool.IsLocal(computerName: null, target: Environment.MachineName));
+        Assert.True(HarnessTool.IsLocal(computerName: ".", target: "."));
+        Assert.True(HarnessTool.IsLocal(computerName: "localhost", target: Environment.MachineName));
+        Assert.False(HarnessTool.IsLocal(computerName: "server01", target: "server01"));
+    }
+
+    [Fact]
+    public void AddComputerAndPendingMeta_ShouldPopulateSharedFields() {
+        var meta = new JsonObject();
+
+        HarnessTool.AddComputer(meta, "server01");
+        HarnessTool.AddPending(meta, includePendingLocal: true, pendingIncluded: false);
+
+        Assert.Equal("server01", meta.GetString("computer_name"));
+        Assert.True(meta.GetBoolean("include_pending_local"));
+        Assert.False(meta.GetBoolean("pending_included"));
+    }
+
+    [Fact]
+    public void BuildFactsMeta_ShouldIncludeComputerAndCustomFields() {
+        var meta = HarnessTool.BuildMeta(
+            count: 5,
+            truncated: false,
+            target: "server01",
+            mutate: json => json.Add("include_policy", true));
+
+        Assert.Equal(5, meta.GetInt64("count"));
+        Assert.False(meta.GetBoolean("truncated"));
+        Assert.Equal("server01", meta.GetString("computer_name"));
+        Assert.True(meta.GetBoolean("include_policy"));
+    }
+
+    [Fact]
+    public void ValidateWindowsSupport_ShouldMatchCurrentHostPlatform() {
+        var response = HarnessTool.ValidateWindows("system_test_tool");
+        if (OperatingSystem.IsWindows()) {
+            Assert.Null(response);
+            return;
+        }
+
+        Assert.NotNull(response);
+        using var doc = JsonDocument.Parse(response!);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("not_supported", root.GetProperty("error_code").GetString());
+        Assert.Equal("system_test_tool is available only on Windows hosts.", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void ResolveTimeoutMs_ShouldClampUsingSharedBounds() {
+        Assert.Equal(10_000, HarnessTool.ResolveTimeout(arguments: null));
+        Assert.Equal(200, HarnessTool.ResolveTimeout(new JsonObject().Add("timeout_ms", 1)));
+        Assert.Equal(120_000, HarnessTool.ResolveTimeout(new JsonObject().Add("timeout_ms", 999_999)));
+        Assert.Equal(8_000, HarnessTool.ResolveTimeout(arguments: null, defaultValue: 8_000));
+    }
+
+    private sealed class HarnessTool : SystemToolBase {
+        private static readonly ToolDefinition DefinitionValue = new(
+            "system_test_harness",
+            "System helper harness.",
+            ToolSchema.Object().NoAdditionalProperties());
+
+        public HarnessTool(int maxResults) : base(new SystemToolOptions { MaxResults = maxResults }) { }
+
+        public override ToolDefinition Definition => DefinitionValue;
+
+        public int ResolveLimit(string argumentName, JsonObject? arguments) {
+            return ResolveBoundedOptionLimit(arguments, argumentName);
+        }
+
+        public int ResolveMax(JsonObject? arguments) {
+            return ResolveMaxResults(arguments);
+        }
+
+        public static void AddMax(JsonObject meta, int maxResults) {
+            AddMaxResultsMeta(meta, maxResults);
+        }
+
+        public static string ResolveTarget(string? computerName) {
+            return ResolveTargetComputerName(computerName);
+        }
+
+        public static bool IsLocal(string? computerName, string target) {
+            return IsLocalTarget(computerName, target);
+        }
+
+        public static void AddComputer(JsonObject meta, string target) {
+            AddComputerNameMeta(meta, target);
+        }
+
+        public static void AddPending(JsonObject meta, bool includePendingLocal, bool pendingIncluded) {
+            AddPendingLocalMeta(meta, includePendingLocal, pendingIncluded);
+        }
+
+        public static JsonObject BuildMeta(int count, bool truncated, string target, Action<JsonObject>? mutate = null) {
+            return BuildFactsMeta(count, truncated, target, mutate);
+        }
+
+        public static string? ValidateWindows(string toolName) {
+            return ValidateWindowsSupport(toolName);
+        }
+
+        public static int ResolveTimeout(JsonObject? arguments, int defaultValue = 10_000) {
+            return ResolveTimeoutMs(arguments, defaultValue: defaultValue);
+        }
+
+        protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+            return Task.FromResult(ToolResponse.OkModel(new { ok = true }));
+        }
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolArgsTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolArgsTests.cs
@@ -36,5 +36,23 @@ public sealed class ToolArgsTests {
         Assert.False(ToolArgs.GetBoolean(args, "include_message", defaultValue: false));
         Assert.True(ToolArgs.GetBoolean(args, "include_message", defaultValue: true));
     }
-}
 
+    [Fact]
+    public void GetOptionBoundedInt32_ShouldClampWithOptionMax() {
+        Assert.Equal(50, ToolArgs.GetOptionBoundedInt32(arguments: null, key: "max_results", optionMaxInclusive: 50));
+        Assert.Equal(1, ToolArgs.GetOptionBoundedInt32(new JsonObject().Add("max_results", 0), "max_results", 50));
+        Assert.Equal(1, ToolArgs.GetOptionBoundedInt32(new JsonObject().Add("max_results", -5), "max_results", 50));
+        Assert.Equal(50, ToolArgs.GetOptionBoundedInt32(new JsonObject().Add("max_results", 999), "max_results", 50));
+        Assert.Equal(23, ToolArgs.GetOptionBoundedInt32(new JsonObject().Add("max_results", 23), "max_results", 50));
+        Assert.Equal(10, ToolArgs.GetOptionBoundedInt32(new JsonObject().Add("max_results", 5), "max_results", 50, minInclusive: 10));
+    }
+
+    [Fact]
+    public void GetPositiveOptionBoundedInt32OrDefault_ShouldKeepDefaultForNonPositiveAndCapHighValues() {
+        Assert.Equal(30, ToolArgs.GetPositiveOptionBoundedInt32OrDefault(arguments: null, key: "top", defaultValue: 30, optionMaxInclusive: 50));
+        Assert.Equal(30, ToolArgs.GetPositiveOptionBoundedInt32OrDefault(new JsonObject().Add("top", 0), "top", 30, 50));
+        Assert.Equal(30, ToolArgs.GetPositiveOptionBoundedInt32OrDefault(new JsonObject().Add("top", -10), "top", 30, 50));
+        Assert.Equal(50, ToolArgs.GetPositiveOptionBoundedInt32OrDefault(new JsonObject().Add("top", 999), "top", 30, 50));
+        Assert.Equal(12, ToolArgs.GetPositiveOptionBoundedInt32OrDefault(new JsonObject().Add("top", 12), "top", 30, 50));
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPackRegistryTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPackRegistryTests.cs
@@ -1,0 +1,67 @@
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class ToolPackRegistryTests {
+    [Fact]
+    public void GetRegisteredToolNames_ReturnsFactoryOrder() {
+        var names = ToolPackRegistry.GetRegisteredToolNames(
+            new StubOptions(),
+            static _ => new ITool[] {
+                new StubTool("stub_a"),
+                new StubTool("stub_b")
+            });
+
+        Assert.Equal(new[] { "stub_a", "stub_b" }, names);
+    }
+
+    [Fact]
+    public void GetRegisteredToolCatalog_ReturnsCatalogEntries() {
+        var catalog = ToolPackRegistry.GetRegisteredToolCatalog(
+            new StubOptions(),
+            static _ => new ITool[] {
+                new StubTool("stub_catalog", "Catalog test tool")
+            });
+
+        ToolPackToolCatalogEntryModel entry = Assert.Single(catalog);
+        Assert.Equal("stub_catalog", entry.Name);
+        Assert.Equal("Catalog test tool", entry.Description);
+    }
+
+    [Fact]
+    public void RegisterPack_RegistersEveryToolAndReturnsRegistry() {
+        var registry = new ToolRegistry();
+
+        ToolRegistry returned = ToolPackRegistry.RegisterPack(
+            registry,
+            new StubOptions(),
+            static _ => new ITool[] {
+                new StubTool("stub_register_a"),
+                new StubTool("stub_register_b")
+            });
+
+        Assert.Same(registry, returned);
+        Assert.True(registry.TryGet("stub_register_a", out _));
+        Assert.True(registry.TryGet("stub_register_b", out _));
+    }
+
+    private sealed class StubOptions { }
+
+    private sealed class StubTool : ITool {
+        public StubTool(string name, string? description = null) {
+            Definition = new ToolDefinition(
+                name,
+                description,
+                ToolSchema.Object(("q", ToolSchema.String("query"))).NoAdditionalProperties());
+        }
+
+        public ToolDefinition Definition { get; }
+
+        public Task<string> InvokeAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+            return Task.FromResult("""{"ok":true}""");
+        }
+    }
+}

--- a/IntelligenceX/Compatibility/IsExternalInit.cs
+++ b/IntelligenceX/Compatibility/IsExternalInit.cs
@@ -1,0 +1,8 @@
+#if NETFRAMEWORK || NETSTANDARD2_0
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Backport shim for init-only setters on legacy target frameworks.
+/// </summary>
+internal static class IsExternalInit { }
+#endif

--- a/IntelligenceX/Tools/ToolRegistry.cs
+++ b/IntelligenceX/Tools/ToolRegistry.cs
@@ -190,25 +190,18 @@ public sealed class ToolRegistry {
                 ToolWriteGovernanceRequest request = CreateGovernanceRequest(arguments, contract);
 
                 if (contract.RequireExplicitConfirmation && !contract.HasExplicitConfirmation(arguments)) {
-                    ToolWriteGovernanceResult denied = new() {
-                        IsAuthorized = false,
-                        ErrorCode = ToolWriteGovernanceErrorCodes.WriteConfirmationRequired,
-                        Error = $"Tool '{_definition.Name}' requires explicit write confirmation via '{contract.ConfirmationArgumentName}=true'.",
-                        Hints = new[] {
+                    ToolWriteGovernanceResult denied = CreateDeniedResult(
+                        request: request,
+                        errorCode: ToolWriteGovernanceErrorCodes.WriteConfirmationRequired,
+                        error: $"Tool '{_definition.Name}' requires explicit write confirmation via '{contract.ConfirmationArgumentName}=true'.",
+                        hints: new[] {
                             $"Set {contract.ConfirmationArgumentName}=true to confirm write intent.",
                             "Provide governance metadata for immutable audit and rollback tracking."
                         },
-                        MissingRequirements = new[] { contract.ConfirmationArgumentName },
-                        IsTransient = false,
-                        ExecutionId = request.ExecutionId,
-                        AuditCorrelationId = request.AuditCorrelationId
-                    };
-                    ToolWriteGovernanceResult? appendFailure = AppendWriteAuditRecord(request, denied);
-                    if (appendFailure is not null) {
-                        return CreateGovernanceErrorOutput(
-                            appendFailure,
-                            ToolWriteGovernanceErrorCodes.WriteAuditAppendFailed,
-                            $"Write governance audit append failed for tool '{_definition.Name}'.");
+                        missingRequirements: new[] { contract.ConfirmationArgumentName });
+                    string? appendFailureOutput = TryCreateAuditAppendFailureOutput(request, denied);
+                    if (appendFailureOutput is not null) {
+                        return appendFailureOutput;
                     }
 
                     return CreateGovernanceErrorOutput(
@@ -219,19 +212,15 @@ public sealed class ToolRegistry {
 
                 if (contract.RequiresGovernanceAuthorization) {
                     if (_owner.RequireWriteAuditSinkForWriteOperations && _owner.WriteAuditSink is null) {
-                        ToolWriteGovernanceResult denied = new() {
-                            IsAuthorized = false,
-                            ErrorCode = ToolWriteGovernanceErrorCodes.WriteAuditSinkRequired,
-                            Error = $"Tool '{_definition.Name}' requires a configured write audit sink for write operations.",
-                            Hints = new[] {
+                        ToolWriteGovernanceResult denied = CreateDeniedResult(
+                            request: request,
+                            errorCode: ToolWriteGovernanceErrorCodes.WriteAuditSinkRequired,
+                            error: $"Tool '{_definition.Name}' requires a configured write audit sink for write operations.",
+                            hints: new[] {
                                 "Configure ToolRegistry.WriteAuditSink.",
                                 $"Required contract: {contract.GovernanceContractId}."
                             },
-                            MissingRequirements = new[] { "write_audit_sink" },
-                            IsTransient = false,
-                            ExecutionId = request.ExecutionId,
-                            AuditCorrelationId = request.AuditCorrelationId
-                        };
+                            missingRequirements: new[] { "write_audit_sink" });
                         return CreateGovernanceErrorOutput(
                             denied,
                             ToolWriteGovernanceErrorCodes.WriteAuditSinkRequired,
@@ -240,25 +229,18 @@ public sealed class ToolRegistry {
 
                     if (_owner.WriteGovernanceRuntime is null) {
                         if (_owner.RequireWriteGovernanceRuntime) {
-                            ToolWriteGovernanceResult denied = new() {
-                                IsAuthorized = false,
-                                ErrorCode = ToolWriteGovernanceErrorCodes.WriteGovernanceRuntimeRequired,
-                                Error = $"Tool '{_definition.Name}' requires a configured write governance runtime.",
-                                Hints = new[] {
+                            ToolWriteGovernanceResult denied = CreateDeniedResult(
+                                request: request,
+                                errorCode: ToolWriteGovernanceErrorCodes.WriteGovernanceRuntimeRequired,
+                                error: $"Tool '{_definition.Name}' requires a configured write governance runtime.",
+                                hints: new[] {
                                     "Configure ToolRegistry.WriteGovernanceRuntime.",
                                     $"Required contract: {contract.GovernanceContractId}."
                                 },
-                                MissingRequirements = new[] { "write_governance_runtime" },
-                                IsTransient = false,
-                                ExecutionId = request.ExecutionId,
-                                AuditCorrelationId = request.AuditCorrelationId
-                            };
-                            ToolWriteGovernanceResult? appendFailure = AppendWriteAuditRecord(request, denied);
-                            if (appendFailure is not null) {
-                                return CreateGovernanceErrorOutput(
-                                    appendFailure,
-                                    ToolWriteGovernanceErrorCodes.WriteAuditAppendFailed,
-                                    $"Write governance audit append failed for tool '{_definition.Name}'.");
+                                missingRequirements: new[] { "write_governance_runtime" });
+                            string? appendFailureOutput = TryCreateAuditAppendFailureOutput(request, denied);
+                            if (appendFailureOutput is not null) {
+                                return appendFailureOutput;
                             }
 
                             return CreateGovernanceErrorOutput(
@@ -269,12 +251,9 @@ public sealed class ToolRegistry {
                     } else {
                         ToolWriteGovernanceResult authorization = _owner.WriteGovernanceRuntime.Authorize(request);
                         ToolWriteGovernanceResult normalizedAuthorization = NormalizeDeniedAuthorizationResult(authorization);
-                        ToolWriteGovernanceResult? appendFailure = AppendWriteAuditRecord(request, normalizedAuthorization);
-                        if (appendFailure is not null) {
-                            return CreateGovernanceErrorOutput(
-                                appendFailure,
-                                ToolWriteGovernanceErrorCodes.WriteAuditAppendFailed,
-                                $"Write governance audit append failed for tool '{_definition.Name}'.");
+                        string? appendFailureOutput = TryCreateAuditAppendFailureOutput(request, normalizedAuthorization);
+                        if (appendFailureOutput is not null) {
+                            return appendFailureOutput;
                         }
 
                         if (!normalizedAuthorization.IsAuthorized) {
@@ -288,6 +267,39 @@ public sealed class ToolRegistry {
             }
 
             return await _inner.InvokeAsync(arguments, cancellationToken).ConfigureAwait(false);
+        }
+
+        private ToolWriteGovernanceResult CreateDeniedResult(
+            ToolWriteGovernanceRequest request,
+            string errorCode,
+            string error,
+            IReadOnlyList<string>? hints = null,
+            IReadOnlyList<string>? missingRequirements = null,
+            bool isTransient = false) {
+            return new ToolWriteGovernanceResult {
+                IsAuthorized = false,
+                ErrorCode = errorCode ?? string.Empty,
+                Error = error ?? string.Empty,
+                Hints = hints ?? Array.Empty<string>(),
+                MissingRequirements = missingRequirements ?? Array.Empty<string>(),
+                IsTransient = isTransient,
+                ExecutionId = request.ExecutionId,
+                AuditCorrelationId = request.AuditCorrelationId
+            };
+        }
+
+        private string? TryCreateAuditAppendFailureOutput(
+            ToolWriteGovernanceRequest request,
+            ToolWriteGovernanceResult authorization) {
+            ToolWriteGovernanceResult? appendFailure = AppendWriteAuditRecord(request, authorization);
+            if (appendFailure is null) {
+                return null;
+            }
+
+            return CreateGovernanceErrorOutput(
+                appendFailure,
+                ToolWriteGovernanceErrorCodes.WriteAuditAppendFailed,
+                $"Write governance audit append failed for tool '{_definition.Name}'.");
         }
 
         private ToolWriteGovernanceRequest CreateGovernanceRequest(

--- a/InternalDocs/agent-playbooks/tool-authoring-playbook.md
+++ b/InternalDocs/agent-playbooks/tool-authoring-playbook.md
@@ -1,0 +1,41 @@
+# Tool Authoring Playbook
+
+Use this playbook when adding or refactoring tools in `IntelligenceX.Tools/**`.
+
+## Goals
+- Keep new tools short, predictable, and easy to review.
+- Reuse shared helper paths before adding tool-specific helper code.
+- Keep behavior contracts stable (`error_code`, metadata keys, table view shape).
+
+## Shared Reuse Rules
+1. Start from the package base class (`ActiveDirectoryToolBase`, `SystemToolBase`, `EventLogToolBase`, `FileSystemToolBase`, etc.).
+2. Use `ToolBase.BuildAutoTableResponse(...)` for table envelopes instead of inline response shaping.
+3. Use `ToolBase.AddMaxResultsMeta(...)` (directly or via package helper wrappers) for `max_results` metadata.
+4. Prefer `ToolQueryHelpers` helpers (`CapRows`, projection filters) over handwritten list-cap/filter plumbing.
+5. Add package-local helpers only when behavior is package-specific (for example AD domain parsing, collection contract mapping).
+
+## Package-Specific Rules
+- Active Directory tools:
+  - Parse domains with `TryReadRequiredDomainName(...)`.
+  - For conventional collection contracts, use `TryExecuteCollectionQuery(...)`.
+  - For standard domain table flows, prefer `ExecuteDomainRowsViewTool(...)`.
+  - For metadata, prefer `AddDomainAndMaxResultsMeta(...)` when applicable.
+- System/EventLog/FileSystem tools:
+  - Keep argument limits option-bounded (`ResolveBoundedOptionLimit`/`ResolveMaxResults`).
+  - Keep error mapping centralized in package base helpers.
+
+## New Tool Checklist
+1. Define `ToolDefinition` with strict schema (`Required(...)`, `NoAdditionalProperties()`).
+2. Normalize/validate arguments through shared helpers.
+3. Execute query path through base helpers (including exception/collection mapping).
+4. Build result model and response via `BuildAutoTableResponse(...)`.
+5. Populate consistent metadata (at minimum: `count/truncated`; include `max_results` when bounded).
+6. Add or update tests for helper logic and any new branching behavior.
+7. Run targeted build/tests for changed package(s).
+
+## Refactor Checklist
+1. Replace duplicated parse/cap/meta logic with shared helper calls.
+2. Avoid changing output contracts unless explicitly intended.
+3. Add regression tests before removing old helper branches.
+4. Keep large formatting/line-ending normalization out of behavior PRs; run as a separate one-shot cleanup PR.
+


### PR DESCRIPTION
## Summary
- centralize shared tooling helpers in `ToolBase` for table response shaping and `max_results` metadata
- remove duplicated helper implementations from AD/EventLog/System/FileSystem package base classes
- continue AD/GPO helper reuse improvements (required-domain parsing + domain/max metadata consolidation)
- add tool authoring governance artifacts:
  - `InternalDocs/agent-playbooks/tool-authoring-playbook.md`
  - `.agents/skills/intelligencex-tools-authoring/SKILL.md`
  - catalog references in `AGENTS.md` and `.agents/skills/README.md`

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`

Both passed (`301` tests).
