### PR TITLE
Tools: unify bounded max-results semantics in ToolArgs

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -91,9 +91,17 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
         JsonObject? arguments,
         string argumentName = "max_results",
         MaxResultsNonPositiveBehavior nonPositiveBehavior = MaxResultsNonPositiveBehavior.ClampToOne) {
-        return nonPositiveBehavior == MaxResultsNonPositiveBehavior.DefaultToOptionCap
-            ? ToolArgs.GetPositiveOptionBoundedInt32OrDefault(arguments, argumentName, Options.MaxResults, Options.MaxResults)
-            : ToolArgs.GetOptionBoundedInt32(arguments, argumentName, Options.MaxResults);
+        var behavior = nonPositiveBehavior == MaxResultsNonPositiveBehavior.DefaultToOptionCap
+            ? ToolArgs.NonPositiveInt32Behavior.UseDefault
+            : ToolArgs.NonPositiveInt32Behavior.ClampToMinimum;
+
+        return ToolArgs.GetOptionBoundedInt32(
+            arguments,
+            argumentName,
+            Options.MaxResults,
+            minInclusive: 1,
+            nonPositiveBehavior: behavior,
+            defaultValue: Options.MaxResults);
     }
 
     /// <summary>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolArgs.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolArgs.cs
@@ -9,6 +9,20 @@ namespace IntelligenceX.Tools.Common;
 /// </summary>
 public static class ToolArgs {
     /// <summary>
+    /// Controls how non-positive numeric arguments are normalized in bounded integer helpers.
+    /// </summary>
+    public enum NonPositiveInt32Behavior {
+        /// <summary>
+        /// Non-positive values are clamped to <c>minInclusive</c>.
+        /// </summary>
+        ClampToMinimum,
+        /// <summary>
+        /// Non-positive values keep the bounded default value.
+        /// </summary>
+        UseDefault
+    }
+
+    /// <summary>
     /// Reads an optional string and trims it. Returns <c>null</c> when missing/empty.
     /// </summary>
     public static string? GetOptionalTrimmed(JsonObject? arguments, string key) {
@@ -48,15 +62,39 @@ public static class ToolArgs {
     /// JSON numbers come in as 64-bit from our JSON model, so we normalize here.
     /// </remarks>
     public static int GetCappedInt32(JsonObject? arguments, string key, int defaultValue, int minInclusive, int maxInclusive) {
+        return GetCappedInt32(arguments, key, defaultValue, minInclusive, maxInclusive, NonPositiveInt32Behavior.ClampToMinimum);
+    }
+
+    /// <summary>
+    /// Reads an optional positive integer argument (stored as JSON integer) and applies a safety cap.
+    /// </summary>
+    /// <remarks>
+    /// JSON numbers come in as 64-bit from our JSON model, so we normalize here.
+    /// </remarks>
+    public static int GetCappedInt32(
+        JsonObject? arguments,
+        string key,
+        int defaultValue,
+        int minInclusive,
+        int maxInclusive,
+        NonPositiveInt32Behavior nonPositiveBehavior) {
         if (maxInclusive < minInclusive) throw new ArgumentOutOfRangeException(nameof(maxInclusive));
+        var boundedDefault = Clamp(defaultValue, minInclusive, maxInclusive);
         if (arguments is null || string.IsNullOrWhiteSpace(key)) {
-            return Clamp(defaultValue, minInclusive, maxInclusive);
+            return boundedDefault;
         }
 
         var raw = arguments.GetInt64(key);
         if (!raw.HasValue) {
-            return Clamp(defaultValue, minInclusive, maxInclusive);
+            return boundedDefault;
         }
+
+        if (raw.Value <= 0) {
+            return nonPositiveBehavior == NonPositiveInt32Behavior.UseDefault
+                ? boundedDefault
+                : minInclusive;
+        }
+
         if (raw.Value < minInclusive) {
             return minInclusive;
         }
@@ -265,18 +303,13 @@ public static class ToolArgs {
             maxInclusive = 1;
         }
 
-        var boundedDefault = Clamp(defaultValue, 1, maxInclusive);
-        if (arguments is null || string.IsNullOrWhiteSpace(key)) {
-            return boundedDefault;
-        }
-
-        var raw = arguments.GetInt64(key);
-        if (!raw.HasValue || raw.Value <= 0) {
-            return boundedDefault;
-        }
-
-        var candidate = raw.Value > int.MaxValue ? int.MaxValue : (int)raw.Value;
-        return Clamp(candidate, 1, maxInclusive);
+        return GetCappedInt32(
+            arguments,
+            key,
+            defaultValue,
+            minInclusive: 1,
+            maxInclusive: maxInclusive,
+            nonPositiveBehavior: NonPositiveInt32Behavior.UseDefault);
     }
 
     /// <summary>
@@ -290,7 +323,32 @@ public static class ToolArgs {
         string key,
         int optionMaxInclusive,
         int minInclusive = 1) {
-        return GetCappedInt32(arguments, key, optionMaxInclusive, minInclusive, optionMaxInclusive);
+        return GetOptionBoundedInt32(
+            arguments,
+            key,
+            optionMaxInclusive,
+            minInclusive,
+            nonPositiveBehavior: NonPositiveInt32Behavior.ClampToMinimum,
+            defaultValue: optionMaxInclusive);
+    }
+
+    /// <summary>
+    /// Reads an optional integer argument bounded by a caller-provided option max value,
+    /// with explicit handling for non-positive values.
+    /// </summary>
+    /// <remarks>
+    /// Use this overload to keep max-results normalization semantics explicit:
+    /// either clamp non-positive values to <paramref name="minInclusive"/> or keep a bounded default.
+    /// </remarks>
+    public static int GetOptionBoundedInt32(
+        JsonObject? arguments,
+        string key,
+        int optionMaxInclusive,
+        int minInclusive,
+        NonPositiveInt32Behavior nonPositiveBehavior,
+        int? defaultValue = null) {
+        var resolvedDefault = defaultValue ?? optionMaxInclusive;
+        return GetCappedInt32(arguments, key, resolvedDefault, minInclusive, optionMaxInclusive, nonPositiveBehavior);
     }
 
     /// <summary>
@@ -305,7 +363,13 @@ public static class ToolArgs {
         string key,
         int defaultValue,
         int optionMaxInclusive) {
-        return GetPositiveCappedInt32OrDefault(arguments, key, defaultValue, optionMaxInclusive);
+        return GetOptionBoundedInt32(
+            arguments,
+            key,
+            optionMaxInclusive,
+            minInclusive: 1,
+            nonPositiveBehavior: NonPositiveInt32Behavior.UseDefault,
+            defaultValue: defaultValue);
     }
 
     /// <summary>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolArgsTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolArgsTests.cs
@@ -55,4 +55,34 @@ public sealed class ToolArgsTests {
         Assert.Equal(50, ToolArgs.GetPositiveOptionBoundedInt32OrDefault(new JsonObject().Add("top", 999), "top", 30, 50));
         Assert.Equal(12, ToolArgs.GetPositiveOptionBoundedInt32OrDefault(new JsonObject().Add("top", 12), "top", 30, 50));
     }
+
+    [Fact]
+    public void GetOptionBoundedInt32_WithClampBehavior_ShouldClampNonPositiveToMinimum() {
+        var args = new JsonObject().Add("max_results", 0);
+
+        var value = ToolArgs.GetOptionBoundedInt32(
+            arguments: args,
+            key: "max_results",
+            optionMaxInclusive: 50,
+            minInclusive: 1,
+            nonPositiveBehavior: ToolArgs.NonPositiveInt32Behavior.ClampToMinimum,
+            defaultValue: 30);
+
+        Assert.Equal(1, value);
+    }
+
+    [Fact]
+    public void GetOptionBoundedInt32_WithUseDefaultBehavior_ShouldKeepDefaultForNonPositive() {
+        var args = new JsonObject().Add("max_results", -10);
+
+        var value = ToolArgs.GetOptionBoundedInt32(
+            arguments: args,
+            key: "max_results",
+            optionMaxInclusive: 50,
+            minInclusive: 1,
+            nonPositiveBehavior: ToolArgs.NonPositiveInt32Behavior.UseDefault,
+            defaultValue: 30);
+
+        Assert.Equal(30, value);
+    }
 }

--- a/InternalDocs/agent-playbooks/tool-authoring-playbook.md
+++ b/InternalDocs/agent-playbooks/tool-authoring-playbook.md
@@ -57,6 +57,7 @@ Internal guidance for adding or refactoring tools with minimal duplication and s
   - For metadata, prefer `AddDomainAndMaxResultsMeta(...)` when applicable.
 - System/EventLog/FileSystem tools:
   - Keep argument limits option-bounded (`ResolveBoundedOptionLimit`/`ResolveMaxResults`).
+  - For non-positive semantics, use canonical `ToolArgs.GetOptionBoundedInt32(..., nonPositiveBehavior, defaultValue)` instead of mixing ad-hoc helper variants.
   - Keep error mapping centralized in package base helpers.
 
 ## Response Rules


### PR DESCRIPTION
## Summary
- introduce canonical bounded-int semantics in `ToolArgs` via `NonPositiveInt32Behavior` + overloaded `GetOptionBoundedInt32(...)`
- route AD `ResolveMaxResults(...)` through the canonical helper path (explicit non-positive behavior instead of split helper branches)
- keep existing helper methods (`GetOptionBoundedInt32`, `GetPositiveOptionBoundedInt32OrDefault`) as compatibility wrappers
- add focused tests for explicit clamp-vs-default behavior
- update internal tool-authoring playbook to prefer the canonical helper path

## Why
This reduces subtle semantic drift risk between near-identical max-results helper paths and makes intent explicit at call sites.

## Validation
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter ToolArgsTests`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "ActiveDirectoryToolBaseErrorMappingTests|SystemToolBaseHelperTests|EventLogToolBaseHelperTests|FileSystemToolBaseHelperTests"`
