### PR TITLE
Improve chat auth reliability and stabilize transcript scrolling

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowAuthenticationFailureClassificationTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowAuthenticationFailureClassificationTests.cs
@@ -1,0 +1,47 @@
+using System;
+using IntelligenceX.Chat.App;
+using IntelligenceX.Chat.Client;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Ensures auth-required failure detection stays stable for queued sign-in recovery logic.
+/// </summary>
+public sealed class MainWindowAuthenticationFailureClassificationTests {
+    /// <summary>
+    /// Verifies structured service error codes classify auth-required failures.
+    /// </summary>
+    [Fact]
+    public void IsAuthenticationRequiredError_ReturnsTrue_ForStructuredNotAuthenticatedCode() {
+        var ex = new ChatServiceRequestException("provider said no", code: "not_authenticated");
+
+        Assert.True(MainWindow.IsAuthenticationRequiredError(ex));
+    }
+
+    /// <summary>
+    /// Verifies common auth-required message text is classified correctly.
+    /// </summary>
+    [Theory]
+    [InlineData("Not authenticated. Run ChatGPT login and retry.")]
+    [InlineData("Authentication required before this request can continue.")]
+    [InlineData("Sign in to continue.")]
+    public void IsAuthenticationRequiredError_ReturnsTrue_ForKnownAuthMessages(string message) {
+        var ex = new InvalidOperationException(message);
+
+        Assert.True(MainWindow.IsAuthenticationRequiredError(ex));
+    }
+
+    /// <summary>
+    /// Verifies non-auth transport/runtime failures are not misclassified.
+    /// </summary>
+    [Theory]
+    [InlineData("Usage limit reached. Retry later.")]
+    [InlineData("Timed out waiting for service pipe.")]
+    [InlineData("")]
+    public void IsAuthenticationRequiredError_ReturnsFalse_ForNonAuthFailures(string message) {
+        var ex = new InvalidOperationException(message);
+
+        Assert.False(MainWindow.IsAuthenticationRequiredError(ex));
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
@@ -29,17 +29,17 @@ public sealed partial class MainWindow : Window {
 
         await SetActivityAsync("Checking account and runtime status...").ConfigureAwait(false);
 
+        var dispatchAuthProbeOutcome = DispatchAuthenticationProbeOutcome.Authenticated;
         if (!IsEffectivelyAuthenticatedForCurrentTransport()) {
-            var authenticatedNow = await RefreshAuthenticationStateAsync(
-                    updateStatus: true,
-                    probeTimeout: EnsureLoginFastPathProbeTimeout)
-                .ConfigureAwait(false);
-            if (authenticatedNow) {
+            dispatchAuthProbeOutcome = await ProbeAuthenticationStateForDispatchAsync(EnsureLoginFastPathProbeTimeout).ConfigureAwait(false);
+            if (dispatchAuthProbeOutcome == DispatchAuthenticationProbeOutcome.Authenticated) {
                 _isAuthenticated = true;
             }
         }
 
-        if (!IsEffectivelyAuthenticatedForCurrentTransport()) {
+        var requireSignInBeforeDispatch = !IsEffectivelyAuthenticatedForCurrentTransport()
+                                          && dispatchAuthProbeOutcome == DispatchAuthenticationProbeOutcome.Unauthenticated;
+        if (requireSignInBeforeDispatch) {
             // User bubble is already rendered for this prompt, so retries after sign-in
             // must reuse that bubble instead of appending duplicate user messages.
             var promptQueued = TryEnqueuePromptAfterLogin(text, conversationId, out var queuedCount, skipUserBubbleOnDispatch: true);
@@ -159,6 +159,10 @@ public sealed partial class MainWindow : Window {
                             }
                         }
 
+                        if (await TryHandleAuthenticationRequiredTurnFailureAsync(turn, resolvedRetryEx).ConfigureAwait(false)) {
+                            return;
+                        }
+
                         var promptQueued = false;
                         if (IsUsageLimitError(resolvedRetryEx)) {
                             MarkUsageLimitForActiveAccount(resolvedRetryEx.Message);
@@ -184,6 +188,10 @@ public sealed partial class MainWindow : Window {
                     } catch (Exception kickoffRetryEx) {
                         resolvedEx = kickoffRetryEx;
                     }
+                }
+
+                if (await TryHandleAuthenticationRequiredTurnFailureAsync(turn, resolvedEx).ConfigureAwait(false)) {
+                    return;
                 }
 
                 var promptQueued = false;
@@ -523,6 +531,49 @@ public sealed partial class MainWindow : Window {
         }
 
         return TryEnqueuePromptAfterLogin(text, (conversationId ?? string.Empty).Trim(), out _);
+    }
+
+    private async Task<bool> TryHandleAuthenticationRequiredTurnFailureAsync(ChatTurnContext turn, Exception ex) {
+        if (!RequiresInteractiveSignInForCurrentTransport() || !IsAuthenticationRequiredError(ex)) {
+            return false;
+        }
+
+        _isAuthenticated = false;
+        _authenticatedAccountId = null;
+        var promptQueued = TryEnqueuePromptAfterLogin(
+            turn.UserText,
+            turn.ConversationId,
+            out var queuedCount,
+            skipUserBubbleOnDispatch: true);
+        var loginStarted = await StartLoginFlowIfNeededAsync().ConfigureAwait(false);
+        if (loginStarted) {
+            var waitingText = promptQueued
+                ? $"Waiting for sign-in... ({queuedCount}/{MaxQueuedTurns} queued)"
+                : "Waiting for sign-in... (queue full)";
+            await SetStatusAsync(waitingText).ConfigureAwait(false);
+        } else {
+            await SetStatusAsync(SessionStatus.SignInRequired()).ConfigureAwait(false);
+        }
+
+        if (!loginStarted) {
+            AppendSystem(turn.Conversation, SystemNotice.SignInRequiredBeforeSendingMessages());
+            await SetActivityAsync("Sign-in required. Prompt will run after login.").ConfigureAwait(false);
+        } else if (!promptQueued) {
+            AppendSystem(turn.Conversation, "Sign-in queue is full. Complete sign-in or wait for queued prompts to run.");
+            await SetActivityAsync("Sign-in queue is full. Waiting for available retry slot.").ConfigureAwait(false);
+        } else {
+            AppendSystem(turn.Conversation, SystemNotice.SignInRequiredBeforeSendingMessages());
+            await SetActivityAsync("Prompt queued for retry after sign-in.").ConfigureAwait(false);
+        }
+
+        var failureMessage = promptQueued
+            ? "Authentication required. Prompt queued for retry after sign-in."
+            : "Authentication required. Sign-in queue is full; complete sign-in and resend.";
+        await ApplyTurnFailureAsync(
+                turn,
+                AssistantTurnOutcome.Error(failureMessage))
+            .ConfigureAwait(false);
+        return true;
     }
 
     internal static bool IsActiveTurnCancellation(Exception ex, CancellationToken cancellationToken) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnQueue.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnQueue.cs
@@ -32,6 +32,8 @@ public sealed partial class MainWindow : Window {
             return;
         }
 
+        MarkStartupInteractivePriorityRequested();
+
         if (_isSending) {
             var queueConversationId = string.IsNullOrWhiteSpace(preferredConversationId)
                 ? _activeConversationId

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
@@ -371,6 +371,23 @@ public sealed partial class MainWindow : Window {
                || message.Contains(" 429", StringComparison.OrdinalIgnoreCase);
     }
 
+    internal static bool IsAuthenticationRequiredError(Exception ex) {
+        if (ex is ChatServiceRequestException requestEx
+            && string.Equals(requestEx.Code, "not_authenticated", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        var message = (ex.Message ?? string.Empty).Trim();
+        if (message.Length == 0) {
+            return false;
+        }
+
+        return message.Contains("not authenticated", StringComparison.OrdinalIgnoreCase)
+               || message.Contains("authentication required", StringComparison.OrdinalIgnoreCase)
+               || message.Contains("login required", StringComparison.OrdinalIgnoreCase)
+               || message.Contains("sign in", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static bool IsMissingTransportThreadError(Exception ex) {
         return ChatThreadRecoveryHeuristics.IsMissingTransportThreadError(ex);
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
@@ -31,6 +31,11 @@ public sealed partial class MainWindow : Window {
     private static readonly TimeSpan EnsureLoginProbeTimeout = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan EnsureLoginFreshProbeTimeout = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan EnsureLoginFastPathProbeTimeout = TimeSpan.FromSeconds(2);
+    private enum DispatchAuthenticationProbeOutcome {
+        Authenticated = 0,
+        Unauthenticated = 1,
+        Unknown = 2
+    }
 
     private bool IsNativeRuntimeTransport() {
         return string.Equals(_localProviderTransport, TransportNative, StringComparison.OrdinalIgnoreCase);
@@ -241,6 +246,41 @@ public sealed partial class MainWindow : Window {
             }
 
             return allowCachedAuthenticatedFallback && _isAuthenticated;
+        }
+    }
+
+    private async Task<DispatchAuthenticationProbeOutcome> ProbeAuthenticationStateForDispatchAsync(TimeSpan? probeTimeout = null) {
+        if (!RequiresInteractiveSignInForCurrentTransport()) {
+            ApplyNonNativeAuthenticationStateIfNeeded();
+            return DispatchAuthenticationProbeOutcome.Authenticated;
+        }
+
+        var client = _client;
+        if (client is null) {
+            _isAuthenticated = false;
+            _authenticatedAccountId = null;
+            return DispatchAuthenticationProbeOutcome.Unknown;
+        }
+
+        try {
+            var timeout = probeTimeout.GetValueOrDefault(EnsureLoginFastPathProbeTimeout);
+            using var probeCts = timeout > TimeSpan.Zero ? new CancellationTokenSource(timeout) : null;
+            var probeToken = probeCts?.Token ?? CancellationToken.None;
+            var login = await client.RequestAsync<LoginStatusMessage>(new EnsureLoginRequest { RequestId = NextId() }, probeToken).ConfigureAwait(false);
+            _isAuthenticated = login.IsAuthenticated;
+            _authenticatedAccountId = login.IsAuthenticated ? (login.AccountId ?? string.Empty).Trim() : null;
+            if (login.IsAuthenticated) {
+                CaptureAuthenticatedAccountIntoActiveSlot();
+                UpdateAccountUsageFromNativeLoginStatus(login);
+                QueuePersistAppState();
+                return DispatchAuthenticationProbeOutcome.Authenticated;
+            }
+
+            return DispatchAuthenticationProbeOutcome.Unauthenticated;
+        } catch (OperationCanceledException) {
+            return DispatchAuthenticationProbeOutcome.Unknown;
+        } catch {
+            return DispatchAuthenticationProbeOutcome.Unknown;
         }
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.cs
@@ -191,6 +191,8 @@ public sealed partial class MainWindow : Window {
                 StartupLog.Write("StartupPhase.Onboarding done");
             } catch (Exception ex) {
                 StartupLog.Write("StartupPhase.Onboarding failed: " + ex.Message);
+            } finally {
+                Interlocked.Exchange(ref _startupOnboardingDeferredQueued, 0);
             }
         });
     }
@@ -216,8 +218,18 @@ public sealed partial class MainWindow : Window {
                 StartupLog.Write("StartupPhase.Auth done");
             } catch (Exception ex) {
                 StartupLog.Write("StartupPhase.Auth failed: " + ex.Message);
+            } finally {
+                Interlocked.Exchange(ref _startupAuthDeferredQueued, 0);
             }
         });
+    }
+
+    private bool IsStartupInteractivePriorityRequested() {
+        return Volatile.Read(ref _startupInteractivePriorityRequested) != 0;
+    }
+
+    private void MarkStartupInteractivePriorityRequested() {
+        Interlocked.Exchange(ref _startupInteractivePriorityRequested, 1);
     }
 
     private void QueueDeferredStartupModelProfileSync() {
@@ -231,8 +243,12 @@ public sealed partial class MainWindow : Window {
 
         _ = Task.Run(async () => {
             try {
-                await Task.Delay(150).ConfigureAwait(false);
+                await Task.Delay(StartupDeferredModelProfileSyncDelay).ConfigureAwait(false);
                 if (_shutdownRequested) {
+                    return;
+                }
+                if (IsStartupInteractivePriorityRequested()) {
+                    StartupLog.Write("StartupConnect.model_profile_sync skipped_interactive_priority");
                     return;
                 }
 
@@ -247,6 +263,8 @@ public sealed partial class MainWindow : Window {
                 if (VerboseServiceLogs || _debugMode) {
                     AppendSystem("Model/profile sync failed: " + ex.Message);
                 }
+            } finally {
+                Interlocked.Exchange(ref _startupModelProfileSyncDeferredQueued, 0);
             }
         });
     }
@@ -262,8 +280,12 @@ public sealed partial class MainWindow : Window {
 
         _ = Task.Run(async () => {
             try {
-                await Task.Delay(100).ConfigureAwait(false);
+                await Task.Delay(StartupDeferredConnectMetadataDelay).ConfigureAwait(false);
                 if (_shutdownRequested) {
+                    return;
+                }
+                if (IsStartupInteractivePriorityRequested()) {
+                    StartupLog.Write("StartupConnect.metadata_sync skipped_interactive_priority");
                     return;
                 }
 
@@ -273,6 +295,10 @@ public sealed partial class MainWindow : Window {
                 }
 
                 try {
+                    if (IsStartupInteractivePriorityRequested()) {
+                        StartupLog.Write("StartupConnect.hello skipped_interactive_priority");
+                        return;
+                    }
                     StartupLog.Write("StartupConnect.hello begin");
                     var hello = await client.RequestAsync<HelloMessage>(new HelloRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
                     _sessionPolicy = hello.Policy;
@@ -288,6 +314,10 @@ public sealed partial class MainWindow : Window {
                 }
 
                 try {
+                    if (IsStartupInteractivePriorityRequested()) {
+                        StartupLog.Write("StartupConnect.list_tools skipped_interactive_priority");
+                        return;
+                    }
                     StartupLog.Write("StartupConnect.list_tools begin");
                     var toolList = await client.RequestAsync<ToolListMessage>(new ListToolsRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
                     UpdateToolCatalog(toolList.Tools);
@@ -300,6 +330,10 @@ public sealed partial class MainWindow : Window {
                 }
 
                 try {
+                    if (IsStartupInteractivePriorityRequested()) {
+                        StartupLog.Write("StartupConnect.auth_refresh skipped_interactive_priority");
+                        return;
+                    }
                     StartupLog.Write("StartupConnect.auth_refresh begin");
                     _ = await RefreshAuthenticationStateAsync(updateStatus: true).ConfigureAwait(false);
                     StartupLog.Write("StartupConnect.auth_refresh done");
@@ -313,6 +347,8 @@ public sealed partial class MainWindow : Window {
                 await PublishOptionsStateSafeAsync().ConfigureAwait(false);
             } catch (Exception ex) {
                 StartupLog.Write("StartupConnect.metadata_sync failed: " + ex.Message);
+            } finally {
+                Interlocked.Exchange(ref _startupConnectMetadataDeferredQueued, 0);
             }
         });
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -72,6 +72,8 @@ public sealed partial class MainWindow : Window {
     private static readonly TimeSpan StartupConnectAttemptHardTimeoutGrace = TimeSpan.FromMilliseconds(350);
     private static readonly TimeSpan StartupConnectAttemptOutlierThreshold = TimeSpan.FromMilliseconds(900);
     private static readonly TimeSpan StartupWebViewBudget = TimeSpan.FromSeconds(4);
+    private static readonly TimeSpan StartupDeferredConnectMetadataDelay = TimeSpan.FromMilliseconds(750);
+    private static readonly TimeSpan StartupDeferredModelProfileSyncDelay = TimeSpan.FromMilliseconds(1250);
     private const int StartupWebViewBudgetFastEnsureThresholdMs = 1200;
     private const int StartupWebViewBudgetMediumEnsureThresholdMs = 2000;
     private const int StartupWebViewBudgetSlowEnsureThresholdMs = 3000;
@@ -336,6 +338,7 @@ public sealed partial class MainWindow : Window {
     private int _startupConnectMetadataDeferredQueued;
     private int _startupModelProfileSyncDeferredQueued;
     private int _startupWebViewPostInitDeferredQueued;
+    private int _startupInteractivePriorityRequested;
     private string _themePreset = "default";
     private string? _sessionUserNameOverride;
     private string? _sessionAssistantPersonaOverride;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
@@ -303,6 +303,21 @@
     enabled: true,
     suppressScrollEvent: false
   };
+  var TRANSCRIPT_FOLLOW_ENABLE_THRESHOLD_PX = 28;
+  var TRANSCRIPT_FOLLOW_DISABLE_THRESHOLD_PX = 84;
+
+  function distanceFromBottom(el) {
+    if (!el) {
+      return 0;
+    }
+
+    var distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (!Number.isFinite(distance)) {
+      return 0;
+    }
+
+    return distance < 0 ? 0 : distance;
+  }
 
   function isNearBottom(el, thresholdPx) {
     if (!el) {
@@ -314,7 +329,7 @@
       threshold = 80;
     }
 
-    return el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+    return distanceFromBottom(el) < threshold;
   }
 
   function setTranscriptScrollTop(top) {
@@ -340,7 +355,18 @@
   }
 
   function refreshTranscriptFollowState() {
-    transcriptFollowState.enabled = isNearBottom(transcript, 16);
+    var distance = distanceFromBottom(transcript);
+    if (transcriptFollowState.enabled) {
+      if (distance > TRANSCRIPT_FOLLOW_DISABLE_THRESHOLD_PX) {
+        transcriptFollowState.enabled = false;
+      }
+      return transcriptFollowState.enabled;
+    }
+
+    if (distance <= TRANSCRIPT_FOLLOW_ENABLE_THRESHOLD_PX) {
+      transcriptFollowState.enabled = true;
+    }
+    return transcriptFollowState.enabled;
   }
 
   transcript.addEventListener("scroll", function() {
@@ -364,7 +390,8 @@
       }
       label.textContent = text + timelineSummary;
       el.classList.add("active");
-      if (transcriptFollowState.enabled && isNearBottom(transcript)) {
+      refreshTranscriptFollowState();
+      if (transcriptFollowState.enabled && isNearBottom(transcript, TRANSCRIPT_FOLLOW_DISABLE_THRESHOLD_PX)) {
         scrollToBottom(transcript);
       }
     } else {
@@ -585,6 +612,7 @@
   var transcriptRenderRevision = 0;
 
   window.ixSetTranscript = function(html) {
+    refreshTranscriptFollowState();
     var shouldStickBottom = transcriptFollowState.enabled;
     var previousTop = transcript.scrollTop;
     var stickAnchorTop = -1;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatServiceClient.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatServiceClient.cs
@@ -87,7 +87,7 @@ public sealed class ChatServiceClient : IAsyncDisposable {
             await SendAsync(request, cancellationToken).ConfigureAwait(false);
             var msg = await tcs.Task.ConfigureAwait(false);
             if (msg is ErrorMessage err) {
-                throw new InvalidOperationException(err.Error);
+                throw new ChatServiceRequestException(err.Error, err.Code);
             }
             if (msg is TResponse typed) {
                 return typed;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatServiceRequestException.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatServiceRequestException.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace IntelligenceX.Chat.Client;
+
+/// <summary>
+/// Exception raised when the chat service returns an explicit error response frame.
+/// </summary>
+public sealed class ChatServiceRequestException : InvalidOperationException {
+    /// <summary>
+    /// Initializes a new exception for a service error response.
+    /// </summary>
+    /// <param name="message">Service-provided error message.</param>
+    /// <param name="code">Optional structured service error code.</param>
+    public ChatServiceRequestException(string message, string? code = null) : base(message) {
+        Code = string.IsNullOrWhiteSpace(code) ? null : code.Trim();
+    }
+
+    /// <summary>
+    /// Gets the service error code when provided.
+    /// </summary>
+    public string? Code { get; }
+}


### PR DESCRIPTION
## Summary
- improve turn dispatch auth probing so transient/unknown probe failures no longer force immediate sign-in queueing, while confirmed unauthenticated state still does
- add explicit auth-required turn failure handling that queues the pending prompt for post-login retry and triggers login flow without duplicating user bubbles
- make startup deferred metadata/model sync background work yield to interactive user activity and reset deferred queue flags reliably
- add structured service error exception (`ChatServiceRequestException`) and auth classification helper coverage tests
- stabilize transcript auto-follow with hysteresis thresholds to prevent up/down scroll jitter while activity updates stream

## Why
This addresses reliability/performance pain around startup/auth/account-switch/cold-start behavior and the UI scroll instability reported while turns are running.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
