### PR TITLE
Tools: harden request-binding hints contract safety

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolRequestBinding.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolRequestBinding.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using IntelligenceX.Json;
 
 namespace IntelligenceX.Tools.Common;
@@ -9,6 +10,8 @@ namespace IntelligenceX.Tools.Common;
 /// </summary>
 /// <typeparam name="TRequest">Typed request model.</typeparam>
 public sealed class ToolRequestBindingResult<TRequest> where TRequest : notnull {
+    private IReadOnlyList<string> _hints = Array.Empty<string>();
+
     private ToolRequestBindingResult() { }
 
     /// <summary>
@@ -34,7 +37,10 @@ public sealed class ToolRequestBindingResult<TRequest> where TRequest : notnull 
     /// <summary>
     /// Optional guidance for callers.
     /// </summary>
-    public IReadOnlyList<string> Hints { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> Hints {
+        get => _hints;
+        init => _hints = NormalizeHints(value);
+    }
 
     /// <summary>
     /// Optional transient marker for bind-time failures.
@@ -67,6 +73,26 @@ public sealed class ToolRequestBindingResult<TRequest> where TRequest : notnull 
             Hints = hints ?? Array.Empty<string>(),
             IsTransient = isTransient
         };
+    }
+
+    private static IReadOnlyList<string> NormalizeHints(IReadOnlyList<string>? hints) {
+        if (hints is null || hints.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        var normalized = new List<string>(hints.Count);
+        for (var i = 0; i < hints.Count; i++) {
+            var hint = hints[i];
+            if (!string.IsNullOrWhiteSpace(hint)) {
+                normalized.Add(hint.Trim());
+            }
+        }
+
+        if (normalized.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        return new ReadOnlyCollection<string>(normalized);
     }
 }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolRequestBindingTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolRequestBindingTests.cs
@@ -45,4 +45,28 @@ public sealed class ToolRequestBindingTests {
         Assert.True(result.Request.Enabled);
         Assert.Equal(new[] { "a", "b" }, result.Request.Tags);
     }
+
+    [Fact]
+    public void Failure_WhenHintsMutableList_ShouldDefensivelyCopyAndExposeReadOnlyView() {
+        var hints = new List<string> { "first" };
+
+        var result = ToolRequestBindingResult<RequestModel>.Failure(
+            error: "bad request",
+            hints: hints);
+
+        hints.Add("second");
+
+        Assert.Equal(new[] { "first" }, result.Hints);
+        var list = Assert.IsAssignableFrom<IList<string>>(result.Hints);
+        Assert.Throws<NotSupportedException>(() => list.Add("x"));
+    }
+
+    [Fact]
+    public void Failure_WhenHintsContainWhitespace_ShouldTrimAndDropEmptyEntries() {
+        var result = ToolRequestBindingResult<RequestModel>.Failure(
+            error: "bad request",
+            hints: new[] { "  first hint  ", " ", string.Empty, "second hint" });
+
+        Assert.Equal(new[] { "first hint", "second hint" }, result.Hints);
+    }
 }


### PR DESCRIPTION
## Summary
- harden `ToolRequestBindingResult<TRequest>.Hints` to normalize on assignment (`trim`, drop blank entries) and defensively copy into a read-only collection
- keep null/empty hints on the canonical `Array.Empty<string>()` path
- add regression tests for mutable-source defensive-copy behavior and whitespace normalization

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolRequestBindingTests" --nologo`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo`