### PR TITLE
Improve Prism token contrast and unify syntax palette

### DIFF
--- a/Website/static/css/home.css
+++ b/Website/static/css/home.css
@@ -118,7 +118,7 @@
 .code-panel .token.comment,
 .code-panel .token.prolog,
 .code-panel .token.doctype,
-.code-panel .token.cdata { color: #94A3B8; }
+.code-panel .token.cdata { color: var(--pf-prism-comment); }
 .code-panel .token.property,
 .code-panel .token.tag,
 .code-panel .token.constant,
@@ -128,52 +128,23 @@
 .code-panel .token.attr-name,
 .code-panel .token.selector,
 .code-panel .token.keyword,
-.code-panel .token.variable { color: #00D9FF; }
+.code-panel .token.variable { color: var(--pf-prism-keyword); }
 .code-panel .token.attr-value,
 .code-panel .token.string,
 .code-panel .token.char,
 .code-panel .token.builtin,
-.code-panel .token.inserted { color: #10B981; }
+.code-panel .token.inserted { color: var(--pf-prism-string); }
 .code-panel .token.punctuation,
 .code-panel .token.operator,
 .code-panel .token.entity,
-.code-panel .token.url { color: var(--pf-ink); }
+.code-panel .token.url { color: var(--pf-prism-punctuation); }
 .code-panel .token.function,
-.code-panel .token.class-name { color: #8B5CF6; }
+.code-panel .token.class-name { color: var(--pf-prism-function); }
 .code-panel .token.number,
 .code-panel .token.boolean,
 .code-panel .token.regex,
-.code-panel .token.important { color: #F59E0B; }
+.code-panel .token.important { color: var(--pf-prism-number); }
 [data-theme="light"] .code-panel pre[class*="language-"] { box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04); }
-[data-theme="light"] .code-panel .token.comment,
-[data-theme="light"] .code-panel .token.prolog,
-[data-theme="light"] .code-panel .token.doctype,
-[data-theme="light"] .code-panel .token.cdata { color: #64748B; }
-[data-theme="light"] .code-panel .token.property,
-[data-theme="light"] .code-panel .token.tag,
-[data-theme="light"] .code-panel .token.constant,
-[data-theme="light"] .code-panel .token.symbol,
-[data-theme="light"] .code-panel .token.deleted,
-[data-theme="light"] .code-panel .token.atrule,
-[data-theme="light"] .code-panel .token.attr-name,
-[data-theme="light"] .code-panel .token.selector,
-[data-theme="light"] .code-panel .token.keyword,
-[data-theme="light"] .code-panel .token.variable { color: #0891B2; }
-[data-theme="light"] .code-panel .token.attr-value,
-[data-theme="light"] .code-panel .token.string,
-[data-theme="light"] .code-panel .token.char,
-[data-theme="light"] .code-panel .token.builtin,
-[data-theme="light"] .code-panel .token.inserted { color: #059669; }
-[data-theme="light"] .code-panel .token.punctuation,
-[data-theme="light"] .code-panel .token.operator,
-[data-theme="light"] .code-panel .token.entity,
-[data-theme="light"] .code-panel .token.url { color: #1E293B; }
-[data-theme="light"] .code-panel .token.function,
-[data-theme="light"] .code-panel .token.class-name { color: #7C3AED; }
-[data-theme="light"] .code-panel .token.number,
-[data-theme="light"] .code-panel .token.boolean,
-[data-theme="light"] .code-panel .token.regex,
-[data-theme="light"] .code-panel .token.important { color: #D97706; }
 
 /* ===== FAQ ===== */
 .faq { padding: 4rem 1.5rem; max-width: var(--pf-max-width); margin: 0 auto; }

--- a/Website/static/css/prism-theme.css
+++ b/Website/static/css/prism-theme.css
@@ -3,6 +3,31 @@
    Loaded globally so all pages (home, docs, API) share the same highlighting.
    ===== */
 
+/* Central token palette so all layouts keep consistent, accessible colors. */
+:root {
+  --pf-prism-comment: #94A3B8;
+  --pf-prism-keyword: #00D9FF;
+  --pf-prism-string: #10B981;
+  --pf-prism-punctuation: var(--pf-ink);
+  --pf-prism-operator: var(--pf-ink);
+  --pf-prism-function: #A78BFA;
+  --pf-prism-number: #F59E0B;
+  --pf-prism-variable: #00D9FF;
+  --pf-prism-important: #F59E0B;
+}
+
+[data-theme="light"] {
+  --pf-prism-comment: #475569;
+  --pf-prism-keyword: #0B6078;
+  --pf-prism-string: #166534;
+  --pf-prism-punctuation: #1E293B;
+  --pf-prism-operator: #1E293B;
+  --pf-prism-function: #6D28D9;
+  --pf-prism-number: #92400E;
+  --pf-prism-variable: #0B6078;
+  --pf-prism-important: #92400E;
+}
+
 /* Base: code block background & text */
 pre[class*="language-"],
 code[class*="language-"] {
@@ -29,7 +54,7 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #94A3B8;
+  color: var(--pf-prism-comment);
 }
 
 /* Keywords, properties, tags */
@@ -42,7 +67,7 @@ pre[class*="language-"] {
 .token.attr-name,
 .token.selector,
 .token.keyword {
-  color: #00D9FF;
+  color: var(--pf-prism-keyword);
 }
 
 /* Strings, inserted text */
@@ -51,102 +76,46 @@ pre[class*="language-"] {
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #10B981;
+  color: var(--pf-prism-string);
 }
 
 /* Punctuation */
 .token.punctuation {
-  color: var(--pf-ink);
+  color: var(--pf-prism-punctuation);
 }
 
 /* Operators, entities, URLs */
 .token.operator,
 .token.entity,
 .token.url {
-  color: var(--pf-ink);
+  color: var(--pf-prism-operator);
 }
 
 /* Functions, class names */
 .token.function,
 .token.class-name {
-  color: #8B5CF6;
+  color: var(--pf-prism-function);
 }
 
 /* Numbers, booleans */
 .token.number,
 .token.boolean {
-  color: #F59E0B;
+  color: var(--pf-prism-number);
 }
 
 /* Variables */
 .token.variable {
-  color: #00D9FF;
+  color: var(--pf-prism-variable);
 }
 
 /* Regex, important */
 .token.regex,
 .token.important {
-  color: #F59E0B;
+  color: var(--pf-prism-important);
 }
 
 /* ===== Light mode overrides ===== */
 
 [data-theme="light"] pre[class*="language-"] {
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
-}
-
-[data-theme="light"] .token.comment,
-[data-theme="light"] .token.prolog,
-[data-theme="light"] .token.doctype,
-[data-theme="light"] .token.cdata {
-  color: #64748B;
-}
-
-[data-theme="light"] .token.property,
-[data-theme="light"] .token.tag,
-[data-theme="light"] .token.constant,
-[data-theme="light"] .token.symbol,
-[data-theme="light"] .token.deleted,
-[data-theme="light"] .token.atrule,
-[data-theme="light"] .token.attr-name,
-[data-theme="light"] .token.selector,
-[data-theme="light"] .token.keyword {
-  color: #0891B2;
-}
-
-[data-theme="light"] .token.attr-value,
-[data-theme="light"] .token.string,
-[data-theme="light"] .token.char,
-[data-theme="light"] .token.builtin,
-[data-theme="light"] .token.inserted {
-  color: #059669;
-}
-
-[data-theme="light"] .token.punctuation {
-  color: #1E293B;
-}
-
-[data-theme="light"] .token.operator,
-[data-theme="light"] .token.entity,
-[data-theme="light"] .token.url {
-  color: #1E293B;
-}
-
-[data-theme="light"] .token.function,
-[data-theme="light"] .token.class-name {
-  color: #7C3AED;
-}
-
-[data-theme="light"] .token.number,
-[data-theme="light"] .token.boolean {
-  color: #D97706;
-}
-
-[data-theme="light"] .token.variable {
-  color: #0891B2;
-}
-
-[data-theme="light"] .token.regex,
-[data-theme="light"] .token.important {
-  color: #D97706;
 }


### PR DESCRIPTION
## Summary
- improve Prism token contrast for accessibility (especially YAML comments/keys flagged by PageSpeed)
- introduce shared Prism token CSS variables in `prism-theme.css` for consistent theme behavior
- upgrade light-mode token colors to WCAG-safe values against `--pf-code-bg` (`#F1F5F9`)
- improve dark-mode function/class-name token contrast as well
- remove duplicated hard-coded homepage Prism light/dark token palette and consume shared variables instead

## Why
We had recurring Prism inconsistencies and low-contrast token colors in some contexts. Consolidating token colors into one palette removes drift and keeps homepage/docs/api code blocks aligned.

## Validation
- `./build.ps1 -Dev` ✅
- `./build.ps1 -CI` ✅
- contrast spot-checks for token classes on code background:
  - light theme (`#F1F5F9`): comment 6.92, keyword 6.48, string 6.51, function 6.49, number 6.47
  - dark theme (`#0D1117`): comment 7.38, keyword 11.15, string 7.46, function 6.95, number 8.81