### PR TITLE
Add public-facing go-live and runner strategy blog guides

### DIFF
--- a/Website/content/blog/_index.md
+++ b/Website/content/blog/_index.md
@@ -8,6 +8,8 @@ layout: page
 
 ## Latest Posts
 
+- [Open-Source Go-Live Security Checklist (GitHub Actions)](/blog/open-source-go-live-security-checklist/)
+- [GitHub-Hosted vs Self-Hosted Runners](/blog/github-hosted-vs-self-hosted-runners/)
 - [Security-First Reviewer Setup Checklist](/blog/security-first-reviewer-setup-checklist/)
 - [Setup Best Practices for Teams](/blog/setup-best-practices-for-teams/)
 - [IX Issue Ops in Action](/blog/ix-issue-ops-in-action/)

--- a/Website/content/blog/github-hosted-vs-self-hosted-runners-tradeoffs.md
+++ b/Website/content/blog/github-hosted-vs-self-hosted-runners-tradeoffs.md
@@ -1,0 +1,105 @@
+---
+title: GitHub-Hosted vs Self-Hosted Runners
+description: A practical decision guide for security, cost, and reliability tradeoffs when choosing runner strategy.
+slug: github-hosted-vs-self-hosted-runners
+collection: blog
+layout: page
+---
+
+Runner strategy is not just an infrastructure choice. It changes how you handle secrets, incident response, and delivery reliability.
+
+This guide helps teams choose intentionally.
+
+## Quick Decision Matrix
+
+Choose GitHub-hosted runners if you prioritize:
+
+- low operational overhead
+- simpler isolation defaults
+- faster onboarding for new repositories
+
+Choose self-hosted runners if you need:
+
+- custom network access or private service dependencies
+- specialized hardware or long-lived build caches
+- strict control over host-level tooling and policies
+
+## Security Comparison
+
+GitHub-hosted runners:
+
+- ephemeral environment by default
+- lower host maintenance burden
+- fewer opportunities for host drift
+
+self-hosted runners:
+
+- full control over host configuration
+- larger responsibility for hardening and patching
+- higher risk if trust boundaries are not isolated
+
+Minimum baseline for self-hosted:
+
+1. one runner group per trust zone
+2. short-lived credentials only
+3. automated host patching and image refresh
+4. restricted outbound network paths
+
+## Cost Comparison
+
+GitHub-hosted runners:
+
+- predictable billing model
+- less staff time spent on maintenance
+
+self-hosted runners:
+
+- potential direct compute savings at scale
+- hidden operational costs in patching, monitoring, and incident handling
+
+Calculate total cost with operations time included, not compute alone.
+
+## Reliability and Throughput
+
+GitHub-hosted runners:
+
+- easy horizontal scale
+- occasional queue-time variability
+
+self-hosted runners:
+
+- performance can be excellent when tuned
+- reliability depends on your patching and autoscaling discipline
+
+If builds are critical-path, add queue and runtime SLOs before migrating.
+
+## Hybrid Model That Works for Most Teams
+
+Use GitHub-hosted by default, then move targeted jobs to self-hosted only when justified.
+
+Example split:
+
+- pull request validation: GitHub-hosted
+- deployment to private network: self-hosted
+- heavy build jobs with custom dependencies: self-hosted
+
+This preserves safety for common paths and control for special paths.
+
+## Rollout Pattern
+
+1. start with one repository and one workflow
+2. compare lead time, queue time, and failure rates for 2 to 4 weeks
+3. keep rollback ready to GitHub-hosted during pilot
+4. expand only after measurable gains
+
+## Common Mistakes
+
+- migrating all workflows at once
+- sharing runner groups across unrelated trust boundaries
+- storing long-lived credentials on runner hosts
+- treating self-hosted as a cost-only project
+
+## Final Take
+
+There is no universal winner.
+Pick the runner model that matches your security posture, operational maturity, and delivery goals, then reevaluate quarterly.

--- a/Website/content/blog/open-source-go-live-security-checklist.md
+++ b/Website/content/blog/open-source-go-live-security-checklist.md
@@ -1,0 +1,123 @@
+---
+title: Open-Source Go-Live Security Checklist (GitHub Actions)
+description: A practical checklist to harden CI/CD, secrets, and branch protection before opening a repository to the public.
+slug: open-source-go-live-security-checklist
+collection: blog
+layout: page
+---
+
+Opening a repository to the public is not only a visibility change. It changes your threat model, automation exposure, and incident response expectations.
+
+Use this checklist to go live safely without slowing delivery.
+
+## Prerequisites
+
+- GitHub branch protection is enabled on your default branch.
+- You can update repository secrets and variables.
+- You have at least one passing CI run from a recent pull request.
+
+## 1. Lock Down Workflow Permissions
+
+Use least privilege at workflow level, then elevate per job only when needed.
+
+```yaml
+name: review
+on:
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+jobs:
+  review:
+    uses: <org>/<workflow-repo>/.github/workflows/review-intelligencex.yml@<pinned-sha>
+    with:
+      review_config_path: .intelligencex/reviewer.json
+```
+
+If a job does not need write scopes, keep it read-only.
+
+## 2. Pin Reusable Workflows and Actions
+
+Pin third-party actions and reusable workflows by full commit SHA.
+This makes upgrades intentional and auditable.
+
+```yaml
+uses: <org>/<workflow-repo>/.github/workflows/review-intelligencex.yml@<40-char-sha>
+```
+
+For internal repositories, decide your agility policy up front:
+
+- strict mode: pin everything, including internal actions
+- balanced mode: pin third-party actions, allow branch refs for internal actions
+
+## 3. Keep Secrets Scoped and Explicit
+
+Prefer explicit secret mapping over broad inheritance in public-facing repositories.
+
+```yaml
+secrets:
+  INTELLIGENCEX_AUTH_B64: ${{ secrets.INTELLIGENCEX_AUTH_B64 }}
+  INTELLIGENCEX_GITHUB_APP_ID: ${{ secrets.INTELLIGENCEX_GITHUB_APP_ID }}
+  INTELLIGENCEX_GITHUB_APP_PRIVATE_KEY: ${{ secrets.INTELLIGENCEX_GITHUB_APP_PRIVATE_KEY }}
+```
+
+Checklist:
+
+1. remove unused secrets
+2. separate production and testing credentials
+3. rotate credentials on a fixed schedule
+
+## 4. Define Branch Protection Behavior Clearly
+
+Pick one merge contract and document it in `README.md` or maintainer docs.
+
+Option A: bot-first automation
+
+- required status check: `review / review`
+- required approving reviews: `0`
+- code owner reviews: optional
+
+Option B: human-gated merges
+
+- required status check: `review / review`
+- required approving reviews: `1+`
+- code owner reviews: enabled for sensitive paths
+
+Switching between modes ad hoc usually causes confusion and merge delays.
+
+## 5. Treat Runner Choice as a Security Control
+
+Runner strategy affects data exposure and cost.
+
+- GitHub-hosted runners: simpler isolation model, low maintenance
+- self-hosted runners: more control, more operational responsibility
+
+If you use self-hosted runners:
+
+1. isolate runner groups per trust boundary
+2. block persistent credentials on the runner host
+3. patch and rotate runner images regularly
+
+## 6. Add an Incident Drill Before Go-Live
+
+Practice one dry run before opening the repo:
+
+1. revoke one credential
+2. rotate and reconfigure secrets
+3. rerun required checks
+4. confirm merge policy still works
+
+If this takes too long, your runbook needs simplification.
+
+## Common Mistakes
+
+- using broad `secrets: inherit` without reviewing exposure
+- using mutable `@main` references for third-party actions
+- enabling strict policy before compatibility checks
+- documenting process in private notes only, not in repo-visible docs
+
+## Final Take
+
+Go-live security is mostly operational clarity.
+If permissions, pins, secrets, and branch policy are explicit, you can move fast in public with fewer surprises.

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -168,7 +168,7 @@
       "noVerify": true,
       "baseline": "./.powerforge/audit-baseline.json",
       "failOnNewIssues": true,
-      "maxTotalFiles": 1120,
+      "maxTotalFiles": 1130,
       "ignoreNav": "sitemap/**,search/**",
       "noDefaultIgnoreNav": true,
       "navSelector": "header nav.ix-nav",


### PR DESCRIPTION
## Summary
- add a new public-facing go-live guide: `open-source-go-live-security-checklist`
- add a new public-facing runner decision guide: `github-hosted-vs-self-hosted-runners`
- update blog index to surface both new posts as latest content
- raise website `maxTotalFiles` budget from `1120` to `1130` in `Website/pipeline.json` to account for content growth and keep doctor gate aligned

## Why
The previous topic framing was too close to internal rollout context. This PR provides neutral, reusable guidance for external users with placeholders and generic patterns.

## Validation
- `dotnet build C:/Support/GitHub/PSPublishModule/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -c Release`
- `dotnet C:/Support/GitHub/PSPublishModule/PowerForge.Web.Cli/bin/Release/net8.0/PowerForge.Web.Cli.dll pipeline --config Website/pipeline.json --mode ci --skip verify`
  - result: pass (`doctor: Doctor ok no-build, no-verify, audit, audit 0e/0w`)