### PR TITLE
Deduplicate chat service tooling bootstrap and refresh availability state

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -462,11 +463,48 @@ internal sealed partial class ChatServiceSession {
     }
 
     private void RebuildToolingFromOptions() {
+        RebuildToolingCore(clearRoutingCaches: true);
+    }
+
+    [MemberNotNull(
+        nameof(_registry),
+        nameof(_packs),
+        nameof(_packAvailability),
+        nameof(_startupWarnings),
+        nameof(_pluginSearchPaths),
+        nameof(_runtimePolicyDiagnostics))]
+    private void RebuildToolingCore(bool clearRoutingCaches) {
         var startupWarnings = new List<string>();
         var runtimePolicyContext = ToolRuntimePolicyBootstrap.CreateContext(
             BuildRuntimePolicyOptions(_options),
             warning => RecordBootstrapWarning(startupWarnings, warning));
-        var bootstrapOptions = new ToolPackBootstrapOptions {
+        var bootstrapOptions = BuildToolPackBootstrapOptions(runtimePolicyContext, startupWarnings);
+        var bootstrapResult = ToolPackBootstrap.CreateDefaultReadOnlyPacksWithAvailability(bootstrapOptions);
+        var pluginSearchPaths = NormalizeDistinctStrings(ToolPackBootstrap.GetPluginSearchPaths(bootstrapOptions), maxItems: 32);
+        var warnings = NormalizeDistinctStrings(startupWarnings, maxItems: 64);
+
+        var registry = new ToolRegistry();
+        _toolPackIdsByToolName.Clear();
+        ToolPackBootstrap.RegisterAll(registry, bootstrapResult.Packs, _toolPackIdsByToolName);
+        _runtimePolicyDiagnostics = ToolRuntimePolicyBootstrap.ApplyToRegistry(registry, runtimePolicyContext);
+
+        _packs = bootstrapResult.Packs;
+        _packAvailability = bootstrapResult.PackAvailability.ToArray();
+        _pluginSearchPaths = pluginSearchPaths;
+        _startupWarnings = warnings;
+        _registry = registry;
+
+        UpdatePackMetadataIndexes(ToolPackBootstrap.GetDescriptors(_packs));
+
+        if (clearRoutingCaches) {
+            ClearToolRoutingCaches();
+        }
+    }
+
+    private ToolPackBootstrapOptions BuildToolPackBootstrapOptions(
+        ToolRuntimePolicyContext runtimePolicyContext,
+        ICollection<string> startupWarnings) {
+        return new ToolPackBootstrapOptions {
             AllowedRoots = _options.AllowedRoots.ToArray(),
             AdDomainController = _options.AdDomainController,
             AdDefaultSearchBaseDn = _options.AdDefaultSearchBaseDn,
@@ -484,23 +522,9 @@ internal sealed partial class ChatServiceSession {
             AuthenticationProfilePath = runtimePolicyContext.Options.AuthenticationProfilePath,
             OnBootstrapWarning = warning => RecordBootstrapWarning(startupWarnings, warning)
         };
+    }
 
-        var packs = ToolPackBootstrap.CreateDefaultReadOnlyPacks(bootstrapOptions);
-        var pluginSearchPaths = NormalizeDistinctStrings(ToolPackBootstrap.GetPluginSearchPaths(bootstrapOptions), maxItems: 32);
-        var warnings = NormalizeDistinctStrings(startupWarnings, maxItems: 64);
-
-        var registry = new ToolRegistry();
-        _toolPackIdsByToolName.Clear();
-        ToolPackBootstrap.RegisterAll(registry, packs, _toolPackIdsByToolName);
-        _runtimePolicyDiagnostics = ToolRuntimePolicyBootstrap.ApplyToRegistry(registry, runtimePolicyContext);
-
-        _packs = packs;
-        _pluginSearchPaths = pluginSearchPaths;
-        _startupWarnings = warnings;
-        _registry = registry;
-
-        UpdatePackMetadataIndexes(ToolPackBootstrap.GetDescriptors(_packs));
-
+    private void ClearToolRoutingCaches() {
         // Tool sets may have changed; clear caches so routing doesn't assume removed tools.
         lock (_toolRoutingStatsLock) {
             _toolRoutingStats.Clear();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
@@ -72,39 +72,7 @@ internal sealed partial class ChatServiceSession {
     public ChatServiceSession(ServiceOptions options, Stream stream) {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
-        var startupWarnings = new List<string>();
-        var runtimePolicyContext = ToolRuntimePolicyBootstrap.CreateContext(
-            BuildRuntimePolicyOptions(_options),
-            warning => RecordBootstrapWarning(startupWarnings, warning));
-        var bootstrapOptions = new ToolPackBootstrapOptions {
-            AllowedRoots = _options.AllowedRoots.ToArray(),
-            AdDomainController = _options.AdDomainController,
-            AdDefaultSearchBaseDn = _options.AdDefaultSearchBaseDn,
-            AdMaxResults = _options.AdMaxResults,
-            EnablePowerShellPack = _options.EnablePowerShellPack,
-            PowerShellAllowWrite = _options.PowerShellAllowWrite,
-            EnableTestimoXPack = _options.EnableTestimoXPack,
-            EnableOfficeImoPack = _options.EnableOfficeImoPack,
-            EnableDefaultPluginPaths = _options.EnableDefaultPluginPaths,
-            PluginPaths = _options.PluginPaths.ToArray(),
-            AuthenticationProbeStore = runtimePolicyContext.AuthenticationProbeStore,
-            RequireSuccessfulSmtpProbeForSend = runtimePolicyContext.RequireSuccessfulSmtpProbeForSend,
-            SmtpProbeMaxAgeSeconds = runtimePolicyContext.SmtpProbeMaxAgeSeconds,
-            RunAsProfilePath = runtimePolicyContext.Options.RunAsProfilePath,
-            AuthenticationProfilePath = runtimePolicyContext.Options.AuthenticationProfilePath,
-            OnBootstrapWarning = warning => RecordBootstrapWarning(startupWarnings, warning)
-        };
-
-        var bootstrapResult = ToolPackBootstrap.CreateDefaultReadOnlyPacksWithAvailability(bootstrapOptions);
-        _packs = bootstrapResult.Packs;
-        _packAvailability = bootstrapResult.PackAvailability.ToArray();
-        _pluginSearchPaths = NormalizeDistinctStrings(ToolPackBootstrap.GetPluginSearchPaths(bootstrapOptions), maxItems: 32);
-        _startupWarnings = NormalizeDistinctStrings(startupWarnings, maxItems: 64);
-        _registry = new ToolRegistry();
-        _toolPackIdsByToolName.Clear();
-        ToolPackBootstrap.RegisterAll(_registry, _packs, _toolPackIdsByToolName);
-        _runtimePolicyDiagnostics = ToolRuntimePolicyBootstrap.ApplyToRegistry(_registry, runtimePolicyContext);
-        UpdatePackMetadataIndexes(ToolPackBootstrap.GetDescriptors(_packs));
+        RebuildToolingCore(clearRoutingCaches: false);
 
         _json = new JsonSerializerOptions {
             TypeInfoResolver = ChatServiceJsonContext.Default

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceToolingBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceToolingBootstrapTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using System.Reflection;
+using IntelligenceX.Chat.Service;
+using IntelligenceX.Chat.Tooling;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class ChatServiceToolingBootstrapTests {
+    [Fact]
+    public void RebuildToolingFromOptions_RefreshesPackAvailabilitySnapshot() {
+        var rebuildMethod = typeof(ChatServiceSession).GetMethod("RebuildToolingFromOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+        var packAvailabilityField = typeof(ChatServiceSession).GetField("_packAvailability", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(rebuildMethod);
+        Assert.NotNull(packAvailabilityField);
+
+        var options = new ServiceOptions {
+            EnableOfficeImoPack = true
+        };
+        var session = new ChatServiceSession(options, Stream.Null);
+
+        var initialAvailability = Assert.IsType<ToolPackAvailabilityInfo[]>(packAvailabilityField!.GetValue(session));
+
+        options.EnableOfficeImoPack = false;
+        rebuildMethod!.Invoke(session, Array.Empty<object>());
+
+        var rebuiltAvailability = Assert.IsType<ToolPackAvailabilityInfo[]>(packAvailabilityField.GetValue(session));
+        Assert.NotSame(initialAvailability, rebuiltAvailability);
+
+        var officeImo = Assert.Single(rebuiltAvailability, static item =>
+            string.Equals(item.Id, "officeimo", StringComparison.OrdinalIgnoreCase));
+        Assert.False(officeImo.Enabled);
+    }
+}


### PR DESCRIPTION
## Summary
- deduplicated Chat Service tool bootstrap so constructor and profile-triggered rebuild both use one shared runtime path (`RebuildToolingCore`)
- fixed rebuild correctness gap where `_packAvailability` was not refreshed after option/profile changes
- extracted bootstrap-option mapping into one helper (`BuildToolPackBootstrapOptions`) and routing-cache reset into `ClearToolRoutingCaches`
- added regression test verifying rebuild refreshes pack-availability snapshot and reflects `EnableOfficeImoPack=false`

## Why
- less repeated code across constructor/rebuild paths
- prevents policy/hello metadata drift after profile switches
- makes future tool-pack additions easier (single mapping path)

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Service/IntelligenceX.Chat.Service.csproj -c Release -f net10.0-windows`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release -f net10.0-windows`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release -f net10.0-windows --no-build --filter "FullyQualifiedName~RebuildToolingFromOptions_RefreshesPackAvailabilitySnapshot"`
