### PR TITLE
refactor(chat): centralize runtime policy/bootstrap option mapping

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
@@ -22,7 +22,7 @@ namespace IntelligenceX.Chat.Host;
 
 internal static partial class Program {
 
-    private sealed class ReplOptions {
+    private sealed class ReplOptions : IToolRuntimePolicySettings, IToolPackRuntimeSettings {
         public string Model { get; set; } = "gpt-5.3-codex";
 
         public OpenAITransportKind OpenAITransport { get; set; } = OpenAITransportKind.Native;
@@ -74,6 +74,10 @@ internal static partial class Program {
         public bool RequireAuthenticationRuntime { get; set; }
         public string? RunAsProfilePath { get; set; }
         public string? AuthenticationProfilePath { get; set; }
+
+        ToolAuthenticationRuntimePreset IToolRuntimePolicySettings.AuthenticationRuntimePreset => AuthenticationRuntimePreset;
+        IReadOnlyList<string> IToolPackRuntimeSettings.AllowedRoots => AllowedRoots;
+        IReadOnlyList<string> IToolPackRuntimeSettings.PluginPaths => PluginPaths;
 
         public static ReplOptions Parse(string[] args, out string? error) {
             error = null;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Policy.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Policy.cs
@@ -34,38 +34,11 @@ internal static partial class Program {
         ReplOptions options,
         ToolRuntimePolicyContext runtimePolicy,
         Action<string>? onBootstrapWarning = null) {
-        return new ToolPackBootstrapOptions {
-            AllowedRoots = options.AllowedRoots.ToArray(),
-            AdDomainController = options.AdDomainController,
-            AdDefaultSearchBaseDn = options.AdDefaultSearchBaseDn,
-            AdMaxResults = options.AdMaxResults,
-            EnablePowerShellPack = options.EnablePowerShellPack,
-            PowerShellAllowWrite = options.PowerShellAllowWrite,
-            EnableTestimoXPack = options.EnableTestimoXPack,
-            EnableOfficeImoPack = options.EnableOfficeImoPack,
-            EnableDefaultPluginPaths = options.EnableDefaultPluginPaths,
-            PluginPaths = options.PluginPaths.ToArray(),
-            AuthenticationProbeStore = runtimePolicy.AuthenticationProbeStore,
-            RequireSuccessfulSmtpProbeForSend = runtimePolicy.RequireSuccessfulSmtpProbeForSend,
-            SmtpProbeMaxAgeSeconds = runtimePolicy.SmtpProbeMaxAgeSeconds,
-            RunAsProfilePath = runtimePolicy.Options.RunAsProfilePath,
-            AuthenticationProfilePath = runtimePolicy.Options.AuthenticationProfilePath,
-            OnBootstrapWarning = onBootstrapWarning
-        };
+        return ToolPackBootstrap.CreateRuntimeBootstrapOptions(options, runtimePolicy, onBootstrapWarning);
     }
 
     private static ToolRuntimePolicyOptions BuildRuntimePolicyOptions(ReplOptions options) {
-        return ToolRuntimePolicyBootstrap.ResolveOptions(new ToolRuntimePolicyOptions {
-            WriteGovernanceMode = options.WriteGovernanceMode,
-            RequireWriteGovernanceRuntime = options.RequireWriteGovernanceRuntime,
-            RequireWriteAuditSinkForWriteOperations = options.RequireWriteAuditSinkForWriteOperations,
-            WriteAuditSinkMode = options.WriteAuditSinkMode,
-            WriteAuditSinkPath = options.WriteAuditSinkPath,
-            AuthenticationPreset = options.AuthenticationRuntimePreset,
-            RequireAuthenticationRuntime = options.RequireAuthenticationRuntime,
-            RunAsProfilePath = options.RunAsProfilePath,
-            AuthenticationProfilePath = options.AuthenticationProfilePath
-        }).Options;
+        return ToolRuntimePolicyBootstrap.CreateOptions(options);
     }
 
     private static void WritePolicyBanner(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PolicyAndTypes.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PolicyAndTypes.cs
@@ -89,17 +89,7 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static ToolRuntimePolicyOptions BuildRuntimePolicyOptions(ServiceOptions options) {
-        return ToolRuntimePolicyBootstrap.ResolveOptions(new ToolRuntimePolicyOptions {
-            WriteGovernanceMode = options.WriteGovernanceMode,
-            RequireWriteGovernanceRuntime = options.RequireWriteGovernanceRuntime,
-            RequireWriteAuditSinkForWriteOperations = options.RequireWriteAuditSinkForWriteOperations,
-            WriteAuditSinkMode = options.WriteAuditSinkMode,
-            WriteAuditSinkPath = options.WriteAuditSinkPath,
-            AuthenticationPreset = options.AuthenticationRuntimePreset,
-            RequireAuthenticationRuntime = options.RequireAuthenticationRuntime,
-            RunAsProfilePath = options.RunAsProfilePath,
-            AuthenticationProfilePath = options.AuthenticationProfilePath
-        }).Options;
+        return ToolRuntimePolicyBootstrap.CreateOptions(options);
     }
 
     private static void RecordBootstrapWarning(ICollection<string> sink, string? warning) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
@@ -478,7 +478,10 @@ internal sealed partial class ChatServiceSession {
         var runtimePolicyContext = ToolRuntimePolicyBootstrap.CreateContext(
             BuildRuntimePolicyOptions(_options),
             warning => RecordBootstrapWarning(startupWarnings, warning));
-        var bootstrapOptions = BuildToolPackBootstrapOptions(runtimePolicyContext, startupWarnings);
+        var bootstrapOptions = ToolPackBootstrap.CreateRuntimeBootstrapOptions(
+            _options,
+            runtimePolicyContext,
+            warning => RecordBootstrapWarning(startupWarnings, warning));
         var bootstrapResult = ToolPackBootstrap.CreateDefaultReadOnlyPacksWithAvailability(bootstrapOptions);
         var pluginSearchPaths = NormalizeDistinctStrings(ToolPackBootstrap.GetPluginSearchPaths(bootstrapOptions), maxItems: 32);
         var warnings = NormalizeDistinctStrings(startupWarnings, maxItems: 64);
@@ -499,29 +502,6 @@ internal sealed partial class ChatServiceSession {
         if (clearRoutingCaches) {
             ClearToolRoutingCaches();
         }
-    }
-
-    private ToolPackBootstrapOptions BuildToolPackBootstrapOptions(
-        ToolRuntimePolicyContext runtimePolicyContext,
-        ICollection<string> startupWarnings) {
-        return new ToolPackBootstrapOptions {
-            AllowedRoots = _options.AllowedRoots.ToArray(),
-            AdDomainController = _options.AdDomainController,
-            AdDefaultSearchBaseDn = _options.AdDefaultSearchBaseDn,
-            AdMaxResults = _options.AdMaxResults,
-            EnablePowerShellPack = _options.EnablePowerShellPack,
-            PowerShellAllowWrite = _options.PowerShellAllowWrite,
-            EnableTestimoXPack = _options.EnableTestimoXPack,
-            EnableOfficeImoPack = _options.EnableOfficeImoPack,
-            EnableDefaultPluginPaths = _options.EnableDefaultPluginPaths,
-            PluginPaths = _options.PluginPaths.ToArray(),
-            AuthenticationProbeStore = runtimePolicyContext.AuthenticationProbeStore,
-            RequireSuccessfulSmtpProbeForSend = runtimePolicyContext.RequireSuccessfulSmtpProbeForSend,
-            SmtpProbeMaxAgeSeconds = runtimePolicyContext.SmtpProbeMaxAgeSeconds,
-            RunAsProfilePath = runtimePolicyContext.Options.RunAsProfilePath,
-            AuthenticationProfilePath = runtimePolicyContext.Options.AuthenticationProfilePath,
-            OnBootstrapWarning = warning => RecordBootstrapWarning(startupWarnings, warning)
-        };
     }
 
     private void ClearToolRoutingCaches() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -11,7 +11,7 @@ using IntelligenceX.Tools;
 
 namespace IntelligenceX.Chat.Service;
 
-internal sealed class ServiceOptions {
+internal sealed class ServiceOptions : IToolRuntimePolicySettings, IToolPackRuntimeSettings {
     public bool ShowHelp { get; set; }
     public string PipeName { get; set; } = "intelligencex.chat";
     public string Model { get; set; } = "gpt-5.3-codex";
@@ -58,6 +58,10 @@ internal sealed class ServiceOptions {
     public bool RequireAuthenticationRuntime { get; set; }
     public string? RunAsProfilePath { get; set; }
     public string? AuthenticationProfilePath { get; set; }
+
+    ToolAuthenticationRuntimePreset IToolRuntimePolicySettings.AuthenticationRuntimePreset => AuthenticationRuntimePreset;
+    IReadOnlyList<string> IToolPackRuntimeSettings.AllowedRoots => AllowedRoots;
+    IReadOnlyList<string> IToolPackRuntimeSettings.PluginPaths => PluginPaths;
 
     public string? InstructionsFile { get; set; }
     public int MaxTableRows { get; set; }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
@@ -8,6 +8,46 @@ namespace IntelligenceX.Chat.Tests;
 
 public sealed class ToolPackBootstrapMetadataTests {
     [Fact]
+    public void CreateRuntimeBootstrapOptions_MapsSettingsAndRuntimePolicyContext() {
+        var runtimePolicyContext = ToolRuntimePolicyBootstrap.CreateContext(new ToolRuntimePolicyOptions {
+            AuthenticationPreset = ToolAuthenticationRuntimePreset.Strict,
+            RunAsProfilePath = "C:/temp/runas.json",
+            AuthenticationProfilePath = "C:/temp/auth.json"
+        });
+
+        var options = ToolPackBootstrap.CreateRuntimeBootstrapOptions(
+            new TestPackRuntimeSettings {
+                AllowedRoots = new[] { "C:/allowed-a", "C:/allowed-b" },
+                AdDomainController = "dc.contoso.local",
+                AdDefaultSearchBaseDn = "DC=contoso,DC=local",
+                AdMaxResults = 2222,
+                EnablePowerShellPack = true,
+                PowerShellAllowWrite = true,
+                EnableTestimoXPack = false,
+                EnableOfficeImoPack = false,
+                EnableDefaultPluginPaths = false,
+                PluginPaths = new[] { "C:/plugins/a", "C:/plugins/b" }
+            },
+            runtimePolicyContext);
+
+        Assert.Equal(new[] { "C:/allowed-a", "C:/allowed-b" }, options.AllowedRoots);
+        Assert.Equal("dc.contoso.local", options.AdDomainController);
+        Assert.Equal("DC=contoso,DC=local", options.AdDefaultSearchBaseDn);
+        Assert.Equal(2222, options.AdMaxResults);
+        Assert.True(options.EnablePowerShellPack);
+        Assert.True(options.PowerShellAllowWrite);
+        Assert.False(options.EnableTestimoXPack);
+        Assert.False(options.EnableOfficeImoPack);
+        Assert.False(options.EnableDefaultPluginPaths);
+        Assert.Equal(new[] { "C:/plugins/a", "C:/plugins/b" }, options.PluginPaths);
+        Assert.Same(runtimePolicyContext.AuthenticationProbeStore, options.AuthenticationProbeStore);
+        Assert.True(options.RequireSuccessfulSmtpProbeForSend);
+        Assert.Equal(600, options.SmtpProbeMaxAgeSeconds);
+        Assert.Equal(runtimePolicyContext.Options.RunAsProfilePath, options.RunAsProfilePath);
+        Assert.Equal(runtimePolicyContext.Options.AuthenticationProfilePath, options.AuthenticationProfilePath);
+    }
+
+    [Fact]
     public void NormalizeSourceKind_Throws_WhenSourceKindMissing() {
         Assert.Throws<ArgumentException>(() => ToolPackBootstrap.NormalizeSourceKind(sourceKind: null, descriptorId: "system"));
     }
@@ -130,5 +170,18 @@ public sealed class ToolPackBootstrapMetadataTests {
 
         Assert.True(toolPackIdsByToolName.TryGetValue("reviewer_setup_pack_info", out var reviewerPackId));
         Assert.Equal("reviewersetup", reviewerPackId);
+    }
+
+    private sealed class TestPackRuntimeSettings : IToolPackRuntimeSettings {
+        public IReadOnlyList<string> AllowedRoots { get; init; } = Array.Empty<string>();
+        public string? AdDomainController { get; init; }
+        public string? AdDefaultSearchBaseDn { get; init; }
+        public int AdMaxResults { get; init; } = 1000;
+        public bool EnablePowerShellPack { get; init; }
+        public bool PowerShellAllowWrite { get; init; }
+        public bool EnableTestimoXPack { get; init; } = true;
+        public bool EnableOfficeImoPack { get; init; } = true;
+        public bool EnableDefaultPluginPaths { get; init; } = true;
+        public IReadOnlyList<string> PluginPaths { get; init; } = Array.Empty<string>();
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolRuntimePolicyBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolRuntimePolicyBootstrapTests.cs
@@ -8,6 +8,31 @@ namespace IntelligenceX.Chat.Tests;
 
 public sealed class ToolRuntimePolicyBootstrapTests {
     [Fact]
+    public void CreateOptions_MapsRuntimePolicySettingsContract() {
+        var options = ToolRuntimePolicyBootstrap.CreateOptions(new TestRuntimePolicySettings {
+            WriteGovernanceMode = ToolWriteGovernanceMode.Yolo,
+            RequireWriteGovernanceRuntime = false,
+            RequireWriteAuditSinkForWriteOperations = true,
+            WriteAuditSinkMode = ToolWriteAuditSinkMode.SqliteAppendOnly,
+            WriteAuditSinkPath = " C:/temp/write-audit.db ",
+            AuthenticationRuntimePreset = ToolAuthenticationRuntimePreset.Strict,
+            RequireAuthenticationRuntime = true,
+            RunAsProfilePath = " C:/temp/runas.json ",
+            AuthenticationProfilePath = " C:/temp/auth.json "
+        });
+
+        Assert.Equal(ToolWriteGovernanceMode.Yolo, options.WriteGovernanceMode);
+        Assert.False(options.RequireWriteGovernanceRuntime);
+        Assert.True(options.RequireWriteAuditSinkForWriteOperations);
+        Assert.Equal(ToolWriteAuditSinkMode.SqliteAppendOnly, options.WriteAuditSinkMode);
+        Assert.Equal(" C:/temp/write-audit.db ", options.WriteAuditSinkPath);
+        Assert.Equal(ToolAuthenticationRuntimePreset.Strict, options.AuthenticationPreset);
+        Assert.True(options.RequireAuthenticationRuntime);
+        Assert.Equal(" C:/temp/runas.json ", options.RunAsProfilePath);
+        Assert.Equal(" C:/temp/auth.json ", options.AuthenticationProfilePath);
+    }
+
+    [Fact]
     public void CreateContext_StrictPreset_RequiresSmtpProbeValidation() {
         var context = ToolRuntimePolicyBootstrap.CreateContext(new ToolRuntimePolicyOptions {
             AuthenticationPreset = ToolAuthenticationRuntimePreset.Strict
@@ -85,5 +110,17 @@ public sealed class ToolRuntimePolicyBootstrapTests {
         } catch {
             // Best-effort cleanup.
         }
+    }
+
+    private sealed class TestRuntimePolicySettings : IToolRuntimePolicySettings {
+        public ToolWriteGovernanceMode WriteGovernanceMode { get; init; } = ToolWriteGovernanceMode.Enforced;
+        public bool RequireWriteGovernanceRuntime { get; init; } = true;
+        public bool RequireWriteAuditSinkForWriteOperations { get; init; }
+        public ToolWriteAuditSinkMode WriteAuditSinkMode { get; init; }
+        public string? WriteAuditSinkPath { get; init; }
+        public ToolAuthenticationRuntimePreset AuthenticationRuntimePreset { get; init; } = ToolAuthenticationRuntimePreset.Default;
+        public bool RequireAuthenticationRuntime { get; init; }
+        public string? RunAsProfilePath { get; init; }
+        public string? AuthenticationProfilePath { get; init; }
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolPackBootstrap.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolPackBootstrap.cs
@@ -151,6 +151,61 @@ public sealed record ToolPackBootstrapOptions {
 }
 
 /// <summary>
+/// Host/service settings contract used to build runtime pack bootstrap options.
+/// </summary>
+public interface IToolPackRuntimeSettings {
+    /// <summary>
+    /// Allowed filesystem roots (used by filesystem tools and EVTX file access).
+    /// </summary>
+    IReadOnlyList<string> AllowedRoots { get; }
+
+    /// <summary>
+    /// Optional Active Directory domain controller.
+    /// </summary>
+    string? AdDomainController { get; }
+
+    /// <summary>
+    /// Optional default AD search base DN.
+    /// </summary>
+    string? AdDefaultSearchBaseDn { get; }
+
+    /// <summary>
+    /// Max AD results returned by AD tools (0 or less = default).
+    /// </summary>
+    int AdMaxResults { get; }
+
+    /// <summary>
+    /// Enables dangerous IX.PowerShell runtime pack when available.
+    /// </summary>
+    bool EnablePowerShellPack { get; }
+
+    /// <summary>
+    /// Enables read-write intent for IX.PowerShell runtime pack.
+    /// </summary>
+    bool PowerShellAllowWrite { get; }
+
+    /// <summary>
+    /// Enables IX.TestimoX diagnostics pack when available.
+    /// </summary>
+    bool EnableTestimoXPack { get; }
+
+    /// <summary>
+    /// Enables IX.OfficeIMO read-only document ingestion pack when available.
+    /// </summary>
+    bool EnableOfficeImoPack { get; }
+
+    /// <summary>
+    /// Enables default plugin search roots.
+    /// </summary>
+    bool EnableDefaultPluginPaths { get; }
+
+    /// <summary>
+    /// Additional plugin search paths (repeatable).
+    /// </summary>
+    IReadOnlyList<string> PluginPaths { get; }
+}
+
+/// <summary>
 /// Availability metadata for a known tool pack in the current runtime.
 /// </summary>
 public sealed record ToolPackAvailabilityInfo {
@@ -290,6 +345,47 @@ public static class ToolPackBootstrap {
         ToolCapabilityTier.SensitiveRead,
         IsDangerous: false,
         PackSourceBuiltin);
+
+    /// <summary>
+    /// Creates runtime bootstrap options from shared host/service settings and policy context.
+    /// </summary>
+    /// <param name="settings">Host/service tool-pack settings.</param>
+    /// <param name="runtimePolicyContext">Resolved runtime policy context.</param>
+    /// <param name="onBootstrapWarning">Optional warning sink used during pack bootstrap.</param>
+    /// <returns>Mapped bootstrap options.</returns>
+    public static ToolPackBootstrapOptions CreateRuntimeBootstrapOptions(
+        IToolPackRuntimeSettings settings,
+        ToolRuntimePolicyContext runtimePolicyContext,
+        Action<string>? onBootstrapWarning = null) {
+        if (settings is null) {
+            throw new ArgumentNullException(nameof(settings));
+        }
+        if (runtimePolicyContext is null) {
+            throw new ArgumentNullException(nameof(runtimePolicyContext));
+        }
+
+        var allowedRoots = settings.AllowedRoots?.ToArray() ?? Array.Empty<string>();
+        var pluginPaths = settings.PluginPaths?.ToArray() ?? Array.Empty<string>();
+
+        return new ToolPackBootstrapOptions {
+            AllowedRoots = allowedRoots,
+            AdDomainController = settings.AdDomainController,
+            AdDefaultSearchBaseDn = settings.AdDefaultSearchBaseDn,
+            AdMaxResults = settings.AdMaxResults,
+            EnablePowerShellPack = settings.EnablePowerShellPack,
+            PowerShellAllowWrite = settings.PowerShellAllowWrite,
+            EnableTestimoXPack = settings.EnableTestimoXPack,
+            EnableOfficeImoPack = settings.EnableOfficeImoPack,
+            EnableDefaultPluginPaths = settings.EnableDefaultPluginPaths,
+            PluginPaths = pluginPaths,
+            AuthenticationProbeStore = runtimePolicyContext.AuthenticationProbeStore,
+            RequireSuccessfulSmtpProbeForSend = runtimePolicyContext.RequireSuccessfulSmtpProbeForSend,
+            SmtpProbeMaxAgeSeconds = runtimePolicyContext.SmtpProbeMaxAgeSeconds,
+            RunAsProfilePath = runtimePolicyContext.Options.RunAsProfilePath,
+            AuthenticationProfilePath = runtimePolicyContext.Options.AuthenticationProfilePath,
+            OnBootstrapWarning = onBootstrapWarning
+        };
+    }
 
     /// <summary>
     /// Builds the default tool packs (public read-only packs plus optional private packs when available).

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolRuntimePolicy.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolRuntimePolicy.cs
@@ -115,6 +115,56 @@ public sealed record ToolRuntimePolicyResolvedOptions {
 }
 
 /// <summary>
+/// Host/service settings contract used to build runtime policy options.
+/// </summary>
+public interface IToolRuntimePolicySettings {
+    /// <summary>
+    /// Write-governance enforcement mode.
+    /// </summary>
+    ToolWriteGovernanceMode WriteGovernanceMode { get; }
+
+    /// <summary>
+    /// When true, writes are blocked if no write-governance runtime is configured.
+    /// </summary>
+    bool RequireWriteGovernanceRuntime { get; }
+
+    /// <summary>
+    /// When true, writes are blocked if no write-audit sink is configured.
+    /// </summary>
+    bool RequireWriteAuditSinkForWriteOperations { get; }
+
+    /// <summary>
+    /// Selected audit sink mode.
+    /// </summary>
+    ToolWriteAuditSinkMode WriteAuditSinkMode { get; }
+
+    /// <summary>
+    /// Optional audit sink path (file/db).
+    /// </summary>
+    string? WriteAuditSinkPath { get; }
+
+    /// <summary>
+    /// Authentication preset used to shape pack-level auth behavior.
+    /// </summary>
+    ToolAuthenticationRuntimePreset AuthenticationRuntimePreset { get; }
+
+    /// <summary>
+    /// When true, strict auth-runtime behavior is required.
+    /// </summary>
+    bool RequireAuthenticationRuntime { get; }
+
+    /// <summary>
+    /// Optional run-as profile catalog path for tools that support run-as references.
+    /// </summary>
+    string? RunAsProfilePath { get; }
+
+    /// <summary>
+    /// Optional authentication profile catalog path for tools that support explicit auth profile references.
+    /// </summary>
+    string? AuthenticationProfilePath { get; }
+}
+
+/// <summary>
 /// Resolved runtime policy context used during bootstrap.
 /// </summary>
 public sealed record ToolRuntimePolicyContext {
@@ -218,6 +268,29 @@ public sealed record ToolRuntimePolicyDiagnostics {
 public static class ToolRuntimePolicyBootstrap {
     private const string StrictImmutableAuditProviderId = "ix.audit.append_only";
     private const string StrictRollbackProviderId = "ix.rollback.catalog";
+
+    /// <summary>
+    /// Creates runtime policy options from shared host/service settings.
+    /// </summary>
+    /// <param name="settings">Runtime policy settings.</param>
+    /// <returns>Mapped runtime policy options.</returns>
+    public static ToolRuntimePolicyOptions CreateOptions(IToolRuntimePolicySettings settings) {
+        if (settings is null) {
+            throw new ArgumentNullException(nameof(settings));
+        }
+
+        return new ToolRuntimePolicyOptions {
+            WriteGovernanceMode = settings.WriteGovernanceMode,
+            RequireWriteGovernanceRuntime = settings.RequireWriteGovernanceRuntime,
+            RequireWriteAuditSinkForWriteOperations = settings.RequireWriteAuditSinkForWriteOperations,
+            WriteAuditSinkMode = settings.WriteAuditSinkMode,
+            WriteAuditSinkPath = settings.WriteAuditSinkPath,
+            AuthenticationPreset = settings.AuthenticationRuntimePreset,
+            RequireAuthenticationRuntime = settings.RequireAuthenticationRuntime,
+            RunAsProfilePath = settings.RunAsProfilePath,
+            AuthenticationProfilePath = settings.AuthenticationProfilePath
+        };
+    }
 
     /// <summary>
     /// Creates a runtime policy context from options.


### PR DESCRIPTION
## Summary\n- add shared tooling contracts for host/service runtime settings (IToolRuntimePolicySettings, IToolPackRuntimeSettings)\n- add canonical mapping helpers (ToolRuntimePolicyBootstrap.CreateOptions, ToolPackBootstrap.CreateRuntimeBootstrapOptions)\n- switch Host and Service bootstrap/runtime wiring to shared mappers to remove duplicated option construction logic\n- add focused tests that pin mapping behavior for both helpers\n\n## Validation\n- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release -f net10.0-windows\n- dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Service/IntelligenceX.Chat.Service.csproj -c Release -f net10.0-windows\n- dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Host/IntelligenceX.Chat.Host.csproj -c Release -f net10.0-windows\n