### PR TITLE
Fix read-only pending-action auto-execution nudge

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
@@ -201,7 +201,13 @@ internal sealed partial class ChatServiceSession {
         var echoedCallToAction = UserMatchesAssistantCallToAction(request, draft);
         var compactFollowUp = LooksLikeCompactFollowUp(request);
         var contextualFollowUp = !compactFollowUp && LooksLikeContextualFollowUpForExecutionNudge(request, draft);
+        var hasSingleReadOnlyPendingActionEnvelope = HasSingleReadOnlyPendingActionEnvelope(draft);
         if (!usedContinuationSubset && !echoedCallToAction && !contextualFollowUp) {
+            if (hasSingleReadOnlyPendingActionEnvelope && !ContainsQuestionSignal(draft)) {
+                reason = "single_readonly_pending_action_envelope";
+                return true;
+            }
+
             reason = "no_continuation_subset_and_no_cta_or_contextual_follow_up";
             return false;
         }
@@ -229,6 +235,11 @@ internal sealed partial class ChatServiceSession {
                                   || draft.Contains('{', StringComparison.Ordinal)
                                   || draft.Contains('[', StringComparison.Ordinal);
         if (hasStructuredOutput) {
+            if (hasSingleReadOnlyPendingActionEnvelope && !asksAnotherQuestion) {
+                reason = "structured_draft_single_readonly_pending_action_envelope";
+                return true;
+            }
+
             // Multi-line drafts are usually results/explanations; avoid retrying tools based on incidental quoted text
             // inside structured output (for example JSON like `"run now",`). Only allow the nudge when the CTA quote
             // is formatted as an explicit option/bullet on its own line.
@@ -263,6 +274,16 @@ internal sealed partial class ChatServiceSession {
 
         reason = "assistant_draft_not_linked_to_follow_up";
         return false;
+    }
+
+    private static bool HasSingleReadOnlyPendingActionEnvelope(string assistantDraft) {
+        var actions = ExtractPendingActions(assistantDraft);
+        if (actions.Count != 1) {
+            return false;
+        }
+
+        var action = actions[0];
+        return action.Mutability == ActionMutability.ReadOnly && !string.IsNullOrWhiteSpace(action.Id);
     }
 
     private static bool LooksLikeActionSelectionPayload(string text) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
@@ -110,6 +110,74 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ShouldAttemptToolExecutionNudge_TriggersForSingleReadOnlyPendingActionEnvelopeWithoutContinuationSubset() {
+        var userRequest = "Could you do analysis of replication and trusts and then show a network diagram?";
+        var assistantDraft = """
+            Absolutely. Proceeding with that now.
+
+            [Action]
+            ix:action:v1
+            id: act_001
+            title: Run replication and trust analysis
+            request: Run replication and trust diagnostics and return a network diagram.
+            mutating: false
+            reply: /act act_001
+            """;
+
+        var result = ShouldAttemptToolExecutionNudgeMethod.Invoke(
+            null,
+            new object?[] { userRequest, assistantDraft, true, 0, 0, false });
+
+        var value = Assert.IsType<bool>(result);
+        Assert.True(value);
+    }
+
+    [Fact]
+    public void ShouldAttemptToolExecutionNudge_DoesNotTriggerForSingleMutatingPendingActionEnvelopeWithoutContinuationSubset() {
+        var userRequest = "Disable stale account evotec\\john and then verify.";
+        var assistantDraft = """
+            Understood. Proceeding with that now.
+
+            [Action]
+            ix:action:v1
+            id: act_disable
+            title: Disable stale account
+            request: Disable stale account evotec\john and verify status.
+            mutating: true
+            reply: /act act_disable
+            """;
+
+        var result = ShouldAttemptToolExecutionNudgeMethod.Invoke(
+            null,
+            new object?[] { userRequest, assistantDraft, true, 0, 0, false });
+
+        var value = Assert.IsType<bool>(result);
+        Assert.False(value);
+    }
+
+    [Fact]
+    public void ShouldAttemptToolExecutionNudge_DoesNotTriggerForSingleUnknownMutabilityPendingActionEnvelopeWithoutContinuationSubset() {
+        var userRequest = "Run replication diagnostics now.";
+        var assistantDraft = """
+            Proceeding now.
+
+            [Action]
+            ix:action:v1
+            id: act_unknown
+            title: Run replication diagnostics
+            request: Run replication diagnostics and summarize findings.
+            reply: /act act_unknown
+            """;
+
+        var result = ShouldAttemptToolExecutionNudgeMethod.Invoke(
+            null,
+            new object?[] { userRequest, assistantDraft, true, 0, 0, false });
+
+        var value = Assert.IsType<bool>(result);
+        Assert.False(value);
+    }
+
+    [Fact]
     public void ShouldEnforceExecuteOrExplainContract_TriggersForMutatingActionSelectionPayload() {
         var userRequest = "{\"ix_action_selection\":{\"id\":\"act_001\",\"title\":\"Reset account password\",\"request\":\"Reset password for user evotec\\\\john.\",\"mutating\":true}}";
         var result = ShouldEnforceExecuteOrExplainContractMethod.Invoke(null, new object?[] { userRequest });


### PR DESCRIPTION
## Summary
- allow execution nudge when assistant draft contains exactly one structured pending-action envelope marked `mutating: false`
- prevent the no-continuation gate from stalling these read-only follow-through turns
- keep mutating or unknown-mutability envelopes blocked by default
- add regression tests for read-only vs mutating vs unknown envelope behavior

## Why
In continued sessions, the assistant could emit a message like "Proceeding with that now" plus a single read-only `[Action] ix:action:v1` envelope, but then wait for user confirmation. This caused the 1:1 bubble stall and unnecessary "go ahead" nudges.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release` (592 passed)