### PR TITLE
Clarify EventLog max-results helper semantics

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEvtxFindTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEvtxFindTool.cs
@@ -87,7 +87,7 @@ public sealed class EventLogEvtxFindTool : EventLogToolBase, ITool {
 
         var query = (arguments?.GetString("query") ?? string.Empty).Trim();
         var logHint = (arguments?.GetString("log_name") ?? string.Empty).Trim();
-        var maxResults = ResolveMaxResults(arguments, MaxDefaultResults, maxInclusive: MaxMaxResults);
+        var maxResults = ResolveCappedMaxResults(arguments, defaultValue: MaxDefaultResults, maxInclusive: MaxMaxResults);
         var maxDepth = Options.EvtxFindMaxDepth;
         var maxDirsScanned = Options.EvtxFindMaxDirsScanned;
         var maxFilesScanned = Options.EvtxFindMaxFilesScanned;

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsCatalogTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsCatalogTool.cs
@@ -64,7 +64,7 @@ public sealed class EventLogNamedEventsCatalogTool : EventLogToolBase, ITool {
         var availableOnly = ToolArgs.GetBoolean(arguments, "available_only");
         var includeEventIds = arguments?.GetBoolean("include_event_ids") ?? true;
         var maxEventIdsPerRow = ToolArgs.GetCappedInt32(arguments, "max_event_ids_per_row", 32, 1, MaxEventIdsPerRowCap);
-        var maxResults = ResolveMaxResults(arguments);
+        var maxResults = ResolveOptionBoundedMaxResults(arguments);
 
         var categoriesFilter = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("categories"));
         List<string>? categories = null;

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogToolBase.cs
@@ -131,12 +131,22 @@ public abstract class EventLogToolBase : ToolBase {
     }
 
     /// <summary>
-    /// Resolves max_results with optional explicit defaults/caps.
+    /// Resolves <c>max_results</c> using the standard option-bounded behavior.
     /// </summary>
-    protected int ResolveMaxResults(JsonObject? arguments, int? defaultValue = null, int minInclusive = 1, int? maxInclusive = null) {
-        var normalizedDefault = defaultValue ?? Options.MaxResults;
+    protected int ResolveOptionBoundedMaxResults(JsonObject? arguments, int minInclusive = 1) {
+        return ResolveBoundedOptionLimit(arguments, "max_results", minInclusive);
+    }
+
+    /// <summary>
+    /// Resolves <c>max_results</c> using an explicit default and optional explicit cap.
+    /// </summary>
+    protected int ResolveCappedMaxResults(
+        JsonObject? arguments,
+        int defaultValue,
+        int minInclusive = 1,
+        int? maxInclusive = null) {
         var normalizedMax = maxInclusive ?? Options.MaxResults;
-        return ToolArgs.GetCappedInt32(arguments, "max_results", normalizedDefault, minInclusive, normalizedMax);
+        return ToolArgs.GetCappedInt32(arguments, "max_results", defaultValue, minInclusive, normalizedMax);
     }
 
     /// <summary>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogToolBaseHelperTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogToolBaseHelperTests.cs
@@ -23,13 +23,23 @@ public class EventLogToolBaseHelperTests {
     }
 
     [Fact]
-    public void ResolveMaxResults_ShouldHonorExplicitDefaultAndCap() {
+    public void ResolveCappedMaxResults_ShouldHonorExplicitDefaultAndCap() {
         var tool = new HarnessTool(maxResults: 200);
 
-        Assert.Equal(20, tool.ResolveMax(arguments: null, defaultValue: 20, maxInclusive: 80));
-        Assert.Equal(1, tool.ResolveMax(new JsonObject().Add("max_results", 0), defaultValue: 20, maxInclusive: 80));
-        Assert.Equal(80, tool.ResolveMax(new JsonObject().Add("max_results", 500), defaultValue: 20, maxInclusive: 80));
-        Assert.Equal(35, tool.ResolveMax(new JsonObject().Add("max_results", 35), defaultValue: 20, maxInclusive: 80));
+        Assert.Equal(20, tool.ResolveCappedMax(arguments: null, defaultValue: 20, maxInclusive: 80));
+        Assert.Equal(1, tool.ResolveCappedMax(new JsonObject().Add("max_results", 0), defaultValue: 20, maxInclusive: 80));
+        Assert.Equal(80, tool.ResolveCappedMax(new JsonObject().Add("max_results", 500), defaultValue: 20, maxInclusive: 80));
+        Assert.Equal(35, tool.ResolveCappedMax(new JsonObject().Add("max_results", 35), defaultValue: 20, maxInclusive: 80));
+    }
+
+    [Fact]
+    public void ResolveOptionBoundedMaxResults_ShouldUseSharedOptionBoundedBehavior() {
+        var tool = new HarnessTool(maxResults: 60);
+
+        Assert.Equal(60, tool.ResolveOptionBoundedMax(arguments: null));
+        Assert.Equal(1, tool.ResolveOptionBoundedMax(new JsonObject().Add("max_results", 0)));
+        Assert.Equal(60, tool.ResolveOptionBoundedMax(new JsonObject().Add("max_results", 999)));
+        Assert.Equal(22, tool.ResolveOptionBoundedMax(new JsonObject().Add("max_results", 22)));
     }
 
     [Fact]
@@ -117,8 +127,12 @@ public class EventLogToolBaseHelperTests {
             return ResolveBoundedOptionLimit(arguments, argumentName);
         }
 
-        public int ResolveMax(JsonObject? arguments, int? defaultValue = null, int? maxInclusive = null) {
-            return ResolveMaxResults(arguments, defaultValue, maxInclusive: maxInclusive);
+        public int ResolveCappedMax(JsonObject? arguments, int defaultValue, int? maxInclusive = null) {
+            return ResolveCappedMaxResults(arguments, defaultValue, maxInclusive: maxInclusive);
+        }
+
+        public int ResolveOptionBoundedMax(JsonObject? arguments) {
+            return ResolveOptionBoundedMaxResults(arguments);
         }
 
         public static void AddMax(JsonObject meta, int maxResults) {


### PR DESCRIPTION
## Summary
- replace ambiguous EventLog ResolveMaxResults(...) helper with explicit helpers:
  - ResolveOptionBoundedMaxResults(...) for option-bounded behavior
  - ResolveCappedMaxResults(...) for explicit default/cap behavior
- update EventLog tool call sites to use the correct explicit helper
- update EventLog helper tests to lock both semantics clearly

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release