### PR TITLE
Tools: centralize test runtime guards and collision coverage

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
@@ -94,6 +94,7 @@ public sealed class OfficeImoReadResult {
 
     /// <summary>
     /// Structured handoff payload for downstream tools.
+    /// Keys are normalized by trimming surrounding whitespace; normalized-key collisions use last-write-wins semantics.
     /// </summary>
     public IReadOnlyDictionary<string, string> Handoff {
         get => _handoff;

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogNamedEventsQueryToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogNamedEventsQueryToolTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using IntelligenceX.Json;
 using IntelligenceX.Tools.EventLog;
 using Xunit;
-using Xunit.Sdk;
 
 namespace IntelligenceX.Tools.Tests;
 
@@ -48,13 +47,10 @@ public sealed class EventLogNamedEventsQueryToolTests {
     }
 
     private static string ResolveNamedEventOrSkip() {
-        if (!OperatingSystem.IsWindows()) {
-            throw SkipException.ForSkip("EventLogNamedEventsQueryToolTests require Windows event log support.");
-        }
+        TestRuntimeGuards.RequireWindows("EventLogNamedEventsQueryToolTests require Windows event log support.");
 
-        if (!TrySelectNamedEventQueryName(out var queryName)) {
-            throw SkipException.ForSkip("No available named event catalog entries were found on this environment.");
-        }
+        var resolved = TrySelectNamedEventQueryName(out var queryName);
+        TestRuntimeGuards.Require(resolved, "No available named event catalog entries were found on this environment.");
 
         return queryName;
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -49,6 +49,21 @@ public class OfficeImoReadToolTests {
     }
 
     [Fact]
+    public void OfficeImoReadResult_WhenTrimmedKeysCollide_LastWriteWins() {
+        var source = new Dictionary<string, string>(StringComparer.Ordinal) {
+            ["contract"] = "first",
+            [" contract "] = "second"
+        };
+
+        var result = new OfficeImoReadResult {
+            Handoff = source
+        };
+
+        Assert.Single(result.Handoff);
+        Assert.Equal("second", result.Handoff["contract"]);
+    }
+
+    [Fact]
     public async Task OfficeImoRead_WhenExtensionsOmitted_DefaultsIncludePdf() {
         var tempRoot = Path.Combine(Path.GetTempPath(), "ix-officeimo-read-" + Guid.NewGuid().ToString("n"));
         Directory.CreateDirectory(tempRoot);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/TestRuntimeGuards.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/TestRuntimeGuards.cs
@@ -1,0 +1,17 @@
+using Xunit.Sdk;
+
+namespace IntelligenceX.Tools.Tests;
+
+internal static class TestRuntimeGuards {
+    internal static void RequireWindows(string reason) {
+        if (!OperatingSystem.IsWindows()) {
+            throw SkipException.ForSkip(reason);
+        }
+    }
+
+    internal static void Require(bool condition, string reason) {
+        if (!condition) {
+            throw SkipException.ForSkip(reason);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `TestRuntimeGuards` helper to centralize runtime skip signaling in tools tests
- migrate `EventLogNamedEventsQueryToolTests` to shared runtime guards (reduces direct coupling to skip internals)
- add explicit trimmed-key collision test for `OfficeImoReadResult.Handoff` (locks last-write-wins behavior)
- promote handoff normalization semantics to `Handoff` XML docs for better API discoverability

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~EventLogNamedEventsQueryToolTests|FullyQualifiedName~OfficeImoReadToolTests"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo
