### PR TITLE
Configure social-card style presets for pages/docs/blog

### DIFF
--- a/Website/site.json
+++ b/Website/site.json
@@ -85,7 +85,19 @@
     "AutoGenerateCards": true,
     "GeneratedCardsPath": "/assets/social/generated",
     "GeneratedCardWidth": 1200,
-    "GeneratedCardHeight": 630
+    "GeneratedCardHeight": 630,
+    "GeneratedCardStyle": "default",
+    "GeneratedCardVariant": "standard",
+    "GeneratedCardStylesByCollection": {
+      "pages": "default",
+      "docs": "docs",
+      "blog": "editorial"
+    },
+    "GeneratedCardVariantsByCollection": {
+      "pages": "hero",
+      "docs": "compact",
+      "blog": "compact"
+    }
   },
   "StructuredData": {
     "Enabled": true,


### PR DESCRIPTION
## Summary\n- configure collection-level social card style/variant presets in Website/site.json\n- use hero for pages and compact for docs/log so cards render with better visual intent\n- keep defaults explicit to simplify future tuning\n\n## Notes\n- this pairs with engine support added in EvotecIT/PSPublishModule#156\n\n## Validation\n- ran Website/build.ps1 in the branch worktree\n- confirmed generated card output differentiates home/docs/blog layouts