### PR TITLE
fix(chat): normalize tight signal-label spacing in transcript markdown

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
@@ -492,6 +492,35 @@ public sealed class TranscriptMarkdownNormalizerTests {
     }
 
     /// <summary>
+    /// Ensures malformed signal-flow bullets with tight label spacing normalize into readable markdown.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_FixesTightLabelSpacingInWrappedSignalFlowBullets() {
+        var text =
+            "- Signal **Only total count checked, not origin split ->**Why it matters:**external/custom rules can drift or disappear between hosts ->**Next action:**break down `rule_origin` (`builtin` vs `external`) and confirm expected external rules are present.**";
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+
+        Assert.Equal(
+            "- Signal **Only total count checked, not origin split** -> **Why it matters:** external/custom rules can drift or disappear between hosts -> **Next action:** break down `rule_origin` (`builtin` vs `external`) and confirm expected external rules are present.",
+            normalized);
+    }
+
+    /// <summary>
+    /// Ensures compact plain-label signal-flow text gets spacing after labels for readability.
+    /// </summary>
+    [Fact]
+    public void NormalizeForRendering_FixesTightSpacingAfterPlainSignalFlowLabels() {
+        var text = "- Signal **Point-in-time snapshot only** -> Why it matters:trend coverage is missing -> Action:collect data every 15 minutes for 24h.";
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForRendering(text);
+
+        Assert.Equal(
+            "- Signal **Point-in-time snapshot only** -> Why it matters: trend coverage is missing -> Action: collect data every 15 minutes for 24h.",
+            normalized);
+    }
+
+    /// <summary>
     /// Ensures sentence-collapsed bullets after a closing parenthesis are split and normalized.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMarkdownNormalizer.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMarkdownNormalizer.cs
@@ -82,8 +82,20 @@ internal static class TranscriptMarkdownNormalizer {
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex WrappedSignalFlowLineRegex = new(
-        @"(?m)^(?<prefix>\s*-\s+[^\r\n]*?)\*\*(?<inner>[^\r\n]*->\s+\*\*[^\r\n]*?)\*\*(?<tail>\s*)$",
+        @"(?m)^(?<prefix>\s*-\s+[^\r\n]*?)\*\*(?<inner>[^\r\n]*->\s*\*\*[^\r\n]*?)\*\*(?<tail>\s*)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex SignalFlowArrowLabelTightRegex = new(
+        @"->\s*\*\*(?=(?:Why it matters|Action|Next action|Fix action):)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex SignalFlowBoldLabelMissingSpaceRegex = new(
+        @"(?<label>\*\*(?:Why it matters|Action|Next action|Fix action):\*\*)(?=\S)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex SignalFlowPlainLabelMissingSpaceRegex = new(
+        @"(?<label>(?<![\p{L}\p{N}_])(?:Why it matters|Action|Next action|Fix action):)(?=\S)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex SentenceCollapsedBulletRegex = new(
         @"(?<=[\.\!\?\)\]])\s*(?=-\s*(?:\*\*[^\r\n]|[A-Z]{2,}\d+\b))",
@@ -194,6 +206,7 @@ internal static class TranscriptMarkdownNormalizer {
             value = LetterToNumberedChoiceJoinRegex.Replace(value, " ");
             value = SentenceCollapsedBulletRegex.Replace(value, "\n");
             value = RepairWrappedSignalFlowLines(value);
+            value = NormalizeSignalFlowLabelSpacing(value);
             value = TightBoldValueRegex.Replace(value, " ");
             value = TightBoldSuffixRegex.Replace(value, "$1 ");
             value = NormalizeOverwrappedStrongSpans(value);
@@ -374,6 +387,24 @@ internal static class TranscriptMarkdownNormalizer {
             var inner = match.Groups["inner"].Value.Trim();
             return inner.Length == 0 ? match.Value : "**" + inner + "**";
         });
+    }
+
+    private static string NormalizeSignalFlowLabelSpacing(string text) {
+        if (string.IsNullOrEmpty(text)) {
+            return text;
+        }
+
+        if (text.IndexOf("why it matters:", StringComparison.OrdinalIgnoreCase) < 0
+            && text.IndexOf("action:", StringComparison.OrdinalIgnoreCase) < 0
+            && text.IndexOf("next action:", StringComparison.OrdinalIgnoreCase) < 0
+            && text.IndexOf("fix action:", StringComparison.OrdinalIgnoreCase) < 0) {
+            return text;
+        }
+
+        var value = SignalFlowArrowLabelTightRegex.Replace(text, "-> **");
+        value = SignalFlowBoldLabelMissingSpaceRegex.Replace(value, static match => match.Groups["label"].Value + " ");
+        value = SignalFlowPlainLabelMissingSpaceRegex.Replace(value, static match => match.Groups["label"].Value + " ");
+        return value;
     }
 
     private static string MergeSplitHostLabelBullets(string text) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.cs
@@ -267,6 +267,8 @@ internal sealed partial class ChatServiceSession {
             - Add a short "Potential issues to verify" section (1-3 bullets).
             - Add a short "Recommended next fixes" section (1-3 bullets).
             - For each bullet, include signal -> why it matters -> exact next validation/fix action.
+            - Keep markdown labels readable: use "Why it matters: <text>" and "Next/Fix action: <text>" with a space after each colon.
+            - Do not nest or overlap bold markers across the full signal/action chain.
             - If confidence is uncertain, say what evidence is missing and how to collect it.
             - Prefer proactive checks that can catch hidden regressions, not just obvious follow-ups.
             - Do not invent tool outputs or claim completed actions that were not executed.


### PR DESCRIPTION
## Summary
- normalize malformed signal-flow bullets when model output glues labels and arrows (for example ->**Why it matters:**external/...)
- expand wrapped-signal detection to handle tight ->** markers and enforce spacing after Why it matters:, Action:, Next action:, and Fix action: labels
- add prompt guidance in the proactive follow-up review instructions to avoid nested/overlapping bold markers in the signal/action chain
- add regression tests using real transcript-style artifacts (including inline code labels like ule_origin)

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter FullyQualifiedName~TranscriptMarkdownNormalizerTests
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_EmitsStableMarkerAndSections
