### PR TITLE
Test runtime-policy shared CLI help and parse message contracts

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolRuntimePolicyBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolRuntimePolicyBootstrapTests.cs
@@ -102,6 +102,26 @@ public sealed class ToolRuntimePolicyBootstrapTests {
         Assert.Equal(context.Options.AuthenticationProfilePath, diagnostics.AuthenticationProfilePath);
     }
 
+    [Fact]
+    public void WriteRuntimePolicyCliHelp_WritesCanonicalPolicyFlags() {
+        var lines = new System.Collections.Generic.List<string>();
+
+        ToolRuntimePolicyBootstrap.WriteRuntimePolicyCliHelp(lines.Add);
+
+        Assert.Contains(lines, static line => line.StartsWith("  --write-governance-mode", StringComparison.Ordinal));
+        Assert.Contains(lines, static line => line.StartsWith("  --write-audit-sink-mode", StringComparison.Ordinal));
+        Assert.Contains(lines, static line => line.StartsWith("  --auth-runtime-preset", StringComparison.Ordinal));
+        Assert.Contains(lines, static line => line.StartsWith("  --run-as-profile-path", StringComparison.Ordinal));
+        Assert.Contains(lines, static line => line.StartsWith("  --auth-profile-path", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ParseErrorConstants_ExposeCanonicalMessages() {
+        Assert.Equal("--write-governance-mode must be one of: enforced, yolo.", ToolRuntimePolicyBootstrap.WriteGovernanceModeParseError);
+        Assert.Equal("--write-audit-sink-mode must be one of: none, file, sqlite.", ToolRuntimePolicyBootstrap.WriteAuditSinkModeParseError);
+        Assert.Equal("--auth-runtime-preset must be one of: default, strict, lab.", ToolRuntimePolicyBootstrap.AuthenticationRuntimePresetParseError);
+    }
+
     private static void TryDelete(string path) {
         try {
             if (File.Exists(path)) {


### PR DESCRIPTION
## Summary
- add focused tests for shared runtime-policy CLI contracts in `ToolRuntimePolicyBootstrapTests`
- verify `WriteRuntimePolicyCliHelp(...)` emits canonical policy flags
- verify canonical parse-error constants are stable

## Why
These tests lock the shared contract introduced in #606 so Host/Service CLI help and parse-error messaging cannot drift silently in future edits.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~ToolRuntimePolicyBootstrapTests"`
  - Passed: 8, Failed: 0