### PR TITLE
refactor(eventlog): harden payload UTC parsing and reflection extraction

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsPayload.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsPayload.cs
@@ -1,11 +1,16 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using EventViewerX;
 
 namespace IntelligenceX.Tools.EventLog;
 
 internal static class EventLogNamedEventsPayload {
+    private static readonly ConcurrentDictionary<Type, PayloadExtractionPlan> PayloadExtractionPlanCache = new();
+
     internal static string ResolveNamedEventName(EventObjectSlim item) {
         return EventLogNamedEventsHelper.TryParseOne(item.Type, out var parsedNamedEvent)
             ? EventLogNamedEventsHelper.GetQueryName(parsedNamedEvent)
@@ -13,36 +18,30 @@ internal static class EventLogNamedEventsPayload {
     }
 
     internal static Dictionary<string, object?> ExtractPayload(EventObjectSlim item) {
-        var payload = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        var type = item.GetType();
+        ArgumentNullException.ThrowIfNull(item);
 
-        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance)) {
-            if (!ShouldIncludeField(field)) {
-                continue;
-            }
+        var plan = PayloadExtractionPlanCache.GetOrAdd(
+            item.GetType(),
+            static type => BuildPayloadExtractionPlan(type));
+        var payload = new Dictionary<string, object?>(
+            plan.FieldAccessors.Length + plan.PropertyAccessors.Length,
+            StringComparer.OrdinalIgnoreCase);
 
-            var value = field.GetValue(item);
-            payload[EventLogNamedEventsQueryShared.ToSnakeCase(field.Name)] = NormalizeValue(value);
+        foreach (var accessor in plan.FieldAccessors) {
+            var value = accessor.Field.GetValue(item);
+            payload[accessor.Key] = NormalizeValue(value);
         }
 
-        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
-            if (!ShouldIncludeProperty(property)) {
-                continue;
-            }
-
-            var key = EventLogNamedEventsQueryShared.ToSnakeCase(property.Name);
-            if (payload.ContainsKey(key)) {
-                continue;
-            }
-
+        foreach (var accessor in plan.PropertyAccessors) {
             object? value;
             try {
-                value = property.GetValue(item);
-            } catch {
+                value = accessor.Property.GetValue(item);
+            } catch (Exception ex) {
+                Debug.WriteLine($"[EventLogNamedEventsPayload] Failed to read payload property '{accessor.Property.Name}': {ex.Message}");
                 continue;
             }
 
-            payload[key] = NormalizeValue(value);
+            payload[accessor.Key] = NormalizeValue(value);
         }
 
         return payload;
@@ -79,15 +78,123 @@ internal static class EventLogNamedEventsPayload {
             return null;
         }
 
-        if (value is string text && DateTime.TryParse(text, out var parsed)) {
-            return parsed.ToUniversalTime().ToString("O");
+        if (value is string text && TryParseUtcValue(text, out var parsedUtc)) {
+            return parsedUtc.ToString("O");
+        }
+
+        if (value is DateTimeOffset dateTimeOffset) {
+            return dateTimeOffset.UtcDateTime.ToString("O");
         }
 
         if (value is DateTime dateTime) {
-            return dateTime.ToUniversalTime().ToString("O");
+            var parsed = dateTime.Kind switch {
+                DateTimeKind.Utc => dateTime,
+                DateTimeKind.Local => dateTime.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
+            };
+            return parsed.ToString("O");
         }
 
         return value.ToString();
+    }
+
+    internal static bool TryParseUtcValue(string? value, out DateTime utc) {
+        utc = default;
+        var text = value ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(text)) {
+            return false;
+        }
+
+        text = text.Trim();
+        var hasExplicitOffset = HasExplicitOffsetOrUtcDesignator(text);
+
+        if (hasExplicitOffset) {
+            if (!DateTimeOffset.TryParse(
+                    text,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.AssumeUniversal,
+                    out var parsedOffset)) {
+                return false;
+            }
+
+            utc = parsedOffset.UtcDateTime;
+            return true;
+        }
+
+        if (!DateTime.TryParse(
+                text,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AllowWhiteSpaces,
+                out var parsedDateTime)) {
+            return false;
+        }
+
+        utc = parsedDateTime.Kind switch {
+            DateTimeKind.Utc => parsedDateTime,
+            DateTimeKind.Local => parsedDateTime.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(parsedDateTime, DateTimeKind.Utc)
+        };
+        return true;
+    }
+
+    private static bool HasExplicitOffsetOrUtcDesignator(string value) {
+        if (value.EndsWith("Z", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        var searchStart = 0;
+        var tIndex = value.IndexOf('T');
+        if (tIndex >= 0 && tIndex + 1 < value.Length) {
+            searchStart = tIndex + 1;
+        } else {
+            var spaceIndex = value.IndexOf(' ');
+            if (spaceIndex >= 0 && spaceIndex + 1 < value.Length) {
+                searchStart = spaceIndex + 1;
+            }
+        }
+
+        for (var i = value.Length - 1; i >= searchStart; i--) {
+            var ch = value[i];
+            if (ch == '+' || ch == '-') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static PayloadExtractionPlan BuildPayloadExtractionPlan(Type type) {
+        var fieldAccessors = new List<PayloadFieldAccessor>();
+        var propertyAccessors = new List<PayloadPropertyAccessor>();
+        var seenKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance)) {
+            if (!ShouldIncludeField(field)) {
+                continue;
+            }
+
+            var key = EventLogNamedEventsQueryShared.ToSnakeCase(field.Name);
+            if (!seenKeys.Add(key)) {
+                continue;
+            }
+
+            fieldAccessors.Add(new PayloadFieldAccessor(field, key));
+        }
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
+            if (!ShouldIncludeProperty(property)) {
+                continue;
+            }
+
+            var key = EventLogNamedEventsQueryShared.ToSnakeCase(property.Name);
+            if (!seenKeys.Add(key)) {
+                continue;
+            }
+
+            propertyAccessors.Add(new PayloadPropertyAccessor(property, key));
+        }
+
+        return new PayloadExtractionPlan(fieldAccessors.ToArray(), propertyAccessors.ToArray());
     }
 
     private static bool ShouldIncludeField(FieldInfo field) {
@@ -135,5 +242,37 @@ internal static class EventLogNamedEventsPayload {
         }
 
         return value;
+    }
+
+    private sealed class PayloadExtractionPlan {
+        public PayloadExtractionPlan(
+            PayloadFieldAccessor[] fieldAccessors,
+            PayloadPropertyAccessor[] propertyAccessors) {
+            FieldAccessors = fieldAccessors;
+            PropertyAccessors = propertyAccessors;
+        }
+
+        public PayloadFieldAccessor[] FieldAccessors { get; }
+        public PayloadPropertyAccessor[] PropertyAccessors { get; }
+    }
+
+    private sealed class PayloadFieldAccessor {
+        public PayloadFieldAccessor(FieldInfo field, string key) {
+            Field = field;
+            Key = key;
+        }
+
+        public FieldInfo Field { get; }
+        public string Key { get; }
+    }
+
+    private sealed class PayloadPropertyAccessor {
+        public PayloadPropertyAccessor(PropertyInfo property, string key) {
+            Property = property;
+            Key = key;
+        }
+
+        public PropertyInfo Property { get; }
+        public string Key { get; }
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogNamedEventsPayloadTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogNamedEventsPayloadTests.cs
@@ -1,0 +1,33 @@
+using System;
+using IntelligenceX.Tools.EventLog;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public class EventLogNamedEventsPayloadTests {
+    [Fact]
+    public void TryParseUtcValue_ShouldTreatUnspecifiedTimestampAsUtc() {
+        var parsed = EventLogNamedEventsPayload.TryParseUtcValue("2026-02-20T12:34:56", out var utc);
+
+        Assert.True(parsed);
+        Assert.Equal(DateTimeKind.Utc, utc.Kind);
+        Assert.Equal(new DateTime(2026, 2, 20, 12, 34, 56, DateTimeKind.Utc), utc);
+    }
+
+    [Fact]
+    public void TryParseUtcValue_ShouldConvertOffsetTimestampToUtc() {
+        var parsed = EventLogNamedEventsPayload.TryParseUtcValue("2026-02-20T12:34:56+02:00", out var utc);
+
+        Assert.True(parsed);
+        Assert.Equal(DateTimeKind.Utc, utc.Kind);
+        Assert.Equal(new DateTime(2026, 2, 20, 10, 34, 56, DateTimeKind.Utc), utc);
+    }
+
+    [Fact]
+    public void TryParseUtcValue_ShouldReturnFalseForInvalidInput() {
+        var parsed = EventLogNamedEventsPayload.TryParseUtcValue("not-a-timestamp", out _);
+
+        Assert.False(parsed);
+    }
+}
+


### PR DESCRIPTION
## Summary
- harden `EventLogNamedEventsPayload` reflection extraction by caching per-type field/property plans
- keep reflection failures non-fatal but now emit `Debug.WriteLine` diagnostics instead of silent swallow
- add explicit UTC parsing helper (`TryParseUtcValue`) for deterministic timestamp normalization
- update `ReadPayloadUtc` to use invariant parsing and consistent UTC semantics for `string`, `DateTimeOffset`, and `DateTime`

## Why
- reduces repeated reflection overhead in high-volume event processing
- avoids locale-dependent `DateTime.TryParse` behavior in payload timestamp handling
- improves debuggability when event payload properties throw during reflection

## Validation
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.EventLog/IntelligenceX.Tools.EventLog.csproj -c Release`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~EventLogNamedEventsPayloadTests|FullyQualifiedName~EventLogTimelineQueryToolTests"`

## Tests Added
- `TryParseUtcValue_ShouldTreatUnspecifiedTimestampAsUtc`
- `TryParseUtcValue_ShouldConvertOffsetTimestampToUtc`
- `TryParseUtcValue_ShouldReturnFalseForInvalidInput`
