### PR TITLE
Refactor chat runtime-policy CLI arg parsing to shared helper

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
@@ -99,6 +99,34 @@ internal static partial class Program {
 
             for (var i = 0; i < args.Length; i++) {
                 var a = args[i] ?? string.Empty;
+
+                (bool Success, string? Value, string? Error) ConsumeRuntimePolicyValue() {
+                    return TryGetValue(args, ref i, out var value, out var valueError)
+                        ? (true, value, null)
+                        : (false, null, valueError);
+                }
+
+                if (!ToolRuntimePolicyBootstrap.TryApplyRuntimePolicyCliArgument(
+                        argument: a,
+                        consumeValue: ConsumeRuntimePolicyValue,
+                        setWriteGovernanceMode: mode => options.WriteGovernanceMode = mode,
+                        setRequireWriteGovernanceRuntime: required => options.RequireWriteGovernanceRuntime = required,
+                        setRequireWriteAuditSinkForWriteOperations: required => options.RequireWriteAuditSinkForWriteOperations = required,
+                        setWriteAuditSinkMode: mode => options.WriteAuditSinkMode = mode,
+                        setWriteAuditSinkPath: path => options.WriteAuditSinkPath = path,
+                        setAuthenticationRuntimePreset: preset => options.AuthenticationRuntimePreset = preset,
+                        setRequireAuthenticationRuntime: required => options.RequireAuthenticationRuntime = required,
+                        setRunAsProfilePath: path => options.RunAsProfilePath = path,
+                        setAuthenticationProfilePath: path => options.AuthenticationProfilePath = path,
+                        handled: out var runtimePolicyHandled,
+                        error: out error)) {
+                    return options;
+                }
+
+                if (runtimePolicyHandled) {
+                    continue;
+                }
+
                 switch (a) {
                     case "-h":
                     case "--help":
@@ -265,72 +293,6 @@ internal static partial class Program {
                         break;
                     case "--no-default-plugin-paths":
                         options.EnableDefaultPluginPaths = false;
-                        break;
-                    case "--write-governance-mode":
-                        if (!TryGetValue(args, ref i, out var writeGovernanceModeValue, out error)) {
-                            return options;
-                        }
-                        if (!ToolRuntimePolicyBootstrap.TryParseWriteGovernanceMode(writeGovernanceModeValue, out var writeGovernanceMode)) {
-                            error = ToolRuntimePolicyBootstrap.WriteGovernanceModeParseError;
-                            return options;
-                        }
-                        options.WriteGovernanceMode = writeGovernanceMode;
-                        break;
-                    case "--require-write-governance-runtime":
-                        options.RequireWriteGovernanceRuntime = true;
-                        break;
-                    case "--no-require-write-governance-runtime":
-                        options.RequireWriteGovernanceRuntime = false;
-                        break;
-                    case "--require-write-audit-sink":
-                        options.RequireWriteAuditSinkForWriteOperations = true;
-                        break;
-                    case "--no-require-write-audit-sink":
-                        options.RequireWriteAuditSinkForWriteOperations = false;
-                        break;
-                    case "--write-audit-sink-mode":
-                        if (!TryGetValue(args, ref i, out var writeAuditSinkModeValue, out error)) {
-                            return options;
-                        }
-                        if (!ToolRuntimePolicyBootstrap.TryParseWriteAuditSinkMode(writeAuditSinkModeValue, out var writeAuditSinkMode)) {
-                            error = ToolRuntimePolicyBootstrap.WriteAuditSinkModeParseError;
-                            return options;
-                        }
-                        options.WriteAuditSinkMode = writeAuditSinkMode;
-                        break;
-                    case "--write-audit-sink-path":
-                        if (!TryGetValue(args, ref i, out var writeAuditSinkPath, out error)) {
-                            return options;
-                        }
-                        options.WriteAuditSinkPath = writeAuditSinkPath;
-                        break;
-                    case "--auth-runtime-preset":
-                        if (!TryGetValue(args, ref i, out var authRuntimePresetValue, out error)) {
-                            return options;
-                        }
-                        if (!ToolRuntimePolicyBootstrap.TryParseAuthenticationRuntimePreset(authRuntimePresetValue, out var authRuntimePreset)) {
-                            error = ToolRuntimePolicyBootstrap.AuthenticationRuntimePresetParseError;
-                            return options;
-                        }
-                        options.AuthenticationRuntimePreset = authRuntimePreset;
-                        break;
-                    case "--require-auth-runtime":
-                        options.RequireAuthenticationRuntime = true;
-                        break;
-                    case "--no-require-auth-runtime":
-                        options.RequireAuthenticationRuntime = false;
-                        break;
-                    case "--run-as-profile-path":
-                        if (!TryGetValue(args, ref i, out var runAsProfilePath, out error)) {
-                            return options;
-                        }
-                        options.RunAsProfilePath = runAsProfilePath;
-                        break;
-                    case "--auth-profile-path":
-                        if (!TryGetValue(args, ref i, out var authenticationProfilePath, out error)) {
-                            return options;
-                        }
-                        options.AuthenticationProfilePath = authenticationProfilePath;
                         break;
                     case "--max-table-rows":
                         if (!TryGetValue(args, ref i, out var maxRows, out error)) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -98,6 +98,34 @@ internal sealed class ServiceOptions : IToolRuntimePolicySettings, IToolPackRunt
 
         for (var i = 0; i < args.Length; i++) {
             var arg = args[i] ?? string.Empty;
+
+            (bool Success, string? Value, string? Error) ConsumeRuntimePolicyValue() {
+                return TryConsume(args, ref i, out var value, out var valueError)
+                    ? (true, value, null)
+                    : (false, null, valueError);
+            }
+
+            if (!ToolRuntimePolicyBootstrap.TryApplyRuntimePolicyCliArgument(
+                    argument: arg,
+                    consumeValue: ConsumeRuntimePolicyValue,
+                    setWriteGovernanceMode: mode => options.WriteGovernanceMode = mode,
+                    setRequireWriteGovernanceRuntime: required => options.RequireWriteGovernanceRuntime = required,
+                    setRequireWriteAuditSinkForWriteOperations: required => options.RequireWriteAuditSinkForWriteOperations = required,
+                    setWriteAuditSinkMode: mode => options.WriteAuditSinkMode = mode,
+                    setWriteAuditSinkPath: path => options.WriteAuditSinkPath = path,
+                    setAuthenticationRuntimePreset: preset => options.AuthenticationRuntimePreset = preset,
+                    setRequireAuthenticationRuntime: required => options.RequireAuthenticationRuntime = required,
+                    setRunAsProfilePath: path => options.RunAsProfilePath = path,
+                    setAuthenticationProfilePath: path => options.AuthenticationProfilePath = path,
+                    handled: out var runtimePolicyHandled,
+                    error: out error)) {
+                return options;
+            }
+
+            if (runtimePolicyHandled) {
+                continue;
+            }
+
             if (arg is "-h" or "--help") {
                 options.ShowHelp = true;
                 continue;
@@ -389,84 +417,6 @@ internal sealed class ServiceOptions : IToolRuntimePolicySettings, IToolPackRunt
             }
             if (arg is "--no-default-plugin-paths") {
                 options.EnableDefaultPluginPaths = false;
-                continue;
-            }
-            if (arg is "--write-governance-mode") {
-                if (!TryConsume(args, ref i, out var value, out error)) {
-                    return options;
-                }
-                if (!ToolRuntimePolicyBootstrap.TryParseWriteGovernanceMode(value, out var mode)) {
-                    error = ToolRuntimePolicyBootstrap.WriteGovernanceModeParseError;
-                    return options;
-                }
-                options.WriteGovernanceMode = mode;
-                continue;
-            }
-            if (arg is "--require-write-governance-runtime") {
-                options.RequireWriteGovernanceRuntime = true;
-                continue;
-            }
-            if (arg is "--no-require-write-governance-runtime") {
-                options.RequireWriteGovernanceRuntime = false;
-                continue;
-            }
-            if (arg is "--require-write-audit-sink") {
-                options.RequireWriteAuditSinkForWriteOperations = true;
-                continue;
-            }
-            if (arg is "--no-require-write-audit-sink") {
-                options.RequireWriteAuditSinkForWriteOperations = false;
-                continue;
-            }
-            if (arg is "--write-audit-sink-mode") {
-                if (!TryConsume(args, ref i, out var value, out error)) {
-                    return options;
-                }
-                if (!ToolRuntimePolicyBootstrap.TryParseWriteAuditSinkMode(value, out var sinkMode)) {
-                    error = ToolRuntimePolicyBootstrap.WriteAuditSinkModeParseError;
-                    return options;
-                }
-                options.WriteAuditSinkMode = sinkMode;
-                continue;
-            }
-            if (arg is "--write-audit-sink-path") {
-                if (!TryConsume(args, ref i, out var value, out error)) {
-                    return options;
-                }
-                options.WriteAuditSinkPath = value;
-                continue;
-            }
-            if (arg is "--auth-runtime-preset") {
-                if (!TryConsume(args, ref i, out var value, out error)) {
-                    return options;
-                }
-                if (!ToolRuntimePolicyBootstrap.TryParseAuthenticationRuntimePreset(value, out var preset)) {
-                    error = ToolRuntimePolicyBootstrap.AuthenticationRuntimePresetParseError;
-                    return options;
-                }
-                options.AuthenticationRuntimePreset = preset;
-                continue;
-            }
-            if (arg is "--require-auth-runtime") {
-                options.RequireAuthenticationRuntime = true;
-                continue;
-            }
-            if (arg is "--no-require-auth-runtime") {
-                options.RequireAuthenticationRuntime = false;
-                continue;
-            }
-            if (arg is "--run-as-profile-path") {
-                if (!TryConsume(args, ref i, out var value, out error)) {
-                    return options;
-                }
-                options.RunAsProfilePath = value;
-                continue;
-            }
-            if (arg is "--auth-profile-path") {
-                if (!TryConsume(args, ref i, out var value, out error)) {
-                    return options;
-                }
-                options.AuthenticationProfilePath = value;
                 continue;
             }
             if (arg is "--max-table-rows") {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolRuntimePolicyBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolRuntimePolicyBootstrapTests.cs
@@ -122,6 +122,91 @@ public sealed class ToolRuntimePolicyBootstrapTests {
         Assert.Equal("--auth-runtime-preset must be one of: default, strict, lab.", ToolRuntimePolicyBootstrap.AuthenticationRuntimePresetParseError);
     }
 
+    [Fact]
+    public void TryApplyRuntimePolicyCliArgument_AppliesWriteGovernanceMode() {
+        var writeMode = ToolWriteGovernanceMode.Enforced;
+        var requireWriteRuntime = true;
+        var requireWriteAuditSink = false;
+        var writeAuditSinkMode = ToolWriteAuditSinkMode.None;
+        string? writeAuditSinkPath = null;
+        var authPreset = ToolAuthenticationRuntimePreset.Default;
+        var requireAuthRuntime = false;
+        string? runAsProfilePath = null;
+        string? authProfilePath = null;
+
+        var ok = ToolRuntimePolicyBootstrap.TryApplyRuntimePolicyCliArgument(
+            argument: "--write-governance-mode",
+            consumeValue: static () => (true, "yolo", null),
+            setWriteGovernanceMode: mode => writeMode = mode,
+            setRequireWriteGovernanceRuntime: required => requireWriteRuntime = required,
+            setRequireWriteAuditSinkForWriteOperations: required => requireWriteAuditSink = required,
+            setWriteAuditSinkMode: mode => writeAuditSinkMode = mode,
+            setWriteAuditSinkPath: path => writeAuditSinkPath = path,
+            setAuthenticationRuntimePreset: preset => authPreset = preset,
+            setRequireAuthenticationRuntime: required => requireAuthRuntime = required,
+            setRunAsProfilePath: path => runAsProfilePath = path,
+            setAuthenticationProfilePath: path => authProfilePath = path,
+            handled: out var handled,
+            error: out var error);
+
+        Assert.True(ok);
+        Assert.True(handled);
+        Assert.Null(error);
+        Assert.Equal(ToolWriteGovernanceMode.Yolo, writeMode);
+        Assert.True(requireWriteRuntime);
+        Assert.False(requireWriteAuditSink);
+        Assert.Equal(ToolWriteAuditSinkMode.None, writeAuditSinkMode);
+        Assert.Null(writeAuditSinkPath);
+        Assert.Equal(ToolAuthenticationRuntimePreset.Default, authPreset);
+        Assert.False(requireAuthRuntime);
+        Assert.Null(runAsProfilePath);
+        Assert.Null(authProfilePath);
+    }
+
+    [Fact]
+    public void TryApplyRuntimePolicyCliArgument_InvalidAuthPreset_ReturnsCanonicalError() {
+        var ok = ToolRuntimePolicyBootstrap.TryApplyRuntimePolicyCliArgument(
+            argument: "--auth-runtime-preset",
+            consumeValue: static () => (true, "invalid", null),
+            setWriteGovernanceMode: static _ => { },
+            setRequireWriteGovernanceRuntime: static _ => { },
+            setRequireWriteAuditSinkForWriteOperations: static _ => { },
+            setWriteAuditSinkMode: static _ => { },
+            setWriteAuditSinkPath: static _ => { },
+            setAuthenticationRuntimePreset: static _ => { },
+            setRequireAuthenticationRuntime: static _ => { },
+            setRunAsProfilePath: static _ => { },
+            setAuthenticationProfilePath: static _ => { },
+            handled: out var handled,
+            error: out var error);
+
+        Assert.False(ok);
+        Assert.True(handled);
+        Assert.Equal(ToolRuntimePolicyBootstrap.AuthenticationRuntimePresetParseError, error);
+    }
+
+    [Fact]
+    public void TryApplyRuntimePolicyCliArgument_UnknownArgument_IsNotHandled() {
+        var ok = ToolRuntimePolicyBootstrap.TryApplyRuntimePolicyCliArgument(
+            argument: "--not-runtime-policy",
+            consumeValue: static () => throw new InvalidOperationException("consumeValue should not be called."),
+            setWriteGovernanceMode: static _ => { },
+            setRequireWriteGovernanceRuntime: static _ => { },
+            setRequireWriteAuditSinkForWriteOperations: static _ => { },
+            setWriteAuditSinkMode: static _ => { },
+            setWriteAuditSinkPath: static _ => { },
+            setAuthenticationRuntimePreset: static _ => { },
+            setRequireAuthenticationRuntime: static _ => { },
+            setRunAsProfilePath: static _ => { },
+            setAuthenticationProfilePath: static _ => { },
+            handled: out var handled,
+            error: out var error);
+
+        Assert.True(ok);
+        Assert.False(handled);
+        Assert.Null(error);
+    }
+
     private static void TryDelete(string path) {
         try {
             if (File.Exists(path)) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolRuntimePolicy.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolRuntimePolicy.cs
@@ -477,6 +477,155 @@ public static class ToolRuntimePolicyBootstrap {
     }
 
     /// <summary>
+    /// Applies one runtime-policy CLI argument using shared parsing and validation semantics.
+    /// </summary>
+    /// <param name="argument">Current CLI argument token.</param>
+    /// <param name="consumeValue">Callback that consumes the next CLI value token when required.</param>
+    /// <param name="setWriteGovernanceMode">Setter for write-governance mode.</param>
+    /// <param name="setRequireWriteGovernanceRuntime">Setter for write-runtime requirement.</param>
+    /// <param name="setRequireWriteAuditSinkForWriteOperations">Setter for write-audit-sink requirement.</param>
+    /// <param name="setWriteAuditSinkMode">Setter for write-audit-sink mode.</param>
+    /// <param name="setWriteAuditSinkPath">Setter for write-audit-sink path.</param>
+    /// <param name="setAuthenticationRuntimePreset">Setter for auth runtime preset.</param>
+    /// <param name="setRequireAuthenticationRuntime">Setter for auth runtime requirement.</param>
+    /// <param name="setRunAsProfilePath">Setter for run-as profile path.</param>
+    /// <param name="setAuthenticationProfilePath">Setter for auth profile path.</param>
+    /// <param name="handled">True when <paramref name="argument" /> is a runtime-policy argument.</param>
+    /// <param name="error">Validation error when parsing fails; otherwise null.</param>
+    /// <returns>True when parsing succeeded (or argument was not handled), false when handled parse failed.</returns>
+    public static bool TryApplyRuntimePolicyCliArgument(
+        string? argument,
+        Func<(bool Success, string? Value, string? Error)> consumeValue,
+        Action<ToolWriteGovernanceMode> setWriteGovernanceMode,
+        Action<bool> setRequireWriteGovernanceRuntime,
+        Action<bool> setRequireWriteAuditSinkForWriteOperations,
+        Action<ToolWriteAuditSinkMode> setWriteAuditSinkMode,
+        Action<string?> setWriteAuditSinkPath,
+        Action<ToolAuthenticationRuntimePreset> setAuthenticationRuntimePreset,
+        Action<bool> setRequireAuthenticationRuntime,
+        Action<string?> setRunAsProfilePath,
+        Action<string?> setAuthenticationProfilePath,
+        out bool handled,
+        out string? error) {
+        if (consumeValue is null) {
+            throw new ArgumentNullException(nameof(consumeValue));
+        }
+        if (setWriteGovernanceMode is null) {
+            throw new ArgumentNullException(nameof(setWriteGovernanceMode));
+        }
+        if (setRequireWriteGovernanceRuntime is null) {
+            throw new ArgumentNullException(nameof(setRequireWriteGovernanceRuntime));
+        }
+        if (setRequireWriteAuditSinkForWriteOperations is null) {
+            throw new ArgumentNullException(nameof(setRequireWriteAuditSinkForWriteOperations));
+        }
+        if (setWriteAuditSinkMode is null) {
+            throw new ArgumentNullException(nameof(setWriteAuditSinkMode));
+        }
+        if (setWriteAuditSinkPath is null) {
+            throw new ArgumentNullException(nameof(setWriteAuditSinkPath));
+        }
+        if (setAuthenticationRuntimePreset is null) {
+            throw new ArgumentNullException(nameof(setAuthenticationRuntimePreset));
+        }
+        if (setRequireAuthenticationRuntime is null) {
+            throw new ArgumentNullException(nameof(setRequireAuthenticationRuntime));
+        }
+        if (setRunAsProfilePath is null) {
+            throw new ArgumentNullException(nameof(setRunAsProfilePath));
+        }
+        if (setAuthenticationProfilePath is null) {
+            throw new ArgumentNullException(nameof(setAuthenticationProfilePath));
+        }
+
+        handled = true;
+        error = null;
+        switch (argument) {
+            case "--write-governance-mode":
+                var writeModeValue = consumeValue();
+                if (!writeModeValue.Success) {
+                    error = writeModeValue.Error;
+                    return false;
+                }
+                if (!TryParseWriteGovernanceMode(writeModeValue.Value, out var writeMode)) {
+                    error = WriteGovernanceModeParseError;
+                    return false;
+                }
+                setWriteGovernanceMode(writeMode);
+                return true;
+            case "--require-write-governance-runtime":
+                setRequireWriteGovernanceRuntime(true);
+                return true;
+            case "--no-require-write-governance-runtime":
+                setRequireWriteGovernanceRuntime(false);
+                return true;
+            case "--require-write-audit-sink":
+                setRequireWriteAuditSinkForWriteOperations(true);
+                return true;
+            case "--no-require-write-audit-sink":
+                setRequireWriteAuditSinkForWriteOperations(false);
+                return true;
+            case "--write-audit-sink-mode":
+                var writeAuditSinkModeValue = consumeValue();
+                if (!writeAuditSinkModeValue.Success) {
+                    error = writeAuditSinkModeValue.Error;
+                    return false;
+                }
+                if (!TryParseWriteAuditSinkMode(writeAuditSinkModeValue.Value, out var writeAuditSinkMode)) {
+                    error = WriteAuditSinkModeParseError;
+                    return false;
+                }
+                setWriteAuditSinkMode(writeAuditSinkMode);
+                return true;
+            case "--write-audit-sink-path":
+                var writeAuditSinkPathValue = consumeValue();
+                if (!writeAuditSinkPathValue.Success) {
+                    error = writeAuditSinkPathValue.Error;
+                    return false;
+                }
+                setWriteAuditSinkPath(writeAuditSinkPathValue.Value);
+                return true;
+            case "--auth-runtime-preset":
+                var authPresetValue = consumeValue();
+                if (!authPresetValue.Success) {
+                    error = authPresetValue.Error;
+                    return false;
+                }
+                if (!TryParseAuthenticationRuntimePreset(authPresetValue.Value, out var authPreset)) {
+                    error = AuthenticationRuntimePresetParseError;
+                    return false;
+                }
+                setAuthenticationRuntimePreset(authPreset);
+                return true;
+            case "--require-auth-runtime":
+                setRequireAuthenticationRuntime(true);
+                return true;
+            case "--no-require-auth-runtime":
+                setRequireAuthenticationRuntime(false);
+                return true;
+            case "--run-as-profile-path":
+                var runAsProfilePath = consumeValue();
+                if (!runAsProfilePath.Success) {
+                    error = runAsProfilePath.Error;
+                    return false;
+                }
+                setRunAsProfilePath(runAsProfilePath.Value);
+                return true;
+            case "--auth-profile-path":
+                var authProfilePath = consumeValue();
+                if (!authProfilePath.Success) {
+                    error = authProfilePath.Error;
+                    return false;
+                }
+                setAuthenticationProfilePath(authProfilePath.Value);
+                return true;
+            default:
+                handled = false;
+                return true;
+        }
+    }
+
+    /// <summary>
     /// Formats write-governance mode for profile persistence.
     /// </summary>
     public static string FormatWriteGovernanceMode(ToolWriteGovernanceMode mode) {


### PR DESCRIPTION
## Summary
- add `ToolRuntimePolicyBootstrap.TryApplyRuntimePolicyCliArgument(...)` for shared runtime-policy CLI parsing
- wire both parsers to this one path:
  - `IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs`
  - `IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs`
- remove duplicated runtime-policy arg blocks from both files
- extend `ToolRuntimePolicyBootstrapTests` to verify:
  - valid apply path
  - invalid preset error mapping
  - unknown arg passthrough

## Why
This reduces parser duplication and keeps Host/Service runtime-policy flag behavior aligned by construction.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~ToolRuntimePolicyBootstrapTests|FullyQualifiedName~ServiceOptionsProfileBootstrapTests"`
  - Passed: 35, Failed: 0