### PR TITLE
Fix chat status-pill UX and tighten post-login auth dispatch

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
@@ -131,8 +131,9 @@ public sealed partial class MainWindow : Window {
     }
 
     private async Task CompleteLoginAndDispatchQueuedTurnAsync() {
+        var refreshSucceeded = false;
         try {
-            await RefreshAuthenticationStateAsync(updateStatus: true).ConfigureAwait(false);
+            refreshSucceeded = await RefreshAuthenticationStateAsync(updateStatus: true, requireFreshProbe: true).ConfigureAwait(false);
         } catch (Exception ex) {
             if (VerboseServiceLogs || _debugMode) {
                 try {
@@ -144,6 +145,12 @@ public sealed partial class MainWindow : Window {
                     // Best-effort diagnostic only.
                 }
             }
+        }
+
+        if (RequiresInteractiveSignInForCurrentTransport() && !refreshSucceeded) {
+            await SetStatusAsync(SessionStatus.SignInRequired()).ConfigureAwait(false);
+            await SetActivityAsync("Post-login verification failed. Waiting for account confirmation...").ConfigureAwait(false);
+            return;
         }
 
         await HandlePostLoginCompletionAsync().ConfigureAwait(false);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnQueue.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnQueue.cs
@@ -46,13 +46,13 @@ public sealed partial class MainWindow : Window {
             return;
         }
 
-        if (_modelKickoffInProgress) {
-            await CancelModelKickoffIfRunningAsync().ConfigureAwait(false);
-        }
-
         var turn = await PrepareChatTurnAsync(text, skipUserBubble).ConfigureAwait(false);
         if (turn is null) {
             return;
+        }
+
+        if (_modelKickoffInProgress) {
+            await CancelModelKickoffIfRunningAsync().ConfigureAwait(false);
         }
 
         // Keep user bubble rendering immediate, but still validate connectivity
@@ -285,6 +285,11 @@ public sealed partial class MainWindow : Window {
     }
 
     private static string BuildUsageLimitQueuedPromptStatus(int? retryAfterMinutes) {
+        _ = retryAfterMinutes;
+        return SessionStatusFormatter.Format(SessionStatus.UsageLimitReached());
+    }
+
+    private static string BuildUsageLimitQueuedPromptActivity(int? retryAfterMinutes) {
         if (retryAfterMinutes.HasValue && retryAfterMinutes.Value > 0) {
             return "Queued prompt paused by account limit (" + retryAfterMinutes.Value + "m remaining). Use Switch Account to run now.";
         }
@@ -299,6 +304,7 @@ public sealed partial class MainWindow : Window {
 
         if (IsActiveUsageLimitDispatchBlocked(out var retryAfterMinutes)) {
             await SetStatusAsync(BuildUsageLimitQueuedPromptStatus(retryAfterMinutes)).ConfigureAwait(false);
+            await SetActivityAsync(BuildUsageLimitQueuedPromptActivity(retryAfterMinutes)).ConfigureAwait(false);
             return false;
         }
 
@@ -375,6 +381,7 @@ public sealed partial class MainWindow : Window {
 
         if (queuedSignIn > 0 && IsActiveUsageLimitDispatchBlocked(out var retryAfterMinutes)) {
             await SetStatusAsync(BuildUsageLimitQueuedPromptStatus(retryAfterMinutes)).ConfigureAwait(false);
+            await SetActivityAsync(BuildUsageLimitQueuedPromptActivity(retryAfterMinutes)).ConfigureAwait(false);
             return;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
@@ -149,7 +149,27 @@ public sealed partial class MainWindow : Window {
         }
     }
 
-    private async Task<bool> RefreshAuthenticationStateAsync(bool updateStatus) {
+    private async Task AppendSystemBestEffortAsync(string text) {
+        var normalized = (text ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return;
+        }
+
+        try {
+            await RunOnUiThreadAsync(() => {
+                AppendSystem(normalized);
+                return Task.CompletedTask;
+            }).ConfigureAwait(false);
+        } catch {
+            // Best-effort diagnostic only.
+        }
+    }
+
+    private Task AppendSystemBestEffortAsync(SystemNotice notice) {
+        return AppendSystemBestEffortAsync(SystemNoticeFormatter.Format(notice));
+    }
+
+    private async Task<bool> RefreshAuthenticationStateAsync(bool updateStatus, bool requireFreshProbe = false) {
         if (!RequiresInteractiveSignInForCurrentTransport()) {
             ApplyNonNativeAuthenticationStateIfNeeded();
             if (updateStatus) {
@@ -189,14 +209,14 @@ public sealed partial class MainWindow : Window {
         } catch (Exception ex) {
             // Transient ensure_login probe failures should not automatically force a new browser login.
             if (VerboseServiceLogs || _debugMode) {
-                AppendSystem(SystemNotice.EnsureLoginFailed(ex.Message));
+                await AppendSystemBestEffortAsync(SystemNotice.EnsureLoginFailed(ex.Message)).ConfigureAwait(false);
             }
 
             if (updateStatus) {
                 await PublishSessionStateAsync().ConfigureAwait(false);
             }
 
-            return _isAuthenticated;
+            return requireFreshProbe ? false : _isAuthenticated;
         }
     }
 
@@ -269,7 +289,7 @@ public sealed partial class MainWindow : Window {
             _isConnected = _client is not null;
             _authenticatedAccountId = null;
             await SetStatusAsync(SessionStatus.SignInFailed()).ConfigureAwait(false);
-            AppendSystem(SystemNotice.SignInFailed(ex.Message));
+            await AppendSystemBestEffortAsync(SystemNotice.SignInFailed(ex.Message)).ConfigureAwait(false);
             return false;
         }
     }
@@ -320,7 +340,8 @@ public sealed partial class MainWindow : Window {
             await PersistAppStateAsync().ConfigureAwait(false);
         } catch (Exception ex) {
             if (VerboseServiceLogs || _debugMode) {
-                AppendSystem("Account switch will continue, but clearing saved account pin failed: " + ex.Message);
+                await AppendSystemBestEffortAsync("Account switch will continue, but clearing saved account pin failed: " + ex.Message)
+                    .ConfigureAwait(false);
             }
         }
 
@@ -337,7 +358,8 @@ public sealed partial class MainWindow : Window {
                 .ConfigureAwait(false);
         } catch (Exception ex) {
             if (VerboseServiceLogs || _debugMode) {
-                AppendSystem("Account switch will continue, but runtime account pin reset failed: " + ex.Message);
+                await AppendSystemBestEffortAsync("Account switch will continue, but runtime account pin reset failed: " + ex.Message)
+                    .ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
## What this fixes
- Makes first user message render immediately even when model kickoff cancellation is still running.
- Keeps top status chip compact for usage-limit queue pauses by using typed `SessionStatus.UsageLimitReached()` and moving countdown detail into activity text.
- Tightens post-login queued dispatch: requires a fresh auth refresh probe before dispatching queued turns.
- Hardens async auth catch-path diagnostics by marshaling `AppendSystem` calls to UI thread in `MainWindow.ServiceAuth.cs`.

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.App/IntelligenceX.Chat.App.csproj -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~MainWindowUsageLimitDispatchTests|FullyQualifiedName~UiShellAssetsTests|FullyQualifiedName~SystemNoticeFormatterTests|FullyQualifiedName~SessionStatusFormatterTests"`
  - Passed: 42