### PR TITLE
chore(tools): bump EventViewerX fallback package to v3.3.2

### DIFF
--- a/IntelligenceX.Tools/Directory.Build.props
+++ b/IntelligenceX.Tools/Directory.Build.props
@@ -35,7 +35,7 @@
 
     <!-- Public package fallbacks for CI/consumers when local engine sources are unavailable. -->
     <MailozaurrNuGetVersion Condition="'$(MailozaurrNuGetVersion)'==''">2.0.5</MailozaurrNuGetVersion>
-    <EventViewerXNuGetVersion Condition="'$(EventViewerXNuGetVersion)'==''">3.3.1</EventViewerXNuGetVersion>
+    <EventViewerXNuGetVersion Condition="'$(EventViewerXNuGetVersion)'==''">3.3.2</EventViewerXNuGetVersion>
     <OfficeImoReaderNuGetVersion Condition="'$(OfficeImoReaderNuGetVersion)'==''">0.1.5</OfficeImoReaderNuGetVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- bump `EventViewerXNuGetVersion` fallback from `3.3.1` to `3.3.2` in `IntelligenceX.Tools/Directory.Build.props`
- aligns IntelligenceX.Tools package fallback dependency with newly published EventViewerX release

## Why
- for CI/consumer scenarios without local `PSEventViewer` sources, tooling should use latest released EventViewerX fixes

## Validation
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.EventLog/IntelligenceX.Tools.EventLog.csproj -c Release`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~EventLogNamedEventsPayloadTests|FullyQualifiedName~EventLogTimelineQueryToolTests|FullyQualifiedName~EventLogEntityHandoffTests"`
