### PR TITLE
fix(chat): prevent usage-limit retry prompt recursion

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowUsageLimitDispatchTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowUsageLimitDispatchTests.cs
@@ -1,0 +1,102 @@
+using System;
+using IntelligenceX.Chat.App;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Guards usage-limit queue dispatch gating to prevent replay loops.
+/// </summary>
+public sealed class MainWindowUsageLimitDispatchTests {
+    /// <summary>
+    /// Ensures future retry windows block queued dispatch and surface remaining minutes.
+    /// </summary>
+    [Fact]
+    public void IsUsageLimitDispatchBlocked_ReturnsTrueWhenRetryWindowIsInFuture() {
+        var nowUtc = new DateTime(2026, 2, 21, 10, 0, 0, DateTimeKind.Utc);
+        var retryAfterUtc = nowUtc.AddMinutes(11);
+
+        var blocked = MainWindow.IsUsageLimitDispatchBlocked(
+            nowUtc,
+            usageLimitHitUtc: null,
+            usageLimitRetryAfterUtc: retryAfterUtc,
+            rateLimitReached: null,
+            out var retryAfterMinutes);
+
+        Assert.True(blocked);
+        Assert.Equal(11, retryAfterMinutes);
+    }
+
+    /// <summary>
+    /// Ensures expired retry windows do not keep dispatch blocked when hard limit signals are absent.
+    /// </summary>
+    [Fact]
+    public void IsUsageLimitDispatchBlocked_ReturnsFalseWhenRetryWindowExpiredAndNoHardLimitSignal() {
+        var nowUtc = new DateTime(2026, 2, 21, 10, 0, 0, DateTimeKind.Utc);
+        var retryAfterUtc = nowUtc.AddMinutes(-1);
+
+        var blocked = MainWindow.IsUsageLimitDispatchBlocked(
+            nowUtc,
+            usageLimitHitUtc: null,
+            usageLimitRetryAfterUtc: retryAfterUtc,
+            rateLimitReached: false,
+            out var retryAfterMinutes);
+
+        Assert.False(blocked);
+        Assert.Null(retryAfterMinutes);
+    }
+
+    /// <summary>
+    /// Ensures explicit provider limit flags block dispatch even without retry-after hints.
+    /// </summary>
+    [Fact]
+    public void IsUsageLimitDispatchBlocked_ReturnsTrueWhenRateLimitReachedIsTrueWithoutRetryAfter() {
+        var nowUtc = new DateTime(2026, 2, 21, 10, 0, 0, DateTimeKind.Utc);
+
+        var blocked = MainWindow.IsUsageLimitDispatchBlocked(
+            nowUtc,
+            usageLimitHitUtc: null,
+            usageLimitRetryAfterUtc: null,
+            rateLimitReached: true,
+            out var retryAfterMinutes);
+
+        Assert.True(blocked);
+        Assert.Null(retryAfterMinutes);
+    }
+
+    /// <summary>
+    /// Ensures recent usage-limit hits trigger a short cooldown when providers omit retry-after.
+    /// </summary>
+    [Fact]
+    public void IsUsageLimitDispatchBlocked_ReturnsTrueDuringRecentFallbackCooldown() {
+        var nowUtc = new DateTime(2026, 2, 21, 10, 0, 0, DateTimeKind.Utc);
+
+        var blocked = MainWindow.IsUsageLimitDispatchBlocked(
+            nowUtc,
+            usageLimitHitUtc: nowUtc.AddSeconds(-30),
+            usageLimitRetryAfterUtc: null,
+            rateLimitReached: null,
+            out var retryAfterMinutes);
+
+        Assert.True(blocked);
+        Assert.Null(retryAfterMinutes);
+    }
+
+    /// <summary>
+    /// Ensures stale usage-limit hits do not keep dispatch blocked forever.
+    /// </summary>
+    [Fact]
+    public void IsUsageLimitDispatchBlocked_ReturnsFalseWhenFallbackCooldownElapsed() {
+        var nowUtc = new DateTime(2026, 2, 21, 10, 0, 0, DateTimeKind.Utc);
+
+        var blocked = MainWindow.IsUsageLimitDispatchBlocked(
+            nowUtc,
+            usageLimitHitUtc: nowUtc.AddMinutes(-10),
+            usageLimitRetryAfterUtc: null,
+            rateLimitReached: null,
+            out var retryAfterMinutes);
+
+        Assert.False(blocked);
+        Assert.Null(retryAfterMinutes);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.SignalFlowTail.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.SignalFlowTail.cs
@@ -6,6 +6,10 @@ using Xunit;
 namespace IntelligenceX.Chat.App.Tests;
 
 public sealed partial class TranscriptMarkdownNormalizerTests {
+    /// <summary>
+    /// Ensures malformed signal-flow bullets with tight label spacing normalize into readable markdown.
+    /// </summary>
+    [Fact]
     public void NormalizeForRendering_FixesTightLabelSpacingInWrappedSignalFlowBullets() {
         var text =
             "- Signal **Only total count checked, not origin split ->**Why it matters:**external/custom rules can drift or disappear between hosts ->**Next action:**break down `rule_origin` (`builtin` vs `external`) and confirm expected external rules are present.**";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownNormalizerTests.cs
@@ -528,8 +528,4 @@ public sealed partial class TranscriptMarkdownNormalizerTests {
         Assert.Equal(expected, normalized);
     }
 
-    /// <summary>
-    /// Ensures malformed signal-flow bullets with tight label spacing normalize into readable markdown.
-    /// </summary>
-    [Fact]
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.AccountUsage.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.AccountUsage.cs
@@ -9,6 +9,7 @@ namespace IntelligenceX.Chat.App;
 
 public sealed partial class MainWindow : Window {
     private const int MaxTrackedAccounts = 12;
+    private static readonly TimeSpan UsageLimitDispatchCooldown = TimeSpan.FromMinutes(2);
     private static readonly Regex UsageRetryAfterMinutesRegex = new(
         @"(?:in\s+about|about)\s+(?<minutes>\d+)\s+minute",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -438,6 +439,54 @@ public sealed partial class MainWindow : Window {
             TrimAccountUsageCacheLocked();
             SyncAccountUsageToAppStateLocked();
         }
+    }
+
+    private bool IsActiveUsageLimitDispatchBlocked(out int? retryAfterMinutes) {
+        var identity = ResolveActiveUsageIdentity();
+        var nowUtc = DateTime.UtcNow;
+        lock (_turnDiagnosticsSync) {
+            if (!_accountUsageByKey.TryGetValue(identity.Key, out var snapshot)) {
+                retryAfterMinutes = null;
+                return false;
+            }
+
+            return IsUsageLimitDispatchBlocked(
+                nowUtc,
+                snapshot.UsageLimitHitUtc,
+                snapshot.UsageLimitRetryAfterUtc,
+                snapshot.RateLimitReached,
+                out retryAfterMinutes);
+        }
+    }
+
+    internal static bool IsUsageLimitDispatchBlocked(
+        DateTime nowUtc,
+        DateTime? usageLimitHitUtc,
+        DateTime? usageLimitRetryAfterUtc,
+        bool? rateLimitReached,
+        out int? retryAfterMinutes) {
+        retryAfterMinutes = null;
+        var normalizedNowUtc = EnsureUtc(nowUtc);
+
+        if (usageLimitRetryAfterUtc.HasValue) {
+            var remaining = EnsureUtc(usageLimitRetryAfterUtc.Value) - normalizedNowUtc;
+            if (remaining > TimeSpan.Zero) {
+                retryAfterMinutes = (int)Math.Ceiling(remaining.TotalMinutes);
+                return true;
+            }
+        }
+
+        if (rateLimitReached == true) {
+            return true;
+        }
+
+        if (!usageLimitHitUtc.HasValue) {
+            return false;
+        }
+
+        var hitUtc = EnsureUtc(usageLimitHitUtc.Value);
+        // If provider omitted Retry-After, keep a short cooldown to prevent immediate replay loops.
+        return normalizedNowUtc <= hitUtc || normalizedNowUtc - hitUtc < UsageLimitDispatchCooldown;
     }
 
     private void RestoreAccountUsageFromAppState() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
@@ -15,6 +15,7 @@ public sealed partial class MainWindow : Window {
         ConversationRuntime Conversation,
         string ConversationId,
         string RequestId,
+        string UserText,
         string RequestText,
         string? AssistantModelLabel);
 
@@ -89,6 +90,7 @@ public sealed partial class MainWindow : Window {
             conversation,
             conversationId,
             NextId(),
+            text,
             BuildRequestTextForService(text),
             assistantModelLabel);
     }
@@ -134,7 +136,7 @@ public sealed partial class MainWindow : Window {
                         var promptQueued = false;
                         if (IsUsageLimitError(resolvedRetryEx)) {
                             MarkUsageLimitForActiveAccount(resolvedRetryEx.Message);
-                            promptQueued = QueuePromptAfterSignIn(turn.RequestText, turn.ConversationId);
+                            promptQueued = QueuePromptAfterSignIn(turn.UserText, turn.ConversationId);
                             await SetStatusAsync(SessionStatus.UsageLimitReached()).ConfigureAwait(false);
                             if (promptQueued) {
                                 AppendSystem(turn.Conversation, SystemNotice.PromptQueuedAfterUsageLimit());
@@ -161,7 +163,7 @@ public sealed partial class MainWindow : Window {
                 var promptQueued = false;
                 if (IsUsageLimitError(resolvedEx)) {
                     MarkUsageLimitForActiveAccount(resolvedEx.Message);
-                    promptQueued = QueuePromptAfterSignIn(turn.RequestText, turn.ConversationId);
+                    promptQueued = QueuePromptAfterSignIn(turn.UserText, turn.ConversationId);
                     await SetStatusAsync(SessionStatus.UsageLimitReached()).ConfigureAwait(false);
                     if (promptQueued) {
                         AppendSystem(turn.Conversation, SystemNotice.PromptQueuedAfterUsageLimit());
@@ -488,8 +490,8 @@ public sealed partial class MainWindow : Window {
                || text.StartsWith("[canceled]", StringComparison.OrdinalIgnoreCase);
     }
 
-    private bool QueuePromptAfterSignIn(string requestText, string conversationId) {
-        var text = (requestText ?? string.Empty).Trim();
+    private bool QueuePromptAfterSignIn(string userText, string conversationId) {
+        var text = (userText ?? string.Empty).Trim();
         if (text.Length == 0) {
             return false;
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnQueue.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnQueue.cs
@@ -267,8 +267,21 @@ public sealed partial class MainWindow : Window {
         }
     }
 
+    private static string BuildUsageLimitQueuedPromptStatus(int? retryAfterMinutes) {
+        if (retryAfterMinutes.HasValue && retryAfterMinutes.Value > 0) {
+            return "Queued prompt paused by account limit (" + retryAfterMinutes.Value + "m remaining). Use Switch Account to run now.";
+        }
+
+        return "Queued prompt paused by account limit. Use Switch Account to run now.";
+    }
+
     private async Task<bool> TryDispatchQueuedPromptAfterLoginAsync(bool honorAutoDispatch = true) {
         if (_isSending || !IsEffectivelyAuthenticatedForCurrentTransport() || _loginInProgress || (honorAutoDispatch && !_queueAutoDispatchEnabled)) {
+            return false;
+        }
+
+        if (IsActiveUsageLimitDispatchBlocked(out var retryAfterMinutes)) {
+            await SetStatusAsync(BuildUsageLimitQueuedPromptStatus(retryAfterMinutes)).ConfigureAwait(false);
             return false;
         }
 
@@ -330,6 +343,11 @@ public sealed partial class MainWindow : Window {
 
         if (!IsEffectivelyAuthenticatedForCurrentTransport() && queuedSignIn > 0) {
             await SetStatusAsync($"Waiting for sign-in... ({queuedSignIn}/{MaxQueuedTurns} queued)").ConfigureAwait(false);
+            return;
+        }
+
+        if (queuedSignIn > 0 && IsActiveUsageLimitDispatchBlocked(out var retryAfterMinutes)) {
+            await SetStatusAsync(BuildUsageLimitQueuedPromptStatus(retryAfterMinutes)).ConfigureAwait(false);
             return;
         }
 


### PR DESCRIPTION
## Summary
- stop usage-limit replay loops by queuing raw user text (not the already-expanded service envelope)
- gate queued-after-login auto-dispatch while the active account is still usage-limited
- add focused tests for usage-limit dispatch blocking logic
- repair a pre-existing dangling `[Fact]` in transcript normalizer tests so the test project compiles cleanly

## Why this fixes the loop
- previously, usage-limit recovery queued `turn.RequestText`, which already contains session/runtime envelope blocks
- replaying that text re-wrapped the envelope repeatedly and could spin in retry cycles
- now we queue `turn.UserText` and hold queued dispatch until account limit signals clear (or user switches account)

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~MainWindowUsageLimitDispatchTests"`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
  - currently has 3 pre-existing failures in `MainWindowExecutionContractBlockerTests` unrelated to this change
