### PR TITLE
AD tools: fix replication schedule serialization in chat output

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationConnectionsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationConnectionsTool.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.DirectoryServices.ActiveDirectory;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,6 +16,30 @@ namespace IntelligenceX.Tools.ADPlayground;
 /// </summary>
 public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, ITool {
     private const int MaxViewTop = 5000;
+
+    internal sealed record AdReplicationConnectionSchedule(
+        int Days,
+        int HoursPerDay,
+        int SlotsPerHour,
+        int AllowedSlots,
+        int TotalSlots,
+        IReadOnlyList<int> AllowedSlotsByDay,
+        IReadOnlyList<IReadOnlyList<bool>> AllowedHoursGrid);
+
+    internal sealed record AdReplicationConnectionRow(
+        string Name,
+        string Site,
+        string? SourceServer,
+        string DestinationServer,
+        ActiveDirectoryTransportType Transport,
+        bool Enabled,
+        bool GeneratedByKcc,
+        bool ReciprocalReplicationEnabled,
+        NotificationStatus ChangeNotificationStatus,
+        bool DataCompressionEnabled,
+        bool ReplicationScheduleOwnedByUser,
+        ReplicationSpan ReplicationSpan,
+        AdReplicationConnectionSchedule? ReplicationSchedule);
 
     private static readonly ToolDefinition DefinitionValue = new(
         "ad_replication_connections",
@@ -44,7 +69,7 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
         string State,
         string Origin,
         string SummaryBy,
-        IReadOnlyList<SiteConnectionInfo> Connections,
+        IReadOnlyList<AdReplicationConnectionRow> Connections,
         IReadOnlyList<ConnectionSummary> SummaryRows);
 
     /// <summary>
@@ -111,7 +136,7 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
                 State: state,
                 Origin: origin,
                 SummaryBy: summaryBy,
-                Connections: Array.Empty<SiteConnectionInfo>(),
+                Connections: Array.Empty<AdReplicationConnectionRow>(),
                 SummaryRows: rows);
 
             return Task.FromResult(BuildAutoTableResponse(
@@ -131,9 +156,9 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
                 }));
         }
 
-        var scannedConnections = filtered.Count;
-        var connectionRows = scannedConnections > maxResults ? filtered.Take(maxResults).ToArray() : filtered;
-        var truncatedConnections = scannedConnections > connectionRows.Count;
+        var connectionRows = CapRows(filtered, maxResults, out var scannedConnections, out var truncatedConnections)
+            .Select(MapConnectionForResponse)
+            .ToArray();
 
         var rawResult = new AdReplicationConnectionsResult(
             Mode: "raw",
@@ -160,6 +185,88 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
                 meta.Add("mode", "raw");
                 AddMaxResultsMeta(meta, maxResults);
             }));
+    }
+
+    internal static AdReplicationConnectionRow MapConnectionForResponse(SiteConnectionInfo connection) {
+        if (connection is null) {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        return new AdReplicationConnectionRow(
+            Name: connection.Name,
+            Site: connection.Site,
+            SourceServer: connection.SourceServer,
+            DestinationServer: connection.DestinationServer,
+            Transport: connection.Transport,
+            Enabled: connection.Enabled,
+            GeneratedByKcc: connection.GeneratedByKcc,
+            ReciprocalReplicationEnabled: connection.ReciprocalReplicationEnabled,
+            ChangeNotificationStatus: connection.ChangeNotificationStatus,
+            DataCompressionEnabled: connection.DataCompressionEnabled,
+            ReplicationScheduleOwnedByUser: connection.ReplicationScheduleOwnedByUser,
+            ReplicationSpan: connection.ReplicationSpan,
+            ReplicationSchedule: MapReplicationScheduleForResponse(connection.ReplicationSchedule));
+    }
+
+    internal static AdReplicationConnectionSchedule? MapReplicationScheduleForResponse(ActiveDirectorySchedule? schedule) {
+        if (schedule is null) {
+            return null;
+        }
+
+        bool[,,]? rawSchedule;
+        try {
+            rawSchedule = schedule.RawSchedule;
+        } catch {
+            // DirectoryServices can throw when schedule materialization fails on partial objects.
+            return null;
+        }
+
+        if (rawSchedule is null) {
+            return null;
+        }
+
+        var days = rawSchedule.GetLength(0);
+        var hoursPerDay = rawSchedule.GetLength(1);
+        var slotsPerHour = rawSchedule.GetLength(2);
+        if (days <= 0 || hoursPerDay <= 0 || slotsPerHour <= 0) {
+            return null;
+        }
+
+        var allowedSlotsByDay = new int[days];
+        var allowedHoursGrid = new List<IReadOnlyList<bool>>(days);
+        var allowedSlots = 0;
+
+        for (var day = 0; day < days; day++) {
+            var hourRow = new bool[hoursPerDay];
+            var allowedDaySlots = 0;
+
+            for (var hour = 0; hour < hoursPerDay; hour++) {
+                var hourAllowed = false;
+                for (var slot = 0; slot < slotsPerHour; slot++) {
+                    if (!rawSchedule[day, hour, slot]) {
+                        continue;
+                    }
+
+                    hourAllowed = true;
+                    allowedDaySlots++;
+                    allowedSlots++;
+                }
+
+                hourRow[hour] = hourAllowed;
+            }
+
+            allowedSlotsByDay[day] = allowedDaySlots;
+            allowedHoursGrid.Add(hourRow);
+        }
+
+        return new AdReplicationConnectionSchedule(
+            Days: days,
+            HoursPerDay: hoursPerDay,
+            SlotsPerHour: slotsPerHour,
+            AllowedSlots: allowedSlots,
+            TotalSlots: days * hoursPerDay * slotsPerHour,
+            AllowedSlotsByDay: allowedSlotsByDay,
+            AllowedHoursGrid: allowedHoursGrid);
     }
 
     private static IReadOnlyList<string>? ReadStringArrayOrNull(JsonArray? array) {
@@ -210,4 +317,3 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
         };
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/IntelligenceX.Tools.ADPlayground.csproj
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/IntelligenceX.Tools.ADPlayground.csproj
@@ -27,4 +27,9 @@
     <!-- Shared core contract reference; path resolved in IntelligenceX.Tools/Directory.Build.props. -->
     <ProjectReference Include="$(IntelligenceXCoreProject)" Condition="'$(IntelligenceXCoreProject)'!='' AND Exists('$(IntelligenceXCoreProject)')" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>IntelligenceX.Tools.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdReplicationConnectionsToolSerializationTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdReplicationConnectionsToolSerializationTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.DirectoryServices.ActiveDirectory;
+using System.Text.Json;
+using ADPlayground.Replication;
+using IntelligenceX.Tools.ADPlayground;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class AdReplicationConnectionsToolSerializationTests {
+    [Fact]
+    public void MapReplicationScheduleForResponse_FlattensScheduleToSerializableView() {
+        var schedule = new ActiveDirectorySchedule();
+        var raw = new bool[7, 24, 4];
+        raw[0, 0, 0] = true;
+        raw[0, 0, 1] = true;
+        raw[2, 5, 3] = true;
+        schedule.RawSchedule = raw;
+
+        var view = AdReplicationConnectionsTool.MapReplicationScheduleForResponse(schedule);
+
+        Assert.NotNull(view);
+        Assert.Equal(7, view!.Days);
+        Assert.Equal(24, view.HoursPerDay);
+        Assert.Equal(4, view.SlotsPerHour);
+        Assert.Equal(3, view.AllowedSlots);
+        Assert.Equal(7 * 24 * 4, view.TotalSlots);
+        Assert.Equal(2, view.AllowedSlotsByDay[0]);
+        Assert.Equal(1, view.AllowedSlotsByDay[2]);
+        Assert.True(view.AllowedHoursGrid[0][0]);
+        Assert.True(view.AllowedHoursGrid[2][5]);
+        Assert.False(view.AllowedHoursGrid[1][0]);
+
+        var json = JsonSerializer.Serialize(view);
+        Assert.Contains("AllowedHoursGrid", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MapConnectionForResponse_ReplacesUnsupportedSchedulePayload() {
+        var schedule = new ActiveDirectorySchedule();
+        var raw = new bool[7, 24, 4];
+        raw[1, 7, 2] = true;
+        schedule.RawSchedule = raw;
+
+        var connection = new SiteConnectionInfo(
+            Name: "CN=Conn-01",
+            Site: "Default-First-Site-Name",
+            SourceServer: "DC01",
+            DestinationServer: "DC02",
+            Transport: ActiveDirectoryTransportType.Rpc,
+            Enabled: true,
+            GeneratedByKcc: true,
+            ReciprocalReplicationEnabled: false,
+            ChangeNotificationStatus: NotificationStatus.IntraSiteOnly,
+            DataCompressionEnabled: true,
+            ReplicationScheduleOwnedByUser: false,
+            ReplicationSpan: ReplicationSpan.InterSite,
+            ReplicationSchedule: schedule);
+
+        Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(connection));
+
+        var row = AdReplicationConnectionsTool.MapConnectionForResponse(connection);
+        var rowJson = JsonSerializer.Serialize(row);
+        Assert.Contains("ReplicationSchedule", rowJson, StringComparison.Ordinal);
+        Assert.DoesNotContain("RawSchedule", rowJson, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- fix `ad_replication_connections` serialization by mapping `ActiveDirectorySchedule.RawSchedule` (`bool[,,]`) into a JSON-safe schedule view
- keep existing connection fields while replacing raw `ActiveDirectorySchedule` payload with a flattened structure (`AllowedSlotsByDay` + 7x24 `AllowedHoursGrid`)
- add regression tests proving raw `SiteConnectionInfo` fails JSON serialization and mapped rows serialize correctly
- expose ADPlayground internals to `IntelligenceX.Tools.Tests` for stable contract-focused coverage

## Why
`System.Text.Json` does not support multidimensional arrays. `SiteConnectionInfo` includes `ActiveDirectorySchedule`, whose `RawSchedule` is `bool[,,]`, causing serialization failures in Chat tool responses.

## Validation
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/IntelligenceX.Tools.ADPlayground.csproj -c Release --nologo`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo`
