### PR TITLE
feat(eventlog): add structured entity handoff metadata for AD correlation

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEntityHandoff.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogEntityHandoff.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using IntelligenceX.Json;
+using IntelligenceX.Tools.Common;
+
+namespace IntelligenceX.Tools.EventLog;
+
+internal static class EventLogEntityHandoff {
+    private const int DefaultMaxCandidates = 50;
+    private const int MaxCandidatesCap = 200;
+
+    private sealed class CandidateAccumulator {
+        public int Count { get; set; }
+        public HashSet<string> SourceFields { get; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private sealed record EntityCandidateModel(
+        string Value,
+        int Count,
+        IReadOnlyList<string> SourceFields);
+
+    private sealed record TargetHintModel(
+        string Tool,
+        string Argument,
+        IReadOnlyList<string> Values,
+        string Note);
+
+    private sealed record EntityHandoffModel(
+        string Contract,
+        int Version,
+        int ScannedRows,
+        int IdentityCandidatesTotal,
+        int ComputerCandidatesTotal,
+        IReadOnlyList<EntityCandidateModel> IdentityCandidates,
+        IReadOnlyList<EntityCandidateModel> ComputerCandidates,
+        IReadOnlyList<TargetHintModel> TargetHints);
+
+    internal static JsonObject BuildFromRows<T>(
+        IEnumerable<T> rows,
+        Func<T, string?> whoSelector,
+        Func<T, string?> objectAffectedSelector,
+        Func<T, string?> computerSelector,
+        int maxCandidates = DefaultMaxCandidates) {
+        if (rows is null) {
+            throw new ArgumentNullException(nameof(rows));
+        }
+        if (whoSelector is null) {
+            throw new ArgumentNullException(nameof(whoSelector));
+        }
+        if (objectAffectedSelector is null) {
+            throw new ArgumentNullException(nameof(objectAffectedSelector));
+        }
+        if (computerSelector is null) {
+            throw new ArgumentNullException(nameof(computerSelector));
+        }
+
+        var boundedMaxCandidates = Math.Clamp(maxCandidates, 1, MaxCandidatesCap);
+        var identityCandidates = new Dictionary<string, CandidateAccumulator>(StringComparer.OrdinalIgnoreCase);
+        var computerCandidates = new Dictionary<string, CandidateAccumulator>(StringComparer.OrdinalIgnoreCase);
+        var scannedRows = 0;
+
+        foreach (var row in rows) {
+            scannedRows++;
+
+            AddCandidate(identityCandidates, whoSelector(row), "who");
+            AddCandidate(identityCandidates, objectAffectedSelector(row), "object_affected");
+
+            var computer = NormalizeCandidate(computerSelector(row));
+            if (computer is not null) {
+                AddCandidate(identityCandidates, computer, "computer");
+                AddCandidate(computerCandidates, computer, "computer");
+            }
+        }
+
+        var identityTop = ToCandidateModels(identityCandidates, boundedMaxCandidates);
+        var computerTop = ToCandidateModels(computerCandidates, boundedMaxCandidates);
+        var topIdentityValues = identityTop
+            .Select(static x => x.Value)
+            .ToArray();
+
+        var model = new EntityHandoffModel(
+            Contract: "eventlog_entity_handoff",
+            Version: 1,
+            ScannedRows: scannedRows,
+            IdentityCandidatesTotal: identityCandidates.Count,
+            ComputerCandidatesTotal: computerCandidates.Count,
+            IdentityCandidates: identityTop,
+            ComputerCandidates: computerTop,
+            TargetHints: new[] {
+                new TargetHintModel(
+                    Tool: "ad_object_resolve",
+                    Argument: "identities",
+                    Values: topIdentityValues,
+                    Note: "Pass deduplicated identity candidates as bulk identities input for AD resolution."),
+                new TargetHintModel(
+                    Tool: "ad_search",
+                    Argument: "identity",
+                    Values: topIdentityValues,
+                    Note: "Use the first high-confidence candidate as identity, then iterate remaining values as needed.")
+            });
+
+        return ToolJson.ToJsonObjectSnakeCase(model);
+    }
+
+    private static void AddCandidate(
+        Dictionary<string, CandidateAccumulator> store,
+        string? rawValue,
+        string sourceField) {
+        var normalized = NormalizeCandidate(rawValue);
+        if (normalized is null) {
+            return;
+        }
+
+        if (!store.TryGetValue(normalized, out var accumulator)) {
+            accumulator = new CandidateAccumulator();
+            store[normalized] = accumulator;
+        }
+
+        accumulator.Count++;
+        accumulator.SourceFields.Add(sourceField);
+    }
+
+    private static IReadOnlyList<EntityCandidateModel> ToCandidateModels(
+        Dictionary<string, CandidateAccumulator> store,
+        int maxCandidates) {
+        return store
+            .Select(static kvp => new EntityCandidateModel(
+                Value: kvp.Key,
+                Count: kvp.Value.Count,
+                SourceFields: kvp.Value.SourceFields
+                    .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+                    .ToArray()))
+            .OrderByDescending(static row => row.Count)
+            .ThenBy(static row => row.Value, StringComparer.OrdinalIgnoreCase)
+            .Take(maxCandidates)
+            .ToArray();
+    }
+
+    private static string? NormalizeCandidate(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        var normalized = value.Trim();
+        if (normalized.Length == 1 && normalized[0] == '-') {
+            return null;
+        }
+
+        return normalized;
+    }
+}
+

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryTool.cs
@@ -182,6 +182,12 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
             Truncated: truncated,
             Events: rows);
 
+        var entityHandoff = EventLogEntityHandoff.BuildFromRows(
+            rows: rows,
+            whoSelector: static row => row.Who,
+            objectAffectedSelector: static row => row.ObjectAffected,
+            computerSelector: static row => row.Computer);
+
         return BuildAutoTableResponse(
             arguments: arguments,
             model: result,
@@ -224,6 +230,7 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
                 if (timePeriod.HasValue) {
                     meta.Add("time_period", EventLogNamedEventsQueryShared.ToSnakeCase(timePeriod.Value.ToString()));
                 }
+                meta.Add("entity_handoff", entityHandoff);
             });
     }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogTimelineQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogTimelineQueryTool.cs
@@ -179,6 +179,12 @@ public sealed class EventLogTimelineQueryTool : EventLogToolBase, ITool {
             return ToolResponse.Error("query_failed", "Timeline query failed.");
         }
 
+        var entityHandoff = EventLogEntityHandoff.BuildFromRows(
+            rows: result.Timeline,
+            whoSelector: static row => row.Who,
+            objectAffectedSelector: static row => row.ObjectAffected,
+            computerSelector: static row => row.Computer);
+
         return BuildAutoTableResponse(
             arguments: context.Arguments,
             model: result,
@@ -232,6 +238,7 @@ public sealed class EventLogTimelineQueryTool : EventLogToolBase, ITool {
                 if (!string.IsNullOrWhiteSpace(context.Request.CorrelationProfile)) {
                     meta.Add("correlation_profile", context.Request.CorrelationProfile);
                 }
+                meta.Add("entity_handoff", entityHandoff);
             });
     }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogEntityHandoffTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogEntityHandoffTests.cs
@@ -1,0 +1,86 @@
+using System.Linq;
+using IntelligenceX.Tools.EventLog;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public class EventLogEntityHandoffTests {
+    private sealed record Row(string? Who, string? ObjectAffected, string? Computer);
+
+    [Fact]
+    public void BuildFromRows_ShouldAggregateDistinctCandidatesAndSourceFields() {
+        var rows = new[] {
+            new Row("alice", "CN=Alice,CN=Users,DC=lab,DC=local", "DC01.lab.local"),
+            new Row("alice", " ", "dc01.lab.local"),
+            new Row("bob", "CN=Alice,CN=Users,DC=lab,DC=local", "DC02.lab.local"),
+            new Row("-", null, null)
+        };
+
+        var handoff = EventLogEntityHandoff.BuildFromRows(
+            rows: rows,
+            whoSelector: static row => row.Who,
+            objectAffectedSelector: static row => row.ObjectAffected,
+            computerSelector: static row => row.Computer);
+
+        Assert.Equal("eventlog_entity_handoff", handoff.GetString("contract"));
+        Assert.Equal(1, handoff.GetInt64("version"));
+        Assert.Equal(4, handoff.GetInt64("scanned_rows"));
+        Assert.Equal(5, handoff.GetInt64("identity_candidates_total"));
+        Assert.Equal(2, handoff.GetInt64("computer_candidates_total"));
+
+        var identityCandidates = handoff.GetArray("identity_candidates");
+        Assert.NotNull(identityCandidates);
+        Assert.True(identityCandidates!.Count >= 1);
+
+        var topIdentity = identityCandidates[0].AsObject();
+        Assert.NotNull(topIdentity);
+        Assert.Equal("alice", topIdentity.GetString("value"));
+        Assert.Equal(2, topIdentity.GetInt64("count"));
+        var sourceFields = topIdentity.GetArray("source_fields");
+        Assert.NotNull(sourceFields);
+        Assert.Equal(
+            new[] { "who" },
+            sourceFields!.Select(static x => x.AsString()).Where(static x => !string.IsNullOrWhiteSpace(x)));
+
+        var hints = handoff.GetArray("target_hints");
+        Assert.NotNull(hints);
+        Assert.Equal(2, hints!.Count);
+        var firstHint = hints[0].AsObject();
+        Assert.NotNull(firstHint);
+        Assert.Equal("ad_object_resolve", firstHint.GetString("tool"));
+        Assert.Equal("identities", firstHint.GetString("argument"));
+        var hintValues = firstHint.GetArray("values");
+        Assert.NotNull(hintValues);
+        Assert.True(hintValues!.Count >= 1);
+    }
+
+    [Fact]
+    public void BuildFromRows_WhenInputEmpty_ShouldReturnEmptyCandidateCollections() {
+        var handoff = EventLogEntityHandoff.BuildFromRows(
+            rows: Enumerable.Empty<Row>(),
+            whoSelector: static row => row.Who,
+            objectAffectedSelector: static row => row.ObjectAffected,
+            computerSelector: static row => row.Computer);
+
+        Assert.Equal(0, handoff.GetInt64("scanned_rows"));
+        Assert.Equal(0, handoff.GetInt64("identity_candidates_total"));
+        Assert.Equal(0, handoff.GetInt64("computer_candidates_total"));
+        var identityCandidates = handoff.GetArray("identity_candidates");
+        Assert.NotNull(identityCandidates);
+        Assert.Equal(0, identityCandidates!.Count);
+        var computerCandidates = handoff.GetArray("computer_candidates");
+        Assert.NotNull(computerCandidates);
+        Assert.Equal(0, computerCandidates!.Count);
+
+        var hints = handoff.GetArray("target_hints");
+        Assert.NotNull(hints);
+        Assert.Equal(2, hints!.Count);
+        foreach (var hint in hints) {
+            var hintObject = hint.AsObject();
+            Assert.NotNull(hintObject);
+            var values = hintObject.GetArray("values");
+            Assert.NotNull(values);
+            Assert.Equal(0, values!.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `EventLogEntityHandoff` helper to compute deduplicated identity/computer candidates from normalized EventLog evidence rows
- enrich `eventlog_named_events_query` metadata with structured `meta.entity_handoff`
- enrich `eventlog_timeline_query` metadata with structured `meta.entity_handoff`
- add focused unit tests for aggregation, normalization, and empty-input behavior

## Why
- enables reusable cross-tool correlation (especially EventLog -> AD) without hardcoded incident templates
- keeps existing root output contracts stable while adding planner-friendly handoff metadata

## Validation
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.EventLog/IntelligenceX.Tools.EventLog.csproj -c Release`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~EventLogEntityHandoffTests|FullyQualifiedName~EventLogTimelineQueryToolTests"`

## Contract Notes
- new metadata key: `meta.entity_handoff`
- stable fields include: `contract`, `version`, `identity_candidates`, `computer_candidates`, and `target_hints`
