### PR TITLE
Consolidate AD max-results helper naming

### DIFF
--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityAdRequiredDomainHelper.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityAdRequiredDomainHelper.cs
@@ -35,7 +35,7 @@ public sealed class SampleBadAdDomainTool : ActiveDirectoryToolBase, ITool {
 
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ToolArgs.GetOptionBoundedInt32(arguments, "max_results", 1000);
         return Task.FromResult(ToolResponse.Ok(new {
             domainName,
             maxResults

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -87,7 +87,7 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     /// <param name="argumentName">Argument name (defaults to <c>max_results</c>).</param>
     /// <param name="nonPositiveBehavior">Behavior used when provided value is zero or negative.</param>
     /// <returns>Normalized max-results value.</returns>
-    protected int ResolveBoundedMaxResults(
+    protected int ResolveMaxResults(
         JsonObject? arguments,
         string argumentName = "max_results",
         MaxResultsNonPositiveBehavior nonPositiveBehavior = MaxResultsNonPositiveBehavior.ClampToOne) {
@@ -132,7 +132,7 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
 
         request = new RequiredDomainQueryRequest(
             DomainName: domainName,
-            MaxResults: ResolveBoundedMaxResults(arguments, maxResultsArgumentName, nonPositiveBehavior));
+            MaxResults: ResolveMaxResults(arguments, maxResultsArgumentName, nonPositiveBehavior));
         errorResponse = null;
         return true;
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdAzureAdSsoTool.cs
@@ -76,7 +76,7 @@ public sealed class AdAzureAdSsoTool : ActiveDirectoryToolBase, ITool {
         var onlyPresent = ToolArgs.GetBoolean(arguments, "only_present", defaultValue: false);
         var riskyOnly = ToolArgs.GetBoolean(arguments, "risky_only", defaultValue: false);
         var includeSpns = ToolArgs.GetBoolean(arguments, "include_spns", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDangerousExtendedRightsTool.cs
@@ -71,7 +71,7 @@ public sealed class AdDangerousExtendedRightsTool : ActiveDirectoryToolBase, ITo
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var includeFindings = ToolArgs.GetBoolean(arguments, "include_findings", defaultValue: true);
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 200, 1, Options.MaxResults);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcFleetPostureTool.cs
@@ -78,7 +78,7 @@ public sealed class AdDcFleetPostureTool : ActiveDirectoryToolBase, ITool {
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: false);
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 2000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDcShadowIndicatorsTool.cs
@@ -67,7 +67,7 @@ public sealed class AdDcShadowIndicatorsTool : ActiveDirectoryToolBase, ITool {
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var includeFindings = ToolArgs.GetBoolean(arguments, "include_findings", defaultValue: true);
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDelegationAuditTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDelegationAuditTool.cs
@@ -54,7 +54,7 @@ public sealed class AdDelegationAuditTool : ActiveDirectoryToolBase, ITool {
             ? (int)Math.Min(requestedMaxValues.Value, MaxValuesPerAttributeCap)
             : 50;
 
-        var maxResults = ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var maxResults = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDirectoryDiscoveryDiagnosticsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDirectoryDiscoveryDiagnosticsTool.cs
@@ -55,7 +55,7 @@ public sealed class AdDirectoryDiscoveryDiagnosticsTool : ActiveDirectoryToolBas
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var domains = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("domains"));
         var asIssue = ToolArgs.GetBoolean(arguments, "as_issue", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         var maxIssues = ToolArgs.GetCappedInt32(arguments, "max_issues", 5000, 1, 100_000);
         var dnsResolveTimeoutMs = ToolArgs.GetCappedInt32(arguments, "dns_resolve_timeout_ms", 1500, 200, 120_000);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsDelegationTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsDelegationTool.cs
@@ -67,7 +67,7 @@ public sealed class AdDnsDelegationTool : ActiveDirectoryToolBase, ITool {
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var zoneNameContains = ToolArgs.GetOptionalTrimmed(arguments, "zone_name_contains");
         var identityContains = ToolArgs.GetOptionalTrimmed(arguments, "identity_contains");
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsScavengingTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsScavengingTool.cs
@@ -61,7 +61,7 @@ public sealed class AdDnsScavengingTool : ActiveDirectoryToolBase, ITool {
         var mismatchedOnly = ToolArgs.GetBoolean(arguments, "mismatched_only", defaultValue: false);
         var staleOnly = ToolArgs.GetBoolean(arguments, "stale_only", defaultValue: false);
         var scavengingEnabledOnly = ToolArgs.GetBoolean(arguments, "scavenging_enabled_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryExecute(
                 action: () => new DnsScavengingAnalyzer()

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsServerConfigTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsServerConfigTool.cs
@@ -71,7 +71,7 @@ public sealed class AdDnsServerConfigTool : ActiveDirectoryToolBase, ITool {
         var recursionDisabledOnly = ToolArgs.GetBoolean(arguments, "recursion_disabled_only", defaultValue: false);
         var missingForwardersOnly = ToolArgs.GetBoolean(arguments, "missing_forwarders_only", defaultValue: false);
         var maxServers = ToolArgs.GetCappedInt32(arguments, "max_servers", 200, 1, 5000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
         var errors = new List<DnsServerConfigError>();
 
         var servers = new List<string>(maxServers);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneConfigTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneConfigTool.cs
@@ -71,7 +71,7 @@ public sealed class AdDnsZoneConfigTool : ActiveDirectoryToolBase, ITool {
         var zoneNameContains = ToolArgs.GetOptionalTrimmed(arguments, "zone_name_contains");
         var dynamicUpdatesOnly = ToolArgs.GetBoolean(arguments, "dynamic_updates_only", defaultValue: false);
         var insecureUpdatesOnly = ToolArgs.GetBoolean(arguments, "insecure_updates_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryExecute(
                 action: () => DnsZoneConfigService.GetZonesResult(dnsServer),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDnsZoneSecurityTool.cs
@@ -89,7 +89,7 @@ public sealed class AdDnsZoneSecurityTool : ActiveDirectoryToolBase, ITool {
         var broadWriteMin = ToolArgs.GetCappedInt32(arguments, "broad_write_min", 0, 0, 100000);
         var includeOffendingPrincipals = ToolArgs.GetBoolean(arguments, "include_offending_principals", defaultValue: false);
         var maxOffendingRows = ToolArgs.GetCappedInt32(arguments, "max_offending_rows", 500, 1, 50000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainAdminsSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainAdminsSummaryTool.cs
@@ -47,7 +47,7 @@ public sealed class AdDomainAdminsSummaryTool : ActiveDirectoryToolBase, ITool {
 
         var includeMembers = arguments?.GetBoolean("include_members") ?? true;
 
-        var maxResults = ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var maxResults = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
 
         try {
             var summary = await DomainAdminsSummaryService

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainContainerDefaultsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainContainerDefaultsTool.cs
@@ -64,7 +64,7 @@ public sealed class AdDomainContainerDefaultsTool : ActiveDirectoryToolBase, ITo
 
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var changedOnly = ToolArgs.GetBoolean(arguments, "changed_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerFactsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerFactsTool.cs
@@ -78,7 +78,7 @@ public sealed class AdDomainControllerFactsTool : ActiveDirectoryToolBase, ITool
         var onlyGlobalCatalog = ToolArgs.GetBoolean(arguments, "only_global_catalog", defaultValue: false);
         var onlyRodc = ToolArgs.GetBoolean(arguments, "only_rodc", defaultValue: false);
         var timeoutMs = ToolArgs.GetCappedInt32(arguments, "timeout_ms", 3000, 300, 60000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllerSecurityTool.cs
@@ -75,7 +75,7 @@ public sealed class AdDomainControllerSecurityTool : ActiveDirectoryToolBase, IT
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var domainController = ToolArgs.GetOptionalTrimmed(arguments, "domain_controller");
         var insecureOnly = ToolArgs.GetBoolean(arguments, "insecure_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!string.IsNullOrWhiteSpace(domainController) && string.IsNullOrWhiteSpace(domainName)) {
             return ToolResponse.Error(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllersTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainControllersTool.cs
@@ -33,7 +33,7 @@ public sealed class AdDomainControllersTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var max = ResolveBoundedMaxResults(arguments);
+        var max = ResolveMaxResults(arguments);
 
         var (dc, defaultNc) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
         if (string.IsNullOrWhiteSpace(defaultNc)) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainStatisticsTool.cs
@@ -70,7 +70,7 @@ public sealed class AdDomainStatisticsTool : ActiveDirectoryToolBase, ITool {
 
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var includeDomainControllers = ToolArgs.GetBoolean(arguments, "include_domain_controllers", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDuplicateAccountsTool.cs
@@ -87,7 +87,7 @@ public sealed class AdDuplicateAccountsTool : ActiveDirectoryToolBase, ITool {
         var conflictsOnly = ToolArgs.GetBoolean(arguments, "conflicts_only", defaultValue: false);
         var duplicatesOnly = ToolArgs.GetBoolean(arguments, "duplicates_only", defaultValue: false);
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 5000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoHealthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoHealthTool.cs
@@ -62,7 +62,7 @@ public sealed class AdGpoHealthTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", "gpo_ids must contain at least one GUID."));
         }
 
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
         var requestedCount = rawIds.Count;
         var truncated = requestedCount > maxResults;
         if (rawIds.Count > maxResults) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGpoListTool.cs
@@ -103,7 +103,7 @@ public sealed class AdGpoListTool : ActiveDirectoryToolBase, ITool {
             return Task.FromResult(ToolResponse.Error("invalid_argument", $"modified_since_utc: {modifiedSinceError}"));
         }
 
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
         var items = new List<GpoListItem>(Math.Min(maxResults, 512));
         var scanned = 0;
         var truncated = false;

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupMembersResolvedTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupMembersResolvedTool.cs
@@ -72,7 +72,7 @@ public sealed class AdGroupMembersResolvedTool : ActiveDirectoryToolBase, ITool 
             return Task.FromResult(Error("identity is required."));
         }
 
-        var maxResults = ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var maxResults = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
 
         var includeNested = ToolArgs.GetBoolean(arguments, "include_nested");
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupsListTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdGroupsListTool.cs
@@ -70,7 +70,7 @@ public sealed class AdGroupsListTool : ActiveDirectoryToolBase, ITool {
         var nameContains = ToolArgs.GetOptionalTrimmed(arguments, "name_contains");
         var namePrefix = ToolArgs.GetOptionalTrimmed(arguments, "name_prefix");
 
-        var maxResults = ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var maxResults = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
 
         var offset = Math.Max(arguments?.GetInt64("offset") ?? 0, 0);
         var requestedPageSize = arguments?.GetInt64("page_size");

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKerberosCryptoPostureTool.cs
@@ -62,7 +62,7 @@ public sealed class AdKerberosCryptoPostureTool : ActiveDirectoryToolBase, ITool
         cancellationToken.ThrowIfCancellationRequested();
 
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKrbtgtHealthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdKrbtgtHealthTool.cs
@@ -56,7 +56,7 @@ public sealed class AdKrbtgtHealthTool : ActiveDirectoryToolBase, ITool {
 
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var ageThresholdDays = ToolArgs.GetCappedInt32(arguments, "age_threshold_days", 180, 1, 3650);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLanManagerSettingsTool.cs
@@ -71,7 +71,7 @@ public sealed class AdLanManagerSettingsTool : ActiveDirectoryToolBase, ITool {
         var allowLmHashOnly = ToolArgs.GetBoolean(arguments, "allow_lm_hash_only", defaultValue: false);
         var legacyNtlmOnly = ToolArgs.GetBoolean(arguments, "legacy_ntlm_only", defaultValue: false);
         var maxDomainControllers = ToolArgs.GetCappedInt32(arguments, "max_domain_controllers", 200, 1, 2000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         var rows = new List<LanManagerSettingsRow>(maxDomainControllers);
         var errors = new List<LanManagerSettingsError>();

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsCoverageTool.cs
@@ -91,7 +91,7 @@ public sealed class AdLapsCoverageTool : ActiveDirectoryToolBase, ITool {
         var expiredOnly = ToolArgs.GetBoolean(arguments, "expired_only", defaultValue: false);
         var includeSamples = ToolArgs.GetBoolean(arguments, "include_samples", defaultValue: false);
         var maxSampleRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_sample_rows_per_domain", 50, 1, 1000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLapsSchemaPostureTool.cs
@@ -79,7 +79,7 @@ public sealed class AdLapsSchemaPostureTool : ActiveDirectoryToolBase, ITool {
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var onlyFindings = ToolArgs.GetBoolean(arguments, "only_findings", defaultValue: false);
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryPagedTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryPagedTool.cs
@@ -61,7 +61,7 @@ public sealed class AdLdapQueryPagedTool : ActiveDirectoryToolBase, ITool {
             ? (int)Math.Min(requestedMaxValues.Value, LdapQueryPolicy.MaxValuesPerAttributeCap)
             : LdapQueryPolicy.DefaultMaxValuesPerAttribute;
 
-        var maxResults = ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var maxResults = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
 
         var requestedPageSize = arguments?.GetInt64("page_size");
         var pageSize = requestedPageSize.HasValue && requestedPageSize.Value > 0

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdLdapQueryTool.cs
@@ -56,7 +56,7 @@ public sealed class AdLdapQueryTool : ActiveDirectoryToolBase, ITool {
             ? (int)Math.Min(requestedMaxValues.Value, LdapQueryPolicy.MaxValuesPerAttributeCap)
             : LdapQueryPolicy.DefaultMaxValuesPerAttribute;
 
-        var maxResults = ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var maxResults = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdMachineAccountQuotaTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdMachineAccountQuotaTool.cs
@@ -66,7 +66,7 @@ public sealed class AdMachineAccountQuotaTool : ActiveDirectoryToolBase, ITool {
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var threshold = ToolArgs.GetCappedInt32(arguments, "threshold", 0, -1, int.MaxValue);
         var riskyOnly = ToolArgs.GetBoolean(arguments, "risky_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNullSessionPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdNullSessionPostureTool.cs
@@ -68,7 +68,7 @@ public sealed class AdNullSessionPostureTool : ActiveDirectoryToolBase, ITool {
         var anonymousSamOnly = ToolArgs.GetBoolean(arguments, "anonymous_sam_only", defaultValue: false);
         var nullSessionOnly = ToolArgs.GetBoolean(arguments, "null_session_only", defaultValue: false);
         var maxDomainControllers = ToolArgs.GetCappedInt32(arguments, "max_domain_controllers", 200, 1, 2000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         var dcRows = new List<(string DomainName, string DomainController)>();
         if (explicitDcs.Count > 0) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdOuProtectionTool.cs
@@ -76,7 +76,7 @@ public sealed class AdOuProtectionTool : ActiveDirectoryToolBase, ITool {
         var unprotectedOnly = ToolArgs.GetBoolean(arguments, "unprotected_only", defaultValue: false);
         var includeUnprotectedOus = ToolArgs.GetBoolean(arguments, "include_unprotected_ous", defaultValue: false);
         var maxOuRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_ou_rows_per_domain", 100, 1, 5000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyLengthTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyLengthTool.cs
@@ -59,7 +59,7 @@ public sealed class AdPasswordPolicyLengthTool : ActiveDirectoryToolBase, ITool 
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var recommendedMinimumLength = ToolArgs.GetCappedInt32(arguments, "recommended_minimum_length", 12, 1, 512);
         var belowRecommendedOnly = ToolArgs.GetBoolean(arguments, "below_recommended_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyRollupTool.cs
@@ -78,7 +78,7 @@ public sealed class AdPasswordPolicyRollupTool : ActiveDirectoryToolBase, ITool 
         var psoHistoryMin = ToolArgs.GetCappedInt32(arguments, "pso_history_min", 24, 0, 1024);
         var includePsoDetails = ToolArgs.GetBoolean(arguments, "include_pso_details", defaultValue: true);
         var maxPsoRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_pso_rows_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPasswordPolicyTool.cs
@@ -58,7 +58,7 @@ public sealed class AdPasswordPolicyTool : ActiveDirectoryToolBase, ITool {
 
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var includeFineGrained = ToolArgs.GetBoolean(arguments, "include_fine_grained", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         var domains = LdapQueryHelper.GetTargetDomains(domainName, forestName)
             .Where(static x => !string.IsNullOrWhiteSpace(x))

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiTemplatesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiTemplatesTool.cs
@@ -58,8 +58,8 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
         var codeSigningRiskOnly = ToolArgs.GetBoolean(arguments, "code_signing_risk_only", defaultValue: false);
         var clientAuthRiskOnly = ToolArgs.GetBoolean(arguments, "client_auth_risk_only", defaultValue: false);
         var includeTakeoverRows = ToolArgs.GetBoolean(arguments, "include_takeover_rows", defaultValue: true);
-        var maxResults = ResolveBoundedMaxResults(arguments);
-        var maxTakeoverRows = ResolveBoundedMaxResults(arguments, "max_takeover_rows");
+        var maxResults = ResolveMaxResults(arguments);
+        var maxTakeoverRows = ResolveMaxResults(arguments, "max_takeover_rows");
 
         if (!TryExecute(
                 action: () => PkiApi.GetTemplates(forestName),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdRegistrationPostureTool.cs
@@ -88,7 +88,7 @@ public sealed class AdRegistrationPostureTool : ActiveDirectoryToolBase, ITool {
         var missingSubnetOnly = ToolArgs.GetBoolean(arguments, "missing_subnet_only", defaultValue: false);
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: false);
         var maxDetailRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_detail_rows_per_domain", 100, 1, 5000);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationConnectionsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationConnectionsTool.cs
@@ -64,7 +64,7 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
         var origin = NormalizeValue(ToolArgs.GetOptionalTrimmed(arguments, "origin"), "any");
         var summary = ToolArgs.GetBoolean(arguments, "summary", defaultValue: false);
         var summaryBy = NormalizeValue(ToolArgs.GetOptionalTrimmed(arguments, "summary_by"), "site");
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!IsOneOf(transport, "any", "rpc", "smtp")) {
             return Task.FromResult(ToolResponse.Error("invalid_argument", "transport must be one of: any, rpc, smtp."));

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationStatusTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationStatusTool.cs
@@ -48,7 +48,7 @@ public sealed class AdReplicationStatusTool : ActiveDirectoryToolBase, ITool {
 
         var requestedComputerNames = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("computer_names"));
         var healthOnly = ToolArgs.GetBoolean(arguments, "health_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         IReadOnlyList<string> targetServers = requestedComputerNames.Count == 0
             ? DomainHelper.EnumerateDomainControllers().Distinct(StringComparer.OrdinalIgnoreCase).ToArray()

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSchemaVersionTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSchemaVersionTool.cs
@@ -47,7 +47,7 @@ public sealed class AdSchemaVersionTool : ActiveDirectoryToolBase, ITool {
         cancellationToken.ThrowIfCancellationRequested();
 
         var mismatchedOnly = ToolArgs.GetBoolean(arguments, "mismatched_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryExecute(
                 action: () => {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchFacetsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchFacetsTool.cs
@@ -100,7 +100,7 @@ public sealed class AdSearchFacetsTool : ActiveDirectoryToolBase, ITool {
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var maxResults = ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var maxResults = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
 
         var requestedPageSize = arguments?.GetInt64("page_size");
         var pageSize = requestedPageSize.HasValue && requestedPageSize.Value > 0

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSearchTool.cs
@@ -53,7 +53,7 @@ public sealed class AdSearchTool : ActiveDirectoryToolBase, ITool {
         var kindArg = ToolArgs.GetOptionalTrimmed(arguments, "kind");
         var kind = string.IsNullOrWhiteSpace(kindArg) ? "any" : kindArg.Trim().ToLowerInvariant();
 
-        var maxResults = ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var maxResults = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
 
         var maxValuesPerAttribute = ToolArgs.GetCappedInt32(
             arguments,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdShadowCredentialsRiskTool.cs
@@ -67,7 +67,7 @@ public sealed class AdShadowCredentialsRiskTool : ActiveDirectoryToolBase, ITool
         ReadDomainAndForestScope(arguments, out var domainName, out var forestName);
         var includeFindings = ToolArgs.GetBoolean(arguments, "include_findings", defaultValue: true);
         var maxFindingsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_findings_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteCoverageTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteCoverageTool.cs
@@ -62,7 +62,7 @@ public sealed class AdSiteCoverageTool : ActiveDirectoryToolBase, ITool {
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var includeRegistry = ToolArgs.GetBoolean(arguments, "include_registry", defaultValue: false);
         var raw = ToolArgs.GetBoolean(arguments, "raw", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!raw) {
             if (!TryExecute(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteLinksTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSiteLinksTool.cs
@@ -99,7 +99,7 @@ public sealed class AdSiteLinksTool : ActiveDirectoryToolBase, ITool {
 
         var hasSchedule = ToolArgs.GetBoolean(arguments, "has_schedule", defaultValue: false);
         var expandSchedule = ToolArgs.GetBoolean(arguments, "expand_schedule", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryParseRequiredOptions(arguments, out var requiredOptions, out var optionNames, out var optionError)) {
             return Task.FromResult(ToolResponse.Error("invalid_argument", optionError ?? "Invalid options_all value."));

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSitesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSitesTool.cs
@@ -53,7 +53,7 @@ public sealed class AdSitesTool : ActiveDirectoryToolBase, ITool {
         var includeSubnets = ToolArgs.GetBoolean(arguments, "include_subnets", defaultValue: false);
         var includeOptions = ToolArgs.GetBoolean(arguments, "include_options", defaultValue: false);
         var noDcOnly = ToolArgs.GetBoolean(arguments, "no_dc_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryExecute(
                 action: () => TopologyService.GetSites(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSmartCardPostureTool.cs
@@ -75,7 +75,7 @@ public sealed class AdSmartCardPostureTool : ActiveDirectoryToolBase, ITool {
         var includeDetails = ToolArgs.GetBoolean(arguments, "include_details", defaultValue: true);
         var maxPrivilegedRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_privileged_rows_per_domain", 100, 1, Options.MaxResults);
         var maxFindingRowsPerDomain = ToolArgs.GetCappedInt32(arguments, "max_finding_rows_per_domain", 100, 1, Options.MaxResults);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnHygieneTool.cs
@@ -87,7 +87,7 @@ public sealed class AdSpnHygieneTool : ActiveDirectoryToolBase, ITool {
         var topN = ToolArgs.GetCappedInt32(arguments, "top_n", 10, 1, 50);
         var includeInvalidSpnSample = ToolArgs.GetBoolean(arguments, "include_invalid_spn_sample", defaultValue: true);
         var maxInvalidSpnSample = ToolArgs.GetCappedInt32(arguments, "max_invalid_spn_sample", 25, 1, 200);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnSearchTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnSearchTool.cs
@@ -51,7 +51,7 @@ public sealed class AdSpnSearchTool : ActiveDirectoryToolBase, ITool {
         var kind = string.IsNullOrWhiteSpace(kindArg) ? "any" : kindArg.Trim().ToLowerInvariant();
         var enabledOnly = ToolArgs.GetBoolean(arguments, "enabled_only");
 
-        var maxResults = ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var maxResults = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
 
         var maxValuesPerAttribute = ToolArgs.GetCappedInt32(
             arguments,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnStatsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSpnStatsTool.cs
@@ -54,7 +54,7 @@ public sealed class AdSpnStatsTool : ActiveDirectoryToolBase, ITool {
         var enabledOnly = ToolArgs.GetBoolean(arguments, "enabled_only");
         var includeExamples = ToolArgs.GetBoolean(arguments, "include_examples");
 
-        var maxObjects = ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var maxObjects = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
 
         var requestedServiceClasses = arguments?.GetInt64("max_service_classes");
         var maxServiceClasses = requestedServiceClasses.HasValue && requestedServiceClasses.Value > 0

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdStaleAccountsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdStaleAccountsTool.cs
@@ -53,7 +53,7 @@ public sealed class AdStaleAccountsTool : ActiveDirectoryToolBase, ITool {
 
         var match = ParseMatch(ToolArgs.GetOptionalTrimmed(arguments, "match"));
 
-        var maxResults = ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var maxResults = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSubnetsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSubnetsTool.cs
@@ -55,7 +55,7 @@ public sealed class AdSubnetsTool : ActiveDirectoryToolBase, ITool {
 
         var forestName = ToolArgs.GetOptionalTrimmed(arguments, "forest_name");
         var summary = ToolArgs.GetBoolean(arguments, "summary", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (summary) {
             if (!TryExecute(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSystemStateBackupTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdSystemStateBackupTool.cs
@@ -71,7 +71,7 @@ public sealed class AdSystemStateBackupTool : ActiveDirectoryToolBase, ITool {
         var thresholdDays = ToolArgs.GetCappedInt32(arguments, "threshold_days", 30, 1, 3650);
         var missingOnly = ToolArgs.GetBoolean(arguments, "missing_only", defaultValue: false);
         var staleOnly = ToolArgs.GetBoolean(arguments, "stale_only", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         if (!TryResolveTargetDomains(
                 domainName: domainName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTrustTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdTrustTool.cs
@@ -88,7 +88,7 @@ public sealed class AdTrustTool : ActiveDirectoryToolBase, ITool {
         var includeCommunicationIssues = ToolArgs.GetBoolean(arguments, "include_communication_issues", defaultValue: false);
         var summary = ToolArgs.GetBoolean(arguments, "summary", defaultValue: false);
         var summaryMatrix = ToolArgs.GetBoolean(arguments, "summary_matrix", defaultValue: false);
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         var status = NormalizeEnumValue(ToolArgs.GetOptionalTrimmed(arguments, "status"), "any");
         var trustType = NormalizeEnumValue(ToolArgs.GetOptionalTrimmed(arguments, "trust_type"), "any");

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdUsersExpiredTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdUsersExpiredTool.cs
@@ -39,7 +39,7 @@ public sealed class AdUsersExpiredTool : ActiveDirectoryToolBase, ITool {
         }
         var referenceUtc = referenceUtcOpt ?? DateTime.UtcNow;
 
-        var maxResults = ResolveBoundedMaxResults(arguments);
+        var maxResults = ResolveMaxResults(arguments);
 
         var (dc, baseDn) = ResolveDomainControllerAndSearchBase(arguments, cancellationToken);
         if (string.IsNullOrWhiteSpace(baseDn)) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ActiveDirectoryToolBaseErrorMappingTests.cs
@@ -251,13 +251,13 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
     }
 
     [Fact]
-    public void ResolveBoundedMaxResults_ShouldClampToOneAndCapHighValues() {
+    public void ResolveMaxResults_ShouldClampToOneAndCapHighValues_ByDefault() {
         var tool = new HarnessTool();
 
-        Assert.Equal(1, tool.ResolveStrictlyBoundedMaxResults(new JsonObject().Add("max_results", 0)));
-        Assert.Equal(1, tool.ResolveStrictlyBoundedMaxResults(new JsonObject().Add("max_results", -5)));
-        Assert.Equal(1000, tool.ResolveStrictlyBoundedMaxResults(new JsonObject().Add("max_results", 5000)));
-        Assert.Equal(50, tool.ResolveStrictlyBoundedMaxResults(new JsonObject().Add("max_results", 50)));
+        Assert.Equal(1, tool.ResolveClampedMaxResults(new JsonObject().Add("max_results", 0)));
+        Assert.Equal(1, tool.ResolveClampedMaxResults(new JsonObject().Add("max_results", -5)));
+        Assert.Equal(1000, tool.ResolveClampedMaxResults(new JsonObject().Add("max_results", 5000)));
+        Assert.Equal(50, tool.ResolveClampedMaxResults(new JsonObject().Add("max_results", 50)));
     }
 
     [Fact]
@@ -484,11 +484,11 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
         }
 
         public int ResolveDefaultingMaxResults(JsonObject? arguments) {
-            return ResolveBoundedMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+            return ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
         }
 
-        public int ResolveStrictlyBoundedMaxResults(JsonObject? arguments) {
-            return ResolveBoundedMaxResults(arguments);
+        public int ResolveClampedMaxResults(JsonObject? arguments) {
+            return ResolveMaxResults(arguments);
         }
 
         public JsonObject CreateScopeMeta(string? domainName, string? forestName) {
@@ -598,4 +598,3 @@ public class ActiveDirectoryToolBaseErrorMappingTests {
             IReadOnlyList<PolicyAttribution> Attribution);
     }
 }
-


### PR DESCRIPTION
## Summary
- consolidate AD max-results helper naming to a single canonical helper: `ResolveMaxResults(...)` in `ActiveDirectoryToolBase`
- migrate AD tool call sites from `ResolveBoundedMaxResults(...)` to `ResolveMaxResults(...)` while preserving existing non-positive behavior via `MaxResultsNonPositiveBehavior`
- align AD helper tests to canonical naming and remove legacy helper references from analyzer fixture sample code

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release -f net8.0-windows`
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release -f net8.0`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`