### PR TITLE
Deploy Website: treat Cloudflare DYNAMIC as acceptable verify state

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -194,4 +194,5 @@ jobs:
           dotnet PSPublishModule/PowerForge.Web.Cli/bin/Release/net10.0/PowerForge.Web.Cli.dll \
             cloudflare verify \
             --site-config "Website/site.json" \
-            --warmup 1
+            --warmup 1 \
+            --allow-status "HIT,REVALIDATED,EXPIRED,STALE,DYNAMIC"


### PR DESCRIPTION
## Summary
- extend Cloudflare verify allowed statuses to include DYNAMIC
- keeps existing warmup behavior and verification step

## Why
Deploy now succeeds through Pages upload/deploy, but workflow still failed when /docs and /api returned cf-cache-status: DYNAMIC. This change keeps verification useful while matching current Cloudflare rule behavior.