### PR TITLE
Fix Mermaid/Chart visual export stability and DOCX visual rendering

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
@@ -313,8 +313,14 @@ public sealed class UiShellAssetsTests {
         AssertContainsAll(
             html,
             "ensureMermaidThemeInitialized",
+            "normalizeMermaidExportSvg",
+            "htmlLabels: normalizedRenderProfile !== \"export\"",
+            "svg.replace(/<br\\s*\\/?\\s*>/gi, \"<br/>\")",
             "themeVariables",
             "applyChartThemeDefaults",
+            "host.style.width = String(ixVisualExportState.chartWidth) + \"px\"",
+            "(!parsedData || !parsedData.dataBase64) && canvas && typeof canvas.toDataURL === \"function\"",
+            "window.requestAnimationFrame(function()",
             "Object.prototype.hasOwnProperty.call(rawEdge, \"source\")",
             "Object.prototype.hasOwnProperty.call(rawEdge, \"target\")");
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Prompts/ExecutionBehavior.md
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Prompts/ExecutionBehavior.md
@@ -28,6 +28,7 @@
   - Always include a one-line summary immediately before each visual block and one short interpretation line immediately after it.
   - Visual fences must be closed.
   - Mermaid blocks must be syntactically valid.
+  - For Mermaid label line breaks, prefer `<br/>` over escaped `\n` for better export compatibility.
   - `ix-chart` blocks must contain valid JSON object payloads.
   - `ix-network` blocks must contain valid JSON object payloads with compact nodes/edges.
   - Keep visuals compact: max 8 Mermaid blocks per message (max 12000 source characters each).

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.21.core.visuals.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.21.core.visuals.js
@@ -315,14 +315,17 @@
     };
   }
 
-  function ensureMermaidThemeInitialized(themeMode) {
+  function ensureMermaidThemeInitialized(themeMode, renderProfile) {
     if (!window.mermaid || typeof window.mermaid.initialize !== "function") {
       return;
     }
 
     var normalizedThemeMode = normalizeVisualExportThemeMode(themeMode);
+    var normalizedRenderProfile = String(renderProfile || "ui").trim().toLowerCase() === "export"
+      ? "export"
+      : "ui";
     var themeVariables = resolveMermaidThemeVariables(normalizedThemeMode);
-    var signature = normalizedThemeMode + "|" + JSON.stringify(themeVariables);
+    var signature = normalizedThemeMode + "|" + normalizedRenderProfile + "|" + JSON.stringify(themeVariables);
     if (ixVisualMermaidState.initialized && ixVisualMermaidState.lastThemeSignature === signature) {
       return;
     }
@@ -331,7 +334,10 @@
       startOnLoad: false,
       securityLevel: "strict",
       theme: "base",
-      themeVariables: themeVariables
+      themeVariables: themeVariables,
+      flowchart: {
+        htmlLabels: normalizedRenderProfile !== "export"
+      }
     });
     ixVisualMermaidState.initialized = true;
     ixVisualMermaidState.lastThemeSignature = signature;
@@ -339,7 +345,7 @@
 
   function ensureMermaidReady() {
     if (window.mermaid && typeof window.mermaid.render === "function") {
-      ensureMermaidThemeInitialized("preserve_ui_theme");
+      ensureMermaidThemeInitialized("preserve_ui_theme", "ui");
       return Promise.resolve(true);
     }
 
@@ -363,7 +369,7 @@
           return false;
         }
 
-        ensureMermaidThemeInitialized("preserve_ui_theme");
+        ensureMermaidThemeInitialized("preserve_ui_theme", "ui");
 
         return true;
       })
@@ -424,7 +430,7 @@
 
     pre.setAttribute("data-ix-mermaid-pending", "1");
     try {
-      ensureMermaidThemeInitialized("preserve_ui_theme");
+      ensureMermaidThemeInitialized("preserve_ui_theme", "ui");
 
       if (typeof window.mermaid.parse === "function") {
         var parseResult = window.mermaid.parse(source);
@@ -2894,6 +2900,15 @@
     return "\n";
   }
 
+  function normalizeMermaidExportSvg(svg) {
+    if (typeof svg !== "string" || !svg) {
+      return "";
+    }
+
+    // Keep Mermaid SVG XML-compatible for strict parsers (Edge/file viewers, Office renderers).
+    return svg.replace(/<br\s*\/?\s*>/gi, "<br/>");
+  }
+
   function withVisualExportBackground(svg, palette) {
     if (typeof svg !== "string" || !svg) {
       return "";
@@ -3203,7 +3218,7 @@
     var normalizedThemeMode = normalizeVisualExportThemeMode(themeMode);
     var restoreUiTheme = normalizedThemeMode !== "preserve_ui_theme";
     try {
-      ensureMermaidThemeInitialized(normalizedThemeMode);
+      ensureMermaidThemeInitialized(normalizedThemeMode, "export");
 
       if (typeof window.mermaid.parse === "function") {
         var parseResult = window.mermaid.parse(source);
@@ -3227,6 +3242,11 @@
         return null;
       }
 
+      svg = normalizeMermaidExportSvg(svg);
+      if (!svg) {
+        return null;
+      }
+
       var palette = resolveVisualExportPalette(themeMode);
       var themed = withVisualExportBackground(svg, palette);
       var encoded = utf8ToBase64(themed);
@@ -3244,7 +3264,7 @@
       return null;
     } finally {
       if (restoreUiTheme) {
-        ensureMermaidThemeInitialized("preserve_ui_theme");
+        ensureMermaidThemeInitialized("preserve_ui_theme", "ui");
       }
     }
   }
@@ -3279,32 +3299,59 @@
       animation: false
     });
 
+    var palette = resolveVisualExportPalette(themeMode);
+    var host = document.createElement("div");
+    host.style.position = "fixed";
+    host.style.left = "-10000px";
+    host.style.top = "-10000px";
+    host.style.width = String(ixVisualExportState.chartWidth) + "px";
+    host.style.height = String(ixVisualExportState.chartHeight) + "px";
+    host.style.background = palette.background;
+    host.style.padding = "0";
+    host.style.margin = "0";
+    document.body.appendChild(host);
+
     var canvas = document.createElement("canvas");
     canvas.width = ixVisualExportState.chartWidth;
     canvas.height = ixVisualExportState.chartHeight;
+    canvas.style.width = String(ixVisualExportState.chartWidth) + "px";
+    canvas.style.height = String(ixVisualExportState.chartHeight) + "px";
+    host.appendChild(canvas);
 
     var context = canvas.getContext("2d");
     if (!context) {
+      host.remove();
       return null;
     }
 
     var chart = null;
     try {
+      context.fillStyle = palette.background || "#ffffff";
+      context.fillRect(0, 0, canvas.width, canvas.height);
+
       chart = new window.Chart(context, chartConfig);
       if (chart && typeof chart.update === "function") {
         chart.update("none");
       }
       await new Promise(function(resolve) {
-        setTimeout(resolve, 40);
+        if (typeof window.requestAnimationFrame === "function") {
+          window.requestAnimationFrame(function() {
+            window.requestAnimationFrame(resolve);
+          });
+          return;
+        }
+        setTimeout(resolve, 48);
       });
 
       var dataUrl = "";
       if (chart && typeof chart.toBase64Image === "function") {
         dataUrl = chart.toBase64Image("image/png", 1) || "";
-      } else if (canvas && typeof canvas.toDataURL === "function") {
-        dataUrl = canvas.toDataURL("image/png");
       }
       var parsedData = parseDataUrlPayload(dataUrl);
+      if ((!parsedData || !parsedData.dataBase64) && canvas && typeof canvas.toDataURL === "function") {
+        dataUrl = canvas.toDataURL("image/png");
+        parsedData = parseDataUrlPayload(dataUrl);
+      }
       if (!parsedData || !parsedData.dataBase64) {
         return null;
       }
@@ -3321,6 +3368,7 @@
       if (chart && typeof chart.destroy === "function") {
         chart.destroy();
       }
+      host.remove();
     }
   }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.ExportArtifacts/DocxVisualFenceMaterializer.Helpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.ExportArtifacts/DocxVisualFenceMaterializer.Helpers.cs
@@ -86,6 +86,17 @@ internal static partial class DocxVisualFenceMaterializer {
             .Trim();
     }
 
+    private static string NormalizeEscapedLineBreaks(string value) {
+        if (string.IsNullOrEmpty(value)) {
+            return string.Empty;
+        }
+
+        return value
+            .Replace("\\r\\n", "\n", StringComparison.Ordinal)
+            .Replace("\\n", "\n", StringComparison.Ordinal)
+            .Replace("\\r", "\n", StringComparison.Ordinal);
+    }
+
     private static string ToMarkdownPath(string path) {
         return (path ?? string.Empty).Replace('\\', '/');
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.ExportArtifacts/DocxVisualFenceMaterializer.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.ExportArtifacts/DocxVisualFenceMaterializer.cs
@@ -14,6 +14,7 @@ internal static partial class DocxVisualFenceMaterializer {
     private const int MaxNetworkChars = 24000;
     private const int MaxNetworkNodes = 220;
     private const int MaxNetworkEdges = 520;
+    private const int DocxImageMaxWidthPx = 760;
 
     private static readonly string[] SupportedLanguages = ["mermaid", "ix-chart", "chart", "ix-network"];
     private static readonly string[] Palette = [
@@ -67,7 +68,7 @@ internal static partial class DocxVisualFenceMaterializer {
             var source = string.Join("\n", lines.Skip(i + 1).Take(Math.Max(0, closingIndex - i - 1)));
             tempDirectory ??= CreateTempDirectory();
             if (TryRenderVisual(language, source, tempDirectory, ++imageIndex, out var imagePath, out var altText)) {
-                outputLines.Add("![" + altText + "](<" + ToMarkdownPath(imagePath) + ">)");
+                outputLines.Add("![" + altText + "](<" + ToMarkdownPath(imagePath) + ">)" + "{width=" + DocxImageMaxWidthPx.ToString(CultureInfo.InvariantCulture) + "}");
                 replacedAny = true;
             } else {
                 AppendLines(lines, outputLines, i, closingIndex);
@@ -146,6 +147,7 @@ internal static partial class DocxVisualFenceMaterializer {
     private static string RenderMermaidPreviewSvg(string source) {
         var lines = source
             .Split('\n')
+            .SelectMany(static line => NormalizeEscapedLineBreaks(line).Split('\n'))
             .Select(static line => line.TrimEnd())
             .Where(static line => line.Length > 0)
             .Take(28)
@@ -566,7 +568,10 @@ internal static partial class DocxVisualFenceMaterializer {
             if (!string.IsNullOrWhiteSpace(edge.Label)) {
                 var midX = (from.X + to.X) / 2.0;
                 var midY = (from.Y + to.Y) / 2.0;
-                var label = edge.Label.Length > 26 ? edge.Label[..23] + "..." : edge.Label;
+                var label = NormalizeEscapedLineBreaks(edge.Label).Replace('\n', ' ').Trim();
+                if (label.Length > 26) {
+                    label = label[..23] + "...";
+                }
                 sb.Append("<text x='").Append(midX.ToString("0.##", CultureInfo.InvariantCulture))
                     .Append("' y='").Append((midY - 6).ToString("0.##", CultureInfo.InvariantCulture))
                     .Append("' fill='#5a7088' font-size='11' text-anchor='middle' font-family='Segoe UI, Arial'>")
@@ -579,13 +584,17 @@ internal static partial class DocxVisualFenceMaterializer {
             var node = nodes[i];
             var point = positions[node.Id];
             var color = Palette[i % Palette.Length];
+            var nodeLabel = NormalizeEscapedLineBreaks(node.Label).Replace('\n', ' ').Trim();
+            if (nodeLabel.Length > 22) {
+                nodeLabel = nodeLabel[..19] + "...";
+            }
             sb.Append("<circle cx='").Append(point.X.ToString("0.##", CultureInfo.InvariantCulture))
                 .Append("' cy='").Append(point.Y.ToString("0.##", CultureInfo.InvariantCulture))
                 .Append("' r='24' fill='").Append(color).Append("' stroke='#2f4256' stroke-width='1.2'/>");
             sb.Append("<text x='").Append(point.X.ToString("0.##", CultureInfo.InvariantCulture))
                 .Append("' y='").Append((point.Y + 41).ToString("0.##", CultureInfo.InvariantCulture))
                 .Append("' fill='#293f57' font-size='12' text-anchor='middle' font-family='Segoe UI, Arial'>")
-                .Append(EscapeXml(node.Label.Length > 22 ? node.Label[..19] + "..." : node.Label))
+                .Append(EscapeXml(nodeLabel))
                 .Append("</text>");
         }
 


### PR DESCRIPTION
## Summary
- fix Mermaid export XML compatibility for strict SVG consumers (Edge/file viewers/Office) by normalizing `<br/>` and using export-safe Mermaid profile
- harden Chart export/popout rendering path with offscreen host rendering and stronger PNG fallback capture
- improve DOCX visual fallback normalization for escaped line breaks and constrain rendered visual image width for better page fitting
- update visual shell asset regression anchors

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "LocalExportArtifactWriterTests|UiShellAssetsTests"