### PR TITLE
Tools: add typed pipeline, request binder, and response v2 foundation

### DIFF
--- a/.agents/skills/intelligencex-tools-authoring/SKILL.md
+++ b/.agents/skills/intelligencex-tools-authoring/SKILL.md
@@ -16,11 +16,12 @@ Use this skill when changing files in `IntelligenceX.Tools/**`, especially when 
 
 ## Strict Execution Order
 1. Identify target package and existing base helpers.
-2. Reuse shared helper paths first (`ToolBase`, `ToolQueryHelpers`, package base helpers).
-3. Implement tool/refactor changes with no output contract drift.
-4. Add or update tests for helper behavior and edge cases.
-5. Run targeted build/tests for changed tool packages.
-6. Summarize reusable pattern changes for future tools.
+2. Reuse shared helper paths first (`ToolBase`, `ToolQueryHelpers`, `ToolPipeline`, package base helpers).
+3. Build typed request binder (`ToolRequestBinder` + `ToolRequestBindingResult<TRequest>`).
+4. Implement tool/refactor changes with no output contract drift, using `ToolResultV2` for output envelopes.
+5. Add or update tests for helper behavior and edge cases.
+6. Run targeted build/tests for changed tool packages.
+7. Summarize reusable pattern changes for future tools.
 
 ## Commands
 - Targeted build:
@@ -36,7 +37,9 @@ Use this skill when changing files in `IntelligenceX.Tools/**`, especially when 
 - Do not add package-specific duplicate helpers when a shared helper exists.
 - Do not change `error_code`/metadata/table view contracts without explicit intent.
 - Keep mass normalization (for example line endings) in a dedicated cleanup PR, not mixed with behavior changes.
+- Prefer typed request models over direct `arguments?.Get...` reads in new/refactored tools.
+- Prefer middleware composition over inline precondition blocks when preconditions are reusable.
 
 ## References
 - `InternalDocs/agent-playbooks/tool-authoring-playbook.md`
-
+- `templates/tool-pipeline-template.md`

--- a/.agents/skills/intelligencex-tools-authoring/templates/tool-pipeline-template.md
+++ b/.agents/skills/intelligencex-tools-authoring/templates/tool-pipeline-template.md
@@ -1,0 +1,62 @@
+# Pipeline Tool Template
+
+Use this template when adding a new tool that should follow the shared bind -> middleware -> execute flow.
+
+```csharp
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+
+public sealed class ExampleTool : ToolBase, ITool {
+    private sealed record RequestModel(string Name, bool IncludeDetails);
+
+    private static readonly ToolDefinition DefinitionValue = new(
+        "example_tool",
+        "Describe what the tool does.",
+        ToolSchema.Object(
+                ("name", ToolSchema.String("Target name.")),
+                ("include_details", ToolSchema.Boolean("Include detail rows.")))
+            .Required("name")
+            .NoAdditionalProperties());
+
+    public override ToolDefinition Definition => DefinitionValue;
+
+    protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+        return RunPipelineAsync(
+            arguments: arguments,
+            cancellationToken: cancellationToken,
+            binder: BindRequest,
+            execute: ExecuteRequestAsync,
+            middleware: Array.Empty<ToolPipelineMiddleware<RequestModel>>());
+    }
+
+    private static ToolRequestBindingResult<RequestModel> BindRequest(JsonObject? arguments) {
+        return ToolRequestBinder.Bind(arguments, reader => {
+            if (!reader.TryReadRequiredString("name", out var name, out var error)) {
+                return ToolRequestBindingResult<RequestModel>.Failure(error);
+            }
+
+            return ToolRequestBindingResult<RequestModel>.Success(new RequestModel(
+                Name: name,
+                IncludeDetails: reader.Boolean("include_details")));
+        });
+    }
+
+    private static Task<string> ExecuteRequestAsync(
+        ToolPipelineContext<RequestModel> context,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var model = new {
+            Name = context.Request.Name,
+            IncludeDetails = context.Request.IncludeDetails
+        };
+        return Task.FromResult(ToolResultV2.OkModel(model));
+    }
+}
+```
+
+## Notes
+- Use `ToolRequestBinder` for argument parsing and validation.
+- Keep middleware small and composable; prefer reusable middleware in package base classes.
+- Use `ToolResultV2` for envelope generation and immutable metadata handling.

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolBase.cs
@@ -25,6 +25,25 @@ public abstract class ToolBase : ITool {
     }
 
     /// <summary>
+    /// Runs a typed bind -> middleware -> execute pipeline.
+    /// </summary>
+    protected Task<string> RunPipelineAsync<TRequest>(
+        JsonObject? arguments,
+        CancellationToken cancellationToken,
+        Func<JsonObject?, ToolRequestBindingResult<TRequest>> binder,
+        ToolPipelineNext<TRequest> execute,
+        IReadOnlyList<ToolPipelineMiddleware<TRequest>>? middleware = null)
+        where TRequest : notnull {
+        return ToolPipeline.RunAsync(
+            definition: Definition,
+            arguments: arguments,
+            cancellationToken: cancellationToken,
+            binder: binder,
+            terminal: execute,
+            middleware: middleware);
+    }
+
+    /// <summary>
     /// Adds max_results metadata consistently across tool responses.
     /// </summary>
     protected static void AddMaxResultsMeta(JsonObject meta, int maxResults) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+
+namespace IntelligenceX.Tools.Common;
+
+/// <summary>
+/// Terminal pipeline delegate.
+/// </summary>
+public delegate Task<string> ToolPipelineNext<TRequest>(
+    ToolPipelineContext<TRequest> context,
+    CancellationToken cancellationToken)
+    where TRequest : notnull;
+
+/// <summary>
+/// Middleware delegate for typed tool execution pipelines.
+/// </summary>
+public delegate Task<string> ToolPipelineMiddleware<TRequest>(
+    ToolPipelineContext<TRequest> context,
+    CancellationToken cancellationToken,
+    ToolPipelineNext<TRequest> next)
+    where TRequest : notnull;
+
+/// <summary>
+/// Context available to typed tool pipelines.
+/// </summary>
+public sealed class ToolPipelineContext<TRequest> where TRequest : notnull {
+    private readonly Dictionary<string, object?> _items = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Initializes a new pipeline context.
+    /// </summary>
+    public ToolPipelineContext(ToolDefinition definition, JsonObject? arguments, TRequest request) {
+        Definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        Request = request ?? throw new ArgumentNullException(nameof(request));
+        Arguments = arguments;
+    }
+
+    /// <summary>
+    /// Tool definition being executed.
+    /// </summary>
+    public ToolDefinition Definition { get; }
+
+    /// <summary>
+    /// Raw tool arguments.
+    /// </summary>
+    public JsonObject? Arguments { get; }
+
+    /// <summary>
+    /// Typed request produced by the binder stage.
+    /// </summary>
+    public TRequest Request { get; }
+
+    /// <summary>
+    /// Stores middleware state.
+    /// </summary>
+    public void SetItem<TValue>(string key, TValue value) {
+        if (string.IsNullOrWhiteSpace(key)) {
+            throw new ArgumentException("Key is required.", nameof(key));
+        }
+
+        _items[key.Trim()] = value;
+    }
+
+    /// <summary>
+    /// Resolves middleware state.
+    /// </summary>
+    public bool TryGetItem<TValue>(string key, out TValue? value) {
+        value = default;
+        if (string.IsNullOrWhiteSpace(key)) {
+            return false;
+        }
+
+        if (!_items.TryGetValue(key.Trim(), out var boxed) || boxed is null) {
+            return false;
+        }
+
+        if (boxed is not TValue typed) {
+            return false;
+        }
+
+        value = typed;
+        return true;
+    }
+}
+
+/// <summary>
+/// Shared typed pipeline runner for tool execution.
+/// </summary>
+public static class ToolPipeline {
+    /// <summary>
+    /// Runs binder, middleware, and terminal execution for a tool call.
+    /// </summary>
+    public static Task<string> RunAsync<TRequest>(
+        ToolDefinition definition,
+        JsonObject? arguments,
+        CancellationToken cancellationToken,
+        Func<JsonObject?, ToolRequestBindingResult<TRequest>> binder,
+        ToolPipelineNext<TRequest> terminal,
+        IReadOnlyList<ToolPipelineMiddleware<TRequest>>? middleware = null)
+        where TRequest : notnull {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(binder);
+        ArgumentNullException.ThrowIfNull(terminal);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var binding = binder(arguments);
+        if (!binding.IsValid || binding.Request is null) {
+            return Task.FromResult(ToolResponse.Error(
+                binding.ErrorCode,
+                binding.Error,
+                hints: binding.Hints,
+                isTransient: binding.IsTransient));
+        }
+
+        var context = new ToolPipelineContext<TRequest>(definition, arguments, binding.Request);
+        ToolPipelineNext<TRequest> chain = terminal;
+
+        if (middleware is not null && middleware.Count > 0) {
+            for (var i = middleware.Count - 1; i >= 0; i--) {
+                var current = middleware[i] ?? throw new ArgumentNullException(nameof(middleware));
+                var next = chain;
+                chain = (ctx, token) => current(ctx, token, next);
+            }
+        }
+
+        return chain(context, cancellationToken);
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolRequestBinding.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolRequestBinding.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using IntelligenceX.Json;
+
+namespace IntelligenceX.Tools.Common;
+
+/// <summary>
+/// Result returned by typed tool-request binders.
+/// </summary>
+/// <typeparam name="TRequest">Typed request model.</typeparam>
+public sealed class ToolRequestBindingResult<TRequest> where TRequest : notnull {
+    private ToolRequestBindingResult() { }
+
+    /// <summary>
+    /// True when binding succeeded.
+    /// </summary>
+    public bool IsValid { get; init; }
+
+    /// <summary>
+    /// Bound request model when <see cref="IsValid"/> is true.
+    /// </summary>
+    public TRequest? Request { get; init; }
+
+    /// <summary>
+    /// Error code when binding fails.
+    /// </summary>
+    public string ErrorCode { get; init; } = "invalid_argument";
+
+    /// <summary>
+    /// Error message when binding fails.
+    /// </summary>
+    public string Error { get; init; } = "Invalid arguments.";
+
+    /// <summary>
+    /// Optional guidance for callers.
+    /// </summary>
+    public IReadOnlyList<string> Hints { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Optional transient marker for bind-time failures.
+    /// </summary>
+    public bool IsTransient { get; init; }
+
+    /// <summary>
+    /// Creates a successful binding result.
+    /// </summary>
+    public static ToolRequestBindingResult<TRequest> Success(TRequest request) {
+        ArgumentNullException.ThrowIfNull(request);
+        return new ToolRequestBindingResult<TRequest> {
+            IsValid = true,
+            Request = request
+        };
+    }
+
+    /// <summary>
+    /// Creates a failed binding result.
+    /// </summary>
+    public static ToolRequestBindingResult<TRequest> Failure(
+        string error,
+        string errorCode = "invalid_argument",
+        IReadOnlyList<string>? hints = null,
+        bool isTransient = false) {
+        return new ToolRequestBindingResult<TRequest> {
+            IsValid = false,
+            ErrorCode = string.IsNullOrWhiteSpace(errorCode) ? "invalid_argument" : errorCode.Trim(),
+            Error = string.IsNullOrWhiteSpace(error) ? "Invalid arguments." : error.Trim(),
+            Hints = hints ?? Array.Empty<string>(),
+            IsTransient = isTransient
+        };
+    }
+}
+
+/// <summary>
+/// Typed argument reader used by request binders.
+/// </summary>
+public sealed class ToolArgumentReader {
+    private readonly JsonObject? _arguments;
+
+    /// <summary>
+    /// Initializes a new argument reader.
+    /// </summary>
+    public ToolArgumentReader(JsonObject? arguments) {
+        _arguments = arguments;
+    }
+
+    /// <summary>
+    /// Reads an optional trimmed string value.
+    /// </summary>
+    public string? OptionalString(string key) {
+        return ToolArgs.GetOptionalTrimmed(_arguments, key);
+    }
+
+    /// <summary>
+    /// Reads a required trimmed string value.
+    /// </summary>
+    public bool TryReadRequiredString(string key, out string value, out string error) {
+        value = OptionalString(key) ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(value)) {
+            error = string.Empty;
+            return true;
+        }
+
+        var normalizedKey = string.IsNullOrWhiteSpace(key) ? "value" : key.Trim();
+        error = $"{normalizedKey} is required.";
+        return false;
+    }
+
+    /// <summary>
+    /// Reads a boolean value with default.
+    /// </summary>
+    public bool Boolean(string key, bool defaultValue = false) {
+        return ToolArgs.GetBoolean(_arguments, key, defaultValue);
+    }
+
+    /// <summary>
+    /// Reads an integer value with bounds.
+    /// </summary>
+    public int CappedInt32(string key, int defaultValue, int minInclusive, int maxInclusive) {
+        return ToolArgs.GetCappedInt32(_arguments, key, defaultValue, minInclusive, maxInclusive);
+    }
+
+    /// <summary>
+    /// Reads a 64-bit integer value with bounds.
+    /// </summary>
+    public long CappedInt64(string key, long defaultValue, long minInclusive, long maxInclusive) {
+        return ToolArgs.GetCappedInt64(_arguments, key, defaultValue, minInclusive, maxInclusive);
+    }
+
+    /// <summary>
+    /// Reads a trimmed string array.
+    /// </summary>
+    public IReadOnlyList<string> StringArray(string key) {
+        return ToolArgs.ReadStringArray(_arguments?.GetArray(key));
+    }
+
+    /// <summary>
+    /// Reads a distinct trimmed string array.
+    /// </summary>
+    public IReadOnlyList<string> DistinctStringArray(string key) {
+        return ToolArgs.ReadDistinctStringArray(_arguments?.GetArray(key));
+    }
+}
+
+/// <summary>
+/// Convenience entry point for typed tool-request binders.
+/// </summary>
+public static class ToolRequestBinder {
+    /// <summary>
+    /// Executes a binder callback with a typed argument reader.
+    /// </summary>
+    public static ToolRequestBindingResult<TRequest> Bind<TRequest>(
+        JsonObject? arguments,
+        Func<ToolArgumentReader, ToolRequestBindingResult<TRequest>> binder)
+        where TRequest : notnull {
+        ArgumentNullException.ThrowIfNull(binder);
+        return binder(new ToolArgumentReader(arguments));
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolResultV2.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolResultV2.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using IntelligenceX.Json;
+
+namespace IntelligenceX.Tools.Common;
+
+/// <summary>
+/// Canonical response factory for tool output envelopes (v2).
+/// </summary>
+public static class ToolResultV2 {
+    /// <summary>
+    /// Creates an error envelope.
+    /// </summary>
+    public static string Error(string errorCode, string error, IReadOnlyList<string>? hints = null, bool isTransient = false) {
+        return ToolResponse.Error(errorCode, error, hints, isTransient);
+    }
+
+    /// <summary>
+    /// Creates a success envelope from a typed model.
+    /// </summary>
+    public static string OkModel<T>(T model, JsonObject? meta = null, string? summaryMarkdown = null, JsonObject? render = null) {
+        return ToolResponse.OkModel(
+            model: model,
+            meta: CloneObject(meta),
+            summaryMarkdown: summaryMarkdown,
+            render: CloneObject(render));
+    }
+
+    /// <summary>
+    /// Creates a facts-table success envelope from a typed model.
+    /// </summary>
+    public static string OkFactsModel<T>(
+        T model,
+        string title,
+        IReadOnlyList<(string Key, string Value)> facts,
+        JsonObject? meta = null,
+        string keyHeader = "Field",
+        string valueHeader = "Value",
+        bool truncated = false,
+        JsonObject? render = null) {
+        return ToolResponse.OkFactsModel(
+            model: model,
+            title: title,
+            facts: facts,
+            meta: CloneObject(meta),
+            keyHeader: keyHeader,
+            valueHeader: valueHeader,
+            truncated: truncated,
+            render: CloneObject(render));
+    }
+
+    /// <summary>
+    /// Creates a standardized mutating-tool success envelope.
+    /// </summary>
+    public static string OkWriteActionModel<T>(
+        T model,
+        string action,
+        bool writeApplied,
+        IReadOnlyList<(string Key, string Value)>? facts = null,
+        JsonObject? meta = null,
+        JsonObject? render = null,
+        string? summaryTitle = null) {
+        return ToolResponse.OkWriteActionModel(
+            model: model,
+            action: action,
+            writeApplied: writeApplied,
+            facts: facts,
+            meta: CloneObject(meta),
+            render: CloneObject(render),
+            summaryTitle: summaryTitle);
+    }
+
+    private static JsonObject? CloneObject(JsonObject? source) {
+        if (source is null) {
+            return null;
+        }
+
+        var clone = new JsonObject(StringComparer.Ordinal);
+        foreach (var item in source) {
+            clone.Add(item.Key, CloneValue(item.Value));
+        }
+
+        return clone;
+    }
+
+    private static JsonArray? CloneArray(JsonArray? source) {
+        if (source is null) {
+            return null;
+        }
+
+        var clone = new JsonArray();
+        foreach (var item in source) {
+            clone.Add(CloneValue(item));
+        }
+
+        return clone;
+    }
+
+    private static JsonValue CloneValue(JsonValue? source) {
+        if (source is null) {
+            return JsonValue.Null;
+        }
+
+        return source.Kind switch {
+            JsonValueKind.Null => JsonValue.Null,
+            JsonValueKind.Boolean => JsonValue.From(source.AsBoolean()),
+            JsonValueKind.String => JsonValue.From(source.AsString()),
+            JsonValueKind.Number => CloneNumber(source),
+            JsonValueKind.Object => JsonValue.From(CloneObject(source.AsObject()) ?? new JsonObject(StringComparer.Ordinal)),
+            JsonValueKind.Array => JsonValue.From(CloneArray(source.AsArray()) ?? new JsonArray()),
+            _ => JsonValue.Null
+        };
+    }
+
+    private static JsonValue CloneNumber(JsonValue source) {
+        return source.Value switch {
+            long l => JsonValue.From(l),
+            int i => JsonValue.From((long)i),
+            double d => JsonValue.From(d),
+            _ => JsonValue.From(source.AsDouble() ?? 0d)
+        };
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailSmtpProbeTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailSmtpProbeTool.cs
@@ -13,6 +13,8 @@ namespace IntelligenceX.Tools.Email;
 /// Verifies SMTP connectivity/authentication and returns a probe id for strict send gating.
 /// </summary>
 public sealed class EmailSmtpProbeTool : EmailToolBase, ITool {
+    private sealed record ProbeRequest;
+
     private static readonly ToolDefinition DefinitionValue = new(
         SmtpProbePolicy.ProbeToolName,
         "Validate SMTP connectivity/authentication and return auth_probe_id for strict send workflows.",
@@ -32,11 +34,28 @@ public sealed class EmailSmtpProbeTool : EmailToolBase, ITool {
 
     /// <inheritdoc />
     protected override async Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        var smtpOptions = Options.Smtp;
-        if (smtpOptions is null) {
-            return ToolResponse.Error("not_configured", "SMTP is not configured.");
+        return await RunPipelineAsync(
+            arguments: arguments,
+            cancellationToken: cancellationToken,
+            binder: BindRequest,
+            execute: ExecuteRequestAsync,
+            middleware: new ToolPipelineMiddleware<ProbeRequest>[] {
+                EnsureSmtpConfiguredAsync
+            }).ConfigureAwait(false);
+    }
+
+    private static ToolRequestBindingResult<ProbeRequest> BindRequest(JsonObject? arguments) {
+        return ToolRequestBindingResult<ProbeRequest>.Success(new ProbeRequest());
+    }
+
+    private async Task<string> ExecuteRequestAsync(
+        ToolPipelineContext<ProbeRequest> context,
+        CancellationToken cancellationToken) {
+        if (!context.TryGetItem<SmtpAccountOptions>(SmtpOptionsContextKey, out var smtpOptions) ||
+            smtpOptions is null) {
+            return ToolResultV2.Error("not_configured", "SMTP is not configured.");
         }
-        smtpOptions.Validate();
+
         cancellationToken.ThrowIfCancellationRequested();
 
         var smtp = SmtpClientFactory.Create(smtpOptions, dryRun: true);
@@ -44,7 +63,7 @@ public sealed class EmailSmtpProbeTool : EmailToolBase, ITool {
         try {
             var connectAuthResult = await SmtpClientFactory.ConnectAndAuthenticateAsync(smtp, smtpOptions).ConfigureAwait(false);
             if (!connectAuthResult.IsSuccess) {
-                return ToolResponse.Error(
+                return ToolResultV2.Error(
                     connectAuthResult.ErrorCode,
                     connectAuthResult.Error,
                     isTransient: connectAuthResult.IsTransient);
@@ -78,7 +97,7 @@ public sealed class EmailSmtpProbeTool : EmailToolBase, ITool {
                 .Add("provider", "smtp")
                 .Add("auth_probe_id", probeRecord.ProbeId);
 
-            return ToolResponse.OkFactsModel(
+            return ToolResultV2.OkFactsModel(
                 model: root,
                 title: "SMTP probe",
                 facts: summaryFacts,
@@ -86,7 +105,7 @@ public sealed class EmailSmtpProbeTool : EmailToolBase, ITool {
         } catch (OperationCanceledException) {
             throw;
         } catch (Exception ex) {
-            return ToolResponse.Error(
+            return ToolResultV2.Error(
                 "smtp_probe_failed",
                 $"SMTP probe failed. {ex.Message}",
                 isTransient: true);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailSmtpSendTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailSmtpSendTool.cs
@@ -13,6 +13,18 @@ namespace IntelligenceX.Tools.Email;
 /// Sends an email via SMTP. Defaults to dry-run unless explicitly confirmed.
 /// </summary>
 public sealed class EmailSmtpSendTool : EmailToolBase, ITool {
+    private sealed record SendRequest(
+        string From,
+        IReadOnlyList<string> To,
+        IReadOnlyList<string> Cc,
+        IReadOnlyList<string> Bcc,
+        string? ReplyTo,
+        string Subject,
+        string TextBody,
+        string HtmlBody,
+        bool Send,
+        string? ProbeId);
+
     private static readonly ToolDefinition DefinitionValue = new(
         "email_smtp_send",
         "Send an email via SMTP. By default performs a dry-run unless send=true is provided.",
@@ -57,63 +69,107 @@ public sealed class EmailSmtpSendTool : EmailToolBase, ITool {
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>JSON string result.</returns>
     protected override async Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
-        var smtpOptions = Options.Smtp;
-        if (smtpOptions is null) {
-            return ToolResponse.Error("not_configured", "SMTP is not configured.");
-        }
-        smtpOptions.Validate();
+        return await RunPipelineAsync(
+            arguments: arguments,
+            cancellationToken: cancellationToken,
+            binder: BindRequest,
+            execute: ExecuteRequestAsync,
+            middleware: new ToolPipelineMiddleware<SendRequest>[] {
+                EnsureSmtpConfiguredAsync,
+                ValidateStrictProbeAsync
+            }).ConfigureAwait(false);
+    }
 
-        var from = arguments?.GetString("from") ?? string.Empty;
-        var to = ToolArgs.ReadStringArray(arguments?.GetArray("to"));
-        var cc = ToolArgs.ReadStringArray(arguments?.GetArray("cc"));
-        var bcc = ToolArgs.ReadStringArray(arguments?.GetArray("bcc"));
-        var replyTo = arguments?.GetString("reply_to");
-        var subject = arguments?.GetString("subject") ?? string.Empty;
-        var textBody = arguments?.GetString("text_body") ?? string.Empty;
-        var htmlBody = arguments?.GetString("html_body") ?? string.Empty;
-        var send = arguments?.GetBoolean("send") ?? false;
-        var probeId = ToolArgs.GetOptionalTrimmed(arguments, ToolAuthenticationArgumentNames.ProbeId);
+    private static ToolRequestBindingResult<SendRequest> BindRequest(JsonObject? arguments) {
+        return ToolRequestBinder.Bind(arguments, reader => {
+            if (!reader.TryReadRequiredString("from", out var from, out var fromError)) {
+                return ToolRequestBindingResult<SendRequest>.Failure(fromError);
+            }
 
-        if (string.IsNullOrWhiteSpace(from)) {
-            return ToolResponse.Error("invalid_argument", "from is required.");
+            var to = reader.StringArray("to");
+            if (to.Count == 0) {
+                return ToolRequestBindingResult<SendRequest>.Failure("to must contain at least one recipient.");
+            }
+
+            if (!reader.TryReadRequiredString("subject", out var subject, out var subjectError)) {
+                return ToolRequestBindingResult<SendRequest>.Failure(subjectError);
+            }
+
+            var textBody = reader.OptionalString("text_body") ?? string.Empty;
+            var htmlBody = reader.OptionalString("html_body") ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(textBody) && string.IsNullOrWhiteSpace(htmlBody)) {
+                return ToolRequestBindingResult<SendRequest>.Failure("Either text_body or html_body must be provided.");
+            }
+
+            return ToolRequestBindingResult<SendRequest>.Success(new SendRequest(
+                From: from,
+                To: to,
+                Cc: reader.StringArray("cc"),
+                Bcc: reader.StringArray("bcc"),
+                ReplyTo: reader.OptionalString("reply_to"),
+                Subject: subject,
+                TextBody: textBody,
+                HtmlBody: htmlBody,
+                Send: reader.Boolean("send"),
+                ProbeId: reader.OptionalString(ToolAuthenticationArgumentNames.ProbeId)));
+        });
+    }
+
+    private Task<string> ValidateStrictProbeAsync(
+        ToolPipelineContext<SendRequest> context,
+        CancellationToken cancellationToken,
+        ToolPipelineNext<SendRequest> next) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!context.Request.Send) {
+            return next(context, cancellationToken);
         }
-        if (to.Count == 0) {
-            return ToolResponse.Error("invalid_argument", "to must contain at least one recipient.");
+
+        if (!context.TryGetItem<SmtpAccountOptions>(SmtpOptionsContextKey, out var smtpOptions) ||
+            smtpOptions is null) {
+            return Task.FromResult(ToolResultV2.Error("not_configured", "SMTP is not configured."));
         }
-        if (string.IsNullOrWhiteSpace(subject)) {
-            return ToolResponse.Error("invalid_argument", "subject is required.");
-        }
-        if (string.IsNullOrWhiteSpace(textBody) && string.IsNullOrWhiteSpace(htmlBody)) {
-            return ToolResponse.Error("invalid_argument", "Either text_body or html_body must be provided.");
-        }
-        if (send && !SmtpProbePolicy.TryValidateForStrictSend(
+
+        if (!SmtpProbePolicy.TryValidateForStrictSend(
                 options: Options,
                 smtpOptions: smtpOptions,
-                probeId: probeId,
+                probeId: context.Request.ProbeId,
                 nowUtc: DateTimeOffset.UtcNow,
                 out var probeErrorCode,
                 out var probeError)) {
-            return ToolResponse.Error(probeErrorCode, probeError);
+            return Task.FromResult(ToolResultV2.Error(probeErrorCode, probeError));
         }
 
-        var smtp = SmtpClientFactory.Create(smtpOptions, dryRun: !send);
+        return next(context, cancellationToken);
+    }
+
+    private async Task<string> ExecuteRequestAsync(
+        ToolPipelineContext<SendRequest> context,
+        CancellationToken cancellationToken) {
+        if (!context.TryGetItem<SmtpAccountOptions>(SmtpOptionsContextKey, out var smtpOptions) ||
+            smtpOptions is null) {
+            return ToolResultV2.Error("not_configured", "SMTP is not configured.");
+        }
+
+        var request = context.Request;
+        var smtp = SmtpClientFactory.Create(smtpOptions, dryRun: !request.Send);
 
         try {
-            smtp.From = from;
-            smtp.To = to;
-            if (cc.Count > 0) smtp.Cc = cc;
-            if (bcc.Count > 0) smtp.Bcc = bcc;
-            if (!string.IsNullOrWhiteSpace(replyTo)) smtp.ReplyTo = replyTo;
-            smtp.Subject = subject;
-            smtp.TextBody = textBody;
-            smtp.HtmlBody = htmlBody;
+            smtp.From = request.From;
+            smtp.To = new List<string>(request.To);
+            if (request.Cc.Count > 0) smtp.Cc = new List<string>(request.Cc);
+            if (request.Bcc.Count > 0) smtp.Bcc = new List<string>(request.Bcc);
+            if (!string.IsNullOrWhiteSpace(request.ReplyTo)) smtp.ReplyTo = request.ReplyTo;
+            smtp.Subject = request.Subject;
+            smtp.TextBody = request.TextBody;
+            smtp.HtmlBody = request.HtmlBody;
 
             // Ensure the MIME message exists before attempting send.
             await smtp.CreateMessageAsync(cancellationToken).ConfigureAwait(false);
 
             var connectAuthResult = await SmtpClientFactory.ConnectAndAuthenticateAsync(smtp, smtpOptions).ConfigureAwait(false);
             if (!connectAuthResult.IsSuccess) {
-                return ToolResponse.Error(
+                return ToolResultV2.Error(
                     connectAuthResult.ErrorCode,
                     connectAuthResult.Error,
                     isTransient: connectAuthResult.IsTransient);
@@ -121,46 +177,46 @@ public sealed class EmailSmtpSendTool : EmailToolBase, ITool {
 
             var sendResult = await smtp.SendAsync(cancellationToken).ConfigureAwait(false);
             if (!sendResult.Status) {
-                return ToolResponse.Error("send_failed", sendResult.Error ?? "Send failed", isTransient: true);
+                return ToolResultV2.Error("send_failed", sendResult.Error ?? "Send failed", isTransient: true);
             }
 
             var root = new {
-                Sent = send,
+                Sent = request.Send,
                 Provider = "smtp",
                 Server = smtpOptions.Server,
                 Port = smtpOptions.Port,
                 MessageId = sendResult.MessageId ?? string.Empty,
-                ProbeId = probeId ?? string.Empty
+                ProbeId = request.ProbeId ?? string.Empty
             };
 
             var summaryItems = new List<(string Key, string Value)> {
-                ("From", from),
-                ("To", string.Join("; ", to)),
-                ("Subject", subject),
+                ("From", request.From),
+                ("To", string.Join("; ", request.To)),
+                ("Subject", request.Subject),
                 ("Server", $"{smtpOptions.Server}:{smtpOptions.Port}"),
                 ("Message ID", sendResult.MessageId ?? string.Empty)
             };
-            if (cc.Count > 0) {
-                summaryItems.Add(("Cc", string.Join("; ", cc)));
+            if (request.Cc.Count > 0) {
+                summaryItems.Add(("Cc", string.Join("; ", request.Cc)));
             }
-            if (bcc.Count > 0) {
-                summaryItems.Add(("Bcc", string.Join("; ", bcc)));
+            if (request.Bcc.Count > 0) {
+                summaryItems.Add(("Bcc", string.Join("; ", request.Bcc)));
             }
-            if (!string.IsNullOrWhiteSpace(probeId)) {
-                summaryItems.Add(("Probe ID", probeId));
+            if (!string.IsNullOrWhiteSpace(request.ProbeId)) {
+                summaryItems.Add(("Probe ID", request.ProbeId));
             }
 
             var meta = ToolOutputHints.Meta(count: 1, truncated: false)
-                .Add("sent", send)
+                .Add("sent", request.Send)
                 .Add("provider", "smtp");
-            if (!string.IsNullOrWhiteSpace(probeId)) {
-                meta.Add("auth_probe_id", probeId);
+            if (!string.IsNullOrWhiteSpace(request.ProbeId)) {
+                meta.Add("auth_probe_id", request.ProbeId);
             }
 
-            return ToolResponse.OkWriteActionModel(
+            return ToolResultV2.OkWriteActionModel(
                 model: root,
                 action: "smtp_send",
-                writeApplied: send,
+                writeApplied: request.Send,
                 facts: summaryItems,
                 meta: meta,
                 summaryTitle: "SMTP send");

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailToolBase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using MailKit.Security;
 using IntelligenceX.Tools.Common;
 
@@ -8,6 +10,11 @@ namespace IntelligenceX.Tools.Email;
 /// Base class for email tool implementations.
 /// </summary>
 public abstract class EmailToolBase : ToolBase {
+    /// <summary>
+    /// Pipeline context key used to cache validated SMTP options.
+    /// </summary>
+    protected const string SmtpOptionsContextKey = "email.smtp_options";
+
     /// <summary>
     /// Shared options for email tools.
     /// </summary>
@@ -22,6 +29,27 @@ public abstract class EmailToolBase : ToolBase {
     protected EmailToolBase(EmailToolOptions options) {
         Options = options ?? throw new ArgumentNullException(nameof(options));
         Options.Validate();
+    }
+
+    /// <summary>
+    /// Shared middleware that requires SMTP configuration and caches validated options in pipeline context.
+    /// </summary>
+    protected Task<string> EnsureSmtpConfiguredAsync<TRequest>(
+        ToolPipelineContext<TRequest> context,
+        CancellationToken cancellationToken,
+        ToolPipelineNext<TRequest> next)
+        where TRequest : notnull {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var smtpOptions = Options.Smtp;
+        if (smtpOptions is null) {
+            return Task.FromResult(ToolResultV2.Error("not_configured", "SMTP is not configured."));
+        }
+
+        smtpOptions.Validate();
+        context.SetItem(SmtpOptionsContextKey, smtpOptions);
+        return next(context, cancellationToken);
     }
 
     internal static SecureSocketOptions ParseSecureSocketOptions(string? value) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPipelineTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPipelineTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class ToolPipelineTests {
+    private sealed record StubRequest(int Value);
+
+    [Fact]
+    public async Task RunAsync_WhenBindingFails_ShouldReturnInvalidArgumentEnvelope() {
+        var definition = new ToolDefinition(
+            "pipeline_stub",
+            "Pipeline stub",
+            ToolSchema.Object().NoAdditionalProperties());
+
+        var json = await ToolPipeline.RunAsync(
+            definition: definition,
+            arguments: null,
+            cancellationToken: CancellationToken.None,
+            binder: _ => ToolRequestBindingResult<StubRequest>.Failure("value is required."),
+            terminal: (_, _) => Task.FromResult(ToolResultV2.OkModel(new { Value = 1 })));
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        Assert.Equal("value is required.", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldApplyMiddlewareInOrder() {
+        var definition = new ToolDefinition(
+            "pipeline_stub",
+            "Pipeline stub",
+            ToolSchema.Object().NoAdditionalProperties());
+        var sequence = new List<string>();
+
+        var json = await ToolPipeline.RunAsync(
+            definition: definition,
+            arguments: null,
+            cancellationToken: CancellationToken.None,
+            binder: _ => ToolRequestBindingResult<StubRequest>.Success(new StubRequest(7)),
+            terminal: (_, _) => {
+                sequence.Add("terminal");
+                return Task.FromResult(ToolResultV2.OkModel(new { Sequence = string.Join(",", sequence) }));
+            },
+            middleware: new ToolPipelineMiddleware<StubRequest>[] {
+                async (context, cancellationToken, next) => {
+                    sequence.Add("a_before");
+                    var result = await next(context, cancellationToken).ConfigureAwait(false);
+                    sequence.Add("a_after");
+                    return result;
+                },
+                async (context, cancellationToken, next) => {
+                    sequence.Add("b_before");
+                    var result = await next(context, cancellationToken).ConfigureAwait(false);
+                    sequence.Add("b_after");
+                    return result;
+                }
+            });
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("a_before,b_before,terminal", root.GetProperty("sequence").GetString());
+        Assert.Equal(
+            new[] { "a_before", "b_before", "terminal", "b_after", "a_after" },
+            sequence);
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldExposeBoundRequestToTerminal() {
+        var definition = new ToolDefinition(
+            "pipeline_stub",
+            "Pipeline stub",
+            ToolSchema.Object(("value", ToolSchema.Integer())).NoAdditionalProperties());
+        var arguments = new JsonObject().Add("value", 42);
+
+        var json = await ToolPipeline.RunAsync(
+            definition: definition,
+            arguments: arguments,
+            cancellationToken: CancellationToken.None,
+            binder: args => {
+                var value = args?.GetInt64("value") ?? 0;
+                return ToolRequestBindingResult<StubRequest>.Success(new StubRequest((int)value));
+            },
+            terminal: (context, _) => Task.FromResult(ToolResultV2.OkModel(new {
+                Value = context.Request.Value
+            })));
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(42, root.GetProperty("value").GetInt32());
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolRequestBindingTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolRequestBindingTests.cs
@@ -1,0 +1,48 @@
+using IntelligenceX.Json;
+using IntelligenceX.Tools.Common;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class ToolRequestBindingTests {
+    private sealed record RequestModel(string Name, bool Enabled, IReadOnlyList<string> Tags);
+
+    [Fact]
+    public void ArgumentReader_TryReadRequiredString_ShouldFailWhenMissing() {
+        var reader = new ToolArgumentReader(new JsonObject());
+
+        var ok = reader.TryReadRequiredString("name", out var value, out var error);
+
+        Assert.False(ok);
+        Assert.Equal(string.Empty, value);
+        Assert.Equal("name is required.", error);
+    }
+
+    [Fact]
+    public void RequestBinder_Bind_ShouldProduceTypedRequestModel() {
+        var arguments = new JsonObject()
+            .Add("name", " Tool ")
+            .Add("enabled", true)
+            .Add("tags", new JsonArray()
+                .Add("a")
+                .Add("A")
+                .Add(" b "));
+
+        var result = ToolRequestBinder.Bind(arguments, reader => {
+            if (!reader.TryReadRequiredString("name", out var name, out var error)) {
+                return ToolRequestBindingResult<RequestModel>.Failure(error);
+            }
+
+            return ToolRequestBindingResult<RequestModel>.Success(new RequestModel(
+                Name: name,
+                Enabled: reader.Boolean("enabled"),
+                Tags: reader.DistinctStringArray("tags")));
+        });
+
+        Assert.True(result.IsValid);
+        Assert.NotNull(result.Request);
+        Assert.Equal("Tool", result.Request!.Name);
+        Assert.True(result.Request.Enabled);
+        Assert.Equal(new[] { "a", "b" }, result.Request.Tags);
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolResultV2Tests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolResultV2Tests.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using IntelligenceX.Json;
+using IntelligenceX.Tools.Common;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class ToolResultV2Tests {
+    [Fact]
+    public void OkWriteActionModel_ShouldNotMutateCallerMetaObject() {
+        var meta = new JsonObject()
+            .Add("trace_id", "abc-123");
+
+        var json = ToolResultV2.OkWriteActionModel(
+            model: new { Result = "ok" },
+            action: "demo_action",
+            writeApplied: true,
+            meta: meta);
+
+        Assert.Null(meta.GetString("mode"));
+        Assert.Null(meta.GetString("action"));
+        Assert.False(meta.GetBoolean("write_applied", defaultValue: false));
+        Assert.Equal("abc-123", meta.GetString("trace_id"));
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        var responseMeta = root.GetProperty("meta");
+        Assert.Equal("apply", responseMeta.GetProperty("mode").GetString());
+        Assert.Equal("demo_action", responseMeta.GetProperty("action").GetString());
+        Assert.True(responseMeta.GetProperty("write_applied").GetBoolean());
+        Assert.Equal("abc-123", responseMeta.GetProperty("trace_id").GetString());
+    }
+}

--- a/InternalDocs/agent-playbooks/tool-authoring-playbook.md
+++ b/InternalDocs/agent-playbooks/tool-authoring-playbook.md
@@ -18,10 +18,12 @@ Internal guidance for adding or refactoring tools with minimal duplication and s
 
 ## Shared Reuse Rules
 1. Start from package base classes (`ActiveDirectoryToolBase`, `SystemToolBase`, `EventLogToolBase`, `FileSystemToolBase`, etc.).
-2. Use `ToolBase.BuildAutoTableResponse(...)` for table envelopes instead of inline response shaping.
-3. Use `ToolBase.AddMaxResultsMeta(...)` (directly or via package wrappers) for `max_results` metadata.
-4. Prefer `ToolQueryHelpers` (`CapRows`, projection filters) over handwritten list-cap/filter plumbing.
-5. Add package-local helpers only when behavior is package-specific.
+2. Prefer `ToolBase.RunPipelineAsync(...)` + `ToolPipeline` middleware for bind/precondition/execute orchestration.
+3. Use typed binders (`ToolRequestBinder` + `ToolRequestBindingResult<TRequest>`) instead of ad-hoc `arguments?.Get...` parsing in new/refactored tools.
+4. Use `ToolBase.BuildAutoTableResponse(...)` for table envelopes instead of inline response shaping.
+5. Use `ToolBase.AddMaxResultsMeta(...)` (directly or via package wrappers) for `max_results` metadata.
+6. Prefer `ToolQueryHelpers` (`CapRows`, projection filters) over handwritten list-cap/filter plumbing.
+7. Add package-local helpers only when behavior is package-specific.
 
 ## Schema Rules
 - Start with `ToolSchema.Object(...)`.
@@ -57,9 +59,10 @@ Internal guidance for adding or refactoring tools with minimal duplication and s
   - Keep error mapping centralized in package base helpers.
 
 ## Response Rules
-- Use `ToolResponse.OkModel(...)` for read-style responses.
-- Use `ToolResponse.OkWriteActionModel(...)` for mutating actions.
-- Use `ToolResponse.Error(...)` for failure envelopes.
+- Prefer `ToolResultV2` helpers for new/refactored tools to keep metadata immutable at call boundaries.
+- Use `ToolResultV2.OkModel(...)` for read-style responses.
+- Use `ToolResultV2.OkWriteActionModel(...)` for mutating actions.
+- Use `ToolResultV2.Error(...)` for failure envelopes.
 - Keep error codes stable and machine-readable.
 
 ## Required Tests


### PR DESCRIPTION
## Summary
This PR delivers the next tooling-reuse foundation batch focused on less code, less maintenance, and easier new-tool onboarding.

Implements requested areas:
- 1) `ToolPipeline` middleware foundation
- 2) typed request binder primitives
- 3) `ToolResult` response factory v2 (immutable-call-site behavior)
- 6) tool-authoring template + skill/playbook updates

## What changed
- Added shared pipeline primitives in `IntelligenceX.Tools.Common`:
  - `ToolPipelineContext<TRequest>`
  - `ToolPipelineMiddleware<TRequest>` and `ToolPipelineNext<TRequest>`
  - `ToolPipeline.RunAsync(...)`
- Added typed binder primitives:
  - `ToolRequestBindingResult<TRequest>`
  - `ToolArgumentReader`
  - `ToolRequestBinder.Bind(...)`
- Added response v2 facade:
  - `ToolResultV2` with `OkModel`, `OkFactsModel`, `OkWriteActionModel`, `Error`
  - defensive cloning of `meta`/`render` to avoid caller-side mutation
- Added `ToolBase.RunPipelineAsync(...)` helper for low-friction adoption.
- Refactored SMTP tools to use the new shared pattern:
  - `email_smtp_probe`
  - `email_smtp_send`
  - Includes reusable SMTP configured middleware path in `EmailToolBase`.
- Updated authoring guidance:
  - `.agents/skills/intelligencex-tools-authoring/SKILL.md`
  - `.agents/skills/intelligencex-tools-authoring/templates/tool-pipeline-template.md`
  - `InternalDocs/agent-playbooks/tool-authoring-playbook.md`

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release -f net8.0-windows`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release -f net8.0-windows --no-build`

Result: `Passed: 344, Failed: 0`.

## Follow-up
This establishes the reusable foundation so we can migrate additional tool packs incrementally without contract drift.
