### PR TITLE
Analysis: harden internal maintainability handler coverage

### DIFF
--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.InternalMaintainability.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.InternalMaintainability.cs
@@ -64,29 +64,30 @@ internal static partial class AnalyzeRunCommand {
         GeneratedHeaderLinesTagPrefix,
         ExcludedDirectoryTagPrefix
     };
+    // Handler order defines first-match precedence when predicates overlap.
     private static readonly InternalMaintainabilityRuleHandler[] InternalMaintainabilityRuleHandlers = {
         new(IsMaxLinesRule, static (rules, sourceFiles, excludedOutputPath, warnings) =>
-            new InternalMaintainabilityRuleExecutionResult(
+            new InternalMaintainabilityResult(
                 RunMaxLinesChecks(rules, sourceFiles, excludedOutputPath, warnings),
                 Array.Empty<DuplicationRuleMetrics>())),
         new(IsDuplicationRule, static (rules, sourceFiles, excludedOutputPath, warnings) => {
             var result = RunDuplicationChecks(rules, sourceFiles, excludedOutputPath, warnings);
-            return new InternalMaintainabilityRuleExecutionResult(result.Findings, result.RuleMetrics);
+            return new InternalMaintainabilityResult(result.Findings, result.RuleMetrics);
         }),
         new(IsWriteToolSchemaRule, static (rules, sourceFiles, excludedOutputPath, warnings) =>
-            new InternalMaintainabilityRuleExecutionResult(
+            new InternalMaintainabilityResult(
                 RunWriteToolSchemaChecks(rules, sourceFiles, excludedOutputPath, warnings),
                 Array.Empty<DuplicationRuleMetrics>())),
         new(IsAdRequiredDomainHelperRule, static (rules, sourceFiles, excludedOutputPath, warnings) =>
-            new InternalMaintainabilityRuleExecutionResult(
+            new InternalMaintainabilityResult(
                 RunAdRequiredDomainHelperChecks(rules, sourceFiles, excludedOutputPath, warnings),
                 Array.Empty<DuplicationRuleMetrics>())),
         new(IsMaxResultsMetaHelperRule, static (rules, sourceFiles, excludedOutputPath, warnings) =>
-            new InternalMaintainabilityRuleExecutionResult(
+            new InternalMaintainabilityResult(
                 RunMaxResultsMetaHelperChecks(rules, sourceFiles, excludedOutputPath, warnings),
                 Array.Empty<DuplicationRuleMetrics>())),
         new(IsCanonicalBoundedIntHelperRule, static (rules, sourceFiles, excludedOutputPath, warnings) =>
-            new InternalMaintainabilityRuleExecutionResult(
+            new InternalMaintainabilityResult(
                 RunCanonicalBoundedIntHelperChecks(rules, sourceFiles, excludedOutputPath, warnings),
                 Array.Empty<DuplicationRuleMetrics>()))
     };
@@ -220,26 +221,47 @@ internal static partial class AnalyzeRunCommand {
             return new InternalMaintainabilityResult(findings, duplicationRuleMetrics);
         }
 
-        var selectedRuleGroups = new List<(InternalMaintainabilityRuleHandler Handler, List<AnalysisPolicyRule> Rules)>();
-        foreach (var handler in InternalMaintainabilityRuleHandlers) {
-            var matchedRules = rules
-                .Where(rule => rule?.Rule is not null && handler.Matches(rule.Rule))
-                .ToList();
-            if (matchedRules.Count == 0) {
+        var mappedRulesByHandler = new List<AnalysisPolicyRule>[InternalMaintainabilityRuleHandlers.Length];
+        var mappedRuleCount = 0;
+        foreach (var policyRule in rules.Where(static rule => rule?.Rule is not null)) {
+            var firstMatchIndex = -1;
+            var matchCount = 0;
+            for (var i = 0; i < InternalMaintainabilityRuleHandlers.Length; i++) {
+                if (!InternalMaintainabilityRuleHandlers[i].Matches(policyRule.Rule)) {
+                    continue;
+                }
+
+                if (firstMatchIndex < 0) {
+                    firstMatchIndex = i;
+                }
+                matchCount++;
+            }
+
+            if (firstMatchIndex < 0) {
+                warnings.Add(
+                    $"Internal maintainability rule {policyRule.Rule.Id} is configured but has no registered handler and will be skipped.");
                 continue;
             }
 
-            selectedRuleGroups.Add((handler, matchedRules));
+            if (matchCount > 1) {
+                warnings.Add(
+                    $"Internal maintainability rule {policyRule.Rule.Id} matched multiple handlers; using first registered handler. Ensure handler predicates are mutually exclusive.");
+            }
+
+            mappedRulesByHandler[firstMatchIndex] ??= new List<AnalysisPolicyRule>();
+            mappedRulesByHandler[firstMatchIndex]!.Add(policyRule);
+            mappedRuleCount++;
         }
 
-        if (selectedRuleGroups.Count == 0) {
+        if (mappedRuleCount == 0) {
             return new InternalMaintainabilityResult(findings, duplicationRuleMetrics);
         }
 
         // Build a candidate source set once; each rule applies its own filtering tags on top.
         var includedSourceExtensions = ResolveIncludedSourceExtensionsForRules(
-            selectedRuleGroups
-                .SelectMany(static group => group.Rules)
+            mappedRulesByHandler
+                .Where(static group => group is { Count: > 0 })
+                .SelectMany(static group => group!)
                 .Where(static item => item?.Rule is not null)
                 .Select(static item => item.Rule),
             warnings);
@@ -259,8 +281,14 @@ internal static partial class AnalyzeRunCommand {
             return new InternalMaintainabilityResult(findings, duplicationRuleMetrics);
         }
 
-        foreach (var ruleGroup in selectedRuleGroups) {
-            var result = ruleGroup.Handler.Run(ruleGroup.Rules, sourceFiles, excludedOutputPath, warnings);
+        for (var i = 0; i < InternalMaintainabilityRuleHandlers.Length; i++) {
+            var rulesForHandler = mappedRulesByHandler[i];
+            if (rulesForHandler is null || rulesForHandler.Count == 0) {
+                continue;
+            }
+
+            var result = InternalMaintainabilityRuleHandlers[i].Run(rulesForHandler, sourceFiles, excludedOutputPath,
+                warnings);
             findings.AddRange(result.Findings);
             duplicationRuleMetrics.AddRange(result.DuplicationRuleMetrics);
         }
@@ -709,13 +737,9 @@ internal static partial class AnalyzeRunCommand {
     private sealed record InternalMaintainabilityRuleHandler(
         Func<AnalysisRule, bool> Matches,
         Func<IReadOnlyList<AnalysisPolicyRule>, IReadOnlyList<SourceFileEntry>, string?, List<string>,
-            InternalMaintainabilityRuleExecutionResult> Run);
+            InternalMaintainabilityResult> Run);
 
     private sealed record InternalMaintainabilityResult(
-        IReadOnlyList<AnalysisFindingItem> Findings,
-        IReadOnlyList<DuplicationRuleMetrics> DuplicationRuleMetrics);
-
-    private sealed record InternalMaintainabilityRuleExecutionResult(
         IReadOnlyList<AnalysisFindingItem> Findings,
         IReadOnlyList<DuplicationRuleMetrics> DuplicationRuleMetrics);
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityRuleDispatch.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityRuleDispatch.cs
@@ -1,0 +1,97 @@
+namespace IntelligenceX.Tests;
+
+#if INTELLIGENCEX_REVIEWER
+internal static partial class Program {
+    private static void TestAnalyzeRunInternalMaintainabilityWarnsOnUnmappedInternalRule() {
+        var temp = Path.Combine(Path.GetTempPath(), "ix-analyze-internal-dispatch-unmapped-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        try {
+            SetupInternalMaintainabilityDispatchWorkspace(temp, "IXTOOL999", new[] {
+                "include-ext:cs"
+            });
+
+            var output = Path.Combine(temp, "artifacts");
+            var result = RunAnalyzeWithConsoleOutput(temp, Path.Combine(temp, ".intelligencex", "reviewer.json"), output);
+
+            AssertEqual(0, result.ExitCode, "analyze run internal dispatch unmapped exit");
+            AssertEqual(
+                true,
+                result.Output.Contains("IXTOOL999", StringComparison.OrdinalIgnoreCase) &&
+                result.Output.Contains("no registered handler", StringComparison.OrdinalIgnoreCase),
+                "analyze run internal dispatch unmapped warning");
+
+            var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
+            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL999", StringComparison.OrdinalIgnoreCase)),
+                "analyze run internal dispatch unmapped no findings");
+        } finally {
+            DeleteDirectoryIfExistsWithRetries(temp);
+        }
+    }
+
+    private static void TestAnalyzeRunInternalMaintainabilityWarnsOnAmbiguousInternalRuleMatch() {
+        var temp = Path.Combine(Path.GetTempPath(), "ix-analyze-internal-dispatch-ambiguous-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        try {
+            SetupInternalMaintainabilityDispatchWorkspace(temp, "IXLOC001", new[] {
+                "max-lines:700",
+                "dup-window-lines:8",
+                "include-ext:cs"
+            });
+
+            var output = Path.Combine(temp, "artifacts");
+            var result = RunAnalyzeWithConsoleOutput(temp, Path.Combine(temp, ".intelligencex", "reviewer.json"), output);
+
+            AssertEqual(0, result.ExitCode, "analyze run internal dispatch ambiguous exit");
+            AssertEqual(
+                true,
+                result.Output.Contains("IXLOC001", StringComparison.OrdinalIgnoreCase) &&
+                result.Output.Contains("matched multiple handlers", StringComparison.OrdinalIgnoreCase),
+                "analyze run internal dispatch ambiguous warning");
+        } finally {
+            DeleteDirectoryIfExistsWithRetries(temp);
+        }
+    }
+
+    private static void SetupInternalMaintainabilityDispatchWorkspace(string workspacePath, string ruleId,
+        IReadOnlyList<string> tags) {
+        Directory.CreateDirectory(Path.Combine(workspacePath, ".intelligencex"));
+        Directory.CreateDirectory(Path.Combine(workspacePath, "Analysis", "Catalog", "rules", "internal"));
+        Directory.CreateDirectory(Path.Combine(workspacePath, "Analysis", "Packs"));
+
+        File.WriteAllText(Path.Combine(workspacePath, ".intelligencex", "reviewer.json"), """
+{
+  "analysis": {
+    "enabled": true,
+    "packs": ["intelligencex-maintainability-default"]
+  }
+}
+""");
+
+        var tagsJson = string.Join(", ", (tags ?? Array.Empty<string>()).Select(static tag => $"\"{tag}\""));
+        File.WriteAllText(Path.Combine(workspacePath, "Analysis", "Catalog", "rules", "internal", $"{ruleId}.json"), $$"""
+{
+  "id": "{{ruleId}}",
+  "language": "internal",
+  "tool": "IntelligenceX.Maintainability",
+  "toolRuleId": "{{ruleId}}",
+  "title": "Internal dispatch test rule",
+  "description": "Verifies internal maintainability dispatch behavior.",
+  "category": "Maintainability",
+  "defaultSeverity": "warning",
+  "tags": [{{tagsJson}}]
+}
+""");
+
+        File.WriteAllText(Path.Combine(workspacePath, "Analysis", "Packs", "intelligencex-maintainability-default.json"),
+            $$"""
+{
+  "id": "intelligencex-maintainability-default",
+  "label": "IntelligenceX Maintainability",
+  "rules": ["{{ruleId}}"]
+}
+""");
+
+        File.WriteAllText(Path.Combine(workspacePath, "Sample.cs"), "public static class Sample { }\n");
+    }
+}
+#endif

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -647,6 +647,10 @@ internal static partial class Program {
             TestAnalyzeRunInternalCanonicalBoundedIntHelperRuleIgnoresToolArgsImplementationFile);
         failed += Run("Analyze run internal canonical bounded-int helper rule ignores IntelligenceX.Tools.Tests project",
             TestAnalyzeRunInternalCanonicalBoundedIntHelperRuleIgnoresToolsTestsProject);
+        failed += Run("Analyze run internal maintainability warns on unmapped internal rule",
+            TestAnalyzeRunInternalMaintainabilityWarnsOnUnmappedInternalRule);
+        failed += Run("Analyze run internal maintainability warns on ambiguous internal rule match",
+            TestAnalyzeRunInternalMaintainabilityWarnsOnAmbiguousInternalRuleMatch);
         failed += Run("Analyze run internal duplication threshold",
             TestAnalyzeRunInternalDuplicationRuleRespectsThreshold);
         failed += Run("Analyze run internal duplication malformed tags warn",


### PR DESCRIPTION
## Summary
- add explicit internal maintainability dispatch guardrails: unmapped rules now warn+skip, ambiguous matches warn and use first handler deterministically
- document handler ordering semantics at the registry definition
- simplify duplicated result record types by using one internal maintainability result shape for both dispatch and final aggregation
- add focused tests for dispatch warnings (unmapped rule and ambiguous match)

## Validation
- dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release -f net8.0
- dotnet .\\IntelligenceX.Tests\\bin\\Release\\net8.0\\IntelligenceX.Tests.dll
- pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.ps1 -Mode fast