### PR TITLE
fix(website): harden homepage Prism startup with hashed assets

### DIFF
--- a/Website/static/js/main.js
+++ b/Website/static/js/main.js
@@ -5,6 +5,13 @@
   document.documentElement.setAttribute('data-theme', preferred);
 })();
 
+// Prevent Prism from auto-highlighting before autoloader path is configured.
+// Hashed Prism filenames can break its default path inference and cache failures.
+(function () {
+  window.Prism = window.Prism || {};
+  window.Prism.manual = true;
+})();
+
 // Mobile nav toggle
 document.addEventListener('DOMContentLoaded', function () {
   var mermaidScriptUrl = 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js';
@@ -381,8 +388,23 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
+  function highlightCodeBlocksWhenReady(scope, attemptsLeft) {
+    if (window.Prism) {
+      highlightCodeBlocks(scope);
+      return;
+    }
+
+    if ((attemptsLeft || 0) <= 0) {
+      return;
+    }
+
+    window.setTimeout(function () {
+      highlightCodeBlocksWhenReady(scope, attemptsLeft - 1);
+    }, 60);
+  }
+
   window.addEventListener('load', function () {
-    highlightCodeBlocks(document);
+    highlightCodeBlocksWhenReady(document, 20);
   });
 
   // Code tabs
@@ -400,7 +422,7 @@ document.addEventListener('DOMContentLoaded', function () {
         var panel = container.querySelector('[data-panel="' + target + '"]');
         if (panel) {
           panel.classList.add('active');
-          highlightCodeBlocks(panel);
+          highlightCodeBlocksWhenReady(panel, 20);
         }
       });
     });


### PR DESCRIPTION
## Summary\n- force window.Prism.manual = true before Prism loads\n- prevent Prism autoloader from failing early when hashed autoloader filenames break default path inference\n- keep explicit language path setup (/assets/prism/components/) and trigger highlighting manually\n- add small retry loop so highlight still runs if Prism arrives slightly later in script order\n\n## Why this fixes the regression\nHomepage code tabs were intermittently unhighlighted because Prism could auto-run before path configuration, then cache language load failures.\n\n## Validation\n- rebuilt Website locally via uild.ps1\n- confirmed emitted hashed JS bundle includes:\n  - window.Prism.manual = true\n  - highlightCodeBlocksWhenReady(...) retry logic\n  - explicit utoloader.languages_path setup