### PR TITLE
Tools: harden chaining contract safety and runtime coverage

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolChainingHints.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolChainingHints.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 
@@ -9,6 +10,14 @@ namespace IntelligenceX.Tools.Common;
 /// Shared contract helpers for model-driven continuation/chaining hints in tool responses.
 /// </summary>
 public static class ToolChainingHints {
+    private static readonly IReadOnlyDictionary<string, string> EmptyStringMap =
+        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.Ordinal));
+
+    /// <summary>
+    /// Shared immutable empty string map.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> EmptyMap => EmptyStringMap;
+
     /// <summary>
     /// Creates a normalized continuation contract payload.
     /// </summary>
@@ -54,6 +63,10 @@ public static class ToolChainingHints {
     /// Builds a simple dictionary payload from key/value entries.
     /// </summary>
     public static IReadOnlyDictionary<string, string> Map(params (string Key, object? Value)[] entries) {
+        if (entries is null || entries.Length == 0) {
+            return EmptyStringMap;
+        }
+
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
         for (var i = 0; i < entries.Length; i++) {
             var key = entries[i].Key;
@@ -64,7 +77,9 @@ public static class ToolChainingHints {
             map[key.Trim()] = Convert.ToString(entries[i].Value, CultureInfo.InvariantCulture) ?? string.Empty;
         }
 
-        return map;
+        return map.Count == 0
+            ? EmptyStringMap
+            : new ReadOnlyDictionary<string, string>(map);
     }
 
     /// <summary>
@@ -127,7 +142,7 @@ public static class ToolChainingHints {
 
     private static IReadOnlyDictionary<string, string> NormalizeMap(IReadOnlyDictionary<string, string>? source) {
         if (source is null || source.Count == 0) {
-            return new Dictionary<string, string>(StringComparer.Ordinal);
+            return EmptyStringMap;
         }
 
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -137,7 +152,9 @@ public static class ToolChainingHints {
             }
         }
 
-        return map;
+        return map.Count == 0
+            ? EmptyStringMap
+            : new ReadOnlyDictionary<string, string>(map);
     }
 }
 
@@ -163,7 +180,7 @@ public sealed class ToolChainContractModel {
     /// <summary>
     /// Structured handoff payload for cross-tool chaining.
     /// </summary>
-    public IReadOnlyDictionary<string, string> Handoff { get; init; } = new Dictionary<string, string>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, string> Handoff { get; init; } = ToolChainingHints.EmptyMap;
 
     /// <summary>
     /// Best-effort confidence score (0..1) for the emitted result context.
@@ -188,7 +205,7 @@ public sealed class ToolNextActionModel {
     /// <summary>
     /// Suggested argument skeleton for follow-up.
     /// </summary>
-    public IReadOnlyDictionary<string, string> SuggestedArguments { get; init; } = new Dictionary<string, string>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, string> SuggestedArguments { get; init; } = ToolChainingHints.EmptyMap;
 
     /// <summary>
     /// Indicates this action is optional/advisory and should not block autonomous planning.

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
@@ -92,7 +92,7 @@ public sealed class OfficeImoReadResult {
     /// <summary>
     /// Structured handoff payload for downstream tools.
     /// </summary>
-    public IReadOnlyDictionary<string, string> Handoff { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, string> Handoff { get; set; } = ToolChainingHints.EmptyMap;
 
     /// <summary>
     /// Best-effort confidence score (0..1) for this extraction context.

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdForestDiscoverToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdForestDiscoverToolTests.cs
@@ -28,6 +28,7 @@ public sealed class AdForestDiscoverToolTests {
         Assert.True(root.TryGetProperty("handoff", out var handoff));
         Assert.True(root.TryGetProperty("confidence", out var confidence));
         Assert.True(nextActions.ValueKind == global::System.Text.Json.JsonValueKind.Array);
+        Assert.Equal("ad_scope_discovery", nextActions[0].GetProperty("tool").GetString());
         Assert.Equal("ad_forest_discover_handoff", handoff.GetProperty("contract").GetString());
         Assert.False(string.IsNullOrWhiteSpace(cursor.GetString()));
         Assert.False(string.IsNullOrWhiteSpace(resumeToken.GetString()));

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdScopeDiscoveryToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdScopeDiscoveryToolTests.cs
@@ -74,6 +74,7 @@ public class AdScopeDiscoveryToolTests {
         Assert.True(root.TryGetProperty("handoff", out var handoff));
         Assert.True(root.TryGetProperty("confidence", out var confidence));
         Assert.True(nextActions.ValueKind == global::System.Text.Json.JsonValueKind.Array);
+        Assert.Equal("ad_forest_discover", nextActions[0].GetProperty("tool").GetString());
         Assert.Equal("ad_scope_discovery_handoff", handoff.GetProperty("contract").GetString());
         Assert.False(string.IsNullOrWhiteSpace(cursor.GetString()));
         Assert.False(string.IsNullOrWhiteSpace(resumeToken.GetString()));

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogNamedEventsQueryToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogNamedEventsQueryToolTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+using IntelligenceX.Tools.EventLog;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class EventLogNamedEventsQueryToolTests {
+    [Fact]
+    public async Task InvokeAsync_WhenQuerySucceeds_EmitsChainingContractFields() {
+        var tool = new EventLogNamedEventsQueryTool(new EventLogToolOptions());
+        var namedEvent = SelectNamedEventQueryName();
+        var start = DateTime.UtcNow.AddDays(1);
+        var end = start.AddHours(1);
+
+        var json = await tool.InvokeAsync(
+            arguments: new JsonObject()
+                .Add("named_events", new JsonArray().Add(namedEvent))
+                .Add("start_time_utc", start.ToString("O"))
+                .Add("end_time_utc", end.ToString("O"))
+                .Add("max_events", 1)
+                .Add("max_threads", 1)
+                .Add("include_payload", false),
+            cancellationToken: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("ok").GetBoolean());
+
+        Assert.True(root.TryGetProperty("next_actions", out var nextActions));
+        Assert.True(root.TryGetProperty("cursor", out var cursor));
+        Assert.True(root.TryGetProperty("resume_token", out var resumeToken));
+        Assert.True(root.TryGetProperty("handoff", out var handoff));
+        Assert.True(root.TryGetProperty("confidence", out var confidence));
+
+        Assert.Equal(global::System.Text.Json.JsonValueKind.Array, nextActions.ValueKind);
+        Assert.True(nextActions.GetArrayLength() >= 2);
+        Assert.Equal("ad_handoff_prepare", nextActions[0].GetProperty("tool").GetString());
+        Assert.Equal("eventlog_entity_handoff", handoff.GetProperty("contract").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(cursor.GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(resumeToken.GetString()));
+        Assert.InRange(confidence.GetDouble(), 0d, 1d);
+    }
+
+    private static string SelectNamedEventQueryName() {
+        var preferred = EventLogNamedEventsHelper.GetCatalogRows()
+            .Where(static row => row.Available)
+            .FirstOrDefault(row =>
+                row.LogNames.Any(static logName =>
+                    string.Equals(logName, "Application", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(logName, "System", StringComparison.OrdinalIgnoreCase)));
+
+        if (preferred is not null) {
+            return preferred.QueryName;
+        }
+
+        return EventLogNamedEventsHelper.GetCatalogRows()
+            .First(static row => row.Available)
+            .QueryName;
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -84,6 +84,7 @@ public class OfficeImoReadToolTests {
             Assert.True(root.TryGetProperty("handoff", out var handoff));
             Assert.True(root.TryGetProperty("confidence", out var confidence));
             Assert.True(nextActions.ValueKind == global::System.Text.Json.JsonValueKind.Array);
+            Assert.Equal("officeimo_read", nextActions[0].GetProperty("tool").GetString());
             Assert.Equal("officeimo_read_handoff", handoff.GetProperty("contract").GetString());
             Assert.False(string.IsNullOrWhiteSpace(cursor.GetString()));
             Assert.False(string.IsNullOrWhiteSpace(resumeToken.GetString()));

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/SourceGuardrailTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/SourceGuardrailTests.cs
@@ -248,20 +248,6 @@ public class SourceGuardrailTests {
         }
     }
 
-    [Fact]
-    public void EventLogNamedEventsQueryTool_ShouldPopulateAllNamedEventsQueryResultChainFields() {
-        var repoRoot = FindRepoRoot();
-        var filePath = Path.Combine(repoRoot, "IntelligenceX.Tools.EventLog", "EventLogNamedEventsQueryTool.cs");
-        var source = File.ReadAllText(filePath);
-
-        Assert.Contains("new NamedEventsQueryResult(", source, StringComparison.Ordinal);
-        Assert.Contains("NextActions: chain.NextActions", source, StringComparison.Ordinal);
-        Assert.Contains("Cursor: chain.Cursor", source, StringComparison.Ordinal);
-        Assert.Contains("ResumeToken: chain.ResumeToken", source, StringComparison.Ordinal);
-        Assert.Contains("Handoff: chain.Handoff", source, StringComparison.Ordinal);
-        Assert.Contains("Confidence: chain.Confidence", source, StringComparison.Ordinal);
-    }
-
     private static string FindRepoRoot() {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir is not null) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolChainingHintsTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolChainingHintsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using IntelligenceX.Tools.Common;
 using Xunit;
 
@@ -39,5 +40,25 @@ public sealed class ToolChainingHintsTests {
         Assert.StartsWith("eventlog:", token, StringComparison.Ordinal);
         Assert.Contains("name=Kerberos%20auth", token, StringComparison.Ordinal);
         Assert.Contains("machine=dc01.contoso.com", token, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Map_ShouldReturnReadOnlyDictionary() {
+        var map = ToolChainingHints.Map(("contract", "test"));
+
+        var dictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(map);
+        Assert.Throws<NotSupportedException>(() => dictionary.Add("x", "1"));
+    }
+
+    [Fact]
+    public void Create_WhenInputsEmpty_ShouldReturnReadOnlyEmptyMap() {
+        var chain = ToolChainingHints.Create();
+
+        Assert.Empty(chain.NextActions);
+        Assert.Equal(string.Empty, chain.Cursor);
+        Assert.Equal(string.Empty, chain.ResumeToken);
+
+        var dictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(chain.Handoff);
+        Assert.Throws<NotSupportedException>(() => dictionary.Add("x", "1"));
     }
 }


### PR DESCRIPTION
## Summary
- harden ToolChainingHints map outputs to read-only dictionaries (including shared immutable empty map)
- make OfficeImoReadResult.Handoff default to immutable empty contract map
- replace brittle source-text guardrail with runtime eventlog_named_events_query contract test
- strengthen AD/Office contract tests with next_actions[0].tool assertions
- add negative/default map safety assertions in ToolChainingHintsTests

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~ToolChainingHintsTests|FullyQualifiedName~EventLogNamedEventsQueryToolTests|FullyQualifiedName~AdScopeDiscoveryToolTests|FullyQualifiedName~AdForestDiscoverToolTests|FullyQualifiedName~OfficeImoReadToolTests"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo
