### PR TITLE
Tools: harden AD/Office payload models with typed DTOs

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDefenderAsrPolicyTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdDefenderAsrPolicyTool.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ADPlayground.Gpo;
@@ -27,16 +28,46 @@ public sealed class AdDefenderAsrPolicyTool : ActiveDirectoryToolBase, ITool {
             .Required("domain_name")
             .NoAdditionalProperties());
 
+    internal sealed record AdDefenderAsrEntryResponse(
+        string RuleId,
+        uint? Value,
+        string RuleName,
+        string Mode);
+
+    internal sealed record AdDefenderAsrFriendlyEntryResponse(
+        string RuleName,
+        string RuleId,
+        string Mode);
+
+    internal sealed record AdDefenderAsrResponse(
+        string DomainName,
+        string TargetDn,
+        IReadOnlyList<AdDefenderAsrEntryResponse> Entries,
+        bool AnyEnabled,
+        IReadOnlyList<AdDefenderAsrFriendlyEntryResponse> EntriesFriendly);
+
+    internal sealed record AdDefenderCloudResponse(
+        string DomainName,
+        string TargetDn,
+        uint? DisableBlockAtFirstSeen,
+        uint? SpynetReporting,
+        uint? SubmitSamplesConsent);
+
+    internal sealed record AdDefenderCloudFriendlyResponse(
+        string BlockAtFirstSight,
+        string Maps,
+        string SampleSubmission);
+
     private sealed record AdDefenderAsrPolicyResult(
         string DomainName,
         bool IncludeAttribution,
         bool ConfiguredAttributionOnly,
         int Scanned,
         bool Truncated,
-        object Asr,
-        object Cloud,
-        IReadOnlyList<object> AsrEntriesFriendly,
-        object CloudFriendly,
+        AdDefenderAsrResponse Asr,
+        AdDefenderCloudResponse Cloud,
+        IReadOnlyList<AdDefenderAsrFriendlyEntryResponse> AsrEntriesFriendly,
+        AdDefenderCloudFriendlyResponse CloudFriendly,
         string? AttributionTopWriters,
         string? NetworkProtectionMode,
         bool? NetworkProtectionNotOff,
@@ -66,25 +97,101 @@ public sealed class AdDefenderAsrPolicyTool : ActiveDirectoryToolBase, ITool {
             query: static domainName => DefenderAsrPolicyService.Get(domainName),
             attributionSelector: static view => view.Attribution,
             additionalUnconfiguredValues: AdditionalUnconfiguredAttributionValues,
-            resultFactory: static (request, view, scanned, truncated, rows) => new AdDefenderAsrPolicyResult(
-                DomainName: request.DomainName,
-                IncludeAttribution: request.IncludeAttribution,
-                ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
-                Scanned: scanned,
-                Truncated: truncated,
-                Asr: view.Asr,
-                Cloud: view.Cloud,
-                AsrEntriesFriendly: view.AsrEntriesFriendly,
-                CloudFriendly: view.CloudFriendly,
-                AttributionTopWriters: view.AttributionTopWriters,
-                NetworkProtectionMode: view.NetworkProtectionMode,
-                NetworkProtectionNotOff: view.NetworkProtectionNotOff,
-                PuaProtectionMode: view.PuaProtectionMode,
-                PuaNotDisabled: view.PuaNotDisabled,
-                RtpRealtimeEnabled: view.RtpRealtimeEnabled,
-                RtpBehaviorEnabled: view.RtpBehaviorEnabled,
-                RtpIoavEnabled: view.RtpIoavEnabled,
-                RtpScriptEnabled: view.RtpScriptEnabled,
-                Attribution: rows));
+            resultFactory: static (request, view, scanned, truncated, rows) => {
+                var asr = MapAsrForResponse(view.Asr);
+                return new AdDefenderAsrPolicyResult(
+                    DomainName: request.DomainName,
+                    IncludeAttribution: request.IncludeAttribution,
+                    ConfiguredAttributionOnly: request.ConfiguredAttributionOnly,
+                    Scanned: scanned,
+                    Truncated: truncated,
+                    Asr: asr,
+                    Cloud: MapCloudForResponse(view.Cloud),
+                    AsrEntriesFriendly: asr.EntriesFriendly,
+                    CloudFriendly: MapCloudFriendlyForResponse(view.Cloud),
+                    AttributionTopWriters: view.AttributionTopWriters,
+                    NetworkProtectionMode: view.NetworkProtectionMode,
+                    NetworkProtectionNotOff: view.NetworkProtectionNotOff,
+                    PuaProtectionMode: view.PuaProtectionMode,
+                    PuaNotDisabled: view.PuaNotDisabled,
+                    RtpRealtimeEnabled: view.RtpRealtimeEnabled,
+                    RtpBehaviorEnabled: view.RtpBehaviorEnabled,
+                    RtpIoavEnabled: view.RtpIoavEnabled,
+                    RtpScriptEnabled: view.RtpScriptEnabled,
+                    Attribution: rows);
+            });
+    }
+
+    internal static AdDefenderAsrResponse MapAsrForResponse(DefenderAsrEvaluator.View? asr) {
+        var mappedEntries = asr?.Entries is { Count: > 0 }
+            ? asr.Entries.Select(static entry => new AdDefenderAsrEntryResponse(
+                RuleId: entry.RuleId ?? string.Empty,
+                Value: entry.Value,
+                RuleName: entry.RuleName ?? string.Empty,
+                Mode: entry.Mode ?? string.Empty)).ToArray()
+            : Array.Empty<AdDefenderAsrEntryResponse>();
+
+        var friendlyEntries = mappedEntries.Select(static entry => new AdDefenderAsrFriendlyEntryResponse(
+            RuleName: entry.RuleName,
+            RuleId: entry.RuleId,
+            Mode: entry.Mode)).ToArray();
+
+        return new AdDefenderAsrResponse(
+            DomainName: asr?.DomainName ?? string.Empty,
+            TargetDn: asr?.TargetDn ?? string.Empty,
+            Entries: mappedEntries,
+            AnyEnabled: asr?.AnyEnabled ?? false,
+            EntriesFriendly: friendlyEntries);
+    }
+
+    internal static AdDefenderCloudResponse MapCloudForResponse(DefenderCloudEvaluator.View? cloud) {
+        return new AdDefenderCloudResponse(
+            DomainName: cloud?.DomainName ?? string.Empty,
+            TargetDn: cloud?.TargetDn ?? string.Empty,
+            DisableBlockAtFirstSeen: cloud?.DisableBlockAtFirstSeen,
+            SpynetReporting: cloud?.SpynetReporting,
+            SubmitSamplesConsent: cloud?.SubmitSamplesConsent);
+    }
+
+    internal static AdDefenderCloudFriendlyResponse MapCloudFriendlyForResponse(DefenderCloudEvaluator.View? cloud) {
+        return new AdDefenderCloudFriendlyResponse(
+            BlockAtFirstSight: ToBlockAtFirstSightLabel(cloud?.DisableBlockAtFirstSeen),
+            Maps: ToMapsLabel(cloud?.SpynetReporting),
+            SampleSubmission: ToSampleSubmissionLabel(cloud?.SubmitSamplesConsent));
+    }
+
+    private static string ToBlockAtFirstSightLabel(uint? value) {
+        if (!value.HasValue) {
+            return "Not configured";
+        }
+
+        return value.Value == 1u ? "Off (disabled)" : "On";
+    }
+
+    private static string ToMapsLabel(uint? value) {
+        if (!value.HasValue) {
+            return "Not configured";
+        }
+
+        return value.Value switch {
+            0u => "Disabled",
+            1u => "Basic",
+            2u => "Advanced",
+            _ => $"Unknown ({value.Value})"
+        };
+    }
+
+    private static string ToSampleSubmissionLabel(uint? value) {
+        if (!value.HasValue) {
+            return "Not configured";
+        }
+
+        return value.Value switch {
+            0u => "Always prompt",
+            1u => "Send safe samples automatically",
+            2u => "Never send",
+            3u => "Send all samples",
+            _ => $"Unknown ({value.Value})"
+        };
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
@@ -140,6 +140,86 @@ public sealed class OfficeImoDocument {
 }
 
 /// <summary>
+/// Normalized source location metadata for a chunk.
+/// </summary>
+public sealed class OfficeImoChunkLocation {
+    /// <summary>
+    /// Source path used for citations.
+    /// </summary>
+    public string? Path { get; set; }
+
+    /// <summary>
+    /// Optional emitted chunk index (0-based).
+    /// </summary>
+    public int? BlockIndex { get; set; }
+
+    /// <summary>
+    /// Optional source block index within the input document.
+    /// </summary>
+    public int? SourceBlockIndex { get; set; }
+
+    /// <summary>
+    /// Optional 1-based start line number (Markdown/text inputs).
+    /// </summary>
+    public int? StartLine { get; set; }
+
+    /// <summary>
+    /// Optional heading path label.
+    /// </summary>
+    public string? HeadingPath { get; set; }
+
+    /// <summary>
+    /// Optional sheet name (Excel).
+    /// </summary>
+    public string? Sheet { get; set; }
+
+    /// <summary>
+    /// Optional A1 range descriptor (Excel).
+    /// </summary>
+    public string? A1Range { get; set; }
+
+    /// <summary>
+    /// Optional 1-based slide number (PowerPoint).
+    /// </summary>
+    public int? Slide { get; set; }
+
+    /// <summary>
+    /// Optional 1-based page number (PDF).
+    /// </summary>
+    public int? Page { get; set; }
+}
+
+/// <summary>
+/// Normalized table payload for chunk outputs.
+/// </summary>
+public sealed class OfficeImoChunkTable {
+    /// <summary>
+    /// Optional title/label.
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Column headers.
+    /// </summary>
+    public IReadOnlyList<string> Columns { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Rows aligned with <see cref="Columns"/>.
+    /// </summary>
+    public IReadOnlyList<IReadOnlyList<string>> Rows { get; set; } = Array.Empty<IReadOnlyList<string>>();
+
+    /// <summary>
+    /// Total row count before truncation.
+    /// </summary>
+    public int TotalRowCount { get; set; }
+
+    /// <summary>
+    /// True when <see cref="Rows"/> was truncated.
+    /// </summary>
+    public bool Truncated { get; set; }
+}
+
+/// <summary>
 /// Minimal chunk shape intended for stable tool contracts.
 /// </summary>
 public sealed class OfficeImoChunk {
@@ -166,12 +246,12 @@ public sealed class OfficeImoChunk {
     /// <summary>
     /// Optional location metadata.
     /// </summary>
-    public object? Location { get; set; }
+    public OfficeImoChunkLocation? Location { get; set; }
 
     /// <summary>
     /// Optional table data (Excel or extracted tables).
     /// </summary>
-    public object? Tables { get; set; }
+    public IReadOnlyList<OfficeImoChunkTable>? Tables { get; set; }
 
     /// <summary>
     /// Optional per-chunk warnings.

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadTool.Helpers.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadTool.Helpers.cs
@@ -309,8 +309,8 @@ public sealed partial class OfficeImoReadTool : OfficeImoToolBase, ITool {
             Kind = chunk.Kind.ToString().ToLowerInvariant(),
             Text = chunk.Text ?? string.Empty,
             Markdown = chunk.Markdown,
-            Location = chunk.Location,
-            Tables = chunk.Tables,
+            Location = MapLocation(chunk.Location),
+            Tables = MapTables(chunk.Tables),
             Warnings = chunk.Warnings,
             SourceId = chunk.SourceId,
             SourceHash = chunk.SourceHash,
@@ -319,6 +319,65 @@ public sealed partial class OfficeImoReadTool : OfficeImoToolBase, ITool {
             SourceLengthBytes = chunk.SourceLengthBytes,
             TokenEstimate = chunk.TokenEstimate
         };
+    }
+
+    private static OfficeImoChunkLocation? MapLocation(ReaderLocation? location) {
+        if (location is null) {
+            return null;
+        }
+
+        return new OfficeImoChunkLocation {
+            Path = location.Path,
+            BlockIndex = location.BlockIndex,
+            SourceBlockIndex = location.SourceBlockIndex,
+            StartLine = location.StartLine,
+            HeadingPath = location.HeadingPath,
+            Sheet = location.Sheet,
+            A1Range = location.A1Range,
+            Slide = location.Slide,
+            Page = location.Page
+        };
+    }
+
+    private static IReadOnlyList<OfficeImoChunkTable>? MapTables(IReadOnlyList<ReaderTable>? tables) {
+        if (tables is null || tables.Count == 0) {
+            return null;
+        }
+
+        var mapped = new List<OfficeImoChunkTable>(tables.Count);
+        for (var i = 0; i < tables.Count; i++) {
+            var table = tables[i];
+            if (table is null) {
+                continue;
+            }
+
+            var columns = table.Columns is null
+                ? Array.Empty<string>()
+                : table.Columns.Select(static value => value ?? string.Empty).ToArray();
+
+            var rows = new List<IReadOnlyList<string>>();
+            if (table.Rows is not null) {
+                for (var rowIndex = 0; rowIndex < table.Rows.Count; rowIndex++) {
+                    var row = table.Rows[rowIndex];
+                    if (row is null) {
+                        rows.Add(Array.Empty<string>());
+                        continue;
+                    }
+
+                    rows.Add(row.Select(static value => value ?? string.Empty).ToArray());
+                }
+            }
+
+            mapped.Add(new OfficeImoChunkTable {
+                Title = table.Title,
+                Columns = columns,
+                Rows = rows,
+                TotalRowCount = table.TotalRowCount,
+                Truncated = table.Truncated
+            });
+        }
+
+        return mapped.Count == 0 ? null : mapped;
     }
 
     private static int SumTokenEstimate(IReadOnlyList<OfficeImoChunk> chunks) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPayloadModelHardeningTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPayloadModelHardeningTests.cs
@@ -1,0 +1,93 @@
+using System.Reflection;
+using System.Text.Json;
+using ADPlayground.Gpo;
+using IntelligenceX.Tools.ADPlayground;
+using IntelligenceX.Tools.Common;
+using IntelligenceX.Tools.OfficeIMO;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class ToolPayloadModelHardeningTests {
+    [Fact]
+    public void AdDefenderAsrPolicy_ResponseMapping_ShouldSerializeTypedDtos() {
+        var asrView = new DefenderAsrEvaluator.View(
+            DomainName: "contoso.com",
+            TargetDn: "OU=Domain Controllers,DC=contoso,DC=com",
+            Entries: new[] { new DefenderAsrEvaluator.AsrEntry("56a863a9-875e-4185-98a7-b882c64b5ce5", 1u) },
+            AnyEnabled: true);
+
+        var cloudView = new DefenderCloudEvaluator.View(
+            DomainName: "contoso.com",
+            TargetDn: "OU=Domain Controllers,DC=contoso,DC=com",
+            DisableBlockAtFirstSeen: 0u,
+            SpynetReporting: 2u,
+            SubmitSamplesConsent: 1u);
+
+        var asr = AdDefenderAsrPolicyTool.MapAsrForResponse(asrView);
+        var cloud = AdDefenderAsrPolicyTool.MapCloudForResponse(cloudView);
+        var cloudFriendly = AdDefenderAsrPolicyTool.MapCloudFriendlyForResponse(cloudView);
+
+        var json = ToolResponse.OkModel(new {
+            asr,
+            cloud,
+            asr_entries_friendly = asr.EntriesFriendly,
+            cloud_friendly = cloudFriendly
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("contoso.com", root.GetProperty("asr").GetProperty("domain_name").GetString());
+        Assert.Equal("contoso.com", root.GetProperty("cloud").GetProperty("domain_name").GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("asr_entries_friendly").ValueKind);
+        Assert.Equal("On", root.GetProperty("cloud_friendly").GetProperty("block_at_first_sight").GetString());
+        Assert.Equal("Advanced", root.GetProperty("cloud_friendly").GetProperty("maps").GetString());
+    }
+
+    [Fact]
+    public void AdDefenderAsrPolicy_ResultContract_ShouldNotUseObjectTypedFields() {
+        var resultType = typeof(AdDefenderAsrPolicyTool).GetNestedType(
+            "AdDefenderAsrPolicyResult",
+            BindingFlags.NonPublic);
+
+        Assert.NotNull(resultType);
+        Assert.DoesNotContain(resultType!.GetProperties(), static property => property.PropertyType == typeof(object));
+    }
+
+    [Fact]
+    public void OfficeImoChunk_ShouldSerializeTypedLocationAndTables() {
+        var chunk = new OfficeImoChunk {
+            Id = "chunk-1",
+            Kind = "markdown",
+            Text = "Hello",
+            Location = new OfficeImoChunkLocation {
+                Path = @"C:\\docs\\notes.md",
+                BlockIndex = 2,
+                StartLine = 5
+            },
+            Tables = new[] {
+                new OfficeImoChunkTable {
+                    Title = "Sample",
+                    Columns = new[] { "name", "value" },
+                    Rows = new[] { new[] { "alpha", "1" } },
+                    TotalRowCount = 1,
+                    Truncated = false
+                }
+            }
+        };
+
+        var json = ToolResponse.OkModel(new { chunks = new[] { chunk } });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var first = root.GetProperty("chunks")[0];
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(@"C:\\docs\\notes.md", first.GetProperty("location").GetProperty("path").GetString());
+        Assert.Equal(2, first.GetProperty("location").GetProperty("block_index").GetInt32());
+        Assert.Equal(JsonValueKind.Array, first.GetProperty("tables").ValueKind);
+        Assert.Equal("Sample", first.GetProperty("tables")[0].GetProperty("title").GetString());
+    }
+}


### PR DESCRIPTION
## Summary
- replace `ad_defender_asr_policy` response internals that used `object` with explicit typed DTOs (`asr`, `cloud`, `asr_entries_friendly`, `cloud_friendly`)
- replace `officeimo_read` chunk `location`/`tables` object payloads with explicit stable models (`OfficeImoChunkLocation`, `OfficeImoChunkTable`)
- add tests to lock typed contracts and serialization behavior for both areas

## Why
Follow-up hardening after the serialization incident: reduce ambiguous `object` payloads in tool contracts while preserving agent flexibility and existing output shape semantics.

## Testing
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo`
