### PR TITLE
CI: keep test checks green when artifact storage quota is exhausted

### DIFF
--- a/.github/workflows/test-dotnet-hosted.yml
+++ b/.github/workflows/test-dotnet-hosted.yml
@@ -57,6 +57,7 @@ jobs:
             - name: Upload test results
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               if: always()
+              continue-on-error: true
               with:
                   name: test-results-${{ matrix.os }}
                   path: '**/*.trx'
@@ -64,6 +65,7 @@ jobs:
             - name: Upload coverage reports
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               if: ${{ always() && hashFiles('**/coverage.cobertura.xml') != '' }}
+              continue-on-error: true
               with:
                   name: coverage-reports-${{ matrix.os }}
                   path: '**/coverage.cobertura.xml'

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -62,6 +62,7 @@ jobs:
             - name: Upload test results
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               if: always()
+              continue-on-error: true
               with:
                   name: test-results-windows
                   path: '**/*.trx'
@@ -69,6 +70,7 @@ jobs:
             - name: Upload coverage reports
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               if: ${{ always() && hashFiles('**/coverage.cobertura.xml') != '' }}
+              continue-on-error: true
               with:
                   name: coverage-reports-windows
                   path: '**/coverage.cobertura.xml'
@@ -117,6 +119,7 @@ jobs:
             - name: Upload test results
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               if: always()
+              continue-on-error: true
               with:
                   name: test-results-ubuntu
                   path: '**/*.trx'
@@ -167,6 +170,7 @@ jobs:
             - name: Upload test results
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               if: always()
+              continue-on-error: true
               with:
                   name: test-results-macos
                   path: '**/*.trx'


### PR DESCRIPTION
## Summary
- make artifact upload steps in test workflows best-effort by setting `continue-on-error: true`
- apply this to:
  - `.github/workflows/test-dotnet.yml`
  - `.github/workflows/test-dotnet-hosted.yml`

## Why
Artifact storage quota exhaustion should not fail required test checks when build and tests themselves pass. This reduces CI churn from infra-only upload failures.

## Scope
No test/build logic changed; only post-test artifact upload behavior.