### PR TITLE
tests: verify helper diagnostics for path and suffix variants

### DIFF
--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityAssertions.Tests.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisMaintainabilityAssertions.Tests.cs
@@ -44,6 +44,47 @@ internal static partial class Program {
         }
     }
 
+    private static void TestAnalyzeRunInternalMaintainabilityHelpersFailureIncludesMatchCountForPathAndSuffix() {
+        var findings = new List<(string RuleId, string Path)> {
+            ("IXTOOL003", "IntelligenceX.Tools/IntelligenceX.Tools.Sample/OnlyTool.cs"),
+            ("IXDUP001", "src/check.py")
+        };
+
+        try {
+            AssertHasFinding(findings, "IXTOOL003", "IntelligenceX.Tools/IntelligenceX.Tools.Sample/MissingTool.cs",
+                "missing path should fail");
+            throw new InvalidOperationException("Expected missing-path helper assertion to fail.");
+        } catch (InvalidOperationException ex) {
+            AssertContainsText(ex.Message, "missing path should fail (matches=0)",
+                "analyze run internal maintainability helper match-count message for missing path");
+        }
+
+        try {
+            AssertNoFinding(findings, "IXTOOL003", "IntelligenceX.Tools/IntelligenceX.Tools.Sample/OnlyTool.cs",
+                "existing path should fail");
+            throw new InvalidOperationException("Expected existing-path helper assertion to fail.");
+        } catch (InvalidOperationException ex) {
+            AssertContainsText(ex.Message, "existing path should fail (matches=1)",
+                "analyze run internal maintainability helper match-count message for existing path");
+        }
+
+        try {
+            AssertHasFindingWithPathSuffix(findings, "IXDUP001", ".cs", "missing suffix should fail");
+            throw new InvalidOperationException("Expected missing-suffix helper assertion to fail.");
+        } catch (InvalidOperationException ex) {
+            AssertContainsText(ex.Message, "missing suffix should fail (matches=0)",
+                "analyze run internal maintainability helper match-count message for missing suffix");
+        }
+
+        try {
+            AssertNoFindingWithPathSuffix(findings, "IXDUP001", ".py", "existing suffix should fail");
+            throw new InvalidOperationException("Expected existing-suffix helper assertion to fail.");
+        } catch (InvalidOperationException ex) {
+            AssertContainsText(ex.Message, "existing suffix should fail (matches=1)",
+                "analyze run internal maintainability helper match-count message for existing suffix");
+        }
+    }
+
     private static void TestAnalyzeRunInternalMaintainabilityHelpersRejectEmptyRuleId() {
         var findings = new List<(string RuleId, string Path)> {
             ("IXTOOL001", "IntelligenceX.Tools/IntelligenceX.Tools.Sample/SampleBadTool.cs")

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -613,6 +613,8 @@ internal static partial class Program {
             TestAnalyzeRunInternalMaintainabilityHelpersPositivePaths);
         failed += Run("Analyze run internal maintainability helper failure includes match count",
             TestAnalyzeRunInternalMaintainabilityHelpersFailureIncludesMatchCount);
+        failed += Run("Analyze run internal maintainability helper path and suffix failure include match count",
+            TestAnalyzeRunInternalMaintainabilityHelpersFailureIncludesMatchCountForPathAndSuffix);
         failed += Run("Analyze run internal maintainability helper rejects empty rule id",
             TestAnalyzeRunInternalMaintainabilityHelpersRejectEmptyRuleId);
         failed += Run("Analyze run internal maintainability helper rejects empty path suffix",


### PR DESCRIPTION
## Summary
- extend maintainability helper diagnostics tests to cover remaining assertion variants
- verify match-count diagnostics `(matches=...)` for:
  - `AssertHasFinding(rule+path)` failure
  - `AssertNoFinding(rule+path)` failure
  - `AssertHasFindingWithPathSuffix` failure
  - `AssertNoFindingWithPathSuffix` failure
- register new test in the shared test runner

## Validation
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release`
- `dotnet .\\IntelligenceX.Tests\\bin\\Release\\net8.0\\IntelligenceX.Tests.dll`
- `dotnet .\\IntelligenceX.Tests\\bin\\Release\\net10.0\\IntelligenceX.Tests.dll`