### PR TITLE
Tools: harden table-view contract initializer safety

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolTableView.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolTableView.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using IntelligenceX.Json;
@@ -11,10 +12,15 @@ namespace IntelligenceX.Tools.Common;
 /// Common request contract for tabular tool result shaping.
 /// </summary>
 public sealed class ToolTableViewRequest {
+    private IReadOnlyList<string> _columns = Array.Empty<string>();
+
     /// <summary>
     /// Selected columns in preferred display order. Empty means default/all.
     /// </summary>
-    public IReadOnlyList<string> Columns { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> Columns {
+        get => _columns;
+        init => _columns = NormalizeColumns(value);
+    }
 
     /// <summary>
     /// Optional column key used for sorting.
@@ -30,6 +36,32 @@ public sealed class ToolTableViewRequest {
     /// Optional output row cap.
     /// </summary>
     public int? Top { get; init; }
+
+    private static IReadOnlyList<string> NormalizeColumns(IReadOnlyList<string>? columns) {
+        if (columns is null || columns.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        var normalized = new List<string>(columns.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < columns.Count; i++) {
+            var column = columns[i];
+            if (string.IsNullOrWhiteSpace(column)) {
+                continue;
+            }
+
+            var trimmed = column.Trim();
+            if (seen.Add(trimmed)) {
+                normalized.Add(trimmed);
+            }
+        }
+
+        if (normalized.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        return new ReadOnlyCollection<string>(normalized);
+    }
 }
 
 /// <summary>
@@ -81,10 +113,16 @@ public sealed class ToolTableColumnSpec<TRow> {
 /// Result of applying a tabular view request to typed rows.
 /// </summary>
 public sealed class ToolTableViewResult {
+    private IReadOnlyList<ToolColumn> _columns = Array.Empty<ToolColumn>();
+    private IReadOnlyList<IReadOnlyList<string>> _previewRows = Array.Empty<IReadOnlyList<string>>();
+
     /// <summary>
     /// Selected render columns.
     /// </summary>
-    public IReadOnlyList<ToolColumn> Columns { get; init; } = Array.Empty<ToolColumn>();
+    public IReadOnlyList<ToolColumn> Columns {
+        get => _columns;
+        init => _columns = NormalizeColumns(value);
+    }
 
     /// <summary>
     /// Projected rows (JSON-safe values).
@@ -94,7 +132,10 @@ public sealed class ToolTableViewResult {
     /// <summary>
     /// Preview rows (string cells) for summary markdown.
     /// </summary>
-    public IReadOnlyList<IReadOnlyList<string>> PreviewRows { get; init; } = Array.Empty<IReadOnlyList<string>>();
+    public IReadOnlyList<IReadOnlyList<string>> PreviewRows {
+        get => _previewRows;
+        init => _previewRows = NormalizePreviewRows(value);
+    }
 
     /// <summary>
     /// Number of projected rows.
@@ -105,6 +146,33 @@ public sealed class ToolTableViewResult {
     /// Indicates whether rows were truncated by view-level constraints.
     /// </summary>
     public bool TruncatedByView { get; init; }
+
+    private static IReadOnlyList<ToolColumn> NormalizeColumns(IReadOnlyList<ToolColumn>? columns) {
+        if (columns is null || columns.Count == 0) {
+            return Array.Empty<ToolColumn>();
+        }
+
+        return new ReadOnlyCollection<ToolColumn>(columns.ToList());
+    }
+
+    private static IReadOnlyList<IReadOnlyList<string>> NormalizePreviewRows(IReadOnlyList<IReadOnlyList<string>>? previewRows) {
+        if (previewRows is null || previewRows.Count == 0) {
+            return Array.Empty<IReadOnlyList<string>>();
+        }
+
+        var normalized = new List<IReadOnlyList<string>>(previewRows.Count);
+        for (var i = 0; i < previewRows.Count; i++) {
+            var row = previewRows[i];
+            if (row is null || row.Count == 0) {
+                normalized.Add(Array.Empty<string>());
+                continue;
+            }
+
+            normalized.Add(new ReadOnlyCollection<string>(row.Select(static cell => cell ?? string.Empty).ToList()));
+        }
+
+        return new ReadOnlyCollection<IReadOnlyList<string>>(normalized);
+    }
 }
 
 /// <summary>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolTableViewTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolTableViewTests.cs
@@ -222,6 +222,50 @@ public class ToolTableViewTests {
         Assert.Contains("\"error_code\":\"invalid_argument\"", response);
     }
 
+    [Fact]
+    public void ToolTableViewRequest_ObjectInitializer_ShouldNormalizeAndDefensivelyCopyColumns() {
+        var columns = new List<string> { "  name ", "id", "name", " " };
+
+        var request = new ToolTableViewRequest {
+            Columns = columns
+        };
+
+        columns.Add("memory_usage");
+
+        Assert.Equal(new[] { "name", "id" }, request.Columns);
+        var requestColumns = Assert.IsAssignableFrom<IList<string>>(request.Columns);
+        Assert.Throws<NotSupportedException>(() => requestColumns.Add("x"));
+    }
+
+    [Fact]
+    public void ToolTableViewResult_ObjectInitializer_ShouldDefensivelyCopyColumnsAndPreviewRows() {
+        var columns = new List<ToolColumn> {
+            new("id", "ID", "int")
+        };
+        var firstRow = new List<string> { "alpha" };
+        var previewRows = new List<IReadOnlyList<string>> { firstRow };
+
+        var result = new ToolTableViewResult {
+            Columns = columns,
+            PreviewRows = previewRows
+        };
+
+        columns.Add(new ToolColumn("name", "Name", "string"));
+        firstRow.Add("beta");
+        previewRows.Add(new[] { "gamma" });
+
+        Assert.Single(result.Columns);
+        Assert.Single(result.PreviewRows);
+        Assert.Equal(new[] { "alpha" }, result.PreviewRows[0]);
+
+        var resultColumns = Assert.IsAssignableFrom<IList<ToolColumn>>(result.Columns);
+        Assert.Throws<NotSupportedException>(() => resultColumns.Add(new ToolColumn("x", "X", "string")));
+        var resultRows = Assert.IsAssignableFrom<IList<IReadOnlyList<string>>>(result.PreviewRows);
+        Assert.Throws<NotSupportedException>(() => resultRows.Add(Array.Empty<string>()));
+        var firstResultRow = Assert.IsAssignableFrom<IList<string>>(result.PreviewRows[0]);
+        Assert.Throws<NotSupportedException>(() => firstResultRow.Add("x"));
+    }
+
     private sealed record Row(int Id, string Name, long MemoryUsage);
     private sealed record AutoRow(int Id, string DisplayName, DateTime StartTimeUtc, IReadOnlyList<string> Tags);
 


### PR DESCRIPTION
## Summary
- harden `ToolTableViewRequest.Columns` initializer path with normalization (`trim`, de-dup, drop blank) and defensive-copy read-only storage
- harden `ToolTableViewResult.Columns` and nested `PreviewRows` initializer paths with defensive-copy read-only storage
- preserve stable table-view contract behavior while preventing mutable-list aliasing regressions
- add regression tests for object-initializer defensive-copy/read-only semantics for both request and result models

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolTableViewTests" --nologo`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --nologo`