### PR TITLE
Tools: harden OfficeIMO nested readonly collection contracts

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
@@ -264,6 +264,9 @@ public sealed class OfficeImoChunkLocation {
 /// Normalized table payload for chunk outputs.
 /// </summary>
 public sealed class OfficeImoChunkTable {
+    private IReadOnlyList<string> _columns = Array.Empty<string>();
+    private IReadOnlyList<IReadOnlyList<string>> _rows = Array.Empty<IReadOnlyList<string>>();
+
     /// <summary>
     /// Optional title/label.
     /// </summary>
@@ -272,12 +275,18 @@ public sealed class OfficeImoChunkTable {
     /// <summary>
     /// Column headers.
     /// </summary>
-    public IReadOnlyList<string> Columns { get; set; } = Array.Empty<string>();
+    public IReadOnlyList<string> Columns {
+        get => _columns;
+        set => _columns = NormalizeStringList(value);
+    }
 
     /// <summary>
     /// Rows aligned with <see cref="Columns"/>.
     /// </summary>
-    public IReadOnlyList<IReadOnlyList<string>> Rows { get; set; } = Array.Empty<IReadOnlyList<string>>();
+    public IReadOnlyList<IReadOnlyList<string>> Rows {
+        get => _rows;
+        set => _rows = NormalizeNestedStringList(value);
+    }
 
     /// <summary>
     /// Total row count before truncation.
@@ -288,12 +297,38 @@ public sealed class OfficeImoChunkTable {
     /// True when <see cref="Rows"/> was truncated.
     /// </summary>
     public bool Truncated { get; set; }
+
+    private static IReadOnlyList<string> NormalizeStringList(IReadOnlyList<string>? value) {
+        if (value is null || value.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        return new ReadOnlyCollection<string>(value.ToList());
+    }
+
+    private static IReadOnlyList<IReadOnlyList<string>> NormalizeNestedStringList(IReadOnlyList<IReadOnlyList<string>>? value) {
+        if (value is null || value.Count == 0) {
+            return Array.Empty<IReadOnlyList<string>>();
+        }
+
+        var normalized = value
+            .Where(static row => row is not null)
+            .Select(static row => (IReadOnlyList<string>)new ReadOnlyCollection<string>(row.ToList()))
+            .ToList();
+
+        return normalized.Count == 0
+            ? Array.Empty<IReadOnlyList<string>>()
+            : new ReadOnlyCollection<IReadOnlyList<string>>(normalized);
+    }
 }
 
 /// <summary>
 /// Minimal chunk shape intended for stable tool contracts.
 /// </summary>
 public sealed class OfficeImoChunk {
+    private IReadOnlyList<OfficeImoChunkTable>? _tables;
+    private IReadOnlyList<string>? _warnings;
+
     /// <summary>
     /// Stable chunk identifier.
     /// </summary>
@@ -322,12 +357,18 @@ public sealed class OfficeImoChunk {
     /// <summary>
     /// Optional table data (Excel or extracted tables).
     /// </summary>
-    public IReadOnlyList<OfficeImoChunkTable>? Tables { get; set; }
+    public IReadOnlyList<OfficeImoChunkTable>? Tables {
+        get => _tables;
+        set => _tables = NormalizeTableList(value);
+    }
 
     /// <summary>
     /// Optional per-chunk warnings.
     /// </summary>
-    public IReadOnlyList<string>? Warnings { get; set; }
+    public IReadOnlyList<string>? Warnings {
+        get => _warnings;
+        set => _warnings = NormalizeOptionalStringList(value);
+    }
 
     /// <summary>
     /// Stable source identifier when available.
@@ -358,4 +399,26 @@ public sealed class OfficeImoChunk {
     /// Best-effort token estimate for prompt budgeting.
     /// </summary>
     public int? TokenEstimate { get; set; }
+
+    private static IReadOnlyList<OfficeImoChunkTable>? NormalizeTableList(IReadOnlyList<OfficeImoChunkTable>? value) {
+        if (value is null) {
+            return null;
+        }
+        if (value.Count == 0) {
+            return Array.Empty<OfficeImoChunkTable>();
+        }
+
+        return new ReadOnlyCollection<OfficeImoChunkTable>(value.ToList());
+    }
+
+    private static IReadOnlyList<string>? NormalizeOptionalStringList(IReadOnlyList<string>? value) {
+        if (value is null) {
+            return null;
+        }
+        if (value.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        return new ReadOnlyCollection<string>(value.ToList());
+    }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -14,6 +14,70 @@ namespace IntelligenceX.Tools.Tests;
 
 public class OfficeImoReadToolTests {
     [Fact]
+    public void OfficeImoChunkTable_WhenColumnsAndRowsAssignedMutableLists_AreCopiedAndReadOnly() {
+        var columns = new List<string> { "name", "value" };
+        var row = new List<string> { "alpha", "1" };
+        var rows = new List<IReadOnlyList<string>> { row };
+
+        var table = new OfficeImoChunkTable {
+            Columns = columns,
+            Rows = rows
+        };
+
+        columns.Add("extra");
+        row.Add("2");
+        rows.Add(new List<string> { "beta", "3" });
+
+        Assert.Equal(new[] { "name", "value" }, table.Columns);
+        Assert.Single(table.Rows);
+        Assert.Equal(new[] { "alpha", "1" }, table.Rows[0]);
+
+        var columnsList = Assert.IsAssignableFrom<IList<string>>(table.Columns);
+        Assert.Throws<NotSupportedException>(() => columnsList.Add("x"));
+        var rowsList = Assert.IsAssignableFrom<IList<IReadOnlyList<string>>>(table.Rows);
+        Assert.Throws<NotSupportedException>(() => rowsList.Add(Array.Empty<string>()));
+        var rowList = Assert.IsAssignableFrom<IList<string>>(table.Rows[0]);
+        Assert.Throws<NotSupportedException>(() => rowList.Add("x"));
+    }
+
+    [Fact]
+    public void OfficeImoChunk_WhenTablesAndWarningsAssignedMutableLists_AreCopiedAndReadOnly() {
+        var table = new OfficeImoChunkTable { Columns = new[] { "name" }, Rows = new[] { new[] { "alpha" } } };
+        var tables = new List<OfficeImoChunkTable> { table };
+        var warnings = new List<string> { "one" };
+
+        var chunk = new OfficeImoChunk {
+            Tables = tables,
+            Warnings = warnings
+        };
+
+        tables.Add(new OfficeImoChunkTable { Columns = new[] { "value" }, Rows = new[] { new[] { "1" } } });
+        warnings.Add("two");
+
+        Assert.NotNull(chunk.Tables);
+        Assert.NotNull(chunk.Warnings);
+        Assert.Single(chunk.Tables!);
+        Assert.Single(chunk.Warnings!);
+        Assert.Equal("one", chunk.Warnings![0]);
+
+        var tablesList = Assert.IsAssignableFrom<IList<OfficeImoChunkTable>>(chunk.Tables!);
+        Assert.Throws<NotSupportedException>(() => tablesList.Add(table));
+        var warningsList = Assert.IsAssignableFrom<IList<string>>(chunk.Warnings!);
+        Assert.Throws<NotSupportedException>(() => warningsList.Add("x"));
+    }
+
+    [Fact]
+    public void OfficeImoChunk_WhenTablesAndWarningsAssignedNull_RemainNull() {
+        var chunk = new OfficeImoChunk {
+            Tables = null,
+            Warnings = null
+        };
+
+        Assert.Null(chunk.Tables);
+        Assert.Null(chunk.Warnings);
+    }
+
+    [Fact]
     public void OfficeImoReadResult_WhenNextActionsAssignedNullOrEmpty_UsesEmptyList() {
         var result = new OfficeImoReadResult {
             NextActions = null!


### PR DESCRIPTION
## Summary
- harden nested OfficeIMO model collection assignments against aliasing/mutation leaks:
  - `OfficeImoChunkTable.Columns`
  - `OfficeImoChunkTable.Rows`
  - `OfficeImoChunk.Tables`
  - `OfficeImoChunk.Warnings`
- normalize to copied read-only collections while preserving null semantics for optional lists
- add direct tests for copy-on-assign/read-only behavior and null semantics in `OfficeImoReadToolTests`

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~OfficeImoReadToolTests|FullyQualifiedName~ToolPayloadModelHardeningTests|FullyQualifiedName~ToolSerializationStressTests"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo
