### PR TITLE
Tools: harden next-actions assignment and test skip signaling

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using IntelligenceX.Tools.Common;
 
 namespace IntelligenceX.Tools.OfficeIMO;
@@ -9,6 +10,7 @@ namespace IntelligenceX.Tools.OfficeIMO;
 /// Result model for <c>officeimo_read</c>.
 /// </summary>
 public sealed class OfficeImoReadResult {
+    private IReadOnlyList<ToolNextActionModel> _nextActions = Array.Empty<ToolNextActionModel>();
     private IReadOnlyDictionary<string, string> _handoff = ToolChainingHints.EmptyMap;
 
     /// <summary>
@@ -80,7 +82,10 @@ public sealed class OfficeImoReadResult {
     /// <summary>
     /// Advisory next actions for model/tool chaining.
     /// </summary>
-    public IReadOnlyList<ToolNextActionModel> NextActions { get; set; } = Array.Empty<ToolNextActionModel>();
+    public IReadOnlyList<ToolNextActionModel> NextActions {
+        get => _nextActions;
+        set => _nextActions = NormalizeNextActions(value);
+    }
 
     /// <summary>
     /// Opaque continuation cursor.
@@ -105,6 +110,21 @@ public sealed class OfficeImoReadResult {
     /// Best-effort confidence score (0..1) for this extraction context.
     /// </summary>
     public double Confidence { get; set; } = 0.5d;
+
+    private static IReadOnlyList<ToolNextActionModel> NormalizeNextActions(IReadOnlyList<ToolNextActionModel>? value) {
+        if (value is null || value.Count == 0) {
+            return Array.Empty<ToolNextActionModel>();
+        }
+
+        var normalized = value
+            .Where(static action => action is not null)
+            .ToList();
+        if (normalized.Count == 0) {
+            return Array.Empty<ToolNextActionModel>();
+        }
+
+        return new ReadOnlyCollection<ToolNextActionModel>(normalized);
+    }
 
     // Keys are trimmed; collisions after normalization are resolved as last-write-wins.
     private static IReadOnlyDictionary<string, string> NormalizeHandoff(IReadOnlyDictionary<string, string>? value) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EngineQueryBehaviorTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EngineQueryBehaviorTests.cs
@@ -152,9 +152,9 @@ public sealed class EngineQueryBehaviorTests {
 
     [Fact]
     public async Task PowerShellExecuteAsync_ReturnsWithoutBlockingCaller() {
-        if (PowerShellCommandQueryExecutor.GetAvailableHosts().Count == 0) {
-            return;
-        }
+        TestRuntimeGuards.Require(
+            condition: PowerShellCommandQueryExecutor.GetAvailableHosts().Count > 0,
+            reason: "PowerShell query host is unavailable on this environment.");
 
         var request = new PowerShellCommandQueryRequest {
             Script = "Start-Sleep -Milliseconds 1500; 'done'",
@@ -172,9 +172,9 @@ public sealed class EngineQueryBehaviorTests {
 
     [Fact]
     public async Task PowerShellTryExecuteAsync_CanceledTokenIsNotReportedAsTimeout() {
-        if (PowerShellCommandQueryExecutor.GetAvailableHosts().Count == 0) {
-            return;
-        }
+        TestRuntimeGuards.Require(
+            condition: PowerShellCommandQueryExecutor.GetAvailableHosts().Count > 0,
+            reason: "PowerShell query host is unavailable on this environment.");
 
         var request = new PowerShellCommandQueryRequest {
             Script = "Start-Sleep -Seconds 10; 'done'",
@@ -193,9 +193,9 @@ public sealed class EngineQueryBehaviorTests {
 
     [Fact]
     public async Task PowerShellTryExecuteAsync_TimeoutIsNotReportedAsCancelled() {
-        if (PowerShellCommandQueryExecutor.GetAvailableHosts().Count == 0) {
-            return;
-        }
+        TestRuntimeGuards.Require(
+            condition: PowerShellCommandQueryExecutor.GetAvailableHosts().Count > 0,
+            reason: "PowerShell query host is unavailable on this environment.");
 
         var request = new PowerShellCommandQueryRequest {
             Script = "Start-Sleep -Seconds 10; 'done'",

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -14,6 +14,36 @@ namespace IntelligenceX.Tools.Tests;
 
 public class OfficeImoReadToolTests {
     [Fact]
+    public void OfficeImoReadResult_WhenNextActionsAssignedNullOrEmpty_UsesEmptyList() {
+        var result = new OfficeImoReadResult {
+            NextActions = null!
+        };
+
+        Assert.Empty(result.NextActions);
+
+        result.NextActions = Array.Empty<ToolNextActionModel>();
+        Assert.Empty(result.NextActions);
+    }
+
+    [Fact]
+    public void OfficeImoReadResult_WhenNextActionsAssignedMutableList_IsCopiedAndReadOnly() {
+        var source = new List<ToolNextActionModel> {
+            new() { Tool = "officeimo_read", Reason = "follow-up", Optional = true }
+        };
+
+        var result = new OfficeImoReadResult {
+            NextActions = source
+        };
+        source.Add(new ToolNextActionModel { Tool = "ad_scope_discovery", Reason = "extra", Optional = true });
+
+        Assert.Single(result.NextActions);
+        Assert.Equal("officeimo_read", result.NextActions[0].Tool);
+
+        var list = Assert.IsAssignableFrom<IList<ToolNextActionModel>>(result.NextActions);
+        Assert.Throws<NotSupportedException>(() => list.Add(new ToolNextActionModel { Tool = "x", Reason = "y" }));
+    }
+
+    [Fact]
     public void OfficeImoReadResult_WhenHandoffAssignedNullOrEmpty_UsesSharedEmptyMap() {
         var result = new OfficeImoReadResult {
             Handoff = null!

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/TestRuntimeGuards.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/TestRuntimeGuards.cs
@@ -2,6 +2,9 @@ using Xunit.Sdk;
 
 namespace IntelligenceX.Tools.Tests;
 
+/// <summary>
+/// Shared test-runtime guards that intentionally use xUnit skip signaling for environment-dependent tests.
+/// </summary>
 internal static class TestRuntimeGuards {
     internal static void RequireWindows(string reason) {
         if (!OperatingSystem.IsWindows()) {


### PR DESCRIPTION
## Summary
- normalize `OfficeImoReadResult.NextActions` assignments by copying to an internal read-only collection (prevents external list mutation leakage)
- add `OfficeImoReadResult` tests for next-actions null/empty behavior and copy/read-only semantics
- convert PowerShell host-dependent `EngineQueryBehaviorTests` from silent return to explicit runtime skip signaling
- document runtime-guard purpose in `TestRuntimeGuards`

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~OfficeImoReadToolTests|FullyQualifiedName~EngineQueryBehaviorTests|FullyQualifiedName~EventLogNamedEventsQueryToolTests"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo
