### PR TITLE
Tools: harden reliability profile immutability

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.Reliability.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.Reliability.cs
@@ -88,6 +88,28 @@ public sealed class ToolPipelineReliabilityOptions {
     /// </summary>
     public Func<TimeSpan, CancellationToken, Task>? DelayAsync { get; init; }
 
+    /// <summary>
+    /// Creates a defensive copy of the reliability options.
+    /// </summary>
+    public ToolPipelineReliabilityOptions Clone() {
+        return new ToolPipelineReliabilityOptions {
+            MaxAttempts = MaxAttempts,
+            RetryTransientErrors = RetryTransientErrors,
+            RetryExceptions = RetryExceptions,
+            RetryNonTransientExceptions = RetryNonTransientExceptions,
+            AttemptTimeoutMs = AttemptTimeoutMs,
+            BaseDelayMs = BaseDelayMs,
+            MaxDelayMs = MaxDelayMs,
+            JitterRatio = JitterRatio,
+            EnableCircuitBreaker = EnableCircuitBreaker,
+            CircuitFailureThreshold = CircuitFailureThreshold,
+            CircuitOpenMs = CircuitOpenMs,
+            CircuitKey = CircuitKey,
+            UtcNowProvider = UtcNowProvider,
+            DelayAsync = DelayAsync
+        };
+    }
+
     internal ToolPipelineReliabilityOptions Normalize() {
         var maxAttempts = Math.Clamp(MaxAttempts, 1, 10);
         var attemptTimeoutMs = Math.Clamp(AttemptTimeoutMs, 0, 300_000);
@@ -120,10 +142,7 @@ public sealed class ToolPipelineReliabilityOptions {
 /// Shared reliability presets used by tools to avoid option drift.
 /// </summary>
 public static class ToolPipelineReliabilityProfiles {
-    /// <summary>
-    /// Balanced retries for read-only queries.
-    /// </summary>
-    public static ToolPipelineReliabilityOptions ReadOnlyQuery => new() {
+    private static readonly ToolPipelineReliabilityOptions ReadOnlyQueryTemplate = new() {
         MaxAttempts = 3,
         RetryTransientErrors = true,
         RetryExceptions = true,
@@ -137,10 +156,7 @@ public static class ToolPipelineReliabilityProfiles {
         CircuitOpenMs = 15_000
     };
 
-    /// <summary>
-    /// Aggressive but bounded retries for fast connectivity probes.
-    /// </summary>
-    public static ToolPipelineReliabilityOptions FastNetworkProbe => new() {
+    private static readonly ToolPipelineReliabilityOptions FastNetworkProbeTemplate = new() {
         MaxAttempts = 3,
         RetryTransientErrors = true,
         RetryExceptions = true,
@@ -153,6 +169,18 @@ public static class ToolPipelineReliabilityProfiles {
         CircuitFailureThreshold = 4,
         CircuitOpenMs = 10_000
     };
+
+    /// <summary>
+    /// Balanced retries for read-only queries.
+    /// Returns a defensive copy safe for per-tool customization.
+    /// </summary>
+    public static ToolPipelineReliabilityOptions ReadOnlyQuery => ReadOnlyQueryTemplate.Clone();
+
+    /// <summary>
+    /// Aggressive but bounded retries for fast connectivity probes.
+    /// Returns a defensive copy safe for per-tool customization.
+    /// </summary>
+    public static ToolPipelineReliabilityOptions FastNetworkProbe => FastNetworkProbeTemplate.Clone();
 }
 
 public static partial class ToolPipeline {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPipelineTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPipelineTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.IO;
+using System.Threading;
 using IntelligenceX.Json;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
@@ -214,7 +215,7 @@ public sealed class ToolPipelineTests {
             cancellationToken: CancellationToken.None,
             binder: _ => ToolRequestBindingResult<StubRequest>.Success(new StubRequest(7)),
             terminal: async (_, cancellationToken) => {
-                await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
                 return ToolResultV2.OkModel(new { Attempt = 1 });
             },
             reliability: new ToolPipelineReliabilityOptions {
@@ -312,6 +313,69 @@ public sealed class ToolPipelineTests {
 
         Assert.Equal(cancellationSource.Token, cancellation.CancellationToken);
         Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public async Task Reliability_WhenCallerCancellationOccurs_ShouldNotInvokeRetryDelay() {
+        var definition = new ToolDefinition(
+            "pipeline_stub",
+            "Pipeline stub",
+            ToolSchema.Object().NoAdditionalProperties());
+        using var cancellationSource = new CancellationTokenSource();
+        var delayCalls = 0;
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => {
+            await ToolPipeline.RunAsync(
+                definition: definition,
+                arguments: null,
+                cancellationToken: cancellationSource.Token,
+                binder: _ => ToolRequestBindingResult<StubRequest>.Success(new StubRequest(7)),
+                terminal: (_, cancellationToken) => {
+                    cancellationSource.Cancel();
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return Task.FromResult(ToolResultV2.OkModel(new { Attempt = 1 }));
+                },
+                reliability: new ToolPipelineReliabilityOptions {
+                    MaxAttempts = 3,
+                    RetryTransientErrors = true,
+                    RetryExceptions = true,
+                    BaseDelayMs = 1,
+                    MaxDelayMs = 1,
+                    DelayAsync = (_, _) => {
+                        Interlocked.Increment(ref delayCalls);
+                        return Task.CompletedTask;
+                    }
+                });
+        });
+
+        Assert.Equal(0, delayCalls);
+    }
+
+    [Fact]
+    public void ReliabilityProfiles_ShouldReturnEquivalentButDistinctInstances() {
+        var firstReadOnly = ToolPipelineReliabilityProfiles.ReadOnlyQuery;
+        var secondReadOnly = ToolPipelineReliabilityProfiles.ReadOnlyQuery;
+        Assert.NotSame(firstReadOnly, secondReadOnly);
+        Assert.Equal(firstReadOnly.MaxAttempts, secondReadOnly.MaxAttempts);
+        Assert.Equal(firstReadOnly.AttemptTimeoutMs, secondReadOnly.AttemptTimeoutMs);
+        Assert.Equal(firstReadOnly.BaseDelayMs, secondReadOnly.BaseDelayMs);
+        Assert.Equal(firstReadOnly.MaxDelayMs, secondReadOnly.MaxDelayMs);
+
+        var firstProbe = ToolPipelineReliabilityProfiles.FastNetworkProbe;
+        var secondProbe = ToolPipelineReliabilityProfiles.FastNetworkProbe;
+        Assert.NotSame(firstProbe, secondProbe);
+        Assert.Equal(firstProbe.MaxAttempts, secondProbe.MaxAttempts);
+        Assert.Equal(firstProbe.AttemptTimeoutMs, secondProbe.AttemptTimeoutMs);
+        Assert.Equal(firstProbe.BaseDelayMs, secondProbe.BaseDelayMs);
+        Assert.Equal(firstProbe.MaxDelayMs, secondProbe.MaxDelayMs);
+
+        var clone = firstProbe.Clone();
+        Assert.NotSame(firstProbe, clone);
+        Assert.Equal(firstProbe.MaxAttempts, clone.MaxAttempts);
+        Assert.Equal(firstProbe.RetryTransientErrors, clone.RetryTransientErrors);
+        Assert.Equal(firstProbe.RetryExceptions, clone.RetryExceptions);
+        Assert.Equal(firstProbe.CircuitFailureThreshold, clone.CircuitFailureThreshold);
+        Assert.Equal(firstProbe.CircuitOpenMs, clone.CircuitOpenMs);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add `ToolPipelineReliabilityOptions.Clone()` for explicit defensive-copy semantics
- back shared profiles with private templates and return cloned instances to avoid accidental cross-call state sharing
- add reliability tests for:
  - caller cancellation does not invoke retry delay path
  - profile properties return equivalent but distinct instances (including clone behavior)
- harden timeout regression test to be deterministic under high-load test runs by waiting on infinite delay and relying on cancellation

## Why
- keep shared reliability presets safe and predictable as tool adoption grows
- remove subtle mutable-state/contract ambiguity around shared profile reuse
- reduce flaky timing behavior in reliability tests

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolPipelineTests|FullyQualifiedName~EmailSmtpProbeStrictModeTests"`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`