### PR TITLE
Tools: add shared reliability profiles and semantics tests

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.Reliability.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.Reliability.cs
@@ -16,19 +16,7 @@ public sealed class ToolPipelineReliabilityOptions {
     /// <summary>
     /// Recommended defaults for read-only tools where retries are safe.
     /// </summary>
-    public static ToolPipelineReliabilityOptions ReadOnlyDefaults => new() {
-        MaxAttempts = 3,
-        RetryTransientErrors = true,
-        RetryExceptions = true,
-        RetryNonTransientExceptions = false,
-        AttemptTimeoutMs = 0,
-        BaseDelayMs = 120,
-        MaxDelayMs = 1200,
-        JitterRatio = 0.10d,
-        EnableCircuitBreaker = true,
-        CircuitFailureThreshold = 4,
-        CircuitOpenMs = 15_000
-    };
+    public static ToolPipelineReliabilityOptions ReadOnlyDefaults => ToolPipelineReliabilityProfiles.ReadOnlyQuery;
 
     /// <summary>
     /// Total attempts including the first execution.
@@ -126,6 +114,45 @@ public sealed class ToolPipelineReliabilityOptions {
             DelayAsync = DelayAsync
         };
     }
+}
+
+/// <summary>
+/// Shared reliability presets used by tools to avoid option drift.
+/// </summary>
+public static class ToolPipelineReliabilityProfiles {
+    /// <summary>
+    /// Balanced retries for read-only queries.
+    /// </summary>
+    public static ToolPipelineReliabilityOptions ReadOnlyQuery => new() {
+        MaxAttempts = 3,
+        RetryTransientErrors = true,
+        RetryExceptions = true,
+        RetryNonTransientExceptions = false,
+        AttemptTimeoutMs = 0,
+        BaseDelayMs = 120,
+        MaxDelayMs = 1200,
+        JitterRatio = 0.10d,
+        EnableCircuitBreaker = true,
+        CircuitFailureThreshold = 4,
+        CircuitOpenMs = 15_000
+    };
+
+    /// <summary>
+    /// Aggressive but bounded retries for fast connectivity probes.
+    /// </summary>
+    public static ToolPipelineReliabilityOptions FastNetworkProbe => new() {
+        MaxAttempts = 3,
+        RetryTransientErrors = true,
+        RetryExceptions = true,
+        RetryNonTransientExceptions = false,
+        AttemptTimeoutMs = 12_000,
+        BaseDelayMs = 150,
+        MaxDelayMs = 1_000,
+        JitterRatio = 0.10d,
+        EnableCircuitBreaker = true,
+        CircuitFailureThreshold = 4,
+        CircuitOpenMs = 10_000
+    };
 }
 
 public static partial class ToolPipeline {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.cs
@@ -94,6 +94,11 @@ public static partial class ToolPipeline {
     /// <summary>
     /// Runs binder, middleware, and terminal execution for a tool call.
     /// </summary>
+    /// <remarks>
+    /// Execution order is binder -> reliability (optional) -> middleware chain (optional) -> terminal.
+    /// When reliability is enabled, retries wrap the full middleware+terminal chain and re-run it per attempt.
+    /// Caller-triggered cancellation is propagated and not retried.
+    /// </remarks>
     public static Task<string> RunAsync<TRequest>(
         ToolDefinition definition,
         JsonObject? arguments,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailSmtpProbeTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Email/EmailSmtpProbeTool.cs
@@ -14,18 +14,8 @@ namespace IntelligenceX.Tools.Email;
 /// </summary>
 public sealed class EmailSmtpProbeTool : EmailToolBase, ITool {
     private sealed record ProbeRequest;
-    private static readonly ToolPipelineReliabilityOptions ReliabilityOptions = new() {
-        MaxAttempts = 3,
-        RetryTransientErrors = true,
-        RetryExceptions = true,
-        AttemptTimeoutMs = 12_000,
-        BaseDelayMs = 150,
-        MaxDelayMs = 1_000,
-        JitterRatio = 0.10d,
-        EnableCircuitBreaker = true,
-        CircuitFailureThreshold = 4,
-        CircuitOpenMs = 10_000
-    };
+    private static readonly ToolPipelineReliabilityOptions ReliabilityOptions =
+        ToolPipelineReliabilityProfiles.FastNetworkProbe;
 
     private static readonly ToolDefinition DefinitionValue = new(
         SmtpProbePolicy.ProbeToolName,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPipelineTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPipelineTests.cs
@@ -231,6 +231,90 @@ public sealed class ToolPipelineTests {
     }
 
     [Fact]
+    public async Task Reliability_ShouldWrapMiddlewareChainAndRetryTransientMiddlewareFailures() {
+        var definition = new ToolDefinition(
+            "pipeline_stub",
+            "Pipeline stub",
+            ToolSchema.Object().NoAdditionalProperties());
+
+        var middlewareCalls = 0;
+        var terminalCalls = 0;
+
+        var json = await ToolPipeline.RunAsync(
+            definition: definition,
+            arguments: null,
+            cancellationToken: CancellationToken.None,
+            binder: _ => ToolRequestBindingResult<StubRequest>.Success(new StubRequest(7)),
+            terminal: (_, _) => {
+                terminalCalls++;
+                return Task.FromResult(ToolResultV2.OkModel(new {
+                    MiddlewareCalls = middlewareCalls,
+                    TerminalCalls = terminalCalls
+                }));
+            },
+            reliability: new ToolPipelineReliabilityOptions {
+                MaxAttempts = 3,
+                RetryTransientErrors = true,
+                BaseDelayMs = 0,
+                MaxDelayMs = 0,
+                DelayAsync = static (_, _) => Task.CompletedTask
+            },
+            middleware: new ToolPipelineMiddleware<StubRequest>[] {
+                (context, token, next) => {
+                    middlewareCalls++;
+                    if (middlewareCalls == 1) {
+                        return Task.FromResult(ToolResponse.Error("timeout", "Transient middleware failure.", isTransient: true));
+                    }
+
+                    return next(context, token);
+                }
+            });
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(2, root.GetProperty("middleware_calls").GetInt32());
+        Assert.Equal(1, root.GetProperty("terminal_calls").GetInt32());
+        Assert.Equal(2, middlewareCalls);
+        Assert.Equal(1, terminalCalls);
+    }
+
+    [Fact]
+    public async Task Reliability_WhenCallerCancellationOccurs_ShouldPropagateWithoutRetry() {
+        var definition = new ToolDefinition(
+            "pipeline_stub",
+            "Pipeline stub",
+            ToolSchema.Object().NoAdditionalProperties());
+        using var cancellationSource = new CancellationTokenSource();
+        var attempts = 0;
+
+        var cancellation = await Assert.ThrowsAsync<OperationCanceledException>(async () => {
+            await ToolPipeline.RunAsync(
+                definition: definition,
+                arguments: null,
+                cancellationToken: cancellationSource.Token,
+                binder: _ => ToolRequestBindingResult<StubRequest>.Success(new StubRequest(7)),
+                terminal: (_, cancellationToken) => {
+                    attempts++;
+                    cancellationSource.Cancel();
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return Task.FromResult(ToolResultV2.OkModel(new { Attempt = attempts }));
+                },
+                reliability: new ToolPipelineReliabilityOptions {
+                    MaxAttempts = 3,
+                    RetryTransientErrors = true,
+                    RetryExceptions = true,
+                    BaseDelayMs = 0,
+                    MaxDelayMs = 0,
+                    DelayAsync = static (_, _) => Task.CompletedTask
+                });
+        });
+
+        Assert.Equal(cancellationSource.Token, cancellation.CancellationToken);
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
     public async Task Reliability_WhenCircuitOpens_ShouldShortCircuitUntilCooldownExpires() {
         var definition = new ToolDefinition(
             "pipeline_stub",


### PR DESCRIPTION
## Summary
- add shared `ToolPipelineReliabilityProfiles` presets to centralize reliability option tuning and reduce per-tool drift
- route `ToolPipelineReliabilityOptions.ReadOnlyDefaults` through the shared profile entrypoint
- update `EmailSmtpProbeTool` to use a shared fast-network-probe reliability profile
- clarify `ToolPipeline.RunAsync` execution-order semantics in XML docs (reliability wraps middleware+terminal and caller cancellation is not retried)
- add tests for reliability wrapping order and caller cancellation propagation

## Why
- improve consistency and safer usage of tools in long chat flows while keeping agent freedom
- lock in retry/cancellation semantics so future refactors do not break execution guarantees

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolPipelineTests|FullyQualifiedName~EmailSmtpProbeStrictModeTests"`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`