### PR TITLE
Follow up IX review: clarify max-results helpers and domain/glob contracts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,9 +25,9 @@
 .gitattributes text eol=lf
 .editorconfig text eol=lf
 
-# Keep active AD/tooling development paths explicitly normalized to LF.
-IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/*.cs text eol=lf
-IntelligenceX.Tools/IntelligenceX.Tools.Tests/*.cs text eol=lf
+# Keep active AD/tooling development paths explicitly normalized to LF (recursive).
+IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/**/*.cs text eol=lf
+IntelligenceX.Tools/IntelligenceX.Tools.Tests/**/*.cs text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -60,12 +60,12 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     }
 
     /// <summary>
-    /// Resolves a positive max-results argument capped by pack options.
+    /// Resolves max-results where non-positive input falls back to the default option cap.
     /// </summary>
     /// <param name="arguments">Tool arguments.</param>
     /// <param name="argumentName">Argument name (defaults to <c>max_results</c>).</param>
     /// <returns>Normalized max-results value.</returns>
-    protected int ResolveMaxResults(JsonObject? arguments, string argumentName = "max_results") {
+    protected int ResolveMaxResultsDefaultOnNonPositive(JsonObject? arguments, string argumentName = "max_results") {
         return ToolArgs.GetPositiveOptionBoundedInt32OrDefault(
             arguments,
             argumentName,
@@ -74,12 +74,12 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     }
 
     /// <summary>
-    /// Resolves a max-results argument with strict lower-bound clamping (minimum 1).
+    /// Resolves max-results where non-positive input is clamped to 1 (strictly positive).
     /// </summary>
     /// <param name="arguments">Tool arguments.</param>
     /// <param name="argumentName">Argument name (defaults to <c>max_results</c>).</param>
     /// <returns>Normalized max-results value.</returns>
-    protected int ResolveBoundedMaxResults(JsonObject? arguments, string argumentName = "max_results") {
+    protected int ResolveMaxResultsClampToOne(JsonObject? arguments, string argumentName = "max_results") {
         return ToolArgs.GetOptionBoundedInt32(
             arguments,
             argumentName,
@@ -380,7 +380,7 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
             return Task.FromResult(argumentError!);
         }
 
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecuteCollectionQuery(
                 query: () => query(domainName),
@@ -673,10 +673,8 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         JsonObject? arguments,
         out PolicyAttributionToolRequest request,
         out string? errorResponse) {
-        var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        if (string.IsNullOrWhiteSpace(domainName)) {
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out errorResponse)) {
             request = default;
-            errorResponse = ToolResponse.Error("invalid_argument", "domain_name is required.");
             return false;
         }
 
@@ -684,7 +682,7 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
             DomainName: domainName,
             IncludeAttribution: ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true),
             ConfiguredAttributionOnly: ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false),
-            MaxResults: ResolveBoundedMaxResults(arguments));
+            MaxResults: ResolveMaxResultsClampToOne(arguments));
         errorResponse = null;
         return true;
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
@@ -77,7 +77,7 @@ public sealed class AdAzureAdSsoTool : ActiveDirectoryToolBase, ITool {
         var onlyPresent = ToolArgs.GetBoolean(arguments, "only_present", defaultValue: false);
         var riskyOnly = ToolArgs.GetBoolean(arguments, "risky_only", defaultValue: false);
         var includeSpns = ToolArgs.GetBoolean(arguments, "include_spns", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -155,4 +155,3 @@ public sealed class AdAzureAdSsoTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
@@ -72,7 +72,7 @@ public sealed class AdDangerousExtendedRightsTool : ActiveDirectoryToolBase, ITo
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeFindings = ToolArgs.GetBoolean(arguments, "include_findings", defaultValue: true);
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 200, 1, Options.MaxResults);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -143,4 +143,3 @@ public sealed class AdDangerousExtendedRightsTool : ActiveDirectoryToolBase, ITo
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
@@ -79,7 +79,7 @@ public sealed class AdDcFleetPostureTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: false);
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 2000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -157,4 +157,3 @@ public sealed class AdDcFleetPostureTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
@@ -68,7 +68,7 @@ public sealed class AdDcShadowIndicatorsTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeFindings = ToolArgs.GetBoolean(arguments, "include_findings", defaultValue: true);
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -134,4 +134,3 @@ public sealed class AdDcShadowIndicatorsTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDelegationAuditTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDelegationAuditTool.cs
@@ -54,7 +54,7 @@ public sealed class AdDelegationAuditTool : ActiveDirectoryToolBase, ITool {
             ? (int)Math.Min(requestedMaxValues.Value, MaxValuesPerAttributeCap)
             : 50;
 
-        var maxResults = ResolveMaxResults(arguments);
+        var maxResults = ResolveMaxResultsDefaultOnNonPositive(arguments);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDirectoryDiscoveryDiagnosticsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDirectoryDiscoveryDiagnosticsTool.cs
@@ -55,7 +55,7 @@ public sealed class AdDirectoryDiscoveryDiagnosticsTool : ActiveDirectoryToolBas
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var domains = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("domains"));
         var asIssue = ToolArgs.GetBoolean(arguments, "as_issue", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         var maxIssues = ToolArgs.GetCappedInt32(arguments, "max_issues", 5000, 1, 100_000);
         var dnsResolveTimeoutMs = ToolArgs.GetCappedInt32(arguments, "dns_resolve_timeout_ms", 1500, 200, 120_000);
@@ -122,4 +122,3 @@ public sealed class AdDirectoryDiscoveryDiagnosticsTool : ActiveDirectoryToolBas
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsDelegationTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsDelegationTool.cs
@@ -68,7 +68,7 @@ public sealed class AdDnsDelegationTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var zoneNameContains = ToolArgs.GetOptionalTrimmed(arguments, "zone_name_contains");
         var identityContains = ToolArgs.GetOptionalTrimmed(arguments, "identity_contains");
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -146,4 +146,3 @@ public sealed class AdDnsDelegationTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsScavengingTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsScavengingTool.cs
@@ -61,7 +61,7 @@ public sealed class AdDnsScavengingTool : ActiveDirectoryToolBase, ITool {
         var mismatchedOnly = ToolArgs.GetBoolean(arguments, "mismatched_only", defaultValue: false);
         var staleOnly = ToolArgs.GetBoolean(arguments, "stale_only", defaultValue: false);
         var scavengingEnabledOnly = ToolArgs.GetBoolean(arguments, "scavenging_enabled_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecute(
                 action: () => new DnsScavengingAnalyzer()
@@ -116,4 +116,3 @@ public sealed class AdDnsScavengingTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsServerConfigTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsServerConfigTool.cs
@@ -72,7 +72,7 @@ public sealed class AdDnsServerConfigTool : ActiveDirectoryToolBase, ITool {
         var recursionDisabledOnly = ToolArgs.GetBoolean(arguments, "recursion_disabled_only", defaultValue: false);
         var missingForwardersOnly = ToolArgs.GetBoolean(arguments, "missing_forwarders_only", defaultValue: false);
         var maxServers = ToolArgs.GetCappedInt32(arguments, "max_servers", 200, 1, 5000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
         var errors = new List<DnsServerConfigError>();
 
         var servers = new List<string>(maxServers);
@@ -179,4 +179,3 @@ public sealed class AdDnsServerConfigTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneConfigTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneConfigTool.cs
@@ -71,7 +71,7 @@ public sealed class AdDnsZoneConfigTool : ActiveDirectoryToolBase, ITool {
         var zoneNameContains = ToolArgs.GetOptionalTrimmed(arguments, "zone_name_contains");
         var dynamicUpdatesOnly = ToolArgs.GetBoolean(arguments, "dynamic_updates_only", defaultValue: false);
         var insecureUpdatesOnly = ToolArgs.GetBoolean(arguments, "insecure_updates_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecute(
                 action: () => DnsZoneConfigService.GetZonesResult(dnsServer),
@@ -140,4 +140,3 @@ public sealed class AdDnsZoneConfigTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
@@ -90,7 +90,7 @@ public sealed class AdDnsZoneSecurityTool : ActiveDirectoryToolBase, ITool {
         var broadWriteMin = ToolArgs.GetCappedInt32(arguments, "broad_write_min", 0, 0, 100000);
         var includeOffendingPrincipals = ToolArgs.GetBoolean(arguments, "include_offending_principals", defaultValue: false);
         var maxOffendingRows = ToolArgs.GetCappedInt32(arguments, "max_offending_rows", 500, 1, 50000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -200,4 +200,3 @@ public sealed class AdDnsZoneSecurityTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainAdminsSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainAdminsSummaryTool.cs
@@ -47,7 +47,7 @@ public sealed class AdDomainAdminsSummaryTool : ActiveDirectoryToolBase, ITool {
 
         var includeMembers = arguments?.GetBoolean("include_members") ?? true;
 
-        var maxResults = ResolveMaxResults(arguments);
+        var maxResults = ResolveMaxResultsDefaultOnNonPositive(arguments);
 
         try {
             var summary = await DomainAdminsSummaryService

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainContainerDefaultsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainContainerDefaultsTool.cs
@@ -65,7 +65,7 @@ public sealed class AdDomainContainerDefaultsTool : ActiveDirectoryToolBase, ITo
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var changedOnly = ToolArgs.GetBoolean(arguments, "changed_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -133,4 +133,3 @@ public sealed class AdDomainContainerDefaultsTool : ActiveDirectoryToolBase, ITo
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerFactsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerFactsTool.cs
@@ -79,7 +79,7 @@ public sealed class AdDomainControllerFactsTool : ActiveDirectoryToolBase, ITool
         var onlyGlobalCatalog = ToolArgs.GetBoolean(arguments, "only_global_catalog", defaultValue: false);
         var onlyRodc = ToolArgs.GetBoolean(arguments, "only_rodc", defaultValue: false);
         var timeoutMs = ToolArgs.GetCappedInt32(arguments, "timeout_ms", 3000, 300, 60000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -166,4 +166,3 @@ public sealed class AdDomainControllerFactsTool : ActiveDirectoryToolBase, ITool
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
@@ -76,7 +76,7 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var domainController = ToolArgs.GetOptionalTrimmed(arguments, "domain_controller");
         var insecureOnly = ToolArgs.GetBoolean(arguments, "insecure_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!string.IsNullOrWhiteSpace(domainController) && string.IsNullOrWhiteSpace(domainName)) {
             return ToolResponse.Error(
@@ -192,4 +192,3 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
             });
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllersTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllersTool.cs
@@ -33,7 +33,7 @@ public sealed class AdDomainControllersTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var max = ResolveBoundedMaxResults(arguments);
+        var max = ResolveMaxResultsClampToOne(arguments);
 
         var (dc, defaultNc) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
         if (string.IsNullOrWhiteSpace(defaultNc)) {
@@ -72,4 +72,3 @@ public sealed class AdDomainControllersTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
@@ -71,7 +71,7 @@ public sealed class AdDomainStatisticsTool : ActiveDirectoryToolBase, ITool {
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeDomainControllers = ToolArgs.GetBoolean(arguments, "include_domain_controllers", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -167,4 +167,3 @@ public sealed class AdDomainStatisticsTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
@@ -88,7 +88,7 @@ public sealed class AdDuplicateAccountsTool : ActiveDirectoryToolBase, ITool {
         var conflictsOnly = ToolArgs.GetBoolean(arguments, "conflicts_only", defaultValue: false);
         var duplicatesOnly = ToolArgs.GetBoolean(arguments, "duplicates_only", defaultValue: false);
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 5000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -185,4 +185,3 @@ public sealed class AdDuplicateAccountsTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoChangesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoChangesTool.cs
@@ -53,7 +53,7 @@ public sealed class AdGpoChangesTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", $"since_utc: {sinceError}"));
         }
 
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
         var items = new List<GpoListItem>(Math.Min(maxResults, 512));
         var scanned = 0;
         var truncated = false;

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoHealthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoHealthTool.cs
@@ -62,7 +62,7 @@ public sealed class AdGpoHealthTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", "gpo_ids must contain at least one GUID."));
         }
 
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
         var requestedCount = rawIds.Count;
         var truncated = requestedCount > maxResults;
         if (rawIds.Count > maxResults) {
@@ -117,4 +117,3 @@ public sealed class AdGpoHealthTool : ActiveDirectoryToolBase, ITool {
             : null;
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoIntegrityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoIntegrityTool.cs
@@ -60,7 +60,7 @@ public sealed class AdGpoIntegrityTool : ActiveDirectoryToolBase, ITool {
         var sysvolMissingOnly = ToolArgs.GetBoolean(arguments, "sysvol_missing_only", defaultValue: false);
         var adMissingOnly = ToolArgs.GetBoolean(arguments, "ad_missing_only", defaultValue: false);
         var errorsOnly = ToolArgs.GetBoolean(arguments, "errors_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoIntegrityService.Get(domainName),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoListTool.cs
@@ -104,7 +104,7 @@ public sealed class AdGpoListTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", $"modified_since_utc: {modifiedSinceError}"));
         }
 
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
         var items = new List<GpoListItem>(Math.Min(maxResults, 512));
         var scanned = 0;
         var truncated = false;
@@ -192,4 +192,3 @@ public sealed class AdGpoListTool : ActiveDirectoryToolBase, ITool {
         return true;
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionAdministrativeTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionAdministrativeTool.cs
@@ -59,7 +59,7 @@ public sealed class AdGpoPermissionAdministrativeTool : ActiveDirectoryToolBase,
         var includeCompliant = ToolArgs.GetBoolean(arguments, "include_compliant", defaultValue: false);
         var errorsOnly = ToolArgs.GetBoolean(arguments, "errors_only", defaultValue: false);
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionAdministrativeService.Get(domainName, includeCompliant: includeCompliant, maxGpos: maxGpos),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionConsistencyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionConsistencyTool.cs
@@ -75,7 +75,7 @@ public sealed class AdGpoPermissionConsistencyTool : ActiveDirectoryToolBase, IT
 
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
         var sysvolScanCap = ToolArgs.GetCappedInt32(arguments, "sysvol_scan_cap", 2000, 1, 500000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionConsistencyService.Get(domainName, verifyInheritance: verifyInheritance, includeConsistent: includeConsistent, maxGpos: maxGpos, sysvolScanCap: sysvolScanCap),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReadTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReadTool.cs
@@ -60,7 +60,7 @@ public sealed class AdGpoPermissionReadTool : ActiveDirectoryToolBase, ITool {
         var includeCompliant = ToolArgs.GetBoolean(arguments, "include_compliant", defaultValue: false);
         var denyOnly = ToolArgs.GetBoolean(arguments, "deny_only", defaultValue: false);
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionReadService.Get(domainName, includeCompliant: includeCompliant, maxGpos: maxGpos),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReportTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReportTool.cs
@@ -88,7 +88,7 @@ public sealed class AdGpoPermissionReportTool : ActiveDirectoryToolBase, ITool {
 
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
         var maxRows = ToolArgs.GetCappedInt32(arguments, "max_rows", 200000, 1, 2000000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionReportService.Get(domainName, gpoId: gpoId, gpoName: gpoName, maxGpos: maxGpos, maxRows: maxRows),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionRootTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionRootTool.cs
@@ -71,7 +71,7 @@ public sealed class AdGpoPermissionRootTool : ActiveDirectoryToolBase, ITool {
         var denyOnly = ToolArgs.GetBoolean(arguments, "deny_only", defaultValue: false);
         var inheritedOnly = ToolArgs.GetBoolean(arguments, "inherited_only", defaultValue: false);
         var maxRows = ToolArgs.GetCappedInt32(arguments, "max_rows", 100000, 1, 1000000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionRootService.Get(domainName, maxRows: maxRows),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionUnknownTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionUnknownTool.cs
@@ -62,7 +62,7 @@ public sealed class AdGpoPermissionUnknownTool : ActiveDirectoryToolBase, ITool 
         var inheritedOnly = ToolArgs.GetBoolean(arguments, "inherited_only", defaultValue: false);
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
         var maxFindings = ToolArgs.GetCappedInt32(arguments, "max_findings", 200000, 1, 2000000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionUnknownService.Get(domainName, maxGpos: maxGpos, maxFindings: maxFindings),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoRedirectTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoRedirectTool.cs
@@ -65,7 +65,7 @@ public sealed class AdGpoRedirectTool : ActiveDirectoryToolBase, ITool {
 
         var gpoNames = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("gpo_names"));
         var actualPathContains = ToolArgs.GetOptionalTrimmed(arguments, "actual_path_contains");
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoRedirectAnalyzer.Get(domainName, ids: gpoIds.Count == 0 ? null : gpoIds.ToArray(), names: gpoNames.Count == 0 ? null : gpoNames.ToArray()),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupMembersResolvedTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupMembersResolvedTool.cs
@@ -72,7 +72,7 @@ public sealed class AdGroupMembersResolvedTool : ActiveDirectoryToolBase, ITool 
             return Task.FromResult(Error("identity is required."));
         }
 
-        var maxResults = ResolveMaxResults(arguments);
+        var maxResults = ResolveMaxResultsDefaultOnNonPositive(arguments);
 
         var includeNested = ToolArgs.GetBoolean(arguments, "include_nested");
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupsListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupsListTool.cs
@@ -70,7 +70,7 @@ public sealed class AdGroupsListTool : ActiveDirectoryToolBase, ITool {
         var nameContains = ToolArgs.GetOptionalTrimmed(arguments, "name_contains");
         var namePrefix = ToolArgs.GetOptionalTrimmed(arguments, "name_prefix");
 
-        var maxResults = ResolveMaxResults(arguments);
+        var maxResults = ResolveMaxResultsDefaultOnNonPositive(arguments);
 
         var offset = Math.Max(arguments?.GetInt64("offset") ?? 0, 0);
         var requestedPageSize = arguments?.GetInt64("page_size");

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
@@ -63,7 +63,7 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
 
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -121,4 +121,3 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
             });
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKrbtgtHealthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKrbtgtHealthTool.cs
@@ -57,7 +57,7 @@ public sealed class AdKrbtgtHealthTool : ActiveDirectoryToolBase, ITool {
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var ageThresholdDays = ToolArgs.GetCappedInt32(arguments, "age_threshold_days", 180, 1, 3650);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -109,4 +109,3 @@ public sealed class AdKrbtgtHealthTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
@@ -72,7 +72,7 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
         var allowLmHashOnly = ToolArgs.GetBoolean(arguments, "allow_lm_hash_only", defaultValue: false);
         var legacyNtlmOnly = ToolArgs.GetBoolean(arguments, "legacy_ntlm_only", defaultValue: false);
         var maxDomainControllers = ToolArgs.GetCappedInt32(arguments, "max_domain_controllers", 200, 1, 2000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         var rows = new List<LanManagerSettingsRow>(maxDomainControllers);
         var errors = new List<LanManagerSettingsError>();
@@ -176,4 +176,3 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
             });
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
@@ -92,7 +92,7 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
         var expiredOnly = ToolArgs.GetBoolean(arguments, "expired_only", defaultValue: false);
         var includeSamples = ToolArgs.GetBoolean(arguments, "include_samples", defaultValue: false);
         var maxSampleRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_sample_rows_per_domain", 50, 1, 1000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -186,4 +186,3 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
             });
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
@@ -80,7 +80,7 @@ public sealed class AdLapsSchemaPostureTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var onlyFindings = ToolArgs.GetBoolean(arguments, "only_findings", defaultValue: false);
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -173,4 +173,3 @@ public sealed class AdLapsSchemaPostureTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryPagedTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryPagedTool.cs
@@ -61,7 +61,7 @@ public sealed class AdLdapQueryPagedTool : ActiveDirectoryToolBase, ITool {
             ? (int)Math.Min(requestedMaxValues.Value, LdapQueryPolicy.MaxValuesPerAttributeCap)
             : LdapQueryPolicy.DefaultMaxValuesPerAttribute;
 
-        var maxResults = ResolveMaxResults(arguments);
+        var maxResults = ResolveMaxResultsDefaultOnNonPositive(arguments);
 
         var requestedPageSize = arguments?.GetInt64("page_size");
         var pageSize = requestedPageSize.HasValue && requestedPageSize.Value > 0

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryTool.cs
@@ -56,7 +56,7 @@ public sealed class AdLdapQueryTool : ActiveDirectoryToolBase, ITool {
             ? (int)Math.Min(requestedMaxValues.Value, LdapQueryPolicy.MaxValuesPerAttributeCap)
             : LdapQueryPolicy.DefaultMaxValuesPerAttribute;
 
-        var maxResults = ResolveMaxResults(arguments);
+        var maxResults = ResolveMaxResultsDefaultOnNonPositive(arguments);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdMachineAccountQuotaTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdMachineAccountQuotaTool.cs
@@ -67,7 +67,7 @@ public sealed class AdMachineAccountQuotaTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var threshold = ToolArgs.GetCappedInt32(arguments, "threshold", 0, -1, int.MaxValue);
         var riskyOnly = ToolArgs.GetBoolean(arguments, "risky_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -137,4 +137,3 @@ public sealed class AdMachineAccountQuotaTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNullSessionPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNullSessionPostureTool.cs
@@ -69,7 +69,7 @@ public sealed class AdNullSessionPostureTool : ActiveDirectoryToolBase, ITool {
         var anonymousSamOnly = ToolArgs.GetBoolean(arguments, "anonymous_sam_only", defaultValue: false);
         var nullSessionOnly = ToolArgs.GetBoolean(arguments, "null_session_only", defaultValue: false);
         var maxDomainControllers = ToolArgs.GetCappedInt32(arguments, "max_domain_controllers", 200, 1, 2000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         var dcRows = new List<(string DomainName, string DomainController)>();
         if (explicitDcs.Count > 0) {
@@ -171,4 +171,3 @@ public sealed class AdNullSessionPostureTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
@@ -77,7 +77,7 @@ public sealed class AdOuProtectionTool : ActiveDirectoryToolBase, ITool {
         var unprotectedOnly = ToolArgs.GetBoolean(arguments, "unprotected_only", defaultValue: false);
         var includeUnprotectedOus = ToolArgs.GetBoolean(arguments, "include_unprotected_ous", defaultValue: false);
         var maxOuRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_ou_rows_per_domain", 100, 1, 5000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -167,4 +167,3 @@ public sealed class AdOuProtectionTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyLengthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyLengthTool.cs
@@ -60,7 +60,7 @@ public sealed class AdPasswordPolicyLengthTool : ActiveDirectoryToolBase, ITool 
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var recommendedMinimumLength = ToolArgs.GetCappedInt32(arguments, "recommended_minimum_length", 12, 1, 512);
         var belowRecommendedOnly = ToolArgs.GetBoolean(arguments, "below_recommended_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -126,4 +126,3 @@ public sealed class AdPasswordPolicyLengthTool : ActiveDirectoryToolBase, ITool 
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
@@ -79,7 +79,7 @@ public sealed class AdPasswordPolicyRollupTool : ActiveDirectoryToolBase, ITool 
         var psoHistoryMin = ToolArgs.GetCappedInt32(arguments, "pso_history_min", 24, 0, 1024);
         var includePsoDetails = ToolArgs.GetBoolean(arguments, "include_pso_details", defaultValue: true);
         var maxPsoRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_pso_rows_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -155,4 +155,3 @@ public sealed class AdPasswordPolicyRollupTool : ActiveDirectoryToolBase, ITool 
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyTool.cs
@@ -59,7 +59,7 @@ public sealed class AdPasswordPolicyTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
         var includeFineGrained = ToolArgs.GetBoolean(arguments, "include_fine_grained", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         var domains = LdapQueryHelper.GetTargetDomains(domainName, forestName)
             .Where(static x => !string.IsNullOrWhiteSpace(x))
@@ -139,4 +139,3 @@ public sealed class AdPasswordPolicyTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiTemplatesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiTemplatesTool.cs
@@ -58,8 +58,8 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
         var codeSigningRiskOnly = ToolArgs.GetBoolean(arguments, "code_signing_risk_only", defaultValue: false);
         var clientAuthRiskOnly = ToolArgs.GetBoolean(arguments, "client_auth_risk_only", defaultValue: false);
         var includeTakeoverRows = ToolArgs.GetBoolean(arguments, "include_takeover_rows", defaultValue: true);
-        var maxResults = ResolveBoundedMaxResults(arguments);
-        var maxTakeoverRows = ResolveBoundedMaxResults(arguments, "max_takeover_rows");
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
+        var maxTakeoverRows = ResolveMaxResultsClampToOne(arguments, "max_takeover_rows");
 
         if (!TryExecute(
                 action: () => PkiApi.GetTemplates(forestName),
@@ -117,4 +117,3 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
@@ -89,7 +89,7 @@ public sealed class AdRegistrationPostureTool : ActiveDirectoryToolBase, ITool {
         var missingSubnetOnly = ToolArgs.GetBoolean(arguments, "missing_subnet_only", defaultValue: false);
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: false);
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 5000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -194,4 +194,3 @@ public sealed class AdRegistrationPostureTool : ActiveDirectoryToolBase, ITool {
             HasMatchingSubnet: item.HasMatchingSubnet);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationConnectionsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationConnectionsTool.cs
@@ -64,7 +64,7 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
         var origin = NormalizeValue(ToolArgs.GetOptionalTrimmed(arguments, "origin"), "any");
         var summary = ToolArgs.GetBoolean(arguments, "summary", defaultValue: false);
         var summaryBy = NormalizeValue(ToolArgs.GetOptionalTrimmed(arguments, "summary_by"), "site");
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!IsOneOf(transport, "any", "rpc", "smtp")) {
             return Task.FromResult(ToolResponse.Error("invalid_argument", "transport must be one of: any, rpc, smtp."));
@@ -210,4 +210,3 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
         };
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationStatusTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationStatusTool.cs
@@ -48,7 +48,7 @@ public sealed class AdReplicationStatusTool : ActiveDirectoryToolBase, ITool {
 
         var requestedComputerNames = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("computer_names"));
         var healthOnly = ToolArgs.GetBoolean(arguments, "health_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         IReadOnlyList<string> targetServers = requestedComputerNames.Count == 0
             ? DomainHelper.EnumerateDomainControllers().Distinct(StringComparer.OrdinalIgnoreCase).ToArray()
@@ -88,4 +88,3 @@ public sealed class AdReplicationStatusTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSchemaVersionTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSchemaVersionTool.cs
@@ -47,7 +47,7 @@ public sealed class AdSchemaVersionTool : ActiveDirectoryToolBase, ITool {
         cancellationToken.ThrowIfCancellationRequested();
 
         var mismatchedOnly = ToolArgs.GetBoolean(arguments, "mismatched_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecute(
                 action: () => {
@@ -98,4 +98,3 @@ public sealed class AdSchemaVersionTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchFacetsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchFacetsTool.cs
@@ -100,7 +100,7 @@ public sealed class AdSearchFacetsTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var maxResults = ResolveMaxResults(arguments);
+        var maxResults = ResolveMaxResultsDefaultOnNonPositive(arguments);
 
         var requestedPageSize = arguments?.GetInt64("page_size");
         var pageSize = requestedPageSize.HasValue && requestedPageSize.Value > 0

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchTool.cs
@@ -53,7 +53,7 @@ public sealed class AdSearchTool : ActiveDirectoryToolBase, ITool {
         var kindArg = ToolArgs.GetOptionalTrimmed(arguments, "kind");
         var kind = string.IsNullOrWhiteSpace(kindArg) ? "any" : kindArg.Trim().ToLowerInvariant();
 
-        var maxResults = ResolveMaxResults(arguments);
+        var maxResults = ResolveMaxResultsDefaultOnNonPositive(arguments);
 
         var maxValuesPerAttribute = ToolArgs.GetCappedInt32(
             arguments,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
@@ -68,7 +68,7 @@ public sealed class AdShadowCredentialsRiskTool : ActiveDirectoryToolBase, ITool
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeFindings = ToolArgs.GetBoolean(arguments, "include_findings", defaultValue: true);
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -134,4 +134,3 @@ public sealed class AdShadowCredentialsRiskTool : ActiveDirectoryToolBase, ITool
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteCoverageTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteCoverageTool.cs
@@ -62,7 +62,7 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeRegistry = ToolArgs.GetBoolean(arguments, "include_registry", defaultValue: false);
         var raw = ToolArgs.GetBoolean(arguments, "raw", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!raw) {
             if (!TryExecute(
@@ -151,4 +151,3 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteLinksTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteLinksTool.cs
@@ -99,7 +99,7 @@ public sealed class AdSiteLinksTool : ActiveDirectoryToolBase, ITool {
 
         var hasSchedule = ToolArgs.GetBoolean(arguments, "has_schedule", defaultValue: false);
         var expandSchedule = ToolArgs.GetBoolean(arguments, "expand_schedule", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryParseRequiredOptions(arguments, out var requiredOptions, out var optionNames, out var optionError)) {
             return Task.FromResult(ToolResponse.Error("invalid_argument", optionError ?? "Invalid options_all value."));
@@ -287,4 +287,3 @@ public sealed class AdSiteLinksTool : ActiveDirectoryToolBase, ITool {
         };
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSitesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSitesTool.cs
@@ -53,7 +53,7 @@ public sealed class AdSitesTool : ActiveDirectoryToolBase, ITool {
         var includeSubnets = ToolArgs.GetBoolean(arguments, "include_subnets", defaultValue: false);
         var includeOptions = ToolArgs.GetBoolean(arguments, "include_options", defaultValue: false);
         var noDcOnly = ToolArgs.GetBoolean(arguments, "no_dc_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryExecute(
                 action: () => TopologyService.GetSites(
@@ -100,4 +100,3 @@ public sealed class AdSitesTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(response);
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
@@ -76,7 +76,7 @@ public sealed class AdSmartCardPostureTool : ActiveDirectoryToolBase, ITool {
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: true);
         var maxPrivilegedRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_privileged_rows_per_domain", 100, 1, Options.MaxResults);
         var maxFindingRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_finding_rows_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -154,4 +154,3 @@ public sealed class AdSmartCardPostureTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
@@ -88,7 +88,7 @@ public sealed class AdSpnHygieneTool : ActiveDirectoryToolBase, ITool {
         var topN = ToolArgs.GetCappedInt32(arguments, "top_n", 10, 1, 50);
         var includeInvalidSpnSample = ToolArgs.GetBoolean(arguments, "include_invalid_spn_sample", defaultValue: true);
         var maxInvalidSpnSample = ToolArgs.GetCappedInt32(arguments, "max_invalid_spn_sample", 25, 1, 200);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -178,4 +178,3 @@ public sealed class AdSpnHygieneTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnSearchTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnSearchTool.cs
@@ -51,7 +51,7 @@ public sealed class AdSpnSearchTool : ActiveDirectoryToolBase, ITool {
         var kind = string.IsNullOrWhiteSpace(kindArg) ? "any" : kindArg.Trim().ToLowerInvariant();
         var enabledOnly = ToolArgs.GetBoolean(arguments, "enabled_only");
 
-        var maxResults = ResolveMaxResults(arguments);
+        var maxResults = ResolveMaxResultsDefaultOnNonPositive(arguments);
 
         var maxValuesPerAttribute = ToolArgs.GetCappedInt32(
             arguments,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnStatsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnStatsTool.cs
@@ -54,7 +54,7 @@ public sealed class AdSpnStatsTool : ActiveDirectoryToolBase, ITool {
         var enabledOnly = ToolArgs.GetBoolean(arguments, "enabled_only");
         var includeExamples = ToolArgs.GetBoolean(arguments, "include_examples");
 
-        var maxObjects = ResolveMaxResults(arguments);
+        var maxObjects = ResolveMaxResultsDefaultOnNonPositive(arguments);
 
         var requestedServiceClasses = arguments?.GetInt64("max_service_classes");
         var maxServiceClasses = requestedServiceClasses.HasValue && requestedServiceClasses.Value > 0

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdStaleAccountsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdStaleAccountsTool.cs
@@ -53,7 +53,7 @@ public sealed class AdStaleAccountsTool : ActiveDirectoryToolBase, ITool {
 
         var match = ParseMatch(ToolArgs.GetOptionalTrimmed(arguments, "match"));
 
-        var maxResults = ResolveMaxResults(arguments);
+        var maxResults = ResolveMaxResultsDefaultOnNonPositive(arguments);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSubnetsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSubnetsTool.cs
@@ -55,7 +55,7 @@ public sealed class AdSubnetsTool : ActiveDirectoryToolBase, ITool {
 
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var summary = ToolArgs.GetBoolean(arguments, "summary", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (summary) {
             if (!TryExecute(
@@ -135,4 +135,3 @@ public sealed class AdSubnetsTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSystemStateBackupTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSystemStateBackupTool.cs
@@ -72,7 +72,7 @@ public sealed class AdSystemStateBackupTool : ActiveDirectoryToolBase, ITool {
         var thresholdDays = ToolArgs.GetCappedInt32(arguments, "threshold_days", 30, 1, 3650);
         var missingOnly = ToolArgs.GetBoolean(arguments, "missing_only", defaultValue: false);
         var staleOnly = ToolArgs.GetBoolean(arguments, "stale_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,
@@ -155,4 +155,3 @@ public sealed class AdSystemStateBackupTool : ActiveDirectoryToolBase, ITool {
             }));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTrustTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTrustTool.cs
@@ -88,7 +88,7 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
         var includeCommunicationIssues = ToolArgs.GetBoolean(arguments, "include_communication_issues", defaultValue: false);
         var summary = ToolArgs.GetBoolean(arguments, "summary", defaultValue: false);
         var summaryMatrix = ToolArgs.GetBoolean(arguments, "summary_matrix", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         var status = NormalizeEnumValue(ToolArgs.GetOptionalTrimmed(arguments, "status"), "any");
         var trustType = NormalizeEnumValue(ToolArgs.GetOptionalTrimmed(arguments, "trust_type"), "any");
@@ -419,4 +419,3 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
         };
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdUsersExpiredTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdUsersExpiredTool.cs
@@ -39,7 +39,7 @@ public sealed class AdUsersExpiredTool : ActiveDirectoryToolBase, ITool {
         }
         var referenceUtc = referenceUtcOpt ?? DateTime.UtcNow;
 
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResultsClampToOne(arguments);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
         if (string.IsNullOrWhiteSpace(baseDn)) {
@@ -58,4 +58,3 @@ public sealed class AdUsersExpiredTool : ActiveDirectoryToolBase, ITool {
         return Task.FromResult(ToolResponse.OkModel(res));
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
@@ -104,6 +104,7 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
         var root = doc.RootElement;
         Assert.False(root.GetProperty("ok").GetBoolean());
         Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        Assert.Equal("domain_name is required.", root.GetProperty("error").GetString());
     }
 
     [Fact]
@@ -427,11 +428,11 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
         }
 
         public int ResolveDefaultingMaxResults(JsonObject? arguments) {
-            return ResolveMaxResults(arguments);
+            return ResolveMaxResultsDefaultOnNonPositive(arguments);
         }
 
         public int ResolveStrictlyBoundedMaxResults(JsonObject? arguments) {
-            return ResolveBoundedMaxResults(arguments);
+            return ResolveMaxResultsClampToOne(arguments);
         }
 
         public JsonObject CreateScopeMeta(string? domainName, string? forestName) {


### PR DESCRIPTION
## Summary
Addresses the follow-up items from IntelligenceX review "Other Issues"/"Next Steps":

- clarify AD max-results helper semantics by replacing ambiguous names:
  - `ResolveMaxResults` -> `ResolveMaxResultsDefaultOnNonPositive`
  - `ResolveBoundedMaxResults` -> `ResolveMaxResultsClampToOne`
- route policy request `domain_name` parsing through `TryReadRequiredDomainName(...)` for one consistent invalid-argument envelope path
- tighten `.gitattributes` recursive coverage for explicit tooling paths:
  - `IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/**/*.cs`
  - `IntelligenceX.Tools/IntelligenceX.Tools.Tests/**/*.cs`
- add assertion coverage for policy-request required-domain error message contract

## Validation
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/IntelligenceX.Tools.ADPlayground.csproj -c Release`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`

All passed (`301` tests).
