### PR TITLE
Update tool playbook for explicit EventLog max helpers

### DIFF
--- a/InternalDocs/agent-playbooks/tool-authoring-playbook.md
+++ b/InternalDocs/agent-playbooks/tool-authoring-playbook.md
@@ -56,7 +56,10 @@ Internal guidance for adding or refactoring tools with minimal duplication and s
   - For standard domain table flows, prefer `ExecuteDomainRowsViewTool(...)` so required-domain parsing stays centralized.
   - For metadata, prefer `AddDomainAndMaxResultsMeta(...)` when applicable.
 - System/EventLog/FileSystem tools:
-  - Keep argument limits option-bounded (`ResolveBoundedOptionLimit`/`ResolveMaxResults`).
+  - Keep argument limits option-bounded by default (`ResolveBoundedOptionLimit` / package `ResolveMaxResults`).
+  - In EventLog tools, use explicit helpers to avoid semantic drift:
+    - `ResolveOptionBoundedMaxResults(...)` for option-bounded `max_results`.
+    - `ResolveCappedMaxResults(...)` only when you need an explicit default/cap different from package options.
   - For non-positive semantics, use canonical `ToolArgs.GetOptionBoundedInt32(..., nonPositiveBehavior, defaultValue)` instead of mixing ad-hoc helper variants.
   - Keep error mapping centralized in package base helpers.
 


### PR DESCRIPTION
## Summary
- update 	ool-authoring-playbook.md guidance to reflect explicit EventLog max-results helper semantics
- document when to use ResolveOptionBoundedMaxResults(...) vs ResolveCappedMaxResults(...)
- keep package-level authoring guidance aligned with current helper contracts to reduce future misuse

## Validation
- docs-only change (no runtime behavior changes)