### PR TITLE
Harden blog setup/security guidance and placeholders

### DIFF
--- a/Website/content/blog/ix-reviewer-in-action.md
+++ b/Website/content/blog/ix-reviewer-in-action.md
@@ -79,7 +79,7 @@ The trust model is intentionally BYO:
 - authentication uses your own `intelligencex auth login` flow
 - usage runs on your own account/subscription limits
 - bot identity can use your own GitHub App installation
-- provider/model is configurable (`gpt-5.3-codex` by default, but not required)
+- provider/model is configurable (for example `gpt-5.3-codex`)
 
 ## Options You Can Tune
 
@@ -101,11 +101,11 @@ If you want output shape similar to this walkthrough, start with this split.
 ```yaml
 jobs:
   review:
-    uses: evotecit/github-actions/.github/workflows/review-intelligencex.yml@5f823fad4dbdb34a2de64c741cdc9cdfbcd1e4cf
+    uses: <org>/<workflow-repo>/.github/workflows/review-intelligencex.yml@<pinned-sha>
     with:
       reviewer_source: source
       provider: openai
-      model: gpt-5.3-codex
+      model: <model-id>
       mode: hybrid
       length: medium
       review_config_path: .intelligencex/reviewer.json
@@ -118,6 +118,9 @@ jobs:
       INTELLIGENCEX_GITHUB_APP_ID: ${{ secrets.INTELLIGENCEX_GITHUB_APP_ID }}
       INTELLIGENCEX_GITHUB_APP_PRIVATE_KEY: ${{ secrets.INTELLIGENCEX_GITHUB_APP_PRIVATE_KEY }}
 ```
+
+Replace `<org>`, `<workflow-repo>`, `<pinned-sha>`, and `<model-id>` with your values.
+For latest examples, see [/docs/examples/](/docs/examples/).
 
 ### Reviewer JSON
 
@@ -142,16 +145,18 @@ This keeps CI wiring in YAML and policy in JSON, which makes behavior easier to 
 For a quick local verification before pushing workflow/config changes:
 
 ```bash
-export INPUT_REPO=owner/name
-export INPUT_PR_NUMBER=123
+export INPUT_REPO=<owner>/<repo>
+export INPUT_PR_NUMBER=<pr-number>
 intelligencex reviewer run
 ```
 
 Then after fixes are pushed:
 
 ```bash
-intelligencex reviewer resolve-threads --repo owner/name --pr 123
+intelligencex reviewer resolve-threads --repo <owner>/<repo> --pr <pr-number>
 ```
+
+Replace `<owner>`, `<repo>`, and `<pr-number>` with your real values.
 
 That mirrors the practical PR dance: run review, fix blockers, re-run, then resolve stale bot threads when evidence is present.
 

--- a/Website/content/blog/open-source-go-live-security-checklist.md
+++ b/Website/content/blog/open-source-go-live-security-checklist.md
@@ -35,6 +35,8 @@ jobs:
       review_config_path: .intelligencex/reviewer.json
 ```
 
+Replace `<org>`, `<workflow-repo>`, and `<pinned-sha>` with your values.
+
 If a job does not need write scopes, keep it read-only.
 
 ## 2. Pin Reusable Workflows and Actions
@@ -50,6 +52,8 @@ For internal repositories, decide your agility policy up front:
 
 - strict mode: pin everything, including internal actions
 - balanced mode: pin third-party actions, allow branch refs for internal actions
+
+For latest examples, see [/docs/examples/](/docs/examples/).
 
 ## 3. Keep Secrets Scoped and Explicit
 
@@ -72,17 +76,20 @@ Checklist:
 
 Pick one merge contract and document it in `README.md` or maintainer docs.
 
-Option A: bot-first automation
-
-- required status check: `review / review`
-- required approving reviews: `0`
-- code owner reviews: optional
-
-Option B: human-gated merges
+Option A: human-gated baseline (recommended)
 
 - required status check: `review / review`
 - required approving reviews: `1+`
 - code owner reviews: enabled for sensitive paths
+
+Option B: bot-first automation (advanced)
+
+- required status check: `review / review`
+- required approving reviews: `0`
+- code owner reviews: policy dependent
+- only use when org policy explicitly allows bot-first merges and write access is tightly controlled
+
+If org policy is unclear, default to `1+` approving reviews.
 
 Switching between modes ad hoc usually causes confusion and merge delays.
 

--- a/Website/content/blog/reviewer-yaml-vs-json-playbook.md
+++ b/Website/content/blog/reviewer-yaml-vs-json-playbook.md
@@ -28,18 +28,18 @@ These overrides are per key, not full-object replacement.
 
 ## Concrete YAML vs JSON Comparison
 
-Below is a real side-by-side where both files set overlapping keys.
+Below is a side-by-side example where both files set overlapping keys.
 
 ### Workflow YAML (`.github/workflows/review-intelligencex.yml`)
 
 ```yaml
 jobs:
   review:
-    uses: evotecit/github-actions/.github/workflows/review-intelligencex.yml@5f823fad4dbdb34a2de64c741cdc9cdfbcd1e4cf
+    uses: <org>/<workflow-repo>/.github/workflows/review-intelligencex.yml@<pinned-sha>
     with:
       review_config_path: .intelligencex/reviewer.json
       provider: openai
-      model: gpt-5.3-codex
+      model: <model-id>
       mode: hybrid
       length: medium
       progress_updates: true
@@ -48,6 +48,9 @@ jobs:
       INTELLIGENCEX_GITHUB_APP_ID: ${{ secrets.INTELLIGENCEX_GITHUB_APP_ID }}
       INTELLIGENCEX_GITHUB_APP_PRIVATE_KEY: ${{ secrets.INTELLIGENCEX_GITHUB_APP_PRIVATE_KEY }}
 ```
+
+Replace `<org>`, `<workflow-repo>`, `<pinned-sha>`, and `<model-id>` with your values.
+For latest examples, see [/docs/examples/](/docs/examples/).
 
 ### Reviewer JSON (`.intelligencex/reviewer.json`)
 
@@ -108,11 +111,11 @@ This gives CI engineers control of infrastructure and reviewers/maintainers cont
 ```yaml
 jobs:
   review:
-    uses: evotecit/github-actions/.github/workflows/review-intelligencex.yml@5f823fad4dbdb34a2de64c741cdc9cdfbcd1e4cf
+    uses: <org>/<workflow-repo>/.github/workflows/review-intelligencex.yml@<pinned-sha>
     with:
       reviewer_source: source
       provider: openai
-      model: gpt-5.3-codex
+      model: <model-id>
       review_config_path: .intelligencex/reviewer.json
     secrets:
       INTELLIGENCEX_AUTH_B64: ${{ secrets.INTELLIGENCEX_AUTH_B64 }}

--- a/Website/content/blog/security-first-reviewer-setup-checklist.md
+++ b/Website/content/blog/security-first-reviewer-setup-checklist.md
@@ -15,11 +15,11 @@ Use a pinned reusable workflow SHA so upgrades are intentional and auditable.
 ```yaml
 jobs:
   review:
-    uses: evotecit/github-actions/.github/workflows/review-intelligencex.yml@5f823fad4dbdb34a2de64c741cdc9cdfbcd1e4cf
+    uses: <org>/<workflow-repo>/.github/workflows/review-intelligencex.yml@<pinned-sha>
     with:
       reviewer_source: source
       provider: openai
-      model: gpt-5.3-codex
+      model: <model-id>
       review_config_path: .intelligencex/reviewer.json
       progress_updates: true
     secrets:
@@ -27,6 +27,9 @@ jobs:
       INTELLIGENCEX_GITHUB_APP_ID: ${{ secrets.INTELLIGENCEX_GITHUB_APP_ID }}
       INTELLIGENCEX_GITHUB_APP_PRIVATE_KEY: ${{ secrets.INTELLIGENCEX_GITHUB_APP_PRIVATE_KEY }}
 ```
+
+Replace `<org>`, `<workflow-repo>`, `<pinned-sha>`, and `<model-id>` with your values.
+For latest examples, see [/docs/examples/](/docs/examples/).
 
 ## 2. Keep Policy in reviewer.json
 
@@ -60,15 +63,17 @@ Use it only in a trusted local session with shell history and terminal logging c
 
 Pick one mode per repo and document it:
 
-- Bot-first automation mode:
-  - required check: `review / review`
-  - required approving reviews: `0`
-  - code owner review requirement: `false`
-- Human-gated mode:
+- Recommended baseline (most public repos):
   - required check: `review / review`
   - required approving reviews: `1+`
-  - code owner review requirement: team dependent
+  - code owner review requirement: enabled for sensitive paths
+- Bot-first mode (advanced, explicit approval):
+  - required check: `review / review`
+  - required approving reviews: `0`
+  - code owner review requirement: policy dependent
+  - use only when merge access is tightly limited and audit controls are in place
 
+If your organization policy is unclear, default to `1+` approving reviews.
 Mixing modes ad hoc is what causes merge confusion.
 
 ## 5. Keep Runner Strategy Explicit

--- a/Website/content/blog/setup-best-practices-for-teams.md
+++ b/Website/content/blog/setup-best-practices-for-teams.md
@@ -45,17 +45,19 @@ Before pushing setup changes:
 ```bash
 dotnet build IntelligenceX.sln -c Release
 dotnet test IntelligenceX.sln -c Release
-dotnet exec ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
-dotnet exec ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
 ```
+
+If your repository also uses framework-specific harness binaries, run those commands from your repo's CI or maintainer docs instead of hardcoding framework paths.
 
 Then validate reviewer behavior against a known PR:
 
 ```bash
-export INPUT_REPO=owner/name
-export INPUT_PR_NUMBER=123
+export INPUT_REPO=<owner>/<repo>
+export INPUT_PR_NUMBER=<pr-number>
 intelligencex reviewer run
 ```
+
+Replace `<owner>`, `<repo>`, and `<pr-number>` with your real values.
 
 ## 5. Treat Overrides as Temporary
 


### PR DESCRIPTION
## Summary
- remove brittle hardcoded framework test-DLL commands from `setup-best-practices-for-teams` and replace with stable build/test baseline + guidance for repo-specific harness commands
- add explicit placeholder replacement callouts near copy/paste command blocks (`<owner>/<repo>`, `<pr-number>`, `<org>`, `<workflow-repo>`, `<pinned-sha>`, `<model-id>`)
- tighten branch protection guidance in security-focused posts:
  - make `1+` approving reviews the recommended baseline for public repos
  - keep `0` approvals as advanced bot-first mode with explicit scope/caveats
- reduce stale literal drift by replacing repeated pinned SHA/model literals in blog examples and linking to `/docs/examples/` for latest references

## Why
Follow-up to review feedback: the previous text could be interpreted as a weak default branch-protection baseline and some copy/paste examples were too repo-specific.

## Validation
- `dotnet C:/Support/GitHub/PSPublishModule/PowerForge.Web.Cli/bin/Release/net8.0/PowerForge.Web.Cli.dll pipeline --config Website/pipeline.json --mode ci --skip verify`
  - result: pass (`doctor: Doctor ok no-build, no-verify, audit, audit 0e/0w`)