### PR TITLE
test(chat-export): harden docx markdown normalizer contracts

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/LocalExportArtifactWriterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/LocalExportArtifactWriterTests.cs
@@ -272,6 +272,41 @@ public sealed class LocalExportArtifactWriterTests {
     }
 
     /// <summary>
+    /// Ensures clean transcript markdown is returned byte-for-byte when no normalization signal exists.
+    /// </summary>
+    [Fact]
+    public void ExportTranscript_Docx_NormalizationLeavesCleanMarkdownUnchanged() {
+        const string markdown = """
+            # Transcript
+
+            - Signal **Healthy baseline established** -> **Why it matters:** repeatability is preserved.
+            - Next step: collect another sample tomorrow.
+            """;
+
+        var normalized = OfficeImoArtifactWriter.NormalizeTranscriptMarkdownForDocx(markdown);
+
+        Assert.Equal(markdown, normalized);
+    }
+
+    /// <summary>
+    /// Ensures malformed transcript normalization is idempotent after the first repair pass.
+    /// </summary>
+    [Fact]
+    public void ExportTranscript_Docx_NormalizationIsIdempotentForMalformedSignalFlow() {
+        const string markdown = """
+            # Transcript
+
+            - Signal **Only total count checked, not origin split -> **Why it matters:**external/custom rules can drift or disappear between hosts ->**Next action:**break down `rule_origin` (`builtin` vs `external`) and confirm expected external rules are present.**
+            - TestimoX rules available ****359****
+            """;
+
+        var once = OfficeImoArtifactWriter.NormalizeTranscriptMarkdownForDocx(markdown);
+        var twice = OfficeImoArtifactWriter.NormalizeTranscriptMarkdownForDocx(once);
+
+        Assert.Equal(once, twice);
+    }
+
+    /// <summary>
     /// Ensures DOCX transcript export materializes supported visual fences into embedded images.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.ExportArtifacts/OfficeImoArtifactWriter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.ExportArtifacts/OfficeImoArtifactWriter.cs
@@ -11,27 +11,43 @@ namespace IntelligenceX.Chat.ExportArtifacts;
 /// OfficeIMO-backed document writers used by chat export flows.
 /// </summary>
 public static class OfficeImoArtifactWriter {
+    private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(250);
+
+    // Detect ordered-list starters so definition-list escaping can skip true list items.
     private static readonly Regex OrderedListLineRegex = new(
         @"^\s*\d+[.)]\s",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        RegexMatchTimeout);
+    // Repair malformed strong spans like ****359**** into valid markdown emphasis.
     private static readonly Regex OverwrappedStrongSpanRegex = new(
         @"(?<!\*)\*{4}(?<inner>[^*\r\n]+)\*{4}(?!\*)",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        RegexMatchTimeout);
+    // Detect single wrapped signal-flow bullets where one outer strong span swallowed inner labels.
     private static readonly Regex WrappedSignalFlowLineRegex = new(
         @"^(?<prefix>\s*-\s+[^\r\n]*?)\*\*(?<inner>[^\r\n]*->\s*\*\*[^\r\n]*?)\*\*(?<tail>\s*)$",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        RegexMatchTimeout);
+    // Normalize tight arrow-label joins like "->**Why it matters:**" to "-> **Why it matters:**".
     private static readonly Regex SignalFlowArrowLabelTightRegex = new(
         @"->\s*\*\*(?=(?:Why it matters|Action|Next action|Fix action):)",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+        RegexMatchTimeout);
+    // Ensure a space after bold labels such as "**Action:**next".
     private static readonly Regex SignalFlowBoldLabelMissingSpaceRegex = new(
         @"(?<label>\*\*(?:Why it matters|Action|Next action|Fix action):\*\*)(?=\S)",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+        RegexMatchTimeout);
+    // Ensure a space after plain labels such as "Action:next", excluding markdown emphasis starts.
     private static readonly Regex SignalFlowPlainLabelMissingSpaceRegex = new(
         @"(?<label>(?<![\p{L}\p{N}_])(?:Why it matters|Action|Next action|Fix action):)(?=\S)(?!\*)",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+        RegexMatchTimeout);
+    // Fast gate for deciding whether signal-label spacing repairs are needed at all.
     private static readonly Regex TightSignalLabelRegex = new(
         @"(?:Why it matters|Action|Next action|Fix action):\S",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+        RegexMatchTimeout);
 
     /// <summary>
     /// Writes tabular rows to an Excel workbook using OfficeIMO.Excel.


### PR DESCRIPTION
## Summary
- add explicit regex timeouts to DOCX transcript typography-normalization regexes
- add short intent comments for each normalization regex to reduce future maintenance risk
- add regression tests that enforce two core contracts:
  - clean markdown remains byte-for-byte unchanged
  - malformed markdown normalization is idempotent

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~LocalExportArtifactWriterTests.ExportTranscript_Docx_NormalizesSignalFlowTypographyArtifacts|FullyQualifiedName~LocalExportArtifactWriterTests.ExportTranscript_Docx_NormalizationLeavesCleanMarkdownUnchanged|FullyQualifiedName~LocalExportArtifactWriterTests.ExportTranscript_Docx_NormalizationIsIdempotentForMalformedSignalFlow|FullyQualifiedName~LocalExportArtifactWriterTests.ExportTranscript_Docx_MaterializesVisualFencesIntoImages|FullyQualifiedName~LocalExportArtifactWriterTests.ExportTranscript_Docx_LeavesInvalidVisualFenceAsCode"`
