### PR TITLE
Use tuple key for ToolChainingHints dedupe

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolChainingHints.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolChainingHints.cs
@@ -128,7 +128,7 @@ public static class ToolChainingHints {
         }
 
         var deduplicated = normalized
-            .DistinctBy(static action => $"{action.Tool}|{action.Reason}")
+            .DistinctBy(static action => (action.Tool, action.Reason))
             .ToList();
         if (deduplicated.Count == 0) {
             return Array.Empty<ToolNextActionModel>();


### PR DESCRIPTION
## Summary
- switch `ToolChainingHints.NormalizeActions` dedupe key from interpolated string to tuple `(action.Tool, action.Reason)`
- preserve current dedupe semantics while avoiding per-item temporary string allocation

## Testing
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolChainingHintsTests"`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`