### PR TITLE
chat: improve bridge runtime auth/reasoning switching UX

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
@@ -570,30 +570,17 @@ Quick start prompts:
         if (string.Equals(normalizedTransport, TransportCopilotCli, StringComparison.OrdinalIgnoreCase)) {
             return false;
         }
-
-        if (!string.Equals(normalizedTransport, TransportCompatibleHttp, StringComparison.OrdinalIgnoreCase)) {
-            return true;
-        }
-
-        var preset = DetectCompatibleProviderPreset(baseUrl);
-        return !string.Equals(preset, "anthropic-bridge", StringComparison.OrdinalIgnoreCase)
-               && !string.Equals(preset, "gemini-bridge", StringComparison.OrdinalIgnoreCase);
+        return true;
     }
 
     private static string DescribeLocalProviderReasoningSupport(string? transport, string? baseUrl) {
         if (SupportsLocalProviderReasoningControls(transport, baseUrl)) {
-            return "enabled (provider may clamp unsupported values)";
+            return "enabled (pass-through; provider may clamp unsupported values)";
         }
 
         var normalizedTransport = NormalizeLocalProviderTransport(transport);
         if (string.Equals(normalizedTransport, TransportCopilotCli, StringComparison.OrdinalIgnoreCase)) {
             return "not exposed by Copilot subscription runtime";
-        }
-
-        var preset = DetectCompatibleProviderPreset(baseUrl);
-        if (string.Equals(preset, "anthropic-bridge", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(preset, "gemini-bridge", StringComparison.OrdinalIgnoreCase)) {
-            return "bridge preset uses provider defaults";
         }
 
         return "not exposed by current runtime profile";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -315,11 +315,11 @@ public sealed partial class MainWindow : Window {
         }
 
         if (string.Equals(compatiblePreset, "anthropic-bridge", StringComparison.OrdinalIgnoreCase)) {
-            return "Anthropic bridge runtime";
+            return "Anthropic subscription bridge runtime";
         }
 
         if (string.Equals(compatiblePreset, "gemini-bridge", StringComparison.OrdinalIgnoreCase)) {
-            return "Gemini bridge runtime";
+            return "Gemini subscription bridge runtime";
         }
 
         if (copilotConnected) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -812,18 +812,10 @@
 
   function resolveReasoningSupport(transport, compatiblePreset) {
     var normalizedTransport = normalizeLocalTransport(transport);
-    var preset = String(compatiblePreset || "manual").trim().toLowerCase();
     if (normalizedTransport === "copilot-cli") {
       return {
         supported: false,
         reason: "GitHub Copilot subscription runtime currently does not expose reasoning controls."
-      };
-    }
-    if (normalizedTransport === "compatible-http"
-      && (preset === "anthropic-bridge" || preset === "gemini-bridge")) {
-      return {
-        supported: false,
-        reason: "Experimental Anthropic/Gemini bridge presets currently use provider-default reasoning."
       };
     }
     return {
@@ -854,10 +846,10 @@
       return "Azure OpenAI runtime";
     }
     if (preset === "anthropic-bridge") {
-      return "Anthropic bridge runtime";
+      return "Anthropic subscription bridge runtime";
     }
     if (preset === "gemini-bridge") {
-      return "Gemini bridge runtime";
+      return "Gemini subscription bridge runtime";
     }
     if (copilotConnected) {
       return "GitHub Copilot runtime";
@@ -1016,11 +1008,13 @@
             ? "No Authorization header will be sent."
             : "Use API key for Bearer authentication.");
       if (compatiblePreset === "anthropic-bridge" || compatiblePreset === "gemini-bridge") {
-        authStatus = "limited";
+        authStatus = openAIAuthMode === "none" ? "limited" : "supported";
         if (openAIAuthMode === "basic") {
           authValue = "Bridge credentials (Basic)";
         }
-        authNote = "Bridge presets use endpoint credentials managed by the bridge service. Browser subscription session reuse is not wired yet.";
+        authNote = openAIAuthMode === "basic"
+          ? "Use bridge login/email and secret/token for your subscription-backed bridge session."
+          : "Subscription bridge endpoints typically expect Basic credentials (login + secret/token).";
       }
       appendRuntimeCapabilityRow(listEl, "Authentication", authStatus, authValue, authNote);
     }
@@ -1555,6 +1549,18 @@
       btnPresetAzureOpenAI.disabled = isApplying;
     }
 
+    var btnPresetAnthropicBridge = byId("btnLocalPresetAnthropicBridge");
+    if (btnPresetAnthropicBridge) {
+      btnPresetAnthropicBridge.hidden = !isCompatible;
+      btnPresetAnthropicBridge.disabled = isApplying;
+    }
+
+    var btnPresetGeminiBridge = byId("btnLocalPresetGeminiBridge");
+    if (btnPresetGeminiBridge) {
+      btnPresetGeminiBridge.hidden = !isCompatible;
+      btnPresetGeminiBridge.disabled = isApplying;
+    }
+
     var baseUrlRow = byId("optLocalBaseUrlRow");
     if (baseUrlRow) {
       baseUrlRow.hidden = !isCompatible;
@@ -1638,7 +1644,7 @@
       if (!isCompatible) {
         authHint.textContent = "";
       } else if (compatiblePreset === "anthropic-bridge" || compatiblePreset === "gemini-bridge") {
-        authHint.textContent = "Subscription bridges are experimental. Configure the bridge endpoint and usually set auth mode to Basic.";
+        authHint.textContent = "Subscription bridge runtime is active. Use bridge login/email + secret/token (usually Basic auth).";
       } else if (compatiblePreset === "azure-openai") {
         authHint.textContent = "Azure OpenAI typically uses Bearer auth and deployment-specific base URLs.";
       } else if (compatiblePreset === "openai") {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -750,16 +750,6 @@
       };
     }
 
-    if (normalizedTransport === "compatible-http") {
-      var preset = detectCompatibleProviderPreset(baseUrl);
-      if (preset === "anthropic-bridge" || preset === "gemini-bridge") {
-        return {
-          supported: false,
-          reason: "Experimental Anthropic/Gemini bridge presets currently use provider-default reasoning."
-        };
-      }
-    }
-
     return {
       supported: true,
       reason: ""
@@ -872,18 +862,18 @@
     }
     if (basicUsername) {
       if (key === "anthropic-bridge") {
-        basicUsername.placeholder = "Anthropic login/email";
+        basicUsername.placeholder = "Anthropic bridge login/email";
       } else if (key === "gemini-bridge") {
-        basicUsername.placeholder = "Gemini login/email";
+        basicUsername.placeholder = "Gemini bridge login/email";
       } else {
         basicUsername.placeholder = "Leave blank to keep current value";
       }
     }
     if (basicPassword) {
       if (key === "anthropic-bridge") {
-        basicPassword.placeholder = "Anthropic password/session secret";
+        basicPassword.placeholder = "Anthropic bridge secret/token";
       } else if (key === "gemini-bridge") {
-        basicPassword.placeholder = "Gemini password/session secret";
+        basicPassword.placeholder = "Gemini bridge secret/token";
       } else {
         basicPassword.placeholder = "Leave blank to keep existing secret";
       }
@@ -1260,6 +1250,8 @@
     if (autoDetectButton) {
       autoDetectButton.hidden = !isCompatible;
     }
+
+    scheduleLocalProviderApply(false);
   });
 
   byId("optLocalProviderPreset").addEventListener("change", function(e) {
@@ -1268,12 +1260,42 @@
       applyCompatiblePresetSelection(preset);
     }
     syncCustomSelect(e.target);
+    scheduleLocalProviderApply(false);
   });
 
   byId("optLocalAuthMode").addEventListener("change", function(e) {
     e.target.value = normalizeCompatibleAuthMode(e.target.value || "bearer");
     syncCustomSelect(e.target);
     byId("optLocalTransport").dispatchEvent(new Event("change"));
+    scheduleLocalProviderApply(false);
+  });
+
+  byId("optLocalBaseUrl").addEventListener("change", function() {
+    scheduleLocalProviderApply(false);
+  });
+
+  byId("optLocalApiKey").addEventListener("change", function() {
+    scheduleLocalProviderApply(false);
+  });
+
+  byId("optLocalModelInput").addEventListener("change", function() {
+    scheduleLocalProviderApply(false);
+  });
+
+  byId("optReasoningEffort").addEventListener("change", function() {
+    scheduleLocalProviderApply(false);
+  });
+
+  byId("optReasoningSummary").addEventListener("change", function() {
+    scheduleLocalProviderApply(false);
+  });
+
+  byId("optTextVerbosity").addEventListener("change", function() {
+    scheduleLocalProviderApply(false);
+  });
+
+  byId("optTemperature").addEventListener("change", function() {
+    scheduleLocalProviderApply(false);
   });
 
   byId("optLocalBasicUsername").addEventListener("change", function() {
@@ -1300,6 +1322,7 @@
     if (modelInput) {
       modelInput.value = selected;
     }
+    scheduleLocalProviderApply(false);
   });
 
   byId("optNativeAccountSlot").addEventListener("change", function(e) {
@@ -1372,6 +1395,16 @@
 
   byId("btnLocalPresetAzureOpenAI").addEventListener("click", function() {
     applyCompatiblePresetSelection("azure-openai");
+    applyLocalProviderSettings(true);
+  });
+
+  byId("btnLocalPresetAnthropicBridge").addEventListener("click", function() {
+    applyCompatiblePresetSelection("anthropic-bridge");
+    applyLocalProviderSettings(true);
+  });
+
+  byId("btnLocalPresetGeminiBridge").addEventListener("click", function() {
+    applyCompatiblePresetSelection("gemini-bridge");
     applyLocalProviderSettings(true);
   });
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -234,8 +234,8 @@
                 <option value="ollama">Ollama (local)</option>
                 <option value="openai">OpenAI API</option>
                 <option value="azure-openai">Azure OpenAI</option>
-                <option value="anthropic-bridge">Anthropic bridge (experimental)</option>
-                <option value="gemini-bridge">Gemini bridge (experimental)</option>
+                <option value="anthropic-bridge">Anthropic subscription bridge</option>
+                <option value="gemini-bridge">Gemini subscription bridge</option>
               </select>
             </div>
             <div class="options-row" id="optLocalTransportRow">
@@ -271,7 +271,7 @@
               <input id="optLocalBasicPassword" type="password" class="options-input options-input-sm" placeholder="Leave blank to keep existing secret" autocomplete="off" />
             </div>
             <div class="options-note" id="optLocalApiKeyHint">Use Clear Saved API Key to remove the currently stored key.</div>
-            <div class="options-note" id="optLocalAuthHint">Compatible HTTP supports Bearer/API key or Basic auth. Anthropic/Gemini subscription bridges are experimental and require a bridge endpoint.</div>
+            <div class="options-note" id="optLocalAuthHint">Compatible HTTP supports Bearer/API key or Basic auth. Anthropic/Gemini subscriptions use a bridge endpoint with bridge-managed credentials.</div>
             <div class="options-note">Auto Detect scans LM Studio/Ollama endpoints. Compatible HTTP also supports API key providers (Azure/OpenAI-compatible endpoints).</div>
             <div class="options-actions options-actions-wrap">
               <button id="btnAutoDetectLocalRuntime" class="options-btn options-btn-sm">Auto Detect Runtime</button>
@@ -279,6 +279,8 @@
               <button id="btnLocalPresetOllama" class="options-btn options-btn-sm options-btn-ghost">Use Ollama Runtime</button>
               <button id="btnLocalPresetOpenAI" class="options-btn options-btn-sm options-btn-ghost">Use OpenAI API</button>
               <button id="btnLocalPresetAzureOpenAI" class="options-btn options-btn-sm options-btn-ghost">Use Azure OpenAI</button>
+              <button id="btnLocalPresetAnthropicBridge" class="options-btn options-btn-sm options-btn-ghost">Use Anthropic Bridge</button>
+              <button id="btnLocalPresetGeminiBridge" class="options-btn options-btn-sm options-btn-ghost">Use Gemini Bridge</button>
               <button id="btnLocalPresetCopilot" class="options-btn options-btn-sm options-btn-ghost">Use Copilot Endpoint (API key)</button>
               <button id="btnClearLocalApiKey" class="options-btn options-btn-sm options-btn-ghost">Clear Saved API Key</button>
               <button id="btnClearLocalBasicAuth" class="options-btn options-btn-sm options-btn-ghost">Clear Saved Basic Auth</button>


### PR DESCRIPTION
## Summary
- remove the Anthropic/Gemini bridge "experimental" gating in runtime UX and capability messaging
- allow reasoning controls to pass through for bridge-compatible runtimes (Copilot subscription remains explicitly unsupported)
- add direct advanced-runtime preset buttons for Anthropic and Gemini bridges for faster switching
- improve runtime fluidity by scheduling live apply on key runtime form changes (transport, preset, auth mode, model, reasoning, base URL, API key)
- improve bridge auth copy/placeholders to clearly use bridge login/email + secret/token semantics

## Why
This keeps runtime switching end-to-end live without restart behavior, makes bridge auth workflows clearer, and makes model/reasoning/runtime edits feel immediate with visible queued/applying progress.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter UiShellAssetsTests`
- `dotnet build IntelligenceX.sln -c Release`
