### PR TITLE
Fix chat auth stalls, follow-up rewrites, and account identity clarity

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.AccountUsage.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.AccountUsage.cs
@@ -146,13 +146,19 @@ public sealed partial class MainWindow : Window {
         return canonical;
     }
 
-    private static ActiveUsageIdentity ResolveNativeUsageIdentity(string? accountId) {
+    private static ActiveUsageIdentity ResolveNativeUsageIdentity(string? accountId, string? email = null) {
         var normalized = (accountId ?? string.Empty).Trim();
+        var normalizedEmail = (email ?? string.Empty).Trim();
         if (normalized.Length == 0) {
-            return new ActiveUsageIdentity("native:unknown", "ChatGPT (unknown account)");
+            return normalizedEmail.Length == 0
+                ? new ActiveUsageIdentity("native:unknown", "ChatGPT (unknown account)")
+                : new ActiveUsageIdentity("native:unknown", "ChatGPT (" + normalizedEmail + ")");
         }
 
-        return new ActiveUsageIdentity(BuildNativeUsageKey(normalized), "ChatGPT (" + normalized + ")");
+        var label = normalizedEmail.Length == 0
+            ? "ChatGPT (" + normalized + ")"
+            : "ChatGPT (" + normalizedEmail + " | " + normalized + ")";
+        return new ActiveUsageIdentity(BuildNativeUsageKey(normalized), label);
     }
 
     private static AccountUsageSnapshot CreateEmptyUsageSnapshot(ActiveUsageIdentity identity) {
@@ -324,7 +330,7 @@ public sealed partial class MainWindow : Window {
             }
 
             _accountUsageByKey[identity.Key] = current with {
-                Label = identity.Label,
+                Label = string.IsNullOrWhiteSpace(current.Label) ? identity.Label : current.Label,
                 PromptTokens = checked(current.PromptTokens + promptTokens),
                 CompletionTokens = checked(current.CompletionTokens + completionTokens),
                 TotalTokens = checked(current.TotalTokens + totalTokens),
@@ -350,7 +356,9 @@ public sealed partial class MainWindow : Window {
             accountId = NormalizeLocalProviderOpenAIAccountId(login.AccountId);
         }
 
-        var identity = ResolveNativeUsageIdentity(accountId);
+        var planType = NormalizeOptionalText(usage.PlanType);
+        var email = NormalizeOptionalText(usage.Email);
+        var identity = ResolveNativeUsageIdentity(accountId, email);
         var nowUtc = DateTime.UtcNow;
         var rateLimit = usage.RateLimit;
         var rateLimitResetUtc = TryResolveRateLimitResetUtc(rateLimit, nowUtc);
@@ -360,8 +368,6 @@ public sealed partial class MainWindow : Window {
         var usageRetrievedAtUtc = usage.RetrievedAtUtc.HasValue
             ? EnsureUtc(usage.RetrievedAtUtc.Value)
             : (DateTime?)null;
-        var planType = NormalizeOptionalText(usage.PlanType);
-        var email = NormalizeOptionalText(usage.Email);
         var snapshotSource = NormalizeOptionalText(usage.Source);
 
         var credits = usage.Credits;
@@ -431,7 +437,7 @@ public sealed partial class MainWindow : Window {
             }
 
             _accountUsageByKey[identity.Key] = current with {
-                Label = identity.Label,
+                Label = string.IsNullOrWhiteSpace(current.Label) ? identity.Label : current.Label,
                 UsageLimitHitUtc = nowUtc,
                 UsageLimitRetryAfterUtc = retryAfterUtc
             };

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
@@ -30,7 +30,10 @@ public sealed partial class MainWindow : Window {
         await SetActivityAsync("Checking account and runtime status...").ConfigureAwait(false);
 
         if (!IsEffectivelyAuthenticatedForCurrentTransport()) {
-            var authenticatedNow = await RefreshAuthenticationStateAsync(updateStatus: true).ConfigureAwait(false);
+            var authenticatedNow = await RefreshAuthenticationStateAsync(
+                    updateStatus: true,
+                    probeTimeout: EnsureLoginFastPathProbeTimeout)
+                .ConfigureAwait(false);
             if (authenticatedNow) {
                 _isAuthenticated = true;
             }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
@@ -131,10 +131,16 @@ public sealed partial class MainWindow : Window {
     }
 
     private async Task<bool> VerifyPostLoginAuthenticationAsync() {
-        const int maxProbeAttempts = 8;
+        const int maxProbeAttempts = 5;
         var runtimePinCleared = false;
         for (var attempt = 0; attempt < maxProbeAttempts; attempt++) {
-            if (await RefreshAuthenticationStateAsync(updateStatus: true, requireFreshProbe: true).ConfigureAwait(false)) {
+            var allowCachedFallback = attempt >= 2;
+            if (await RefreshAuthenticationStateAsync(
+                    updateStatus: true,
+                    requireFreshProbe: true,
+                    allowCachedAuthenticatedFallback: allowCachedFallback,
+                    probeTimeout: EnsureLoginFreshProbeTimeout)
+                .ConfigureAwait(false)) {
                 return true;
             }
 
@@ -185,7 +191,7 @@ public sealed partial class MainWindow : Window {
 
         if (RequiresInteractiveSignInForCurrentTransport() && !refreshSucceeded) {
             await SetStatusAsync(SessionStatus.SignInRequired()).ConfigureAwait(false);
-            await SetActivityAsync("Post-login verification failed. Waiting for account confirmation...").ConfigureAwait(false);
+            await SetActivityAsync("Post-login verification did not confirm account state. Use Sign In or Switch Account.").ConfigureAwait(false);
             return;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
@@ -28,6 +28,10 @@ using Windows.Graphics;
 namespace IntelligenceX.Chat.App;
 
 public sealed partial class MainWindow : Window {
+    private static readonly TimeSpan EnsureLoginProbeTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan EnsureLoginFreshProbeTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan EnsureLoginFastPathProbeTimeout = TimeSpan.FromSeconds(2);
+
     private bool IsNativeRuntimeTransport() {
         return string.Equals(_localProviderTransport, TransportNative, StringComparison.OrdinalIgnoreCase);
     }
@@ -169,7 +173,11 @@ public sealed partial class MainWindow : Window {
         return AppendSystemBestEffortAsync(SystemNoticeFormatter.Format(notice));
     }
 
-    private async Task<bool> RefreshAuthenticationStateAsync(bool updateStatus, bool requireFreshProbe = false) {
+    private async Task<bool> RefreshAuthenticationStateAsync(
+        bool updateStatus,
+        bool requireFreshProbe = false,
+        bool allowCachedAuthenticatedFallback = true,
+        TimeSpan? probeTimeout = null) {
         if (!RequiresInteractiveSignInForCurrentTransport()) {
             ApplyNonNativeAuthenticationStateIfNeeded();
             if (updateStatus) {
@@ -191,7 +199,10 @@ public sealed partial class MainWindow : Window {
         }
 
         try {
-            var login = await client.RequestAsync<LoginStatusMessage>(new EnsureLoginRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
+            var timeout = probeTimeout.GetValueOrDefault(requireFreshProbe ? EnsureLoginFreshProbeTimeout : EnsureLoginProbeTimeout);
+            using var probeCts = timeout > TimeSpan.Zero ? new CancellationTokenSource(timeout) : null;
+            var probeToken = probeCts?.Token ?? CancellationToken.None;
+            var login = await client.RequestAsync<LoginStatusMessage>(new EnsureLoginRequest { RequestId = NextId() }, probeToken).ConfigureAwait(false);
             _isAuthenticated = login.IsAuthenticated;
             _authenticatedAccountId = login.IsAuthenticated ? (login.AccountId ?? string.Empty).Trim() : null;
             if (login.IsAuthenticated) {
@@ -206,6 +217,19 @@ public sealed partial class MainWindow : Window {
             }
 
             return login.IsAuthenticated;
+        } catch (OperationCanceledException) when (!requireFreshProbe) {
+            // Regular auth probes should not force user-visible auth churn when the service is briefly slow.
+            if (updateStatus) {
+                await PublishSessionStateAsync().ConfigureAwait(false);
+            }
+
+            return allowCachedAuthenticatedFallback && _isAuthenticated;
+        } catch (OperationCanceledException) when (requireFreshProbe) {
+            if (updateStatus) {
+                await PublishSessionStateAsync().ConfigureAwait(false);
+            }
+
+            return allowCachedAuthenticatedFallback && _isAuthenticated;
         } catch (Exception ex) {
             // Transient ensure_login probe failures should not automatically force a new browser login.
             if (VerboseServiceLogs || _debugMode) {
@@ -216,7 +240,7 @@ public sealed partial class MainWindow : Window {
                 await PublishSessionStateAsync().ConfigureAwait(false);
             }
 
-            return requireFreshProbe ? false : _isAuthenticated;
+            return allowCachedAuthenticatedFallback && _isAuthenticated;
         }
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.15.core.tools.js
@@ -1526,6 +1526,25 @@
       return null;
     }
 
+    function resolveNativeAccountEmail(accountId) {
+      var normalizedAccountId = normalizeModelText(accountId || "");
+      if (!normalizedAccountId) {
+        return "";
+      }
+      var expectedKey = "native:" + normalizedAccountId.toLowerCase();
+      for (var i = 0; i < accountUsage.length; i++) {
+        var usage = accountUsage[i] || {};
+        var usageKey = normalizeModelText(usage.key || "").toLowerCase();
+        if (usageKey !== expectedKey) {
+          continue;
+        }
+
+        return normalizeModelText(usage.email || "");
+      }
+
+      return "";
+    }
+
     var nativeSlotSelectRow = byId("optNativeAccountSlotRow");
     var nativeAccountIdRow = byId("optNativeAccountIdRow");
     var nativeAccountHint = byId("optNativeAccountHint");
@@ -1546,9 +1565,13 @@
       for (var slotIndex = 1; slotIndex <= maxNativeAccountSlots; slotIndex++) {
         var slotState = resolveNativeSlotState(slotIndex) || {};
         var slotAccountId = normalizeModelText(slotState.accountId || "");
+        var slotAccountEmail = resolveNativeAccountEmail(slotAccountId);
         var slotLabel = "Slot " + String(slotIndex);
         if (slotAccountId) {
           slotLabel += " | " + slotAccountId;
+          if (slotAccountEmail) {
+            slotLabel += " | " + slotAccountEmail;
+          }
           var slotUsageTokens = Number(slotState.usageTotalTokens);
           if (Number.isFinite(slotUsageTokens) && slotUsageTokens > 0) {
             slotLabel += " | " + formatTokenCount(slotUsageTokens) + " tok";
@@ -1569,8 +1592,10 @@
     var selectedSlotAccountId = selectedSlotState
       ? normalizeModelText(selectedSlotState.accountId || "")
       : "";
+    var selectedSlotAccountEmail = resolveNativeAccountEmail(selectedSlotAccountId);
     if (!selectedSlotAccountId) {
       selectedSlotAccountId = openAIAccountId;
+      selectedSlotAccountEmail = resolveNativeAccountEmail(selectedSlotAccountId);
     }
     if (nativeAccountIdInput) {
       nativeAccountIdInput.value = selectedSlotAccountId;
@@ -1580,10 +1605,17 @@
       var hintParts = ["Select a slot to switch accounts quickly."];
       hintParts.push("Available slots: " + String(maxNativeAccountSlots) + ".");
       if (selectedSlotAccountId) {
-        hintParts.push("Selected slot account: " + selectedSlotAccountId + ".");
+        var selectedSlotAccountText = selectedSlotAccountEmail
+          ? (selectedSlotAccountId + " (" + selectedSlotAccountEmail + ")")
+          : selectedSlotAccountId;
+        hintParts.push("Selected slot account: " + selectedSlotAccountText + ".");
       }
       if (authenticatedAccountId) {
-        hintParts.push("Authenticated now: " + authenticatedAccountId + ".");
+        var authenticatedAccountEmail = resolveNativeAccountEmail(authenticatedAccountId);
+        var authenticatedAccountText = authenticatedAccountEmail
+          ? (authenticatedAccountId + " (" + authenticatedAccountEmail + ")")
+          : authenticatedAccountId;
+        hintParts.push("Authenticated now: " + authenticatedAccountText + ".");
       }
       if (selectedSlotState) {
         var slotPlanType = normalizeModelText(selectedSlotState.planType || "");
@@ -2109,7 +2141,12 @@
 
           var usageLabel = document.createElement("div");
           usageLabel.className = "options-usage-label";
-          usageLabel.textContent = normalizeModelText(usage.label || usage.key || "account");
+          var usageLabelText = normalizeModelText(usage.label || usage.key || "account");
+          var usageEmail = normalizeModelText(usage.email || "");
+          if (usageEmail && usageLabelText.toLowerCase().indexOf(usageEmail.toLowerCase()) < 0) {
+            usageLabelText += " | " + usageEmail;
+          }
+          usageLabel.textContent = usageLabelText;
           usageHead.appendChild(usageLabel);
 
           var usageTurns = Number(usage.turns);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingHelpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingHelpers.cs
@@ -223,7 +223,7 @@ internal sealed partial class ChatServiceSession {
         }
 
         if (ShouldSkipWeightedRouting(userRequest)) {
-            return (SelectDeterministicToolSubset(definitions, limit), new List<ToolRoutingInsight>());
+            return (definitions, new List<ToolRoutingInsight>());
         }
 
         var plannerCandidates = BuildModelPlannerCandidates(definitions, limit);
@@ -265,7 +265,7 @@ internal sealed partial class ChatServiceSession {
         }
 
         if (ShouldSkipWeightedRouting(userRequest)) {
-            return SelectDeterministicToolSubset(definitions, limit);
+            return definitions;
         }
 
         var routingTokens = TokenizeRoutingTokens(userRequest, maxTokens: 16);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -69,10 +69,15 @@ internal sealed partial class ChatServiceSession {
         var routedUserRequest = ExpandContinuationUserRequest(threadId, userRequest);
         var executionContractApplies = ShouldEnforceExecuteOrExplainContract(routedUserRequest);
         var proactiveModeEnabled = TryReadProactiveModeFromRequestText(request.Text, out var proactiveMode) && proactiveMode;
+        var compactFollowUpTurn = LooksLikeContinuationFollowUp(userRequest);
         var usedContinuationSubset = false;
         if (weightedToolRouting && toolDefs.Count > 0) {
             if (!executionContractApplies) {
-                if (!TryGetContinuationToolSubset(threadId, userRequest, toolDefs, out var continuationSubset)) {
+                if (compactFollowUpTurn) {
+                    // Keep follow-up turns unconstrained so users don't see "subset retry" rewrites for
+                    // short continuation requests (for example "go ahead", "run it", "check replication").
+                    routingInsights = new List<ToolRoutingInsight>();
+                } else if (!TryGetContinuationToolSubset(threadId, userRequest, toolDefs, out var continuationSubset)) {
                     var routed = await SelectWeightedToolSubsetAsync(
                             client,
                             threadId,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -99,7 +99,7 @@ public sealed class ChatServicePlannerPromptTests {
     }
 
     [Fact]
-    public void SelectWeightedToolSubset_UsesRequestedLimit_WhenWeightedRoutingIsSkippedForShortPrompt() {
+    public void SelectWeightedToolSubset_UsesFullToolSet_WhenWeightedRoutingIsSkippedForShortPrompt() {
         var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
         var definitions = new List<ToolDefinition>();
         for (var i = 0; i < 20; i++) {
@@ -117,9 +117,9 @@ public sealed class ChatServicePlannerPromptTests {
         };
         var selected = Assert.IsAssignableFrom<IReadOnlyList<ToolDefinition>>(SelectWeightedToolSubsetMethod.Invoke(session, args));
 
-        Assert.Equal(6, selected.Count);
+        Assert.Equal(definitions.Count, selected.Count);
         Assert.Equal("ix_probe_tool_00", selected[0].Name);
-        Assert.Equal("ix_probe_tool_05", selected[5].Name);
+        Assert.Equal("ix_probe_tool_19", selected[19].Name);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add bounded auth probe timeouts in Chat app to prevent long "checking account/runtime" stalls and allow cached authenticated fallback for transient probe failures
- tighten post-login verification behavior to reduce auth-loop dead-ends and surface clearer activity text
- keep compact follow-up turns on full tool availability (avoid continuation subset narrowing + later rewrite/retry churn)
- improve account visibility by surfacing email alongside native account ids in runtime usage/slot UI labels
- update routing unit test expectation for short follow-up weighted-routing skip behavior

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release
