### PR TITLE
Share optional AD domain query hint resolution

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/ActiveDirectoryToolBase.cs
@@ -171,6 +171,17 @@ public abstract class ActiveDirectoryToolBase : ToolBase {
     }
 
     /// <summary>
+    /// Resolves optional domain query hints with shared trimming and option fallback semantics.
+    /// </summary>
+    protected (string? DomainName, string? SearchBaseDnHint, string? DomainControllerHint) ResolveOptionalDomainQueryHints(
+        JsonObject? arguments) {
+        return (
+            DomainName: ToolArgs.GetOptionalTrimmed(arguments, "domain_name"),
+            SearchBaseDnHint: ToolArgs.GetOptionalTrimmed(arguments, "search_base_dn") ?? Options.DefaultSearchBaseDn,
+            DomainControllerHint: ToolArgs.GetOptionalTrimmed(arguments, "domain_controller") ?? Options.DomainController);
+    }
+
+    /// <summary>
     /// Resolves tool-requested AD attribute list via ADPlayground policy helper.
     /// </summary>
     protected static List<string> ResolveAttributes(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainAdminsSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDomainAdminsSummaryTool.cs
@@ -48,14 +48,15 @@ public sealed class AdDomainAdminsSummaryTool : ActiveDirectoryToolBase, ITool {
         var includeMembers = arguments?.GetBoolean("include_members") ?? true;
 
         var maxResults = ResolveMaxResults(arguments, nonPositiveBehavior: MaxResultsNonPositiveBehavior.DefaultToOptionCap);
+        var scopeHints = ResolveOptionalDomainQueryHints(arguments);
 
         try {
             var summary = await DomainAdminsSummaryService
                 .QueryAsync(
                     new DomainAdminsSummaryQueryOptions {
-                        DomainControllerHint = ToolArgs.GetOptionalTrimmed(arguments, "domain_controller") ?? Options.DomainController,
-                        SearchBaseDnHint = ToolArgs.GetOptionalTrimmed(arguments, "search_base_dn") ?? Options.DefaultSearchBaseDn,
-                        DomainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name"),
+                        DomainControllerHint = scopeHints.DomainControllerHint,
+                        SearchBaseDnHint = scopeHints.SearchBaseDnHint,
+                        DomainName = scopeHints.DomainName,
                         IncludeNested = includeNested,
                         UsersOnly = usersOnly,
                         ComputersOnly = computersOnly,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPrivilegedGroupsSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPrivilegedGroupsSummaryTool.cs
@@ -46,13 +46,14 @@ public sealed class AdPrivilegedGroupsSummaryTool : ActiveDirectoryToolBase, ITo
         var memberSampleSize = requestedSampleSize.HasValue && requestedSampleSize.Value > 0
             ? (int)Math.Min(requestedSampleSize.Value, MaxMembersSampleSize)
             : DefaultMembersSampleSize;
+        var scopeHints = ResolveOptionalDomainQueryHints(arguments);
 
         var summary = await PrivilegedGroupsSummaryService
             .QueryAsync(
                 new PrivilegedGroupsSummaryQueryOptions {
-                    DomainControllerHint = ToolArgs.GetOptionalTrimmed(arguments, "domain_controller") ?? Options.DomainController,
-                    SearchBaseDnHint = ToolArgs.GetOptionalTrimmed(arguments, "search_base_dn") ?? Options.DefaultSearchBaseDn,
-                    DomainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name"),
+                    DomainControllerHint = scopeHints.DomainControllerHint,
+                    SearchBaseDnHint = scopeHints.SearchBaseDnHint,
+                    DomainName = scopeHints.DomainName,
                     IncludeMemberCount = includeMemberCount,
                     IncludeMemberSample = includeMemberSample,
                     MemberSampleSize = memberSampleSize


### PR DESCRIPTION
## Summary
- add ResolveOptionalDomainQueryHints(...) in ActiveDirectoryToolBase for shared domain/search-base/DC argument normalization
- switch d_domain_admins_summary and d_privileged_groups_summary to use the shared helper
- keep behavior consistent while reducing repeated argument plumbing logic

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release