### PR TITLE
Stabilize runtime model switching and reviewer no-blockers triage

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Protocol/MetricsDtos.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Protocol/MetricsDtos.cs
@@ -58,6 +58,10 @@ public sealed record ChatMetricsMessage : ChatServiceMessage {
     /// </summary>
     public string? Model { get; init; }
     /// <summary>
+    /// Requested model override for the turn, when one was provided.
+    /// </summary>
+    public string? RequestedModel { get; init; }
+    /// <summary>
     /// Runtime transport used for the turn (native/appserver/compatible-http/copilot-cli).
     /// </summary>
     public string? Transport { get; init; }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
@@ -193,6 +193,7 @@ public sealed partial class MainWindow : Window {
                 CachedPromptTokens: metrics.Usage?.CachedPromptTokens,
                 ReasoningTokens: metrics.Usage?.ReasoningTokens,
                 Model: string.IsNullOrWhiteSpace(metrics.Model) ? null : metrics.Model.Trim(),
+                RequestedModel: string.IsNullOrWhiteSpace(metrics.RequestedModel) ? null : metrics.RequestedModel.Trim(),
                 Transport: string.IsNullOrWhiteSpace(metrics.Transport) ? null : metrics.Transport.Trim(),
                 EndpointHost: string.IsNullOrWhiteSpace(metrics.EndpointHost) ? null : metrics.EndpointHost.Trim());
         }
@@ -208,6 +209,7 @@ public sealed partial class MainWindow : Window {
                + (metrics.Usage?.TotalTokens is null ? string.Empty : " tokens=" + metrics.Usage.TotalTokens.Value.ToString(CultureInfo.InvariantCulture))
                + " tools=" + metrics.ToolCallsCount.ToString(CultureInfo.InvariantCulture)
                + " rounds=" + metrics.ToolRounds.ToString(CultureInfo.InvariantCulture)
+               + (string.IsNullOrWhiteSpace(metrics.RequestedModel) ? string.Empty : " requestedModel=" + metrics.RequestedModel.Trim())
                + (string.IsNullOrWhiteSpace(metrics.Model) ? string.Empty : " model=" + metrics.Model.Trim())
                + (string.IsNullOrWhiteSpace(metrics.Transport) ? string.Empty : " transport=" + metrics.Transport.Trim())
                + (string.IsNullOrWhiteSpace(metrics.EndpointHost) ? string.Empty : " endpoint=" + metrics.EndpointHost.Trim())

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -433,6 +433,7 @@ public sealed partial class MainWindow : Window {
         long? CachedPromptTokens,
         long? ReasoningTokens,
         string? Model,
+        string? RequestedModel,
         string? Transport,
         string? EndpointHost);
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.cs
@@ -30,7 +30,8 @@ internal sealed partial class ChatServiceSession {
         int ToolCallsCount,
         int ToolRounds,
         int ProjectionFallbackCount,
-        IReadOnlyList<ToolErrorMetricDto> ToolErrors);
+        IReadOnlyList<ToolErrorMetricDto> ToolErrors,
+        string? ResolvedModel);
 
     private static (bool ParallelTools, bool AllowMutatingParallel, string Mode) ResolveParallelToolExecutionMode(ChatRequestOptions? options,
         bool serviceDefaultParallelTools) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -560,7 +560,8 @@ internal sealed partial class ChatServiceSession {
                     ToolCallsCount: toolCalls.Count,
                     ToolRounds: toolRounds,
                     ProjectionFallbackCount: projectionFallbackCount,
-                    ToolErrors: BuildToolErrorMetrics(toolCalls, toolOutputs));
+                    ToolErrors: BuildToolErrorMetrics(toolCalls, toolOutputs),
+                    ResolvedModel: resolvedModel);
             }
 
             toolRounds++;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.ModelCatalog.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.ModelCatalog.cs
@@ -211,7 +211,7 @@ internal sealed partial class ChatServiceSession {
         }
     }
 
-    private async Task TryRecordRecentModelAsync(string model, CancellationToken cancellationToken) {
+    private async Task TryRecordRecentModelAsync(string? model, CancellationToken cancellationToken) {
         var profileName = (_options.ProfileName ?? string.Empty).Trim();
         var normalizedModel = (model ?? string.Empty).Trim();
         if (_options.NoStateDb || string.IsNullOrWhiteSpace(profileName) || string.IsNullOrWhiteSpace(normalizedModel)) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
@@ -635,8 +635,10 @@ internal sealed partial class ChatServiceSession {
         bool currentInsecureHttpNonLoopback,
         string? previousModel,
         string? currentModel) {
+        var previousBaseUrlNormalized = NormalizeRuntimeBaseUrlForComparison(previousBaseUrl);
+        var currentBaseUrlNormalized = NormalizeRuntimeBaseUrlForComparison(currentBaseUrl);
         var reconnect = previousTransport != currentTransport
-                        || !string.Equals(previousBaseUrl, currentBaseUrl, StringComparison.Ordinal)
+                        || !string.Equals(previousBaseUrlNormalized, currentBaseUrlNormalized, StringComparison.Ordinal)
                         || previousAuthMode != currentAuthMode
                         || !string.Equals(previousApiKey, currentApiKey, StringComparison.Ordinal)
                         || !string.Equals(previousBasicUsername, currentBasicUsername, StringComparison.Ordinal)
@@ -646,7 +648,37 @@ internal sealed partial class ChatServiceSession {
                         || previousInsecureHttp != currentInsecureHttp
                         || previousInsecureHttpNonLoopback != currentInsecureHttpNonLoopback;
 
-        var modelChanged = !string.Equals(previousModel, currentModel, StringComparison.Ordinal);
+        var modelChanged = !string.Equals(
+            NormalizeRuntimeModelForComparison(previousModel),
+            NormalizeRuntimeModelForComparison(currentModel),
+            StringComparison.Ordinal);
         return (reconnect, modelChanged);
+    }
+
+    internal static string? NormalizeRuntimeBaseUrlForComparison(string? baseUrl) {
+        var trimmed = (baseUrl ?? string.Empty).Trim();
+        if (trimmed.Length == 0) {
+            return null;
+        }
+
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) || uri is null) {
+            return trimmed;
+        }
+
+        var scheme = uri.Scheme.ToLowerInvariant();
+        var host = uri.IdnHost.ToLowerInvariant();
+        var port = uri.IsDefaultPort ? string.Empty : ":" + uri.Port;
+        var path = (uri.AbsolutePath ?? string.Empty).TrimEnd('/');
+        if (path.Length == 0) {
+            path = string.Empty;
+        }
+
+        var query = uri.Query ?? string.Empty;
+        return scheme + "://" + host + port + path + query;
+    }
+
+    private static string? NormalizeRuntimeModelForComparison(string? model) {
+        var normalized = (model ?? string.Empty).Trim();
+        return normalized.Length == 0 ? null : normalized;
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
@@ -250,7 +250,12 @@ internal sealed partial class ChatServiceSession {
             var outcome = "ok";
             string? outcomeCode = null;
             var threadIdForDelta = run.ThreadId ?? string.Empty;
-            var usedModel = request.Options?.Model ?? _options.Model;
+            var requestedModel = NormalizeModelTelemetryValue(request.Options?.Model);
+            var runtimeDefaultModel = NormalizeModelTelemetryValue(_options.Model);
+            var telemetryModel = ResolveEffectiveTurnModelForTelemetry(
+                resolvedModel: null,
+                requestedModel,
+                runtimeDefaultModel);
             var bufferDraftDeltasForSmartReview = ShouldBufferDraftDeltasForSmartReview(request);
             try {
                 if (bufferDraftDeltasForSmartReview) {
@@ -280,9 +285,13 @@ internal sealed partial class ChatServiceSession {
                 toolRounds = result.ToolRounds;
                 projectionFallbackCount = result.ProjectionFallbackCount;
                 toolErrors = result.ToolErrors;
+                telemetryModel = ResolveEffectiveTurnModelForTelemetry(
+                    result.ResolvedModel,
+                    requestedModel,
+                    runtimeDefaultModel);
                 await WriteAsync(writer, result.Result, CancellationToken.None).ConfigureAwait(false);
 
-                await TryRecordRecentModelAsync(usedModel, CancellationToken.None).ConfigureAwait(false);
+                await TryRecordRecentModelAsync(telemetryModel, CancellationToken.None).ConfigureAwait(false);
             } catch (OpenAIAuthenticationRequiredException) {
                 outcome = "error";
                 outcomeCode = "not_authenticated";
@@ -341,7 +350,8 @@ internal sealed partial class ChatServiceSession {
                         ToolRounds = toolRounds,
                         ProjectionFallbackCount = projectionFallbackCount,
                         ToolErrors = toolErrors is { Count: > 0 } ? toolErrors : null,
-                        Model = string.IsNullOrWhiteSpace(usedModel) ? null : usedModel.Trim(),
+                        Model = telemetryModel,
+                        RequestedModel = requestedModel,
                         Transport = metricsTransport,
                         EndpointHost = metricsEndpointHost,
                         Outcome = outcome,
@@ -392,6 +402,25 @@ internal sealed partial class ChatServiceSession {
             CachedPromptTokens = usage.CachedInputTokens,
             ReasoningTokens = usage.ReasoningTokens
         };
+    }
+
+    internal static string? ResolveEffectiveTurnModelForTelemetry(string? resolvedModel, string? requestedModel, string? runtimeDefaultModel) {
+        var resolved = NormalizeModelTelemetryValue(resolvedModel);
+        if (resolved is not null) {
+            return resolved;
+        }
+
+        var requested = NormalizeModelTelemetryValue(requestedModel);
+        if (requested is not null) {
+            return requested;
+        }
+
+        return NormalizeModelTelemetryValue(runtimeDefaultModel);
+    }
+
+    private static string? NormalizeModelTelemetryValue(string? model) {
+        var normalized = (model ?? string.Empty).Trim();
+        return normalized.Length == 0 ? null : normalized;
     }
 
     private string ResolveMetricsTransport() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRuntimeReconnectPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRuntimeReconnectPolicyTests.cs
@@ -64,6 +64,19 @@ public sealed class ChatServiceRuntimeReconnectPolicyTests {
     }
 
     /// <summary>
+    /// Ensures model whitespace differences do not register as a model change.
+    /// </summary>
+    [Fact]
+    public void ResolveRuntimeClientReconfigureDecision_ModelWhitespaceOnly_DoesNotReconnect() {
+        var decision = ResolveDecision(
+            previous: settings => settings.Model = "gpt-5.3-codex",
+            current: settings => settings.Model = "  gpt-5.3-codex  ");
+
+        Assert.False(decision.ReconnectClient);
+        Assert.False(decision.ModelChanged);
+    }
+
+    /// <summary>
     /// Ensures transport changes require provider-client reconnect.
     /// </summary>
     [Fact]
@@ -123,6 +136,23 @@ public sealed class ChatServiceRuntimeReconnectPolicyTests {
         });
 
         Assert.True(decision.ReconnectClient);
+        Assert.False(decision.ModelChanged);
+    }
+
+    /// <summary>
+    /// Ensures equivalent endpoint formatting does not force reconnect.
+    /// </summary>
+    [Theory]
+    [InlineData("https://api.example.com/v1", "https://api.example.com/v1/")]
+    [InlineData("https://api.example.com:443/v1", "https://api.example.com/v1")]
+    [InlineData("HTTPS://API.EXAMPLE.COM/v1", "https://api.example.com/v1")]
+    [InlineData(" https://api.example.com/v1 ", "https://api.example.com/v1")]
+    public void ResolveRuntimeClientReconfigureDecision_EquivalentBaseUrl_DoesNotReconnect(string previousBaseUrl,
+        string currentBaseUrl) {
+        var decision = ResolveDecision(previous: settings => settings.BaseUrl = previousBaseUrl,
+            current: settings => settings.BaseUrl = currentBaseUrl);
+
+        Assert.False(decision.ReconnectClient);
         Assert.False(decision.ModelChanged);
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceTelemetryModelResolutionTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceTelemetryModelResolutionTests.cs
@@ -1,0 +1,36 @@
+using IntelligenceX.Chat.Service;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class ChatServiceTelemetryModelResolutionTests {
+    [Fact]
+    public void ResolveEffectiveTurnModelForTelemetry_UsesResolvedModel_WhenAvailable() {
+        var model = ChatServiceSession.ResolveEffectiveTurnModelForTelemetry(
+            resolvedModel: "gpt-5.3-codex-spark",
+            requestedModel: "gpt-5.3-codex",
+            runtimeDefaultModel: "gpt-5.3");
+
+        Assert.Equal("gpt-5.3-codex-spark", model);
+    }
+
+    [Fact]
+    public void ResolveEffectiveTurnModelForTelemetry_FallsBackToRequestedModel() {
+        var model = ChatServiceSession.ResolveEffectiveTurnModelForTelemetry(
+            resolvedModel: " ",
+            requestedModel: "  gpt-5.3-codex  ",
+            runtimeDefaultModel: "gpt-5.3");
+
+        Assert.Equal("gpt-5.3-codex", model);
+    }
+
+    [Fact]
+    public void ResolveEffectiveTurnModelForTelemetry_FallsBackToRuntimeDefault() {
+        var model = ChatServiceSession.ResolveEffectiveTurnModelForTelemetry(
+            resolvedModel: null,
+            requestedModel: null,
+            runtimeDefaultModel: "  gpt-5.3  ");
+
+        Assert.Equal("gpt-5.3", model);
+    }
+}

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -287,7 +287,7 @@ internal sealed partial class ReviewSettings {
     /// When enabled, sweep and resolve remaining bot-only kept threads after a no-blockers review.
     /// Useful for repositories that enforce resolved review conversations before merge.
     /// </summary>
-    public bool ReviewThreadsAutoResolveSweepNoBlockers { get; set; }
+    public bool ReviewThreadsAutoResolveSweepNoBlockers { get; set; } = false;
     public bool ReviewThreadsAutoResolveAIPostComment { get; set; }
     public bool ReviewThreadsAutoResolveAIEmbed { get; set; } = true;
     /// <summary>

--- a/IntelligenceX.Reviewer/ReviewerApp.Core.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.Core.cs
@@ -375,6 +375,8 @@ public static partial class ReviewerApp {
 
             var reviewBody = await runner.RunAsync(prompt, onPartial, TimeSpan.FromSeconds(settings.ProgressUpdateSeconds),
                 cancellationToken).ConfigureAwait(false);
+            // Merge-blocker detection depends on the review markdown contract (Todo/Critical sections)
+            // produced by ReviewFormatter and prompts. Keep parser + formatter in sync.
             var hasMergeBlockers = ReviewSummaryParser.HasMergeBlockers(reviewBody);
             var effectiveProvider = runner.EffectiveProvider;
             if (runner.FallbackActivated && settings.Diagnostics) {

--- a/IntelligenceX.Reviewer/ReviewerApp.ThreadResolution.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.ThreadResolution.cs
@@ -635,7 +635,7 @@ public static partial class ReviewerApp {
 
             sweepResolved++;
             sweepResolvedIds.Add(normalizedId);
-            resolved.Add(new ThreadAssessment(item.Id, "resolve", $"{item.Reason} (no-blockers sweep)", item.Evidence));
+            resolved.Add(new ThreadAssessment(item.Id, "resolve", FormatNoBlockersSweepReason(item.Reason), item.Evidence));
         }
 
         if (sweepResolvedIds.Count > 0) {
@@ -643,6 +643,11 @@ public static partial class ReviewerApp {
         }
 
         return sweepResolved;
+    }
+
+    private static string FormatNoBlockersSweepReason(string reason) {
+        const string suffix = "(no-blockers sweep)";
+        return string.IsNullOrWhiteSpace(reason) ? suffix : $"{reason} {suffix}";
     }
 
     private static async Task<(bool Resolved, string? Error)> TryResolveThreadAsync(GitHubClient github,


### PR DESCRIPTION
## Summary
- fix reviewer no-blockers sweep follow-up nits:
  - explicit `ReviewThreadsAutoResolveSweepNoBlockers = false` initializer
  - guard empty reason when appending `(no-blockers sweep)`
  - document merge-blocker parser/formatter contract near `HasMergeBlockers(reviewBody)`
- improve chat runtime fluidity and telemetry:
  - treat equivalent base URL formatting (trailing slash/default port/casing/trim) as non-reconnect in runtime reconfigure decision
  - normalize model comparison for whitespace-only changes
  - propagate resolved turn model into per-turn metrics and recent-model recording (instead of request/default fallback)
  - add `RequestedModel` to `ChatMetricsMessage` telemetry and surface in metrics trace
- add tests for reconnect-policy normalization and telemetry model resolution precedence

## Validation
- `dotnet build IntelligenceX.Reviewer/IntelligenceX.Reviewer.csproj -c Release` ✅
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Service/IntelligenceX.Chat.Service.csproj -c Release` ✅
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release` ✅
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRuntimeReconnectPolicyTests|FullyQualifiedName~ChatServiceTelemetryModelResolutionTests"` ✅
- `dotnet build IntelligenceX.sln -c Release` ❌ (unrelated baseline failure in `IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs`: `ToolSchema` symbol missing)
- `dotnet test IntelligenceX.sln -c Release` ❌ (same unrelated `ToolSchema` baseline failure)
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll` ✅
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll` ✅

## Notes
- No `.cs` files are currently over 700 LOC in this branch.