### PR TITLE
Deploy Website: remove python dependency from artifact cleanup

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -72,79 +72,53 @@ jobs:
             .
 
       - name: Prune stale github-pages artifacts
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          python - <<'PY'
-          import datetime as dt
-          import json
-          import os
-          import urllib.error
-          import urllib.parse
-          import urllib.request
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const keepNewest = 3;
+            const minAgeHours = 6;
+            const now = Date.now();
+            const { owner, repo } = context.repo;
+            const artifacts = [];
 
-          token = os.environ.get("GH_TOKEN", "")
-          repo = os.environ.get("GH_REPO", "")
-          if not token or not repo:
-              print("Skipping artifact prune: missing GH token or repo context.")
-              raise SystemExit(0)
+            for await (const page of github.paginate.iterator(
+              github.rest.actions.listArtifactsForRepo,
+              { owner, repo, name: "github-pages", per_page: 100 }
+            )) {
+              artifacts.push(...page.data.artifacts);
+            }
 
-          keep_newest = 3
-          min_age_hours = 6
-          now_utc = dt.datetime.now(dt.timezone.utc)
-          headers = {
-              "Authorization": f"Bearer {token}",
-              "Accept": "application/vnd.github+json",
-              "X-GitHub-Api-Version": "2022-11-28",
-              "User-Agent": "powerforge-pages-artifact-prune",
-          }
+            artifacts.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
-          query = urllib.parse.urlencode({"name": "github-pages", "per_page": 100})
-          list_url = f"https://api.github.com/repos/{repo}/actions/artifacts?{query}"
-          list_req = urllib.request.Request(list_url, headers=headers)
-          with urllib.request.urlopen(list_req) as response:
-              payload = json.load(response)
+            let deleted = 0;
+            let skippedRecent = 0;
+            let failures = 0;
 
-          artifacts = payload.get("artifacts", [])
-          artifacts.sort(key=lambda item: item.get("created_at", ""), reverse=True)
-          deleted = 0
-          skipped_recent = 0
-          delete_failures = 0
+            for (const artifact of artifacts.slice(keepNewest)) {
+              const created = new Date(artifact.created_at).getTime();
+              const ageHours = Number.isFinite(created) ? (now - created) / (1000 * 60 * 60) : minAgeHours + 1;
+              if (ageHours < minAgeHours) {
+                skippedRecent++;
+                continue;
+              }
 
-          for artifact in artifacts[keep_newest:]:
-              created_raw = artifact.get("created_at", "")
-              try:
-                  created_at = dt.datetime.strptime(created_raw, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=dt.timezone.utc)
-              except ValueError:
-                  created_at = now_utc - dt.timedelta(hours=min_age_hours + 1)
+              try {
+                await github.rest.actions.deleteArtifact({
+                  owner,
+                  repo,
+                  artifact_id: artifact.id,
+                });
+                deleted++;
+                core.info(`Deleted artifact id=${artifact.id} created_at=${artifact.created_at}`);
+              } catch (error) {
+                failures++;
+                core.warning(`Failed to delete artifact id=${artifact.id}: ${error.message}`);
+              }
+            }
 
-              age_hours = (now_utc - created_at).total_seconds() / 3600.0
-              if age_hours < min_age_hours:
-                  skipped_recent += 1
-                  continue
-
-              artifact_id = artifact.get("id")
-              delete_url = f"https://api.github.com/repos/{repo}/actions/artifacts/{artifact_id}"
-              delete_req = urllib.request.Request(delete_url, method="DELETE", headers=headers)
-              try:
-                  urllib.request.urlopen(delete_req).read()
-                  deleted += 1
-                  print(f"Deleted artifact id={artifact_id} created_at={created_raw}")
-              except urllib.error.HTTPError as ex:
-                  delete_failures += 1
-                  print(f"Warning: failed to delete artifact id={artifact_id} (HTTP {ex.code})")
-              except Exception as ex:  # pragma: no cover - defensive for runner env differences
-                  delete_failures += 1
-                  print(f"Warning: failed to delete artifact id={artifact_id} ({ex})")
-
-          print(
-              "Artifact prune summary: "
-              f"found={len(artifacts)}, kept={min(len(artifacts), keep_newest)}, "
-              f"deleted={deleted}, skipped_recent={skipped_recent}, failures={delete_failures}"
-          )
-          PY
+            core.info(
+              `Artifact prune summary: found=${artifacts.length}, kept=${Math.min(artifacts.length, keepNewest)}, deleted=${deleted}, skipped_recent=${skippedRecent}, failures=${failures}`
+            );
 
       - name: Upload Pages artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Summary
- replace python-based artifact pruning with pinned ctions/github-script
- keep same pruning policy: keep newest 3 github-pages artifacts, prune older than 6h
- retain ctions: write permission needed for artifact deletion

## Why
The previous implementation failed on self-hosted runners because python was not available (python: command not found).
This version is runner-portable and keeps deploy storage cleanup active.