### PR TITLE
De-duplicate IXTOOL003 same-line findings

### DIFF
--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.InternalMaintainability.MaxResultsMetaHelper.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.InternalMaintainability.MaxResultsMetaHelper.cs
@@ -70,7 +70,11 @@ internal static partial class AnalyzeRunCommand {
 
         var syntaxTree = CSharpSyntaxTree.ParseText(content ?? string.Empty);
         var root = syntaxTree.GetRoot();
+        var seenLines = new HashSet<int>();
         foreach (var line in EnumerateDirectMaxResultsMetadataWriteLines(root, syntaxTree)) {
+            if (!seenLines.Add(line)) {
+                continue;
+            }
             findings.Add(new AnalysisFindingItem {
                 Path = sourceFile.RelativePath,
                 Line = line,

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityMaxResultsMetaHelper.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityMaxResultsMetaHelper.cs
@@ -460,5 +460,64 @@ public sealed class SampleMixedMetaAddsTool : ToolBase {
             }
         }
     }
+
+    private static void TestAnalyzeRunInternalMaxResultsMetaHelperRuleDeduplicatesSameLineMatches() {
+        var temp = Path.Combine(Path.GetTempPath(), "ix-analyze-max-results-meta-sameline-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        try {
+            SetupToolContractAnalysisWorkspace(temp);
+
+            File.WriteAllText(Path.Combine(temp, "IntelligenceX.Tools", "IntelligenceX.Tools.Sample",
+                "SampleSameLineMaxResultsMetaTool.cs"), """
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+
+namespace IntelligenceX.Tools.Sample;
+
+public sealed class SampleSameLineMaxResultsMetaTool : ToolBase {
+    private static readonly ToolDefinition DefinitionValue = new(
+        "sample_same_line_max_results_meta_tool",
+        "Sample tool with same-line max_results metadata writes.",
+        ToolSchema.Object(("query", ToolSchema.String("Query value."))).NoAdditionalProperties());
+
+    public override ToolDefinition Definition => DefinitionValue;
+
+    protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+        var maxResults = 100;
+        return Task.FromResult(BuildAutoTableResponse(
+            arguments: arguments,
+            model: new { rows = Array.Empty<object>() },
+            sourceRows: Array.Empty<object>(),
+            viewRowsPath: "rows",
+            title: "Sample",
+            baseTruncated: false,
+            scanned: 0,
+            maxTop: 1000,
+            metaMutate: meta => { meta.Add("max_results", maxResults); meta["max_results"] = maxResults; }));
+    }
+}
+""");
+
+            var output = Path.Combine(temp, "artifacts");
+            var exit = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.RunAsync(new[] {
+                "--workspace", temp,
+                "--config", Path.Combine(temp, ".intelligencex", "reviewer.json"),
+                "--out", output
+            }).GetAwaiter().GetResult();
+
+            AssertEqual(0, exit, "analyze run max-results metadata helper same-line dedupe exit");
+            var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
+            var matchingFindings = findings.Count(item =>
+                item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase) &&
+                item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleSameLineMaxResultsMetaTool.cs",
+                    StringComparison.OrdinalIgnoreCase));
+            AssertEqual(1, matchingFindings, "analyze run max-results metadata helper same-line dedupe single finding");
+        } finally {
+            if (Directory.Exists(temp)) {
+                Directory.Delete(temp, true);
+            }
+        }
+    }
 }
 #endif

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -637,6 +637,8 @@ internal static partial class Program {
             TestAnalyzeRunInternalMaxResultsMetaHelperRuleFlagsCaseVariantMetadataKey);
         failed += Run("Analyze run internal max-results metadata helper rule flags only max_results in mixed adds",
             TestAnalyzeRunInternalMaxResultsMetaHelperRuleFlagsOnlyMaxResultsInMixedMetaAdds);
+        failed += Run("Analyze run internal max-results metadata helper rule deduplicates same-line matches",
+            TestAnalyzeRunInternalMaxResultsMetaHelperRuleDeduplicatesSameLineMatches);
         failed += Run("Analyze run internal duplication threshold",
             TestAnalyzeRunInternalDuplicationRuleRespectsThreshold);
         failed += Run("Analyze run internal duplication malformed tags warn",


### PR DESCRIPTION
## Summary
- de-duplicate `IXTOOL003` findings by source line so dual matcher hits on the same line do not emit duplicate diagnostics
- add a focused regression test with same-line `meta.Add("max_results", ...)` plus `meta["max_results"] = ...` to lock in non-noisy behavior
- register the new test in the reviewer harness

## Validation
- `dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- analyze validate-catalog --workspace .`
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release -f net8.0`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.ps1 -Mode fast`
