### PR TITLE
fix(chat-export): harden transcript docx against definition-list leakage

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/LocalExportArtifactWriterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/LocalExportArtifactWriterTests.cs
@@ -172,6 +172,66 @@ public sealed class LocalExportArtifactWriterTests {
         }
     }
 
+    /// <summary>
+    /// Ensures longer outer fences are not closed by inner shorter fence markers during DOCX pre-pass.
+    /// </summary>
+    [Fact]
+    public void ExportTranscript_Docx_PreservesContentInsideLongerOuterFence() {
+        const string markdown = """
+            # Transcript
+
+            ````markdown
+            ```powershell
+            key: value
+            ```
+            ````
+            """;
+
+        var root = CreateTempDirectory();
+        try {
+            var docxPath = Path.Combine(root, "transcript-outer-fence.docx");
+            LocalExportArtifactWriter.ExportTranscript(ExportPreferencesContract.FormatDocx, "transcript", markdown, docxPath);
+            Assert.True(File.Exists(docxPath));
+
+            using var docx = WordDocument.Load(docxPath, readOnly: true);
+            var bodyText = string.Join("\n", docx.Paragraphs.Select(p => p.Text));
+
+            Assert.Contains("key", bodyText, StringComparison.Ordinal);
+            Assert.Contains("value", bodyText, StringComparison.Ordinal);
+            Assert.DoesNotContain("key\\: value", bodyText, StringComparison.Ordinal);
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Ensures separator detection ignores colon-space sequences inside inline code spans.
+    /// </summary>
+    [Fact]
+    public void ExportTranscript_Docx_DoesNotEscapeSeparatorInsideInlineCode() {
+        const string markdown = """
+            # Transcript
+
+            Use `key: value` syntax when defining pairs.
+            """;
+
+        var root = CreateTempDirectory();
+        try {
+            var docxPath = Path.Combine(root, "transcript-inline-code.docx");
+            LocalExportArtifactWriter.ExportTranscript(ExportPreferencesContract.FormatDocx, "transcript", markdown, docxPath);
+            Assert.True(File.Exists(docxPath));
+
+            using var docx = WordDocument.Load(docxPath, readOnly: true);
+            var bodyText = string.Join("\n", docx.Paragraphs.Select(p => p.Text));
+
+            Assert.Contains("key", bodyText, StringComparison.Ordinal);
+            Assert.Contains("value", bodyText, StringComparison.Ordinal);
+            Assert.DoesNotContain("key\\: value", bodyText, StringComparison.Ordinal);
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static string CreateTempDirectory() {
         var path = Path.Combine(Path.GetTempPath(), "ixchat-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(path);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.ExportArtifacts/OfficeImoArtifactWriter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.ExportArtifacts/OfficeImoArtifactWriter.cs
@@ -129,10 +129,21 @@ public static class OfficeImoArtifactWriter {
                     insideFence = true;
                     fenceMarker = marker;
                     fenceLength = markerRunLength;
-                } else if (marker == fenceMarker && markerRunLength >= fenceLength) {
+                    continue;
+                }
+
+                if (marker == fenceMarker &&
+                    markerRunLength >= fenceLength &&
+                    IsClosingFenceLine(trimmed, markerRunLength)) {
                     insideFence = false;
                     fenceMarker = '\0';
                     fenceLength = 0;
+                    continue;
+                }
+
+                // Fence-like content inside an active fence should never be rewritten.
+                if (insideFence) {
+                    continue;
                 }
 
                 continue;
@@ -182,19 +193,42 @@ public static class OfficeImoArtifactWriter {
             return false;
         }
 
-        var scanFrom = 0;
-        while (scanFrom < line.Length) {
-            var separator = line.IndexOf(':', scanFrom);
-            if (separator < 1) {
-                return false;
+        var inlineFenceLength = 0;
+        var i = 0;
+        while (i < line.Length) {
+            var ch = line[i];
+
+            // Respect escaped punctuation and escaped backticks.
+            if (ch == '\\' && i + 1 < line.Length) {
+                i += 2;
+                continue;
             }
 
-            if (separator + 1 < line.Length && char.IsWhiteSpace(line[separator + 1])) {
-                index = separator;
+            if (ch == '`') {
+                var runLength = CountRunLength(line, i, '`');
+                if (inlineFenceLength == 0) {
+                    inlineFenceLength = runLength;
+                    i += runLength;
+                    continue;
+                }
+
+                if (runLength >= inlineFenceLength) {
+                    inlineFenceLength = 0;
+                    i += runLength;
+                    continue;
+                }
+            }
+
+            if (inlineFenceLength == 0 &&
+                ch == ':' &&
+                i > 0 &&
+                i + 1 < line.Length &&
+                char.IsWhiteSpace(line[i + 1])) {
+                index = i;
                 return true;
             }
 
-            scanFrom = separator + 1;
+            i++;
         }
 
         return false;
@@ -236,6 +270,29 @@ public static class OfficeImoArtifactWriter {
         marker = first;
         runLength = length;
         return true;
+    }
+
+    private static bool IsClosingFenceLine(string trimmedLine, int fenceLength) {
+        if (fenceLength < 3 || trimmedLine.Length < fenceLength) {
+            return false;
+        }
+
+        for (int i = fenceLength; i < trimmedLine.Length; i++) {
+            if (!char.IsWhiteSpace(trimmedLine[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int CountRunLength(string text, int startIndex, char marker) {
+        var length = 0;
+        while (startIndex + length < text.Length && text[startIndex + length] == marker) {
+            length++;
+        }
+
+        return length;
     }
 
     private static void AppendMarkdownTableRow(StringBuilder builder, IReadOnlyList<string> cells) {


### PR DESCRIPTION
## Summary
- add a DOCX-export pre-pass that neutralizes accidental single-line `Term: Definition` parsing for transcript prose
- keep markdown as source of truth; only adjust the Word conversion path to avoid leaking literal `**` markers
- add regression coverage for transcript line `Short answer: **no — nothing is failed** ✅`

## Why
OfficeIMO.Markdown can parse `Term: Definition` as a definition list block. In chat transcripts this pattern is often plain prose (for example `Short answer: ...`). In those cases, Word conversion could surface markdown delimiters literally if block mapping/fallback behavior is hit.

This change provides immediate app-side hardening while the upstream OfficeIMO converter fix is rolling out.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter FullyQualifiedName~LocalExportArtifactWriterTests.ExportTranscript`

## Upstream
- Companion OfficeIMO PR: https://github.com/EvotecIT/OfficeIMO/pull/1447