### PR TITLE
Improve chat reliability for startup, auth probes, and scroll stability

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
@@ -63,6 +63,27 @@ public sealed class MainWindowStartupConnectTimeoutPolicyTests {
     }
 
     /// <summary>
+    /// Ensures explicit connect-budget overrides are honored for dispatch connects,
+    /// and non-positive overrides disable the budget.
+    /// </summary>
+    [Theory]
+    [InlineData(8000, 8000)]
+    [InlineData(0, null)]
+    [InlineData(-10, null)]
+    public void ResolveStartupConnectBudget_HonorsOverrideWhenProvided(
+        int overrideBudgetMs,
+        int? expectedTimeoutMs) {
+        var timeout = MainWindow.ResolveStartupConnectBudget(
+            fromUserAction: false,
+            captureStartupPhaseTelemetry: false,
+            overrideBudget: TimeSpan.FromMilliseconds(overrideBudgetMs));
+        var expected = expectedTimeoutMs.HasValue
+            ? TimeSpan.FromMilliseconds(expectedTimeoutMs.Value)
+            : (TimeSpan?)null;
+        Assert.Equal(expected, timeout);
+    }
+
+    /// <summary>
     /// Ensures startup webview wait budget is enabled only during startup flow telemetry capture.
     /// </summary>
     [Theory]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
@@ -42,7 +42,11 @@ public sealed partial class MainWindow : Window {
         return fromUserAction || hasTrackedRunningServiceProcess;
     }
 
-    internal static TimeSpan? ResolveStartupConnectBudget(bool fromUserAction, bool captureStartupPhaseTelemetry) {
+    internal static TimeSpan? ResolveStartupConnectBudget(bool fromUserAction, bool captureStartupPhaseTelemetry, TimeSpan? overrideBudget = null) {
+        if (overrideBudget.HasValue) {
+            return overrideBudget.Value > TimeSpan.Zero ? overrideBudget : null;
+        }
+
         if (fromUserAction || !captureStartupPhaseTelemetry) {
             return null;
         }
@@ -118,7 +122,7 @@ public sealed partial class MainWindow : Window {
         return captureStartupPhaseTelemetry;
     }
 
-    private async Task ConnectAsync(bool fromUserAction = false) {
+    private async Task ConnectAsync(bool fromUserAction = false, TimeSpan? connectBudgetOverride = null) {
         await _connectGate.WaitAsync().ConfigureAwait(false);
         try {
             var captureStartupPhaseTelemetry = !fromUserAction && Volatile.Read(ref _startupFlowState) == 1;
@@ -127,7 +131,7 @@ public sealed partial class MainWindow : Window {
                     StartupLog.Write("StartupConnect." + phase + " " + state);
                 }
             }
-            var startupConnectBudget = ResolveStartupConnectBudget(fromUserAction, captureStartupPhaseTelemetry);
+            var startupConnectBudget = ResolveStartupConnectBudget(fromUserAction, captureStartupPhaseTelemetry, connectBudgetOverride);
             var startupConnectStopwatch = startupConnectBudget.HasValue ? Stopwatch.StartNew() : null;
             var startupBudgetExhaustedLogged = false;
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
@@ -342,6 +342,7 @@ public sealed partial class MainWindow : Window {
             await DisposeClientAsync().ConfigureAwait(false);
             _isAuthenticated = false;
             _authenticatedAccountId = null;
+            ResetEnsureLoginProbeCache();
             _loginInProgress = false;
             _isConnected = false;
             _autoSignInAttempted = _appState.OnboardingCompleted || AnyConversationHasMessages();
@@ -358,7 +359,7 @@ public sealed partial class MainWindow : Window {
             return true;
         }
 
-        await ConnectAsync(fromUserAction: false).ConfigureAwait(false);
+        await ConnectAsync(fromUserAction: false, connectBudgetOverride: DispatchConnectBudget).ConfigureAwait(false);
         var connected = _client is not null && await IsClientAliveAsync(_client).ConfigureAwait(false);
         _isConnected = connected;
         if (!connected) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
@@ -31,10 +31,132 @@ public sealed partial class MainWindow : Window {
     private static readonly TimeSpan EnsureLoginProbeTimeout = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan EnsureLoginFreshProbeTimeout = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan EnsureLoginFastPathProbeTimeout = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan EnsureLoginProbeCacheTtl = TimeSpan.FromMilliseconds(900);
+    private enum EnsureLoginProbeState {
+        Unknown = 0,
+        Authenticated = 1,
+        Unauthenticated = 2
+    }
+
+    private readonly record struct EnsureLoginProbeSnapshot(
+        EnsureLoginProbeState State,
+        string? AccountId,
+        LoginStatusMessage? LoginStatus,
+        Exception? Error,
+        bool IsTimeout,
+        bool FromCache);
+
+    private readonly SemaphoreSlim _ensureLoginProbeGate = new(1, 1);
+    private bool _ensureLoginProbeCacheHasValue;
+    private bool _ensureLoginProbeCachedIsAuthenticated;
+    private string? _ensureLoginProbeCachedAccountId;
+    private DateTime _ensureLoginProbeCachedAtUtc;
+
     private enum DispatchAuthenticationProbeOutcome {
         Authenticated = 0,
         Unauthenticated = 1,
         Unknown = 2
+    }
+
+    private void ResetEnsureLoginProbeCache() {
+        _ensureLoginProbeCacheHasValue = false;
+        _ensureLoginProbeCachedIsAuthenticated = false;
+        _ensureLoginProbeCachedAccountId = null;
+        _ensureLoginProbeCachedAtUtc = DateTime.MinValue;
+    }
+
+    private bool TryGetEnsureLoginProbeCache(bool requireFreshProbe, out EnsureLoginProbeSnapshot snapshot) {
+        snapshot = default;
+        if (requireFreshProbe || !_ensureLoginProbeCacheHasValue) {
+            return false;
+        }
+
+        var elapsed = DateTime.UtcNow - _ensureLoginProbeCachedAtUtc;
+        if (elapsed < TimeSpan.Zero || elapsed > EnsureLoginProbeCacheTtl) {
+            return false;
+        }
+
+        var state = _ensureLoginProbeCachedIsAuthenticated
+            ? EnsureLoginProbeState.Authenticated
+            : EnsureLoginProbeState.Unauthenticated;
+        snapshot = new EnsureLoginProbeSnapshot(
+            State: state,
+            AccountId: _ensureLoginProbeCachedAccountId,
+            LoginStatus: null,
+            Error: null,
+            IsTimeout: false,
+            FromCache: true);
+        return true;
+    }
+
+    private void CacheEnsureLoginProbeSnapshot(EnsureLoginProbeState state, string? accountId) {
+        if (state == EnsureLoginProbeState.Unknown) {
+            ResetEnsureLoginProbeCache();
+            return;
+        }
+
+        _ensureLoginProbeCacheHasValue = true;
+        _ensureLoginProbeCachedIsAuthenticated = state == EnsureLoginProbeState.Authenticated;
+        _ensureLoginProbeCachedAccountId = _ensureLoginProbeCachedIsAuthenticated ? (accountId ?? string.Empty).Trim() : null;
+        _ensureLoginProbeCachedAtUtc = DateTime.UtcNow;
+    }
+
+    private async Task<EnsureLoginProbeSnapshot> ProbeEnsureLoginAsync(TimeSpan timeout, bool requireFreshProbe) {
+        if (TryGetEnsureLoginProbeCache(requireFreshProbe, out var cached)) {
+            return cached;
+        }
+
+        await _ensureLoginProbeGate.WaitAsync().ConfigureAwait(false);
+        try {
+            if (TryGetEnsureLoginProbeCache(requireFreshProbe, out cached)) {
+                return cached;
+            }
+
+            var client = _client;
+            if (client is null) {
+                return new EnsureLoginProbeSnapshot(
+                    State: EnsureLoginProbeState.Unknown,
+                    AccountId: null,
+                    LoginStatus: null,
+                    Error: null,
+                    IsTimeout: false,
+                    FromCache: false);
+            }
+
+            try {
+                using var probeCts = timeout > TimeSpan.Zero ? new CancellationTokenSource(timeout) : null;
+                var probeToken = probeCts?.Token ?? CancellationToken.None;
+                var login = await client.RequestAsync<LoginStatusMessage>(new EnsureLoginRequest { RequestId = NextId() }, probeToken).ConfigureAwait(false);
+                var accountId = login.IsAuthenticated ? (login.AccountId ?? string.Empty).Trim() : null;
+                var state = login.IsAuthenticated ? EnsureLoginProbeState.Authenticated : EnsureLoginProbeState.Unauthenticated;
+                CacheEnsureLoginProbeSnapshot(state, accountId);
+                return new EnsureLoginProbeSnapshot(
+                    State: state,
+                    AccountId: accountId,
+                    LoginStatus: login,
+                    Error: null,
+                    IsTimeout: false,
+                    FromCache: false);
+            } catch (OperationCanceledException) {
+                return new EnsureLoginProbeSnapshot(
+                    State: EnsureLoginProbeState.Unknown,
+                    AccountId: null,
+                    LoginStatus: null,
+                    Error: null,
+                    IsTimeout: true,
+                    FromCache: false);
+            } catch (Exception ex) {
+                return new EnsureLoginProbeSnapshot(
+                    State: EnsureLoginProbeState.Unknown,
+                    AccountId: null,
+                    LoginStatus: null,
+                    Error: ex,
+                    IsTimeout: false,
+                    FromCache: false);
+            }
+        } finally {
+            _ensureLoginProbeGate.Release();
+        }
     }
 
     private bool IsNativeRuntimeTransport() {
@@ -195,6 +317,7 @@ public sealed partial class MainWindow : Window {
 
         var client = _client;
         if (client is null) {
+            ResetEnsureLoginProbeCache();
             _isAuthenticated = false;
             _authenticatedAccountId = null;
             if (updateStatus) {
@@ -203,49 +326,46 @@ public sealed partial class MainWindow : Window {
             return false;
         }
 
-        try {
-            var timeout = probeTimeout.GetValueOrDefault(requireFreshProbe ? EnsureLoginFreshProbeTimeout : EnsureLoginProbeTimeout);
-            using var probeCts = timeout > TimeSpan.Zero ? new CancellationTokenSource(timeout) : null;
-            var probeToken = probeCts?.Token ?? CancellationToken.None;
-            var login = await client.RequestAsync<LoginStatusMessage>(new EnsureLoginRequest { RequestId = NextId() }, probeToken).ConfigureAwait(false);
-            _isAuthenticated = login.IsAuthenticated;
-            _authenticatedAccountId = login.IsAuthenticated ? (login.AccountId ?? string.Empty).Trim() : null;
-            if (login.IsAuthenticated) {
+        var timeout = probeTimeout.GetValueOrDefault(requireFreshProbe ? EnsureLoginFreshProbeTimeout : EnsureLoginProbeTimeout);
+        var probe = await ProbeEnsureLoginAsync(timeout, requireFreshProbe).ConfigureAwait(false);
+        switch (probe.State) {
+            case EnsureLoginProbeState.Authenticated:
+                _isAuthenticated = true;
+                _authenticatedAccountId = (probe.AccountId ?? string.Empty).Trim();
                 CaptureAuthenticatedAccountIntoActiveSlot();
-                UpdateAccountUsageFromNativeLoginStatus(login);
-                QueuePersistAppState();
-            }
+                if (probe.LoginStatus is { IsAuthenticated: true } loginStatus) {
+                    UpdateAccountUsageFromNativeLoginStatus(loginStatus);
+                }
+                if (!probe.FromCache) {
+                    QueuePersistAppState();
+                }
 
-            if (updateStatus) {
-                await SetStatusAsync(SessionStatus.ForConnectedAuth(login.IsAuthenticated)).ConfigureAwait(false);
-                await PublishOptionsStateAsync().ConfigureAwait(false);
-            }
+                if (updateStatus) {
+                    await SetStatusAsync(SessionStatus.ForConnectedAuth(isAuthenticated: true)).ConfigureAwait(false);
+                    await PublishOptionsStateAsync().ConfigureAwait(false);
+                }
 
-            return login.IsAuthenticated;
-        } catch (OperationCanceledException) when (!requireFreshProbe) {
-            // Regular auth probes should not force user-visible auth churn when the service is briefly slow.
-            if (updateStatus) {
-                await PublishSessionStateAsync().ConfigureAwait(false);
-            }
+                return true;
+            case EnsureLoginProbeState.Unauthenticated:
+                _isAuthenticated = false;
+                _authenticatedAccountId = null;
+                if (updateStatus) {
+                    await SetStatusAsync(SessionStatus.ForConnectedAuth(isAuthenticated: false)).ConfigureAwait(false);
+                    await PublishOptionsStateAsync().ConfigureAwait(false);
+                }
 
-            return allowCachedAuthenticatedFallback && _isAuthenticated;
-        } catch (OperationCanceledException) when (requireFreshProbe) {
-            if (updateStatus) {
-                await PublishSessionStateAsync().ConfigureAwait(false);
-            }
+                return false;
+            default:
+                // Transient ensure_login probe failures should not automatically force a new browser login.
+                if (probe.Error is not null && (VerboseServiceLogs || _debugMode)) {
+                    await AppendSystemBestEffortAsync(SystemNotice.EnsureLoginFailed(probe.Error.Message)).ConfigureAwait(false);
+                }
 
-            return allowCachedAuthenticatedFallback && _isAuthenticated;
-        } catch (Exception ex) {
-            // Transient ensure_login probe failures should not automatically force a new browser login.
-            if (VerboseServiceLogs || _debugMode) {
-                await AppendSystemBestEffortAsync(SystemNotice.EnsureLoginFailed(ex.Message)).ConfigureAwait(false);
-            }
+                if (updateStatus) {
+                    await PublishSessionStateAsync().ConfigureAwait(false);
+                }
 
-            if (updateStatus) {
-                await PublishSessionStateAsync().ConfigureAwait(false);
-            }
-
-            return allowCachedAuthenticatedFallback && _isAuthenticated;
+                return allowCachedAuthenticatedFallback && _isAuthenticated;
         }
     }
 
@@ -257,30 +377,33 @@ public sealed partial class MainWindow : Window {
 
         var client = _client;
         if (client is null) {
+            ResetEnsureLoginProbeCache();
             _isAuthenticated = false;
             _authenticatedAccountId = null;
             return DispatchAuthenticationProbeOutcome.Unknown;
         }
 
-        try {
-            var timeout = probeTimeout.GetValueOrDefault(EnsureLoginFastPathProbeTimeout);
-            using var probeCts = timeout > TimeSpan.Zero ? new CancellationTokenSource(timeout) : null;
-            var probeToken = probeCts?.Token ?? CancellationToken.None;
-            var login = await client.RequestAsync<LoginStatusMessage>(new EnsureLoginRequest { RequestId = NextId() }, probeToken).ConfigureAwait(false);
-            _isAuthenticated = login.IsAuthenticated;
-            _authenticatedAccountId = login.IsAuthenticated ? (login.AccountId ?? string.Empty).Trim() : null;
-            if (login.IsAuthenticated) {
+        var timeout = probeTimeout.GetValueOrDefault(EnsureLoginFastPathProbeTimeout);
+        var probe = await ProbeEnsureLoginAsync(timeout, requireFreshProbe: false).ConfigureAwait(false);
+        switch (probe.State) {
+            case EnsureLoginProbeState.Authenticated:
+                _isAuthenticated = true;
+                _authenticatedAccountId = (probe.AccountId ?? string.Empty).Trim();
                 CaptureAuthenticatedAccountIntoActiveSlot();
-                UpdateAccountUsageFromNativeLoginStatus(login);
-                QueuePersistAppState();
-                return DispatchAuthenticationProbeOutcome.Authenticated;
-            }
+                if (probe.LoginStatus is { IsAuthenticated: true } loginStatus) {
+                    UpdateAccountUsageFromNativeLoginStatus(loginStatus);
+                }
+                if (!probe.FromCache) {
+                    QueuePersistAppState();
+                }
 
-            return DispatchAuthenticationProbeOutcome.Unauthenticated;
-        } catch (OperationCanceledException) {
-            return DispatchAuthenticationProbeOutcome.Unknown;
-        } catch {
-            return DispatchAuthenticationProbeOutcome.Unknown;
+                return DispatchAuthenticationProbeOutcome.Authenticated;
+            case EnsureLoginProbeState.Unauthenticated:
+                _isAuthenticated = false;
+                _authenticatedAccountId = null;
+                return DispatchAuthenticationProbeOutcome.Unauthenticated;
+            default:
+                return DispatchAuthenticationProbeOutcome.Unknown;
         }
     }
 
@@ -338,6 +461,7 @@ public sealed partial class MainWindow : Window {
 
         try {
             _loginInProgress = true;
+            ResetEnsureLoginProbeCache();
             _isConnected = true;
             _isAuthenticated = false;
             _authenticatedAccountId = null;
@@ -351,6 +475,7 @@ public sealed partial class MainWindow : Window {
         } catch (Exception ex) {
             _loginInProgress = false;
             _isConnected = _client is not null;
+            ResetEnsureLoginProbeCache();
             _authenticatedAccountId = null;
             await SetStatusAsync(SessionStatus.SignInFailed()).ConfigureAwait(false);
             await AppendSystemBestEffortAsync(SystemNotice.SignInFailed(ex.Message)).ConfigureAwait(false);
@@ -369,6 +494,7 @@ public sealed partial class MainWindow : Window {
         }
 
         await ClearNativeAccountPinForSwitchAsync().ConfigureAwait(false);
+        ResetEnsureLoginProbeCache();
         _isAuthenticated = false;
         _authenticatedAccountId = null;
         _loginInProgress = false;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -67,6 +67,7 @@ public sealed partial class MainWindow : Window {
     private static readonly TimeSpan StartupInitialPipeConnectTimeout = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan StartupInitialPipeConnectColdStartTimeout = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan StartupConnectBudget = TimeSpan.FromSeconds(4);
+    private static readonly TimeSpan DispatchConnectBudget = TimeSpan.FromSeconds(8);
     private static readonly TimeSpan StartupConnectMinAttemptTimeout = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan StartupConnectRetryDelay = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan StartupConnectAttemptHardTimeoutGrace = TimeSpan.FromMilliseconds(350);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
@@ -391,9 +391,6 @@
       label.textContent = text + timelineSummary;
       el.classList.add("active");
       refreshTranscriptFollowState();
-      if (transcriptFollowState.enabled && isNearBottom(transcript, TRANSCRIPT_FOLLOW_DISABLE_THRESHOLD_PX)) {
-        scrollToBottom(transcript);
-      }
     } else {
       el.classList.remove("active");
     }
@@ -610,18 +607,28 @@
   }
 
   var transcriptRenderRevision = 0;
+  var transcriptLastHtml = null;
 
   window.ixSetTranscript = function(html) {
     refreshTranscriptFollowState();
     var shouldStickBottom = transcriptFollowState.enabled;
     var previousTop = transcript.scrollTop;
+    var previousDistance = distanceFromBottom(transcript);
     var stickAnchorTop = -1;
     var renderRevision = ++transcriptRenderRevision;
     var visualRenderTask = null;
+    var nextHtml = html || "";
+    if (transcriptLastHtml === nextHtml) {
+      if (shouldStickBottom && transcriptFollowState.enabled && isNearBottom(transcript, TRANSCRIPT_FOLLOW_DISABLE_THRESHOLD_PX)) {
+        scrollToBottom(transcript);
+      }
+      return;
+    }
     if (window.ixDisposeTranscriptVisuals) {
       window.ixDisposeTranscriptVisuals(transcript);
     }
-    transcript.innerHTML = html || "";
+    transcript.innerHTML = nextHtml;
+    transcriptLastHtml = nextHtml;
     if (window.ixRenderTranscriptVisuals) {
       visualRenderTask = window.ixRenderTranscriptVisuals(transcript);
     }
@@ -637,7 +644,15 @@
       scrollToBottom(transcript);
       stickAnchorTop = transcript.scrollTop;
     } else {
-      setTranscriptScrollTop(previousTop);
+      var restoreTop = previousTop;
+      if (Number.isFinite(previousDistance)) {
+        var maxScrollTop = Math.max(0, transcript.scrollHeight - transcript.clientHeight);
+        var anchoredTop = transcript.scrollHeight - transcript.clientHeight - previousDistance;
+        if (Number.isFinite(anchoredTop)) {
+          restoreTop = Math.max(0, Math.min(maxScrollTop, anchoredTop));
+        }
+      }
+      setTranscriptScrollTop(restoreTop);
     }
 
     if (shouldStickBottom && visualRenderTask && typeof visualRenderTask.then === "function") {


### PR DESCRIPTION
## Summary
- stabilize transcript scrolling by removing activity-only auto-scroll jumps and preserving a distance-from-bottom anchor when follow mode is off
- avoid redundant full transcript DOM rewrites when rendered HTML did not change
- add a bounded dispatch connect budget so turn dispatch does not stall behind long reconnect ladders
- de-duplicate `ensure_login` probes with single-flight + short TTL cache, and reset probe cache on disconnect/login-switch transitions
- add startup connect budget override tests

## Why
This addresses recurring reliability/performance pain points seen in chat startup and first-turn dispatch:
- intermittent long connect stalls before a turn can start
- repeated auth probes during dispatch/login transitions
- transcript jumping while status/activity updates stream in

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~MainWindowStartupConnectTimeoutPolicyTests"` (64 passed)
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release` (429 passed)