### PR TITLE
Tests: centralize reviewer temp-directory cleanup with retry helper

### DIFF
--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisAndPatch.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisAndPatch.cs
@@ -49,9 +49,7 @@ internal static partial class Program {
             AssertNotNull(items, "analyze run disabled findings items");
             AssertEqual(0, items!.Count, "analyze run disabled findings count");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -267,9 +265,7 @@ internal static partial class Program {
 
             return IntelligenceX.Cli.Analysis.AnalyzeRunCommand.RunAsync(args.ToArray()).GetAwaiter().GetResult();
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -362,9 +358,7 @@ internal static partial class Program {
             AssertEqual(true, hasMappedInternalRule, "analyze run internal rule/tool correlation");
             AssertEqual(true, content.Contains("LargeFile.cs", StringComparison.Ordinal), "analyze run internal file path");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -454,9 +448,7 @@ internal static partial class Program {
             }
             AssertEqual(true, matched, "analyze run internal metadata finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -528,9 +520,7 @@ internal static partial class Program {
             var content = File.ReadAllText(findingsPath);
             AssertEqual(false, content.Contains("IXLOC001", StringComparison.Ordinal), "analyze run internal severity none suppresses rule");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -620,9 +610,7 @@ internal static partial class Program {
             AssertEqual(true, content.Contains("obj-model/StillIncluded.cs", StringComparison.OrdinalIgnoreCase),
                 "analyze run internal does not exclude directory substring");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisCatalogAndPolicy.Commands.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisCatalogAndPolicy.Commands.cs
@@ -92,9 +92,7 @@ internal static partial class Program {
             AssertContainsText(text, "\"status\": \"to-review\"", "hotspots state default status");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -106,9 +104,7 @@ internal static partial class Program {
             var configPath = Path.Combine(temp, "missing-config.json");
             var statePath = Path.Combine(temp, ".intelligencex", "hotspots.json");
             var stateDir = Path.GetDirectoryName(statePath);
-            if (!string.IsNullOrWhiteSpace(stateDir) && Directory.Exists(stateDir)) {
-                Directory.Delete(stateDir, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(stateDir);
 
             var (syncExit, syncOutput) = RunAnalyzeAndCaptureOutput(new[] {
                 "hotspots",
@@ -142,9 +138,7 @@ internal static partial class Program {
             AssertEqual(false, Directory.Exists(Path.Combine(temp, ".intelligencex")), "hotspots set --help should not create state dir");
             AssertEqual(false, File.Exists(statePath), "hotspots set --help should not write state");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -287,14 +281,10 @@ internal static partial class Program {
             AssertEqual(true, File.Exists(outsideStatePath), "hotspots set allow outside should write state");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
             // Clean up any files written outside the workspace when allow-outside-workspace is set.
             try {
-                if (Directory.Exists(outsideRoot)) {
-                    Directory.Delete(outsideRoot, true);
-                }
+                DeleteDirectoryIfExistsWithRetries(outsideRoot);
             } catch {
                 // best-effort cleanup
             }
@@ -349,9 +339,7 @@ internal static partial class Program {
             }).GetAwaiter().GetResult();
             AssertEqual(1, invalidExit, "analyze validate-catalog invalid exit");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -429,9 +417,7 @@ internal static partial class Program {
             AssertSequenceEqual(new[] { "alpha", "beta" }, ids, "analyze list-packs --ids sorted ids");
             AssertEqual(string.Empty, stderr.Trim(), "analyze list-packs --ids stderr");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -533,9 +519,7 @@ internal static partial class Program {
             ids.Sort(StringComparer.OrdinalIgnoreCase);
             AssertSequenceEqual(new[] { "IX001", "IX002", "IX003" }, ids, "analyze list-rules json pack includes");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -646,9 +630,7 @@ internal static partial class Program {
             AssertNotNull(parsed, "analyze list-rules json warnings payload");
             AssertContainsText(stderr, "Warning: Included pack not found: missing-pack", "analyze list-rules json warnings stderr");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -672,9 +654,7 @@ internal static partial class Program {
             AssertEqual("[]", stdout.Trim(), "analyze list-rules empty json payload");
             AssertEqual(string.Empty, stderr.Trim(), "analyze list-rules empty json stderr");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -722,9 +702,7 @@ internal static partial class Program {
             var resolvedDocsPath = Path.Combine(temp, rule.Docs!.Replace('/', Path.DirectorySeparatorChar));
             AssertEqual(true, File.Exists(resolvedDocsPath), "analysis docs path resolves from workspace");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisCatalogAndPolicy.Part2.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisCatalogAndPolicy.Part2.cs
@@ -52,9 +52,7 @@ internal static partial class Program {
             AssertEqual(false, block.Contains("fp-123", StringComparison.Ordinal), "hotspots suggested key does not include raw fingerprint");
         } finally {
             Environment.CurrentDirectory = originalCwd;
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -111,9 +109,7 @@ internal static partial class Program {
                 "hotspots state path not absolute (slash)");
         } finally {
             Environment.CurrentDirectory = originalCwd;
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -177,12 +173,8 @@ internal static partial class Program {
             AssertContainsText(block, "Missing state entries: 1", "hotspots reviewer does not load outside-workspace state file");
         } finally {
             Environment.CurrentDirectory = originalCwd;
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-            if (Directory.Exists(outsideRoot)) {
-                Directory.Delete(outsideRoot, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
+            DeleteDirectoryIfExistsWithRetries(outsideRoot);
         }
     }
 
@@ -245,9 +237,7 @@ internal static partial class Program {
             AssertContainsText(limited, "- Showing first 2 of 11 hotspot(s).", "hotspots maxItems 2 limits items");
         } finally {
             Environment.CurrentDirectory = originalCwd;
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -316,9 +306,7 @@ internal static partial class Program {
                 "hotspots list excludes suppressed key");
         } finally {
             Environment.CurrentDirectory = originalCwd;
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -401,9 +389,7 @@ internal static partial class Program {
             AssertContainsText(block, "Note: `'oops' **bold**`", "hotspots note is rendered as safe inline code");
         } finally {
             Environment.CurrentDirectory = originalCwd;
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -471,9 +457,7 @@ internal static partial class Program {
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
             Environment.CurrentDirectory = originalCwd;
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisCatalogAndPolicy.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisCatalogAndPolicy.cs
@@ -52,9 +52,7 @@ internal static partial class Program {
             AssertEqual(true, psConfig.Contains("PSUseSupportsShouldProcess", StringComparison.Ordinal),
                 "psconfig PSUseSupportsShouldProcess");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -186,12 +184,8 @@ internal static partial class Program {
             AssertEqual(true, nestedResult, "analysis catalog loader accepts nested path");
             AssertEqual(false, siblingResult, "analysis catalog loader rejects sibling prefix path");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-            if (Directory.Exists(sibling)) {
-                Directory.Delete(sibling, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
+            DeleteDirectoryIfExistsWithRetries(sibling);
         }
     }
 
@@ -216,9 +210,7 @@ internal static partial class Program {
             AssertEqual(expectCaseInsensitive, caseVariantResult,
                 "analysis catalog loader root comparison follows platform case semantics");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -246,9 +238,7 @@ internal static partial class Program {
             AssertEqual(true, mixedCandidateResult, "analysis catalog loader accepts mixed-separator candidate path");
             AssertEqual(true, mixedRootResult, "analysis catalog loader accepts mixed-separator root path");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -350,9 +340,7 @@ internal static partial class Program {
             AssertEqual(true, validation.Errors.Any(error => error.Contains("Pack include cycle detected", StringComparison.OrdinalIgnoreCase)),
                 "catalog validator include cycle");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -381,9 +369,7 @@ internal static partial class Program {
                     StringComparison.OrdinalIgnoreCase)),
                 "catalog validator missing required metadata");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -425,9 +411,7 @@ internal static partial class Program {
             AssertEqual(true, rule.Tags.Contains("base"), "override tags include base");
             AssertEqual(true, rule.Tags.Contains("override"), "override tags include override");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -719,9 +703,7 @@ internal static partial class Program {
             AssertEqual(true, catalog.Rules.TryGetValue("IXSEC001", out var rule), "override invalid-type rule exists");
             AssertEqual("vulnerability", rule!.Type, "override invalid type falls back to inferred category type");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -758,9 +740,7 @@ internal static partial class Program {
             AssertEqual(true, validation.Errors.Any(error => error.Contains("does not match any base rule", StringComparison.OrdinalIgnoreCase)),
                 "dangling override error");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Baseline.Part2.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Baseline.Part2.cs
@@ -62,9 +62,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate suppresses dot-relative legacy baseline key with normalized path");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -132,9 +130,7 @@ internal static partial class Program {
             AssertEqual(true, !string.IsNullOrWhiteSpace(first!.GetString("key")), "baseline item key");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Baseline.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Baseline.cs
@@ -67,9 +67,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate baseline suppresses existing findings");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -138,9 +136,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate baseline fails on new findings");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -209,9 +205,7 @@ internal static partial class Program {
             AssertContainsText(output, "schema inferred as 'intelligencex.findings.v1'", "analyze gate baseline schema inference note");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -280,9 +274,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate large legacy line does not wrap and suppress line 0 finding");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -351,9 +343,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate preserves int-max legacy line and suppresses matching finding");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -398,9 +388,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate baseline missing returns unavailable");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -445,9 +433,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate baseline missing can pass when unavailable allowed");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -511,9 +497,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate suppresses legacy baseline key with normalized path");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Commands.Hotspots.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Commands.Hotspots.cs
@@ -91,9 +91,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate exit (hotspots minSeverity filters info)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -206,9 +204,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate exit (hotspots honor ruleIds even when type filter excludes)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Commands.Part2.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Commands.Part2.cs
@@ -85,9 +85,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate exit (absolute changed file normalized)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -175,12 +173,8 @@ internal static partial class Program {
             AssertEqual(1, exit, "analyze gate exit (absolute changed file outside workspace)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-            if (Directory.Exists(outsideRoot)) {
-                Directory.Delete(outsideRoot, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
+            DeleteDirectoryIfExistsWithRetries(outsideRoot);
         }
     }
 
@@ -262,9 +256,7 @@ internal static partial class Program {
             AssertEqual(1, exit, "analyze gate exit (relative traversal outside workspace)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -357,9 +349,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate exit (hotspots to-review blocks)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -456,12 +446,8 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate exit (hotspots state path outside workspace)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-            if (Directory.Exists(outsideRoot)) {
-                Directory.Delete(outsideRoot, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
+            DeleteDirectoryIfExistsWithRetries(outsideRoot);
         }
     }
 }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Commands.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Commands.cs
@@ -26,12 +26,8 @@ internal static partial class Program {
             }).GetAwaiter().GetResult();
             AssertEqual(1, exit, "analyze gate exit (config outside workspace rejected)");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-            if (Directory.Exists(outsideRoot)) {
-                Directory.Delete(outsideRoot, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
+            DeleteDirectoryIfExistsWithRetries(outsideRoot);
         }
     }
 
@@ -77,12 +73,8 @@ internal static partial class Program {
             AssertEqual(0, load.Report.ResolvedInputFiles, "analysis loader resolves 0 inputs (outside ignored)");
             AssertEqual(0, load.Findings.Count, "analysis loader findings empty (outside ignored)");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-            if (Directory.Exists(outsideRoot)) {
-                Directory.Delete(outsideRoot, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
+            DeleteDirectoryIfExistsWithRetries(outsideRoot);
         }
     }
 
@@ -100,12 +92,8 @@ internal static partial class Program {
             var result = (string?)method!.Invoke(null, new object[] { temp, candidate });
             AssertEqual(null, result, "analysis loader rejects sibling prefix path");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-            if (Directory.Exists(sibling)) {
-                Directory.Delete(sibling, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
+            DeleteDirectoryIfExistsWithRetries(sibling);
         }
     }
 
@@ -152,12 +140,8 @@ internal static partial class Program {
             var expected = Path.GetFullPath(siblingFile).Replace('\\', '/');
             AssertEqual(expected, load.Findings[0].Path, "analysis loader keeps outside path absolute");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
-            if (Directory.Exists(sibling)) {
-                Directory.Delete(sibling, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
+            DeleteDirectoryIfExistsWithRetries(sibling);
         }
     }
 
@@ -189,9 +173,7 @@ internal static partial class Program {
                 normalized,
                 "analysis loader normalize path follows platform case semantics");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -227,9 +209,7 @@ internal static partial class Program {
                 normalizedMixedPath,
                 "analysis loader normalize path accepts mixed-separator candidate");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -244,9 +224,7 @@ internal static partial class Program {
             var result = (string?)method!.Invoke(null, new object[] { temp, temp });
             AssertEqual(Path.GetFullPath(temp), result, "resolve workspace bound path accepts workspace root");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -309,9 +287,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate exit (disabled)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -395,9 +371,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate exit (violations)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -461,9 +435,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate exit (clean)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -519,9 +491,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate exit (no enabled rules)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -589,9 +559,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate exit (loader exception -> unavailable)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -666,9 +634,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate exit (minSeverity filters info)");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -762,9 +728,7 @@ internal static partial class Program {
             AssertContainsText(output, "- Violations: 0", "analyze gate ruleIds-only filter violations");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -860,9 +824,7 @@ internal static partial class Program {
             AssertContainsText(output, "IX002", "analyze gate additive ruleIds violation output");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -945,9 +907,7 @@ internal static partial class Program {
             AssertContainsText(output, "IX002", "analyze gate normalized filters violation output");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Duplication.LegacyFingerprints.Part4.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Duplication.LegacyFingerprints.Part4.cs
@@ -31,9 +31,7 @@ internal static partial class Program {
             AssertEqual(true, string.IsNullOrWhiteSpace(error), "duplication file baseline loads legacy file fingerprint error empty");
             AssertEqual(true, baselines.ContainsKey("IXDUP001|all|src/test.cs"), "duplication file baseline loads legacy file fingerprint key");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -66,9 +64,7 @@ internal static partial class Program {
             AssertEqual(true, string.IsNullOrWhiteSpace(error), "duplication file baseline loads legacy file-uri fingerprint error empty");
             AssertEqual(true, baselines.ContainsKey("IXDUP001|all|src/test.cs"), "duplication file baseline loads legacy file-uri fingerprint key");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Duplication.Part2.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Duplication.Part2.cs
@@ -59,9 +59,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate duplication overall delta missing baseline unavailable");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -133,9 +131,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate duplication per-file delta blocks");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -169,9 +165,7 @@ internal static partial class Program {
             AssertEqual(true, baselines.ContainsKey("IXDUP001|changed-files|C:/src/test.cs"),
                 "duplication file baseline loads colon path key");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -241,9 +235,7 @@ internal static partial class Program {
                 "analyze gate write baseline file snapshots fingerprint uses encoded file-uri format");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -300,9 +292,7 @@ internal static partial class Program {
             AssertContainsText(content, ".intelligencex/duplication-overall", "analyze gate write baseline includes duplication overall snapshot");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -336,9 +326,7 @@ internal static partial class Program {
             AssertEqual(true, string.IsNullOrWhiteSpace(error), "duplication file baseline skips null items error empty");
             AssertEqual(true, baselines.ContainsKey("IXDUP001|all|src/test.cs"), "duplication file baseline skips null items key exists");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -411,9 +399,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate duplication overall delta window mismatch unavailable");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -516,9 +502,7 @@ internal static partial class Program {
             AssertEqual(2, deltaExit, "analyze gate overall delta uses baseline written by write-baseline");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -624,9 +608,7 @@ internal static partial class Program {
             AssertEqual(2, deltaExit, "analyze gate file delta normalizes ./ paths");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -660,9 +642,7 @@ internal static partial class Program {
             AssertEqual(true, baselines.ContainsKey("IXDUP001|changed-files|/tmp/weird:scope:changed-files/test.cs"),
                 "duplication file baseline loads scope tokens in path key");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Duplication.Part3.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Duplication.Part3.cs
@@ -32,9 +32,7 @@ internal static partial class Program {
             AssertEqual(true, string.IsNullOrWhiteSpace(error), "duplication overall baseline skips null items error empty");
             AssertEqual(true, baselines.ContainsKey("IXDUP001|all"), "duplication overall baseline skips null items key exists");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -75,9 +73,7 @@ internal static partial class Program {
             AssertEqual(true, string.IsNullOrWhiteSpace(error), "duplication overall baseline rejects malformed fp error empty");
             AssertEqual(0, baselines.Count, "duplication overall baseline rejects malformed fp no entries");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -180,9 +176,7 @@ internal static partial class Program {
             AssertEqual(2, deltaExit, "analyze gate file delta normalizes ../ paths");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -285,9 +279,7 @@ internal static partial class Program {
             AssertEqual(2, deltaExit, "analyze gate file delta normalizes // paths");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -392,9 +384,7 @@ internal static partial class Program {
             AssertEqual(2, deltaExit, "analyze gate file delta window mismatch unavailable");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -473,9 +463,7 @@ internal static partial class Program {
             AssertEqual(2, deltaExit, "analyze gate file delta baseline window missing unavailable");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Duplication.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Duplication.cs
@@ -51,9 +51,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate duplication per-file threshold blocks");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -106,9 +104,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate duplication per-file threshold passes");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -163,9 +159,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate duplication uses per-file configured threshold");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -210,9 +204,7 @@ internal static partial class Program {
             AssertContainsText(output, "duplication gate: unavailable", "analyze gate duplication unavailable output");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -257,9 +249,7 @@ internal static partial class Program {
             AssertContainsText(output, "duplication gate: unavailable", "analyze gate duplication unavailable output");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -313,9 +303,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate duplication overall threshold blocks");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -388,9 +376,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate duplication overall new-only suppresses baseline finding");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -447,9 +433,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate duplication changed-files scope ignores untouched file");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -506,9 +490,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate duplication changed-files scope blocks changed file");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -580,9 +562,7 @@ internal static partial class Program {
             AssertEqual(0, exit, "analyze gate duplication new-only suppresses baseline finding");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -653,9 +633,7 @@ internal static partial class Program {
             AssertEqual(2, exit, "analyze gate duplication overall delta blocks");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisLoadReporting.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisLoadReporting.cs
@@ -71,9 +71,7 @@ internal static partial class Program {
                 "sarif-empty-results");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -101,9 +99,7 @@ internal static partial class Program {
             AssertEqual(1, result.Report.FailedInputFiles, "analysis load failed files");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -129,9 +125,7 @@ internal static partial class Program {
             AssertEqual(0, result.Report.FailedInputFiles, "analysis load empty file failed");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -173,9 +167,7 @@ internal static partial class Program {
             }, "glob-last");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -204,9 +196,7 @@ internal static partial class Program {
             AssertEqual(1, result.Report.FailedInputFiles, "analysis load duplicate bad failed");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityAdRequiredDomainHelper.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityAdRequiredDomainHelper.cs
@@ -59,9 +59,7 @@ public sealed class SampleBadAdDomainTool : ActiveDirectoryToolBase, ITool {
                         StringComparison.OrdinalIgnoreCase)),
                 "analyze run AD required-domain helper missing canonical path finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -121,9 +119,7 @@ public sealed class SampleGoodAdDomainTool : ActiveDirectoryToolBase, ITool {
             AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL002", StringComparison.OrdinalIgnoreCase)),
                 "analyze run AD required-domain helper canonical path no finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityDuplication.Part2.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityDuplication.Part2.cs
@@ -61,9 +61,7 @@ internal static partial class Program {
                               content.Contains("file-b.js", StringComparison.Ordinal),
                 "analyze run duplication tokenized javascript finding path");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -134,9 +132,7 @@ return beta - 2;
             AssertEqual(false, content.Contains("\"ruleId\": \"IXDUP001\"", StringComparison.Ordinal),
                 "analyze run duplication ignores js imports no finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -207,9 +203,7 @@ continue
             AssertEqual(false, content.Contains("\"ruleId\": \"IXDUP001\"", StringComparison.Ordinal),
                 "analyze run duplication ignores powershell using no finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -272,9 +266,7 @@ continue
                               content.Contains("file_b.py", StringComparison.Ordinal),
                 "analyze run duplication tokenized python finding path");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -344,9 +336,7 @@ return x
             AssertEqual(false, content.Contains("\"ruleId\": \"IXDUP001\"", StringComparison.Ordinal),
                 "analyze run duplication ignores python imports no finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -406,9 +396,7 @@ return x
             AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXDUP001", StringComparison.OrdinalIgnoreCase)),
                 "analyze run duplication python triple-quote hash does not produce false positive");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -502,9 +490,7 @@ public class Oversized {
                     item.Path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)),
                 "analyze run include-ext per-rule does not apply python duplication to csharp");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -570,9 +556,7 @@ public class Oversized {
             AssertContainsText(metricsContent, "\"configuredMaxPercent\": 15",
                 "analyze run duplication language threshold emits per-file configured threshold");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -638,11 +622,8 @@ public class Oversized {
             AssertContainsText(metricsContent, "\"configuredMaxPercent\": 15",
                 "analyze run duplication language-only tag uses language threshold");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 }
 #endif
-

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityDuplication.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityDuplication.cs
@@ -76,9 +76,7 @@ internal static partial class Program {
             AssertEqual(true, content.Contains("Duplicated significant lines", StringComparison.Ordinal),
                 "analyze run internal multi-rule includes duplication message");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -138,9 +136,7 @@ internal static partial class Program {
             AssertEqual(false, content.Contains("\"ruleId\": \"IXDUP001\"", StringComparison.Ordinal),
                 "analyze run duplication threshold suppresses below-limit findings");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -198,9 +194,7 @@ internal static partial class Program {
                 result.Output.Contains("malformed tag 'dup-window-lines:1'", StringComparison.OrdinalIgnoreCase),
                 "analyze run duplication malformed window warning");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityLoc.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityLoc.cs
@@ -63,9 +63,7 @@ internal static partial class Program {
             AssertEqual(false, content.Contains("Generated.generated.cs", StringComparison.OrdinalIgnoreCase),
                 "analyze run internal custom suffix keeps default generated suffixes");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -133,9 +131,7 @@ internal static partial class Program {
             AssertEqual(false, content.Contains("LongHeaderGenerated.cs", StringComparison.OrdinalIgnoreCase),
                 "analyze run internal header depth generated marker beyond default window");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -203,9 +199,7 @@ internal static partial class Program {
             AssertEqual(true, content.Contains("build-cache-extra/Included.cs", StringComparison.OrdinalIgnoreCase),
                 "analyze run internal exclude-dir does not match substrings");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -270,9 +264,7 @@ internal static partial class Program {
             AssertEqual(true, content.Contains("LfTrailing.cs", StringComparison.Ordinal),
                 "analyze run internal newline lf trailing counted");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -335,9 +327,7 @@ internal static partial class Program {
             var content = File.ReadAllText(findingsPath);
             AssertEqual(true, content.Contains("Regular.cs", StringComparison.Ordinal), "analyze run malformed tags fallback still reports file");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -400,9 +390,7 @@ internal static partial class Program {
             AssertEqual(true, content.Contains("Generated.generated.cs", StringComparison.OrdinalIgnoreCase),
                 "analyze run unknown tags does not silently apply typoed suffix");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -463,9 +451,7 @@ internal static partial class Program {
             AssertEqual(true, content.Contains("HeaderGenerated.cs", StringComparison.OrdinalIgnoreCase),
                 "analyze run header disabled does not exclude file by marker");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -528,9 +514,7 @@ internal static partial class Program {
             AssertEqual(false, content.Contains("Generated.py", StringComparison.OrdinalIgnoreCase),
                 "analyze run hash header marker excludes generated python file");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityMaxResultsMetaHelper.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityMaxResultsMetaHelper.cs
@@ -58,9 +58,7 @@ public sealed class SampleBadMaxResultsMetaTool : ToolBase {
                         StringComparison.OrdinalIgnoreCase)),
                 "analyze run max-results metadata helper missing canonical helper finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -117,9 +115,7 @@ public sealed class SampleGoodMaxResultsMetaTool : ToolBase {
             AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase)),
                 "analyze run max-results metadata helper canonical helper no finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -154,9 +150,7 @@ public static class SampleBadMaxResultsMetaHelper {
             AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase)),
                 "analyze run max-results metadata helper ignores non-tool files");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -212,9 +206,7 @@ public sealed class SampleNearMissMaxResultsMetaTool : ToolBase {
             AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase)),
                 "analyze run max-results metadata helper near-miss key no finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -270,9 +262,7 @@ public sealed class SampleQualifiedMaxResultsMetaTool : ToolBase {
             AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase)),
                 "analyze run max-results metadata helper qualified canonical helper no finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -331,9 +321,7 @@ public sealed class SampleIndexerMaxResultsMetaTool : ToolBase {
                         StringComparison.OrdinalIgnoreCase)),
                 "analyze run max-results metadata helper indexer assignment finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -392,9 +380,7 @@ public sealed class SampleCaseVariantMaxResultsMetaTool : ToolBase {
                         StringComparison.OrdinalIgnoreCase)),
                 "analyze run max-results metadata helper case-variant key finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -455,9 +441,7 @@ public sealed class SampleMixedMetaAddsTool : ToolBase {
                     StringComparison.OrdinalIgnoreCase));
             AssertEqual(1, matchingFindings, "analyze run max-results metadata helper mixed meta adds only max_results finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -514,9 +498,7 @@ public sealed class SampleSameLineMaxResultsMetaTool : ToolBase {
                     StringComparison.OrdinalIgnoreCase));
             AssertEqual(1, matchingFindings, "analyze run max-results metadata helper same-line dedupe single finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityWriteToolSchema.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityWriteToolSchema.cs
@@ -43,9 +43,7 @@ public sealed class SampleBadTool {
                         StringComparison.OrdinalIgnoreCase)),
                 "analyze run write-tool schema missing helper finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -108,9 +106,7 @@ public sealed class SampleGoodProbeTool {
             AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL001", StringComparison.OrdinalIgnoreCase)),
                 "analyze run write-tool schema canonical helpers no finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -148,9 +144,7 @@ public sealed class SampleReadOnlyTool {
             AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL001", StringComparison.OrdinalIgnoreCase)),
                 "analyze run write-tool schema read-only no finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -190,9 +184,7 @@ public sealed class SampleAuthOnlyTool {
             AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL001", StringComparison.OrdinalIgnoreCase)),
                 "analyze run write-tool schema auth-only no finding");
         } finally {
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisReporting.Part2.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisReporting.Part2.cs
@@ -51,9 +51,7 @@ internal static partial class Program {
                 "analysis policy unicode replacement-char absence");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -88,9 +86,7 @@ internal static partial class Program {
                 "analysis policy enabled-outside-only outside rules");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -118,9 +114,7 @@ internal static partial class Program {
             AssertPolicyLineEquals(policy, "Outside-pack rules", "none", "analysis policy null-findings outside rules");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -158,9 +152,7 @@ internal static partial class Program {
             AssertPolicyLineEquals(policy, "Clean rules", "none", "analysis policy deterministic clean rules");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisReporting.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisReporting.cs
@@ -55,9 +55,7 @@ internal static partial class Program {
                 "analysis policy enabled rule preview");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -89,9 +87,7 @@ internal static partial class Program {
                 "analysis policy gate rule outcomes");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -121,9 +117,7 @@ internal static partial class Program {
                 "analysis policy gate rule outcomes case-insensitive lookup");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -160,9 +154,7 @@ internal static partial class Program {
                 "analysis policy includes enabled preview");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -187,9 +179,7 @@ internal static partial class Program {
                 "analysis unavailable policy outcomes");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -293,9 +283,7 @@ internal static partial class Program {
                 "analysis failure skips summary when disabled");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -329,9 +317,7 @@ internal static partial class Program {
             AssertEqual(summary, updated, "analysis failure no-output unchanged summary");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -357,9 +343,7 @@ internal static partial class Program {
                 "analysis policy no files outcomes");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -391,9 +375,7 @@ internal static partial class Program {
             AssertPolicyLineEquals(policy, "Outside-pack rules", "PS9999=1", "analysis policy outside-only outside rules");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -422,9 +404,7 @@ internal static partial class Program {
                 "analysis policy no-enabled-rules truncation absence");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -456,9 +436,7 @@ internal static partial class Program {
                 "analysis policy configurable clean preview");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -496,9 +474,7 @@ internal static partial class Program {
                 "analysis policy hidden outside rules");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -528,9 +504,7 @@ internal static partial class Program {
                 "analysis policy negative hidden clean rules");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -560,9 +534,7 @@ internal static partial class Program {
                 "analysis policy max clamp enabled preview");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 
@@ -626,9 +598,7 @@ internal static partial class Program {
                 "analysis policy preview single truncation marker");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previousWorkspace);
-            if (Directory.Exists(temp)) {
-                Directory.Delete(temp, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(temp);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.cs
@@ -58,12 +58,8 @@ internal static partial class Program {
             AssertEqual<string?>(null, settings.ResolveTemplate(), "outside template");
         } finally {
             Environment.SetEnvironmentVariable("GITHUB_WORKSPACE", previous);
-            if (Directory.Exists(root)) {
-                Directory.Delete(root, true);
-            }
-            if (Directory.Exists(outsideRoot)) {
-                Directory.Delete(outsideRoot, true);
-            }
+            DeleteDirectoryIfExistsWithRetries(root);
+            DeleteDirectoryIfExistsWithRetries(outsideRoot);
         }
     }
 

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -56,9 +56,7 @@ internal static partial class Program {
             Environment.SetEnvironmentVariable("INTELLIGENCEX_AUTH_B64", previousAuthB64);
             Environment.SetEnvironmentVariable("INTELLIGENCEX_AUTH_PATH", previousAuthPath);
             try {
-                if (Directory.Exists(tempDir)) {
-                    Directory.Delete(tempDir, recursive: true);
-                }
+                DeleteDirectoryIfExistsWithRetries(tempDir);
             } catch {
                 // Best-effort cleanup.
             }

--- a/IntelligenceX.Tests/Program.Reviewer.InternalCalls.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.InternalCalls.cs
@@ -14,7 +14,7 @@ internal static partial class Program {
         } finally {
             Environment.SetEnvironmentVariable("REVIEW_CONFIG_PATH", previousPath);
             try {
-                Directory.Delete(tempDir, true);
+                DeleteDirectoryIfExistsWithRetries(tempDir);
             } catch {
                 // best-effort cleanup
             }

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -100,7 +100,7 @@ internal static partial class Program {
             Environment.SetEnvironmentVariable("INTELLIGENCEX_AUTH_PATH", previousAuthPath);
             Environment.SetEnvironmentVariable("GITHUB_RUN_NUMBER", previousRunNumber);
             try {
-                Directory.Delete(tempDir, recursive: true);
+                DeleteDirectoryIfExistsWithRetries(tempDir);
             } catch {
                 // Best-effort cleanup.
             }
@@ -145,7 +145,7 @@ internal static partial class Program {
         } finally {
             Environment.SetEnvironmentVariable("INTELLIGENCEX_AUTH_PATH", previousAuthPath);
             try {
-                Directory.Delete(tempDir, recursive: true);
+                DeleteDirectoryIfExistsWithRetries(tempDir);
             } catch {
                 // Best-effort cleanup.
             }

--- a/IntelligenceX.Tests/Program.Reviewer.TempDirectoryCleanup.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.TempDirectoryCleanup.cs
@@ -1,0 +1,34 @@
+namespace IntelligenceX.Tests;
+
+#if INTELLIGENCEX_REVIEWER
+internal static partial class Program {
+    private static void DeleteDirectoryIfExistsWithRetries(string? path, int maxAttempts = 5, int delayMilliseconds = 50) {
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path)) {
+            return;
+        }
+
+        if (maxAttempts < 1) {
+            maxAttempts = 1;
+        }
+
+        if (delayMilliseconds < 0) {
+            delayMilliseconds = 0;
+        }
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                Directory.Delete(path, true);
+                return;
+            } catch (IOException) when (attempt < maxAttempts) {
+                if (delayMilliseconds > 0) {
+                    System.Threading.Thread.Sleep(delayMilliseconds);
+                }
+            } catch (UnauthorizedAccessException) when (attempt < maxAttempts) {
+                if (delayMilliseconds > 0) {
+                    System.Threading.Thread.Sleep(delayMilliseconds);
+                }
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add a shared reviewer-test helper: `DeleteDirectoryIfExistsWithRetries(string? path, int maxAttempts = 5, int delayMilliseconds = 50)`
- replace duplicated `Directory.Exists(...) + Directory.Delete(..., true)` cleanup blocks across `Program.Reviewer*` test partials
- keep best-effort cleanup semantics while reducing repeated boilerplate and adding retry resilience for transient file locks

## Validation
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release -f net8.0`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
