### PR TITLE
chat: harden auth secret transport and temperature validation

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Protocol/ChatServiceEnvironmentVariables.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Protocol/ChatServiceEnvironmentVariables.cs
@@ -1,0 +1,11 @@
+namespace IntelligenceX.Chat.Abstractions.Protocol;
+
+/// <summary>
+/// Canonical environment variable names shared across chat app/service launch paths.
+/// </summary>
+public static class ChatServiceEnvironmentVariables {
+    /// <summary>
+    /// Optional compatible-http Basic auth password used by service startup.
+    /// </summary>
+    public const string OpenAIBasicPassword = "INTELLIGENCEX_OPENAI_BASIC_PASSWORD";
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ServiceLaunchArgumentsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ServiceLaunchArgumentsTests.cs
@@ -167,10 +167,10 @@ public sealed class ServiceLaunchArgumentsTests {
     }
 
     /// <summary>
-    /// Ensures compatible-http auth mode + basic credentials are emitted when configured.
+    /// Ensures compatible-http auth mode + basic username are emitted, while password is not passed on CLI args.
     /// </summary>
     [Fact]
-    public void Build_IncludesCompatibleHttpAuthModeAndBasicCredentials_WhenConfigured() {
+    public void Build_IncludesCompatibleHttpAuthModeAndBasicUsername_ButOmitsBasicPasswordArg_WhenConfigured() {
         var args = ServiceLaunchArguments.Build(
             "intelligencex.chat",
             detachedServiceMode: true,
@@ -187,8 +187,8 @@ public sealed class ServiceLaunchArgumentsTests {
         Assert.Contains("basic", args);
         Assert.Contains("--openai-basic-username", args);
         Assert.Contains("user", args);
-        Assert.Contains("--openai-basic-password", args);
-        Assert.Contains("secret", args);
+        Assert.DoesNotContain("--openai-basic-password", args);
+        Assert.DoesNotContain("secret", args);
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Launch/ServiceLaunchArguments.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Launch/ServiceLaunchArguments.cs
@@ -81,7 +81,6 @@ internal static class ServiceLaunchArguments {
             args.Add("--openai-clear-basic-auth");
         } else {
             AddKeyValueArg(args, "--openai-basic-username", profileOptions.OpenAIBasicUsername);
-            AddKeyValueArg(args, "--openai-basic-password", profileOptions.OpenAIBasicPassword);
         }
         AddKeyValueArg(args, "--openai-account-id", profileOptions.OpenAIAccountId);
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
@@ -445,6 +445,13 @@ public sealed partial class MainWindow : Window {
                     psi.ArgumentList.Add(arg);
                 }
             }
+            psi.Environment.Remove(ChatServiceEnvironmentVariables.OpenAIBasicPassword);
+            if (pending is not null && !pending.ClearOpenAIBasicAuth) {
+                var basicPassword = (pending.OpenAIBasicPassword ?? string.Empty).Trim();
+                if (basicPassword.Length > 0) {
+                    psi.Environment[ChatServiceEnvironmentVariables.OpenAIBasicPassword] = basicPassword;
+                }
+            }
 
             var p = new Process { StartInfo = psi, EnableRaisingEvents = true };
             p.OutputDataReceived += (_, e) => {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
@@ -622,6 +622,15 @@ internal sealed partial class ChatServiceSession {
             }, cancellationToken).ConfigureAwait(false);
             return activeThreadId;
         }
+        if (!TryValidateChatRequestOptions(request.Options, out var optionsValidationError)) {
+            await WriteAsync(writer, new ErrorMessage {
+                Kind = ChatServiceMessageKind.Response,
+                RequestId = request.RequestId,
+                Error = optionsValidationError ?? "Invalid chat options.",
+                Code = "invalid_argument"
+            }, cancellationToken).ConfigureAwait(false);
+            return activeThreadId;
+        }
 
         ChatRun? existingRun;
         lock (_chatRunLock) {
@@ -790,6 +799,23 @@ internal sealed partial class ChatServiceSession {
         }, CancellationToken.None);
 
         return activeThreadId;
+    }
+
+    private static bool TryValidateChatRequestOptions(ChatRequestOptions? options, out string? error) {
+        error = null;
+        if (options is null) {
+            return true;
+        }
+
+        if (options.Temperature.HasValue) {
+            var temperature = options.Temperature.Value;
+            if (double.IsNaN(temperature) || double.IsInfinity(temperature) || temperature < 0d || temperature > 2d) {
+                error = "temperature must be between 0 and 2.";
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static TokenUsageDto? MapUsage(TurnUsage? usage) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.Profiles;
 using IntelligenceX.Chat.Tooling;
 using IntelligenceX.OpenAI;
@@ -81,6 +82,7 @@ internal sealed class ServiceOptions : IToolRuntimePolicySettings, IToolPackRunt
     public static ServiceOptions Parse(string[] args, out string? error) {
         error = null;
         var options = new ServiceOptions();
+        var clearOpenAIBasicAuthRequested = false;
 
         // Pre-scan for state/profile flags so we can load defaults before applying overrides.
         PreScanProfileFlags(args, options, out error);
@@ -226,6 +228,7 @@ internal sealed class ServiceOptions : IToolRuntimePolicySettings, IToolPackRunt
             if (arg is "--openai-clear-basic-auth") {
                 options.OpenAIBasicUsername = null;
                 options.OpenAIBasicPassword = null;
+                clearOpenAIBasicAuthRequested = true;
                 continue;
             }
             if (arg is "--openai-stream") {
@@ -521,6 +524,9 @@ internal sealed class ServiceOptions : IToolRuntimePolicySettings, IToolPackRunt
         options.OpenAIBasicUsername = string.IsNullOrWhiteSpace(options.OpenAIBasicUsername)
             ? null
             : options.OpenAIBasicUsername.Trim();
+        if (string.IsNullOrWhiteSpace(options.OpenAIBasicPassword) && !clearOpenAIBasicAuthRequested) {
+            options.OpenAIBasicPassword = Environment.GetEnvironmentVariable(ChatServiceEnvironmentVariables.OpenAIBasicPassword);
+        }
         options.OpenAIBasicPassword = string.IsNullOrWhiteSpace(options.OpenAIBasicPassword)
             ? null
             : options.OpenAIBasicPassword.Trim();
@@ -557,7 +563,7 @@ internal sealed class ServiceOptions : IToolRuntimePolicySettings, IToolPackRunt
         Console.WriteLine("  --openai-auth-mode <MODE>  Compatible-http auth mode: bearer|basic|none (default: bearer).");
         Console.WriteLine("  --openai-api-key <KEY>  Optional Bearer token for compatible-http.");
         Console.WriteLine("  --openai-basic-username <NAME>  Optional Basic auth username for compatible-http.");
-        Console.WriteLine("  --openai-basic-password <SECRET>  Optional Basic auth password for compatible-http.");
+        Console.WriteLine("  --openai-basic-password <SECRET>  Optional Basic auth password for compatible-http (legacy; prefer INTELLIGENCEX_OPENAI_BASIC_PASSWORD env var).");
         Console.WriteLine("  --openai-account-id <ID>  Native ChatGPT account id to pin when multiple auth bundles exist.");
         Console.WriteLine("  --openai-clear-api-key Clear any saved compatible-http API key when profile overrides are saved.");
         Console.WriteLine("  --openai-clear-basic-auth Clear any saved compatible-http basic auth username/password when profile overrides are saved.");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.Part3.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.Part3.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.Service;
 using Xunit;
 
@@ -186,5 +187,29 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.DoesNotContain("ix:action-selection:v1", expanded, StringComparison.OrdinalIgnoreCase);
         Assert.Equal("/act act_001", expanded);
+    }
+
+    [Fact]
+    public void TryValidateChatRequestOptions_RejectsOutOfRangeTemperature() {
+        var invokeArgs = new object?[] {
+            new ChatRequestOptions { Temperature = 2.01d },
+            null
+        };
+
+        var result = Assert.IsType<bool>(TryValidateChatRequestOptionsMethod.Invoke(null, invokeArgs));
+        Assert.False(result);
+        Assert.Equal("temperature must be between 0 and 2.", Assert.IsType<string>(invokeArgs[1]));
+    }
+
+    [Fact]
+    public void TryValidateChatRequestOptions_AcceptsValidTemperature() {
+        var invokeArgs = new object?[] {
+            new ChatRequestOptions { Temperature = 1.5d },
+            null
+        };
+
+        var result = Assert.IsType<bool>(TryValidateChatRequestOptionsMethod.Invoke(null, invokeArgs));
+        Assert.True(result);
+        Assert.Null(invokeArgs[1]);
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
@@ -125,6 +125,9 @@ public sealed partial class ChatServiceRoutingTrimTests {
     private static readonly MethodInfo ExpandContinuationUserRequestMethod =
         typeof(ChatServiceSession).GetMethod("ExpandContinuationUserRequest", BindingFlags.NonPublic | BindingFlags.Instance)
         ?? throw new InvalidOperationException("ExpandContinuationUserRequest not found.");
+    private static readonly MethodInfo TryValidateChatRequestOptionsMethod =
+        typeof(ChatServiceSession).GetMethod("TryValidateChatRequestOptions", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("TryValidateChatRequestOptions not found.");
     private static readonly MethodInfo ParsePlannerSelectedDefinitionsMethod =
         typeof(ChatServiceSession).GetMethod("ParsePlannerSelectedDefinitions", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("ParsePlannerSelectedDefinitions not found.");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ServiceOptionsProfileBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ServiceOptionsProfileBootstrapTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using DBAClientX;
+using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.Service;
 using IntelligenceX.Chat.Tooling;
 using IntelligenceX.OpenAI;
@@ -15,6 +16,8 @@ namespace IntelligenceX.Chat.Tests;
 /// Covers profile bootstrap semantics for service startup argument parsing.
 /// </summary>
 public sealed class ServiceOptionsProfileBootstrapTests {
+    private static readonly object EnvironmentVariablesSync = new();
+
     [Fact]
     public void Parse_DefaultsToNoResponseShapingLimits() {
         var options = ServiceOptions.Parse(Array.Empty<string>(), out var error);
@@ -193,6 +196,52 @@ public sealed class ServiceOptionsProfileBootstrapTests {
     }
 
     [Fact]
+    public void Parse_ReadsBasicPasswordFromEnvironment_WhenCliValueMissing() {
+        WithTemporaryEnvironmentVariable(ChatServiceEnvironmentVariables.OpenAIBasicPassword, "env-secret", () => {
+            var options = ServiceOptions.Parse(new[] {
+                "--openai-auth-mode", "basic",
+                "--openai-basic-username", "user1"
+            }, out var error);
+
+            Assert.NotNull(options);
+            Assert.True(string.IsNullOrWhiteSpace(error));
+            Assert.Equal("user1", options.OpenAIBasicUsername);
+            Assert.Equal("env-secret", options.OpenAIBasicPassword);
+        });
+    }
+
+    [Fact]
+    public void Parse_DoesNotReadBasicPasswordFromEnvironment_WhenBasicAuthClearFlagPresent() {
+        WithTemporaryEnvironmentVariable(ChatServiceEnvironmentVariables.OpenAIBasicPassword, "env-secret", () => {
+            var options = ServiceOptions.Parse(new[] {
+                "--openai-auth-mode", "basic",
+                "--openai-basic-username", "user1",
+                "--openai-clear-basic-auth"
+            }, out var error);
+
+            Assert.NotNull(options);
+            Assert.True(string.IsNullOrWhiteSpace(error));
+            Assert.Null(options.OpenAIBasicUsername);
+            Assert.Null(options.OpenAIBasicPassword);
+        });
+    }
+
+    [Fact]
+    public void Parse_CliBasicPasswordWinsOverEnvironmentValue() {
+        WithTemporaryEnvironmentVariable(ChatServiceEnvironmentVariables.OpenAIBasicPassword, "env-secret", () => {
+            var options = ServiceOptions.Parse(new[] {
+                "--openai-auth-mode", "basic",
+                "--openai-basic-username", "user1",
+                "--openai-basic-password", "cli-secret"
+            }, out var error);
+
+            Assert.NotNull(options);
+            Assert.True(string.IsNullOrWhiteSpace(error));
+            Assert.Equal("cli-secret", options.OpenAIBasicPassword);
+        });
+    }
+
+    [Fact]
     public void Parse_RejectsInvalidWriteGovernanceMode() {
         _ = ServiceOptions.Parse(new[] {
             "--write-governance-mode", "invalid_mode"
@@ -251,6 +300,18 @@ public sealed class ServiceOptionsProfileBootstrapTests {
             }
         } catch {
             // Best-effort cleanup only.
+        }
+    }
+
+    private static void WithTemporaryEnvironmentVariable(string name, string? value, Action action) {
+        lock (EnvironmentVariablesSync) {
+            var original = Environment.GetEnvironmentVariable(name);
+            try {
+                Environment.SetEnvironmentVariable(name, value);
+                action();
+            } finally {
+                Environment.SetEnvironmentVariable(name, original);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- stop passing OpenAI Basic auth passwords on process command line for Chat service launches
- add environment-variable based secret handoff (`INTELLIGENCEX_OPENAI_BASIC_PASSWORD`) from app -> service
- keep legacy CLI password parsing for compatibility, but prefer env fallback when not explicitly cleared
- harden request options validation by rejecting invalid temperature values (`NaN`, `Infinity`, and out-of-range outside `0..2`) at chat request handling
- update/add tests for launch args behavior, env fallback precedence, clear-auth behavior, and temperature validation

## Why
- command-line args are visible to process inspection and logs; moving secrets to ephemeral process env significantly reduces accidental exposure
- request-time validation provides stable, deterministic guardrails before provider calls

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter ServiceLaunchArgumentsTests`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "ServiceOptionsProfileBootstrapTests|TryValidateChatRequestOptions"`