### PR TITLE
refactor(chat-export): centralize signal labels and add stress coverage

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/LocalExportArtifactWriterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/LocalExportArtifactWriterTests.cs
@@ -307,6 +307,24 @@ public sealed class LocalExportArtifactWriterTests {
     }
 
     /// <summary>
+    /// Ensures large adversarial transcript inputs do not trigger regex timeout failures.
+    /// </summary>
+    [Fact]
+    public void ExportTranscript_Docx_NormalizationHandlesLargeAdversarialInput() {
+        var repeatedStrongChunk = string.Concat(Enumerable.Repeat("**A**", 2200));
+        var longStarRun = new string('*', 8000);
+        var longTail = new string('x', 9000);
+        var markdown =
+            "# Transcript\n\n"
+            + "- Signal **" + repeatedStrongChunk + " -> **Why it matters:**tight spacing persists -> **Action:**normalize quickly.**\n"
+            + "- Signal **Probe " + longStarRun + " -> **Next action:**" + longTail + "**\n";
+
+        var exception = Record.Exception(() => OfficeImoArtifactWriter.NormalizeTranscriptMarkdownForDocx(markdown));
+
+        Assert.Null(exception);
+    }
+
+    /// <summary>
     /// Ensures DOCX transcript export materializes supported visual fences into embedded images.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.ExportArtifacts/OfficeImoArtifactWriter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.ExportArtifacts/OfficeImoArtifactWriter.cs
@@ -11,6 +11,8 @@ namespace IntelligenceX.Chat.ExportArtifacts;
 /// OfficeIMO-backed document writers used by chat export flows.
 /// </summary>
 public static class OfficeImoArtifactWriter {
+    private const string SignalFlowLabelAlternation = "Why it matters|Action|Next action|Fix action";
+    private static readonly string[] SignalFlowLabels = ["Why it matters", "Action", "Next action", "Fix action"];
     private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(250);
 
     // Detect ordered-list starters so definition-list escaping can skip true list items.
@@ -30,22 +32,22 @@ public static class OfficeImoArtifactWriter {
         RegexMatchTimeout);
     // Normalize tight arrow-label joins like "->**Why it matters:**" to "-> **Why it matters:**".
     private static readonly Regex SignalFlowArrowLabelTightRegex = new(
-        @"->\s*\*\*(?=(?:Why it matters|Action|Next action|Fix action):)",
+        @"->\s*\*\*(?=(?:" + SignalFlowLabelAlternation + @"):)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
         RegexMatchTimeout);
     // Ensure a space after bold labels such as "**Action:**next".
     private static readonly Regex SignalFlowBoldLabelMissingSpaceRegex = new(
-        @"(?<label>\*\*(?:Why it matters|Action|Next action|Fix action):\*\*)(?=\S)",
+        @"(?<label>\*\*(?:" + SignalFlowLabelAlternation + @"):\*\*)(?=\S)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
         RegexMatchTimeout);
     // Ensure a space after plain labels such as "Action:next", excluding markdown emphasis starts.
     private static readonly Regex SignalFlowPlainLabelMissingSpaceRegex = new(
-        @"(?<label>(?<![\p{L}\p{N}_])(?:Why it matters|Action|Next action|Fix action):)(?=\S)(?!\*)",
+        @"(?<label>(?<![\p{L}\p{N}_])(?:" + SignalFlowLabelAlternation + @"):)(?=\S)(?!\*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
         RegexMatchTimeout);
     // Fast gate for deciding whether signal-label spacing repairs are needed at all.
     private static readonly Regex TightSignalLabelRegex = new(
-        @"(?:Why it matters|Action|Next action|Fix action):\S",
+        @"(?:" + SignalFlowLabelAlternation + @"):\S",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
         RegexMatchTimeout);
 
@@ -275,10 +277,7 @@ public static class OfficeImoArtifactWriter {
 
         return markdown.Contains("****", StringComparison.Ordinal)
                || markdown.Contains("->**", StringComparison.Ordinal)
-               || markdown.Contains("-> **Why it matters:**", StringComparison.OrdinalIgnoreCase)
-               || markdown.Contains("-> **Action:**", StringComparison.OrdinalIgnoreCase)
-               || markdown.Contains("-> **Next action:**", StringComparison.OrdinalIgnoreCase)
-               || markdown.Contains("-> **Fix action:**", StringComparison.OrdinalIgnoreCase)
+               || ContainsAnySignalFlowBoldLabel(markdown)
                || TightSignalLabelRegex.IsMatch(markdown);
     }
 
@@ -334,10 +333,7 @@ public static class OfficeImoArtifactWriter {
             return string.Empty;
         }
 
-        if (line.IndexOf("why it matters:", StringComparison.OrdinalIgnoreCase) < 0
-            && line.IndexOf("action:", StringComparison.OrdinalIgnoreCase) < 0
-            && line.IndexOf("next action:", StringComparison.OrdinalIgnoreCase) < 0
-            && line.IndexOf("fix action:", StringComparison.OrdinalIgnoreCase) < 0) {
+        if (!ContainsAnySignalFlowLabelPrefix(line)) {
             return line;
         }
 
@@ -345,6 +341,36 @@ public static class OfficeImoArtifactWriter {
         value = SignalFlowBoldLabelMissingSpaceRegex.Replace(value, "${label} ");
         value = SignalFlowPlainLabelMissingSpaceRegex.Replace(value, "${label} ");
         return value;
+    }
+
+    private static bool ContainsAnySignalFlowBoldLabel(string text) {
+        if (string.IsNullOrEmpty(text)) {
+            return false;
+        }
+
+        for (var i = 0; i < SignalFlowLabels.Length; i++) {
+            var marker = "-> **" + SignalFlowLabels[i] + ":**";
+            if (text.Contains(marker, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsAnySignalFlowLabelPrefix(string text) {
+        if (string.IsNullOrEmpty(text)) {
+            return false;
+        }
+
+        for (var i = 0; i < SignalFlowLabels.Length; i++) {
+            var marker = SignalFlowLabels[i] + ":";
+            if (text.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string NeutralizeSingleLineDefinitionLists(string markdown) {


### PR DESCRIPTION
## Summary
- centralize signal-flow labels into shared constants used by regex patterns and pre-gate checks
- remove duplicate hardcoded label strings across regex/gating paths to reduce drift risk
- add a large adversarial-input normalization regression test to guard against timeout/backtracking regressions

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~LocalExportArtifactWriterTests.ExportTranscript_Docx_NormalizationLeavesCleanMarkdownUnchanged|FullyQualifiedName~LocalExportArtifactWriterTests.ExportTranscript_Docx_NormalizationIsIdempotentForMalformedSignalFlow|FullyQualifiedName~LocalExportArtifactWriterTests.ExportTranscript_Docx_NormalizationHandlesLargeAdversarialInput|FullyQualifiedName~LocalExportArtifactWriterTests.ExportTranscript_Docx_NormalizesSignalFlowTypographyArtifacts"`
