### PR TITLE
Normalize AD domain scope argument reads

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainAdminsSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainAdminsSummaryTool.cs
@@ -53,9 +53,9 @@ public sealed class AdDomainAdminsSummaryTool : ActiveDirectoryToolBase, ITool {
             var summary = await DomainAdminsSummaryService
                 .QueryAsync(
                     new DomainAdminsSummaryQueryOptions {
-                        DomainControllerHint = arguments?.GetString("domain_controller") ?? Options.DomainController,
-                        SearchBaseDnHint = arguments?.GetString("search_base_dn") ?? Options.DefaultSearchBaseDn,
-                        DomainName = arguments?.GetString("domain_name"),
+                        DomainControllerHint = ToolArgs.GetOptionalTrimmed(arguments, "domain_controller") ?? Options.DomainController,
+                        SearchBaseDnHint = ToolArgs.GetOptionalTrimmed(arguments, "search_base_dn") ?? Options.DefaultSearchBaseDn,
+                        DomainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name"),
                         IncludeNested = includeNested,
                         UsersOnly = usersOnly,
                         ComputersOnly = computersOnly,
@@ -72,4 +72,3 @@ public sealed class AdDomainAdminsSummaryTool : ActiveDirectoryToolBase, ITool {
         }
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPrivilegedGroupsSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPrivilegedGroupsSummaryTool.cs
@@ -50,9 +50,9 @@ public sealed class AdPrivilegedGroupsSummaryTool : ActiveDirectoryToolBase, ITo
         var summary = await PrivilegedGroupsSummaryService
             .QueryAsync(
                 new PrivilegedGroupsSummaryQueryOptions {
-                    DomainControllerHint = arguments?.GetString("domain_controller") ?? Options.DomainController,
-                    SearchBaseDnHint = arguments?.GetString("search_base_dn") ?? Options.DefaultSearchBaseDn,
-                    DomainName = arguments?.GetString("domain_name"),
+                    DomainControllerHint = ToolArgs.GetOptionalTrimmed(arguments, "domain_controller") ?? Options.DomainController,
+                    SearchBaseDnHint = ToolArgs.GetOptionalTrimmed(arguments, "search_base_dn") ?? Options.DefaultSearchBaseDn,
+                    DomainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name"),
                     IncludeMemberCount = includeMemberCount,
                     IncludeMemberSample = includeMemberSample,
                     MemberSampleSize = memberSampleSize

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationSummaryTool.cs
@@ -76,8 +76,8 @@ public sealed class AdReplicationSummaryTool : ActiveDirectoryToolBase, ITool {
 
         var result = ReplicationSummaryQueryService.Query(
             new ReplicationSummaryQueryOptions {
-                DomainController = arguments?.GetString("domain_controller"),
-                DomainName = arguments?.GetString("domain_name"),
+                DomainController = ToolArgs.GetOptionalTrimmed(arguments, "domain_controller"),
+                DomainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name"),
                 Outbound = outbound,
                 BySource = bySource,
                 StaleThresholdHours = staleThresholdHours,


### PR DESCRIPTION
## Summary
- replace raw GetString(...) reads for domain_name, domain_controller, and search_base_dn in three AD summary tools
- use shared ToolArgs.GetOptionalTrimmed(...) semantics for consistent whitespace handling and fallback behavior
- keep tool behavior unchanged except that whitespace-only argument values now normalize to null/fallback consistently

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release