### PR TITLE
fix(chat): normalize signal typography during streaming preview

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
@@ -348,6 +348,43 @@ public sealed class TranscriptMarkdownNormalizerTests {
     }
 
     /// <summary>
+    /// Ensures streaming preview normalizes wrapped signal-flow labels and overwrapped strong spans.
+    /// </summary>
+    [Fact]
+    public void NormalizeForStreamingPreview_RepairsSignalFlowTypographyArtifacts() {
+        var text = string.Join('\n', [
+            "- Signal **Catalog count includes hidden/disabled/deprecated rules -> **Why it matters:**external/custom rules can drift or disappear between hosts ->**Next action:**break down `rule_origin` (`builtin` vs `external`) and confirm expected external rules are present.**",
+            "- TestimoX rules available ****359****"
+        ]);
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForStreamingPreview(text);
+
+        var expected = string.Join('\n', [
+            "- Signal **Catalog count includes hidden/disabled/deprecated rules** -> **Why it matters:** external/custom rules can drift or disappear between hosts -> **Next action:** break down `rule_origin` (`builtin` vs `external`) and confirm expected external rules are present.",
+            "- TestimoX rules available **359**"
+        ]);
+
+        Assert.Equal(expected, normalized);
+    }
+
+    /// <summary>
+    /// Ensures streaming preview does not rewrite signal-flow artifacts inside fenced code.
+    /// </summary>
+    [Fact]
+    public void NormalizeForStreamingPreview_DoesNotRewriteSignalFlowTypographyInsideFencedCode() {
+        var text = """
+                   ```text
+                   - Signal **Catalog count includes hidden rules -> **Why it matters:**external drift ->**Next action:**compare inventories.**
+                   - TestimoX rules available ****359****
+                   ```
+                   """;
+
+        var normalized = TranscriptMarkdownNormalizer.NormalizeForStreamingPreview(text);
+
+        Assert.Equal(text, normalized);
+    }
+
+    /// <summary>
     /// Ensures nested strong markers inside signal bullets are flattened into one strong span.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMarkdownNormalizer.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMarkdownNormalizer.cs
@@ -281,6 +281,10 @@ internal static class TranscriptMarkdownNormalizer {
 
         return ApplyTransformOutsideFencedCodeBlocks(normalized, static segment => {
             var value = ZeroWidthWhitespaceRegex.Replace(segment, string.Empty);
+            if (RequiresStreamingFullTypographyNormalization(value)) {
+                return NormalizeForRendering(value);
+            }
+
             value = LineStartUnicodeDashBulletRegex.Replace(value, "${indent}-");
             value = LineStartMissingSpaceBeforeBoldBulletRegex.Replace(value, "${indent}- ");
             value = LineStartHostLabelBulletRegex.Replace(value, "${indent}- ");
@@ -445,6 +449,23 @@ internal static class TranscriptMarkdownNormalizer {
 
         var trimmed = line.TrimStart();
         return !StructuralMarkdownLineRegex.IsMatch(trimmed);
+    }
+
+    private static bool RequiresStreamingFullTypographyNormalization(string text) {
+        if (string.IsNullOrEmpty(text)) {
+            return false;
+        }
+
+        return text.Contains("****", StringComparison.Ordinal)
+               || text.Contains("->**", StringComparison.Ordinal)
+               || text.Contains("-> **Why it matters:**", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("-> **Action:**", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("-> **Next action:**", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("-> **Fix action:**", StringComparison.OrdinalIgnoreCase)
+               || text.IndexOf("why it matters:", StringComparison.OrdinalIgnoreCase) >= 0
+               || text.IndexOf("action:", StringComparison.OrdinalIgnoreCase) >= 0
+               || text.IndexOf("next action:", StringComparison.OrdinalIgnoreCase) >= 0
+               || text.IndexOf("fix action:", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private static string FlattenNestedStrongOutsideInlineCode(string body) {


### PR DESCRIPTION
## Summary
- improve streaming-preview markdown normalization for known signal typography artifacts
- when streaming text contains signal-label/overwrapped artifacts, route through full rendering normalization for safe inline-code-aware repair
- keep lightweight streaming path for normal text
- add focused tests for streaming behavior:
  - repairs wrapped signal-flow + overwrapped strong
  - keeps fenced code unchanged

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~TranscriptMarkdownNormalizerTests.NormalizeForStreamingPreview_RepairsLineStartBulletsConservatively|FullyQualifiedName~TranscriptMarkdownNormalizerTests.NormalizeForStreamingPreview_RepairsSignalFlowTypographyArtifacts|FullyQualifiedName~TranscriptMarkdownNormalizerTests.NormalizeForStreamingPreview_DoesNotRewriteSignalFlowTypographyInsideFencedCode|FullyQualifiedName~TranscriptMarkdownNormalizerTests.NormalizeForRendering_RepairsMalformedWrappedSignalFlowBullets|FullyQualifiedName~TranscriptMarkdownNormalizerTests.NormalizeForRendering_FixesTightLabelSpacingInWrappedSignalFlowBullets"`
