### PR TITLE
fix(tools-tests): restore ToolSchema contract test baseline

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using IntelligenceX.Json;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.ADPlayground;
+using IntelligenceX.Tools.Common;
 using IntelligenceX.Tools.Email;
 using IntelligenceX.Tools.EventLog;
 using IntelligenceX.Tools.FileSystem;


### PR DESCRIPTION
## Summary
- fix baseline compile failure in tools tests by importing `IntelligenceX.Tools.Common` in `ToolDefinitionContractTests`
- keep change minimal and isolated to test project

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolDefinitionContractTests"
