### PR TITLE
refactor(chat): centralize response shaping/redaction helpers

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Policy.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Policy.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Chat.Tooling;
@@ -123,44 +122,15 @@ internal static partial class Program {
     }
 
     private static string? ApplyRuntimeShaping(string? instructions, ReplOptions options) {
-        var shaping = BuildShapingInstructions(options);
-        if (string.IsNullOrWhiteSpace(shaping)) {
-            return instructions;
-        }
-        if (string.IsNullOrWhiteSpace(instructions)) {
-            return shaping;
-        }
-        return instructions + Environment.NewLine + Environment.NewLine + shaping;
+        return ToolResponseShaping.AppendSessionResponseShapingInstructions(
+            instructions,
+            options.MaxTableRows,
+            options.MaxSample,
+            options.Redact);
     }
-
-    private static string? BuildShapingInstructions(ReplOptions options) {
-        if (options.MaxTableRows <= 0 && options.MaxSample <= 0 && !options.Redact) {
-            return null;
-        }
-
-        var lines = new List<string> {
-            "## Session Response Shaping",
-            "Follow these display constraints for all assistant responses:"
-        };
-        if (options.MaxTableRows > 0) {
-            lines.Add($"- Max table rows: {options.MaxTableRows} (show a preview, then offer to paginate/refine).");
-        }
-        if (options.MaxSample > 0) {
-            lines.Add($"- Max sample items: {options.MaxSample} (for long lists, show a sample and counts).");
-        }
-        if (options.Redact) {
-            lines.Add("- Redaction: redact emails/UPNs in assistant output. Prefer summaries over raw identifiers.");
-        }
-        return string.Join(Environment.NewLine, lines);
-    }
-
-    private static readonly Regex EmailRegex = new(@"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     private static string RedactText(string text) {
-        if (string.IsNullOrEmpty(text)) {
-            return string.Empty;
-        }
-        return EmailRegex.Replace(text, "[redacted_email]");
+        return ToolResponseShaping.RedactEmailLikeTokens(text);
     }
 
     private static CancellationTokenSource? CreateTimeoutCts(CancellationToken ct, int seconds) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PolicyAndTypes.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PolicyAndTypes.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JsonValueKind = System.Text.Json.JsonValueKind;
@@ -188,51 +187,15 @@ internal sealed partial class ChatServiceSession {
             instructions = null;
         }
 
-        var shaping = BuildShapingInstructions(options);
-        if (string.IsNullOrWhiteSpace(shaping)) {
-            return instructions;
-        }
-        if (string.IsNullOrWhiteSpace(instructions)) {
-            return shaping;
-        }
-        return instructions + Environment.NewLine + Environment.NewLine + shaping;
+        return ToolResponseShaping.AppendSessionResponseShapingInstructions(
+            instructions,
+            options.MaxTableRows,
+            options.MaxSample,
+            options.Redact);
     }
-
-    private static string? BuildShapingInstructions(ServiceOptions options) {
-        var maxTableRows = options.MaxTableRows;
-        var maxSample = options.MaxSample;
-        var redact = options.Redact;
-
-        if (maxTableRows <= 0 && maxSample <= 0 && !redact) {
-            return null;
-        }
-
-        var lines = new List<string> {
-            "## Session Response Shaping",
-            "Follow these display constraints for all assistant responses:"
-        };
-
-        if (maxTableRows > 0) {
-            lines.Add($"- Max table rows: {maxTableRows} (show a preview, then offer to paginate/refine).");
-        }
-        if (maxSample > 0) {
-            lines.Add($"- Max sample items: {maxSample} (for long lists, show a sample and counts).");
-        }
-        if (redact) {
-            lines.Add("- Redaction: redact emails/UPNs in assistant output. Prefer summaries over raw identifiers.");
-        }
-
-        return string.Join(Environment.NewLine, lines);
-    }
-
-    private static readonly Regex EmailRegex = new(@"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     private static string RedactText(string text) {
-        if (string.IsNullOrEmpty(text)) {
-            return string.Empty;
-        }
-        // Best-effort: redact email/UPN-like tokens.
-        return EmailRegex.Replace(text, "[redacted_email]");
+        return ToolResponseShaping.RedactEmailLikeTokens(text);
     }
 
     private sealed class ChatRun {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolResponseShapingTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolResponseShapingTests.cs
@@ -1,0 +1,55 @@
+using System;
+using IntelligenceX.Chat.Tooling;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class ToolResponseShapingTests {
+    [Fact]
+    public void BuildSessionResponseShapingInstructions_ReturnsNull_WhenNoConstraintsEnabled() {
+        var shaping = ToolResponseShaping.BuildSessionResponseShapingInstructions(
+            maxTableRows: 0,
+            maxSample: 0,
+            redact: false);
+
+        Assert.Null(shaping);
+    }
+
+    [Fact]
+    public void BuildSessionResponseShapingInstructions_IncludesConfiguredConstraints() {
+        var shaping = ToolResponseShaping.BuildSessionResponseShapingInstructions(
+            maxTableRows: 25,
+            maxSample: 10,
+            redact: true);
+
+        Assert.NotNull(shaping);
+        Assert.Contains("## Session Response Shaping", shaping);
+        Assert.Contains("Max table rows: 25", shaping);
+        Assert.Contains("Max sample items: 10", shaping);
+        Assert.Contains("Redaction: redact emails/UPNs", shaping);
+    }
+
+    [Fact]
+    public void AppendSessionResponseShapingInstructions_AppendsToExistingInstructions() {
+        var appended = ToolResponseShaping.AppendSessionResponseShapingInstructions(
+            instructions: "Base instructions",
+            maxTableRows: 5,
+            maxSample: 0,
+            redact: false);
+
+        Assert.NotNull(appended);
+        Assert.StartsWith("Base instructions" + Environment.NewLine + Environment.NewLine, appended);
+        Assert.Contains("Max table rows: 5", appended);
+    }
+
+    [Fact]
+    public void RedactEmailLikeTokens_RedactsEmailAndHandlesEmptyInput() {
+        var redacted = ToolResponseShaping.RedactEmailLikeTokens("Contact admin@contoso.local now.");
+        var empty = ToolResponseShaping.RedactEmailLikeTokens(string.Empty);
+        var nullText = ToolResponseShaping.RedactEmailLikeTokens(null);
+
+        Assert.Equal("Contact [redacted_email] now.", redacted);
+        Assert.Equal(string.Empty, empty);
+        Assert.Equal(string.Empty, nullText);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolResponseShaping.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolResponseShaping.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace IntelligenceX.Chat.Tooling;
+
+/// <summary>
+/// Shared response-shaping and redaction helpers for chat host/service runtimes.
+/// </summary>
+public static class ToolResponseShaping {
+    private static readonly Regex EmailLikeTokenRegex = new(@"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Builds response-shaping guidance text, or null when no shaping constraints are active.
+    /// </summary>
+    /// <param name="maxTableRows">Max table rows (0 = unlimited).</param>
+    /// <param name="maxSample">Max sample items (0 = unlimited).</param>
+    /// <param name="redact">When true, redact output guidance is included.</param>
+    /// <returns>Guidance text or null.</returns>
+    public static string? BuildSessionResponseShapingInstructions(int maxTableRows, int maxSample, bool redact) {
+        if (maxTableRows <= 0 && maxSample <= 0 && !redact) {
+            return null;
+        }
+
+        var lines = new List<string> {
+            "## Session Response Shaping",
+            "Follow these display constraints for all assistant responses:"
+        };
+        if (maxTableRows > 0) {
+            lines.Add($"- Max table rows: {maxTableRows} (show a preview, then offer to paginate/refine).");
+        }
+        if (maxSample > 0) {
+            lines.Add($"- Max sample items: {maxSample} (for long lists, show a sample and counts).");
+        }
+        if (redact) {
+            lines.Add("- Redaction: redact emails/UPNs in assistant output. Prefer summaries over raw identifiers.");
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    /// <summary>
+    /// Appends shaping guidance to base instructions when shaping constraints are active.
+    /// </summary>
+    /// <param name="instructions">Base instructions.</param>
+    /// <param name="maxTableRows">Max table rows (0 = unlimited).</param>
+    /// <param name="maxSample">Max sample items (0 = unlimited).</param>
+    /// <param name="redact">When true, redact output guidance is included.</param>
+    /// <returns>Instructions with optional shaping guidance appended.</returns>
+    public static string? AppendSessionResponseShapingInstructions(string? instructions, int maxTableRows, int maxSample, bool redact) {
+        var shaping = BuildSessionResponseShapingInstructions(maxTableRows, maxSample, redact);
+        if (string.IsNullOrWhiteSpace(shaping)) {
+            return instructions;
+        }
+        if (string.IsNullOrWhiteSpace(instructions)) {
+            return shaping;
+        }
+
+        return instructions + Environment.NewLine + Environment.NewLine + shaping;
+    }
+
+    /// <summary>
+    /// Best-effort redaction of email/UPN-like tokens.
+    /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <returns>Redacted text.</returns>
+    public static string RedactEmailLikeTokens(string? text) {
+        if (string.IsNullOrEmpty(text)) {
+            return string.Empty;
+        }
+
+        return EmailLikeTokenRegex.Replace(text, "[redacted_email]");
+    }
+}


### PR DESCRIPTION
## Summary\n- add shared ToolResponseShaping helper in IntelligenceX.Chat.Tooling for:\n  - session response-shaping instruction generation/append\n  - best-effort email/UPN redaction\n- switch Host and Service to call shared helper instead of maintaining local duplicate implementations\n- add focused tests for shaping instruction and redaction behavior\n\n## Validation\n- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release -f net10.0-windows\n- dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Service/IntelligenceX.Chat.Service.csproj -c Release -f net10.0-windows\n- dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Host/IntelligenceX.Chat.Host.csproj -c Release -f net10.0-windows\n