### PR TITLE
Improve tool JSON fallback for multidimensional arrays

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolJson.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolJson.cs
@@ -200,6 +200,10 @@ public static class ToolJson {
         }
 
         try {
+            if (value is Array array && array.Rank > 1) {
+                return SanitizeMultidimensionalArrayFallback(array, seen, depth + 1);
+            }
+
             if (value is IDictionary dictionary) {
                 var normalized = new Dictionary<string, object?>(StringComparer.Ordinal);
                 foreach (DictionaryEntry entry in dictionary) {
@@ -253,6 +257,57 @@ public static class ToolJson {
                 seen.Remove(value);
             }
         }
+    }
+
+    private static Dictionary<string, object?> SanitizeMultidimensionalArrayFallback(
+        Array array,
+        HashSet<object> seen,
+        int depth) {
+        var rank = array.Rank;
+        var lengths = new int[rank];
+        for (var dimension = 0; dimension < rank; dimension++) {
+            lengths[dimension] = array.GetLength(dimension);
+        }
+
+        var indexes = new int[rank];
+        var values = SanitizeMultidimensionalArrayLevel(
+            array: array,
+            dimension: 0,
+            indexes: indexes,
+            seen: seen,
+            depth: depth);
+
+        return new Dictionary<string, object?>(StringComparer.Ordinal) {
+            ["rank"] = rank,
+            ["lengths"] = lengths,
+            ["values"] = values
+        };
+    }
+
+    private static List<object?> SanitizeMultidimensionalArrayLevel(
+        Array array,
+        int dimension,
+        int[] indexes,
+        HashSet<object> seen,
+        int depth) {
+        var length = array.GetLength(dimension);
+        var values = new List<object?>(length);
+
+        if (dimension == array.Rank - 1) {
+            for (var index = 0; index < length; index++) {
+                indexes[dimension] = index;
+                values.Add(SanitizeForJsonFallback(array.GetValue(indexes), seen, depth + 1));
+            }
+
+            return values;
+        }
+
+        for (var index = 0; index < length; index++) {
+            indexes[dimension] = index;
+            values.Add(SanitizeMultidimensionalArrayLevel(array, dimension + 1, indexes, seen, depth + 1));
+        }
+
+        return values;
     }
 
     private static string ConvertToInvariantString(object? value) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolJsonSerializationSafetyTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolJsonSerializationSafetyTests.cs
@@ -22,8 +22,20 @@ public sealed class ToolJsonSerializationSafetyTests {
         Assert.Equal("grid", root.GetProperty("name").GetString());
 
         var raw = root.GetProperty("raw");
-        Assert.Equal(JsonValueKind.Array, raw.ValueKind);
-        Assert.Equal(8, raw.GetArrayLength());
+        Assert.Equal(JsonValueKind.Object, raw.ValueKind);
+        Assert.Equal(3, raw.GetProperty("rank").GetInt32());
+
+        var lengths = raw.GetProperty("lengths");
+        Assert.Equal(JsonValueKind.Array, lengths.ValueKind);
+        Assert.Equal(3, lengths.GetArrayLength());
+        Assert.Equal(2, lengths[0].GetInt32());
+        Assert.Equal(2, lengths[1].GetInt32());
+        Assert.Equal(2, lengths[2].GetInt32());
+
+        var values = raw.GetProperty("values");
+        Assert.Equal(JsonValueKind.Array, values.ValueKind);
+        Assert.Equal(2, values.GetArrayLength());
+        Assert.True(values[1][0][1].GetBoolean());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- preserve shape for `Array` values with `Rank > 1` in `ToolJson` fallback sanitization
- serialize multidimensional arrays as `{ rank, lengths, values }` instead of flattening
- update safety test expectations to lock the structured contract and boolean indexing behavior

## Why
Some tool payloads can contain multidimensional arrays (for example schedule-like grids). Flattened fallback serialization is valid JSON but loses structure and makes downstream chat/tool interpretation and chaining less reliable.

## Testing
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolJsonSerializationSafetyTests|FullyQualifiedName~ToolSerializationStressTests|FullyQualifiedName~AdReplicationConnectionsToolSerializationTests"`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`
