### PR TITLE
Improve tool reliability profile overrides with builder API

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.Reliability.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolPipeline.Reliability.cs
@@ -118,9 +118,9 @@ public sealed class ToolPipelineReliabilityOptions {
     /// Returns a customized copy of the current options using a mutable builder.
     /// </summary>
     /// <param name="configure">
-    /// Builder mutation callback. The builder starts from the current option values
-    /// and is normalized when the customized options are built (including clamping
-    /// out-of-range values to supported bounds).
+    /// Builder mutation callback. The callback runs before normalization. The builder
+    /// starts from the current option values and is normalized when the customized
+    /// options are built (including clamping out-of-range values to supported bounds).
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="configure"/> is <see langword="null"/>.</exception>
     public ToolPipelineReliabilityOptions With(Action<ToolPipelineReliabilityOptionsBuilder> configure) {
@@ -324,9 +324,9 @@ public static class ToolPipelineReliabilityProfiles {
     /// Balanced retries for read-only queries with explicit overrides.
     /// </summary>
     /// <param name="configure">
-    /// Builder mutation callback. The builder starts from the profile template values
-    /// and is normalized when the customized options are built (including clamping
-    /// out-of-range values to supported bounds).
+    /// Builder mutation callback. The callback runs before normalization. The builder
+    /// starts from the profile template values and is normalized when the customized
+    /// options are built (including clamping out-of-range values to supported bounds).
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="configure"/> is <see langword="null"/>.</exception>
     public static ToolPipelineReliabilityOptions ReadOnlyQueryWith(Action<ToolPipelineReliabilityOptionsBuilder> configure) {
@@ -343,9 +343,9 @@ public static class ToolPipelineReliabilityProfiles {
     /// Aggressive but bounded retries for fast connectivity probes with explicit overrides.
     /// </summary>
     /// <param name="configure">
-    /// Builder mutation callback. The builder starts from the profile template values
-    /// and is normalized when the customized options are built (including clamping
-    /// out-of-range values to supported bounds).
+    /// Builder mutation callback. The callback runs before normalization. The builder
+    /// starts from the profile template values and is normalized when the customized
+    /// options are built (including clamping out-of-range values to supported bounds).
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="configure"/> is <see langword="null"/>.</exception>
     public static ToolPipelineReliabilityOptions FastNetworkProbeWith(Action<ToolPipelineReliabilityOptionsBuilder> configure) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPipelineTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPipelineTests.cs
@@ -505,6 +505,36 @@ public sealed class ToolPipelineTests {
     }
 
     [Fact]
+    public async Task ReliabilityProfilesWithOverrides_ShouldKeepTemplatesUnchangedAcrossConcurrentCalls() {
+        var tasks = new List<Task<ToolPipelineReliabilityOptions>>();
+        for (var i = 0; i < 20; i++) {
+            var local = i;
+            tasks.Add(Task.Run(() => ToolPipelineReliabilityProfiles.ReadOnlyQueryWith(options => {
+                options.MaxAttempts = (local % 10) + 1;
+                options.CircuitKey = $"concurrent_{local}";
+            })));
+        }
+
+        var results = await Task.WhenAll(tasks);
+
+        for (var i = 0; i < results.Length; i++) {
+            var result = results[i];
+            Assert.Equal((i % 10) + 1, result.MaxAttempts);
+            Assert.Equal($"concurrent_{i}", result.CircuitKey);
+            Assert.Equal(120, result.BaseDelayMs);
+            Assert.Equal(1200, result.MaxDelayMs);
+            Assert.True(result.EnableCircuitBreaker);
+        }
+
+        var baseline = ToolPipelineReliabilityProfiles.ReadOnlyQuery;
+        Assert.Equal(3, baseline.MaxAttempts);
+        Assert.Null(baseline.CircuitKey);
+        Assert.Equal(120, baseline.BaseDelayMs);
+        Assert.Equal(1200, baseline.MaxDelayMs);
+        Assert.True(baseline.EnableCircuitBreaker);
+    }
+
+    [Fact]
     public void ReliabilityOptionsBuilderBuild_ShouldNormalizeOutOfRangeValues() {
         var options = new ToolPipelineReliabilityOptionsBuilder {
             MaxAttempts = 99,


### PR DESCRIPTION
## Summary
- add `ToolPipelineReliabilityOptions.With(...)` for safe copy-based option customization
- add `ToolPipelineReliabilityOptionsBuilder` to support explicit, strongly-typed reliability overrides
- add `ReadOnlyQueryWith(...)` and `FastNetworkProbeWith(...)` profile helpers that apply overrides without mutating shared templates
- add tests proving override behavior and template immutability

## Why
- keeps profile defaults stable while still giving tools/agents freedom to tune reliability per call
- makes override intent explicit and reusable instead of hand-cloning option objects in many places
- improves consistency for long chained tool flows where retry/timeout/circuit settings may need targeted adjustments

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolPipelineTests|FullyQualifiedName~EmailSmtpProbeStrictModeTests"`