### PR TITLE
Refactor write tools: centralize schema defaults for governance/probe

### DIFF
--- a/.agents/skills/intelligencex-write-tool-authoring/SKILL.md
+++ b/.agents/skills/intelligencex-write-tool-authoring/SKILL.md
@@ -14,9 +14,9 @@ Use this skill when adding or refactoring write-capable (mutating) tools.
 ## Required Build Pattern
 1. Define schema with shared extensions:
    - Start with `ToolSchema.Object(...)`.
-   - Add `.WithWriteGovernanceMetadata()`.
-   - For probe-aware auth flows add `.WithAuthenticationProbeReference()`.
-   - End with `.NoAdditionalProperties()`.
+   - Prefer `.WithWriteGovernanceDefaults()` for write tools.
+   - For probe-aware auth flows prefer `.WithWriteGovernanceAndAuthenticationProbe()`.
+   - Use low-level `.WithWriteGovernanceMetadata()` / `.WithAuthenticationProbeReference()` only for advanced custom ordering.
 2. Define write contract with shared factories:
    - Boolean intent: `ToolWriteGovernanceConventions.BooleanFlagTrue(...)`.
    - String intent: `ToolWriteGovernanceConventions.StringEquals(...)`.
@@ -44,7 +44,7 @@ Use this skill when adding or refactoring write-capable (mutating) tools.
 ## Authentication + Probe Rules
 - When tool supports auth preflight probes:
   - set `supportsConnectivityProbe: true` and provide `probeToolName`.
-  - expose `auth_probe_id` in schema using `.WithAuthenticationProbeReference()`.
+  - expose `auth_probe_id` in schema using `.WithWriteGovernanceAndAuthenticationProbe()` (or `.WithAuthenticationProbeReference()` for custom pipelines).
   - do not hand-roll schema argument names; use `ToolAuthenticationArgumentNames`.
 - For strict probe gating before writes:
   - validate probe references through `ToolAuthenticationProbeValidator`.

--- a/.agents/skills/intelligencex-write-tool-authoring/templates/write-tool-template.cs.txt
+++ b/.agents/skills/intelligencex-write-tool-authoring/templates/write-tool-template.cs.txt
@@ -17,9 +17,7 @@ public sealed class __TOOL_CLASS_NAME__ : ToolBase, ITool {
                 ("apply", ToolSchema.Boolean("When true, executes the write action. When false, returns a dry-run plan."))
                 // Add tool-specific args here.
             )
-            .WithWriteGovernanceMetadata()
-            .WithAuthenticationProbeReference()
-            .NoAdditionalProperties());
+            .WithWriteGovernanceAndAuthenticationProbe());
 
     private static readonly ToolWriteGovernanceContract WriteContract = ToolWriteGovernanceConventions.BooleanFlagTrue(
         intentArgumentName: "apply",

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolSchema.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolSchema.cs
@@ -201,6 +201,41 @@ public static class ToolSchemaExtensions {
     }
 
     /// <summary>
+    /// Applies the standard write-tool schema shape:
+    /// canonical write-governance metadata + <c>additionalProperties=false</c>.
+    /// </summary>
+    /// <param name="schema">Schema to mutate.</param>
+    public static JsonObject WithWriteGovernanceDefaults(this JsonObject schema) {
+        if (schema is null) {
+            throw new ArgumentNullException(nameof(schema));
+        }
+
+        return schema
+            .WithWriteGovernanceMetadata()
+            .NoAdditionalProperties();
+    }
+
+    /// <summary>
+    /// Applies probe-aware write-tool schema defaults:
+    /// auth probe reference + canonical write-governance metadata + <c>additionalProperties=false</c>.
+    /// </summary>
+    /// <param name="schema">Schema to mutate.</param>
+    /// <param name="argumentName">Probe-id argument name.</param>
+    /// <param name="description">Optional custom probe description.</param>
+    public static JsonObject WithWriteGovernanceAndAuthenticationProbe(
+        this JsonObject schema,
+        string argumentName = ToolAuthenticationArgumentNames.ProbeId,
+        string? description = null) {
+        if (schema is null) {
+            throw new ArgumentNullException(nameof(schema));
+        }
+
+        return schema
+            .WithAuthenticationProbeReference(argumentName, description)
+            .WithWriteGovernanceDefaults();
+    }
+
+    /// <summary>
     /// Adds an authentication profile reference argument to an object schema.
     /// </summary>
     /// <param name="schema">Schema to mutate.</param>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailSmtpSendTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailSmtpSendTool.cs
@@ -38,11 +38,9 @@ public sealed class EmailSmtpSendTool : EmailToolBase, ITool {
                 ("text_body", ToolSchema.String("Plain text body.")),
                 ("html_body", ToolSchema.String("HTML body.")),
                 ("send", ToolSchema.Boolean("When true, actually sends. Otherwise dry-run.")))
-            .WithAuthenticationProbeReference(
-                description: "Optional auth probe id from email_smtp_probe. Required only when strict probe gating is enabled.")
             .Required("from", "to", "subject")
-            .WithWriteGovernanceMetadata()
-            .NoAdditionalProperties(),
+            .WithWriteGovernanceAndAuthenticationProbe(
+                description: "Optional auth probe id from email_smtp_probe. Required only when strict probe gating is enabled."),
         writeGovernance: ToolWriteGovernanceConventions.BooleanFlagTrue(
             intentArgumentName: "send",
             confirmationArgumentName: "send"),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellRunTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.PowerShell/PowerShellRunTool.cs
@@ -85,8 +85,7 @@ public sealed class PowerShellRunTool : PowerShellToolBase, ITool {
                 ("timeout_ms", ToolSchema.Integer("Execution timeout in milliseconds.")),
                 ("max_output_chars", ToolSchema.Integer("Maximum combined output characters to return.")),
                 ("include_error_stream", ToolSchema.Boolean("When true, include stderr in output. Default true.")))
-            .WithWriteGovernanceMetadata()
-            .NoAdditionalProperties(),
+            .WithWriteGovernanceDefaults(),
         writeGovernance: ToolWriteGovernanceConventions.StringEquals(
             intentArgumentName: "intent",
             intentStringValue: "read_write",

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSchemaExtensionsTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSchemaExtensionsTests.cs
@@ -38,6 +38,23 @@ public class ToolSchemaExtensionsTests {
     }
 
     [Fact]
+    public void WithWriteGovernanceDefaults_ShouldAddGovernanceMetadataAndDisableAdditionalProperties() {
+        var schema = ToolSchema.Object(
+                ("send", ToolSchema.Boolean("apply write action")))
+            .WithWriteGovernanceDefaults();
+
+        var properties = schema.GetObject("properties");
+        Assert.NotNull(properties);
+        Assert.NotNull(properties!.GetObject(ToolWriteGovernanceArgumentNames.ExecutionId));
+        Assert.NotNull(properties.GetObject(ToolWriteGovernanceArgumentNames.ActorId));
+        Assert.NotNull(properties.GetObject(ToolWriteGovernanceArgumentNames.ChangeReason));
+        Assert.NotNull(properties.GetObject(ToolWriteGovernanceArgumentNames.RollbackPlanId));
+        Assert.NotNull(properties.GetObject(ToolWriteGovernanceArgumentNames.RollbackProviderId));
+        Assert.NotNull(properties.GetObject(ToolWriteGovernanceArgumentNames.AuditCorrelationId));
+        Assert.False(schema.GetBoolean("additionalProperties", true));
+    }
+
+    [Fact]
     public void WithAuthenticationProfileReference_ShouldAddAuthProfileProperty() {
         var schema = ToolSchema.Object(
                 ("query", ToolSchema.String("query text")))
@@ -71,5 +88,23 @@ public class ToolSchemaExtensionsTests {
         var properties = schema.GetObject("properties");
         Assert.NotNull(properties);
         Assert.NotNull(properties!.GetObject(ToolAuthenticationArgumentNames.ProbeId));
+    }
+
+    [Fact]
+    public void WithWriteGovernanceAndAuthenticationProbe_ShouldAddProbeAndGovernanceAndDisableAdditionalProperties() {
+        var schema = ToolSchema.Object(
+                ("send", ToolSchema.Boolean("apply write action")))
+            .WithWriteGovernanceAndAuthenticationProbe();
+
+        var properties = schema.GetObject("properties");
+        Assert.NotNull(properties);
+        Assert.NotNull(properties!.GetObject(ToolAuthenticationArgumentNames.ProbeId));
+        Assert.NotNull(properties.GetObject(ToolWriteGovernanceArgumentNames.ExecutionId));
+        Assert.NotNull(properties.GetObject(ToolWriteGovernanceArgumentNames.ActorId));
+        Assert.NotNull(properties.GetObject(ToolWriteGovernanceArgumentNames.ChangeReason));
+        Assert.NotNull(properties.GetObject(ToolWriteGovernanceArgumentNames.RollbackPlanId));
+        Assert.NotNull(properties.GetObject(ToolWriteGovernanceArgumentNames.RollbackProviderId));
+        Assert.NotNull(properties.GetObject(ToolWriteGovernanceArgumentNames.AuditCorrelationId));
+        Assert.False(schema.GetBoolean("additionalProperties", true));
     }
 }


### PR DESCRIPTION
## Summary
- add reusable schema helpers for write tools:
  - `WithWriteGovernanceDefaults()`
  - `WithWriteGovernanceAndAuthenticationProbe()`
- migrate existing write-capable tools to the new helpers:
  - `email_smtp_send`
  - `powershell_run`
- add tests locking helper behavior (governance metadata + probe field + `additionalProperties=false`)
- update write-tool authoring skill/template to guide new tools toward these centralized helpers

## Why
This trims repetitive schema wiring from write tools and standardizes the default authoring pattern, making new write tools faster to add and less error-prone.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolSchemaExtensionsTests|FullyQualifiedName~ToolWriteGovernanceRegistryTests|FullyQualifiedName~ToolAuthenticationRegistryTests"`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release` (Passed: 347)