### PR TITLE
Tools: harden read-model shape and schedule readonly contracts

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationConnectionsTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdReplicationConnectionsTool.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.DirectoryServices.ActiveDirectory;
 using System.Linq;
 using System.Threading;
@@ -256,7 +257,7 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
             }
 
             allowedSlotsByDay[day] = allowedDaySlots;
-            allowedHoursGrid.Add(hourRow);
+            allowedHoursGrid.Add(Array.AsReadOnly(hourRow));
         }
 
         return new AdReplicationConnectionSchedule(
@@ -265,8 +266,8 @@ public sealed class AdReplicationConnectionsTool : ActiveDirectoryToolBase, IToo
             SlotsPerHour: slotsPerHour,
             AllowedSlots: allowedSlots,
             TotalSlots: days * hoursPerDay * slotsPerHour,
-            AllowedSlotsByDay: allowedSlotsByDay,
-            AllowedHoursGrid: allowedHoursGrid);
+            AllowedSlotsByDay: Array.AsReadOnly(allowedSlotsByDay),
+            AllowedHoursGrid: new ReadOnlyCollection<IReadOnlyList<bool>>(allowedHoursGrid));
     }
 
     private static IReadOnlyList<string>? ReadStringArrayOrNull(JsonArray? array) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
@@ -311,14 +311,18 @@ public sealed class OfficeImoChunkTable {
             return Array.Empty<IReadOnlyList<string>>();
         }
 
-        var normalized = value
-            .Where(static row => row is not null)
-            .Select(static row => (IReadOnlyList<string>)new ReadOnlyCollection<string>(row.ToList()))
-            .ToList();
+        var normalized = new List<IReadOnlyList<string>>(value.Count);
+        for (var i = 0; i < value.Count; i++) {
+            var row = value[i];
+            if (row is null || row.Count == 0) {
+                normalized.Add(Array.Empty<string>());
+                continue;
+            }
 
-        return normalized.Count == 0
-            ? Array.Empty<IReadOnlyList<string>>()
-            : new ReadOnlyCollection<IReadOnlyList<string>>(normalized);
+            normalized.Add(new ReadOnlyCollection<string>(row.ToList()));
+        }
+
+        return new ReadOnlyCollection<IReadOnlyList<string>>(normalized);
     }
 }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdReplicationConnectionsToolSerializationTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdReplicationConnectionsToolSerializationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.DirectoryServices.ActiveDirectory;
 using System.Text.Json;
 using ADPlayground.Replication;
@@ -33,6 +34,26 @@ public sealed class AdReplicationConnectionsToolSerializationTests {
 
         var json = JsonSerializer.Serialize(view);
         Assert.Contains("AllowedHoursGrid", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MapReplicationScheduleForResponse_UsesReadOnlyCollections() {
+        var schedule = new ActiveDirectorySchedule();
+        var raw = new bool[7, 24, 4];
+        raw[0, 0, 0] = true;
+        schedule.RawSchedule = raw;
+
+        var view = AdReplicationConnectionsTool.MapReplicationScheduleForResponse(schedule);
+        Assert.NotNull(view);
+
+        var slotsByDay = Assert.IsAssignableFrom<IList<int>>(view!.AllowedSlotsByDay);
+        Assert.Throws<NotSupportedException>(() => slotsByDay.Add(1));
+
+        var hoursGrid = Assert.IsAssignableFrom<IList<IReadOnlyList<bool>>>(view.AllowedHoursGrid);
+        Assert.Throws<NotSupportedException>(() => hoursGrid.Add(Array.Empty<bool>()));
+
+        var firstDay = Assert.IsAssignableFrom<IList<bool>>(view.AllowedHoursGrid[0]);
+        Assert.Throws<NotSupportedException>(() => firstDay[0] = false);
     }
 
     [Fact]

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -41,6 +41,23 @@ public class OfficeImoReadToolTests {
     }
 
     [Fact]
+    public void OfficeImoChunkTable_WhenRowsContainNull_PreservesRowShapeWithEmptyRows() {
+        IReadOnlyList<string>?[] rows = {
+            new[] { "alpha", "1" },
+            null
+        };
+
+        var table = new OfficeImoChunkTable {
+            Columns = new[] { "name", "value" },
+            Rows = rows!
+        };
+
+        Assert.Equal(2, table.Rows.Count);
+        Assert.Equal(new[] { "alpha", "1" }, table.Rows[0]);
+        Assert.Empty(table.Rows[1]);
+    }
+
+    [Fact]
     public void OfficeImoChunk_WhenTablesAndWarningsAssignedMutableLists_AreCopiedAndReadOnly() {
         var table = new OfficeImoChunkTable { Columns = new[] { "name" }, Rows = new[] { new[] { "alpha" } } };
         var tables = new List<OfficeImoChunkTable> { table };


### PR DESCRIPTION
## Summary
- harden `ad_replication_connections` schedule mapping to emit runtime read-only collection views for both day-slot counts and per-day hour grids
- preserve OfficeIMO table row alignment by normalizing `null` rows to empty rows instead of silently dropping them
- add regression tests for both behaviors to keep tool payload contracts stable under long chat flows

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~OfficeImoReadToolTests|FullyQualifiedName~AdReplicationConnectionsToolSerializationTests" --nologo`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo`