### PR TITLE
feat(tools): add reusable entity handoff contract for pack guidance

### DIFF
--- a/IntelligenceX.Tools/Docs/ToolOutputContract.md
+++ b/IntelligenceX.Tools/Docs/ToolOutputContract.md
@@ -114,6 +114,7 @@ Each pack should expose a `*_pack_info` tool with:
 - setup expectations and limits
 - recommended tool-call sequences (`recommended_flow`, `recommended_flow_steps`)
 - capability catalog (`capabilities`)
+- structured cross-tool entity handoff guidance (`entity_handoffs`)
 - runtime-derived tool catalog (`tool_catalog`) with descriptions, required args, argument hints, and structured `traits` (projection/paging/time-range/dynamic-attributes/scoping/action flags)
 - output-contract guidance (raw payload vs view projection)
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPackInfoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPackInfoTool.cs
@@ -143,6 +143,22 @@ public sealed class AdPackInfoTool : ActiveDirectoryToolBase, ITool {
                     summary: "Run ADPlayground.Monitoring probes (ldap/dns/kerberos/ntp/replication/port/https/dns_service/adws/directory/ping) for server/domain/forest scope.",
                     primaryTools: new[] { "ad_monitoring_probe_catalog", "ad_monitoring_probe_run" })
             },
+            entityHandoffs: new[] {
+                ToolPackGuidance.EntityHandoff(
+                    id: "external_identity_to_ad_resolution",
+                    summary: "Consume identity/host indicators from other packs and normalize them for AD object resolution.",
+                    entityKinds: new[] { "identity", "user", "group", "computer", "host" },
+                    sourceTools: new[] { "eventlog_named_events_query", "eventlog_timeline_query", "system_whoami", "powershell_run" },
+                    targetTools: new[] { "ad_object_resolve", "ad_search", "ad_object_get", "ad_group_members_resolved" },
+                    fieldMappings: new[] {
+                        ToolPackGuidance.EntityFieldMapping("*.who", "identities", "Batch and deduplicate values for ad_object_resolve."),
+                        ToolPackGuidance.EntityFieldMapping("*.object_affected", "identities", "Batch and deduplicate values for ad_object_resolve."),
+                        ToolPackGuidance.EntityFieldMapping("*.computer", "identity", "Use hostname/FQDN as identity for ad_search/ad_object_get."),
+                        ToolPackGuidance.EntityFieldMapping("identity.account_name", "identity", "Use as direct identity input for ad_search/ad_object_get."),
+                        ToolPackGuidance.EntityFieldMapping("resolved[].distinguished_name", "identity", "Use direct DN for follow-up detail lookups.")
+                    },
+                    notes: "Prefer ad_object_resolve for bulk correlation to avoid N+1 lookups.")
+            },
             toolCatalog: ToolRegistryActiveDirectoryExtensions.GetRegisteredToolCatalog(Options),
             rawPayloadPolicy: "Preserve raw engine payloads (including dynamic LDAP attribute bags and nested objects).",
             viewProjectionPolicy: "Projection arguments are optional and view-only; they must not replace raw payload.",

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPackGuidance.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPackGuidance.cs
@@ -62,6 +62,11 @@ public sealed class ToolPackInfoModel {
     public IReadOnlyList<ToolPackCapabilityModel> Capabilities { get; init; } = Array.Empty<ToolPackCapabilityModel>();
 
     /// <summary>
+    /// Structured entity handoff guidance for cross-tool and cross-pack correlation.
+    /// </summary>
+    public IReadOnlyList<ToolPackEntityHandoffModel> EntityHandoffs { get; init; } = Array.Empty<ToolPackEntityHandoffModel>();
+
+    /// <summary>
     /// Tool-level catalog derived from runtime registrations and schemas.
     /// </summary>
     public IReadOnlyList<ToolPackToolCatalogEntryModel> ToolCatalog { get; init; } = Array.Empty<ToolPackToolCatalogEntryModel>();
@@ -145,6 +150,66 @@ public sealed class ToolPackCapabilityModel {
     /// Optional notes for this capability.
     /// </summary>
     public string? Notes { get; init; }
+}
+
+/// <summary>
+/// Structured descriptor for handing entity evidence from source tools to follow-up tools.
+/// </summary>
+public sealed class ToolPackEntityHandoffModel {
+    /// <summary>
+    /// Stable handoff identifier.
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable handoff summary.
+    /// </summary>
+    public string Summary { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Entity kinds promoted by this handoff (for example user/computer/domain).
+    /// </summary>
+    public IReadOnlyList<string> EntityKinds { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Source tools that emit the handoff entities.
+    /// </summary>
+    public IReadOnlyList<string> SourceTools { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Follow-up tools that should consume the handoff entities.
+    /// </summary>
+    public IReadOnlyList<string> TargetTools { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Optional field-level mapping hints between source payload fields and target arguments.
+    /// </summary>
+    public IReadOnlyList<ToolPackEntityFieldMappingModel> FieldMappings { get; init; } = Array.Empty<ToolPackEntityFieldMappingModel>();
+
+    /// <summary>
+    /// Optional notes for this handoff.
+    /// </summary>
+    public string? Notes { get; init; }
+}
+
+/// <summary>
+/// Field mapping hint for entity handoffs.
+/// </summary>
+public sealed class ToolPackEntityFieldMappingModel {
+    /// <summary>
+    /// Source payload field path or symbolic field name.
+    /// </summary>
+    public string SourceField { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Target tool argument name.
+    /// </summary>
+    public string TargetArgument { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional normalization hint for model/tool routing.
+    /// </summary>
+    public string? Normalization { get; init; }
 }
 
 /// <summary>
@@ -406,6 +471,53 @@ public static class ToolPackGuidance {
     }
 
     /// <summary>
+    /// Creates a structured entity handoff descriptor.
+    /// </summary>
+    public static ToolPackEntityHandoffModel EntityHandoff(
+        string id,
+        string summary,
+        IEnumerable<string>? entityKinds = null,
+        IEnumerable<string>? sourceTools = null,
+        IEnumerable<string>? targetTools = null,
+        IEnumerable<ToolPackEntityFieldMappingModel>? fieldMappings = null,
+        string? notes = null) {
+        if (string.IsNullOrWhiteSpace(id)) {
+            throw new ArgumentException("Entity handoff id is required.", nameof(id));
+        }
+        if (string.IsNullOrWhiteSpace(summary)) {
+            throw new ArgumentException("Entity handoff summary is required.", nameof(summary));
+        }
+
+        return new ToolPackEntityHandoffModel {
+            Id = id.Trim(),
+            Summary = summary.Trim(),
+            EntityKinds = NormalizeValues(entityKinds),
+            SourceTools = NormalizeValues(sourceTools),
+            TargetTools = NormalizeValues(targetTools),
+            FieldMappings = NormalizeEntityFieldMappings(fieldMappings),
+            Notes = string.IsNullOrWhiteSpace(notes) ? null : notes.Trim()
+        };
+    }
+
+    /// <summary>
+    /// Creates a source-field to target-argument mapping descriptor for entity handoffs.
+    /// </summary>
+    public static ToolPackEntityFieldMappingModel EntityFieldMapping(string sourceField, string targetArgument, string? normalization = null) {
+        if (string.IsNullOrWhiteSpace(sourceField)) {
+            throw new ArgumentException("Source field is required.", nameof(sourceField));
+        }
+        if (string.IsNullOrWhiteSpace(targetArgument)) {
+            throw new ArgumentException("Target argument is required.", nameof(targetArgument));
+        }
+
+        return new ToolPackEntityFieldMappingModel {
+            SourceField = sourceField.Trim(),
+            TargetArgument = targetArgument.Trim(),
+            Normalization = string.IsNullOrWhiteSpace(normalization) ? null : normalization.Trim()
+        };
+    }
+
+    /// <summary>
     /// Builds a tool catalog from runtime tool instances.
     /// </summary>
     /// <param name="tools">Tool instances used for registration.</param>
@@ -462,6 +574,7 @@ public static class ToolPackGuidance {
     /// <param name="recommendedFlow">Optional flow guidance.</param>
     /// <param name="flowSteps">Optional structured flow steps.</param>
     /// <param name="capabilities">Optional structured capability descriptors.</param>
+    /// <param name="entityHandoffs">Optional structured entity handoff descriptors.</param>
     /// <param name="toolCatalog">Optional tool catalog derived from runtime registrations and schemas.</param>
     /// <param name="rawPayloadPolicy">Optional raw payload policy override.</param>
     /// <param name="viewProjectionPolicy">Optional projection policy override.</param>
@@ -479,6 +592,7 @@ public static class ToolPackGuidance {
         IEnumerable<string>? recommendedFlow = null,
         IEnumerable<ToolPackFlowStepModel>? flowSteps = null,
         IEnumerable<ToolPackCapabilityModel>? capabilities = null,
+        IEnumerable<ToolPackEntityHandoffModel>? entityHandoffs = null,
         IEnumerable<ToolPackToolCatalogEntryModel>? toolCatalog = null,
         string? rawPayloadPolicy = null,
         string? viewProjectionPolicy = null,
@@ -499,6 +613,7 @@ public static class ToolPackGuidance {
         var flow = NormalizeValues(recommendedFlow, distinct: false);
         var resolvedFlowSteps = NormalizeFlowSteps(flowSteps);
         var resolvedCapabilities = NormalizeCapabilities(capabilities);
+        var resolvedEntityHandoffs = NormalizeEntityHandoffs(entityHandoffs);
         var resolvedToolCatalog = NormalizeToolCatalog(toolCatalog);
 
         return new ToolPackInfoModel {
@@ -521,6 +636,7 @@ public static class ToolPackGuidance {
             RecommendedFlow = flow,
             RecommendedFlowSteps = resolvedFlowSteps,
             Capabilities = resolvedCapabilities,
+            EntityHandoffs = resolvedEntityHandoffs,
             ToolCatalog = resolvedToolCatalog,
             Tools = resolvedTools,
             Note = string.IsNullOrWhiteSpace(note) ? null : note.Trim()
@@ -570,6 +686,60 @@ public static class ToolPackGuidance {
                 Summary = capability.Summary.Trim(),
                 PrimaryTools = NormalizeValues(capability.PrimaryTools),
                 Notes = string.IsNullOrWhiteSpace(capability.Notes) ? null : capability.Notes.Trim()
+            });
+        }
+
+        return list;
+    }
+
+    private static IReadOnlyList<ToolPackEntityHandoffModel> NormalizeEntityHandoffs(IEnumerable<ToolPackEntityHandoffModel>? handoffs) {
+        var list = new List<ToolPackEntityHandoffModel>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var handoff in handoffs ?? Array.Empty<ToolPackEntityHandoffModel>()) {
+            if (handoff is null || string.IsNullOrWhiteSpace(handoff.Id) || string.IsNullOrWhiteSpace(handoff.Summary)) {
+                continue;
+            }
+
+            var id = handoff.Id.Trim();
+            if (!seen.Add(id)) {
+                continue;
+            }
+
+            list.Add(new ToolPackEntityHandoffModel {
+                Id = id,
+                Summary = handoff.Summary.Trim(),
+                EntityKinds = NormalizeValues(handoff.EntityKinds),
+                SourceTools = NormalizeValues(handoff.SourceTools),
+                TargetTools = NormalizeValues(handoff.TargetTools),
+                FieldMappings = NormalizeEntityFieldMappings(handoff.FieldMappings),
+                Notes = string.IsNullOrWhiteSpace(handoff.Notes) ? null : handoff.Notes.Trim()
+            });
+        }
+
+        return list;
+    }
+
+    private static IReadOnlyList<ToolPackEntityFieldMappingModel> NormalizeEntityFieldMappings(IEnumerable<ToolPackEntityFieldMappingModel>? mappings) {
+        var list = new List<ToolPackEntityFieldMappingModel>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var mapping in mappings ?? Array.Empty<ToolPackEntityFieldMappingModel>()) {
+            if (mapping is null || string.IsNullOrWhiteSpace(mapping.SourceField) || string.IsNullOrWhiteSpace(mapping.TargetArgument)) {
+                continue;
+            }
+
+            var source = mapping.SourceField.Trim();
+            var target = mapping.TargetArgument.Trim();
+            var key = $"{source}|{target}";
+            if (!seen.Add(key)) {
+                continue;
+            }
+
+            list.Add(new ToolPackEntityFieldMappingModel {
+                SourceField = source,
+                TargetArgument = target,
+                Normalization = string.IsNullOrWhiteSpace(mapping.Normalization) ? null : mapping.Normalization.Trim()
             });
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogPackInfoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogPackInfoTool.cs
@@ -100,6 +100,23 @@ public sealed class EventLogPackInfoTool : EventLogToolBase, ITool {
                     primaryTools: new[] { "eventlog_named_events_catalog", "eventlog_timeline_query", "eventlog_named_events_query", "eventlog_evtx_query" },
                     notes: "Use ad_environment_discover + ad_search in the AD pack for identity enrichment.")
             },
+            entityHandoffs: new[] {
+                ToolPackGuidance.EntityHandoff(
+                    id: "event_identity_to_ad_lookup",
+                    summary: "Promote normalized identity and host fields from EventLog evidence into AD lookup workflows.",
+                    entityKinds: new[] { "identity", "user", "host", "computer" },
+                    sourceTools: new[] { "eventlog_named_events_query", "eventlog_timeline_query" },
+                    targetTools: new[] { "ad_environment_discover", "ad_search", "ad_object_resolve" },
+                    fieldMappings: new[] {
+                        ToolPackGuidance.EntityFieldMapping("events[].who", "identity", "Trim and preserve UPN/DOMAIN\\\\user forms."),
+                        ToolPackGuidance.EntityFieldMapping("events[].object_affected", "identity", "Use when object_affected represents a user/computer identity."),
+                        ToolPackGuidance.EntityFieldMapping("events[].computer", "identity", "Prefer hostname/FQDN values for AD computer lookups."),
+                        ToolPackGuidance.EntityFieldMapping("timeline[].who", "identities", "Batch values into identities for ad_object_resolve."),
+                        ToolPackGuidance.EntityFieldMapping("timeline[].object_affected", "identities", "Batch values into identities for ad_object_resolve."),
+                        ToolPackGuidance.EntityFieldMapping("timeline[].computer", "identities", "Batch host identities into ad_object_resolve inputs.")
+                    },
+                    notes: "Use structured field correlation (not incident-specific templates) and de-duplicate identities before AD calls.")
+            },
             toolCatalog: ToolRegistryEventLogExtensions.GetRegisteredToolCatalog(Options),
             rawPayloadPolicy: "Preserve raw event arrays and report objects for model reasoning.",
             viewProjectionPolicy: "Projection arguments are optional and view-only.",

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPackGuidanceTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPackGuidanceTests.cs
@@ -83,6 +83,58 @@ public class ToolPackGuidanceTests {
     }
 
     [Fact]
+    public void EntityHandoff_ShouldNormalizeFieldsAndTools() {
+        var handoff = ToolPackGuidance.EntityHandoff(
+            id: " identity_bridge ",
+            summary: " bridge summary ",
+            entityKinds: new[] { "user", "USER", " computer " },
+            sourceTools: new[] { " eventlog_named_events_query ", "EVENTLOG_NAMED_EVENTS_QUERY", "eventlog_timeline_query" },
+            targetTools: new[] { "ad_search", "AD_SEARCH", " ad_object_resolve " },
+            fieldMappings: new[] {
+                ToolPackGuidance.EntityFieldMapping(" events[].who ", " identity ", " trim "),
+                ToolPackGuidance.EntityFieldMapping("events[].who", "identity"),
+                ToolPackGuidance.EntityFieldMapping("timeline[].computer", "identities")
+            },
+            notes: " note ");
+
+        Assert.Equal("identity_bridge", handoff.Id);
+        Assert.Equal("bridge summary", handoff.Summary);
+        Assert.Equal(new[] { "user", "computer" }, handoff.EntityKinds);
+        Assert.Equal(new[] { "eventlog_named_events_query", "eventlog_timeline_query" }, handoff.SourceTools);
+        Assert.Equal(new[] { "ad_search", "ad_object_resolve" }, handoff.TargetTools);
+        Assert.Equal(2, handoff.FieldMappings.Count);
+        Assert.Equal("events[].who", handoff.FieldMappings[0].SourceField);
+        Assert.Equal("identity", handoff.FieldMappings[0].TargetArgument);
+        Assert.Equal("trim", handoff.FieldMappings[0].Normalization);
+        Assert.Equal("note", handoff.Notes);
+    }
+
+    [Fact]
+    public void Create_ShouldExposeEntityHandoffs() {
+        var model = ToolPackGuidance.Create(
+            pack: "eventlog",
+            engine: "EventViewerX",
+            tools: new[] { "eventlog_pack_info" },
+            entityHandoffs: new[] {
+                ToolPackGuidance.EntityHandoff(
+                    id: "identity_to_ad",
+                    summary: "Forward identities to AD tools.",
+                    sourceTools: new[] { "eventlog_named_events_query" },
+                    targetTools: new[] { "ad_object_resolve" },
+                    fieldMappings: new[] {
+                        ToolPackGuidance.EntityFieldMapping("events[].who", "identities")
+                    })
+            });
+
+        var handoff = Assert.Single(model.EntityHandoffs);
+        Assert.Equal("identity_to_ad", handoff.Id);
+        Assert.Equal("Forward identities to AD tools.", handoff.Summary);
+        Assert.Equal(new[] { "eventlog_named_events_query" }, handoff.SourceTools);
+        Assert.Equal(new[] { "ad_object_resolve" }, handoff.TargetTools);
+        Assert.Single(handoff.FieldMappings);
+    }
+
+    [Fact]
     public void CatalogFromTools_ShouldExposeRequiredArgsAndProjectionSupport() {
         var catalog = ToolPackGuidance.CatalogFromTools(new ITool[] {
             new StubTool(new ToolDefinition(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPackInfoContractTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPackInfoContractTests.cs
@@ -202,6 +202,36 @@ public class ToolPackInfoContractTests {
                 var primaryTools = ReadStringArray(capability.GetProperty("primary_tools"));
                 Assert.True(primaryTools.Length > 0);
             }
+
+            var entityHandoffs = root.GetProperty("entity_handoffs");
+            Assert.Equal(JsonValueKind.Array, entityHandoffs.ValueKind);
+            foreach (var handoff in entityHandoffs.EnumerateArray()) {
+                var handoffId = handoff.GetProperty("id").GetString() ?? string.Empty;
+                var summary = handoff.GetProperty("summary").GetString() ?? string.Empty;
+                Assert.False(string.IsNullOrWhiteSpace(handoffId));
+                Assert.False(string.IsNullOrWhiteSpace(summary));
+
+                var sourceTools = ReadStringArray(handoff.GetProperty("source_tools"));
+                var targetTools = ReadStringArray(handoff.GetProperty("target_tools"));
+                Assert.True(sourceTools.Length > 0);
+                Assert.True(targetTools.Length > 0);
+
+                var fieldMappings = handoff.GetProperty("field_mappings");
+                Assert.Equal(JsonValueKind.Array, fieldMappings.ValueKind);
+                foreach (var mapping in fieldMappings.EnumerateArray()) {
+                    var sourceField = mapping.GetProperty("source_field").GetString() ?? string.Empty;
+                    var targetArgument = mapping.GetProperty("target_argument").GetString() ?? string.Empty;
+                    Assert.False(string.IsNullOrWhiteSpace(sourceField));
+                    Assert.False(string.IsNullOrWhiteSpace(targetArgument));
+                    Assert.True(mapping.TryGetProperty("normalization", out var normalizationNode));
+                    Assert.True(normalizationNode.ValueKind == JsonValueKind.String || normalizationNode.ValueKind == JsonValueKind.Null);
+                }
+            }
+
+            if (string.Equals(@case.Pack, "active_directory", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(@case.Pack, "eventlog", StringComparison.OrdinalIgnoreCase)) {
+                Assert.True(entityHandoffs.GetArrayLength() > 0);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add structured `entity_handoffs` contract to `ToolPackGuidance` for reusable cross-tool/cross-pack correlation hints
- add typed field-mapping helpers (`EntityHandoff`, `EntityFieldMapping`) with normalization/deduplication
- wire EventLog and AD pack info tools to publish concrete identity handoff guidance without hardcoded incident templates
- document the new pack-info section in `ToolOutputContract.md`

## Validation
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/IntelligenceX.Tools.ADPlayground.csproj -c Release`
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.EventLog/IntelligenceX.Tools.EventLog.csproj -c Release`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolPackGuidanceTests|FullyQualifiedName~ToolPackInfoContractTests"`

## Notes
- Keeps runtime behavior unchanged; this is contract/guidance enrichment for planner reuse and correlation handoff clarity.
