### PR TITLE
Tools: add response guardrails and serialization stress tests

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolResponseContractGuardrailTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolResponseContractGuardrailTests.cs
@@ -1,0 +1,135 @@
+using System.Reflection;
+using IntelligenceX.Tools.ADPlayground;
+using IntelligenceX.Tools.Common;
+using IntelligenceX.Tools.Email;
+using IntelligenceX.Tools.EventLog;
+using IntelligenceX.Tools.FileSystem;
+using IntelligenceX.Tools.OfficeIMO;
+using IntelligenceX.Tools.PowerShell;
+using IntelligenceX.Tools.ReviewerSetup;
+using IntelligenceX.Tools.System;
+using IntelligenceX.Tools.TestimoX;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class ToolResponseContractGuardrailTests {
+    private static readonly HashSet<string> AllowedRiskyResponseProperties = new(StringComparer.Ordinal) {
+        // Dynamic "receipt step output" contracts currently used by discovery tools.
+        "IntelligenceX.Tools.ADPlayground.AdForestDiscoverTool+DiscoveryStep.Output",
+        "IntelligenceX.Tools.ADPlayground.AdScopeDiscoveryTool+ScopeDiscoveryStep.Output",
+
+        // Existing dynamic payload contracts kept for backward compatibility.
+        "IntelligenceX.Tools.ADPlayground.AdKdcProxyPolicyTool+AdKdcProxyPolicyResult.Values",
+        "IntelligenceX.Tools.EventLog.EventLogEvtxSecuritySummaryTool+SecuritySummaryEnvelope.Report",
+        "IntelligenceX.Tools.EventLog.EventLogNamedEventsQueryTool+NamedEventsQueryRow.Payload",
+        "IntelligenceX.Tools.TestimoX.TestimoXRulesRunTool+TestimoRuleRunRow.ResultRows",
+
+        // Pack guidance remains intentionally open-ended.
+        "IntelligenceX.Tools.Common.ToolPackInfoModel.SetupHints",
+        "IntelligenceX.Tools.Common.ToolPackInfoModel.Safety",
+        "IntelligenceX.Tools.Common.ToolPackInfoModel.Limits"
+    };
+
+    [Fact]
+    public void ResponseContracts_ShouldNotIntroduceNewObjectLikeProperties() {
+        var discovered = DiscoverRiskyResponseProperties();
+        var unexpected = discovered
+            .Where(static signature => !AllowedRiskyResponseProperties.Contains(signature))
+            .OrderBy(static signature => signature, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            unexpected.Length == 0,
+            "New risky response-model property/properties detected. Add typed DTOs or explicitly allowlist intentional dynamic fields:\n" +
+            string.Join(Environment.NewLine, unexpected));
+    }
+
+    private static IReadOnlyList<string> DiscoverRiskyResponseProperties() {
+        var assemblies = new[] {
+            typeof(AdPackInfoTool).Assembly,
+            typeof(EventLogPackInfoTool).Assembly,
+            typeof(OfficeImoPackInfoTool).Assembly,
+            typeof(SystemPackInfoTool).Assembly,
+            typeof(FileSystemPackInfoTool).Assembly,
+            typeof(EmailPackInfoTool).Assembly,
+            typeof(PowerShellPackInfoTool).Assembly,
+            typeof(TestimoXPackInfoTool).Assembly,
+            typeof(ReviewerSetupPackInfoTool).Assembly,
+            typeof(ToolResponse).Assembly
+        };
+
+        var signatures = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var assembly in assemblies.Distinct()) {
+            foreach (var type in GetLoadableTypes(assembly)) {
+                if (!LooksLikeResponseContractType(type)) {
+                    continue;
+                }
+
+                foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
+                    if (property.GetIndexParameters().Length != 0) {
+                        continue;
+                    }
+
+                    if (!ContainsObjectLikeType(property.PropertyType)) {
+                        continue;
+                    }
+
+                    signatures.Add($"{type.FullName}.{property.Name}");
+                }
+            }
+        }
+
+        return signatures.OrderBy(static signature => signature, StringComparer.Ordinal).ToArray();
+    }
+
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly) {
+        try {
+            return assembly.GetTypes();
+        } catch (ReflectionTypeLoadException ex) {
+            return ex.Types.Where(static type => type is not null)!;
+        }
+    }
+
+    private static bool LooksLikeResponseContractType(Type type) {
+        if (string.IsNullOrWhiteSpace(type.FullName) || string.IsNullOrWhiteSpace(type.Namespace)) {
+            return false;
+        }
+        if (!type.Namespace.StartsWith("IntelligenceX.Tools", StringComparison.Ordinal)) {
+            return false;
+        }
+        if (type.IsGenericTypeDefinition || type.ContainsGenericParameters) {
+            return false;
+        }
+        if (typeof(Delegate).IsAssignableFrom(type)) {
+            return false;
+        }
+
+        var name = type.Name;
+        return name.Contains("Result", StringComparison.Ordinal) ||
+               name.Contains("Response", StringComparison.Ordinal) ||
+               name.Contains("Row", StringComparison.Ordinal) ||
+               name.Contains("Envelope", StringComparison.Ordinal) ||
+               name.Contains("Chunk", StringComparison.Ordinal) ||
+               name.Contains("Step", StringComparison.Ordinal) ||
+               name.Contains("Model", StringComparison.Ordinal);
+    }
+
+    private static bool ContainsObjectLikeType(Type type) {
+        if (type == typeof(object)) {
+            return true;
+        }
+        if (type.IsArray) {
+            return ContainsObjectLikeType(type.GetElementType()!);
+        }
+        if (type.IsGenericType) {
+            foreach (var genericArgument in type.GetGenericArguments()) {
+                if (ContainsObjectLikeType(genericArgument)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSerializationStressTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSerializationStressTests.cs
@@ -1,0 +1,171 @@
+using System.DirectoryServices.ActiveDirectory;
+using System.Text.Json;
+using ADPlayground.Replication;
+using IntelligenceX.Tools.ADPlayground;
+using IntelligenceX.Tools.Common;
+using IntelligenceX.Tools.OfficeIMO;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class ToolSerializationStressTests {
+    [Fact]
+    public void AdScopeDiscoveryStylePayload_WithLargeReceiptAndCycle_ShouldSerialize() {
+        var cyclicOutput = new Dictionary<string, object?>(StringComparer.Ordinal) {
+            ["count"] = 2,
+            ["sample"] = new[] { "dc01.contoso.com", "dc02.contoso.com" }
+        };
+        cyclicOutput["self"] = cyclicOutput;
+
+        var steps = Enumerable.Range(0, 180)
+            .Select(index => new {
+                name = $"domain_controllers:dns_srv:{index}",
+                ok = index % 7 != 0,
+                duration_ms = 5 + index,
+                timeout_ms = 2_000,
+                endpoints_checked = new[] { $"dc{index:000}.contoso.com" },
+                retries = 0,
+                output = index == 0
+                    ? (object?)cyclicOutput
+                    : new Dictionary<string, object?>(StringComparer.Ordinal) {
+                        ["count"] = index,
+                        ["sample"] = new[] { $"dc{index:000}.contoso.com" },
+                        ["flags"] = new[] { true, false }
+                    }
+            })
+            .ToArray();
+
+        var json = ToolResponse.OkModel(new {
+            receipt = new {
+                steps,
+                summary = new { domains = 3, domain_controllers = 180, failed_steps = 26, total_steps = steps.Length }
+            }
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(180, root.GetProperty("receipt").GetProperty("steps").GetArrayLength());
+        Assert.Equal("[cycle]", root.GetProperty("receipt").GetProperty("steps")[0].GetProperty("output").GetProperty("self").GetString());
+    }
+
+    [Fact]
+    public void AdForestDiscoverStylePayload_WithDeepNestingAndLargeCollections_ShouldSerialize() {
+        var deep = CreateDeepNode(14);
+        var domains = Enumerable.Range(0, 220).Select(static index => $"child{index:000}.contoso.com").ToArray();
+        var dcs = Enumerable.Range(0, 300).Select(static index => $"dc{index:000}.contoso.com").ToArray();
+
+        var json = ToolResponse.OkModel(new {
+            domains,
+            domain_controllers = dcs,
+            receipt = new {
+                deep,
+                summary = new { domains = domains.Length, domain_controllers = dcs.Length, trusts = 4 }
+            }
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(220, root.GetProperty("domains").GetArrayLength());
+        Assert.Equal(300, root.GetProperty("domain_controllers").GetArrayLength());
+    }
+
+    [Fact]
+    public void AdReplicationConnectionsPayload_WithManyMappedRows_ShouldSerialize() {
+        var rows = new List<object>(320);
+        for (var i = 0; i < 320; i++) {
+            var schedule = new ActiveDirectorySchedule();
+            var raw = new bool[7, 24, 4];
+            raw[i % 7, i % 24, i % 4] = true;
+            schedule.RawSchedule = raw;
+
+            var connection = new SiteConnectionInfo(
+                Name: $"CN=Conn-{i:000}",
+                Site: "Default-First-Site-Name",
+                SourceServer: $"DC{i:000}",
+                DestinationServer: $"DC{i + 1:000}",
+                Transport: ActiveDirectoryTransportType.Rpc,
+                Enabled: true,
+                GeneratedByKcc: true,
+                ReciprocalReplicationEnabled: i % 2 == 0,
+                ChangeNotificationStatus: NotificationStatus.IntraSiteOnly,
+                DataCompressionEnabled: true,
+                ReplicationScheduleOwnedByUser: false,
+                ReplicationSpan: ReplicationSpan.InterSite,
+                ReplicationSchedule: schedule);
+
+            rows.Add(AdReplicationConnectionsTool.MapConnectionForResponse(connection));
+        }
+
+        var json = ToolResponse.OkModel(new {
+            scanned = rows.Count,
+            truncated = false,
+            connections = rows
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(320, root.GetProperty("connections").GetArrayLength());
+    }
+
+    [Fact]
+    public void OfficeImoReadPayload_WithHighVolumeChunks_ShouldSerialize() {
+        var chunks = Enumerable.Range(0, 420).Select(index => new OfficeImoChunk {
+            Id = $"chunk-{index:0000}",
+            Kind = "markdown",
+            Text = $"Paragraph {index}",
+            Location = new OfficeImoChunkLocation {
+                Path = $@"C:\\docs\\{index:0000}.md",
+                BlockIndex = index,
+                StartLine = index + 1
+            },
+            Tables = new[] {
+                new OfficeImoChunkTable {
+                    Title = "Sample",
+                    Columns = new[] { "name", "value" },
+                    Rows = new[] { new[] { "alpha", index.ToString() } },
+                    TotalRowCount = 1,
+                    Truncated = false
+                }
+            },
+            TokenEstimate = 16
+        }).ToArray();
+
+        var json = ToolResponse.OkModel(new {
+            output_mode = "chunks",
+            chunks_returned = chunks.Length,
+            chunks
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var chunkArray = root.GetProperty("chunks");
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(420, chunkArray.GetArrayLength());
+        Assert.Equal("Sample", chunkArray[0].GetProperty("tables")[0].GetProperty("title").GetString());
+    }
+
+    private static StressNode CreateDeepNode(int depth) {
+        var root = new StressNode { Name = "root" };
+        var current = root;
+        for (var i = 0; i < depth; i++) {
+            var next = new StressNode { Name = $"level-{i:00}" };
+            current.Child = next;
+            current = next;
+        }
+
+        return root;
+    }
+
+    private sealed class StressNode {
+        public string Name { get; set; } = string.Empty;
+
+        public StressNode? Child { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reflection-based guardrail test that snapshots currently-allowed dynamic response fields and fails CI when new `object`/`IEnumerable<object>` response properties are introduced without explicit allowlisting
- add serialization stress tests for chat-critical payload shapes (`ad_scope_discovery`, `ad_forest_discover`, `ad_replication_connections`, `officeimo_read`)
- include cycle, deep nesting, mixed dictionary payloads, and high-volume rows/chunks to exercise tool envelope safety under long flows

## Testing
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo`
