### PR TITLE
Chat: harden status and help option contracts

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.cs
@@ -522,8 +522,7 @@ internal static partial class Program {
         Console.WriteLine("  --max-table-rows <N>    Max rows to show in table-like output (0 = no limit; default: 0).");
         Console.WriteLine("  --max-sample <N>        Max sample items to show from long lists (0 = no limit; default: 0).");
         Console.WriteLine("  --redact                Best-effort redact output for display/logging (default: off).");
-        Console.WriteLine(
-            $"  --max-tool-rounds <N>   Max tool-call rounds per user message ({ChatRequestOptionLimits.MinToolRounds}..{ChatRequestOptionLimits.MaxToolRounds}; default: {ChatRequestOptionLimits.DefaultToolRounds}).");
+        Console.WriteLine(BuildMaxToolRoundsHelpLine());
         Console.WriteLine("  --parallel-tools        Execute tool calls in parallel when possible (default: on).");
         Console.WriteLine("  --no-parallel-tools     Disable parallel tool calls.");
         Console.WriteLine("  --allow-mutating-parallel-tools  Allow parallel execution for write-capable tool calls (default: off).");
@@ -540,6 +539,11 @@ internal static partial class Program {
         Console.WriteLine("REPL commands:");
         Console.WriteLine("  /help, /tools, /toolhealth [filters], /roots, /profiles, /profile <name>, /models, /model <name>, /favorites, /favorite <model>, /unfavorite <model>, /compare <p1,p2,...> -- <prompt>, /exit");
         Console.WriteLine("  /toolhealth filters: open|closed|private|builtin|pack:<id> (repeatable)");
+    }
+
+    internal static string BuildMaxToolRoundsHelpLine() {
+        return
+            $"  --max-tool-rounds <N>   Max tool-call rounds per user message ({ChatRequestOptionLimits.MinToolRounds}..{ChatRequestOptionLimits.MaxToolRounds}; default: {ChatRequestOptionLimits.DefaultToolRounds}).";
     }
 
     private static string? LoadInstructions(ReplOptions options) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -538,8 +538,7 @@ internal sealed partial class ServiceOptions : IToolRuntimePolicySettings, ITool
         Console.WriteLine("  --no-state-db           Disable SQLite state storage (profiles unavailable).");
         Console.WriteLine("  --allow-root <PATH>     Allow filesystem/evtx operations under PATH (repeatable).");
         Console.WriteLine("  --instructions-file <PATH>  Load system instructions from a file (default: bundled HostSystemPrompt.md).");
-        Console.WriteLine(
-            $"  --max-tool-rounds <N>   Max tool-call rounds per user message ({ChatRequestOptionLimits.MinToolRounds}..{ChatRequestOptionLimits.MaxToolRounds}; default: {ChatRequestOptionLimits.DefaultToolRounds}).");
+        Console.WriteLine(BuildMaxToolRoundsHelpLine());
         Console.WriteLine("  --parallel-tools        Execute tool calls in parallel when possible (default: on).");
         Console.WriteLine("  --no-parallel-tools     Disable parallel tool calls.");
         Console.WriteLine("  --allow-mutating-parallel-tools  Allow mutating/write-capable tool calls to run in parallel (default: off).");
@@ -565,6 +564,11 @@ internal sealed partial class ServiceOptions : IToolRuntimePolicySettings, ITool
         Console.WriteLine("  --exit-on-disconnect    Exit when parent app disconnects (runtime-managed mode).");
         Console.WriteLine("  --parent-pid <PID>      Parent process id used with --exit-on-disconnect.");
         Console.WriteLine("  -h, --help              Show help.");
+    }
+
+    internal static string BuildMaxToolRoundsHelpLine() {
+        return
+            $"  --max-tool-rounds <N>   Max tool-call rounds per user message ({ChatRequestOptionLimits.MinToolRounds}..{ChatRequestOptionLimits.MaxToolRounds}; default: {ChatRequestOptionLimits.DefaultToolRounds}).";
     }
 
     private static bool TryParseTransport(string value, out OpenAITransportKind kind) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatContractsProtocolStabilityTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatContractsProtocolStabilityTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using IntelligenceX.Chat.Abstractions.Protocol;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+/// <summary>
+/// Guards wire-contract tokens and shared bounds used across host/service/app.
+/// </summary>
+public sealed class ChatContractsProtocolStabilityTests {
+    [Fact]
+    public void ChatStatusCodes_ExposeStableWireTokens() {
+        Assert.Equal("thinking", ChatStatusCodes.Thinking);
+        Assert.Equal("model_selected", ChatStatusCodes.ModelSelected);
+        Assert.Equal("routing", ChatStatusCodes.Routing);
+        Assert.Equal("routing_meta", ChatStatusCodes.RoutingMeta);
+        Assert.Equal("routing_tool", ChatStatusCodes.RoutingTool);
+        Assert.Equal("tool_call", ChatStatusCodes.ToolCall);
+        Assert.Equal("tool_running", ChatStatusCodes.ToolRunning);
+        Assert.Equal("tool_heartbeat", ChatStatusCodes.ToolHeartbeat);
+        Assert.Equal("tool_completed", ChatStatusCodes.ToolCompleted);
+        Assert.Equal("tool_canceled", ChatStatusCodes.ToolCanceled);
+        Assert.Equal("tool_recovered", ChatStatusCodes.ToolRecovered);
+        Assert.Equal("tool_parallel_mode", ChatStatusCodes.ToolParallelMode);
+        Assert.Equal("tool_parallel_forced", ChatStatusCodes.ToolParallelForced);
+        Assert.Equal("tool_parallel_safety_off", ChatStatusCodes.ToolParallelSafetyOff);
+        Assert.Equal("tool_batch_started", ChatStatusCodes.ToolBatchStarted);
+        Assert.Equal("tool_batch_progress", ChatStatusCodes.ToolBatchProgress);
+        Assert.Equal("tool_batch_heartbeat", ChatStatusCodes.ToolBatchHeartbeat);
+        Assert.Equal("tool_batch_recovering", ChatStatusCodes.ToolBatchRecovering);
+        Assert.Equal("tool_batch_recovered", ChatStatusCodes.ToolBatchRecovered);
+        Assert.Equal("tool_batch_completed", ChatStatusCodes.ToolBatchCompleted);
+        Assert.Equal("tool_round_started", ChatStatusCodes.ToolRoundStarted);
+        Assert.Equal("tool_round_completed", ChatStatusCodes.ToolRoundCompleted);
+        Assert.Equal("tool_round_limit_reached", ChatStatusCodes.ToolRoundLimitReached);
+        Assert.Equal("tool_round_cap_applied", ChatStatusCodes.ToolRoundCapApplied);
+        Assert.Equal("review_passes_clamped", ChatStatusCodes.ReviewPassesClamped);
+        Assert.Equal("model_heartbeat_clamped", ChatStatusCodes.ModelHeartbeatClamped);
+        Assert.Equal("phase_plan", ChatStatusCodes.PhasePlan);
+        Assert.Equal("phase_execute", ChatStatusCodes.PhaseExecute);
+        Assert.Equal("phase_review", ChatStatusCodes.PhaseReview);
+        Assert.Equal("phase_heartbeat", ChatStatusCodes.PhaseHeartbeat);
+    }
+
+    [Fact]
+    public void ChatStatusCodes_AreUniqueAndExplicitlyEnumerated() {
+        var values = typeof(ChatStatusCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(string))
+            .Select(field => (string)field.GetRawConstantValue()!)
+            .ToArray();
+
+        Assert.Equal(30, values.Length);
+        Assert.Equal(values.Length, values.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void ChatRequestOptionLimits_ExposeStableSafetyBounds() {
+        Assert.Equal(1, ChatRequestOptionLimits.MinToolRounds);
+        Assert.Equal(256, ChatRequestOptionLimits.MaxToolRounds);
+        Assert.Equal(24, ChatRequestOptionLimits.DefaultToolRounds);
+        Assert.Equal(0, ChatRequestOptionLimits.MinCandidateTools);
+        Assert.Equal(256, ChatRequestOptionLimits.MaxCandidateTools);
+        Assert.Equal(0, ChatRequestOptionLimits.MinTimeoutSeconds);
+        Assert.Equal(3600, ChatRequestOptionLimits.MaxTimeoutSeconds);
+        Assert.Equal(1, ChatRequestOptionLimits.MinPositiveTimeoutSeconds);
+        Assert.Equal(1, ChatRequestOptionLimits.DefaultReviewPasses);
+        Assert.Equal(3, ChatRequestOptionLimits.MaxReviewPasses);
+        Assert.Equal(8, ChatRequestOptionLimits.DefaultModelHeartbeatSeconds);
+        Assert.Equal(60, ChatRequestOptionLimits.MaxModelHeartbeatSeconds);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostOptionsProfileBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostOptionsProfileBootstrapTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Threading;
+using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.Profiles;
 using Xunit;
 
@@ -31,18 +32,33 @@ public sealed class HostOptionsProfileBootstrapTests {
 
     [Fact]
     public void Parse_MaxToolRoundsAcceptsUpperBoundary() {
-        var options = ParseHostOptions(new[] { "--max-tool-rounds", "256" }, out var error);
+        var options = ParseHostOptions(
+            new[] { "--max-tool-rounds", ChatRequestOptionLimits.MaxToolRounds.ToString() },
+            out var error);
 
         Assert.NotNull(options);
         Assert.True(string.IsNullOrWhiteSpace(error));
-        Assert.Equal(256, ReadIntProperty(options!, "MaxToolRounds"));
+        Assert.Equal(ChatRequestOptionLimits.MaxToolRounds, ReadIntProperty(options!, "MaxToolRounds"));
     }
 
     [Fact]
     public void Parse_MaxToolRoundsRejectsOverSafetyLimit() {
-        _ = ParseHostOptions(new[] { "--max-tool-rounds", "257" }, out var error);
+        _ = ParseHostOptions(
+            new[] { "--max-tool-rounds", (ChatRequestOptionLimits.MaxToolRounds + 1).ToString() },
+            out var error);
 
-        Assert.Equal("--max-tool-rounds must be between 1 and 256.", error);
+        Assert.Equal(
+            $"--max-tool-rounds must be between {ChatRequestOptionLimits.MinToolRounds} and {ChatRequestOptionLimits.MaxToolRounds}.",
+            error);
+    }
+
+    [Fact]
+    public void WriteHelp_MaxToolRoundsLineUsesSharedBoundsAndDefault() {
+        var helpLine = InvokeHostBuildMaxToolRoundsHelpLine();
+
+        Assert.Equal(
+            $"--max-tool-rounds <N>   Max tool-call rounds per user message ({ChatRequestOptionLimits.MinToolRounds}..{ChatRequestOptionLimits.MaxToolRounds}; default: {ChatRequestOptionLimits.DefaultToolRounds}).",
+            helpLine.TrimStart());
     }
 
     [Fact]
@@ -170,6 +186,22 @@ public sealed class HostOptionsProfileBootstrapTests {
 
     private static string CreateTempProfileDbPath() {
         return Path.Combine(Path.GetTempPath(), "ix-chat-host-profile-tests-" + Guid.NewGuid().ToString("N") + ".db");
+    }
+
+    private static string InvokeHostBuildMaxToolRoundsHelpLine() {
+        var hostProgramType = ResolveHostProgramType();
+        var buildHelpLine = hostProgramType.GetMethod("BuildMaxToolRoundsHelpLine", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(buildHelpLine);
+        var value = buildHelpLine!.Invoke(null, null);
+        Assert.IsType<string>(value);
+        return (string)value!;
+    }
+
+    private static Type ResolveHostProgramType() {
+        var hostAssembly = Assembly.Load("IntelligenceX.Chat.Host");
+        var hostProgramType = hostAssembly.GetType("IntelligenceX.Chat.Host.Program", throwOnError: true);
+        Assert.NotNull(hostProgramType);
+        return hostProgramType!;
     }
 
     private static void SeedProfile(string dbPath, string profileName, bool allowMutatingParallel) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ServiceOptionsProfileBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ServiceOptionsProfileBootstrapTests.cs
@@ -106,7 +106,11 @@ public sealed class ServiceOptionsProfileBootstrapTests {
     public void Parse_LoadsLegacyProfileWithOversizedMaxToolRounds_ClampsToSafetyLimit() {
         var dbPath = Path.Combine(Path.GetTempPath(), "ix-chat-service-legacy-rounds-" + Guid.NewGuid().ToString("N") + ".db");
         try {
-            SeedLegacyProfileRow(dbPath, profileName: "default", model: "legacy-model", maxToolRounds: 500);
+            SeedLegacyProfileRow(
+                dbPath,
+                profileName: "default",
+                model: "legacy-model",
+                maxToolRounds: ChatRequestOptionLimits.MaxToolRounds + 244);
 
             var options = ServiceOptions.Parse(new[] {
                 "--pipe", "test.pipe",
@@ -116,7 +120,7 @@ public sealed class ServiceOptionsProfileBootstrapTests {
 
             Assert.NotNull(options);
             Assert.True(string.IsNullOrWhiteSpace(error), error);
-            Assert.Equal(256, options.MaxToolRounds);
+            Assert.Equal(ChatRequestOptionLimits.MaxToolRounds, options.MaxToolRounds);
         } finally {
             TryDelete(dbPath);
         }
@@ -157,17 +161,30 @@ public sealed class ServiceOptionsProfileBootstrapTests {
 
     [Fact]
     public void Parse_AcceptsMaxToolRoundsUpperBoundary() {
-        var options = ServiceOptions.Parse(new[] { "--max-tool-rounds", "256" }, out var error);
+        var options = ServiceOptions.Parse(
+            new[] { "--max-tool-rounds", ChatRequestOptionLimits.MaxToolRounds.ToString() },
+            out var error);
 
         Assert.NotNull(options);
         Assert.True(string.IsNullOrWhiteSpace(error));
-        Assert.Equal(256, options.MaxToolRounds);
+        Assert.Equal(ChatRequestOptionLimits.MaxToolRounds, options.MaxToolRounds);
     }
 
     [Fact]
     public void Parse_RejectsMaxToolRoundsOverSafetyLimit() {
-        _ = ServiceOptions.Parse(new[] { "--max-tool-rounds", "257" }, out var error);
-        Assert.Equal("--max-tool-rounds must be between 1 and 256.", error);
+        _ = ServiceOptions.Parse(
+            new[] { "--max-tool-rounds", (ChatRequestOptionLimits.MaxToolRounds + 1).ToString() },
+            out var error);
+        Assert.Equal(
+            $"--max-tool-rounds must be between {ChatRequestOptionLimits.MinToolRounds} and {ChatRequestOptionLimits.MaxToolRounds}.",
+            error);
+    }
+
+    [Fact]
+    public void WriteHelp_MaxToolRoundsLineUsesSharedBoundsAndDefault() {
+        Assert.Equal(
+            $"--max-tool-rounds <N>   Max tool-call rounds per user message ({ChatRequestOptionLimits.MinToolRounds}..{ChatRequestOptionLimits.MaxToolRounds}; default: {ChatRequestOptionLimits.DefaultToolRounds}).",
+            ServiceOptions.BuildMaxToolRoundsHelpLine().TrimStart());
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- add protocol stability tests for `ChatStatusCodes` wire tokens plus uniqueness/enumeration guardrails
- add shared `BuildMaxToolRoundsHelpLine()` helpers in Host and Service so help text for `--max-tool-rounds` is contract-tested and reused by runtime help output
- normalize Host/Service max-tool-rounds parser tests to use `ChatRequestOptionLimits` constants instead of magic values

## Why
- protects wire-level status tokens from accidental drift across service/app consumers
- keeps CLI help and validation bounds/defaults anchored to one shared source of truth
- improves long-running maintenance by failing fast when contract values diverge

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --nologo`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --nologo`
