### PR TITLE
Align AD analyzer fixture with canonical max helper

### DIFF
--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityAdRequiredDomainHelper.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityAdRequiredDomainHelper.cs
@@ -35,7 +35,7 @@ public sealed class SampleBadAdDomainTool : ActiveDirectoryToolBase, ITool {
 
     protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
         var domainName = ToolArgs.GetOptionalTrimmed(arguments, "domain_name");
-        var maxResults = ToolArgs.GetOptionBoundedInt32(arguments, "max_results", 1000);
+        var maxResults = ResolveMaxResults(arguments);
         return Task.FromResult(ToolResponse.Ok(new {
             domainName,
             maxResults


### PR DESCRIPTION
## Summary
- update the internal AD required-domain analyzer fixture sample to use ResolveMaxResults(arguments)
- keep the sample intentionally non-canonical for required domain handling only, so the finding focus stays clear
- reduce mixed helper guidance in analyzer fixture code

## Validation
- dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll