### PR TITLE
Tools: add shared ToolPipeline reliability middleware

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolBase.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolBase.cs
@@ -32,6 +32,7 @@ public abstract class ToolBase : ITool {
         CancellationToken cancellationToken,
         Func<JsonObject?, ToolRequestBindingResult<TRequest>> binder,
         ToolPipelineNext<TRequest> execute,
+        ToolPipelineReliabilityOptions? reliability = null,
         IReadOnlyList<ToolPipelineMiddleware<TRequest>>? middleware = null)
         where TRequest : notnull {
         return ToolPipeline.RunAsync(
@@ -40,6 +41,7 @@ public abstract class ToolBase : ITool {
             cancellationToken: cancellationToken,
             binder: binder,
             terminal: execute,
+            reliability: reliability,
             middleware: middleware);
     }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.Reliability.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.Reliability.cs
@@ -1,0 +1,424 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IntelligenceX.Tools.Common;
+
+/// <summary>
+/// Shared reliability settings for typed tool execution pipelines.
+/// </summary>
+public sealed class ToolPipelineReliabilityOptions {
+    /// <summary>
+    /// Recommended defaults for read-only tools where retries are safe.
+    /// </summary>
+    public static ToolPipelineReliabilityOptions ReadOnlyDefaults => new() {
+        MaxAttempts = 3,
+        RetryTransientErrors = true,
+        RetryExceptions = true,
+        RetryNonTransientExceptions = false,
+        AttemptTimeoutMs = 0,
+        BaseDelayMs = 120,
+        MaxDelayMs = 1200,
+        JitterRatio = 0.10d,
+        EnableCircuitBreaker = true,
+        CircuitFailureThreshold = 4,
+        CircuitOpenMs = 15_000
+    };
+
+    /// <summary>
+    /// Total attempts including the first execution.
+    /// </summary>
+    public int MaxAttempts { get; init; } = 1;
+
+    /// <summary>
+    /// Retries envelope responses marked transient (<c>is_transient=true</c>).
+    /// </summary>
+    public bool RetryTransientErrors { get; init; } = true;
+
+    /// <summary>
+    /// Retries exceptions classified as transient.
+    /// </summary>
+    public bool RetryExceptions { get; init; } = true;
+
+    /// <summary>
+    /// Retries exceptions not classified as transient.
+    /// </summary>
+    public bool RetryNonTransientExceptions { get; init; }
+
+    /// <summary>
+    /// Per-attempt timeout in milliseconds. Set to 0 to disable.
+    /// </summary>
+    public int AttemptTimeoutMs { get; init; }
+
+    /// <summary>
+    /// Base retry delay in milliseconds.
+    /// </summary>
+    public int BaseDelayMs { get; init; } = 100;
+
+    /// <summary>
+    /// Maximum retry delay in milliseconds.
+    /// </summary>
+    public int MaxDelayMs { get; init; } = 1000;
+
+    /// <summary>
+    /// Jitter applied to retry delay (0..0.5).
+    /// </summary>
+    public double JitterRatio { get; init; } = 0.10d;
+
+    /// <summary>
+    /// Enables a best-effort transient-failure circuit breaker.
+    /// </summary>
+    public bool EnableCircuitBreaker { get; init; }
+
+    /// <summary>
+    /// Transient-failure threshold that opens the circuit.
+    /// </summary>
+    public int CircuitFailureThreshold { get; init; } = 4;
+
+    /// <summary>
+    /// Circuit-open duration in milliseconds.
+    /// </summary>
+    public int CircuitOpenMs { get; init; } = 15_000;
+
+    /// <summary>
+    /// Optional circuit-key override. Defaults to tool definition name.
+    /// </summary>
+    public string? CircuitKey { get; init; }
+
+    /// <summary>
+    /// Optional clock provider used by reliability middleware.
+    /// </summary>
+    public Func<DateTimeOffset>? UtcNowProvider { get; init; }
+
+    /// <summary>
+    /// Optional delay provider used by retry backoff logic.
+    /// </summary>
+    public Func<TimeSpan, CancellationToken, Task>? DelayAsync { get; init; }
+
+    internal ToolPipelineReliabilityOptions Normalize() {
+        var maxAttempts = Math.Clamp(MaxAttempts, 1, 10);
+        var attemptTimeoutMs = Math.Clamp(AttemptTimeoutMs, 0, 300_000);
+        var baseDelayMs = Math.Clamp(BaseDelayMs, 0, 30_000);
+        var maxDelayMs = Math.Clamp(MaxDelayMs, baseDelayMs, 120_000);
+        var jitterRatio = Math.Clamp(JitterRatio, 0d, 0.5d);
+        var circuitFailureThreshold = Math.Clamp(CircuitFailureThreshold, 1, 50);
+        var circuitOpenMs = Math.Clamp(CircuitOpenMs, 100, 600_000);
+
+        return new ToolPipelineReliabilityOptions {
+            MaxAttempts = maxAttempts,
+            RetryTransientErrors = RetryTransientErrors,
+            RetryExceptions = RetryExceptions,
+            RetryNonTransientExceptions = RetryNonTransientExceptions,
+            AttemptTimeoutMs = attemptTimeoutMs,
+            BaseDelayMs = baseDelayMs,
+            MaxDelayMs = maxDelayMs,
+            JitterRatio = jitterRatio,
+            EnableCircuitBreaker = EnableCircuitBreaker,
+            CircuitFailureThreshold = circuitFailureThreshold,
+            CircuitOpenMs = circuitOpenMs,
+            CircuitKey = string.IsNullOrWhiteSpace(CircuitKey) ? null : CircuitKey.Trim(),
+            UtcNowProvider = UtcNowProvider,
+            DelayAsync = DelayAsync
+        };
+    }
+}
+
+public static partial class ToolPipeline {
+    /// <summary>
+    /// Context-item key for current reliability attempt number (1-based).
+    /// </summary>
+    public const string ReliabilityAttemptItemKey = "tool_pipeline.reliability.attempt";
+
+    /// <summary>
+    /// Context-item key for retry count completed before current attempt.
+    /// </summary>
+    public const string ReliabilityRetryCountItemKey = "tool_pipeline.reliability.retry_count";
+
+    private static readonly ConcurrentDictionary<string, CircuitState> CircuitStates =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Creates reliability middleware (retry/backoff/timeout/circuit-breaker).
+    /// </summary>
+    public static ToolPipelineMiddleware<TRequest> Reliability<TRequest>(ToolPipelineReliabilityOptions options)
+        where TRequest : notnull {
+        ArgumentNullException.ThrowIfNull(options);
+        var resolved = options.Normalize();
+
+        return async (context, cancellationToken, next) => {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var nowProvider = resolved.UtcNowProvider ?? (() => DateTimeOffset.UtcNow);
+            var delayAsync = resolved.DelayAsync ?? ((delay, token) => Task.Delay(delay, token));
+            var circuitKey = ResolveCircuitKey(context.Definition.Name, resolved.CircuitKey);
+
+            if (resolved.EnableCircuitBreaker &&
+                TryGetCircuitRetryAfter(circuitKey, nowProvider(), out var retryAfter)) {
+                return ToolResponse.Error(
+                    "circuit_open",
+                    "Transient failure circuit is open for this tool. Retry after cooldown.",
+                    hints: new[] { $"retry_after_ms={Math.Max(1, (int)Math.Ceiling(retryAfter.TotalMilliseconds))}" },
+                    isTransient: true);
+            }
+
+            for (var attempt = 1; attempt <= resolved.MaxAttempts; attempt++) {
+                context.SetItem(ReliabilityAttemptItemKey, attempt);
+                context.SetItem(ReliabilityRetryCountItemKey, attempt - 1);
+
+                var outcome = await ExecuteAttemptAsync(
+                    context,
+                    cancellationToken,
+                    next,
+                    attempt,
+                    resolved).ConfigureAwait(false);
+
+                if (!outcome.ShouldRetry) {
+                    RecordCircuitOutcome(circuitKey, nowProvider(), outcome.IsTransientFailure, resolved);
+                    return outcome.Result;
+                }
+
+                await DelayBeforeRetryAsync(
+                    attempt,
+                    resolved,
+                    delayAsync,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            RecordCircuitOutcome(circuitKey, nowProvider(), transientFailure: true, resolved);
+            return ToolResponse.Error("query_failed", "Tool pipeline retry budget was exhausted.", isTransient: true);
+        };
+    }
+
+    private static async Task<ReliabilityAttemptOutcome> ExecuteAttemptAsync<TRequest>(
+        ToolPipelineContext<TRequest> context,
+        CancellationToken cancellationToken,
+        ToolPipelineNext<TRequest> next,
+        int attempt,
+        ToolPipelineReliabilityOptions options)
+        where TRequest : notnull {
+        CancellationTokenSource? linked = null;
+        var attemptToken = cancellationToken;
+
+        try {
+            if (options.AttemptTimeoutMs > 0) {
+                linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                linked.CancelAfter(options.AttemptTimeoutMs);
+                attemptToken = linked.Token;
+            }
+
+            var result = await next(context, attemptToken).ConfigureAwait(false);
+            var status = ClassifyEnvelope(result);
+
+            var transientFailure = status.IsEnvelope && !status.Ok && status.IsTransient;
+            var shouldRetry = transientFailure &&
+                              options.RetryTransientErrors &&
+                              attempt < options.MaxAttempts;
+
+            return new ReliabilityAttemptOutcome(result, transientFailure, shouldRetry);
+        } catch (OperationCanceledException) when (
+            !cancellationToken.IsCancellationRequested &&
+            linked is not null &&
+            linked.IsCancellationRequested) {
+            var timeoutResult = ToolResponse.Error(
+                "timeout",
+                $"Operation timed out after {options.AttemptTimeoutMs}ms.",
+                isTransient: true);
+            var shouldRetry = options.RetryTransientErrors && attempt < options.MaxAttempts;
+            return new ReliabilityAttemptOutcome(timeoutResult, IsTransientFailure: true, ShouldRetry: shouldRetry);
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception ex) {
+            var transientException = IsTransientException(ex);
+            var shouldRetry = attempt < options.MaxAttempts &&
+                              ((transientException && options.RetryExceptions) ||
+                               (!transientException && options.RetryNonTransientExceptions));
+
+            var mapped = MapExceptionEnvelope(ex, transientException);
+            return new ReliabilityAttemptOutcome(
+                mapped,
+                IsTransientFailure: transientException,
+                ShouldRetry: shouldRetry);
+        } finally {
+            linked?.Dispose();
+        }
+    }
+
+    private static async Task DelayBeforeRetryAsync(
+        int attempt,
+        ToolPipelineReliabilityOptions options,
+        Func<TimeSpan, CancellationToken, Task> delayAsync,
+        CancellationToken cancellationToken) {
+        if (options.BaseDelayMs <= 0) {
+            return;
+        }
+
+        var exponent = Math.Clamp(attempt - 1, 0, 30);
+        var candidate = (long)options.BaseDelayMs << exponent;
+        var delayMs = (int)Math.Min(options.MaxDelayMs, candidate);
+
+        if (options.JitterRatio > 0d && delayMs > 0) {
+            var jitterWindow = (int)Math.Round(delayMs * options.JitterRatio, MidpointRounding.AwayFromZero);
+            if (jitterWindow > 0) {
+                delayMs = Math.Max(0, delayMs + Random.Shared.Next(-jitterWindow, jitterWindow + 1));
+            }
+        }
+
+        if (delayMs <= 0) {
+            return;
+        }
+
+        await delayAsync(TimeSpan.FromMilliseconds(delayMs), cancellationToken).ConfigureAwait(false);
+    }
+
+    private static EnvelopeStatus ClassifyEnvelope(string payload) {
+        if (string.IsNullOrWhiteSpace(payload)) {
+            return EnvelopeStatus.NonEnvelope;
+        }
+
+        try {
+            using var document = JsonDocument.Parse(payload);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object ||
+                !root.TryGetProperty("ok", out var okNode) ||
+                okNode.ValueKind is not (JsonValueKind.True or JsonValueKind.False)) {
+                return EnvelopeStatus.NonEnvelope;
+            }
+
+            var ok = okNode.GetBoolean();
+            if (ok) {
+                return new EnvelopeStatus(IsEnvelope: true, Ok: true, IsTransient: false);
+            }
+
+            var isTransient = root.TryGetProperty("is_transient", out var transientNode) &&
+                              transientNode.ValueKind is JsonValueKind.True or JsonValueKind.False &&
+                              transientNode.GetBoolean();
+            if (!isTransient &&
+                root.TryGetProperty("error_code", out var errorCodeNode) &&
+                errorCodeNode.ValueKind == JsonValueKind.String) {
+                var errorCode = errorCodeNode.GetString();
+                isTransient = IsKnownTransientErrorCode(errorCode);
+            }
+
+            return new EnvelopeStatus(IsEnvelope: true, Ok: false, IsTransient: isTransient);
+        } catch {
+            return EnvelopeStatus.NonEnvelope;
+        }
+    }
+
+    private static bool IsKnownTransientErrorCode(string? errorCode) {
+        return errorCode switch {
+            "timeout" => true,
+            "cancelled" => true,
+            "circuit_open" => true,
+            _ => false
+        };
+    }
+
+    private static bool IsTransientException(Exception exception) {
+        return exception is TimeoutException
+            or IOException
+            or SocketException
+            or HttpRequestException
+            or TaskCanceledException;
+    }
+
+    private static string MapExceptionEnvelope(Exception exception, bool transientException) {
+        var mapped = ToolExceptionMapper.ErrorFromException(
+            exception,
+            defaultMessage: "Tool execution failed.",
+            unauthorizedMessage: "Access denied.",
+            timeoutMessage: "Operation timed out.");
+
+        if (!transientException) {
+            return mapped;
+        }
+
+        var status = ClassifyEnvelope(mapped);
+        if (status.IsEnvelope && status.IsTransient) {
+            return mapped;
+        }
+
+        return ToolResponse.Error(
+            "query_failed",
+            ToolExceptionMapper.SanitizeErrorMessage(exception.Message, "Tool execution failed."),
+            isTransient: true);
+    }
+
+    private static string ResolveCircuitKey(string toolName, string? overrideKey) {
+        if (!string.IsNullOrWhiteSpace(overrideKey)) {
+            return overrideKey.Trim();
+        }
+
+        return string.IsNullOrWhiteSpace(toolName)
+            ? "tool_pipeline"
+            : toolName.Trim();
+    }
+
+    private static bool TryGetCircuitRetryAfter(string key, DateTimeOffset nowUtc, out TimeSpan retryAfter) {
+        retryAfter = TimeSpan.Zero;
+        if (!CircuitStates.TryGetValue(key, out var state)) {
+            return false;
+        }
+
+        lock (state.Gate) {
+            if (state.OpenUntilUtc <= nowUtc) {
+                // Keep consecutive failure count while closed so thresholds can accumulate
+                // across separate invocations; clear only the stale open marker.
+                state.OpenUntilUtc = DateTimeOffset.MinValue;
+                return false;
+            }
+
+            retryAfter = state.OpenUntilUtc - nowUtc;
+            return true;
+        }
+    }
+
+    private static void RecordCircuitOutcome(
+        string key,
+        DateTimeOffset nowUtc,
+        bool transientFailure,
+        ToolPipelineReliabilityOptions options) {
+        if (!options.EnableCircuitBreaker) {
+            return;
+        }
+
+        var state = CircuitStates.GetOrAdd(key, static _ => new CircuitState());
+        lock (state.Gate) {
+            if (!transientFailure) {
+                state.ConsecutiveTransientFailures = 0;
+                state.OpenUntilUtc = DateTimeOffset.MinValue;
+                return;
+            }
+
+            state.ConsecutiveTransientFailures++;
+            if (state.ConsecutiveTransientFailures < options.CircuitFailureThreshold) {
+                return;
+            }
+
+            state.ConsecutiveTransientFailures = 0;
+            state.OpenUntilUtc = nowUtc.AddMilliseconds(options.CircuitOpenMs);
+        }
+    }
+
+    private sealed class CircuitState {
+        public object Gate { get; } = new();
+
+        public int ConsecutiveTransientFailures { get; set; }
+
+        public DateTimeOffset OpenUntilUtc { get; set; } = DateTimeOffset.MinValue;
+    }
+
+    private readonly record struct EnvelopeStatus(bool IsEnvelope, bool Ok, bool IsTransient) {
+        public static EnvelopeStatus NonEnvelope { get; } = new(IsEnvelope: false, Ok: true, IsTransient: false);
+    }
+
+    private readonly record struct ReliabilityAttemptOutcome(
+        string Result,
+        bool IsTransientFailure,
+        bool ShouldRetry);
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.cs
@@ -90,7 +90,7 @@ public sealed class ToolPipelineContext<TRequest> where TRequest : notnull {
 /// <summary>
 /// Shared typed pipeline runner for tool execution.
 /// </summary>
-public static class ToolPipeline {
+public static partial class ToolPipeline {
     /// <summary>
     /// Runs binder, middleware, and terminal execution for a tool call.
     /// </summary>
@@ -100,6 +100,7 @@ public static class ToolPipeline {
         CancellationToken cancellationToken,
         Func<JsonObject?, ToolRequestBindingResult<TRequest>> binder,
         ToolPipelineNext<TRequest> terminal,
+        ToolPipelineReliabilityOptions? reliability = null,
         IReadOnlyList<ToolPipelineMiddleware<TRequest>>? middleware = null)
         where TRequest : notnull {
         ArgumentNullException.ThrowIfNull(definition);
@@ -125,6 +126,12 @@ public static class ToolPipeline {
                 var next = chain;
                 chain = (ctx, token) => current(ctx, token, next);
             }
+        }
+
+        if (reliability is not null) {
+            var reliabilityMiddleware = Reliability<TRequest>(reliability);
+            var next = chain;
+            chain = (ctx, token) => reliabilityMiddleware(ctx, token, next);
         }
 
         return chain(context, cancellationToken);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailSmtpProbeTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailSmtpProbeTool.cs
@@ -14,6 +14,18 @@ namespace IntelligenceX.Tools.Email;
 /// </summary>
 public sealed class EmailSmtpProbeTool : EmailToolBase, ITool {
     private sealed record ProbeRequest;
+    private static readonly ToolPipelineReliabilityOptions ReliabilityOptions = new() {
+        MaxAttempts = 3,
+        RetryTransientErrors = true,
+        RetryExceptions = true,
+        AttemptTimeoutMs = 12_000,
+        BaseDelayMs = 150,
+        MaxDelayMs = 1_000,
+        JitterRatio = 0.10d,
+        EnableCircuitBreaker = true,
+        CircuitFailureThreshold = 4,
+        CircuitOpenMs = 10_000
+    };
 
     private static readonly ToolDefinition DefinitionValue = new(
         SmtpProbePolicy.ProbeToolName,
@@ -39,6 +51,7 @@ public sealed class EmailSmtpProbeTool : EmailToolBase, ITool {
             cancellationToken: cancellationToken,
             binder: BindRequest,
             execute: ExecuteRequestAsync,
+            reliability: ReliabilityOptions,
             middleware: new ToolPipelineMiddleware<ProbeRequest>[] {
                 EnsureSmtpConfiguredAsync
             }).ConfigureAwait(false);

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPipelineTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPipelineTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.IO;
 using IntelligenceX.Json;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
@@ -95,5 +96,198 @@ public sealed class ToolPipelineTests {
         var root = document.RootElement;
         Assert.True(root.GetProperty("ok").GetBoolean());
         Assert.Equal(42, root.GetProperty("value").GetInt32());
+    }
+
+    [Fact]
+    public async Task Reliability_ShouldRetryTransientEnvelopeAndEventuallySucceed() {
+        var definition = new ToolDefinition(
+            "pipeline_stub",
+            "Pipeline stub",
+            ToolSchema.Object().NoAdditionalProperties());
+
+        var attempts = 0;
+        var json = await ToolPipeline.RunAsync(
+            definition: definition,
+            arguments: null,
+            cancellationToken: CancellationToken.None,
+            binder: _ => ToolRequestBindingResult<StubRequest>.Success(new StubRequest(7)),
+            terminal: (_, _) => {
+                attempts++;
+                return Task.FromResult(
+                    attempts == 1
+                        ? ToolResponse.Error("timeout", "Temporary timeout.", isTransient: true)
+                        : ToolResultV2.OkModel(new { Attempt = attempts }));
+            },
+            reliability: new ToolPipelineReliabilityOptions {
+                MaxAttempts = 3,
+                RetryTransientErrors = true,
+                BaseDelayMs = 0,
+                MaxDelayMs = 0,
+                DelayAsync = static (_, _) => Task.CompletedTask
+            });
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(2, root.GetProperty("attempt").GetInt32());
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
+    public async Task Reliability_ShouldNotRetryNonTransientEnvelope() {
+        var definition = new ToolDefinition(
+            "pipeline_stub",
+            "Pipeline stub",
+            ToolSchema.Object().NoAdditionalProperties());
+
+        var attempts = 0;
+        var json = await ToolPipeline.RunAsync(
+            definition: definition,
+            arguments: null,
+            cancellationToken: CancellationToken.None,
+            binder: _ => ToolRequestBindingResult<StubRequest>.Success(new StubRequest(7)),
+            terminal: (_, _) => {
+                attempts++;
+                return Task.FromResult(ToolResponse.Error("invalid_argument", "Invalid input."));
+            },
+            reliability: new ToolPipelineReliabilityOptions {
+                MaxAttempts = 3,
+                RetryTransientErrors = true,
+                BaseDelayMs = 0,
+                MaxDelayMs = 0,
+                DelayAsync = static (_, _) => Task.CompletedTask
+            });
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("invalid_argument", root.GetProperty("error_code").GetString());
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public async Task Reliability_ShouldRetryTransientExceptionAndEventuallySucceed() {
+        var definition = new ToolDefinition(
+            "pipeline_stub",
+            "Pipeline stub",
+            ToolSchema.Object().NoAdditionalProperties());
+
+        var attempts = 0;
+        var json = await ToolPipeline.RunAsync(
+            definition: definition,
+            arguments: null,
+            cancellationToken: CancellationToken.None,
+            binder: _ => ToolRequestBindingResult<StubRequest>.Success(new StubRequest(7)),
+            terminal: (_, _) => {
+                attempts++;
+                if (attempts == 1) {
+                    throw new IOException("I/O probe failed.");
+                }
+
+                return Task.FromResult(ToolResultV2.OkModel(new { Attempt = attempts }));
+            },
+            reliability: new ToolPipelineReliabilityOptions {
+                MaxAttempts = 3,
+                RetryExceptions = true,
+                BaseDelayMs = 0,
+                MaxDelayMs = 0,
+                DelayAsync = static (_, _) => Task.CompletedTask
+            });
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(2, root.GetProperty("attempt").GetInt32());
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
+    public async Task Reliability_WhenAttemptTimeoutExceeded_ShouldReturnTimeoutError() {
+        var definition = new ToolDefinition(
+            "pipeline_stub",
+            "Pipeline stub",
+            ToolSchema.Object().NoAdditionalProperties());
+
+        var json = await ToolPipeline.RunAsync(
+            definition: definition,
+            arguments: null,
+            cancellationToken: CancellationToken.None,
+            binder: _ => ToolRequestBindingResult<StubRequest>.Success(new StubRequest(7)),
+            terminal: async (_, cancellationToken) => {
+                await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+                return ToolResultV2.OkModel(new { Attempt = 1 });
+            },
+            reliability: new ToolPipelineReliabilityOptions {
+                MaxAttempts = 1,
+                AttemptTimeoutMs = 40,
+                RetryTransientErrors = false
+            });
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("timeout", root.GetProperty("error_code").GetString());
+        Assert.True(root.GetProperty("is_transient").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Reliability_WhenCircuitOpens_ShouldShortCircuitUntilCooldownExpires() {
+        var definition = new ToolDefinition(
+            "pipeline_stub",
+            "Pipeline stub",
+            ToolSchema.Object().NoAdditionalProperties());
+
+        var now = new DateTimeOffset(2026, 2, 21, 0, 0, 0, TimeSpan.Zero);
+        var circuitKey = "pipeline_test_circuit_" + Guid.NewGuid().ToString("N");
+        var options = new ToolPipelineReliabilityOptions {
+            MaxAttempts = 1,
+            RetryTransientErrors = false,
+            EnableCircuitBreaker = true,
+            CircuitFailureThreshold = 2,
+            CircuitOpenMs = 30_000,
+            CircuitKey = circuitKey,
+            UtcNowProvider = () => now
+        };
+
+        var terminalCalls = 0;
+
+        static ToolRequestBindingResult<StubRequest> BindStub(JsonObject? _) =>
+            ToolRequestBindingResult<StubRequest>.Success(new StubRequest(7));
+
+        async Task<string> InvokeOnce(bool transientFailure) {
+            return await ToolPipeline.RunAsync(
+                definition: definition,
+                arguments: null,
+                cancellationToken: CancellationToken.None,
+                binder: BindStub,
+                terminal: (_, _) => {
+                    terminalCalls++;
+                    return Task.FromResult(
+                        transientFailure
+                            ? ToolResponse.Error("timeout", "Temporary timeout.", isTransient: true)
+                            : ToolResultV2.OkModel(new { Attempt = terminalCalls }));
+                },
+                reliability: options);
+        }
+
+        var first = await InvokeOnce(transientFailure: true);
+        var second = await InvokeOnce(transientFailure: true);
+        var third = await InvokeOnce(transientFailure: false);
+
+        using var firstDoc = JsonDocument.Parse(first);
+        using var secondDoc = JsonDocument.Parse(second);
+        using var thirdDoc = JsonDocument.Parse(third);
+
+        Assert.False(firstDoc.RootElement.GetProperty("ok").GetBoolean());
+        Assert.False(secondDoc.RootElement.GetProperty("ok").GetBoolean());
+        Assert.False(thirdDoc.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal("circuit_open", thirdDoc.RootElement.GetProperty("error_code").GetString());
+        Assert.Equal(2, terminalCalls);
+
+        now = now.AddSeconds(31);
+        var fourth = await InvokeOnce(transientFailure: false);
+        using var fourthDoc = JsonDocument.Parse(fourth);
+        Assert.True(fourthDoc.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal(3, terminalCalls);
     }
 }


### PR DESCRIPTION
## Summary
- add shared `ToolPipeline` reliability middleware with retry/backoff/jitter, per-attempt timeout, and circuit-breaker support
- expose reliability options through `ToolPipeline.RunAsync` and `ToolBase.RunPipelineAsync`
- adopt shared reliability profile in `EmailSmtpProbeTool` to improve transient failure handling
- add focused `ToolPipelineTests` coverage for transient envelopes/exceptions, timeout behavior, and circuit open/cooldown flow

## Why
- fix recurring transient/serialization-related tool instability by standardizing retry + timeout behavior in one reusable layer
- keep tool contracts stable while allowing long multi-step flows to recover safely from temporary failures

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolPipelineTests|FullyQualifiedName~EmailSmtpProbeStrictModeTests"`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`