### PR TITLE
Fix blog list rendering contract on page layout

### DIFF
--- a/Website/static/css/main.css
+++ b/Website/static/css/main.css
@@ -78,6 +78,44 @@ p { margin: 0 0 1rem; color: var(--pf-muted); }
 .ix-article-body li code, .ix-article-body p code, .ix-article-body td code { background: var(--pf-code-bg); border: 1px solid var(--pf-code-border); padding: 0.15em 0.35em; border-radius: 4px; font-family: var(--pf-font-mono); font-size: 0.875em; }
 .ix-article-body img { display: block; margin: 0.75rem 0 1.5rem; border: 1px solid var(--pf-border); border-radius: var(--pf-radius-sm); box-shadow: var(--pf-shadow-card); }
 [data-theme="light"] .ix-article-body img { background: #FFFFFF; }
+.ix-editorial-list { margin-top: 2rem; display: grid; gap: 1rem; }
+.ix-editorial-card {
+  background: var(--pf-card-bg);
+  border: 1px solid var(--pf-border);
+  border-radius: var(--pf-radius-sm);
+  padding: 1rem 1.125rem;
+}
+.ix-editorial-title { margin: 0 0 0.375rem; font-size: 1.25rem; }
+.ix-editorial-title a { color: var(--pf-ink-strong, #fff); }
+.ix-editorial-title a:hover { color: var(--pf-accent); }
+.ix-editorial-meta {
+  margin: 0 0 0.5rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  display: flex;
+  gap: 0.5rem;
+  color: var(--pf-muted);
+}
+.ix-editorial-summary { margin: 0; color: var(--pf-muted); }
+.ix-editorial-pager {
+  margin-top: 1.25rem;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+.ix-editorial-pager-link {
+  border: 1px solid var(--pf-border);
+  border-radius: var(--pf-radius-sm);
+  padding: 0.45rem 0.7rem;
+  font-size: 0.875rem;
+  color: var(--pf-ink);
+  background: var(--pf-card-bg);
+}
+.ix-editorial-pager-link.is-disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
 
 /* ===== Tables ===== */
 table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.9rem; }

--- a/Website/themes/intelligencex/layouts/page.html
+++ b/Website/themes/intelligencex/layouts/page.html
@@ -31,6 +31,36 @@
         <div class="ix-article-body">
 {{ content }}
         </div>
+        {{ if items && items.size > 0 }}
+        <section class="ix-editorial-list" aria-label="Blog entries">
+          {{ for item in items }}
+          <article class="ix-editorial-card">
+            <h2 class="ix-editorial-title"><a href="{{ item.output_path }}">{{ item.title }}</a></h2>
+            <p class="ix-editorial-meta">
+              {{ if item.date }}<time datetime="{{ item.date }}">{{ item.date }}</time>{{ end }}
+              {{ if item.collection }}<span>{{ item.collection }}</span>{{ end }}
+            </p>
+            {{ if item.description }}
+            <p class="ix-editorial-summary">{{ item.description }}</p>
+            {{ end }}
+          </article>
+          {{ end }}
+        </section>
+        {{ if pagination && (pagination.prev_url || pagination.next_url) }}
+        <nav class="ix-editorial-pager" aria-label="Pagination">
+          {{ if pagination.prev_url }}
+          <a class="ix-editorial-pager-link" href="{{ pagination.prev_url }}">Newer posts</a>
+          {{ else }}
+          <span class="ix-editorial-pager-link is-disabled">Newer posts</span>
+          {{ end }}
+          {{ if pagination.next_url }}
+          <a class="ix-editorial-pager-link" href="{{ pagination.next_url }}">Older posts</a>
+          {{ else }}
+          <span class="ix-editorial-pager-link is-disabled">Older posts</span>
+          {{ end }}
+        </nav>
+        {{ end }}
+        {{ end }}
       </article>
     </div>
   </main>
@@ -39,4 +69,3 @@
   {{ extra_scripts_html }}
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- render editorial list cards in page layout when collection items are present
- add previous/next pagination links for list pages via pagination.prev_url and pagination.next_url
- style list cards and pager in main.css to match site chrome

## Why
CI verify flagged the blog list as a page layout that was not rendering list context. This aligns rendering with PowerForge content contracts and prevents regressions.

## Validation
- ./build.ps1 -CI (pass)
