### PR TITLE
Tools: harden dictionary response contract guardrails

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolResponseContractGuardrailTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolResponseContractGuardrailTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace IntelligenceX.Tools.Tests;
 
 public sealed class ToolResponseContractGuardrailTests {
-    private static readonly HashSet<string> AllowedRiskyResponseProperties = new(StringComparer.Ordinal) {
+    private static readonly HashSet<string> AllowedDynamicObjectResponseProperties = new(StringComparer.Ordinal) {
         // Dynamic "receipt step output" contracts currently used by discovery tools.
         "IntelligenceX.Tools.ADPlayground.AdForestDiscoverTool+DiscoveryStep.Output",
         "IntelligenceX.Tools.ADPlayground.AdScopeDiscoveryTool+ScopeDiscoveryStep.Output",
@@ -23,19 +23,24 @@ public sealed class ToolResponseContractGuardrailTests {
         "IntelligenceX.Tools.ADPlayground.AdKdcProxyPolicyTool+AdKdcProxyPolicyResult.Values",
         "IntelligenceX.Tools.EventLog.EventLogEvtxSecuritySummaryTool+SecuritySummaryEnvelope.Report",
         "IntelligenceX.Tools.EventLog.EventLogNamedEventsQueryTool+NamedEventsQueryRow.Payload",
-        "IntelligenceX.Tools.TestimoX.TestimoXRulesRunTool+TestimoRuleRunRow.ResultRows",
+        "IntelligenceX.Tools.TestimoX.TestimoXRulesRunTool+TestimoRuleRunRow.ResultRows"
+    };
 
-        // Pack guidance remains intentionally open-ended.
-        "IntelligenceX.Tools.Common.ToolPackInfoModel.SetupHints",
-        "IntelligenceX.Tools.Common.ToolPackInfoModel.Safety",
-        "IntelligenceX.Tools.Common.ToolPackInfoModel.Limits"
+    private static readonly HashSet<string> AllowedDynamicObjectResponseTypes = new(StringComparer.Ordinal) {
+        // Pack guidance intentionally keeps these optional hints open-ended.
+        "IntelligenceX.Tools.Common.ToolPackInfoModel"
+    };
+
+    private static readonly HashSet<string> AllowedUnsafeDictionaryResponseProperties = new(StringComparer.Ordinal) {
+        // Existing dynamic payload contracts kept for backward compatibility.
+        "IntelligenceX.Tools.EventLog.EventLogNamedEventsQueryTool+NamedEventsQueryRow.Payload"
     };
 
     [Fact]
     public void ResponseContracts_ShouldNotIntroduceNewObjectLikeProperties() {
-        var discovered = DiscoverRiskyResponseProperties();
+        var discovered = DiscoverObjectLikeResponseProperties();
         var unexpected = discovered
-            .Where(static signature => !AllowedRiskyResponseProperties.Contains(signature))
+            .Where(static signature => !AllowedDynamicObjectResponseProperties.Contains(signature))
             .OrderBy(static signature => signature, StringComparer.Ordinal)
             .ToArray();
 
@@ -45,7 +50,21 @@ public sealed class ToolResponseContractGuardrailTests {
             string.Join(Environment.NewLine, unexpected));
     }
 
-    private static IReadOnlyList<string> DiscoverRiskyResponseProperties() {
+    [Fact]
+    public void ResponseContracts_ShouldNotIntroduceUnsafeDictionaryKeyValueProperties() {
+        var discovered = DiscoverUnsafeDictionaryResponseProperties();
+        var unexpected = discovered
+            .Where(static signature => !AllowedUnsafeDictionaryResponseProperties.Contains(signature))
+            .OrderBy(static signature => signature, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            unexpected.Length == 0,
+            "New unsafe dictionary response contract(s) detected. Prefer string/enum keys and typed values, or explicitly allowlist intentional dynamic fields:\n" +
+            string.Join(Environment.NewLine, unexpected));
+    }
+
+    private static IReadOnlyList<string> DiscoverObjectLikeResponseProperties() {
         var assemblies = new[] {
             typeof(AdPackInfoTool).Assembly,
             typeof(EventLogPackInfoTool).Assembly,
@@ -65,13 +84,57 @@ public sealed class ToolResponseContractGuardrailTests {
                 if (!LooksLikeResponseContractType(type)) {
                     continue;
                 }
+                if (AllowedDynamicObjectResponseTypes.Contains(type.FullName!)) {
+                    continue;
+                }
 
                 foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
                     if (property.GetIndexParameters().Length != 0) {
                         continue;
                     }
 
-                    if (!ContainsObjectLikeType(property.PropertyType)) {
+                    if (!ContainsObjectLikeTypeOutsideDictionary(property.PropertyType)) {
+                        continue;
+                    }
+
+                    signatures.Add($"{type.FullName}.{property.Name}");
+                }
+            }
+        }
+
+        return signatures.OrderBy(static signature => signature, StringComparer.Ordinal).ToArray();
+    }
+
+    private static IReadOnlyList<string> DiscoverUnsafeDictionaryResponseProperties() {
+        var assemblies = new[] {
+            typeof(AdPackInfoTool).Assembly,
+            typeof(EventLogPackInfoTool).Assembly,
+            typeof(OfficeImoPackInfoTool).Assembly,
+            typeof(SystemPackInfoTool).Assembly,
+            typeof(FileSystemPackInfoTool).Assembly,
+            typeof(EmailPackInfoTool).Assembly,
+            typeof(PowerShellPackInfoTool).Assembly,
+            typeof(TestimoXPackInfoTool).Assembly,
+            typeof(ReviewerSetupPackInfoTool).Assembly,
+            typeof(ToolResponse).Assembly
+        };
+
+        var signatures = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var assembly in assemblies.Distinct()) {
+            foreach (var type in GetLoadableTypes(assembly)) {
+                if (!LooksLikeResponseContractType(type)) {
+                    continue;
+                }
+                if (AllowedDynamicObjectResponseTypes.Contains(type.FullName!)) {
+                    continue;
+                }
+
+                foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
+                    if (property.GetIndexParameters().Length != 0) {
+                        continue;
+                    }
+
+                    if (!ContainsUnsafeDictionaryType(property.PropertyType)) {
                         continue;
                     }
 
@@ -131,5 +194,117 @@ public sealed class ToolResponseContractGuardrailTests {
         }
 
         return false;
+    }
+
+    private static bool ContainsObjectLikeTypeOutsideDictionary(Type type) {
+        if (TryGetDictionaryTypeArguments(type, out _, out _)) {
+            return false;
+        }
+
+        if (type.IsArray) {
+            return ContainsObjectLikeTypeOutsideDictionary(type.GetElementType()!);
+        }
+
+        if (type.IsGenericType) {
+            foreach (var genericArgument in type.GetGenericArguments()) {
+                if (ContainsObjectLikeTypeOutsideDictionary(genericArgument)) {
+                    return true;
+                }
+            }
+        }
+
+        return type == typeof(object);
+    }
+
+    private static bool ContainsUnsafeDictionaryType(Type type) {
+        var visited = new HashSet<Type>();
+        return ContainsUnsafeDictionaryTypeCore(type, visited);
+    }
+
+    private static bool ContainsUnsafeDictionaryTypeCore(Type type, ISet<Type> visited) {
+        if (!visited.Add(type)) {
+            return false;
+        }
+
+        if (TryGetDictionaryTypeArguments(type, out var keyType, out var valueType)) {
+            if (!IsSupportedDictionaryKeyType(keyType)) {
+                return true;
+            }
+
+            if (ContainsObjectLikeType(valueType)) {
+                return true;
+            }
+
+            return ContainsUnsafeDictionaryTypeCore(valueType, visited);
+        }
+
+        if (type.IsArray) {
+            return ContainsUnsafeDictionaryTypeCore(type.GetElementType()!, visited);
+        }
+
+        if (type.IsGenericType) {
+            foreach (var genericArgument in type.GetGenericArguments()) {
+                if (ContainsUnsafeDictionaryTypeCore(genericArgument, visited)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetDictionaryTypeArguments(Type type, out Type keyType, out Type valueType) {
+        if (type.IsGenericType) {
+            var genericTypeDefinition = type.GetGenericTypeDefinition();
+            if (genericTypeDefinition == typeof(IDictionary<,>) ||
+                genericTypeDefinition == typeof(IReadOnlyDictionary<,>) ||
+                genericTypeDefinition == typeof(Dictionary<,>)) {
+                var args = type.GetGenericArguments();
+                keyType = args[0];
+                valueType = args[1];
+                return true;
+            }
+        }
+
+        var dictionaryInterface = type.GetInterfaces()
+            .FirstOrDefault(static iface =>
+                iface.IsGenericType &&
+                (iface.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
+                 iface.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)));
+        if (dictionaryInterface is not null) {
+            var args = dictionaryInterface.GetGenericArguments();
+            keyType = args[0];
+            valueType = args[1];
+            return true;
+        }
+
+        keyType = typeof(void);
+        valueType = typeof(void);
+        return false;
+    }
+
+    private static bool IsSupportedDictionaryKeyType(Type keyType) {
+        var normalized = Nullable.GetUnderlyingType(keyType) ?? keyType;
+        if (normalized == typeof(string) ||
+            normalized == typeof(bool) ||
+            normalized == typeof(byte) ||
+            normalized == typeof(sbyte) ||
+            normalized == typeof(short) ||
+            normalized == typeof(ushort) ||
+            normalized == typeof(int) ||
+            normalized == typeof(uint) ||
+            normalized == typeof(long) ||
+            normalized == typeof(ulong) ||
+            normalized == typeof(float) ||
+            normalized == typeof(double) ||
+            normalized == typeof(decimal) ||
+            normalized == typeof(Guid) ||
+            normalized == typeof(DateTime) ||
+            normalized == typeof(DateTimeOffset) ||
+            normalized == typeof(TimeSpan)) {
+            return true;
+        }
+
+        return normalized.IsEnum;
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSerializationStressTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSerializationStressTests.cs
@@ -151,6 +151,36 @@ public sealed class ToolSerializationStressTests {
         Assert.Equal("Sample", chunkArray[0].GetProperty("tables")[0].GetProperty("title").GetString());
     }
 
+    [Fact]
+    public void DictionaryPayload_WithCustomKeysAndNestedCycles_ShouldSerializeSafely() {
+        var cyclicBag = new Dictionary<string, object?>(StringComparer.Ordinal) {
+            ["status"] = "ok",
+            ["attempt"] = 1
+        };
+        cyclicBag["self"] = cyclicBag;
+
+        var payload = new Dictionary<object, object?> {
+            [new DictionaryKey("alpha", 1)] = cyclicBag,
+            [new DictionaryKey("beta", 2)] = new Dictionary<string, object?> {
+                ["count"] = 2,
+                ["values"] = new[] { "x", "y" }
+            }
+        };
+
+        var json = ToolResponse.OkModel(new {
+            dictionary_payload = payload
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var dictionary = root.GetProperty("dictionary_payload");
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(JsonValueKind.Object, dictionary.ValueKind);
+        Assert.Equal("[cycle]", dictionary.GetProperty("alpha-1").GetProperty("self").GetString());
+        Assert.Equal(2, dictionary.GetProperty("beta-2").GetProperty("count").GetInt32());
+    }
+
     private static StressNode CreateDeepNode(int depth) {
         var root = new StressNode { Name = "root" };
         var current = root;
@@ -167,5 +197,19 @@ public sealed class ToolSerializationStressTests {
         public string Name { get; set; } = string.Empty;
 
         public StressNode? Child { get; set; }
+    }
+
+    private sealed class DictionaryKey {
+        private readonly string _name;
+        private readonly int _index;
+
+        public DictionaryKey(string name, int index) {
+            _name = name;
+            _index = index;
+        }
+
+        public override string ToString() {
+            return $"{_name}-{_index}";
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a dictionary-focused response-contract guardrail pass for tool response models
- enforce safer dictionary key/value type contracts (string/enum-like keys, no object-like values unless explicitly allowed)
- reduce object-risk allowlist footprint by moving pack guidance flexibility to a single type-level exemption
- add serialization stress coverage for dictionary payloads with custom keys and nested cycles

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~ToolResponseContractGuardrailTests|FullyQualifiedName~ToolSerializationStressTests"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo
