### PR TITLE
chore(ci): centralize PowerForge ref pin in workflows

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -21,7 +21,7 @@ concurrency:
 env:
   # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
   POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || '77253ad381bcc5f70db62f10ef513913f7c37b49' }}
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'ab58992450def6b736a2ea87e6a492400250959f' }}
 
 jobs:
   build:
@@ -127,3 +127,4 @@ jobs:
             cloudflare verify \
             --site-config "Website/site.json" \
             --warmup 1
+

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
   POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || '77253ad381bcc5f70db62f10ef513913f7c37b49' }}
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'ab58992450def6b736a2ea87e6a492400250959f' }}
 
 jobs:
   website-build:
@@ -66,3 +66,4 @@ jobs:
           if [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ] && [ -d "${PLAYWRIGHT_BROWSERS_PATH}" ]; then
             rm -rf "${PLAYWRIGHT_BROWSERS_PATH}"
           fi
+


### PR DESCRIPTION
## Summary
- centralize PowerForge engine checkout settings in workflow-level env vars
- use POWERFORGE_REPOSITORY and POWERFORGE_REF across website build/deploy jobs
- default POWERFORGE_REF to commit b58992450def6b736a2ea87e6a492400250959f (stable baseline)

## Why
This avoids unrelated PR breakage when PSPublishModule/main changes defaults. We can now roll engine upgrades forward in a controlled way by setting repo/org variable POWERFORGE_REF.

## How to roll forward
- Set repository (or organization) Actions variable: POWERFORGE_REF
- Value can be a branch, tag, or commit SHA
- Remove/reset variable to fall back to the pinned default in this workflow