### PR TITLE
Harden common tool collection contracts

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolChainingHints.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolChainingHints.cs
@@ -127,9 +127,14 @@ public static class ToolChainingHints {
             });
         }
 
-        return normalized
+        var deduplicated = normalized
             .DistinctBy(static action => $"{action.Tool}|{action.Reason}")
-            .ToArray();
+            .ToList();
+        if (deduplicated.Count == 0) {
+            return Array.Empty<ToolNextActionModel>();
+        }
+
+        return new ReadOnlyCollection<ToolNextActionModel>(deduplicated);
     }
 
     private static string NormalizeToken(string? token) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPackGuidance.NormalizationHelpers.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPackGuidance.NormalizationHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.Json.Serialization;
 using IntelligenceX.Json;
@@ -96,7 +97,8 @@ public static partial class ToolPackGuidance {
             query = query.Distinct(StringComparer.OrdinalIgnoreCase);
         }
 
-        return query.ToArray();
+        var list = query.ToList();
+        return ToReadOnlyList(list);
     }
 
     private static IReadOnlyList<ToolPackFlowStepModel> NormalizeFlowSteps(IEnumerable<ToolPackFlowStepModel>? flowSteps) {
@@ -114,7 +116,7 @@ public static partial class ToolPackGuidance {
             });
         }
 
-        return list;
+        return ToReadOnlyList(list);
     }
 
     private static IReadOnlyList<ToolPackCapabilityModel> NormalizeCapabilities(IEnumerable<ToolPackCapabilityModel>? capabilities) {
@@ -133,7 +135,7 @@ public static partial class ToolPackGuidance {
             });
         }
 
-        return list;
+        return ToReadOnlyList(list);
     }
 
     private static IReadOnlyList<ToolPackEntityHandoffModel> NormalizeEntityHandoffs(IEnumerable<ToolPackEntityHandoffModel>? handoffs) {
@@ -161,7 +163,7 @@ public static partial class ToolPackGuidance {
             });
         }
 
-        return list;
+        return ToReadOnlyList(list);
     }
 
     private static IReadOnlyList<ToolPackEntityFieldMappingModel> NormalizeEntityFieldMappings(IEnumerable<ToolPackEntityFieldMappingModel>? mappings) {
@@ -187,7 +189,7 @@ public static partial class ToolPackGuidance {
             });
         }
 
-        return list;
+        return ToReadOnlyList(list);
     }
 
     private static IReadOnlyList<ToolPackToolCatalogEntryModel> NormalizeToolCatalog(IEnumerable<ToolPackToolCatalogEntryModel>? entries) {
@@ -237,7 +239,7 @@ public static partial class ToolPackGuidance {
             });
         }
 
-        return list;
+        return ToReadOnlyList(list);
     }
 
     private static ToolPackToolTraitsModel BuildToolTraits(IEnumerable<string>? argumentNames, bool supportsTableViewProjection) {
@@ -351,7 +353,7 @@ public static partial class ToolPackGuidance {
         }
 
         list.Sort(StringComparer.OrdinalIgnoreCase);
-        return list.ToArray();
+        return ToReadOnlyList(list);
     }
 
     private static string NormalizeRoutingToken(string? value, string fallback) {
@@ -420,7 +422,7 @@ public static partial class ToolPackGuidance {
             });
         }
 
-        return list;
+        return ToReadOnlyList(list);
     }
 
     private static IReadOnlyList<string> ReadRequiredArguments(JsonObject? schema) {
@@ -496,10 +498,11 @@ public static partial class ToolPackGuidance {
     private static IReadOnlyList<string> GetObjectKeys(JsonObject obj) {
         var keysProperty = obj.GetType().GetProperty("Keys");
         if (keysProperty?.GetValue(obj) is IEnumerable<string> keys) {
-            return keys
+            var list = keys
                 .Where(static x => !string.IsNullOrWhiteSpace(x))
                 .Select(static x => x.Trim())
-                .ToArray();
+                .ToList();
+            return ToReadOnlyList(list);
         }
 
         if (obj is System.Collections.IEnumerable enumerable) {
@@ -516,7 +519,7 @@ public static partial class ToolPackGuidance {
                 }
             }
 
-            return list;
+            return ToReadOnlyList(list);
         }
 
         return Array.Empty<string>();
@@ -547,7 +550,15 @@ public static partial class ToolPackGuidance {
             }
         }
 
-        return result;
+        return ToReadOnlyList(result);
+    }
+
+    private static IReadOnlyList<T> ToReadOnlyList<T>(List<T> source) {
+        if (source.Count == 0) {
+            return Array.Empty<T>();
+        }
+
+        return new ReadOnlyCollection<T>(source);
     }
 
     private static string? ToAuthenticationModeId(ToolAuthenticationContract? contract) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolTableView.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolTableView.cs
@@ -42,6 +42,8 @@ public sealed class ToolTableViewRequest {
             return Array.Empty<string>();
         }
 
+        // Keep object-initializer and parser semantics aligned:
+        // snapshot caller input, trim entries, and drop case-insensitive duplicates.
         var normalized = new List<string>(columns.Count);
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < columns.Count; i++) {
@@ -152,6 +154,7 @@ public sealed class ToolTableViewResult {
             return Array.Empty<ToolColumn>();
         }
 
+        // Snapshot to prevent callers from mutating object-initializer source collections.
         return new ReadOnlyCollection<ToolColumn>(columns.ToList());
     }
 
@@ -164,10 +167,12 @@ public sealed class ToolTableViewResult {
         for (var i = 0; i < previewRows.Count; i++) {
             var row = previewRows[i];
             if (row is null || row.Count == 0) {
+                // Represent missing/empty rows consistently as empty row snapshots.
                 normalized.Add(Array.Empty<string>());
                 continue;
             }
 
+            // Null cells are normalized to empty strings for stable markdown/json rendering.
             normalized.Add(new ReadOnlyCollection<string>(row.Select(static cell => cell ?? string.Empty).ToList()));
         }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolChainingHintsTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolChainingHintsTests.cs
@@ -99,6 +99,7 @@ public sealed class ToolChainingHintsTests {
 
         var actionsList = Assert.IsAssignableFrom<IList<ToolNextActionModel>>(chain.NextActions);
         Assert.Throws<NotSupportedException>(() => actionsList.Add(new ToolNextActionModel { Tool = "z", Reason = "r" }));
+        Assert.Throws<NotSupportedException>(() => actionsList[0] = new ToolNextActionModel { Tool = "z", Reason = "r" });
         var handoffMap = Assert.IsAssignableFrom<IDictionary<string, string>>(chain.Handoff);
         Assert.Throws<NotSupportedException>(() => handoffMap.Add("x", "1"));
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolCommonCollectionGuardrailTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolCommonCollectionGuardrailTests.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using IntelligenceX.Tools.Common;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class ToolCommonCollectionGuardrailTests {
+    [Fact]
+    public void HardenedCollectionContracts_ShouldDefensivelyCopyAndRejectMutation() {
+        foreach (var guardCase in BuildGuardCases()) {
+            Assert.Equal(guardCase.ModelType, guardCase.Model.GetType());
+
+            var property = guardCase.ModelType.GetProperty(
+                guardCase.PropertyName,
+                BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(property);
+
+            var value = property!.GetValue(guardCase.Model);
+            Assert.NotNull(value);
+
+            guardCase.MutateSource();
+
+            guardCase.AssertSnapshot(value!);
+            guardCase.AssertImmutable(value!);
+        }
+    }
+
+    private static IReadOnlyList<GuardCase> BuildGuardCases() {
+        var hints = new List<string> { "first hint" };
+        var binding = ToolRequestBindingResult<RequestModel>.Failure("invalid", hints: hints);
+
+        var requestColumns = new List<string> { " id ", "name" };
+        var tableRequest = new ToolTableViewRequest {
+            Columns = requestColumns
+        };
+
+        var tableColumns = new List<ToolColumn> { new("id", "ID", "int") };
+        var tableResultColumns = new ToolTableViewResult {
+            Columns = tableColumns
+        };
+
+        var previewRow = new List<string> { "alpha" };
+        var previewRows = new List<IReadOnlyList<string>> { previewRow };
+        var tableResultPreview = new ToolTableViewResult {
+            PreviewRows = previewRows
+        };
+
+        var nextActions = new List<ToolNextActionModel> {
+            new() {
+                Tool = "ad_scope_discovery",
+                Reason = "find boundaries"
+            }
+        };
+        var chain = new ToolChainContractModel {
+            NextActions = nextActions
+        };
+
+        var handoff = new Dictionary<string, string>(StringComparer.Ordinal) {
+            ["contract"] = "scope"
+        };
+        var chainHandoff = new ToolChainContractModel {
+            Handoff = handoff
+        };
+
+        var suggestedArguments = new Dictionary<string, string>(StringComparer.Ordinal) {
+            ["path"] = @"C:\docs"
+        };
+        var nextAction = new ToolNextActionModel {
+            Tool = "officeimo_read",
+            Reason = "inspect file",
+            SuggestedArguments = suggestedArguments
+        };
+
+        var toolCatalog = new List<ToolPackToolCatalogEntryModel> {
+            new() {
+                Name = " system_info ",
+                Description = "System info"
+            }
+        };
+        var packInfo = new ToolPackInfoModel {
+            Pack = "system",
+            Engine = "ComputerX",
+            ToolCatalog = toolCatalog
+        };
+
+        return new[] {
+            new GuardCase(
+                ModelType: typeof(ToolRequestBindingResult<RequestModel>),
+                PropertyName: nameof(ToolRequestBindingResult<RequestModel>.Hints),
+                Model: binding,
+                MutateSource: () => {
+                    hints[0] = "changed";
+                    hints.Add("new");
+                },
+                AssertSnapshot: static value => {
+                    var list = Assert.IsAssignableFrom<IReadOnlyList<string>>(value);
+                    Assert.Equal(new[] { "first hint" }, list);
+                },
+                AssertImmutable: static value => AssertReadOnlyList(value, addValue: "x", replaceValue: "y")),
+
+            new GuardCase(
+                ModelType: typeof(ToolTableViewRequest),
+                PropertyName: nameof(ToolTableViewRequest.Columns),
+                Model: tableRequest,
+                MutateSource: () => {
+                    requestColumns[0] = "mutated";
+                    requestColumns.Add("memory_usage");
+                },
+                AssertSnapshot: static value => {
+                    var list = Assert.IsAssignableFrom<IReadOnlyList<string>>(value);
+                    Assert.Equal(new[] { "id", "name" }, list);
+                },
+                AssertImmutable: static value => AssertReadOnlyList(value, addValue: "x", replaceValue: "y")),
+
+            new GuardCase(
+                ModelType: typeof(ToolTableViewResult),
+                PropertyName: nameof(ToolTableViewResult.Columns),
+                Model: tableResultColumns,
+                MutateSource: () => tableColumns.Add(new ToolColumn("name", "Name", "string")),
+                AssertSnapshot: static value => {
+                    var list = Assert.IsAssignableFrom<IReadOnlyList<ToolColumn>>(value);
+                    var column = Assert.Single(list);
+                    Assert.Equal("id", column.Key);
+                },
+                AssertImmutable: static value => AssertReadOnlyList(
+                    value,
+                    addValue: new ToolColumn("x", "X", "string"),
+                    replaceValue: new ToolColumn("y", "Y", "string"))),
+
+            new GuardCase(
+                ModelType: typeof(ToolTableViewResult),
+                PropertyName: nameof(ToolTableViewResult.PreviewRows),
+                Model: tableResultPreview,
+                MutateSource: () => {
+                    previewRow[0] = "changed";
+                    previewRows.Add(new[] { "beta" });
+                },
+                AssertSnapshot: static value => {
+                    var rows = Assert.IsAssignableFrom<IReadOnlyList<IReadOnlyList<string>>>(value);
+                    Assert.Single(rows);
+                    Assert.Equal("alpha", rows[0][0]);
+                },
+                AssertImmutable: static value => {
+                    AssertReadOnlyList(value, addValue: Array.Empty<string>(), replaceValue: new[] { "x" });
+                    var rows = Assert.IsAssignableFrom<IReadOnlyList<IReadOnlyList<string>>>(value);
+                    AssertReadOnlyList(rows[0], addValue: "z", replaceValue: "mutated");
+                }),
+
+            new GuardCase(
+                ModelType: typeof(ToolChainContractModel),
+                PropertyName: nameof(ToolChainContractModel.NextActions),
+                Model: chain,
+                MutateSource: () => {
+                    nextActions[0] = new ToolNextActionModel {
+                        Tool = "mutated_tool",
+                        Reason = "mutated reason"
+                    };
+                    nextActions.Add(new ToolNextActionModel { Tool = "x", Reason = "y" });
+                },
+                AssertSnapshot: static value => {
+                    var actions = Assert.IsAssignableFrom<IReadOnlyList<ToolNextActionModel>>(value);
+                    var action = Assert.Single(actions);
+                    Assert.Equal("ad_scope_discovery", action.Tool);
+                    Assert.Equal("find boundaries", action.Reason);
+                },
+                AssertImmutable: static value => AssertReadOnlyList(
+                    value,
+                    addValue: new ToolNextActionModel { Tool = "x", Reason = "y" },
+                    replaceValue: new ToolNextActionModel { Tool = "z", Reason = "r" })),
+
+            new GuardCase(
+                ModelType: typeof(ToolChainContractModel),
+                PropertyName: nameof(ToolChainContractModel.Handoff),
+                Model: chainHandoff,
+                MutateSource: () => handoff["new"] = "value",
+                AssertSnapshot: static value => {
+                    var map = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(value);
+                    Assert.Equal("scope", map["contract"]);
+                    Assert.False(map.ContainsKey("new"));
+                },
+                AssertImmutable: static value => AssertReadOnlyDictionary(value)),
+
+            new GuardCase(
+                ModelType: typeof(ToolNextActionModel),
+                PropertyName: nameof(ToolNextActionModel.SuggestedArguments),
+                Model: nextAction,
+                MutateSource: () => suggestedArguments["server"] = "dc01.contoso.com",
+                AssertSnapshot: static value => {
+                    var map = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(value);
+                    Assert.Equal(@"C:\docs", map["path"]);
+                    Assert.False(map.ContainsKey("server"));
+                },
+                AssertImmutable: static value => AssertReadOnlyDictionary(value)),
+
+            new GuardCase(
+                ModelType: typeof(ToolPackInfoModel),
+                PropertyName: nameof(ToolPackInfoModel.ToolCatalog),
+                Model: packInfo,
+                MutateSource: () => toolCatalog.Add(new ToolPackToolCatalogEntryModel {
+                    Name = "eventlog_live_query",
+                    Description = "Added later"
+                }),
+                AssertSnapshot: static value => {
+                    var list = Assert.IsAssignableFrom<IReadOnlyList<ToolPackToolCatalogEntryModel>>(value);
+                    var entry = Assert.Single(list);
+                    Assert.Equal("system_info", entry.Name);
+                },
+                AssertImmutable: static value => AssertReadOnlyList(
+                    value,
+                    addValue: new ToolPackToolCatalogEntryModel {
+                        Name = "x",
+                        Description = "x"
+                    },
+                    replaceValue: new ToolPackToolCatalogEntryModel {
+                        Name = "y",
+                        Description = "y"
+                    }))
+        };
+    }
+
+    private static void AssertReadOnlyList(object value, object addValue, object replaceValue) {
+        var list = Assert.IsAssignableFrom<IList>(value);
+        Assert.Throws<NotSupportedException>(() => list.Add(addValue));
+        if (list.Count > 0) {
+            Assert.Throws<NotSupportedException>(() => list[0] = replaceValue);
+        }
+    }
+
+    private static void AssertReadOnlyDictionary(object value) {
+        var dictionary = Assert.IsAssignableFrom<IDictionary>(value);
+        Assert.Throws<NotSupportedException>(() => dictionary.Add("x", "1"));
+        if (dictionary.Count > 0) {
+            var firstKey = dictionary.Keys.Cast<object>().First();
+            Assert.Throws<NotSupportedException>(() => dictionary[firstKey] = "updated");
+        }
+    }
+
+    private sealed record GuardCase(
+        Type ModelType,
+        string PropertyName,
+        object Model,
+        Action MutateSource,
+        Action<object> AssertSnapshot,
+        Action<object> AssertImmutable);
+
+    private sealed record RequestModel(string Name);
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolTableViewTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolTableViewTests.cs
@@ -224,7 +224,7 @@ public class ToolTableViewTests {
 
     [Fact]
     public void ToolTableViewRequest_ObjectInitializer_ShouldNormalizeAndDefensivelyCopyColumns() {
-        var columns = new List<string> { "  name ", "id", "name", " " };
+        var columns = new List<string> { "  name ", null!, "id", "NAME", " " };
 
         var request = new ToolTableViewRequest {
             Columns = columns
@@ -233,6 +233,17 @@ public class ToolTableViewTests {
         columns.Add("memory_usage");
 
         Assert.Equal(new[] { "name", "id" }, request.Columns);
+        var requestColumns = Assert.IsAssignableFrom<IList<string>>(request.Columns);
+        Assert.Throws<NotSupportedException>(() => requestColumns.Add("x"));
+    }
+
+    [Fact]
+    public void ToolTableViewRequest_ObjectInitializer_WhenAssignedNullColumns_ShouldUseSafeDefaults() {
+        var request = new ToolTableViewRequest {
+            Columns = null!
+        };
+
+        Assert.Empty(request.Columns);
         var requestColumns = Assert.IsAssignableFrom<IList<string>>(request.Columns);
         Assert.Throws<NotSupportedException>(() => requestColumns.Add("x"));
     }
@@ -264,6 +275,41 @@ public class ToolTableViewTests {
         Assert.Throws<NotSupportedException>(() => resultRows.Add(Array.Empty<string>()));
         var firstResultRow = Assert.IsAssignableFrom<IList<string>>(result.PreviewRows[0]);
         Assert.Throws<NotSupportedException>(() => firstResultRow.Add("x"));
+    }
+
+    [Fact]
+    public void ToolTableViewResult_ObjectInitializer_WhenAssignedNullCollections_ShouldUseSafeDefaults() {
+        var result = new ToolTableViewResult {
+            Columns = null!,
+            PreviewRows = null!
+        };
+
+        Assert.Empty(result.Columns);
+        Assert.Empty(result.PreviewRows);
+
+        var resultColumns = Assert.IsAssignableFrom<IList<ToolColumn>>(result.Columns);
+        Assert.Throws<NotSupportedException>(() => resultColumns.Add(new ToolColumn("x", "X", "string")));
+        var resultRows = Assert.IsAssignableFrom<IList<IReadOnlyList<string>>>(result.PreviewRows);
+        Assert.Throws<NotSupportedException>(() => resultRows.Add(Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void ToolTableViewResult_ObjectInitializer_ShouldNormalizeNullRowsAndCells() {
+        var previewRows = new List<IReadOnlyList<string>> {
+            null!,
+            new string?[] { "alpha", null }!
+        };
+
+        var result = new ToolTableViewResult {
+            PreviewRows = previewRows
+        };
+
+        Assert.Equal(2, result.PreviewRows.Count);
+        Assert.Empty(result.PreviewRows[0]);
+        Assert.Equal(new[] { "alpha", string.Empty }, result.PreviewRows[1]);
+
+        var firstResultRow = Assert.IsAssignableFrom<IList<string>>(result.PreviewRows[1]);
+        Assert.Throws<NotSupportedException>(() => firstResultRow[0] = "mutated");
     }
 
     private sealed record Row(int Id, string Name, long MemoryUsage);


### PR DESCRIPTION
## Summary
- harden `ToolTableView` initializer normalization docs and edge-case handling coverage for null-assigned collections/rows/cells
- harden `ToolChainingHints` action normalization to return read-only collections (not mutable arrays)
- harden `ToolPackGuidance` normalization helpers to return read-only snapshots for normalized list contracts
- add a reflection-driven guardrail test suite that verifies key `IntelligenceX.Tools.Common` DTO collection properties are defensively copied and reject external mutation

## Testing
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolTableViewTests|FullyQualifiedName~ToolChainingHintsTests|FullyQualifiedName~ToolCommonCollectionGuardrailTests|FullyQualifiedName~ToolPackGuidanceTests"`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`