### PR TITLE
Harden chat markdown option isolation and normalization guardrails

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ExportPreferencesContractTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ExportPreferencesContractTests.cs
@@ -45,6 +45,27 @@ public sealed class ExportPreferencesContractTests {
     }
 
     /// <summary>
+    /// Ensures host visual-theme aliases stay aligned with shell normalization branches.
+    /// </summary>
+    [Fact]
+    public void VisualThemeMode_ParityWithShellAliasesAndDefaults() {
+        Assert.Equal(ExportPreferencesContract.VisualThemeModePrintFriendly, ExportPreferencesContract.NormalizeVisualThemeMode("PRINT"));
+        Assert.Equal(ExportPreferencesContract.VisualThemeModePrintFriendly, ExportPreferencesContract.NormalizeVisualThemeMode("LIGHT"));
+        Assert.Equal(ExportPreferencesContract.VisualThemeModePreserveUi, ExportPreferencesContract.NormalizeVisualThemeMode("THEME"));
+        Assert.Equal(ExportPreferencesContract.VisualThemeModePreserveUi, ExportPreferencesContract.NormalizeVisualThemeMode("  "));
+
+        var shell = UiShellAssets.Load();
+        Assert.Contains("case \"print_friendly\":", shell, StringComparison.Ordinal);
+        Assert.Contains("case \"print\":", shell, StringComparison.Ordinal);
+        Assert.Contains("case \"light\":", shell, StringComparison.Ordinal);
+        Assert.Contains("case \"preserve_ui_theme\":", shell, StringComparison.Ordinal);
+        Assert.Contains("case \"preserve\":", shell, StringComparison.Ordinal);
+        Assert.Contains("case \"theme\":", shell, StringComparison.Ordinal);
+        Assert.Contains("return \"print_friendly\";", shell, StringComparison.Ordinal);
+        Assert.Contains("return \"preserve_ui_theme\";", shell, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Ensures format parsing accepts canonical and alias values.
     /// </summary>
     [Theory]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using IntelligenceX.Chat.App.Rendering;
 using Xunit;
 
@@ -552,6 +554,69 @@ public sealed class TranscriptMarkdownNormalizerTests {
         Assert.Contains(sentinel, normalized, System.StringComparison.Ordinal);
         Assert.Contains("`a**b`", normalized, System.StringComparison.Ordinal);
         Assert.DoesNotContain("from **Service", normalized, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Ensures large collapsed metric chains expand deterministically without malformed leftovers.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_ExpandsLargeCollapsedMetricChainsDeterministically() {
+        var segments = new List<string> { "**Status: HEALTHY**" };
+        for (var i = 1; i <= 128; i++) {
+            segments.Add("**Metric " + i + ":**" + i);
+        }
+
+        var text = string.Join(" - ", segments);
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+
+        Assert.Contains("Status **HEALTHY**", normalized, StringComparison.Ordinal);
+        Assert.DoesNotContain("-**", normalized, StringComparison.Ordinal);
+        Assert.DoesNotContain("**Metric 1:**", normalized, StringComparison.Ordinal);
+        for (var i = 1; i <= 128; i++) {
+            Assert.Contains("- Metric " + i + " **" + i + "**", normalized, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// Ensures deep nested strong artifacts flatten to a single outer strong pair.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_FlattensDeepNestedStrongSpansWithinBoundedPasses() {
+        var levels = new List<string>();
+        for (var i = 1; i <= 40; i++) {
+            levels.Add("L" + i);
+        }
+
+        var text = "- Signal **" + string.Join(" **", levels) + " complete.**";
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+        var normalizedAgain = TranscriptMarkdownNormalizer.NormalizeForRendering(normalized);
+
+        var strongMarkerCount = normalized.Split("**", StringSplitOptions.None).Length - 1;
+        Assert.True(strongMarkerCount <= 4, "Expected bounded strong markers, got " + strongMarkerCount.ToString());
+        Assert.Contains("L40 complete.", normalized, StringComparison.Ordinal);
+        Assert.DoesNotContain("**L2 **", normalized, StringComparison.Ordinal);
+        Assert.Equal(normalized, normalizedAgain);
+    }
+
+    /// <summary>
+    /// Ensures long host-label bullet stacks merge continuation lines at scale.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_MergesLongHostLabelBulletSeries() {
+        var lines = new List<string>();
+        for (var i = 1; i <= 180; i++) {
+            lines.Add("-AD" + i);
+            lines.Add("host detail " + i);
+        }
+
+        var text = string.Join('\n', lines);
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+        var normalizedLines = normalized.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(180, normalizedLines.Length);
+        Assert.DoesNotContain("\n-AD", normalized, StringComparison.Ordinal);
+        Assert.Contains("- AD1 host detail 1", normalized, StringComparison.Ordinal);
+        Assert.Contains("- AD180 host detail 180", normalized, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.RenderingAndTheme.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.RenderingAndTheme.cs
@@ -88,8 +88,11 @@ public sealed partial class MainWindow : Window {
         return TranscriptMarkdownFormatter.Format(messages, timestampFormat);
     }
 
-    private static string BuildMessagesHtml(IEnumerable<(string Role, string Text, DateTime Time)> messages, string timestampFormat) {
-        return TranscriptHtmlFormatter.Format(messages, timestampFormat, MarkdownOptions);
+    private static string BuildMessagesHtml(
+        IEnumerable<(string Role, string Text, DateTime Time)> messages,
+        string timestampFormat,
+        MarkdownRendererOptions markdownOptions) {
+        return TranscriptHtmlFormatter.Format(messages, timestampFormat, markdownOptions);
     }
 
     private async Task<string?> ShowTranscriptSavePickerAsync(string? title, string preferredFormat) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -105,7 +105,8 @@ public sealed partial class MainWindow : Window {
 
             var messagesSnapshot = SnapshotMessagesForRender(_messages);
             var timestampFormat = _timestampFormat;
-            var html = await Task.Run(() => BuildMessagesHtml(messagesSnapshot, timestampFormat)).ConfigureAwait(false);
+            var markdownOptions = _markdownOptions;
+            var html = await Task.Run(() => BuildMessagesHtml(messagesSnapshot, timestampFormat, markdownOptions)).ConfigureAwait(false);
             latestGeneration = Interlocked.Read(ref _transcriptRenderGeneration);
             if (requestedGeneration < latestGeneration) {
                 return;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -167,6 +167,7 @@ public sealed partial class MainWindow : Window {
 
     private readonly DispatcherQueue _dispatcher;
     private readonly WebView2 _webView;
+    private readonly MarkdownRendererOptions _markdownOptions;
     private readonly Task<Microsoft.Web.WebView2.Core.CoreWebView2Environment?> _webViewEnvironmentTask;
     private delegate IntPtr WindowProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
     private delegate IntPtr LowLevelMouseProc(int nCode, IntPtr wParam, IntPtr lParam);
@@ -210,7 +211,6 @@ public sealed partial class MainWindow : Window {
     private long _wheelForwardedAbsDelta;
     private long _dragMoveWatchdogArmCount;
     private long _dragMoveWatchdogForcedReleaseCount;
-    private static readonly MarkdownRendererOptions MarkdownOptions = ChatMarkdownOptions.Create();
     private static readonly bool VerboseServiceLogs = IsTruthy(Environment.GetEnvironmentVariable("IXCHAT_VERBOSE_SERVICE_LOGS"));
     private static readonly bool DetachedServiceMode = IsTruthy(Environment.GetEnvironmentVariable("IXCHAT_DETACHED_SERVICE"));
     private static readonly GlobalWheelHookMode WheelHookMode = ResolveGlobalWheelHookMode(Environment.GetEnvironmentVariable("IXCHAT_WHEEL_HOOK_MODE"));
@@ -486,6 +486,7 @@ public sealed partial class MainWindow : Window {
     /// </summary>
     public MainWindow() {
         StartupLog.Write("MainWindow.ctor enter");
+        _markdownOptions = ChatMarkdownOptions.Create();
         Title = "IntelligenceX Chat";
         _debugMode = VerboseServiceLogs;
 


### PR DESCRIPTION
## Summary
- make chat markdown renderer options instance-scoped on `MainWindow` instead of static shared state
- add export visual theme alias/default parity guard test tying host normalization to shell normalization branches
- add high-signal pathological transcript normalizer tests for large collapsed metric chains, deep nested strong spans, and long host-label bullet series

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "ExportPreferencesContractTests|TranscriptMarkdownNormalizerTests|ChatMarkdownOptionsTests"`