### PR TITLE
Unify AD required-domain query parsing for GPO tools

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -41,6 +41,13 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         int MaxResults);
 
     /// <summary>
+    /// Standard argument set used by tools that require a domain and max-results cap.
+    /// </summary>
+    protected readonly record struct RequiredDomainQueryRequest(
+        string DomainName,
+        int MaxResults);
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ActiveDirectoryToolBase"/> class.
     /// </summary>
     /// <param name="options">Tool options.</param>
@@ -104,6 +111,28 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
             return false;
         }
 
+        errorResponse = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Reads required domain + max-results arguments using a single validation path.
+    /// </summary>
+    protected bool TryReadRequiredDomainQueryRequest(
+        JsonObject? arguments,
+        out RequiredDomainQueryRequest request,
+        out string? errorResponse,
+        string domainArgumentName = "domain_name",
+        string maxResultsArgumentName = "max_results",
+        MaxResultsNonPositiveBehavior nonPositiveBehavior = MaxResultsNonPositiveBehavior.ClampToOne) {
+        if (!TryReadRequiredDomainName(arguments, out var domainName, out errorResponse, argumentName: domainArgumentName)) {
+            request = default;
+            return false;
+        }
+
+        request = new RequiredDomainQueryRequest(
+            DomainName: domainName,
+            MaxResults: ResolveBoundedMaxResults(arguments, maxResultsArgumentName, nonPositiveBehavior));
         errorResponse = null;
         return true;
     }
@@ -379,11 +408,12 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
             throw new ArgumentNullException(nameof(resultFactory));
         }
 
-        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+        if (!TryReadRequiredDomainQueryRequest(arguments, out var request, out var argumentError)) {
             return Task.FromResult(argumentError!);
         }
 
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var domainName = request.DomainName;
+        var maxResults = request.MaxResults;
 
         if (!TryExecuteCollectionQuery(
                 query: () => query(domainName),
@@ -676,16 +706,16 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         JsonObject? arguments,
         out PolicyAttributionToolRequest request,
         out string? errorResponse) {
-        if (!TryReadRequiredDomainName(arguments, out var domainName, out errorResponse)) {
+        if (!TryReadRequiredDomainQueryRequest(arguments, out var domainQuery, out errorResponse)) {
             request = default;
             return false;
         }
 
         request = new PolicyAttributionToolRequest(
-            DomainName: domainName,
+            DomainName: domainQuery.DomainName,
             IncludeAttribution: ToolArgs.GetBoolean(arguments, "include_attribution", defaultValue: true),
             ConfiguredAttributionOnly: ToolArgs.GetBoolean(arguments, "configured_attribution_only", defaultValue: false),
-            MaxResults: ResolveBoundedMaxResults(arguments));
+            MaxResults: domainQuery.MaxResults);
         errorResponse = null;
         return true;
     }
@@ -784,4 +814,3 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         }
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoChangesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoChangesTool.cs
@@ -45,15 +45,17 @@ public sealed class AdGpoChangesTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+        if (!TryReadRequiredDomainQueryRequest(arguments, out var domainQuery, out var argumentError)) {
             return Task.FromResult(argumentError!);
         }
+
+        var domainName = domainQuery.DomainName;
 
         if (!ToolTime.TryParseUtcOptional(ToolArgs.GetOptionalTrimmed(arguments, "since_utc"), out var sinceUtc, out var sinceError)) {
             return Task.FromResult(ToolResponse.Error("invalid_argument", $"since_utc: {sinceError}"));
         }
 
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = domainQuery.MaxResults;
         var items = new List<GpoListItem>(Math.Min(maxResults, 512));
         var scanned = 0;
         var truncated = false;

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoIntegrityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoIntegrityTool.cs
@@ -53,14 +53,16 @@ public sealed class AdGpoIntegrityTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+        if (!TryReadRequiredDomainQueryRequest(arguments, out var domainQuery, out var argumentError)) {
             return Task.FromResult(argumentError!);
         }
+
+        var domainName = domainQuery.DomainName;
 
         var sysvolMissingOnly = ToolArgs.GetBoolean(arguments, "sysvol_missing_only", defaultValue: false);
         var adMissingOnly = ToolArgs.GetBoolean(arguments, "ad_missing_only", defaultValue: false);
         var errorsOnly = ToolArgs.GetBoolean(arguments, "errors_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = domainQuery.MaxResults;
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoIntegrityService.Get(domainName),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionAdministrativeTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionAdministrativeTool.cs
@@ -52,14 +52,16 @@ public sealed class AdGpoPermissionAdministrativeTool : ActiveDirectoryToolBase,
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+        if (!TryReadRequiredDomainQueryRequest(arguments, out var domainQuery, out var argumentError)) {
             return Task.FromResult(argumentError!);
         }
+
+        var domainName = domainQuery.DomainName;
 
         var includeCompliant = ToolArgs.GetBoolean(arguments, "include_compliant", defaultValue: false);
         var errorsOnly = ToolArgs.GetBoolean(arguments, "errors_only", defaultValue: false);
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = domainQuery.MaxResults;
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionAdministrativeService.Get(domainName, includeCompliant: includeCompliant, maxGpos: maxGpos),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionConsistencyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionConsistencyTool.cs
@@ -59,9 +59,11 @@ public sealed class AdGpoPermissionConsistencyTool : ActiveDirectoryToolBase, IT
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+        if (!TryReadRequiredDomainQueryRequest(arguments, out var domainQuery, out var argumentError)) {
             return Task.FromResult(argumentError!);
         }
+
+        var domainName = domainQuery.DomainName;
 
         var verifyInheritance = ToolArgs.GetBoolean(arguments, "verify_inheritance", defaultValue: false);
         var includeConsistent = ToolArgs.GetBoolean(arguments, "include_consistent", defaultValue: false);
@@ -75,7 +77,7 @@ public sealed class AdGpoPermissionConsistencyTool : ActiveDirectoryToolBase, IT
 
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
         var sysvolScanCap = ToolArgs.GetCappedInt32(arguments, "sysvol_scan_cap", 2000, 1, 500000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = domainQuery.MaxResults;
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionConsistencyService.Get(domainName, verifyInheritance: verifyInheritance, includeConsistent: includeConsistent, maxGpos: maxGpos, sysvolScanCap: sysvolScanCap),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReadTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReadTool.cs
@@ -53,14 +53,16 @@ public sealed class AdGpoPermissionReadTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+        if (!TryReadRequiredDomainQueryRequest(arguments, out var domainQuery, out var argumentError)) {
             return Task.FromResult(argumentError!);
         }
+
+        var domainName = domainQuery.DomainName;
 
         var includeCompliant = ToolArgs.GetBoolean(arguments, "include_compliant", defaultValue: false);
         var denyOnly = ToolArgs.GetBoolean(arguments, "deny_only", defaultValue: false);
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = domainQuery.MaxResults;
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionReadService.Get(domainName, includeCompliant: includeCompliant, maxGpos: maxGpos),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReportTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionReportTool.cs
@@ -59,9 +59,11 @@ public sealed class AdGpoPermissionReportTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+        if (!TryReadRequiredDomainQueryRequest(arguments, out var domainQuery, out var argumentError)) {
             return Task.FromResult(argumentError!);
         }
+
+        var domainName = domainQuery.DomainName;
 
         var gpoIdRaw = ToolArgs.GetOptionalTrimmed(arguments, "gpo_id");
         Guid? gpoId = null;
@@ -88,7 +90,7 @@ public sealed class AdGpoPermissionReportTool : ActiveDirectoryToolBase, ITool {
 
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
         var maxRows = ToolArgs.GetCappedInt32(arguments, "max_rows", 200000, 1, 2000000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = domainQuery.MaxResults;
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionReportService.Get(domainName, gpoId: gpoId, gpoName: gpoName, maxGpos: maxGpos, maxRows: maxRows),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionRootTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionRootTool.cs
@@ -55,9 +55,11 @@ public sealed class AdGpoPermissionRootTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+        if (!TryReadRequiredDomainQueryRequest(arguments, out var domainQuery, out var argumentError)) {
             return Task.FromResult(argumentError!);
         }
+
+        var domainName = domainQuery.DomainName;
 
         var permission = ToolArgs.GetOptionalTrimmed(arguments, "permission");
         if (!string.IsNullOrWhiteSpace(permission) &&
@@ -71,7 +73,7 @@ public sealed class AdGpoPermissionRootTool : ActiveDirectoryToolBase, ITool {
         var denyOnly = ToolArgs.GetBoolean(arguments, "deny_only", defaultValue: false);
         var inheritedOnly = ToolArgs.GetBoolean(arguments, "inherited_only", defaultValue: false);
         var maxRows = ToolArgs.GetCappedInt32(arguments, "max_rows", 100000, 1, 1000000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = domainQuery.MaxResults;
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionRootService.Get(domainName, maxRows: maxRows),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionUnknownTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoPermissionUnknownTool.cs
@@ -54,15 +54,17 @@ public sealed class AdGpoPermissionUnknownTool : ActiveDirectoryToolBase, ITool 
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+        if (!TryReadRequiredDomainQueryRequest(arguments, out var domainQuery, out var argumentError)) {
             return Task.FromResult(argumentError!);
         }
+
+        var domainName = domainQuery.DomainName;
 
         var resolutionErrorContains = ToolArgs.GetOptionalTrimmed(arguments, "resolution_error_contains");
         var inheritedOnly = ToolArgs.GetBoolean(arguments, "inherited_only", defaultValue: false);
         var maxGpos = ToolArgs.GetCappedInt32(arguments, "max_gpos", 50000, 1, 200000);
         var maxFindings = ToolArgs.GetCappedInt32(arguments, "max_findings", 200000, 1, 2000000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = domainQuery.MaxResults;
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoPermissionUnknownService.Get(domainName, maxGpos: maxGpos, maxFindings: maxFindings),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoRedirectTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoRedirectTool.cs
@@ -50,9 +50,11 @@ public sealed class AdGpoRedirectTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!TryReadRequiredDomainName(arguments, out var domainName, out var argumentError)) {
+        if (!TryReadRequiredDomainQueryRequest(arguments, out var domainQuery, out var argumentError)) {
             return Task.FromResult(argumentError!);
         }
+
+        var domainName = domainQuery.DomainName;
 
         var gpoIdsRaw = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("gpo_ids"));
         var gpoIds = new List<Guid>(gpoIdsRaw.Count);
@@ -65,7 +67,7 @@ public sealed class AdGpoRedirectTool : ActiveDirectoryToolBase, ITool {
 
         var gpoNames = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("gpo_names"));
         var actualPathContains = ToolArgs.GetOptionalTrimmed(arguments, "actual_path_contains");
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = domainQuery.MaxResults;
 
         if (!TryExecuteCollectionQuery(
                 query: () => GpoRedirectAnalyzer.Get(domainName, ids: gpoIds.Count == 0 ? null : gpoIds.ToArray(), names: gpoNames.Count == 0 ? null : gpoNames.ToArray()),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
@@ -141,6 +141,44 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
     }
 
     [Fact]
+    public void TryReadRequiredDomainQueryRequest_ShouldReturnDomainAndCappedMaxResults() {
+        var tool = new HarnessTool();
+
+        var ok = tool.TryReadRequiredDomainQuery(
+            arguments: new JsonObject()
+                .Add("domain_name", "contoso.local")
+                .Add("max_results", 0),
+            useOptionCapDefaultForNonPositive: false,
+            out var domainName,
+            out var maxResults,
+            out var errorResponse);
+
+        Assert.True(ok);
+        Assert.Equal("contoso.local", domainName);
+        Assert.Equal(1, maxResults);
+        Assert.Null(errorResponse);
+    }
+
+    [Fact]
+    public void TryReadRequiredDomainQueryRequest_ShouldDefaultToOptionCap_WhenConfigured() {
+        var tool = new HarnessTool();
+
+        var ok = tool.TryReadRequiredDomainQuery(
+            arguments: new JsonObject()
+                .Add("domain_name", "contoso.local")
+                .Add("max_results", 0),
+            useOptionCapDefaultForNonPositive: true,
+            out var domainName,
+            out var maxResults,
+            out var errorResponse);
+
+        Assert.True(ok);
+        Assert.Equal("contoso.local", domainName);
+        Assert.Equal(1000, maxResults);
+        Assert.Null(errorResponse);
+    }
+
+    [Fact]
     public async Task ExecutePolicyAttributionTool_ShouldFilterRowsAndAddStandardMeta() {
         var tool = new HarnessTool();
         var arguments = new JsonObject()
@@ -401,6 +439,24 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
             return TryReadRequiredDomainName(arguments, out domainName, out errorResponse);
         }
 
+        public bool TryReadRequiredDomainQuery(
+            JsonObject? arguments,
+            bool useOptionCapDefaultForNonPositive,
+            out string? domainName,
+            out int maxResults,
+            out string? errorResponse) {
+            var ok = TryReadRequiredDomainQueryRequest(
+                arguments: arguments,
+                request: out var request,
+                errorResponse: out errorResponse,
+                nonPositiveBehavior: useOptionCapDefaultForNonPositive
+                    ? MaxResultsNonPositiveBehavior.DefaultToOptionCap
+                    : MaxResultsNonPositiveBehavior.ClampToOne);
+            domainName = ok ? request.DomainName : null;
+            maxResults = ok ? request.MaxResults : 0;
+            return ok;
+        }
+
         public Task<string> ExecutePolicyToolAsync(
             JsonObject? arguments,
             Func<string, MockPolicyView> query,
@@ -542,5 +598,4 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
             IReadOnlyList<PolicyAttribution> Attribution);
     }
 }
-
 


### PR DESCRIPTION
## Summary
- add `TryReadRequiredDomainQueryRequest` in `ActiveDirectoryToolBase` to centralize required `domain_name` + bounded `max_results` parsing
- reuse this helper in shared domain-row and policy-attribution flows
- migrate 9 AD GPO tools to the shared helper instead of repeating required-domain + max-results parsing
- add focused tests for helper behavior (argument cap + default handling)

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release -f net8.0-windows`