### PR TITLE
Add long-flow fields to tool chaining contracts

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdForestDiscoverTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdForestDiscoverTool.cs
@@ -460,6 +460,9 @@ public sealed class AdForestDiscoverTool : ActiveDirectoryToolBase, ITool {
             NextActions = chain.NextActions,
             Cursor = chain.Cursor,
             ResumeToken = chain.ResumeToken,
+            FlowId = chain.FlowId,
+            StepId = chain.StepId,
+            Checkpoint = chain.Checkpoint,
             Handoff = chain.Handoff,
             Confidence = chain.Confidence
         };
@@ -555,7 +558,17 @@ public sealed class AdForestDiscoverTool : ActiveDirectoryToolBase, ITool {
                 ("fallback", fallbackName),
                 ("failed_steps", failedSteps.ToString())),
             handoff: handoff,
-            confidence: confidence);
+            confidence: confidence,
+            flowId: ToolChainingHints.BuildToken(
+                "ad_forest_discover.flow",
+                ("forest", effectiveForest ?? string.Empty),
+                ("domain", effectiveDomain ?? string.Empty)),
+            stepId: "forest_receipt",
+            checkpoint: ToolChainingHints.Map(
+                ("domains", domains.Count),
+                ("domain_controllers", domainControllers.Count),
+                ("trusts", trusts.Count),
+                ("failed_steps", failedSteps)));
     }
 
     private static async Task CollectDcSourceAsync(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdScopeDiscoveryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdScopeDiscoveryTool.cs
@@ -461,6 +461,9 @@ public sealed class AdScopeDiscoveryTool : ActiveDirectoryToolBase, ITool {
             next_actions = chain.NextActions,
             cursor = chain.Cursor,
             resume_token = chain.ResumeToken,
+            flow_id = chain.FlowId,
+            step_id = chain.StepId,
+            checkpoint = chain.Checkpoint,
             handoff = chain.Handoff,
             confidence = chain.Confidence
         };
@@ -534,7 +537,17 @@ public sealed class AdScopeDiscoveryTool : ActiveDirectoryToolBase, ITool {
                 ("failed_steps", failedSteps.ToString()),
                 ("gaps", gaps.Count.ToString())),
             handoff: handoff,
-            confidence: confidence);
+            confidence: confidence,
+            flowId: ToolChainingHints.BuildToken(
+                "ad_scope_discovery.flow",
+                ("forest", effectiveForest ?? string.Empty),
+                ("domain", effectiveDomain ?? string.Empty)),
+            stepId: "scope_receipt",
+            checkpoint: ToolChainingHints.Map(
+                ("domains", domains.Count),
+                ("domain_controllers", domainControllers.Count),
+                ("gaps", gaps.Count),
+                ("failed_steps", failedSteps)));
     }
 
     private static async Task<StepExecutionResult<T>> ExecuteStepAsync<T>(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolChainingHints.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolChainingHints.cs
@@ -26,13 +26,19 @@ public static class ToolChainingHints {
         string? cursor = null,
         string? resumeToken = null,
         IReadOnlyDictionary<string, string>? handoff = null,
-        double confidence = 0.5d) {
+        double confidence = 0.5d,
+        string? flowId = null,
+        string? stepId = null,
+        IReadOnlyDictionary<string, string>? checkpoint = null) {
         return new ToolChainContractModel {
             NextActions = NormalizeActionsForContract(nextActions),
             Cursor = NormalizeTokenForContract(cursor),
             ResumeToken = NormalizeTokenForContract(resumeToken),
             Handoff = NormalizeMapForContract(handoff),
-            Confidence = NormalizeConfidenceForContract(confidence)
+            Confidence = NormalizeConfidenceForContract(confidence),
+            FlowId = NormalizeTokenForContract(flowId),
+            StepId = NormalizeTokenForContract(stepId),
+            Checkpoint = NormalizeMapForContract(checkpoint)
         };
     }
 
@@ -188,6 +194,9 @@ public sealed class ToolChainContractModel {
     private string _resumeToken = string.Empty;
     private IReadOnlyDictionary<string, string> _handoff = ToolChainingHints.EmptyMap;
     private double _confidence = 0.5d;
+    private string _flowId = string.Empty;
+    private string _stepId = string.Empty;
+    private IReadOnlyDictionary<string, string> _checkpoint = ToolChainingHints.EmptyMap;
 
     /// <summary>
     /// Optional follow-up actions for the model (advisory only).
@@ -227,6 +236,30 @@ public sealed class ToolChainContractModel {
     public double Confidence {
         get => _confidence;
         init => _confidence = ToolChainingHints.NormalizeConfidenceForContract(value);
+    }
+
+    /// <summary>
+    /// Stable flow identifier for multi-step orchestration across tool calls.
+    /// </summary>
+    public string FlowId {
+        get => _flowId;
+        init => _flowId = ToolChainingHints.NormalizeTokenForContract(value);
+    }
+
+    /// <summary>
+    /// Current flow step identifier (for example phase/page marker).
+    /// </summary>
+    public string StepId {
+        get => _stepId;
+        init => _stepId = ToolChainingHints.NormalizeTokenForContract(value);
+    }
+
+    /// <summary>
+    /// Structured checkpoint map for resumable long-flow progression.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Checkpoint {
+        get => _checkpoint;
+        init => _checkpoint = ToolChainingHints.NormalizeMapForContract(value);
     }
 }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.EventLog/EventLogNamedEventsQueryTool.cs
@@ -63,6 +63,9 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
         IReadOnlyList<ToolNextActionModel> NextActions,
         string Cursor,
         string ResumeToken,
+        string FlowId,
+        string StepId,
+        IReadOnlyDictionary<string, string> Checkpoint,
         IReadOnlyDictionary<string, string> Handoff,
         double Confidence);
 
@@ -204,6 +207,9 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
             NextActions: chain.NextActions,
             Cursor: chain.Cursor,
             ResumeToken: chain.ResumeToken,
+            FlowId: chain.FlowId,
+            StepId: chain.StepId,
+            Checkpoint: chain.Checkpoint,
             Handoff: chain.Handoff,
             Confidence: chain.Confidence);
 
@@ -309,7 +315,17 @@ public sealed class EventLogNamedEventsQueryTool : EventLogToolBase, ITool {
                 ("start", ToolTime.FormatUtc(startUtc) ?? string.Empty),
                 ("end", ToolTime.FormatUtc(endUtc) ?? string.Empty)),
             handoff: BuildHandoffMap(entityHandoff),
-            confidence: confidence);
+            confidence: confidence,
+            flowId: ToolChainingHints.BuildToken(
+                "eventlog_named_events_query.flow",
+                ("named_events", namedEvents.Count.ToString()),
+                ("machines", machines.Count.ToString())),
+            stepId: "named_events_page",
+            checkpoint: ToolChainingHints.Map(
+                ("rows", rows.Count),
+                ("truncated", truncated),
+                ("last_record_id", lastRecordId),
+                ("max_events", maxEvents)));
     }
 
     private static IReadOnlyDictionary<string, string> BuildSelfQueryArguments(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadModels.cs
@@ -12,6 +12,7 @@ namespace IntelligenceX.Tools.OfficeIMO;
 public sealed class OfficeImoReadResult {
     private IReadOnlyList<ToolNextActionModel> _nextActions = Array.Empty<ToolNextActionModel>();
     private IReadOnlyDictionary<string, string> _handoff = ToolChainingHints.EmptyMap;
+    private IReadOnlyDictionary<string, string> _checkpoint = ToolChainingHints.EmptyMap;
 
     /// <summary>
     /// Files ingested (resolved full paths).
@@ -96,6 +97,25 @@ public sealed class OfficeImoReadResult {
     /// Opaque resume token for orchestration loops.
     /// </summary>
     public string ResumeToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Stable flow identifier for long-running orchestration.
+    /// </summary>
+    public string FlowId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Current flow step identifier.
+    /// </summary>
+    public string StepId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Structured flow checkpoint used for resumable follow-ups.
+    /// Keys are normalized by trimming surrounding whitespace; normalized-key collisions use last-write-wins semantics.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Checkpoint {
+        get => _checkpoint;
+        set => _checkpoint = NormalizeHandoff(value);
+    }
 
     /// <summary>
     /// Structured handoff payload for downstream tools.

--- a/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.OfficeIMO/OfficeImoReadTool.cs
@@ -348,11 +348,25 @@ public sealed partial class OfficeImoReadTool : OfficeImoToolBase, ITool {
                 ("mode", result.OutputMode),
                 ("truncated", result.Truncated ? "1" : "0")),
             handoff: handoff,
-            confidence: confidence);
+            confidence: confidence,
+            flowId: ToolChainingHints.BuildToken(
+                "officeimo_read.flow",
+                ("path", fullPath ?? string.Empty),
+                ("mode", result.OutputMode)),
+            stepId: "read_result",
+            checkpoint: ToolChainingHints.Map(
+                ("files", result.Files.Count),
+                ("documents", result.Documents.Count),
+                ("chunks", result.ChunksReturned),
+                ("warnings", result.Warnings.Count),
+                ("truncated", result.Truncated)));
 
         result.NextActions = chain.NextActions;
         result.Cursor = chain.Cursor;
         result.ResumeToken = chain.ResumeToken;
+        result.FlowId = chain.FlowId;
+        result.StepId = chain.StepId;
+        result.Checkpoint = chain.Checkpoint;
         result.Handoff = chain.Handoff;
         result.Confidence = chain.Confidence;
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdForestDiscoverToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdForestDiscoverToolTests.cs
@@ -25,6 +25,9 @@ public sealed class AdForestDiscoverToolTests {
         Assert.True(root.TryGetProperty("next_actions", out var nextActions));
         Assert.True(root.TryGetProperty("cursor", out var cursor));
         Assert.True(root.TryGetProperty("resume_token", out var resumeToken));
+        Assert.True(root.TryGetProperty("flow_id", out var flowId));
+        Assert.True(root.TryGetProperty("step_id", out var stepId));
+        Assert.True(root.TryGetProperty("checkpoint", out var checkpoint));
         Assert.True(root.TryGetProperty("handoff", out var handoff));
         Assert.True(root.TryGetProperty("confidence", out var confidence));
         Assert.True(nextActions.ValueKind == global::System.Text.Json.JsonValueKind.Array);
@@ -32,6 +35,9 @@ public sealed class AdForestDiscoverToolTests {
         Assert.Equal("ad_forest_discover_handoff", handoff.GetProperty("contract").GetString());
         Assert.False(string.IsNullOrWhiteSpace(cursor.GetString()));
         Assert.False(string.IsNullOrWhiteSpace(resumeToken.GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(flowId.GetString()));
+        Assert.Equal("forest_receipt", stepId.GetString());
+        Assert.True(checkpoint.TryGetProperty("domains", out _));
         Assert.InRange(confidence.GetDouble(), 0d, 1d);
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdScopeDiscoveryToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdScopeDiscoveryToolTests.cs
@@ -71,6 +71,9 @@ public class AdScopeDiscoveryToolTests {
         Assert.True(root.TryGetProperty("next_actions", out var nextActions));
         Assert.True(root.TryGetProperty("cursor", out var cursor));
         Assert.True(root.TryGetProperty("resume_token", out var resumeToken));
+        Assert.True(root.TryGetProperty("flow_id", out var flowId));
+        Assert.True(root.TryGetProperty("step_id", out var stepId));
+        Assert.True(root.TryGetProperty("checkpoint", out var checkpoint));
         Assert.True(root.TryGetProperty("handoff", out var handoff));
         Assert.True(root.TryGetProperty("confidence", out var confidence));
         Assert.True(nextActions.ValueKind == global::System.Text.Json.JsonValueKind.Array);
@@ -78,6 +81,9 @@ public class AdScopeDiscoveryToolTests {
         Assert.Equal("ad_scope_discovery_handoff", handoff.GetProperty("contract").GetString());
         Assert.False(string.IsNullOrWhiteSpace(cursor.GetString()));
         Assert.False(string.IsNullOrWhiteSpace(resumeToken.GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(flowId.GetString()));
+        Assert.Equal("scope_receipt", stepId.GetString());
+        Assert.True(checkpoint.TryGetProperty("domains", out _));
         Assert.InRange(confidence.GetDouble(), 0d, 1d);
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogNamedEventsQueryToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/EventLogNamedEventsQueryToolTests.cs
@@ -34,6 +34,9 @@ public sealed class EventLogNamedEventsQueryToolTests {
         Assert.True(root.TryGetProperty("next_actions", out var nextActions));
         Assert.True(root.TryGetProperty("cursor", out var cursor));
         Assert.True(root.TryGetProperty("resume_token", out var resumeToken));
+        Assert.True(root.TryGetProperty("flow_id", out var flowId));
+        Assert.True(root.TryGetProperty("step_id", out var stepId));
+        Assert.True(root.TryGetProperty("checkpoint", out var checkpoint));
         Assert.True(root.TryGetProperty("handoff", out var handoff));
         Assert.True(root.TryGetProperty("confidence", out var confidence));
 
@@ -43,6 +46,9 @@ public sealed class EventLogNamedEventsQueryToolTests {
         Assert.Equal("eventlog_entity_handoff", handoff.GetProperty("contract").GetString());
         Assert.False(string.IsNullOrWhiteSpace(cursor.GetString()));
         Assert.False(string.IsNullOrWhiteSpace(resumeToken.GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(flowId.GetString()));
+        Assert.Equal("named_events_page", stepId.GetString());
+        Assert.True(checkpoint.TryGetProperty("rows", out _));
         Assert.InRange(confidence.GetDouble(), 0d, 1d);
     }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -140,6 +140,21 @@ public class OfficeImoReadToolTests {
     }
 
     [Fact]
+    public void OfficeImoReadResult_WhenCheckpointAssignedNullOrEmpty_UsesSharedEmptyMap() {
+        var result = new OfficeImoReadResult {
+            Checkpoint = null!
+        };
+
+        Assert.Same(ToolChainingHints.EmptyMap, result.Checkpoint);
+
+        result.Checkpoint = new Dictionary<string, string>(StringComparer.Ordinal);
+        Assert.Same(ToolChainingHints.EmptyMap, result.Checkpoint);
+
+        var dictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(result.Checkpoint);
+        Assert.Throws<NotSupportedException>(() => dictionary.Add("x", "1"));
+    }
+
+    [Fact]
     public void OfficeImoReadResult_WhenHandoffAssignedMutableMap_IsNormalizedAndReadOnly() {
         var source = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
             [" contract "] = "officeimo_read_handoff",
@@ -156,6 +171,26 @@ public class OfficeImoReadToolTests {
         Assert.False(result.Handoff.ContainsKey("new_key"));
 
         var dictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(result.Handoff);
+        Assert.Throws<NotSupportedException>(() => dictionary.Add("x", "1"));
+    }
+
+    [Fact]
+    public void OfficeImoReadResult_WhenCheckpointAssignedMutableMap_IsNormalizedAndReadOnly() {
+        var source = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+            [" phase "] = "collect",
+            [" "] = "ignored"
+        };
+
+        var result = new OfficeImoReadResult {
+            Checkpoint = source
+        };
+        source["new_key"] = "new_value";
+
+        Assert.True(result.Checkpoint.TryGetValue("phase", out var phase));
+        Assert.Equal("collect", phase);
+        Assert.False(result.Checkpoint.ContainsKey("new_key"));
+
+        var dictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(result.Checkpoint);
         Assert.Throws<NotSupportedException>(() => dictionary.Add("x", "1"));
     }
 
@@ -244,6 +279,9 @@ public class OfficeImoReadToolTests {
             Assert.True(root.TryGetProperty("next_actions", out var nextActions));
             Assert.True(root.TryGetProperty("cursor", out var cursor));
             Assert.True(root.TryGetProperty("resume_token", out var resumeToken));
+            Assert.True(root.TryGetProperty("flow_id", out var flowId));
+            Assert.True(root.TryGetProperty("step_id", out var stepId));
+            Assert.True(root.TryGetProperty("checkpoint", out var checkpoint));
             Assert.True(root.TryGetProperty("handoff", out var handoff));
             Assert.True(root.TryGetProperty("confidence", out var confidence));
             Assert.True(nextActions.ValueKind == global::System.Text.Json.JsonValueKind.Array);
@@ -251,6 +289,9 @@ public class OfficeImoReadToolTests {
             Assert.Equal("officeimo_read_handoff", handoff.GetProperty("contract").GetString());
             Assert.False(string.IsNullOrWhiteSpace(cursor.GetString()));
             Assert.False(string.IsNullOrWhiteSpace(resumeToken.GetString()));
+            Assert.False(string.IsNullOrWhiteSpace(flowId.GetString()));
+            Assert.Equal("read_result", stepId.GetString());
+            Assert.True(checkpoint.TryGetProperty("files", out _));
             Assert.InRange(confidence.GetDouble(), 0d, 1d);
             Assert.True(root.TryGetProperty("documents", out var documents));
             Assert.True(root.TryGetProperty("chunks", out var chunks));

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolChainingHintsTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolChainingHintsTests.cs
@@ -18,7 +18,10 @@ public sealed class ToolChainingHintsTests {
             cursor: "  c1  ",
             resumeToken: "  r1  ",
             handoff: ToolChainingHints.Map(("contract", "test")),
-            confidence: 2.2d);
+            confidence: 2.2d,
+            flowId: "  flow-1  ",
+            stepId: "  step-1  ",
+            checkpoint: ToolChainingHints.Map(("phase", "collect")));
 
         Assert.Single(chain.NextActions);
         Assert.Equal("officeimo_read", chain.NextActions[0].Tool);
@@ -27,6 +30,9 @@ public sealed class ToolChainingHintsTests {
         Assert.Equal("r1", chain.ResumeToken);
         Assert.True(chain.Handoff.TryGetValue("contract", out var contract));
         Assert.Equal("test", contract?.ToString());
+        Assert.Equal("flow-1", chain.FlowId);
+        Assert.Equal("step-1", chain.StepId);
+        Assert.Equal("collect", chain.Checkpoint["phase"]);
         Assert.Equal(1d, chain.Confidence);
     }
 
@@ -57,6 +63,9 @@ public sealed class ToolChainingHintsTests {
         Assert.Empty(chain.NextActions);
         Assert.Equal(string.Empty, chain.Cursor);
         Assert.Equal(string.Empty, chain.ResumeToken);
+        Assert.Equal(string.Empty, chain.FlowId);
+        Assert.Equal(string.Empty, chain.StepId);
+        Assert.Same(ToolChainingHints.EmptyMap, chain.Checkpoint);
 
         var dictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(chain.Handoff);
         Assert.Throws<NotSupportedException>(() => dictionary.Add("x", "1"));
@@ -81,6 +90,11 @@ public sealed class ToolChainingHintsTests {
             NextActions = actions,
             Cursor = " c1 ",
             ResumeToken = " r1 ",
+            FlowId = " flow-1 ",
+            StepId = " step-1 ",
+            Checkpoint = new Dictionary<string, string>(StringComparer.Ordinal) {
+                [" phase "] = "collect"
+            },
             Handoff = handoff,
             Confidence = 2.0d
         };
@@ -93,6 +107,9 @@ public sealed class ToolChainingHintsTests {
         Assert.Equal("follow up", chain.NextActions[0].Reason);
         Assert.Equal("c1", chain.Cursor);
         Assert.Equal("r1", chain.ResumeToken);
+        Assert.Equal("flow-1", chain.FlowId);
+        Assert.Equal("step-1", chain.StepId);
+        Assert.Equal("collect", chain.Checkpoint["phase"]);
         Assert.Equal(1d, chain.Confidence);
         Assert.True(chain.Handoff.ContainsKey("contract"));
         Assert.False(chain.Handoff.ContainsKey("new"));
@@ -100,6 +117,8 @@ public sealed class ToolChainingHintsTests {
         var actionsList = Assert.IsAssignableFrom<IList<ToolNextActionModel>>(chain.NextActions);
         Assert.Throws<NotSupportedException>(() => actionsList.Add(new ToolNextActionModel { Tool = "z", Reason = "r" }));
         Assert.Throws<NotSupportedException>(() => actionsList[0] = new ToolNextActionModel { Tool = "z", Reason = "r" });
+        var checkpointMap = Assert.IsAssignableFrom<IDictionary<string, string>>(chain.Checkpoint);
+        Assert.Throws<NotSupportedException>(() => checkpointMap.Add("x", "1"));
         var handoffMap = Assert.IsAssignableFrom<IDictionary<string, string>>(chain.Handoff);
         Assert.Throws<NotSupportedException>(() => handoffMap.Add("x", "1"));
     }
@@ -133,6 +152,9 @@ public sealed class ToolChainingHintsTests {
             NextActions = null!,
             Cursor = null!,
             ResumeToken = null!,
+            FlowId = null!,
+            StepId = null!,
+            Checkpoint = null!,
             Handoff = null!,
             Confidence = 0.5d
         };
@@ -140,6 +162,9 @@ public sealed class ToolChainingHintsTests {
         Assert.Empty(chain.NextActions);
         Assert.Equal(string.Empty, chain.Cursor);
         Assert.Equal(string.Empty, chain.ResumeToken);
+        Assert.Equal(string.Empty, chain.FlowId);
+        Assert.Equal(string.Empty, chain.StepId);
+        Assert.Same(ToolChainingHints.EmptyMap, chain.Checkpoint);
         Assert.Equal(0.5d, chain.Confidence);
 
         var actions = Assert.IsAssignableFrom<IList<ToolNextActionModel>>(chain.NextActions);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolCommonCollectionGuardrailTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolCommonCollectionGuardrailTests.cs
@@ -66,6 +66,13 @@ public sealed class ToolCommonCollectionGuardrailTests {
             Handoff = handoff
         };
 
+        var checkpoint = new Dictionary<string, string>(StringComparer.Ordinal) {
+            ["phase"] = "collect"
+        };
+        var chainCheckpoint = new ToolChainContractModel {
+            Checkpoint = checkpoint
+        };
+
         var suggestedArguments = new Dictionary<string, string>(StringComparer.Ordinal) {
             ["path"] = @"C:\docs"
         };
@@ -180,6 +187,18 @@ public sealed class ToolCommonCollectionGuardrailTests {
                 AssertSnapshot: static value => {
                     var map = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(value);
                     Assert.Equal("scope", map["contract"]);
+                    Assert.False(map.ContainsKey("new"));
+                },
+                AssertImmutable: static value => AssertReadOnlyDictionary(value)),
+
+            new GuardCase(
+                ModelType: typeof(ToolChainContractModel),
+                PropertyName: nameof(ToolChainContractModel.Checkpoint),
+                Model: chainCheckpoint,
+                MutateSource: () => checkpoint["new"] = "value",
+                AssertSnapshot: static value => {
+                    var map = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(value);
+                    Assert.Equal("collect", map["phase"]);
                     Assert.False(map.ContainsKey("new"));
                 },
                 AssertImmutable: static value => AssertReadOnlyDictionary(value)),


### PR DESCRIPTION
## Summary
- extend `ToolChainContractModel`/`ToolChainingHints.Create` with long-flow fields: `flow_id`, `step_id`, and `checkpoint`
- propagate new flow fields into chain-capable tool responses:
  - `ad_scope_discovery`
  - `ad_forest_discover`
  - `eventlog_named_events_query`
  - `officeimo_read`
- add/extend tests to validate presence, normalization, defensive copying, and read-only behavior for new flow fields

## Testing
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolChainingHintsTests|FullyQualifiedName~AdScopeDiscoveryToolTests|FullyQualifiedName~AdForestDiscoverToolTests|FullyQualifiedName~EventLogNamedEventsQueryToolTests|FullyQualifiedName~OfficeImoReadToolTests|FullyQualifiedName~ToolCommonCollectionGuardrailTests"`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`