### PR TITLE
tests: lock live chat typography normalization in html render path

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
@@ -385,4 +385,34 @@ public sealed class TranscriptHtmlFormatterTests {
         Assert.Contains("<li><strong>AD2</strong> eher Secure-Channel/TLS</li>", html, StringComparison.Ordinal);
         Assert.DoesNotContain("—** AD2**", html, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// Ensures live streaming preview plus transcript HTML rendering repairs tight signal-flow labels and overwrapped strong spans.
+    /// </summary>
+    [Fact]
+    public void Format_StreamingPreviewPipelineRepairsSignalTypographyArtifacts() {
+        var options = MarkdownRendererPresets.CreateChatStrictMinimal();
+        var now = new DateTime(2026, 2, 20, 11, 8, 0, DateTimeKind.Local);
+        var raw = string.Join('\n', [
+            "- Signal **Catalog count includes hidden/disabled/deprecated rules -> **Why it matters:**external/custom rules can drift or disappear between hosts ->**Next action:**break down `rule_origin` (`builtin` vs `external`) and confirm expected external rules are present.**",
+            "- TestimoX rules available ****359****"
+        ]);
+
+        var preview = TranscriptMarkdownNormalizer.NormalizeForStreamingPreview(raw);
+        var html = TranscriptHtmlFormatter.Format(new[] {
+            ("Assistant", preview, now)
+        }, "HH:mm:ss", options);
+
+        Assert.Contains("**Why it matters:** external/custom rules can drift", preview, StringComparison.Ordinal);
+        Assert.Contains("**Next action:** break down `rule_origin`", preview, StringComparison.Ordinal);
+        Assert.Contains("TestimoX rules available **359**", preview, StringComparison.Ordinal);
+        Assert.DoesNotContain("****359****", preview, StringComparison.Ordinal);
+
+        Assert.Contains("<strong>Catalog count includes hidden/disabled/deprecated rules</strong>", html, StringComparison.Ordinal);
+        Assert.Contains("<strong>Why it matters:</strong> external/custom rules can drift or disappear between hosts", html, StringComparison.Ordinal);
+        Assert.Contains("<strong>Next action:</strong> break down <code>rule_origin</code> (<code>builtin</code> vs <code>external</code>)", html, StringComparison.Ordinal);
+        Assert.Contains("TestimoX rules available <strong>359</strong>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("</strong>external/custom", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("</strong>break down", html, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
## Summary
- add an end-to-end chat rendering regression test for the known signal-flow typography artifact pattern
- exercise the live path shape (`NormalizeForStreamingPreview` output rendered via `TranscriptHtmlFormatter.Format`)
- assert no tight-label HTML joins (for example `</strong>external`) and no overwrapped `****` spans survive render

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~TranscriptHtmlFormatterTests"`