### PR TITLE
chat: stabilize runtime switching and show apply progress

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowLocalProviderTransportTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowLocalProviderTransportTests.cs
@@ -1,0 +1,41 @@
+using IntelligenceX.Chat.App;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Guards local-provider transport normalization so runtime apply does not silently fall back to native.
+/// </summary>
+public sealed class MainWindowLocalProviderTransportTests {
+    /// <summary>
+    /// Ensures known transport aliases normalize to supported transport keys.
+    /// </summary>
+    [Theory]
+    [InlineData("native", "native")]
+    [InlineData("compatible-http", "compatible-http")]
+    [InlineData("ollama", "compatible-http")]
+    [InlineData("lmstudio", "compatible-http")]
+    [InlineData("copilot-cli", "copilot-cli")]
+    [InlineData("github-copilot", "copilot-cli")]
+    public void TryNormalizeLocalProviderTransport_AcceptsKnownAliases(string value, string expectedTransport) {
+        var parsed = MainWindow.TryNormalizeLocalProviderTransport(value, out var transport);
+
+        Assert.True(parsed);
+        Assert.Equal(expectedTransport, transport);
+    }
+
+    /// <summary>
+    /// Ensures unknown values are rejected and reported as invalid.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("unsupported")]
+    [InlineData("copilot-subscription")]
+    public void TryNormalizeLocalProviderTransport_RejectsUnknownValues(string value) {
+        var parsed = MainWindow.TryNormalizeLocalProviderTransport(value, out var transport);
+
+        Assert.False(parsed);
+        Assert.Equal("native", transport);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
@@ -220,6 +220,7 @@ public sealed class UiShellAssetsTests {
         var html = UiShellAssets.Load();
 
         Assert.Contains("id=\"optLocalModelManualHint\"", html, StringComparison.Ordinal);
+        Assert.Contains("id=\"optRuntimeApplyProgress\"", html, StringComparison.Ordinal);
         Assert.Contains("id=\"optRuntimeCapabilities\"", html, StringComparison.Ordinal);
         Assert.DoesNotContain("restart_runtime", html, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("Restarting local runtime...", html, StringComparison.Ordinal);
@@ -239,9 +240,12 @@ public sealed class UiShellAssetsTests {
         Assert.Contains("appendRuntimeCapabilityRow(", script, StringComparison.Ordinal);
         Assert.Contains("renderRuntimeCapabilities({", script, StringComparison.Ordinal);
         Assert.Contains("var runtimeCapabilities = local.runtimeCapabilities", script, StringComparison.Ordinal);
+        Assert.Contains("var runtimeApplyProgress = byId(\"optRuntimeApplyProgress\")", script, StringComparison.Ordinal);
+        Assert.Contains("var runtimeApply = local.runtimeApply", script, StringComparison.Ordinal);
         Assert.Contains("runtimeCapabilities.supportsLiveApply", script, StringComparison.Ordinal);
         Assert.Contains(".options-runtime-capability", css, StringComparison.Ordinal);
         Assert.Contains(".options-runtime-capability-value-supported", css, StringComparison.Ordinal);
+        Assert.Contains(".options-runtime-apply-progress", css, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -41,6 +41,14 @@ public sealed partial class MainWindow : Window {
         string? DetectedBaseUrl,
         string? Warning);
 
+    private void UpdateRuntimeApplyProgress(string stage, string? detail, bool active) {
+        var normalizedStage = (stage ?? string.Empty).Trim().ToLowerInvariant();
+        _runtimeApplyStage = normalizedStage.Length == 0 ? "idle" : normalizedStage;
+        _runtimeApplyDetail = (detail ?? string.Empty).Trim();
+        _runtimeApplyActive = active;
+        _runtimeApplyUpdatedUtc = DateTime.UtcNow;
+    }
+
     private async Task RefreshModelsFromUiAsync(bool forceRefresh) {
         if (!await EnsureConnectedAsync().ConfigureAwait(false)) {
             return;
@@ -146,16 +154,6 @@ public sealed partial class MainWindow : Window {
             _modelListIsStale = modelList.IsStale;
             _modelListWarning = string.IsNullOrWhiteSpace(modelList.Warning) ? null : modelList.Warning.Trim();
 
-            var normalizedCurrentModel = (_localProviderModel ?? string.Empty).Trim();
-            // Preserve explicit/manual model selections even when discovery catalogs differ between providers.
-            var shouldAutoSelectModel = _availableModels.Length > 0
-                                        && normalizedCurrentModel.Length == 0;
-            if (shouldAutoSelectModel) {
-                _localProviderModel = _availableModels[0].Model;
-                _appState.LocalProviderModel = _localProviderModel;
-                await PersistAppStateAsync().ConfigureAwait(false);
-            }
-
             CaptureModelCatalogCacheIntoAppState();
             QueuePersistAppState();
         } catch (Exception ex) {
@@ -197,14 +195,27 @@ public sealed partial class MainWindow : Window {
 
         if (Interlocked.CompareExchange(ref _localProviderApplyInFlight, 1, 0) != 0) {
             QueuePendingLocalProviderApply(request);
+            UpdateRuntimeApplyProgress("queued", "Runtime switch queued. Latest settings will apply next.", active: true);
+            await PublishOptionsStateAsync().ConfigureAwait(false);
             await SetStatusAsync("Runtime switch already in progress. Queued latest settings.").ConfigureAwait(false);
             return;
         }
 
         try {
             var current = request;
+            var lastApplySucceeded = false;
+            var anyAttempted = false;
             while (true) {
-                await ApplyLocalProviderCoreAsync(current).ConfigureAwait(false);
+                anyAttempted = true;
+                try {
+                    lastApplySucceeded = await ApplyLocalProviderCoreAsync(current).ConfigureAwait(false);
+                } catch (Exception ex) {
+                    lastApplySucceeded = false;
+                    UpdateRuntimeApplyProgress("failed", "Runtime apply failed: " + ex.Message, active: false);
+                    await SetStatusAsync("Runtime apply failed. " + ex.Message).ConfigureAwait(false);
+                    break;
+                }
+
                 if (!TryTakePendingLocalProviderApply(out var pending)) {
                     break;
                 }
@@ -213,7 +224,12 @@ public sealed partial class MainWindow : Window {
                     continue;
                 }
 
+                UpdateRuntimeApplyProgress("queued", "Applying queued runtime update...", active: true);
                 current = pending;
+            }
+
+            if (anyAttempted && lastApplySucceeded) {
+                UpdateRuntimeApplyProgress("completed", "Runtime settings applied without restarting the service process.", active: false);
             }
         } finally {
             Interlocked.Exchange(ref _localProviderApplyInFlight, 0);
@@ -221,17 +237,28 @@ public sealed partial class MainWindow : Window {
         }
     }
 
-    private async Task ApplyLocalProviderCoreAsync(LocalProviderApplyRequest request) {
+    private async Task<bool> ApplyLocalProviderCoreAsync(LocalProviderApplyRequest request) {
+        UpdateRuntimeApplyProgress("validating", "Validating runtime settings...", active: true);
         await SetStatusAsync("Applying runtime settings...").ConfigureAwait(false);
         await PublishOptionsStateAsync().ConfigureAwait(false);
 
         if (_isSending) {
+            UpdateRuntimeApplyProgress("failed", "Finish the active response before changing runtime settings.", active: false);
             await SetStatusAsync("Finish the active response before changing local runtime settings.").ConfigureAwait(false);
-            return;
+            return false;
         }
 
         var rawTransport = (request.Transport ?? string.Empty).Trim();
-        var normalizedTransport = NormalizeLocalProviderTransport(rawTransport);
+        string normalizedTransport;
+        if (rawTransport.Length == 0) {
+            normalizedTransport = NormalizeLocalProviderTransport(_localProviderTransport);
+        } else if (!TryNormalizeLocalProviderTransport(rawTransport, out normalizedTransport)) {
+            UpdateRuntimeApplyProgress("failed", "Invalid runtime transport value '" + rawTransport + "'.", active: false);
+            await SetStatusAsync("Invalid runtime transport value. Open Runtime settings and try again.").ConfigureAwait(false);
+            await PublishOptionsStateAsync().ConfigureAwait(false);
+            return false;
+        }
+
         var normalizedBaseUrl = NormalizeLocalProviderBaseUrl(request.BaseUrl, normalizedTransport, rawTransport);
         var normalizedModel = NormalizeLocalProviderModel(request.Model, normalizedTransport);
         var normalizedOpenAIAuthMode = NormalizeLocalProviderOpenAIAuthMode(request.OpenAIAuthMode);
@@ -313,18 +340,21 @@ public sealed partial class MainWindow : Window {
         _appState.LocalProviderTemperature = _localProviderTemperature;
 
         var profileSaved = ContainsProfileName(_serviceProfileNames, _appProfileName);
+        UpdateRuntimeApplyProgress("persisting", "Saving runtime settings to the active profile...", active: true);
         CaptureModelCatalogCacheIntoAppState();
         await PersistAppStateAsync().ConfigureAwait(false);
         await PublishOptionsStateAsync().ConfigureAwait(false);
 
         if (!changed && profileSaved) {
+            UpdateRuntimeApplyProgress("syncing", "Refreshing runtime metadata...", active: true);
             await RefreshModelsFromUiAsync(request.ForceModelRefresh).ConfigureAwait(false);
-            return;
+            return true;
         }
 
         ClearConversationThreadIds();
         await PersistAppStateAsync().ConfigureAwait(false);
 
+        UpdateRuntimeApplyProgress("applying", "Applying runtime settings to the live session...", active: true);
         var liveApply = await TryApplyRuntimeSettingsLiveAsync(
                 // Always persist current runtime options for the active app profile so reconnects
                 // can recover transport/model settings without falling back to defaults.
@@ -349,17 +379,24 @@ public sealed partial class MainWindow : Window {
                 enableTestimoXPack: null,
                 enableOfficeImoPack: null).ConfigureAwait(false);
         if (liveApply) {
+            UpdateRuntimeApplyProgress("syncing", "Refreshing runtime discovery and model catalog...", active: true);
             await RefreshLocalRuntimeDetectionAsync(publishOptions: false).ConfigureAwait(false);
             await SyncConnectedServiceProfileAndModelsAsync(
                 forceModelRefresh: true,
                 setProfileNewThread: false,
                 appendWarnings: true).ConfigureAwait(false);
-            return;
+            return true;
         }
+
+        UpdateRuntimeApplyProgress(
+            "failed",
+            "Runtime settings couldn't be applied live. Session stayed running; review credentials/settings and apply again.",
+            active: false);
         await SetStatusAsync(
                 "Runtime settings couldn't be applied live. Session stayed running; verify credentials/settings and apply again.")
             .ConfigureAwait(false);
         await PublishOptionsStateAsync().ConfigureAwait(false);
+        return false;
     }
 
     private async Task<bool> TryApplyRuntimeSettingsLiveAsync(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
@@ -478,23 +478,37 @@ Quick start prompts:
         return parsed;
     }
 
-    private static string NormalizeLocalProviderTransport(string? value) {
+    internal static bool TryNormalizeLocalProviderTransport(string? value, out string transport) {
         var normalized = (value ?? string.Empty).Trim().ToLowerInvariant();
-        return normalized switch {
-            "native" => TransportNative,
-            "compatible-http" => TransportCompatibleHttp,
-            "compatiblehttp" => TransportCompatibleHttp,
-            "http" => TransportCompatibleHttp,
-            "local" => TransportCompatibleHttp,
-            "ollama" => TransportCompatibleHttp,
-            "lmstudio" => TransportCompatibleHttp,
-            "lm-studio" => TransportCompatibleHttp,
-            "copilot" => TransportCopilotCli,
-            "copilot-cli" => TransportCopilotCli,
-            "github-copilot" => TransportCopilotCli,
-            "githubcopilot" => TransportCopilotCli,
-            _ => TransportNative
-        };
+        switch (normalized) {
+            case "native":
+                transport = TransportNative;
+                return true;
+            case "compatible-http":
+            case "compatiblehttp":
+            case "http":
+            case "local":
+            case "ollama":
+            case "lmstudio":
+            case "lm-studio":
+                transport = TransportCompatibleHttp;
+                return true;
+            case "copilot":
+            case "copilot-cli":
+            case "github-copilot":
+            case "githubcopilot":
+                transport = TransportCopilotCli;
+                return true;
+            default:
+                transport = TransportNative;
+                return false;
+        }
+    }
+
+    private static string NormalizeLocalProviderTransport(string? value) {
+        return TryNormalizeLocalProviderTransport(value, out var normalized)
+            ? normalized
+            : TransportNative;
     }
 
     private static string? NormalizeLocalProviderBaseUrl(string? value, string transport, string? transportHint = null) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -424,6 +424,14 @@ public sealed partial class MainWindow : Window {
                     detectedName = _localRuntimeDetectedName ?? string.Empty,
                     detectedBaseUrl = _localRuntimeDetectedBaseUrl ?? string.Empty,
                     warning = _localRuntimeDetectionWarning ?? string.Empty
+                },
+                runtimeApply = new {
+                    stage = _runtimeApplyStage,
+                    detail = _runtimeApplyDetail,
+                    isActive = _runtimeApplyActive,
+                    updatedLocal = _runtimeApplyUpdatedUtc.HasValue
+                        ? _runtimeApplyUpdatedUtc.Value.ToLocalTime().ToString(_timestampFormat, CultureInfo.InvariantCulture)
+                        : string.Empty
                 }
             },
             packs,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -212,7 +212,7 @@ public sealed partial class MainWindow : Window {
     private long _dragMoveWatchdogArmCount;
     private long _dragMoveWatchdogForcedReleaseCount;
     private static readonly bool VerboseServiceLogs = IsTruthy(Environment.GetEnvironmentVariable("IXCHAT_VERBOSE_SERVICE_LOGS"));
-    private static readonly bool DetachedServiceMode = IsTruthy(Environment.GetEnvironmentVariable("IXCHAT_DETACHED_SERVICE"));
+    private static readonly bool DetachedServiceMode = ResolveDetachedServiceMode();
     private static readonly GlobalWheelHookMode WheelHookMode = ResolveGlobalWheelHookMode(Environment.GetEnvironmentVariable("IXCHAT_WHEEL_HOOK_MODE"));
 
     private readonly string _pipeName = "intelligencex.chat";
@@ -375,6 +375,10 @@ public sealed partial class MainWindow : Window {
     private int _localProviderApplyInFlight;
     private readonly object _localProviderApplySync = new();
     private LocalProviderApplyRequest? _pendingLocalProviderApply;
+    private string _runtimeApplyStage = "idle";
+    private string _runtimeApplyDetail = string.Empty;
+    private bool _runtimeApplyActive;
+    private DateTime? _runtimeApplyUpdatedUtc;
 
     private sealed class ConversationRuntime {
         public required string Id { get; init; }
@@ -457,6 +461,21 @@ public sealed partial class MainWindow : Window {
         public bool? EnablePowerShellPack { get; init; }
         public bool? EnableTestimoXPack { get; init; }
         public bool? EnableOfficeImoPack { get; init; }
+    }
+
+    private static bool ResolveDetachedServiceMode() {
+        var forceDetached = IsTruthy(Environment.GetEnvironmentVariable("IXCHAT_DETACHED_SERVICE"));
+        if (forceDetached) {
+            return true;
+        }
+
+        var forceAttached = IsTruthy(Environment.GetEnvironmentVariable("IXCHAT_ATTACHED_SERVICE"));
+        if (forceAttached) {
+            return false;
+        }
+
+        // Default to detached so pipe reconnects do not force sidecar process restarts.
+        return true;
     }
 
     private sealed class MemoryDebugSnapshot {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -1232,6 +1232,9 @@
     var warning = normalizeModelText(local.warning || "");
     var isStale = local.isStale === true;
     var profileSaved = local.profileSaved === true;
+    var runtimeApply = local.runtimeApply && typeof local.runtimeApply === "object"
+      ? local.runtimeApply
+      : {};
     var profileApplyMode = normalizeProfileApplyMode(state.options.profileApplyMode || "session");
     var runtimeDetection = local.runtimeDetection || {};
     var runtimeDetectionHasRun = runtimeDetection.hasRun === true;
@@ -1311,6 +1314,42 @@
         simpleHint.textContent = "LM Studio not detected on http://127.0.0.1:1234/v1. Start LM Studio and click Apply Runtime, or configure Advanced Runtime.";
       } else {
         simpleHint.textContent = "Local runtime is active. Use LM Studio Runtime for the default LM Studio endpoint.";
+      }
+    }
+
+    var runtimeApplyProgress = byId("optRuntimeApplyProgress");
+    if (runtimeApplyProgress) {
+      var applyStage = normalizeModelText(runtimeApply.stage || "").toLowerCase();
+      var applyDetail = normalizeModelText(runtimeApply.detail || "");
+      var applyUpdatedLocal = normalizeModelText(runtimeApply.updatedLocal || "");
+      var applyActive = runtimeApply.isActive === true || isApplying;
+      var showApplyProgress = applyActive
+        || applyStage === "failed"
+        || applyStage === "completed";
+
+      runtimeApplyProgress.hidden = !showApplyProgress;
+      runtimeApplyProgress.classList.toggle("active", applyActive);
+      runtimeApplyProgress.classList.toggle("error", applyStage === "failed");
+
+      if (showApplyProgress) {
+        var label = applyDetail;
+        if (!label) {
+          if (applyActive) {
+            label = "Applying runtime settings...";
+          } else if (applyStage === "completed") {
+            label = "Runtime settings applied.";
+          } else if (applyStage === "failed") {
+            label = "Runtime settings failed to apply.";
+          }
+        }
+
+        if (!applyActive && applyUpdatedLocal) {
+          label += " (" + applyUpdatedLocal + ")";
+        }
+
+        runtimeApplyProgress.textContent = label;
+      } else {
+        runtimeApplyProgress.textContent = "";
       }
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.30.options.css
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.30.options.css
@@ -359,6 +359,27 @@ body.options-open .options-panel {
   color: var(--ix-text-secondary);
 }
 
+.options-runtime-apply-progress {
+  margin-top: 4px;
+  padding: 6px 8px;
+  border: 1px solid rgba(58, 96, 144, 0.45);
+  border-radius: 8px;
+  background: rgba(9, 33, 60, 0.38);
+  color: var(--ix-text-secondary);
+}
+
+.options-runtime-apply-progress.active {
+  border-color: rgba(76, 195, 255, 0.45);
+  background: rgba(76, 195, 255, 0.12);
+  color: #d9f3ff;
+}
+
+.options-runtime-apply-progress.error {
+  border-color: rgba(255, 170, 145, 0.45);
+  background: rgba(120, 40, 26, 0.3);
+  color: #ffd9c9;
+}
+
 .options-policy-list-wrap {
   margin-top: 8px;
   border: 1px solid rgba(58, 96, 144, 0.45);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -170,6 +170,7 @@
         <section class="options-group">
           <div class="options-label">Local Model Selection</div>
           <div class="options-note" id="optLocalSimpleHint">ChatGPT runtime is active. Switch to LM Studio to use local models.</div>
+          <div class="options-note options-runtime-apply-progress" id="optRuntimeApplyProgress" hidden></div>
           <div class="options-row" id="optNativeAccountSlotRow">
             <label class="options-label-inline" for="optNativeAccountSlot">Native account slot</label>
             <select id="optNativeAccountSlot" class="options-select">


### PR DESCRIPTION
## Summary
- default Chat sidecar lifecycle to detached mode so pipe reconnects do not force service process restarts (`IXCHAT_ATTACHED_SERVICE=1` can force attached mode)
- add strict transport normalization for runtime apply so invalid transport values are rejected instead of silently falling back to native/codex
- remove automatic model auto-pick when model id is blank, preventing surprise model flips during provider/runtime switches
- add structured runtime-apply progress state (`queued`, `validating`, `persisting`, `applying`, `syncing`, `completed`, `failed`) and surface it in Runtime UI
- add UI runtime progress panel + styling and regression coverage for new runtime-progress assets
- add transport normalization unit tests

## Why
- fixes restart-driven UX churn during runtime/provider switching
- prevents accidental fallback to native transport when UI payloads are malformed or stale
- keeps model selection stable when switching providers and using manual model input
- gives users clear progress visibility during long runtime apply paths

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "UiShellAssetsTests|MainWindowLocalProviderTransportTests"`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "MainWindowStartupConnectTimeoutPolicyTests"`