### PR TITLE
Centralize internal maintainability dispatch mapping

### DIFF
--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.InternalMaintainability.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.InternalMaintainability.cs
@@ -65,37 +65,68 @@ internal static partial class AnalyzeRunCommand {
         GeneratedHeaderLinesTagPrefix,
         ExcludedDirectoryTagPrefix
     };
+    private static readonly Func<AnalysisRule, bool> NeverMatchInternalRule = static _ => false;
     // Handler order defines first-match precedence when predicates overlap.
     private static readonly InternalMaintainabilityRuleHandler[] InternalMaintainabilityRuleHandlers = {
-        new(IsMaxLinesRule, static (rules, sourceFiles, excludedOutputPath, warnings) =>
+        new(
+            "max-lines",
+            new[] { InternalMaxLinesRuleId },
+            IsMaxLinesRule,
+            static (rules, sourceFiles, excludedOutputPath, warnings) =>
             new InternalMaintainabilityResult(
                 RunMaxLinesChecks(rules, sourceFiles, excludedOutputPath, warnings),
                 Array.Empty<DuplicationRuleMetrics>())),
-        new(IsDuplicationRule, static (rules, sourceFiles, excludedOutputPath, warnings) => {
+        new(
+            "duplication",
+            new[] { InternalDuplicationRuleId },
+            IsDuplicationRule,
+            static (rules, sourceFiles, excludedOutputPath, warnings) => {
             var result = RunDuplicationChecks(rules, sourceFiles, excludedOutputPath, warnings);
             return new InternalMaintainabilityResult(result.Findings, result.RuleMetrics);
         }),
-        new(IsWriteToolSchemaRule, static (rules, sourceFiles, excludedOutputPath, warnings) =>
+        new(
+            "write-tool-schema",
+            new[] { InternalWriteToolSchemaRuleId },
+            NeverMatchInternalRule,
+            static (rules, sourceFiles, excludedOutputPath, warnings) =>
             new InternalMaintainabilityResult(
                 RunWriteToolSchemaChecks(rules, sourceFiles, excludedOutputPath, warnings),
                 Array.Empty<DuplicationRuleMetrics>())),
-        new(IsAdRequiredDomainHelperRule, static (rules, sourceFiles, excludedOutputPath, warnings) =>
+        new(
+            "ad-required-domain-helper",
+            new[] { InternalAdRequiredDomainHelperRuleId },
+            NeverMatchInternalRule,
+            static (rules, sourceFiles, excludedOutputPath, warnings) =>
             new InternalMaintainabilityResult(
                 RunAdRequiredDomainHelperChecks(rules, sourceFiles, excludedOutputPath, warnings),
                 Array.Empty<DuplicationRuleMetrics>())),
-        new(IsMaxResultsMetaHelperRule, static (rules, sourceFiles, excludedOutputPath, warnings) =>
+        new(
+            "max-results-meta-helper",
+            new[] { InternalMaxResultsMetaHelperRuleId },
+            NeverMatchInternalRule,
+            static (rules, sourceFiles, excludedOutputPath, warnings) =>
             new InternalMaintainabilityResult(
                 RunMaxResultsMetaHelperChecks(rules, sourceFiles, excludedOutputPath, warnings),
                 Array.Empty<DuplicationRuleMetrics>())),
-        new(IsCanonicalBoundedIntHelperRule, static (rules, sourceFiles, excludedOutputPath, warnings) =>
+        new(
+            "canonical-bounded-int-helper",
+            new[] { InternalCanonicalBoundedIntHelperRuleId },
+            NeverMatchInternalRule,
+            static (rules, sourceFiles, excludedOutputPath, warnings) =>
             new InternalMaintainabilityResult(
                 RunCanonicalBoundedIntHelperChecks(rules, sourceFiles, excludedOutputPath, warnings),
                 Array.Empty<DuplicationRuleMetrics>())),
-        new(IsEventLogMaxResultsHelperRule, static (rules, sourceFiles, excludedOutputPath, warnings) =>
+        new(
+            "eventlog-max-results-helper",
+            new[] { InternalEventLogMaxResultsHelperRuleId },
+            NeverMatchInternalRule,
+            static (rules, sourceFiles, excludedOutputPath, warnings) =>
             new InternalMaintainabilityResult(
                 RunEventLogMaxResultsHelperChecks(rules, sourceFiles, excludedOutputPath, warnings),
                 Array.Empty<DuplicationRuleMetrics>()))
     };
+    private static readonly IReadOnlyDictionary<string, int> InternalMaintainabilityRuleIdToHandlerIndex =
+        BuildInternalMaintainabilityRuleIdToHandlerIndex();
     private static readonly Regex PowerShellTokenRegex = new(
         "\"(?:`.|[^\"])*\"|'(?:''|[^'])*'|\\$[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_-]*|\\d+(?:\\.\\d+)?|==|!=|<=|>=|\\+=|-=|\\*=|/=|%=|&&|\\|\\||::|=>|\\+\\+|--|[-+*/%=!<>|&.:?]+|[()\\[\\]{};,]",
         RegexOptions.Compiled);
@@ -229,18 +260,7 @@ internal static partial class AnalyzeRunCommand {
         var mappedRulesByHandler = new List<AnalysisPolicyRule>[InternalMaintainabilityRuleHandlers.Length];
         var mappedRuleCount = 0;
         foreach (var policyRule in rules.Where(static rule => rule?.Rule is not null)) {
-            var firstMatchIndex = -1;
-            var matchCount = 0;
-            for (var i = 0; i < InternalMaintainabilityRuleHandlers.Length; i++) {
-                if (!InternalMaintainabilityRuleHandlers[i].Matches(policyRule.Rule)) {
-                    continue;
-                }
-
-                if (firstMatchIndex < 0) {
-                    firstMatchIndex = i;
-                }
-                matchCount++;
-            }
+            var (firstMatchIndex, matchCount) = ResolveInternalMaintainabilityHandler(policyRule.Rule);
 
             if (firstMatchIndex < 0) {
                 warnings.Add(
@@ -706,39 +726,56 @@ internal static partial class AnalyzeRunCommand {
             HasTagWithPrefix(rule.Tags, MaxDuplicationPercentByLanguageTagPrefix);
     }
 
-    private static bool IsWriteToolSchemaRule(AnalysisRule rule) {
+    private static (int FirstMatchIndex, int MatchCount) ResolveInternalMaintainabilityHandler(AnalysisRule rule) {
         if (rule is null) {
-            return false;
+            return (-1, 0);
         }
-        return rule.Id.Equals(InternalWriteToolSchemaRuleId, StringComparison.OrdinalIgnoreCase);
+
+        var firstMatchIndex = -1;
+        var matchCount = 0;
+        if (!string.IsNullOrWhiteSpace(rule.Id) &&
+            InternalMaintainabilityRuleIdToHandlerIndex.TryGetValue(rule.Id, out var canonicalHandlerIndex)) {
+            firstMatchIndex = canonicalHandlerIndex;
+            matchCount = 1;
+        }
+
+        for (var i = 0; i < InternalMaintainabilityRuleHandlers.Length; i++) {
+            if (i == firstMatchIndex) {
+                continue;
+            }
+
+            if (!InternalMaintainabilityRuleHandlers[i].MatchesFallback(rule)) {
+                continue;
+            }
+
+            if (firstMatchIndex < 0) {
+                firstMatchIndex = i;
+            }
+            matchCount++;
+        }
+
+        return (firstMatchIndex, matchCount);
     }
 
-    private static bool IsAdRequiredDomainHelperRule(AnalysisRule rule) {
-        if (rule is null) {
-            return false;
-        }
-        return rule.Id.Equals(InternalAdRequiredDomainHelperRuleId, StringComparison.OrdinalIgnoreCase);
-    }
+    private static IReadOnlyDictionary<string, int> BuildInternalMaintainabilityRuleIdToHandlerIndex() {
+        var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < InternalMaintainabilityRuleHandlers.Length; i++) {
+            var ruleIds = InternalMaintainabilityRuleHandlers[i].CanonicalRuleIds;
+            if (ruleIds is null || ruleIds.Count == 0) {
+                continue;
+            }
 
-    private static bool IsMaxResultsMetaHelperRule(AnalysisRule rule) {
-        if (rule is null) {
-            return false;
-        }
-        return rule.Id.Equals(InternalMaxResultsMetaHelperRuleId, StringComparison.OrdinalIgnoreCase);
-    }
+            foreach (var ruleId in ruleIds.Where(static id => !string.IsNullOrWhiteSpace(id))) {
+                if (map.TryAdd(ruleId, i)) {
+                    continue;
+                }
 
-    private static bool IsCanonicalBoundedIntHelperRule(AnalysisRule rule) {
-        if (rule is null) {
-            return false;
+                throw new InvalidOperationException(
+                    $"Internal maintainability rule id '{ruleId}' is registered by multiple handlers.");
+            }
         }
-        return rule.Id.Equals(InternalCanonicalBoundedIntHelperRuleId, StringComparison.OrdinalIgnoreCase);
-    }
 
-    private static bool IsEventLogMaxResultsHelperRule(AnalysisRule rule) {
-        if (rule is null) {
-            return false;
-        }
-        return rule.Id.Equals(InternalEventLogMaxResultsHelperRuleId, StringComparison.OrdinalIgnoreCase);
+        return map;
     }
 
     private sealed class SourceFileEntry {
@@ -747,7 +784,9 @@ internal static partial class AnalyzeRunCommand {
     }
 
     private sealed record InternalMaintainabilityRuleHandler(
-        Func<AnalysisRule, bool> Matches,
+        string Name,
+        IReadOnlyList<string> CanonicalRuleIds,
+        Func<AnalysisRule, bool> MatchesFallback,
         Func<IReadOnlyList<AnalysisPolicyRule>, IReadOnlyList<SourceFileEntry>, string?, List<string>,
             InternalMaintainabilityResult> Run);
 

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityRuleDispatch.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityRuleDispatch.cs
@@ -62,6 +62,46 @@ internal static partial class Program {
         }
     }
 
+    private static void TestAnalyzeRunInternalMaintainabilityResolvesCanonicalRuleIdRegistration() {
+        var temp = Path.Combine(Path.GetTempPath(),
+            "ix-analyze-internal-dispatch-canonical-rule-id-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        try {
+            SetupInternalMaintainabilityDispatchWorkspace(temp, "IXTOOL005", new[] {
+                "include-ext:cs"
+            });
+
+            var eventLogDir = Path.Combine(temp, "IntelligenceX.Tools", "IntelligenceX.Tools.EventLog");
+            Directory.CreateDirectory(eventLogDir);
+            File.WriteAllText(Path.Combine(eventLogDir, "SampleDispatchEventLogTool.cs"), """
+using IntelligenceX.Json;
+
+namespace IntelligenceX.Tools.EventLog;
+
+public sealed class SampleDispatchEventLogTool {
+    public int Read(JsonObject? arguments) {
+        return ResolveMaxResults(arguments);
+    }
+}
+""");
+
+            var output = Path.Combine(temp, "artifacts");
+            var result = RunAnalyzeWithConsoleOutput(temp, Path.Combine(temp, ".intelligencex", "reviewer.json"), output);
+
+            AssertEqual(0, result.ExitCode, "analyze run internal dispatch canonical rule-id registration exit");
+            AssertEqual(false, result.Output.Contains("no registered handler", StringComparison.OrdinalIgnoreCase),
+                "analyze run internal dispatch canonical rule-id registration no unmapped warning");
+            var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
+            AssertEqual(true, findings.Any(item =>
+                    item.RuleId.Equals("IXTOOL005", StringComparison.OrdinalIgnoreCase) &&
+                    item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.EventLog/SampleDispatchEventLogTool.cs",
+                        StringComparison.OrdinalIgnoreCase)),
+                "analyze run internal dispatch canonical rule-id registration finding");
+        } finally {
+            DeleteDirectoryIfExistsWithRetries(temp);
+        }
+    }
+
     private static void SetupInternalMaintainabilityDispatchWorkspace(string workspacePath, string ruleId,
         IReadOnlyList<string> tags) {
         Directory.CreateDirectory(Path.Combine(workspacePath, ".intelligencex"));

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -657,6 +657,8 @@ internal static partial class Program {
             TestAnalyzeRunInternalEventLogMaxResultsHelperRuleAllowsBoundedOptionForNonMaxResultsArgs);
         failed += Run("Analyze run internal EventLog max-results helper rule ignores non-EventLog tools",
             TestAnalyzeRunInternalEventLogMaxResultsHelperRuleIgnoresNonEventLogTools);
+        failed += Run("Analyze run internal maintainability resolves canonical rule-id registration",
+            TestAnalyzeRunInternalMaintainabilityResolvesCanonicalRuleIdRegistration);
         failed += Run("Analyze run internal maintainability warns on unmapped internal rule",
             TestAnalyzeRunInternalMaintainabilityWarnsOnUnmappedInternalRule);
         failed += Run("Analyze run internal maintainability warns on ambiguous internal rule match",


### PR DESCRIPTION
## Summary
- centralize internal maintainability dispatch registration by declaring canonical rule IDs directly on each handler
- auto-build a rule-id-to-handler map and fail fast on duplicate rule-id registration
- keep fallback predicate matching for tag-driven activation paths, preserving current ambiguous/unmapped warning semantics
- remove duplicated per-rule id predicate methods for IXTOOL handlers
- add a focused dispatch regression test that verifies canonical rule-id registration resolves to the expected handler (`IXTOOL005`)

## Validation
- dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- analyze validate-catalog --workspace .
- dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
- pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.ps1 -Mode fast

## Notes
- Preflight/analysis-suite observed intermittent environment-level warnings already seen in this repo context (file lock retry and transient PSScriptAnalyzer null-reference message), but suite completed successfully and reported `OK: analysis suite completed (fast)`.
