### PR TITLE
Centralize runtime-policy profile mapping

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
@@ -489,21 +489,25 @@ internal static partial class Program {
             if (profile.PluginPaths is { Count: > 0 }) {
                 PluginPaths.AddRange(profile.PluginPaths);
             }
-            if (ToolRuntimePolicyBootstrap.TryParseWriteGovernanceMode(profile.WriteGovernanceMode, out var writeMode)) {
-                WriteGovernanceMode = writeMode;
-            }
-            RequireWriteGovernanceRuntime = profile.RequireWriteGovernanceRuntime;
-            RequireWriteAuditSinkForWriteOperations = profile.RequireWriteAuditSinkForWriteOperations;
-            if (ToolRuntimePolicyBootstrap.TryParseWriteAuditSinkMode(profile.WriteAuditSinkMode, out var writeAuditMode)) {
-                WriteAuditSinkMode = writeAuditMode;
-            }
-            WriteAuditSinkPath = profile.WriteAuditSinkPath;
-            if (ToolRuntimePolicyBootstrap.TryParseAuthenticationRuntimePreset(profile.AuthenticationRuntimePreset, out var authPreset)) {
-                AuthenticationRuntimePreset = authPreset;
-            }
-            RequireAuthenticationRuntime = profile.RequireAuthenticationRuntime;
-            RunAsProfilePath = profile.RunAsProfilePath;
-            AuthenticationProfilePath = profile.AuthenticationProfilePath;
+            ToolRuntimePolicyBootstrap.ApplyProfileRuntimePolicy(
+                writeGovernanceMode: profile.WriteGovernanceMode,
+                requireWriteGovernanceRuntime: profile.RequireWriteGovernanceRuntime,
+                requireWriteAuditSinkForWriteOperations: profile.RequireWriteAuditSinkForWriteOperations,
+                writeAuditSinkMode: profile.WriteAuditSinkMode,
+                writeAuditSinkPath: profile.WriteAuditSinkPath,
+                authenticationRuntimePreset: profile.AuthenticationRuntimePreset,
+                requireAuthenticationRuntime: profile.RequireAuthenticationRuntime,
+                runAsProfilePath: profile.RunAsProfilePath,
+                authenticationProfilePath: profile.AuthenticationProfilePath,
+                setWriteGovernanceMode: mode => WriteGovernanceMode = mode,
+                setRequireWriteGovernanceRuntime: required => RequireWriteGovernanceRuntime = required,
+                setRequireWriteAuditSinkForWriteOperations: required => RequireWriteAuditSinkForWriteOperations = required,
+                setWriteAuditSinkMode: mode => WriteAuditSinkMode = mode,
+                setWriteAuditSinkPath: path => WriteAuditSinkPath = path,
+                setAuthenticationRuntimePreset: preset => AuthenticationRuntimePreset = preset,
+                setRequireAuthenticationRuntime: required => RequireAuthenticationRuntime = required,
+                setRunAsProfilePath: path => RunAsProfilePath = path,
+                setAuthenticationProfilePath: path => AuthenticationProfilePath = path);
 
             InstructionsFile = profile.InstructionsFile;
             MaxTableRows = profile.MaxTableRows;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -685,21 +685,25 @@ internal sealed class ServiceOptions : IToolRuntimePolicySettings, IToolPackRunt
         if (profile.PluginPaths != null && profile.PluginPaths.Count > 0) {
             PluginPaths.AddRange(profile.PluginPaths);
         }
-        if (ToolRuntimePolicyBootstrap.TryParseWriteGovernanceMode(profile.WriteGovernanceMode, out var writeMode)) {
-            WriteGovernanceMode = writeMode;
-        }
-        RequireWriteGovernanceRuntime = profile.RequireWriteGovernanceRuntime;
-        RequireWriteAuditSinkForWriteOperations = profile.RequireWriteAuditSinkForWriteOperations;
-        if (ToolRuntimePolicyBootstrap.TryParseWriteAuditSinkMode(profile.WriteAuditSinkMode, out var writeAuditMode)) {
-            WriteAuditSinkMode = writeAuditMode;
-        }
-        WriteAuditSinkPath = profile.WriteAuditSinkPath;
-        if (ToolRuntimePolicyBootstrap.TryParseAuthenticationRuntimePreset(profile.AuthenticationRuntimePreset, out var authPreset)) {
-            AuthenticationRuntimePreset = authPreset;
-        }
-        RequireAuthenticationRuntime = profile.RequireAuthenticationRuntime;
-        RunAsProfilePath = profile.RunAsProfilePath;
-        AuthenticationProfilePath = profile.AuthenticationProfilePath;
+        ToolRuntimePolicyBootstrap.ApplyProfileRuntimePolicy(
+            writeGovernanceMode: profile.WriteGovernanceMode,
+            requireWriteGovernanceRuntime: profile.RequireWriteGovernanceRuntime,
+            requireWriteAuditSinkForWriteOperations: profile.RequireWriteAuditSinkForWriteOperations,
+            writeAuditSinkMode: profile.WriteAuditSinkMode,
+            writeAuditSinkPath: profile.WriteAuditSinkPath,
+            authenticationRuntimePreset: profile.AuthenticationRuntimePreset,
+            requireAuthenticationRuntime: profile.RequireAuthenticationRuntime,
+            runAsProfilePath: profile.RunAsProfilePath,
+            authenticationProfilePath: profile.AuthenticationProfilePath,
+            setWriteGovernanceMode: mode => WriteGovernanceMode = mode,
+            setRequireWriteGovernanceRuntime: required => RequireWriteGovernanceRuntime = required,
+            setRequireWriteAuditSinkForWriteOperations: required => RequireWriteAuditSinkForWriteOperations = required,
+            setWriteAuditSinkMode: mode => WriteAuditSinkMode = mode,
+            setWriteAuditSinkPath: path => WriteAuditSinkPath = path,
+            setAuthenticationRuntimePreset: preset => AuthenticationRuntimePreset = preset,
+            setRequireAuthenticationRuntime: required => RequireAuthenticationRuntime = required,
+            setRunAsProfilePath: path => RunAsProfilePath = path,
+            setAuthenticationProfilePath: path => AuthenticationProfilePath = path);
 
         InstructionsFile = profile.InstructionsFile;
         MaxTableRows = profile.MaxTableRows;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolRuntimePolicyBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolRuntimePolicyBootstrapTests.cs
@@ -207,6 +207,92 @@ public sealed class ToolRuntimePolicyBootstrapTests {
         Assert.Null(error);
     }
 
+    [Fact]
+    public void ApplyProfileRuntimePolicy_ValidTokens_UpdateAllRuntimePolicyFields() {
+        var writeMode = ToolWriteGovernanceMode.Enforced;
+        var requireWriteRuntime = false;
+        var requireWriteAuditSink = false;
+        var writeAuditSinkMode = ToolWriteAuditSinkMode.None;
+        string? writeAuditSinkPath = null;
+        var authPreset = ToolAuthenticationRuntimePreset.Default;
+        var requireAuthRuntime = false;
+        string? runAsProfilePath = null;
+        string? authProfilePath = null;
+
+        ToolRuntimePolicyBootstrap.ApplyProfileRuntimePolicy(
+            writeGovernanceMode: "yolo",
+            requireWriteGovernanceRuntime: true,
+            requireWriteAuditSinkForWriteOperations: true,
+            writeAuditSinkMode: "sqlite",
+            writeAuditSinkPath: "C:/temp/write-audit.db",
+            authenticationRuntimePreset: "strict",
+            requireAuthenticationRuntime: true,
+            runAsProfilePath: "C:/profiles/runas.json",
+            authenticationProfilePath: "C:/profiles/auth.json",
+            setWriteGovernanceMode: mode => writeMode = mode,
+            setRequireWriteGovernanceRuntime: required => requireWriteRuntime = required,
+            setRequireWriteAuditSinkForWriteOperations: required => requireWriteAuditSink = required,
+            setWriteAuditSinkMode: mode => writeAuditSinkMode = mode,
+            setWriteAuditSinkPath: path => writeAuditSinkPath = path,
+            setAuthenticationRuntimePreset: preset => authPreset = preset,
+            setRequireAuthenticationRuntime: required => requireAuthRuntime = required,
+            setRunAsProfilePath: path => runAsProfilePath = path,
+            setAuthenticationProfilePath: path => authProfilePath = path);
+
+        Assert.Equal(ToolWriteGovernanceMode.Yolo, writeMode);
+        Assert.True(requireWriteRuntime);
+        Assert.True(requireWriteAuditSink);
+        Assert.Equal(ToolWriteAuditSinkMode.SqliteAppendOnly, writeAuditSinkMode);
+        Assert.Equal("C:/temp/write-audit.db", writeAuditSinkPath);
+        Assert.Equal(ToolAuthenticationRuntimePreset.Strict, authPreset);
+        Assert.True(requireAuthRuntime);
+        Assert.Equal("C:/profiles/runas.json", runAsProfilePath);
+        Assert.Equal("C:/profiles/auth.json", authProfilePath);
+    }
+
+    [Fact]
+    public void ApplyProfileRuntimePolicy_InvalidTokens_KeepEnumModesButApplyFlagsAndPaths() {
+        var writeMode = ToolWriteGovernanceMode.Yolo;
+        var requireWriteRuntime = false;
+        var requireWriteAuditSink = true;
+        var writeAuditSinkMode = ToolWriteAuditSinkMode.FileAppendOnly;
+        string? writeAuditSinkPath = "before";
+        var authPreset = ToolAuthenticationRuntimePreset.Strict;
+        var requireAuthRuntime = true;
+        string? runAsProfilePath = "before-runas";
+        string? authProfilePath = "before-auth";
+
+        ToolRuntimePolicyBootstrap.ApplyProfileRuntimePolicy(
+            writeGovernanceMode: "invalid",
+            requireWriteGovernanceRuntime: true,
+            requireWriteAuditSinkForWriteOperations: false,
+            writeAuditSinkMode: "invalid",
+            writeAuditSinkPath: "after",
+            authenticationRuntimePreset: "invalid",
+            requireAuthenticationRuntime: false,
+            runAsProfilePath: "after-runas",
+            authenticationProfilePath: "after-auth",
+            setWriteGovernanceMode: mode => writeMode = mode,
+            setRequireWriteGovernanceRuntime: required => requireWriteRuntime = required,
+            setRequireWriteAuditSinkForWriteOperations: required => requireWriteAuditSink = required,
+            setWriteAuditSinkMode: mode => writeAuditSinkMode = mode,
+            setWriteAuditSinkPath: path => writeAuditSinkPath = path,
+            setAuthenticationRuntimePreset: preset => authPreset = preset,
+            setRequireAuthenticationRuntime: required => requireAuthRuntime = required,
+            setRunAsProfilePath: path => runAsProfilePath = path,
+            setAuthenticationProfilePath: path => authProfilePath = path);
+
+        Assert.Equal(ToolWriteGovernanceMode.Yolo, writeMode);
+        Assert.True(requireWriteRuntime);
+        Assert.False(requireWriteAuditSink);
+        Assert.Equal(ToolWriteAuditSinkMode.FileAppendOnly, writeAuditSinkMode);
+        Assert.Equal("after", writeAuditSinkPath);
+        Assert.Equal(ToolAuthenticationRuntimePreset.Strict, authPreset);
+        Assert.False(requireAuthRuntime);
+        Assert.Equal("after-runas", runAsProfilePath);
+        Assert.Equal("after-auth", authProfilePath);
+    }
+
     private static void TryDelete(string path) {
         try {
             if (File.Exists(path)) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolRuntimePolicy.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolRuntimePolicy.cs
@@ -626,6 +626,96 @@ public static class ToolRuntimePolicyBootstrap {
     }
 
     /// <summary>
+    /// Applies runtime-policy values loaded from a persisted profile.
+    /// </summary>
+    /// <param name="writeGovernanceMode">Persisted write-governance mode token.</param>
+    /// <param name="requireWriteGovernanceRuntime">Persisted write-runtime requirement.</param>
+    /// <param name="requireWriteAuditSinkForWriteOperations">Persisted write-audit-sink requirement.</param>
+    /// <param name="writeAuditSinkMode">Persisted write-audit-sink mode token.</param>
+    /// <param name="writeAuditSinkPath">Persisted write-audit-sink path.</param>
+    /// <param name="authenticationRuntimePreset">Persisted auth runtime preset token.</param>
+    /// <param name="requireAuthenticationRuntime">Persisted auth runtime requirement.</param>
+    /// <param name="runAsProfilePath">Persisted run-as profile path.</param>
+    /// <param name="authenticationProfilePath">Persisted auth profile path.</param>
+    /// <param name="setWriteGovernanceMode">Setter for parsed write-governance mode.</param>
+    /// <param name="setRequireWriteGovernanceRuntime">Setter for write-runtime requirement.</param>
+    /// <param name="setRequireWriteAuditSinkForWriteOperations">Setter for write-audit-sink requirement.</param>
+    /// <param name="setWriteAuditSinkMode">Setter for parsed write-audit-sink mode.</param>
+    /// <param name="setWriteAuditSinkPath">Setter for write-audit-sink path.</param>
+    /// <param name="setAuthenticationRuntimePreset">Setter for parsed auth runtime preset.</param>
+    /// <param name="setRequireAuthenticationRuntime">Setter for auth runtime requirement.</param>
+    /// <param name="setRunAsProfilePath">Setter for run-as profile path.</param>
+    /// <param name="setAuthenticationProfilePath">Setter for auth profile path.</param>
+    public static void ApplyProfileRuntimePolicy(
+        string? writeGovernanceMode,
+        bool requireWriteGovernanceRuntime,
+        bool requireWriteAuditSinkForWriteOperations,
+        string? writeAuditSinkMode,
+        string? writeAuditSinkPath,
+        string? authenticationRuntimePreset,
+        bool requireAuthenticationRuntime,
+        string? runAsProfilePath,
+        string? authenticationProfilePath,
+        Action<ToolWriteGovernanceMode> setWriteGovernanceMode,
+        Action<bool> setRequireWriteGovernanceRuntime,
+        Action<bool> setRequireWriteAuditSinkForWriteOperations,
+        Action<ToolWriteAuditSinkMode> setWriteAuditSinkMode,
+        Action<string?> setWriteAuditSinkPath,
+        Action<ToolAuthenticationRuntimePreset> setAuthenticationRuntimePreset,
+        Action<bool> setRequireAuthenticationRuntime,
+        Action<string?> setRunAsProfilePath,
+        Action<string?> setAuthenticationProfilePath) {
+        if (setWriteGovernanceMode is null) {
+            throw new ArgumentNullException(nameof(setWriteGovernanceMode));
+        }
+        if (setRequireWriteGovernanceRuntime is null) {
+            throw new ArgumentNullException(nameof(setRequireWriteGovernanceRuntime));
+        }
+        if (setRequireWriteAuditSinkForWriteOperations is null) {
+            throw new ArgumentNullException(nameof(setRequireWriteAuditSinkForWriteOperations));
+        }
+        if (setWriteAuditSinkMode is null) {
+            throw new ArgumentNullException(nameof(setWriteAuditSinkMode));
+        }
+        if (setWriteAuditSinkPath is null) {
+            throw new ArgumentNullException(nameof(setWriteAuditSinkPath));
+        }
+        if (setAuthenticationRuntimePreset is null) {
+            throw new ArgumentNullException(nameof(setAuthenticationRuntimePreset));
+        }
+        if (setRequireAuthenticationRuntime is null) {
+            throw new ArgumentNullException(nameof(setRequireAuthenticationRuntime));
+        }
+        if (setRunAsProfilePath is null) {
+            throw new ArgumentNullException(nameof(setRunAsProfilePath));
+        }
+        if (setAuthenticationProfilePath is null) {
+            throw new ArgumentNullException(nameof(setAuthenticationProfilePath));
+        }
+
+        if (TryParseWriteGovernanceMode(writeGovernanceMode, out var parsedWriteMode)) {
+            setWriteGovernanceMode(parsedWriteMode);
+        }
+
+        setRequireWriteGovernanceRuntime(requireWriteGovernanceRuntime);
+        setRequireWriteAuditSinkForWriteOperations(requireWriteAuditSinkForWriteOperations);
+
+        if (TryParseWriteAuditSinkMode(writeAuditSinkMode, out var parsedWriteAuditMode)) {
+            setWriteAuditSinkMode(parsedWriteAuditMode);
+        }
+
+        setWriteAuditSinkPath(writeAuditSinkPath);
+
+        if (TryParseAuthenticationRuntimePreset(authenticationRuntimePreset, out var parsedAuthPreset)) {
+            setAuthenticationRuntimePreset(parsedAuthPreset);
+        }
+
+        setRequireAuthenticationRuntime(requireAuthenticationRuntime);
+        setRunAsProfilePath(runAsProfilePath);
+        setAuthenticationProfilePath(authenticationProfilePath);
+    }
+
+    /// <summary>
     /// Formats write-governance mode for profile persistence.
     /// </summary>
     public static string FormatWriteGovernanceMode(ToolWriteGovernanceMode mode) {


### PR DESCRIPTION
## Summary
- add ToolRuntimePolicyBootstrap.ApplyProfileRuntimePolicy(...) to centralize persisted runtime-policy mapping
- switch both Host and Service profile-apply paths to use the shared helper instead of duplicate parse/assign logic
- add focused bootstrap tests that lock behavior for valid and invalid persisted tokens

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release