### PR TITLE
chat: enforce request-ordered runtime switch UI state

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
@@ -142,8 +142,11 @@ public sealed class UiShellAssetsTests {
         Assert.Contains("function scheduleLocalProviderApply(forceRefresh, clearApiKey, clearBasicAuth)", script, StringComparison.Ordinal);
         Assert.Contains("pendingLocalProviderApply.clearApiKey = pendingLocalProviderApply.clearApiKey || nextClearApiKey;", script, StringComparison.Ordinal);
         Assert.Contains("pendingLocalProviderApply.clearBasicAuth = pendingLocalProviderApply.clearBasicAuth || nextClearBasicAuth;", script, StringComparison.Ordinal);
+        Assert.Contains("var requestId = nextLocalProviderApplyRequestId();", script, StringComparison.Ordinal);
         Assert.Contains("runtimeApply.stage = wasApplying ? \"queued\" : \"applying\";", script, StringComparison.Ordinal);
         Assert.Contains("runtimeApply.detail = wasApplying", script, StringComparison.Ordinal);
+        Assert.Contains("runtimeApply.requestId = requestId;", script, StringComparison.Ordinal);
+        Assert.Contains("requestId: requestId,", script, StringComparison.Ordinal);
         Assert.Contains("state.options.localModel.isApplying = true;", script, StringComparison.Ordinal);
         Assert.Contains("renderLocalModelOptions();", script, StringComparison.Ordinal);
     }
@@ -214,6 +217,20 @@ public sealed class UiShellAssetsTests {
         Assert.Contains("pre.classList && pre.classList.contains(\"mermaid\")", script, StringComparison.Ordinal);
         Assert.Contains("pre.querySelector(\"code.language-ix-chart, code.language-chart\")", script, StringComparison.Ordinal);
         Assert.Contains("pre.querySelector(\"code.language-ix-network\")", script, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Ensures runtime apply updates remain monotonic when options payloads arrive out of order.
+    /// </summary>
+    [Fact]
+    public void Load_IncludesRuntimeApplyRequestOrderingGuardForOptionsSync() {
+        var scriptPath = Path.Combine(UiDirectory, "Shell.18.core.tools.rendering.js");
+        var script = File.ReadAllText(scriptPath);
+
+        Assert.Contains("function resolveRuntimeApplyRequestId(localModel)", script, StringComparison.Ordinal);
+        Assert.Contains("if (currentRequestId > 0 && incomingRequestId > 0 && incomingRequestId < currentRequestId)", script, StringComparison.Ordinal);
+        Assert.Contains("incomingLocalModel.runtimeApply = currentLocalModel.runtimeApply;", script, StringComparison.Ordinal);
+        Assert.Contains("window.ixRememberRuntimeApplyRequestId(resolveRuntimeApplyRequestId(incomingLocalModel));", script, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -41,12 +41,13 @@ public sealed partial class MainWindow : Window {
         string? DetectedBaseUrl,
         string? Warning);
 
-    private void UpdateRuntimeApplyProgress(string stage, string? detail, bool active) {
+    private void UpdateRuntimeApplyProgress(string stage, string? detail, bool active, long requestId) {
         var normalizedStage = (stage ?? string.Empty).Trim().ToLowerInvariant();
         _runtimeApplyStage = normalizedStage.Length == 0 ? "idle" : normalizedStage;
         _runtimeApplyDetail = (detail ?? string.Empty).Trim();
         _runtimeApplyActive = active;
         _runtimeApplyUpdatedUtc = DateTime.UtcNow;
+        _runtimeApplyRequestId = requestId > 0 ? requestId : _runtimeApplyRequestId;
     }
 
     private async Task RefreshModelsFromUiAsync(bool forceRefresh) {
@@ -107,7 +108,8 @@ public sealed partial class MainWindow : Window {
             apiKeyValue: null,
             clearBasicAuth: false,
             clearApiKey: false,
-            forceModelRefresh: forceModelRefresh).ConfigureAwait(false);
+            forceModelRefresh: forceModelRefresh,
+            requestIdValue: null).ConfigureAwait(false);
     }
 
     private async Task RefreshServiceProfilesAsync(ChatServiceClient client, bool publishOptions, bool appendWarnings) {
@@ -173,7 +175,17 @@ public sealed partial class MainWindow : Window {
     private async Task ApplyLocalProviderAsync(string? transportValue, string? baseUrlValue, string? modelValue, string? openAIAuthModeValue,
         string? openAIBasicUsernameValue, string? openAIBasicPasswordValue, string? openAIAccountIdValue, int? activeNativeAccountSlotValue,
         string? activeSlotAccountIdValue, string? reasoningEffortValue, string? reasoningSummaryValue, string? textVerbosityValue,
-        string? temperatureValue, string? apiKeyValue, bool clearBasicAuth, bool clearApiKey, bool forceModelRefresh) {
+        string? temperatureValue, string? apiKeyValue, bool clearBasicAuth, bool clearApiKey, bool forceModelRefresh, long? requestIdValue) {
+        var normalizedRequestId = requestIdValue.GetValueOrDefault();
+        if (normalizedRequestId <= 0) {
+            normalizedRequestId = Interlocked.Increment(ref _runtimeApplyRequestCounter);
+        } else {
+            var currentCounter = Interlocked.Read(ref _runtimeApplyRequestCounter);
+            if (normalizedRequestId > currentCounter) {
+                Interlocked.Exchange(ref _runtimeApplyRequestCounter, normalizedRequestId);
+            }
+        }
+
         var request = new LocalProviderApplyRequest(
             Transport: transportValue,
             BaseUrl: baseUrlValue,
@@ -191,11 +203,12 @@ public sealed partial class MainWindow : Window {
             ApiKey: apiKeyValue,
             ClearBasicAuth: clearBasicAuth,
             ClearApiKey: clearApiKey,
-            ForceModelRefresh: forceModelRefresh);
+            ForceModelRefresh: forceModelRefresh,
+            RequestId: normalizedRequestId);
 
         if (Interlocked.CompareExchange(ref _localProviderApplyInFlight, 1, 0) != 0) {
             QueuePendingLocalProviderApply(request);
-            UpdateRuntimeApplyProgress("queued", "Runtime switch queued. Latest settings will apply next.", active: true);
+            UpdateRuntimeApplyProgress("queued", "Runtime switch queued. Latest settings will apply next.", active: true, request.RequestId);
             await PublishOptionsStateAsync().ConfigureAwait(false);
             await SetStatusAsync("Runtime switch already in progress. Queued latest settings.").ConfigureAwait(false);
             return;
@@ -211,7 +224,7 @@ public sealed partial class MainWindow : Window {
                     lastApplySucceeded = await ApplyLocalProviderCoreAsync(current).ConfigureAwait(false);
                 } catch (Exception ex) {
                     lastApplySucceeded = false;
-                    UpdateRuntimeApplyProgress("failed", "Runtime apply failed: " + ex.Message, active: false);
+                    UpdateRuntimeApplyProgress("failed", "Runtime apply failed: " + ex.Message, active: false, current.RequestId);
                     await SetStatusAsync("Runtime apply failed. " + ex.Message).ConfigureAwait(false);
                     break;
                 }
@@ -224,12 +237,12 @@ public sealed partial class MainWindow : Window {
                     continue;
                 }
 
-                UpdateRuntimeApplyProgress("queued", "Applying queued runtime update...", active: true);
+                UpdateRuntimeApplyProgress("queued", "Applying queued runtime update...", active: true, pending.RequestId);
                 current = pending;
             }
 
             if (anyAttempted && lastApplySucceeded) {
-                UpdateRuntimeApplyProgress("completed", "Runtime settings applied without restarting the service process.", active: false);
+                UpdateRuntimeApplyProgress("completed", "Runtime settings applied without restarting the service process.", active: false, current.RequestId);
             }
         } finally {
             Interlocked.Exchange(ref _localProviderApplyInFlight, 0);
@@ -238,12 +251,12 @@ public sealed partial class MainWindow : Window {
     }
 
     private async Task<bool> ApplyLocalProviderCoreAsync(LocalProviderApplyRequest request) {
-        UpdateRuntimeApplyProgress("validating", "Validating runtime settings...", active: true);
+        UpdateRuntimeApplyProgress("validating", "Validating runtime settings...", active: true, request.RequestId);
         await SetStatusAsync("Applying runtime settings...").ConfigureAwait(false);
         await PublishOptionsStateAsync().ConfigureAwait(false);
 
         if (_isSending) {
-            UpdateRuntimeApplyProgress("failed", "Finish the active response before changing runtime settings.", active: false);
+            UpdateRuntimeApplyProgress("failed", "Finish the active response before changing runtime settings.", active: false, request.RequestId);
             await SetStatusAsync("Finish the active response before changing local runtime settings.").ConfigureAwait(false);
             return false;
         }
@@ -253,7 +266,7 @@ public sealed partial class MainWindow : Window {
         if (rawTransport.Length == 0) {
             normalizedTransport = NormalizeLocalProviderTransport(_localProviderTransport);
         } else if (!TryNormalizeLocalProviderTransport(rawTransport, out normalizedTransport)) {
-            UpdateRuntimeApplyProgress("failed", "Invalid runtime transport value '" + rawTransport + "'.", active: false);
+            UpdateRuntimeApplyProgress("failed", "Invalid runtime transport value '" + rawTransport + "'.", active: false, request.RequestId);
             await SetStatusAsync("Invalid runtime transport value. Open Runtime settings and try again.").ConfigureAwait(false);
             await PublishOptionsStateAsync().ConfigureAwait(false);
             return false;
@@ -340,13 +353,13 @@ public sealed partial class MainWindow : Window {
         _appState.LocalProviderTemperature = _localProviderTemperature;
 
         var profileSaved = ContainsProfileName(_serviceProfileNames, _appProfileName);
-        UpdateRuntimeApplyProgress("persisting", "Saving runtime settings to the active profile...", active: true);
+        UpdateRuntimeApplyProgress("persisting", "Saving runtime settings to the active profile...", active: true, request.RequestId);
         CaptureModelCatalogCacheIntoAppState();
         await PersistAppStateAsync().ConfigureAwait(false);
         await PublishOptionsStateAsync().ConfigureAwait(false);
 
         if (!changed && profileSaved) {
-            UpdateRuntimeApplyProgress("syncing", "Refreshing runtime metadata...", active: true);
+            UpdateRuntimeApplyProgress("syncing", "Refreshing runtime metadata...", active: true, request.RequestId);
             await RefreshModelsFromUiAsync(request.ForceModelRefresh).ConfigureAwait(false);
             return true;
         }
@@ -354,7 +367,7 @@ public sealed partial class MainWindow : Window {
         ClearConversationThreadIds();
         await PersistAppStateAsync().ConfigureAwait(false);
 
-        UpdateRuntimeApplyProgress("applying", "Applying runtime settings to the live session...", active: true);
+        UpdateRuntimeApplyProgress("applying", "Applying runtime settings to the live session...", active: true, request.RequestId);
         var liveApply = await TryApplyRuntimeSettingsLiveAsync(
                 // Always persist current runtime options for the active app profile so reconnects
                 // can recover transport/model settings without falling back to defaults.
@@ -379,7 +392,7 @@ public sealed partial class MainWindow : Window {
                 enableTestimoXPack: null,
                 enableOfficeImoPack: null).ConfigureAwait(false);
         if (liveApply) {
-            UpdateRuntimeApplyProgress("syncing", "Refreshing runtime discovery and model catalog...", active: true);
+            UpdateRuntimeApplyProgress("syncing", "Refreshing runtime discovery and model catalog...", active: true, request.RequestId);
             await RefreshLocalRuntimeDetectionAsync(publishOptions: false).ConfigureAwait(false);
             await SyncConnectedServiceProfileAndModelsAsync(
                 forceModelRefresh: true,
@@ -391,7 +404,8 @@ public sealed partial class MainWindow : Window {
         UpdateRuntimeApplyProgress(
             "failed",
             "Runtime settings couldn't be applied live. Session stayed running; review credentials/settings and apply again.",
-            active: false);
+            active: false,
+            request.RequestId);
         await SetStatusAsync(
                 "Runtime settings couldn't be applied live. Session stayed running; verify credentials/settings and apply again.")
             .ConfigureAwait(false);
@@ -492,7 +506,8 @@ public sealed partial class MainWindow : Window {
                     ApiKey: null,
                     ClearBasicAuth: false,
                     ClearApiKey: false,
-                    ForceModelRefresh: false);
+                    ForceModelRefresh: false,
+                    RequestId: 0);
                 return false;
             }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
@@ -325,6 +325,7 @@ public sealed partial class MainWindow : Window {
                         var clearBasicAuth = TryGetBoolean(root, "clearBasicAuth");
                         var clearApiKey = TryGetBoolean(root, "clearApiKey");
                         var forceRefresh = TryGetBoolean(root, "forceRefresh");
+                        var requestId = TryGetInt64(root, "requestId");
                         await ApplyLocalProviderAsync(
                                 transport,
                                 baseUrl,
@@ -342,7 +343,8 @@ public sealed partial class MainWindow : Window {
                                 apiKey,
                                 clearBasicAuth ?? false,
                                 clearApiKey ?? false,
-                                forceRefresh ?? true)
+                                forceRefresh ?? true,
+                                requestId)
                             .ConfigureAwait(true);
                         break;
                     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
@@ -460,6 +460,23 @@ public sealed partial class MainWindow : Window {
         return null;
     }
 
+    private static long? TryGetInt64(JsonElement obj, string name) {
+        if (obj.ValueKind != JsonValueKind.Object || !obj.TryGetProperty(name, out var el)) {
+            return null;
+        }
+
+        if (el.ValueKind == JsonValueKind.Number && el.TryGetInt64(out var parsedNumber)) {
+            return parsedNumber;
+        }
+
+        if (el.ValueKind == JsonValueKind.String
+            && long.TryParse(el.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedString)) {
+            return parsedString;
+        }
+
+        return null;
+    }
+
     private static bool IsTruthy(string? value) {
         if (string.IsNullOrWhiteSpace(value)) {
             return false;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -429,6 +429,7 @@ public sealed partial class MainWindow : Window {
                     stage = _runtimeApplyStage,
                     detail = _runtimeApplyDetail,
                     isActive = _runtimeApplyActive,
+                    requestId = _runtimeApplyRequestId,
                     updatedLocal = _runtimeApplyUpdatedUtc.HasValue
                         ? _runtimeApplyUpdatedUtc.Value.ToLocalTime().ToString(_timestampFormat, CultureInfo.InvariantCulture)
                         : string.Empty

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -379,6 +379,8 @@ public sealed partial class MainWindow : Window {
     private string _runtimeApplyDetail = string.Empty;
     private bool _runtimeApplyActive;
     private DateTime? _runtimeApplyUpdatedUtc;
+    private long _runtimeApplyRequestId;
+    private long _runtimeApplyRequestCounter;
 
     private sealed class ConversationRuntime {
         public required string Id { get; init; }
@@ -406,7 +408,8 @@ public sealed partial class MainWindow : Window {
         string? ApiKey,
         bool ClearBasicAuth,
         bool ClearApiKey,
-        bool ForceModelRefresh);
+        bool ForceModelRefresh,
+        long RequestId);
 
     private sealed record TurnMetricsSnapshot(
         DateTime CompletedUtc,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -1301,7 +1301,11 @@
     var simpleHint = byId("optLocalSimpleHint");
     if (simpleHint) {
       if (isApplying) {
-        simpleHint.textContent = "Applying runtime settings. Please wait while the runtime updates.";
+        if (normalizeModelText(runtimeApply.stage || "").toLowerCase() === "queued") {
+          simpleHint.textContent = "Runtime switch queued. Current apply will finish first, then latest settings are applied.";
+        } else {
+          simpleHint.textContent = "Applying runtime settings. Please wait while the runtime updates.";
+        }
       } else if (transport === "native") {
         simpleHint.textContent = "ChatGPT runtime is active. Switch to LM Studio runtime to use local models.";
       } else if (isCopilotCli) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
@@ -252,6 +252,25 @@
     renderDebugPanel();
   };
 
+  function normalizeRuntimeApplyRequestId(value) {
+    var parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      return 0;
+    }
+    parsed = Math.floor(parsed);
+    return parsed > 0 ? parsed : 0;
+  }
+
+  function resolveRuntimeApplyRequestId(localModel) {
+    if (!localModel || typeof localModel !== "object") {
+      return 0;
+    }
+    var runtimeApply = localModel.runtimeApply && typeof localModel.runtimeApply === "object"
+      ? localModel.runtimeApply
+      : {};
+    return normalizeRuntimeApplyRequestId(runtimeApply.requestId);
+  }
+
   window.ixSetOptionsData = function(nextOptions) {
     nextOptions = nextOptions || {};
     state.options.timestampMode = nextOptions.timestampMode || state.options.timestampMode;
@@ -265,7 +284,25 @@
     state.options.activeConversationId = nextOptions.activeConversationId || state.options.activeConversationId;
     state.options.conversations = nextOptions.conversations || [];
     state.options.profile = nextOptions.profile || state.options.profile;
-    state.options.localModel = nextOptions.localModel || state.options.localModel;
+    var currentLocalModel = state.options.localModel && typeof state.options.localModel === "object"
+      ? state.options.localModel
+      : null;
+    var incomingLocalModel = nextOptions.localModel && typeof nextOptions.localModel === "object"
+      ? nextOptions.localModel
+      : currentLocalModel;
+    if (incomingLocalModel && currentLocalModel) {
+      var incomingRequestId = resolveRuntimeApplyRequestId(incomingLocalModel);
+      var currentRequestId = resolveRuntimeApplyRequestId(currentLocalModel);
+      if (currentRequestId > 0 && incomingRequestId > 0 && incomingRequestId < currentRequestId) {
+        incomingLocalModel.runtimeApply = currentLocalModel.runtimeApply;
+        incomingLocalModel.isApplying = currentLocalModel.isApplying === true
+          || (currentLocalModel.runtimeApply && currentLocalModel.runtimeApply.isActive === true);
+      }
+    }
+    state.options.localModel = incomingLocalModel;
+    if (window.ixRememberRuntimeApplyRequestId && incomingLocalModel) {
+      window.ixRememberRuntimeApplyRequestId(resolveRuntimeApplyRequestId(incomingLocalModel));
+    }
     state.options.policy = nextOptions.policy || null;
     var incomingPacks = Array.isArray(nextOptions.packs) ? nextOptions.packs : [];
     var incomingTools = Array.isArray(nextOptions.tools) ? nextOptions.tools : [];

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -896,6 +896,28 @@
   var scheduledLocalProviderApplyTimer = 0;
   var localProviderAutoApplyDelayMs = 220;
   var pendingLocalProviderApply = null;
+  var localProviderApplyRequestId = 0;
+
+  function normalizeRuntimeApplyRequestId(value) {
+    var parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      return 0;
+    }
+    parsed = Math.floor(parsed);
+    return parsed > 0 ? parsed : 0;
+  }
+
+  function nextLocalProviderApplyRequestId() {
+    localProviderApplyRequestId = localProviderApplyRequestId + 1;
+    return localProviderApplyRequestId;
+  }
+
+  window.ixRememberRuntimeApplyRequestId = function(value) {
+    var normalized = normalizeRuntimeApplyRequestId(value);
+    if (normalized > localProviderApplyRequestId) {
+      localProviderApplyRequestId = normalized;
+    }
+  };
 
   function clearScheduledLocalProviderApply() {
     if (scheduledLocalProviderApplyTimer) {
@@ -940,6 +962,7 @@
     clearScheduledLocalProviderApply();
     var local = ((state.options || {}).localModel || {});
     var wasApplying = local.isApplying === true;
+    var requestId = nextLocalProviderApplyRequestId();
     var transport = normalizeLocalTransportValue(byId("optLocalTransport").value || "native");
     var baseUrl = transportUsesCompatibleHttp(transport)
       ? (byId("optLocalBaseUrl").value || "").trim()
@@ -1039,9 +1062,11 @@
         : "Applying runtime settings...";
       runtimeApply.isActive = true;
       runtimeApply.updatedLocal = "";
+      runtimeApply.requestId = requestId;
       renderLocalModelOptions();
     }
     post("apply_local_provider", {
+      requestId: requestId,
       transport: transport,
       baseUrl: baseUrl,
       model: model,


### PR DESCRIPTION
## Summary
- add per-apply equestId propagation from runtime options UI to app runtime apply handling
- include untimeApply.requestId in published options state and keep server-side apply request counters monotonic
- guard options sync in the browser so stale lower-id runtime apply payloads cannot overwrite newer queued/applying state
- improve queued-stage hint text so users see clear progress while a prior switch is still in flight

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter UiShellAssetsTests
- dotnet build IntelligenceX.sln -c Release
