### PR TITLE
fix(chat): make proactive follow-up responses natural and format-flexible

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.cs
@@ -283,16 +283,13 @@ internal sealed partial class ChatServiceSession {
 
             Requirements:
             - Keep all existing factual findings that are already supported by tool output.
-            - Add a short "Potential issues to verify" section (1-3 bullets).
-            - Add a short "Recommended next fixes" section (1-3 bullets).
-            - For each bullet, include signal -> why it matters -> exact next validation/fix action.
-            - Use one-line chain format per bullet:
-              "- Signal <text> -> Why it matters: <text> -> Next action: <text>"
-              or
-              "- Signal <text> -> Why it matters: <text> -> Fix action: <text>"
-            - Keep exactly one space after each colon and around each "->" separator.
-            - Do not use `*` or `**` inside the signal chain (except inside inline code spans).
-            - If writing in another language, keep the same punctuation contract: "<label>: <text>".
+            - Keep the response natural and conversational, not scripted.
+            - Add proactive follow-ups only when they provide real value (typically 1-3 key items).
+            - You may present results in the format that best fits the findings: short paragraphs, bullets, compact tables, or simple diagrams/charts.
+            - If a diagram/chart improves clarity, include it directly without asking for permission first.
+            - When listing checks/fixes, make each item actionable and specific.
+            - Include "why it matters" context when the impact is not obvious, but do not force that label on every line.
+            - Vary structure naturally across turns; avoid repeating rigid templates.
             - If confidence is uncertain, say what evidence is missing and how to collect it.
             - Prefer proactive checks that can catch hidden regressions, not just obvious follow-ups.
             - Do not invent tool outputs or claim completed actions that were not executed.

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -268,18 +268,17 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
-    public void BuildProactiveFollowUpReviewPrompt_EmitsStableMarkerAndSections() {
+    public void BuildProactiveFollowUpReviewPrompt_EmitsStableMarkerAndFlexibleGuidance() {
         var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt("analyze failed logons", "Current findings...");
 
         Assert.Contains("ix:proactive-followup:v1", text, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Potential issues to verify", text, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Recommended next fixes", text, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("signal -> why it matters -> exact next validation/fix action", text, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Signal <text> -> Why it matters: <text> -> Next action: <text>", text, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Fix action: <text>", text, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("exactly one space after each colon", text, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("do not use `*` or `**` inside the signal chain", text, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("\"<label>: <text>\"", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("natural and conversational", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("short paragraphs, bullets, compact tables, or simple diagrams/charts", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("without asking for permission first", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("do not force that label on every line", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("avoid repeating rigid templates", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("signal -> why it matters -> exact next validation/fix action", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Signal <text> -> Why it matters: <text> -> Next action: <text>", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("hidden regressions", text, StringComparison.OrdinalIgnoreCase);
     }
 


### PR DESCRIPTION
## Summary
- relax proactive follow-up rewrite prompt so responses are natural and conversational instead of forced into a rigid chain format
- allow assistant to choose best format per context (paragraphs, bullets, compact tables, simple diagrams/charts)
- explicitly permit using diagrams/charts without asking first when they improve clarity
- keep safeguards: no invented tool output, actionable guidance, uncertainty evidence gaps, hidden-regression checks

## Tests
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_EmitsStableMarkerAndFlexibleGuidance"
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~ChatServiceRoutingTrimTests"