### PR TITLE
Tools: improve skip observability and handoff normalization coverage

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
@@ -105,6 +105,7 @@ public sealed class OfficeImoReadResult {
     /// </summary>
     public double Confidence { get; set; } = 0.5d;
 
+    // Keys are trimmed; collisions after normalization are resolved as last-write-wins.
     private static IReadOnlyDictionary<string, string> NormalizeHandoff(IReadOnlyDictionary<string, string>? value) {
         if (value is null || value.Count == 0) {
             return ToolChainingHints.EmptyMap;

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogNamedEventsQueryToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogNamedEventsQueryToolTests.cs
@@ -6,21 +6,15 @@ using System.Threading.Tasks;
 using IntelligenceX.Json;
 using IntelligenceX.Tools.EventLog;
 using Xunit;
+using Xunit.Sdk;
 
 namespace IntelligenceX.Tools.Tests;
 
 public sealed class EventLogNamedEventsQueryToolTests {
     [Fact]
     public async Task InvokeAsync_WhenQuerySucceeds_EmitsChainingContractFields() {
-        if (!OperatingSystem.IsWindows()) {
-            return;
-        }
-
-        if (!TrySelectNamedEventQueryName(out var namedEvent)) {
-            return;
-        }
-
         var tool = new EventLogNamedEventsQueryTool(new EventLogToolOptions());
+        var namedEvent = ResolveNamedEventOrSkip();
         var start = DateTime.UtcNow.AddDays(1);
         var end = start.AddHours(1);
 
@@ -51,6 +45,18 @@ public sealed class EventLogNamedEventsQueryToolTests {
         Assert.False(string.IsNullOrWhiteSpace(cursor.GetString()));
         Assert.False(string.IsNullOrWhiteSpace(resumeToken.GetString()));
         Assert.InRange(confidence.GetDouble(), 0d, 1d);
+    }
+
+    private static string ResolveNamedEventOrSkip() {
+        if (!OperatingSystem.IsWindows()) {
+            throw SkipException.ForSkip("EventLogNamedEventsQueryToolTests require Windows event log support.");
+        }
+
+        if (!TrySelectNamedEventQueryName(out var queryName)) {
+            throw SkipException.ForSkip("No available named event catalog entries were found on this environment.");
+        }
+
+        return queryName;
     }
 
     private static bool TrySelectNamedEventQueryName(out string queryName) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -6,12 +6,28 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Json;
+using IntelligenceX.Tools.Common;
 using IntelligenceX.Tools.OfficeIMO;
 using Xunit;
 
 namespace IntelligenceX.Tools.Tests;
 
 public class OfficeImoReadToolTests {
+    [Fact]
+    public void OfficeImoReadResult_WhenHandoffAssignedNullOrEmpty_UsesSharedEmptyMap() {
+        var result = new OfficeImoReadResult {
+            Handoff = null!
+        };
+
+        Assert.Same(ToolChainingHints.EmptyMap, result.Handoff);
+
+        result.Handoff = new Dictionary<string, string>(StringComparer.Ordinal);
+        Assert.Same(ToolChainingHints.EmptyMap, result.Handoff);
+
+        var dictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(result.Handoff);
+        Assert.Throws<NotSupportedException>(() => dictionary.Add("x", "1"));
+    }
+
     [Fact]
     public void OfficeImoReadResult_WhenHandoffAssignedMutableMap_IsNormalizedAndReadOnly() {
         var source = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {


### PR DESCRIPTION
## Summary
- switch runtime guard behavior in `EventLogNamedEventsQueryToolTests` from silent early-return to explicit xUnit skip signaling (`SkipException.ForSkip(...)`)
- add missing null/empty handoff normalization test coverage for `OfficeImoReadResult`
- document trim/collision semantics in `OfficeImoReadResult.NormalizeHandoff`

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~EventLogNamedEventsQueryToolTests|FullyQualifiedName~OfficeImoReadToolTests"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo
