### PR TITLE
feat(eventlog): add reusable timeline correlation profiles

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsPayload.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsPayload.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using EventViewerX;
+
+namespace IntelligenceX.Tools.EventLog;
+
+internal static class EventLogNamedEventsPayload {
+    internal static string ResolveNamedEventName(EventObjectSlim item) {
+        return EventLogNamedEventsHelper.TryParseOne(item.Type, out var parsedNamedEvent)
+            ? EventLogNamedEventsHelper.GetQueryName(parsedNamedEvent)
+            : EventLogNamedEventsQueryShared.ToSnakeCase(item.Type);
+    }
+
+    internal static Dictionary<string, object?> ExtractPayload(EventObjectSlim item) {
+        var payload = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        var type = item.GetType();
+
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance)) {
+            if (!ShouldIncludeField(field)) {
+                continue;
+            }
+
+            var value = field.GetValue(item);
+            payload[EventLogNamedEventsQueryShared.ToSnakeCase(field.Name)] = NormalizeValue(value);
+        }
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
+            if (!ShouldIncludeProperty(property)) {
+                continue;
+            }
+
+            var key = EventLogNamedEventsQueryShared.ToSnakeCase(property.Name);
+            if (payload.ContainsKey(key)) {
+                continue;
+            }
+
+            object? value;
+            try {
+                value = property.GetValue(item);
+            } catch {
+                continue;
+            }
+
+            payload[key] = NormalizeValue(value);
+        }
+
+        return payload;
+    }
+
+    internal static Dictionary<string, object?> ProjectPayload(
+        Dictionary<string, object?> payload,
+        HashSet<string>? payloadKeySet) {
+        if (payloadKeySet is null || payloadKeySet.Count == 0) {
+            return payload;
+        }
+
+        var projected = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var key in payloadKeySet) {
+            if (payload.TryGetValue(key, out var value)) {
+                projected[key] = value;
+            }
+        }
+
+        return projected;
+    }
+
+    internal static string? ReadPayloadString(IReadOnlyDictionary<string, object?> payload, string key) {
+        if (!payload.TryGetValue(key, out var value) || value is null) {
+            return null;
+        }
+
+        var text = value.ToString();
+        return string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+    }
+
+    internal static string? ReadPayloadUtc(IReadOnlyDictionary<string, object?> payload, string key) {
+        if (!payload.TryGetValue(key, out var value) || value is null) {
+            return null;
+        }
+
+        if (value is string text && DateTime.TryParse(text, out var parsed)) {
+            return parsed.ToUniversalTime().ToString("O");
+        }
+
+        if (value is DateTime dateTime) {
+            return dateTime.ToUniversalTime().ToString("O");
+        }
+
+        return value.ToString();
+    }
+
+    private static bool ShouldIncludeField(FieldInfo field) {
+        if (field.Name.StartsWith("_", StringComparison.Ordinal)) {
+            return false;
+        }
+
+        if (string.Equals(field.Name, nameof(EventObjectSlim.EventID), StringComparison.OrdinalIgnoreCase)
+            || string.Equals(field.Name, nameof(EventObjectSlim.RecordID), StringComparison.OrdinalIgnoreCase)
+            || string.Equals(field.Name, nameof(EventObjectSlim.GatheredFrom), StringComparison.OrdinalIgnoreCase)
+            || string.Equals(field.Name, nameof(EventObjectSlim.GatheredLogName), StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        if (string.Equals(field.FieldType.Name, "EventObject", StringComparison.Ordinal)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool ShouldIncludeProperty(PropertyInfo property) {
+        if (!property.CanRead || property.GetMethod is null || !property.GetMethod.IsPublic) {
+            return false;
+        }
+
+        return property.GetIndexParameters().Length == 0;
+    }
+
+    private static object? NormalizeValue(object? value) {
+        if (value is null) {
+            return null;
+        }
+
+        if (value is DateTime dateTime) {
+            return dateTime.ToUniversalTime().ToString("O");
+        }
+
+        if (value is DateTimeOffset dateTimeOffset) {
+            return dateTimeOffset.ToUniversalTime().ToString("O");
+        }
+
+        if (value is Enum enumValue) {
+            return enumValue.ToString();
+        }
+
+        return value;
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryShared.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryShared.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using EventViewerX;
+using IntelligenceX.Json;
+using IntelligenceX.Tools.Common;
+
+namespace IntelligenceX.Tools.EventLog;
+
+internal static class EventLogNamedEventsQueryShared {
+    internal const int MaxNamedEvents = 24;
+    internal const int MaxCategoryFilters = 16;
+    internal const int MaxMachines = 32;
+    internal const int MaxPayloadKeys = 64;
+    internal const int MaxThreadsCap = 8;
+
+    internal static readonly string[] CategoryNames = EventLogNamedEventsHelper.GetKnownCategories().ToArray();
+    internal static readonly string[] TimePeriodNames = Enum.GetValues<TimePeriod>()
+        .Select(static value => ToSnakeCase(value.ToString()))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+    private static readonly IReadOnlyDictionary<string, TimePeriod> TimePeriodByName = BuildTimePeriodMap();
+
+    internal static bool TryResolveNamedEvents(
+        IReadOnlyList<string> rawNamedEvents,
+        IReadOnlyList<string> rawCategories,
+        out List<NamedEvents> namedEvents,
+        out List<string>? categories,
+        out string? error) {
+        namedEvents = new List<NamedEvents>();
+        categories = null;
+        error = null;
+
+        if (rawNamedEvents.Count == 0 && rawCategories.Count == 0) {
+            error = "Provide at least one of: named_events, categories.";
+            return false;
+        }
+
+        if (rawNamedEvents.Count > 0) {
+            if (!EventLogNamedEventsHelper.TryParseMany(rawNamedEvents, MaxNamedEvents, out var parsedNamedEvents, out var namedEventsError)) {
+                error = namedEventsError ?? "Invalid named_events argument.";
+                return false;
+            }
+
+            namedEvents.AddRange(parsedNamedEvents);
+        }
+
+        if (rawCategories.Count > 0) {
+            if (!EventLogNamedEventsHelper.TryParseCategories(rawCategories, MaxCategoryFilters, out var parsedCategories, out var categoriesError)) {
+                error = categoriesError ?? "Invalid categories argument.";
+                return false;
+            }
+
+            categories = parsedCategories;
+            var categorySet = new HashSet<string>(categories, StringComparer.OrdinalIgnoreCase);
+            foreach (var namedEvent in Enum.GetValues<NamedEvents>()) {
+                if (!categorySet.Contains(EventLogNamedEventsHelper.GetCategory(namedEvent))) {
+                    continue;
+                }
+
+                if (!namedEvents.Contains(namedEvent)) {
+                    namedEvents.Add(namedEvent);
+                }
+            }
+        }
+
+        if (namedEvents.Count == 0) {
+            error = "No named events resolved from provided filters.";
+            return false;
+        }
+
+        if (namedEvents.Count > MaxNamedEvents) {
+            error = $"Resolved named events exceed limit ({MaxNamedEvents}). Narrow your filters.";
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool TryResolveTimeWindow(
+        JsonObject? arguments,
+        out DateTime? startUtc,
+        out DateTime? endUtc,
+        out TimePeriod? timePeriod,
+        out string? error) {
+        error = null;
+        timePeriod = null;
+        startUtc = null;
+        endUtc = null;
+
+        var timePeriodRaw = ToolArgs.GetOptionalTrimmed(arguments, "time_period");
+        var hasExplicitTimeRange = !string.IsNullOrWhiteSpace(ToolArgs.GetOptionalTrimmed(arguments, "start_time_utc"))
+                                   || !string.IsNullOrWhiteSpace(ToolArgs.GetOptionalTrimmed(arguments, "end_time_utc"));
+
+        if (!string.IsNullOrWhiteSpace(timePeriodRaw) && hasExplicitTimeRange) {
+            error = "time_period cannot be combined with start_time_utc/end_time_utc.";
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(timePeriodRaw)) {
+            if (!TryParseTimePeriod(timePeriodRaw, out var parsedTimePeriod, out var timePeriodError)) {
+                error = timePeriodError ?? "Invalid time_period value.";
+                return false;
+            }
+
+            timePeriod = parsedTimePeriod;
+            return true;
+        }
+
+        if (!ToolTime.TryParseUtcRange(arguments, "start_time_utc", "end_time_utc", out startUtc, out endUtc, out var timeErr)) {
+            error = timeErr ?? "Invalid time range.";
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool TryParseTimePeriod(string raw, out TimePeriod timePeriod, out string? error) {
+        timePeriod = default;
+        error = null;
+
+        var normalized = ToSnakeCase(raw);
+        if (string.IsNullOrWhiteSpace(normalized)) {
+            error = "time_period is required when provided.";
+            return false;
+        }
+
+        if (TimePeriodByName.TryGetValue(normalized, out timePeriod)) {
+            return true;
+        }
+
+        error = $"time_period must be one of: {string.Join(", ", TimePeriodNames)}.";
+        return false;
+    }
+
+    internal static List<string> ResolveMachines(JsonObject? arguments, int maxItems = MaxMachines) {
+        var machines = new List<string>();
+
+        var singleMachine = ToolArgs.GetOptionalTrimmed(arguments, "machine_name");
+        if (!string.IsNullOrWhiteSpace(singleMachine)) {
+            machines.Add(singleMachine);
+        }
+
+        var machineNames = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("machine_names"));
+        for (var i = 0; i < machineNames.Count; i++) {
+            var machine = machineNames[i];
+            if (string.IsNullOrWhiteSpace(machine)) {
+                continue;
+            }
+
+            if (!machines.Contains(machine, StringComparer.OrdinalIgnoreCase)) {
+                machines.Add(machine);
+            }
+
+            if (machines.Count >= maxItems) {
+                break;
+            }
+        }
+
+        return machines;
+    }
+
+    internal static string ToSnakeCase(string name) {
+        if (string.IsNullOrWhiteSpace(name)) {
+            return string.Empty;
+        }
+
+        return JsonNamingPolicy.SnakeCaseLower.ConvertName(name);
+    }
+
+    private static IReadOnlyDictionary<string, TimePeriod> BuildTimePeriodMap() {
+        var map = new Dictionary<string, TimePeriod>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in Enum.GetValues<TimePeriod>()) {
+            map[ToSnakeCase(value.ToString())] = value;
+        }
+        return map;
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryTool.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using EventViewerX;
@@ -16,30 +14,17 @@ namespace IntelligenceX.Tools.EventLog;
 /// Queries EventViewerX named-event rules and returns normalized rows for agent reasoning.
 /// </summary>
 public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
-    private const int MaxNamedEvents = 24;
-    private const int MaxCategoryFilters = 16;
-    private const int MaxMachines = 32;
-    private const int MaxPayloadKeys = 64;
-    private const int MaxThreadsCap = 8;
     private const int MaxViewTop = 5000;
-
-    private static readonly string[] CategoryNames = EventLogNamedEventsHelper.GetKnownCategories().ToArray();
-    private static readonly string[] TimePeriodNames = Enum.GetValues<TimePeriod>()
-        .Select(static value => ToSnakeCase(value.ToString()))
-        .Distinct(StringComparer.OrdinalIgnoreCase)
-        .OrderBy(static x => x, StringComparer.OrdinalIgnoreCase)
-        .ToArray();
-    private static readonly IReadOnlyDictionary<string, TimePeriod> TimePeriodByName = BuildTimePeriodMap();
 
     private static readonly ToolDefinition DefinitionValue = new(
         "eventlog_named_events_query",
         "Query EventViewerX named-event rules (for example AD/Kerberos/GPO detections) with optional machine/time filters.",
         ToolSchema.Object(
                 ("named_events", ToolSchema.Array(ToolSchema.String("Named event identifier (enum_name or query_name from eventlog_named_events_catalog)."), "Named events to execute.")),
-                ("categories", ToolSchema.Array(ToolSchema.String("Named-event category from eventlog_named_events_catalog.").Enum(CategoryNames), "Optional category list used to expand named_events.")),
+                ("categories", ToolSchema.Array(ToolSchema.String("Named-event category from eventlog_named_events_catalog.").Enum(EventLogNamedEventsQueryShared.CategoryNames), "Optional category list used to expand named_events.")),
                 ("machine_name", ToolSchema.String("Optional single remote machine name/FQDN. Omit for local machine.")),
                 ("machine_names", ToolSchema.Array(ToolSchema.String(), "Optional remote machine names/FQDNs. Combined with machine_name.")),
-                ("time_period", ToolSchema.String("Optional relative time window. Mutually exclusive with start_time_utc/end_time_utc.").Enum(TimePeriodNames)),
+                ("time_period", ToolSchema.String("Optional relative time window. Mutually exclusive with start_time_utc/end_time_utc.").Enum(EventLogNamedEventsQueryShared.TimePeriodNames)),
                 ("start_time_utc", ToolSchema.String("ISO-8601 UTC lower bound (optional).")),
                 ("end_time_utc", ToolSchema.String("ISO-8601 UTC upper bound (optional).")),
                 ("log_name", ToolSchema.String("Optional exact log-name filter applied to normalized rows (for example Security/System/Application).")),
@@ -90,66 +75,22 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
 
         var rawNamedEvents = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("named_events"));
         var rawCategories = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("categories"));
-        if (rawNamedEvents.Count == 0 && rawCategories.Count == 0) {
-            return ToolResponse.Error("invalid_argument", "Provide at least one of: named_events, categories.");
+        if (!EventLogNamedEventsQueryShared.TryResolveNamedEvents(
+                rawNamedEvents,
+                rawCategories,
+                out var namedEvents,
+                out var categories,
+                out var namedEventsError)) {
+            return ToolResponse.Error("invalid_argument", namedEventsError ?? "Invalid named_events/categories filters.");
         }
 
-        var namedEvents = new List<NamedEvents>();
-        if (rawNamedEvents.Count > 0) {
-            if (!EventLogNamedEventsHelper.TryParseMany(rawNamedEvents, MaxNamedEvents, out var parsedNamedEvents, out var namedEventsError)) {
-                return ToolResponse.Error("invalid_argument", namedEventsError ?? "Invalid named_events argument.");
-            }
-
-            namedEvents.AddRange(parsedNamedEvents);
-        }
-
-        List<string>? categories = null;
-        if (rawCategories.Count > 0) {
-            if (!EventLogNamedEventsHelper.TryParseCategories(rawCategories, MaxCategoryFilters, out var parsedCategories, out var categoriesError)) {
-                return ToolResponse.Error("invalid_argument", categoriesError ?? "Invalid categories argument.");
-            }
-
-            categories = parsedCategories;
-            var categorySet = new HashSet<string>(categories, StringComparer.OrdinalIgnoreCase);
-            foreach (var namedEvent in Enum.GetValues<NamedEvents>()) {
-                if (!categorySet.Contains(EventLogNamedEventsHelper.GetCategory(namedEvent))) {
-                    continue;
-                }
-
-                if (!namedEvents.Contains(namedEvent)) {
-                    namedEvents.Add(namedEvent);
-                }
-            }
-        }
-
-        if (namedEvents.Count == 0) {
-            return ToolResponse.Error("invalid_argument", "No named events resolved from provided filters.");
-        }
-        if (namedEvents.Count > MaxNamedEvents) {
-            return ToolResponse.Error("invalid_argument", $"Resolved named events exceed limit ({MaxNamedEvents}). Narrow your filters.");
-        }
-
-        var timePeriodRaw = ToolArgs.GetOptionalTrimmed(arguments, "time_period");
-        var hasExplicitTimeRange = !string.IsNullOrWhiteSpace(ToolArgs.GetOptionalTrimmed(arguments, "start_time_utc")) ||
-                                   !string.IsNullOrWhiteSpace(ToolArgs.GetOptionalTrimmed(arguments, "end_time_utc"));
-        if (!string.IsNullOrWhiteSpace(timePeriodRaw) && hasExplicitTimeRange) {
-            return ToolResponse.Error("invalid_argument", "time_period cannot be combined with start_time_utc/end_time_utc.");
-        }
-
-        DateTime? startUtc;
-        DateTime? endUtc;
-        TimePeriod? timePeriod = null;
-        if (!string.IsNullOrWhiteSpace(timePeriodRaw)) {
-            if (!TryParseTimePeriod(timePeriodRaw, out var parsedTimePeriod, out var timePeriodError)) {
-                return ToolResponse.Error("invalid_argument", timePeriodError ?? "Invalid time_period value.");
-            }
-            timePeriod = parsedTimePeriod;
-            startUtc = null;
-            endUtc = null;
-        } else {
-            if (!ToolTime.TryParseUtcRange(arguments, "start_time_utc", "end_time_utc", out startUtc, out endUtc, out var timeErr)) {
-                return ToolResponse.Error("invalid_argument", timeErr ?? "Invalid time range.");
-            }
+        if (!EventLogNamedEventsQueryShared.TryResolveTimeWindow(
+                arguments,
+                out var startUtc,
+                out var endUtc,
+                out var timePeriod,
+                out var timeError)) {
+            return ToolResponse.Error("invalid_argument", timeError ?? "Invalid time range.");
         }
 
         var logNameFilter = ToolArgs.GetOptionalTrimmed(arguments, "log_name");
@@ -160,18 +101,19 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
         var eventIdSet = eventIds is null ? null : new HashSet<int>(eventIds);
 
         var maxEvents = ResolveBoundedOptionLimit(arguments, "max_events");
-        var maxThreads = ToolArgs.GetCappedInt32(arguments, "max_threads", 4, 1, MaxThreadsCap);
+        var maxThreads = ToolArgs.GetCappedInt32(arguments, "max_threads", 4, 1, EventLogNamedEventsQueryShared.MaxThreadsCap);
         var maxEventsPerNamedEvent = ToolArgs.ToPositiveInt32OrNull(arguments?.GetInt64("max_events_per_named_event"), maxEvents);
         var includePayload = arguments?.GetBoolean("include_payload") ?? true;
+
         var payloadKeys = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("payload_keys"));
-        if (payloadKeys.Count > MaxPayloadKeys) {
-            return ToolResponse.Error("invalid_argument", $"payload_keys supports at most {MaxPayloadKeys} values.");
+        if (payloadKeys.Count > EventLogNamedEventsQueryShared.MaxPayloadKeys) {
+            return ToolResponse.Error("invalid_argument", $"payload_keys supports at most {EventLogNamedEventsQueryShared.MaxPayloadKeys} values.");
         }
         var payloadKeySet = payloadKeys.Count > 0
-            ? new HashSet<string>(payloadKeys.Select(ToSnakeCase), StringComparer.OrdinalIgnoreCase)
+            ? new HashSet<string>(payloadKeys.Select(EventLogNamedEventsQueryShared.ToSnakeCase), StringComparer.OrdinalIgnoreCase)
             : null;
 
-        var machines = ResolveMachines(arguments, maxItems: MaxMachines);
+        var machines = EventLogNamedEventsQueryShared.ResolveMachines(arguments, EventLogNamedEventsQueryShared.MaxMachines);
 
         var rows = new List<NamedEventsQueryRow>(Math.Min(maxEvents, 256));
         var perNamedEventCount = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
@@ -190,17 +132,17 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
                                cancellationToken: cancellationToken)) {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var namedEventName = ResolveNamedEventName(item);
+                var namedEventName = EventLogNamedEventsPayload.ResolveNamedEventName(item);
                 if (maxEventsPerNamedEvent.HasValue) {
-                    var currentCount = perNamedEventCount.TryGetValue(namedEventName, out var c) ? c : 0;
+                    var currentCount = perNamedEventCount.TryGetValue(namedEventName, out var count) ? count : 0;
                     if (currentCount >= maxEventsPerNamedEvent.Value) {
                         filteredOut++;
                         continue;
                     }
                 }
 
-                if (!string.IsNullOrWhiteSpace(logNameFilter) &&
-                    !string.Equals(item.GatheredLogName, logNameFilter, StringComparison.OrdinalIgnoreCase)) {
+                if (!string.IsNullOrWhiteSpace(logNameFilter)
+                    && !string.Equals(item.GatheredLogName, logNameFilter, StringComparison.OrdinalIgnoreCase)) {
                     filteredOut++;
                     continue;
                 }
@@ -211,7 +153,7 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
                 }
 
                 rows.Add(ToRow(item, namedEventName, includePayload, payloadKeySet));
-                perNamedEventCount[namedEventName] = perNamedEventCount.TryGetValue(namedEventName, out var count) ? count + 1 : 1;
+                perNamedEventCount[namedEventName] = perNamedEventCount.TryGetValue(namedEventName, out var current) ? current + 1 : 1;
                 if (rows.Count >= maxEvents) {
                     truncated = true;
                     break;
@@ -227,7 +169,11 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
         }
 
         var result = new NamedEventsQueryResult(
-            RequestedNamedEvents: namedEvents.Select(EventLogNamedEventsHelper.GetQueryName).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(static x => x, StringComparer.OrdinalIgnoreCase).ToArray(),
+            RequestedNamedEvents: namedEvents
+                .Select(EventLogNamedEventsHelper.GetQueryName)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
             EffectiveMachines: machines,
             StartTimeUtc: startUtc,
             EndTimeUtc: endUtc,
@@ -236,7 +182,7 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
             Truncated: truncated,
             Events: rows);
 
-        var response = BuildAutoTableResponse(
+        return BuildAutoTableResponse(
             arguments: arguments,
             model: result,
             sourceRows: rows,
@@ -257,13 +203,13 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
                     meta.Add("log_name", logNameFilter);
                 }
                 if (eventIdSet is not null) {
-                    meta.Add("event_ids", ToolJson.ToJsonArray(eventIdSet.OrderBy(static x => x)));
+                    meta.Add("event_ids", ToolJson.ToJsonArray(eventIdSet.OrderBy(static value => value)));
                 }
                 if (categories is not null && categories.Count > 0) {
                     meta.Add("categories", ToolJson.ToJsonArray(categories));
                 }
                 if (payloadKeySet is not null && payloadKeySet.Count > 0) {
-                    meta.Add("payload_keys", ToolJson.ToJsonArray(payloadKeySet.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase)));
+                    meta.Add("payload_keys", ToolJson.ToJsonArray(payloadKeySet.OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)));
                 }
                 if (machines.Count > 0) {
                     meta.Add("machines_count", machines.Count);
@@ -276,37 +222,9 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
                     meta.Add("end_time_utc", ToolTime.FormatUtc(endUtc));
                 }
                 if (timePeriod.HasValue) {
-                    meta.Add("time_period", ToSnakeCase(timePeriod.Value.ToString()));
+                    meta.Add("time_period", EventLogNamedEventsQueryShared.ToSnakeCase(timePeriod.Value.ToString()));
                 }
             });
-        return response;
-    }
-
-    private static List<string> ResolveMachines(JsonObject? arguments, int maxItems) {
-        var machines = new List<string>();
-
-        var singleMachine = ToolArgs.GetOptionalTrimmed(arguments, "machine_name");
-        if (!string.IsNullOrWhiteSpace(singleMachine)) {
-            machines.Add(singleMachine);
-        }
-
-        var machineNames = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("machine_names"));
-        for (var i = 0; i < machineNames.Count; i++) {
-            var machine = machineNames[i];
-            if (string.IsNullOrWhiteSpace(machine)) {
-                continue;
-            }
-
-            if (!machines.Contains(machine, StringComparer.OrdinalIgnoreCase)) {
-                machines.Add(machine);
-            }
-
-            if (machines.Count >= maxItems) {
-                break;
-            }
-        }
-
-        return machines;
     }
 
     private static NamedEventsQueryRow ToRow(
@@ -314,9 +232,9 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
         string namedEvent,
         bool includePayload,
         HashSet<string>? payloadKeySet) {
-        var fullPayload = ExtractPayload(item);
+        var fullPayload = EventLogNamedEventsPayload.ExtractPayload(item);
         var payload = includePayload
-            ? ProjectPayload(fullPayload, payloadKeySet)
+            ? EventLogNamedEventsPayload.ProjectPayload(fullPayload, payloadKeySet)
             : new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 
         return new NamedEventsQueryRow(
@@ -326,184 +244,11 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
             RecordId: item.RecordID,
             GatheredFrom: item.GatheredFrom,
             GatheredLogName: item.GatheredLogName,
-            WhenUtc: ReadPayloadUtc(fullPayload, "when"),
-            Who: ReadPayloadString(fullPayload, "who"),
-            ObjectAffected: ReadPayloadString(fullPayload, "object_affected"),
-            Computer: ReadPayloadString(fullPayload, "computer"),
-            Action: ReadPayloadString(fullPayload, "action"),
+            WhenUtc: EventLogNamedEventsPayload.ReadPayloadUtc(fullPayload, "when"),
+            Who: EventLogNamedEventsPayload.ReadPayloadString(fullPayload, "who"),
+            ObjectAffected: EventLogNamedEventsPayload.ReadPayloadString(fullPayload, "object_affected"),
+            Computer: EventLogNamedEventsPayload.ReadPayloadString(fullPayload, "computer"),
+            Action: EventLogNamedEventsPayload.ReadPayloadString(fullPayload, "action"),
             Payload: payload);
-    }
-
-    private static string ResolveNamedEventName(EventObjectSlim item) {
-        return EventLogNamedEventsHelper.TryParseOne(item.Type, out var parsedNamedEvent)
-            ? EventLogNamedEventsHelper.GetQueryName(parsedNamedEvent)
-            : ToSnakeCase(item.Type);
-    }
-
-    private static Dictionary<string, object?> ExtractPayload(EventObjectSlim item) {
-        var payload = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        var type = item.GetType();
-
-        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance)) {
-            if (!ShouldIncludeField(field)) {
-                continue;
-            }
-
-            var value = field.GetValue(item);
-            payload[ToSnakeCase(field.Name)] = NormalizeValue(value);
-        }
-
-        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
-            if (!ShouldIncludeProperty(property)) {
-                continue;
-            }
-
-            var key = ToSnakeCase(property.Name);
-            if (payload.ContainsKey(key)) {
-                continue;
-            }
-
-            object? value;
-            try {
-                value = property.GetValue(item);
-            } catch {
-                continue;
-            }
-
-            payload[key] = NormalizeValue(value);
-        }
-
-        return payload;
-    }
-
-    private static Dictionary<string, object?> ProjectPayload(
-        Dictionary<string, object?> payload,
-        HashSet<string>? payloadKeySet) {
-        if (payloadKeySet is null || payloadKeySet.Count == 0) {
-            return payload;
-        }
-
-        var projected = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        foreach (var key in payloadKeySet) {
-            if (payload.TryGetValue(key, out var value)) {
-                projected[key] = value;
-            }
-        }
-
-        return projected;
-    }
-
-    private static bool ShouldIncludeField(FieldInfo field) {
-        if (field is null) {
-            return false;
-        }
-
-        if (field.Name.StartsWith("_", StringComparison.Ordinal)) {
-            return false;
-        }
-
-        if (string.Equals(field.Name, nameof(EventObjectSlim.EventID), StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(field.Name, nameof(EventObjectSlim.RecordID), StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(field.Name, nameof(EventObjectSlim.GatheredFrom), StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(field.Name, nameof(EventObjectSlim.GatheredLogName), StringComparison.OrdinalIgnoreCase)) {
-            return false;
-        }
-
-        if (string.Equals(field.FieldType.Name, "EventObject", StringComparison.Ordinal)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    private static bool ShouldIncludeProperty(PropertyInfo property) {
-        if (property is null || !property.CanRead || property.GetMethod is null || !property.GetMethod.IsPublic) {
-            return false;
-        }
-
-        if (property.GetIndexParameters().Length != 0) {
-            return false;
-        }
-
-        return true;
-    }
-
-    private static object? NormalizeValue(object? value) {
-        if (value is null) {
-            return null;
-        }
-
-        if (value is DateTime dateTime) {
-            return dateTime.ToUniversalTime().ToString("O");
-        }
-
-        if (value is DateTimeOffset dateTimeOffset) {
-            return dateTimeOffset.ToUniversalTime().ToString("O");
-        }
-
-        if (value is Enum enumValue) {
-            return enumValue.ToString();
-        }
-
-        return value;
-    }
-
-    private static string? ReadPayloadString(IReadOnlyDictionary<string, object?> payload, string key) {
-        if (!payload.TryGetValue(key, out var value) || value is null) {
-            return null;
-        }
-
-        var text = value.ToString();
-        return string.IsNullOrWhiteSpace(text) ? null : text.Trim();
-    }
-
-    private static string? ReadPayloadUtc(IReadOnlyDictionary<string, object?> payload, string key) {
-        if (!payload.TryGetValue(key, out var value) || value is null) {
-            return null;
-        }
-
-        if (value is string text && DateTime.TryParse(text, out var parsed)) {
-            return parsed.ToUniversalTime().ToString("O");
-        }
-
-        if (value is DateTime dateTime) {
-            return dateTime.ToUniversalTime().ToString("O");
-        }
-
-        return value.ToString();
-    }
-
-    private static string ToSnakeCase(string name) {
-        if (string.IsNullOrWhiteSpace(name)) {
-            return string.Empty;
-        }
-
-        return JsonNamingPolicy.SnakeCaseLower.ConvertName(name);
-    }
-
-    private static bool TryParseTimePeriod(string raw, out TimePeriod timePeriod, out string? error) {
-        timePeriod = default;
-        error = null;
-
-        var normalized = ToSnakeCase(raw);
-        if (string.IsNullOrWhiteSpace(normalized)) {
-            error = "time_period is required when provided.";
-            return false;
-        }
-
-        if (TimePeriodByName.TryGetValue(normalized, out timePeriod)) {
-            return true;
-        }
-
-        error = $"time_period must be one of: {string.Join(", ", TimePeriodNames)}.";
-        return false;
-    }
-
-    private static IReadOnlyDictionary<string, TimePeriod> BuildTimePeriodMap() {
-        var map = new Dictionary<string, TimePeriod>(StringComparer.OrdinalIgnoreCase);
-        foreach (var value in Enum.GetValues<TimePeriod>()) {
-            map[ToSnakeCase(value.ToString())] = value;
-        }
-        return map;
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogPackInfoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogPackInfoTool.cs
@@ -46,9 +46,10 @@ public sealed class EventLogPackInfoTool : EventLogToolBase, ITool {
                 "Use eventlog_evtx_query or eventlog_live_query for event evidence.",
                 "Use eventlog_evtx_stats/eventlog_live_stats for top-level aggregation.",
                 "Use eventlog_named_events_catalog/eventlog_named_events_query for rule-based, intent-level detections (AD/Kerberos/GPO/etc).",
+                "Use eventlog_timeline_query to build reusable timeline and correlation views from named-event evidence (no fixed report templates).",
                 "For remote live logs, pass machine_name (and optional session_timeout_ms) to eventlog_live_query/eventlog_live_stats.",
-                "Use security report tools for lockouts/logons/failures when investigating authentication incidents.",
-                "For AD identity correlation: call ad_environment_discover, then ad_search using eventlog report ad_correlation candidates."
+                "For authentication investigations and timeline correlation, use eventlog_named_events_catalog first, then eventlog_timeline_query with named_events/categories and either correlation_profile or explicit correlation_keys.",
+                "For AD identity correlation: call ad_environment_discover, then ad_search using identities extracted from eventlog_named_events_query evidence."
             },
             flowSteps: new[] {
                 ToolPackGuidance.FlowStep(
@@ -65,12 +66,16 @@ public sealed class EventLogPackInfoTool : EventLogToolBase, ITool {
                     goal: "Run named-event rule detections",
                     suggestedTools: new[] { "eventlog_named_events_catalog", "eventlog_named_events_query" }),
                 ToolPackGuidance.FlowStep(
+                    goal: "Build generic event timelines and correlation groups",
+                    suggestedTools: new[] { "eventlog_named_events_catalog", "eventlog_timeline_query" },
+                    notes: "Start with correlation_profile presets, then tune correlation_keys (for example who/object_affected/computer/action) when needed."),
+                ToolPackGuidance.FlowStep(
                     goal: "Investigate authentication incidents",
-                    suggestedTools: new[] { "eventlog_evtx_report_failed_logons", "eventlog_evtx_report_account_lockouts", "eventlog_evtx_report_user_logons" }),
+                    suggestedTools: new[] { "eventlog_named_events_catalog", "eventlog_timeline_query", "eventlog_evtx_query" }),
                 ToolPackGuidance.FlowStep(
                     goal: "Correlate event identities with AD objects",
-                    suggestedTools: new[] { "ad_environment_discover", "ad_search" },
-                    notes: "Use ad_correlation payload from security report tools to drive AD lookups.")
+                    suggestedTools: new[] { "eventlog_timeline_query", "ad_environment_discover", "ad_search" },
+                    notes: "Drive AD lookups from normalized user/domain identities in named-events query evidence.")
             },
             capabilities: new[] {
                 ToolPackGuidance.Capability(
@@ -82,23 +87,23 @@ public sealed class EventLogPackInfoTool : EventLogToolBase, ITool {
                     summary: "Compute top-level statistics from EVTX files and live event channels.",
                     primaryTools: new[] { "eventlog_evtx_stats", "eventlog_live_stats" }),
                 ToolPackGuidance.Capability(
-                    id: "security_reports",
-                    summary: "Produce focused lockout/logon/failure views for security investigations.",
-                    primaryTools: new[] { "eventlog_evtx_report_failed_logons", "eventlog_evtx_report_account_lockouts", "eventlog_evtx_report_user_logons" }),
-                ToolPackGuidance.Capability(
                     id: "named_event_rules",
                     summary: "Run EventViewerX named-event rule detections and return normalized evidence rows.",
                     primaryTools: new[] { "eventlog_named_events_catalog", "eventlog_named_events_query" }),
                 ToolPackGuidance.Capability(
-                    id: "ad_correlation_hints",
-                    summary: "Emit AD follow-up hints/candidate identities from security report aggregates.",
-                    primaryTools: new[] { "eventlog_evtx_report_failed_logons", "eventlog_evtx_report_account_lockouts", "eventlog_evtx_report_user_logons" },
+                    id: "timeline_correlation",
+                    summary: "Build reusable timelines and correlation groups from named-event evidence using caller-selected dimensions.",
+                    primaryTools: new[] { "eventlog_named_events_catalog", "eventlog_timeline_query" }),
+                ToolPackGuidance.Capability(
+                    id: "correlation_workflow",
+                    summary: "Use named-event detections as reusable correlation building blocks across log, timeline, and AD enrichment workflows.",
+                    primaryTools: new[] { "eventlog_named_events_catalog", "eventlog_timeline_query", "eventlog_named_events_query", "eventlog_evtx_query" },
                     notes: "Use ad_environment_discover + ad_search in the AD pack for identity enrichment.")
             },
             toolCatalog: ToolRegistryEventLogExtensions.GetRegisteredToolCatalog(Options),
             rawPayloadPolicy: "Preserve raw event arrays and report objects for model reasoning.",
             viewProjectionPolicy: "Projection arguments are optional and view-only.",
-            correlationGuidance: "Security report tools include ad_correlation candidates to bootstrap AD lookups and cross-pack reasoning.",
+            correlationGuidance: "Use eventlog_timeline_query with correlation_profile presets or explicit correlation_keys, then bootstrap AD lookups from user/domain payload evidence.",
             setupHints: new {
                 Platform = Environment.OSVersion.Platform.ToString(),
                 MaxResults = Options.MaxResults,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogTimelineCorrelationProfiles.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogTimelineCorrelationProfiles.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace IntelligenceX.Tools.EventLog;
+
+internal static class EventLogTimelineCorrelationProfiles {
+    private sealed record CorrelationProfile(string Name, IReadOnlyList<string> Keys);
+
+    private static readonly CorrelationProfile[] ProfilesValue = {
+        new("identity", new[] { "who", "object_affected", "computer" }),
+        new("actor_activity", new[] { "who", "action", "computer" }),
+        new("object_activity", new[] { "object_affected", "action", "who" }),
+        new("host_activity", new[] { "computer", "action", "who" }),
+        new("rule_activity", new[] { "named_event", "who", "object_affected" })
+    };
+
+    private static readonly IReadOnlyDictionary<string, CorrelationProfile> ProfilesByName =
+        ProfilesValue.ToDictionary(static profile => profile.Name, StringComparer.OrdinalIgnoreCase);
+
+    internal static IReadOnlyList<string> Names { get; } = ProfilesValue
+        .Select(static profile => profile.Name)
+        .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+    internal static bool TryResolve(
+        string? rawProfile,
+        out string? normalizedProfile,
+        out IReadOnlyList<string>? keys,
+        out string? error) {
+        normalizedProfile = null;
+        keys = null;
+        error = null;
+
+        var profile = EventLogNamedEventsQueryShared.ToSnakeCase(rawProfile ?? string.Empty);
+        if (string.IsNullOrWhiteSpace(profile)) {
+            return true;
+        }
+
+        if (!ProfilesByName.TryGetValue(profile, out var resolved)) {
+            error = $"correlation_profile ('{rawProfile}') is not recognized. Allowed values: {string.Join(", ", Names)}.";
+            return false;
+        }
+
+        normalizedProfile = resolved.Name;
+        keys = resolved.Keys;
+        return true;
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogTimelineQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogTimelineQueryTool.cs
@@ -19,6 +19,8 @@ public sealed class EventLogTimelineQueryTool : EventLogToolBase, ITool {
 
     private static readonly string[] CorrelationKeyNames = NamedEventsTimelineQueryExecutor.AllowedCorrelationKeys
         .ToArray();
+    private static readonly string[] CorrelationProfileNames = EventLogTimelineCorrelationProfiles.Names
+        .ToArray();
 
     private static readonly ToolDefinition DefinitionValue = new(
         "eventlog_timeline_query",
@@ -36,6 +38,7 @@ public sealed class EventLogTimelineQueryTool : EventLogToolBase, ITool {
                 ("max_events_per_named_event", ToolSchema.Integer("Optional per-rule cap to prevent one named event from dominating results.")),
                 ("max_events", ToolSchema.Integer("Maximum events to return (capped).")),
                 ("max_threads", ToolSchema.Integer("Maximum query concurrency (capped).")),
+                ("correlation_profile", ToolSchema.String("Optional correlation profile preset. Cannot be combined with correlation_keys.").Enum(CorrelationProfileNames)),
                 ("correlation_keys", ToolSchema.Array(ToolSchema.String("Correlation field key.").Enum(CorrelationKeyNames), "Optional correlation dimensions. Defaults to who/object_affected/computer.")),
                 ("include_uncorrelated", ToolSchema.Boolean("When false, events missing all correlation key values are excluded from timeline/groups.")),
                 ("max_groups", ToolSchema.Integer("Maximum correlation groups to return (capped).")),
@@ -47,7 +50,8 @@ public sealed class EventLogTimelineQueryTool : EventLogToolBase, ITool {
 
     private sealed record TimelineRequest(
         NamedEventsTimelineQueryRequest QueryRequest,
-        IReadOnlyList<string>? Categories);
+        IReadOnlyList<string>? Categories,
+        string? CorrelationProfile);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EventLogTimelineQueryTool"/> class.
@@ -119,8 +123,21 @@ public sealed class EventLogTimelineQueryTool : EventLogToolBase, ITool {
             }
 
             var rawCorrelationKeys = reader.DistinctStringArray("correlation_keys");
+            var rawCorrelationProfile = reader.OptionalString("correlation_profile");
+            if (rawCorrelationKeys.Count > 0 && !string.IsNullOrWhiteSpace(rawCorrelationProfile)) {
+                return ToolRequestBindingResult<TimelineRequest>.Failure("correlation_profile cannot be combined with correlation_keys.");
+            }
+
+            if (!EventLogTimelineCorrelationProfiles.TryResolve(
+                    rawCorrelationProfile,
+                    out var correlationProfile,
+                    out var profileCorrelationKeys,
+                    out var correlationProfileError)) {
+                return ToolRequestBindingResult<TimelineRequest>.Failure(correlationProfileError ?? "Invalid correlation_profile.");
+            }
+
             IReadOnlyList<string>? correlationKeys = rawCorrelationKeys.Count == 0
-                ? null
+                ? profileCorrelationKeys
                 : rawCorrelationKeys;
 
             var machines = EventLogNamedEventsQueryShared.ResolveMachines(arguments, EventLogNamedEventsQueryShared.MaxMachines);
@@ -145,7 +162,7 @@ public sealed class EventLogTimelineQueryTool : EventLogToolBase, ITool {
             };
 
             return ToolRequestBindingResult<TimelineRequest>.Success(
-                new TimelineRequest(queryRequest, categories));
+                new TimelineRequest(queryRequest, categories, correlationProfile));
         });
     }
 
@@ -211,6 +228,9 @@ public sealed class EventLogTimelineQueryTool : EventLogToolBase, ITool {
                 }
                 if (request.TimePeriod.HasValue) {
                     meta.Add("time_period", EventLogNamedEventsQueryShared.ToSnakeCase(request.TimePeriod.Value.ToString()));
+                }
+                if (!string.IsNullOrWhiteSpace(context.Request.CorrelationProfile)) {
+                    meta.Add("correlation_profile", context.Request.CorrelationProfile);
                 }
             });
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/ToolRegistryEventLogExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/ToolRegistryEventLogExtensions.cs
@@ -42,14 +42,12 @@ public static class ToolRegistryEventLogExtensions {
         yield return new EventLogProviderListTool(options);
         yield return new EventLogNamedEventsCatalogTool(options);
         yield return new EventLogNamedEventsQueryTool(options);
+        yield return new EventLogTimelineQueryTool(options);
         yield return new EventLogTopEventsTool(options);
         yield return new EventLogLiveQueryTool(options);
         yield return new EventLogLiveStatsTool(options);
         yield return new EventLogEvtxFindTool(options);
         yield return new EventLogEvtxQueryTool(options);
         yield return new EventLogEvtxStatsTool(options);
-        yield return new EventLogEvtxUserLogonsReportTool(options);
-        yield return new EventLogEvtxFailedLogonsReportTool(options);
-        yield return new EventLogEvtxAccountLockoutsReportTool(options);
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogTimelineQueryToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogTimelineQueryToolTests.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+using IntelligenceX.Tools.EventLog;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public class EventLogTimelineQueryToolTests {
+    [Fact]
+    public async Task TimelineQuery_WhenNamedEventsAndCategoriesMissing_ReturnsInvalidArgument() {
+        var tool = new EventLogTimelineQueryTool(new EventLogToolOptions());
+
+        var json = await tool.InvokeAsync(arguments: null, cancellationToken: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        Assert.Contains("Provide at least one of: named_events, categories.", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task TimelineQuery_WhenCorrelationKeyInvalid_ReturnsInvalidArgument() {
+        var tool = new EventLogTimelineQueryTool(new EventLogToolOptions());
+        var args = new JsonObject()
+            .Add("named_events", new JsonArray().Add("ad_user_logon"))
+            .Add("correlation_keys", new JsonArray().Add("invalid_dimension"));
+
+        var json = await tool.InvokeAsync(args, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        Assert.Contains("correlation", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task TimelineQuery_WhenCorrelationProfileInvalid_ReturnsInvalidArgument() {
+        var tool = new EventLogTimelineQueryTool(new EventLogToolOptions());
+        var args = new JsonObject()
+            .Add("named_events", new JsonArray().Add("ad_user_logon"))
+            .Add("correlation_profile", "not_a_profile");
+
+        var json = await tool.InvokeAsync(args, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        Assert.Contains("correlation_profile", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task TimelineQuery_WhenCorrelationProfileCombinedWithKeys_ReturnsInvalidArgument() {
+        var tool = new EventLogTimelineQueryTool(new EventLogToolOptions());
+        var args = new JsonObject()
+            .Add("named_events", new JsonArray().Add("ad_user_logon"))
+            .Add("correlation_profile", "identity")
+            .Add("correlation_keys", new JsonArray().Add("who"));
+
+        var json = await tool.InvokeAsync(args, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        Assert.Contains("cannot be combined", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task TimelineQuery_WhenTimePeriodAndRangeBothProvided_ReturnsInvalidArgument() {
+        var tool = new EventLogTimelineQueryTool(new EventLogToolOptions());
+        var args = new JsonObject()
+            .Add("named_events", new JsonArray().Add("ad_user_logon"))
+            .Add("time_period", "last_7_days")
+            .Add("start_time_utc", "2026-02-01T00:00:00Z");
+
+        var json = await tool.InvokeAsync(args, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        Assert.Contains("time_period cannot be combined", root.GetProperty("error").GetString());
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/SourceGuardrailTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/SourceGuardrailTests.cs
@@ -109,9 +109,6 @@ public class SourceGuardrailTests {
         }
 
         string[] filesToScan = {
-            Path.Combine(repoRoot, "IntelligenceX.Tools.EventLog", "EventLogEvtxFailedLogonsReportTool.cs"),
-            Path.Combine(repoRoot, "IntelligenceX.Tools.EventLog", "EventLogEvtxAccountLockoutsReportTool.cs"),
-            Path.Combine(repoRoot, "IntelligenceX.Tools.EventLog", "EventLogEvtxUserLogonsReportTool.cs"),
             Path.Combine(repoRoot, "IntelligenceX.Tools.EventLog", "EventLogPackInfoTool.cs"),
             Path.Combine(repoRoot, "IntelligenceX.Tools.ADPlayground", "AdSpnStatsTool.cs"),
             Path.Combine(repoRoot, "IntelligenceX.Tools.ADPlayground", "AdStaleAccountsTool.cs"),

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
@@ -63,9 +63,10 @@ public class ToolDefinitionContractTests {
             "eventlog_pack_info",
             "eventlog_named_events_catalog",
             "eventlog_named_events_query",
-            "eventlog_evtx_report_user_logons",
-            "eventlog_evtx_report_failed_logons",
-            "eventlog_evtx_report_account_lockouts"
+            "eventlog_timeline_query",
+            "eventlog_top_events",
+            "eventlog_evtx_query",
+            "eventlog_evtx_stats"
         };
 
         foreach (var name in expected) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSchemaSnapshotTests.EventLogPowerShell.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSchemaSnapshotTests.EventLogPowerShell.cs
@@ -6,24 +6,6 @@ namespace IntelligenceX.Tools.Tests;
 public partial class ToolSchemaSnapshotTests {
     private static IEnumerable<object[]> EventLogAndPowerShellSchemaSnapshots() {
         yield return new object[] {
-            "eventlog_evtx_report_user_logons",
-            new[] { "path", "start_time_utc", "end_time_utc", "max_events_scanned", "top", "include_samples", "sample_size", "columns", "sort_by", "sort_direction" },
-            new[] { "path" }
-        };
-
-        yield return new object[] {
-            "eventlog_evtx_report_failed_logons",
-            new[] { "path", "start_time_utc", "end_time_utc", "max_events_scanned", "top", "include_samples", "sample_size", "columns", "sort_by", "sort_direction" },
-            new[] { "path" }
-        };
-
-        yield return new object[] {
-            "eventlog_evtx_report_account_lockouts",
-            new[] { "path", "start_time_utc", "end_time_utc", "max_events_scanned", "top", "include_samples", "sample_size", "columns", "sort_by", "sort_direction" },
-            new[] { "path" }
-        };
-
-        yield return new object[] {
             "eventlog_evtx_find",
             new[] { "query", "log_name", "max_results" },
             Array.Empty<string>()
@@ -38,6 +20,12 @@ public partial class ToolSchemaSnapshotTests {
         yield return new object[] {
             "eventlog_named_events_query",
             new[] { "named_events", "categories", "machine_name", "machine_names", "time_period", "start_time_utc", "end_time_utc", "log_name", "event_ids", "max_events_per_named_event", "max_events", "max_threads", "include_payload", "payload_keys", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "eventlog_timeline_query",
+            new[] { "named_events", "categories", "machine_name", "machine_names", "time_period", "start_time_utc", "end_time_utc", "log_name", "event_ids", "max_events_per_named_event", "max_events", "max_threads", "correlation_profile", "correlation_keys", "include_uncorrelated", "max_groups", "bucket_minutes", "include_payload", "payload_keys", "columns", "sort_by", "sort_direction", "top" },
             Array.Empty<string>()
         };
 


### PR DESCRIPTION
## Summary
- add data-driven correlation presets for `eventlog_timeline_query` via new `correlation_profile` argument
- keep profile behavior reusable/config-style (no incident hardcoding) and enforce explicit conflict rules (`correlation_profile` cannot be combined with `correlation_keys`)
- expose selected profile in response metadata
- restore shared named-event helper/payload modules and align EventLog registry/contracts/snapshots so timeline tooling is fully wired and test-covered

## Correlation Profiles
- `identity` -> `who`, `object_affected`, `computer`
- `actor_activity` -> `who`, `action`, `computer`
- `object_activity` -> `object_affected`, `action`, `who`
- `host_activity` -> `computer`, `action`, `who`
- `rule_activity` -> `named_event`, `who`, `object_affected`

## Validation
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.EventLog/IntelligenceX.Tools.EventLog.csproj -c Release`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~EventLogTimelineQueryToolTests|FullyQualifiedName~ToolSchemaSnapshotTests|FullyQualifiedName~ToolDefinitionContractTests|FullyQualifiedName~ToolPackInfoContractTests|FullyQualifiedName~SourceGuardrailTests"`
