### PR TITLE
tests: centralize reviewer finding assertions

### DIFF
--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityAdRequiredDomainHelper.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityAdRequiredDomainHelper.cs
@@ -53,10 +53,8 @@ public sealed class SampleBadAdDomainTool : ActiveDirectoryToolBase, ITool {
 
             AssertEqual(0, exit, "analyze run AD required-domain helper missing canonical path exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXTOOL002", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/SampleBadAdDomainTool.cs",
-                        StringComparison.OrdinalIgnoreCase)),
+            AssertHasFinding(findings, "IXTOOL002",
+                "IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/SampleBadAdDomainTool.cs",
                 "analyze run AD required-domain helper missing canonical path finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -116,7 +114,7 @@ public sealed class SampleGoodAdDomainTool : ActiveDirectoryToolBase, ITool {
 
             AssertEqual(0, exit, "analyze run AD required-domain helper canonical path exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL002", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL002",
                 "analyze run AD required-domain helper canonical path no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityCanonicalBoundedIntHelper.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityCanonicalBoundedIntHelper.cs
@@ -43,10 +43,8 @@ public sealed class SampleLegacyBoundedIntHelperTool : ToolBase {
 
             AssertEqual(0, exit, "analyze run canonical bounded-int helper missing canonical path exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXTOOL004", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleLegacyBoundedIntHelperTool.cs",
-                        StringComparison.OrdinalIgnoreCase)),
+            AssertHasFinding(findings, "IXTOOL004",
+                "IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleLegacyBoundedIntHelperTool.cs",
                 "analyze run canonical bounded-int helper missing canonical path finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -100,7 +98,7 @@ public sealed class SampleCanonicalBoundedIntHelperTool : ToolBase {
 
             AssertEqual(0, exit, "analyze run canonical bounded-int helper canonical path exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL004", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL004",
                 "analyze run canonical bounded-int helper canonical path no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -135,7 +133,7 @@ public static class ToolArgs {
 
             AssertEqual(0, exit, "analyze run canonical bounded-int helper ToolArgs implementation scope exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL004", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL004",
                 "analyze run canonical bounded-int helper ToolArgs implementation scope no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -172,10 +170,8 @@ public sealed class SampleLegacyBoundedIntHelperTests {
 
             AssertEqual(0, exit, "analyze run canonical bounded-int helper tools tests scope exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item =>
-                    item.RuleId.Equals("IXTOOL004", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.Tests/SampleLegacyBoundedIntHelperTests.cs",
-                        StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL004",
+                "IntelligenceX.Tools/IntelligenceX.Tools.Tests/SampleLegacyBoundedIntHelperTests.cs",
                 "analyze run canonical bounded-int helper tools tests scope no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityDuplication.Helpers.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityDuplication.Helpers.cs
@@ -80,6 +80,65 @@ def {{functionName}}({{inputName}}):
         return list;
     }
 
+    private static int CountFindings(IReadOnlyList<(string RuleId, string Path)> findings, string ruleId,
+        string? path = null) {
+        if (findings is null || findings.Count == 0 || string.IsNullOrWhiteSpace(ruleId)) {
+            return 0;
+        }
+
+        var hasPath = !string.IsNullOrWhiteSpace(path);
+        return findings.Count(item =>
+            item.RuleId.Equals(ruleId, StringComparison.OrdinalIgnoreCase) &&
+            (!hasPath || item.Path.Equals(path!, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private static int CountFindingsByPathSuffix(IReadOnlyList<(string RuleId, string Path)> findings, string ruleId,
+        string pathSuffix) {
+        if (findings is null || findings.Count == 0 || string.IsNullOrWhiteSpace(ruleId) ||
+            string.IsNullOrWhiteSpace(pathSuffix)) {
+            return 0;
+        }
+
+        return findings.Count(item =>
+            item.RuleId.Equals(ruleId, StringComparison.OrdinalIgnoreCase) &&
+            item.Path.EndsWith(pathSuffix, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void AssertHasFinding(IReadOnlyList<(string RuleId, string Path)> findings, string ruleId,
+        string assertionMessage) {
+        AssertEqual(true, CountFindings(findings, ruleId) > 0, assertionMessage);
+    }
+
+    private static void AssertHasFinding(IReadOnlyList<(string RuleId, string Path)> findings, string ruleId, string path,
+        string assertionMessage) {
+        AssertEqual(true, CountFindings(findings, ruleId, path) > 0, assertionMessage);
+    }
+
+    private static void AssertHasExactlyOneFinding(IReadOnlyList<(string RuleId, string Path)> findings, string ruleId,
+        string path, string assertionMessage) {
+        AssertEqual(1, CountFindings(findings, ruleId, path), assertionMessage);
+    }
+
+    private static void AssertNoFinding(IReadOnlyList<(string RuleId, string Path)> findings, string ruleId,
+        string assertionMessage) {
+        AssertEqual(0, CountFindings(findings, ruleId), assertionMessage);
+    }
+
+    private static void AssertNoFinding(IReadOnlyList<(string RuleId, string Path)> findings, string ruleId, string path,
+        string assertionMessage) {
+        AssertEqual(0, CountFindings(findings, ruleId, path), assertionMessage);
+    }
+
+    private static void AssertHasFindingWithPathSuffix(IReadOnlyList<(string RuleId, string Path)> findings, string ruleId,
+        string pathSuffix, string assertionMessage) {
+        AssertEqual(true, CountFindingsByPathSuffix(findings, ruleId, pathSuffix) > 0, assertionMessage);
+    }
+
+    private static void AssertNoFindingWithPathSuffix(IReadOnlyList<(string RuleId, string Path)> findings, string ruleId,
+        string pathSuffix, string assertionMessage) {
+        AssertEqual(0, CountFindingsByPathSuffix(findings, ruleId, pathSuffix), assertionMessage);
+    }
+
     private static (int ExitCode, string Output) RunAnalyzeDuplicationWithConsoleOutput(string workspace, string configPath,
         string outputPath) {
         var originalOut = Console.Out;
@@ -98,4 +157,3 @@ def {{functionName}}({{inputName}}):
     }
 }
 #endif
-

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityDuplication.Part2.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityDuplication.Part2.cs
@@ -393,7 +393,7 @@ return x
             var findingsPath = Path.Combine(output, "intelligencex.findings.json");
             AssertEqual(true, File.Exists(findingsPath), "analyze run duplication python triple-quote hash findings exists");
             var findings = ReadFindingsRulePathPairs(findingsPath);
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXDUP001", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXDUP001",
                 "analyze run duplication python triple-quote hash does not produce false positive");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -473,21 +473,13 @@ public class Oversized {
             var findingsPath = Path.Combine(output, "intelligencex.findings.json");
             var findings = ReadFindingsRulePathPairs(findingsPath);
 
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXLOC001", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals("oversized.cs", StringComparison.OrdinalIgnoreCase)),
+            AssertHasFinding(findings, "IXLOC001", "oversized.cs",
                 "analyze run include-ext per-rule has csharp max-lines finding");
-            AssertEqual(false, findings.Any(item =>
-                    item.RuleId.Equals("IXLOC001", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.EndsWith(".py", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFindingWithPathSuffix(findings, "IXLOC001", ".py",
                 "analyze run include-ext per-rule does not apply csharp max-lines to python");
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXDUP001", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.EndsWith(".py", StringComparison.OrdinalIgnoreCase)),
+            AssertHasFindingWithPathSuffix(findings, "IXDUP001", ".py",
                 "analyze run include-ext per-rule applies duplication to python");
-            AssertEqual(false, findings.Any(item =>
-                    item.RuleId.Equals("IXDUP001", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFindingWithPathSuffix(findings, "IXDUP001", ".cs",
                 "analyze run include-ext per-rule does not apply python duplication to csharp");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -546,9 +538,7 @@ public class Oversized {
             AssertEqual(0, exit, "analyze run duplication language threshold exit");
             var findingsPath = Path.Combine(output, "intelligencex.findings.json");
             var findings = ReadFindingsRulePathPairs(findingsPath);
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXDUP001", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.EndsWith(".js", StringComparison.OrdinalIgnoreCase)),
+            AssertHasFindingWithPathSuffix(findings, "IXDUP001", ".js",
                 "analyze run duplication language threshold uses javascript override");
 
             var metricsPath = Path.Combine(output, "intelligencex.duplication.json");
@@ -612,9 +602,7 @@ public class Oversized {
             AssertEqual(0, exit, "analyze run duplication language-only tag exit");
             var findingsPath = Path.Combine(output, "intelligencex.findings.json");
             var findings = ReadFindingsRulePathPairs(findingsPath);
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXDUP001", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.EndsWith(".js", StringComparison.OrdinalIgnoreCase)),
+            AssertHasFindingWithPathSuffix(findings, "IXDUP001", ".js",
                 "analyze run duplication language-only tag activates duplication rule");
 
             var metricsPath = Path.Combine(output, "intelligencex.duplication.json");

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityEventLogMaxResultsHelper.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityEventLogMaxResultsHelper.cs
@@ -31,10 +31,8 @@ public sealed class SampleLegacyEventLogBoundedTool {
 
             AssertEqual(0, exit, "analyze run EventLog max helper bounded max_results exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXTOOL005", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.EventLog/SampleLegacyEventLogBoundedTool.cs",
-                        StringComparison.OrdinalIgnoreCase)),
+            AssertHasExactlyOneFinding(findings, "IXTOOL005",
+                "IntelligenceX.Tools/IntelligenceX.Tools.EventLog/SampleLegacyEventLogBoundedTool.cs",
                 "analyze run EventLog max helper bounded max_results finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -70,11 +68,8 @@ public sealed class SampleLegacyEventLogResolveMaxResultsTool {
 
             AssertEqual(0, exit, "analyze run EventLog max helper legacy ResolveMaxResults exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXTOOL005", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals(
-                        "IntelligenceX.Tools/IntelligenceX.Tools.EventLog/SampleLegacyEventLogResolveMaxResultsTool.cs",
-                        StringComparison.OrdinalIgnoreCase)),
+            AssertHasExactlyOneFinding(findings, "IXTOOL005",
+                "IntelligenceX.Tools/IntelligenceX.Tools.EventLog/SampleLegacyEventLogResolveMaxResultsTool.cs",
                 "analyze run EventLog max helper legacy ResolveMaxResults finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -114,7 +109,7 @@ public sealed class SampleCanonicalEventLogMaxResultsTool {
 
             AssertEqual(0, exit, "analyze run EventLog max helper explicit helpers exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL005", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL005",
                 "analyze run EventLog max helper explicit helpers no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -150,7 +145,7 @@ public sealed class SampleCanonicalEventLogMaxEventsTool {
 
             AssertEqual(0, exit, "analyze run EventLog max helper non-max_results bounded path exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL005", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL005",
                 "analyze run EventLog max helper non-max_results bounded path no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -186,10 +181,8 @@ public sealed class SampleNonEventLogBoundedMaxResultsTool {
 
             AssertEqual(0, exit, "analyze run EventLog max helper non-eventlog scope exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item =>
-                    item.RuleId.Equals("IXTOOL005", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleNonEventLogBoundedMaxResultsTool.cs",
-                        StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL005",
+                "IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleNonEventLogBoundedMaxResultsTool.cs",
                 "analyze run EventLog max helper non-eventlog scope no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityMaxResultsMetaHelper.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityMaxResultsMetaHelper.cs
@@ -52,10 +52,8 @@ public sealed class SampleBadMaxResultsMetaTool : ToolBase {
 
             AssertEqual(0, exit, "analyze run max-results metadata helper missing canonical helper exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleBadMaxResultsMetaTool.cs",
-                        StringComparison.OrdinalIgnoreCase)),
+            AssertHasFinding(findings, "IXTOOL003",
+                "IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleBadMaxResultsMetaTool.cs",
                 "analyze run max-results metadata helper missing canonical helper finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -112,7 +110,7 @@ public sealed class SampleGoodMaxResultsMetaTool : ToolBase {
 
             AssertEqual(0, exit, "analyze run max-results metadata helper canonical helper exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL003",
                 "analyze run max-results metadata helper canonical helper no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -147,7 +145,7 @@ public static class SampleBadMaxResultsMetaHelper {
 
             AssertEqual(0, exit, "analyze run max-results metadata helper non-tool file exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL003",
                 "analyze run max-results metadata helper ignores non-tool files");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -203,7 +201,7 @@ public sealed class SampleNearMissMaxResultsMetaTool : ToolBase {
 
             AssertEqual(0, exit, "analyze run max-results metadata helper near-miss key exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL003",
                 "analyze run max-results metadata helper near-miss key no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -259,7 +257,7 @@ public sealed class SampleQualifiedMaxResultsMetaTool : ToolBase {
 
             AssertEqual(0, exit, "analyze run max-results metadata helper qualified canonical helper exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL003",
                 "analyze run max-results metadata helper qualified canonical helper no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -315,10 +313,8 @@ public sealed class SampleIndexerMaxResultsMetaTool : ToolBase {
 
             AssertEqual(0, exit, "analyze run max-results metadata helper indexer assignment exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleIndexerMaxResultsMetaTool.cs",
-                        StringComparison.OrdinalIgnoreCase)),
+            AssertHasFinding(findings, "IXTOOL003",
+                "IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleIndexerMaxResultsMetaTool.cs",
                 "analyze run max-results metadata helper indexer assignment finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -374,10 +370,8 @@ public sealed class SampleCaseVariantMaxResultsMetaTool : ToolBase {
 
             AssertEqual(0, exit, "analyze run max-results metadata helper case-variant key exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleCaseVariantMaxResultsMetaTool.cs",
-                        StringComparison.OrdinalIgnoreCase)),
+            AssertHasFinding(findings, "IXTOOL003",
+                "IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleCaseVariantMaxResultsMetaTool.cs",
                 "analyze run max-results metadata helper case-variant key finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -435,11 +429,9 @@ public sealed class SampleMixedMetaAddsTool : ToolBase {
 
             AssertEqual(0, exit, "analyze run max-results metadata helper mixed meta adds exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            var matchingFindings = findings.Count(item =>
-                item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase) &&
-                item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleMixedMetaAddsTool.cs",
-                    StringComparison.OrdinalIgnoreCase));
-            AssertEqual(1, matchingFindings, "analyze run max-results metadata helper mixed meta adds only max_results finding");
+            AssertHasExactlyOneFinding(findings, "IXTOOL003",
+                "IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleMixedMetaAddsTool.cs",
+                "analyze run max-results metadata helper mixed meta adds only max_results finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
         }
@@ -492,11 +484,9 @@ public sealed class SampleSameLineMaxResultsMetaTool : ToolBase {
 
             AssertEqual(0, exit, "analyze run max-results metadata helper same-line dedupe exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            var matchingFindings = findings.Count(item =>
-                item.RuleId.Equals("IXTOOL003", StringComparison.OrdinalIgnoreCase) &&
-                item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleSameLineMaxResultsMetaTool.cs",
-                    StringComparison.OrdinalIgnoreCase));
-            AssertEqual(1, matchingFindings, "analyze run max-results metadata helper same-line dedupe single finding");
+            AssertHasExactlyOneFinding(findings, "IXTOOL003",
+                "IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleSameLineMaxResultsMetaTool.cs",
+                "analyze run max-results metadata helper same-line dedupe single finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
         }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityRuleDispatch.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityRuleDispatch.cs
@@ -21,7 +21,7 @@ internal static partial class Program {
                 "analyze run internal dispatch unmapped warning");
 
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL999", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL999",
                 "analyze run internal dispatch unmapped no findings");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -49,7 +49,7 @@ internal static partial class Program {
                 "analyze run internal dispatch ambiguous warning");
 
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(true, findings.Any(item => item.RuleId.Equals("IXLOC001", StringComparison.OrdinalIgnoreCase)),
+            AssertHasFinding(findings, "IXLOC001",
                 "analyze run internal dispatch ambiguous first handler emits findings");
 
             using var metricsDocument = System.Text.Json.JsonDocument.Parse(
@@ -92,10 +92,8 @@ public sealed class SampleDispatchEventLogTool {
             AssertEqual(false, result.Output.Contains("no registered handler", StringComparison.OrdinalIgnoreCase),
                 "analyze run internal dispatch canonical rule-id registration no unmapped warning");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXTOOL005", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.EventLog/SampleDispatchEventLogTool.cs",
-                        StringComparison.OrdinalIgnoreCase)),
+            AssertHasExactlyOneFinding(findings, "IXTOOL005",
+                "IntelligenceX.Tools/IntelligenceX.Tools.EventLog/SampleDispatchEventLogTool.cs",
                 "analyze run internal dispatch canonical rule-id registration finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityWriteToolSchema.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityWriteToolSchema.cs
@@ -37,10 +37,7 @@ public sealed class SampleBadTool {
 
             AssertEqual(0, exit, "analyze run write-tool schema missing helper exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(true, findings.Any(item =>
-                    item.RuleId.Equals("IXTOOL001", StringComparison.OrdinalIgnoreCase) &&
-                    item.Path.Equals("IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleBadTool.cs",
-                        StringComparison.OrdinalIgnoreCase)),
+            AssertHasFinding(findings, "IXTOOL001", "IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleBadTool.cs",
                 "analyze run write-tool schema missing helper finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -103,7 +100,7 @@ public sealed class SampleGoodProbeTool {
 
             AssertEqual(0, exit, "analyze run write-tool schema canonical helper exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL001", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL001",
                 "analyze run write-tool schema canonical helpers no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -141,7 +138,7 @@ public sealed class SampleReadOnlyTool {
 
             AssertEqual(0, exit, "analyze run write-tool schema read-only exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL001", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL001",
                 "analyze run write-tool schema read-only no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);
@@ -181,7 +178,7 @@ public sealed class SampleAuthOnlyTool {
 
             AssertEqual(0, exit, "analyze run write-tool schema auth-only exit");
             var findings = ReadFindingsRulePathPairs(Path.Combine(output, "intelligencex.findings.json"));
-            AssertEqual(false, findings.Any(item => item.RuleId.Equals("IXTOOL001", StringComparison.OrdinalIgnoreCase)),
+            AssertNoFinding(findings, "IXTOOL001",
                 "analyze run write-tool schema auth-only no finding");
         } finally {
             DeleteDirectoryIfExistsWithRetries(temp);


### PR DESCRIPTION
## Summary
- add shared finding assertion helpers in maintainability test helper partial (`AssertHasFinding`, `AssertNoFinding`, `AssertHasExactlyOneFinding`, suffix variants)
- refactor maintainability suites to use those helpers instead of repeated inline `findings.Any(...)` predicates
- preserve existing behavior while tightening a few checks to explicit single-finding expectations where contract requires dedupe

## Validation
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release`
- `dotnet .\\IntelligenceX.Tests\\bin\\Release\\net8.0\\IntelligenceX.Tests.dll`
- `dotnet .\\IntelligenceX.Tests\\bin\\Release\\net10.0\\IntelligenceX.Tests.dll`
- `rg "findings\\.Any\\(" IntelligenceX.Tests -n` (no matches)