### PR TITLE
docs(project-ops): address follow-up reliability and readability feedback

### DIFF
--- a/Docs/project-ops/demo-capture-runbook.md
+++ b/Docs/project-ops/demo-capture-runbook.md
@@ -72,12 +72,20 @@ Test-Path artifacts/triage/ix-issue-review.md
 Expected PowerShell result: all three checks return `True`.
 
 ```bash
-test -f artifacts/triage/ix-project-config.json
-test -f artifacts/triage/ix-issue-review.json
-test -f artifacts/triage/ix-issue-review.md
+set -euo pipefail
+for f in \
+  artifacts/triage/ix-project-config.json \
+  artifacts/triage/ix-issue-review.json \
+  artifacts/triage/ix-issue-review.md; do
+  if [ ! -f "$f" ]; then
+    echo "Missing required artifact: $f" >&2
+    exit 1
+  fi
+done
+echo "Artifact verification passed."
 ```
 
-Expected bash result: each `test -f` exits with code `0`.
+Expected bash result: the script prints `Artifact verification passed.` and exits with code `0`.
 
 ## Screenshot shot list
 

--- a/Docs/project-ops/overview.md
+++ b/Docs/project-ops/overview.md
@@ -26,7 +26,14 @@ Project Ops is assistive automation, not autonomous production governance.
 
 Issue Ops creates a maintainer-focused board view for stale/no-longer-applicable blockers:
 
-<img src="/assets/screenshots/ix-issue-ops/ix-issue-ops-01-board-overview.svg" alt="Issue Ops project board overview with issue review action and confidence fields visible for infra blocker triage" width="1600" height="900" loading="lazy" decoding="async" />
+<img
+src="/assets/screenshots/ix-issue-ops/ix-issue-ops-01-board-overview.svg"
+alt="Issue Ops project board overview with issue review action and confidence fields visible for infra blocker triage"
+width="1600"
+height="900"
+loading="lazy"
+decoding="async"
+/>
 
 Key decision fields are synced directly to project rows:
 
@@ -35,7 +42,14 @@ Key decision fields are synced directly to project rows:
 - `Matched Pull Request`
 - `Signal Quality`
 
-<img src="/assets/screenshots/ix-issue-ops/ix-issue-ops-02-review-columns.svg" alt="Issue Ops table detail with action confidence and matched pull request columns used during issue applicability review" width="1600" height="900" loading="lazy" decoding="async" />
+<img
+src="/assets/screenshots/ix-issue-ops/ix-issue-ops-02-review-columns.svg"
+alt="Issue Ops table detail with action confidence and matched pull request columns used during issue applicability review"
+width="1600"
+height="900"
+loading="lazy"
+decoding="async"
+/>
 
 ## Recommended start
 

--- a/Website/content/blog/ix-issue-ops-in-action.md
+++ b/Website/content/blog/ix-issue-ops-in-action.md
@@ -19,7 +19,14 @@ Issue Ops gives maintainers one triage surface where every recommendation includ
 The project view below is optimized for issue triage at scale.
 You can quickly separate likely-invalid blockers from items that still need active ownership.
 
-<img src="/assets/screenshots/ix-issue-ops/ix-issue-ops-01-board-overview.svg" alt="Issue Ops project board view with open infra blocker issues, status, linked pull request columns, and quick filtering for maintainer triage" width="1600" height="900" loading="lazy" decoding="async" />
+<img
+src="/assets/screenshots/ix-issue-ops/ix-issue-ops-01-board-overview.svg"
+alt="Issue Ops project board view with open infra blocker issues, status, linked pull request columns, and quick filtering for maintainer triage"
+width="1600"
+height="900"
+loading="lazy"
+decoding="async"
+/>
 
 ## Signals That Matter
 
@@ -30,7 +37,14 @@ Each issue recommendation includes:
 - linked PR context (`Matched Pull Request`, related PRs)
 - supporting confidence signals (stale age, reopen history, activity recency)
 
-<img src="/assets/screenshots/ix-issue-ops/ix-issue-ops-02-review-columns.svg" alt="Issue Ops table columns showing Issue Review Action, confidence score, and linked pull request matching used for stale infra blocker triage" width="1600" height="900" loading="lazy" decoding="async" />
+<img
+src="/assets/screenshots/ix-issue-ops/ix-issue-ops-02-review-columns.svg"
+alt="Issue Ops table columns showing Issue Review Action, confidence score, and linked pull request matching used for stale infra blocker triage"
+width="1600"
+height="900"
+loading="lazy"
+decoding="async"
+/>
 
 ## Safety First
 


### PR DESCRIPTION
## Summary\n- harden bash artifact verification with set -euo pipefail and explicit missing-file errors\n- keep explicit placeholder-token replacement guidance for owner/repo and owner\n- reformat Issue Ops screenshot <img> markup into readable multiline blocks while preserving loading/decoding hints\n- keep rendering behavior and media audit compatibility for docs + blog pages\n\n## Validation\n- Website/build.ps1 -Dev\n- Website/build.ps1 -CI *(local fails on existing PFWEB.BESTPRACTICE baseline warning unrelated to this change set)*\n