### PR TITLE
Harden tool JSON fallback for lower-bound multidimensional arrays

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolJson.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolJson.cs
@@ -13,6 +13,8 @@ namespace IntelligenceX.Tools.Common;
 /// Common JSON helpers shared by tool implementations.
 /// </summary>
 public static class ToolJson {
+    private const int MaxFallbackDepth = 8;
+
     private static readonly JsonSerializerOptions SnakeCaseSerializerOptions = new() {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
         // Keep dictionary keys as-is. Many tool payloads carry provider-defined keys (event data names, LDAP attribute names, headers)
@@ -80,7 +82,7 @@ public static class ToolJson {
         System.Text.Json.Nodes.JsonNode? node;
         try {
             node = JsonSerializer.SerializeToNode(value, SnakeCaseSerializerOptions);
-        } catch (Exception ex) when (ex is NotSupportedException or InvalidOperationException or JsonException) {
+        } catch (Exception ex) when (ex is NotSupportedException or InvalidOperationException or JsonException or ArgumentException) {
             var sanitized = SanitizeForJsonFallback(
                 value,
                 seen: new HashSet<object>(ReferenceEqualityComparer.Instance),
@@ -140,7 +142,7 @@ public static class ToolJson {
             return null;
         }
 
-        if (depth > 8) {
+        if (depth > MaxFallbackDepth) {
             return ConvertToInvariantString(value);
         }
 
@@ -259,14 +261,24 @@ public static class ToolJson {
         }
     }
 
+    /// <summary>
+    /// Shapes rank-2+ arrays into a stable fallback envelope consumed by chat/tool clients.
+    /// </summary>
+    /// <remarks>
+    /// Contract fields are:
+    /// <c>rank</c>, <c>lengths</c>, <c>lower_bounds</c>, and nested <c>values</c>.
+    /// Values are emitted as zero-based nested lists while preserving source lower bounds in metadata.
+    /// </remarks>
     private static Dictionary<string, object?> SanitizeMultidimensionalArrayFallback(
         Array array,
         HashSet<object> seen,
         int depth) {
         var rank = array.Rank;
         var lengths = new int[rank];
+        var lowerBounds = new int[rank];
         for (var dimension = 0; dimension < rank; dimension++) {
             lengths[dimension] = array.GetLength(dimension);
+            lowerBounds[dimension] = array.GetLowerBound(dimension);
         }
 
         var indexes = new int[rank];
@@ -274,12 +286,14 @@ public static class ToolJson {
             array: array,
             dimension: 0,
             indexes: indexes,
+            lowerBounds: lowerBounds,
             seen: seen,
             depth: depth);
 
         return new Dictionary<string, object?>(StringComparer.Ordinal) {
             ["rank"] = rank,
             ["lengths"] = lengths,
+            ["lower_bounds"] = lowerBounds,
             ["values"] = values
         };
     }
@@ -288,6 +302,7 @@ public static class ToolJson {
         Array array,
         int dimension,
         int[] indexes,
+        int[] lowerBounds,
         HashSet<object> seen,
         int depth) {
         var length = array.GetLength(dimension);
@@ -295,7 +310,7 @@ public static class ToolJson {
 
         if (dimension == array.Rank - 1) {
             for (var index = 0; index < length; index++) {
-                indexes[dimension] = index;
+                indexes[dimension] = lowerBounds[dimension] + index;
                 values.Add(SanitizeForJsonFallback(array.GetValue(indexes), seen, depth + 1));
             }
 
@@ -303,8 +318,8 @@ public static class ToolJson {
         }
 
         for (var index = 0; index < length; index++) {
-            indexes[dimension] = index;
-            values.Add(SanitizeMultidimensionalArrayLevel(array, dimension + 1, indexes, seen, depth + 1));
+            indexes[dimension] = lowerBounds[dimension] + index;
+            values.Add(SanitizeMultidimensionalArrayLevel(array, dimension + 1, indexes, lowerBounds, seen, depth + 1));
         }
 
         return values;

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolJsonSerializationSafetyTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolJsonSerializationSafetyTests.cs
@@ -32,10 +32,46 @@ public sealed class ToolJsonSerializationSafetyTests {
         Assert.Equal(2, lengths[1].GetInt32());
         Assert.Equal(2, lengths[2].GetInt32());
 
+        var lowerBounds = raw.GetProperty("lower_bounds");
+        Assert.Equal(JsonValueKind.Array, lowerBounds.ValueKind);
+        Assert.Equal(3, lowerBounds.GetArrayLength());
+        Assert.Equal(0, lowerBounds[0].GetInt32());
+        Assert.Equal(0, lowerBounds[1].GetInt32());
+        Assert.Equal(0, lowerBounds[2].GetInt32());
+
         var values = raw.GetProperty("values");
         Assert.Equal(JsonValueKind.Array, values.ValueKind);
         Assert.Equal(2, values.GetArrayLength());
         Assert.True(values[1][0][1].GetBoolean());
+    }
+
+    [Fact]
+    public void OkModel_WhenPayloadContainsNonZeroLowerBoundMultidimensionalArray_ShouldPreserveBounds() {
+        var grid = Array.CreateInstance(typeof(int), lengths: [2, 2], lowerBounds: [1, -2]);
+        grid.SetValue(21, [1, -2]);
+        grid.SetValue(42, [2, -1]);
+
+        var json = ToolResponse.OkModel(new {
+            Name = "grid",
+            Raw = grid
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var raw = root.GetProperty("raw");
+
+        Assert.Equal(JsonValueKind.Object, raw.ValueKind);
+        Assert.Equal(2, raw.GetProperty("rank").GetInt32());
+
+        var lowerBounds = raw.GetProperty("lower_bounds");
+        Assert.Equal(2, lowerBounds.GetArrayLength());
+        Assert.Equal(1, lowerBounds[0].GetInt32());
+        Assert.Equal(-2, lowerBounds[1].GetInt32());
+
+        var values = raw.GetProperty("values");
+        Assert.Equal(2, values.GetArrayLength());
+        Assert.Equal(21, values[0][0].GetInt32());
+        Assert.Equal(42, values[1][1].GetInt32());
     }
 
     [Fact]

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSerializationStressTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSerializationStressTests.cs
@@ -74,6 +74,58 @@ public sealed class ToolSerializationStressTests {
     }
 
     [Fact]
+    public void MixedEventFlowPayload_WithLowerBoundMatricesAndCycles_ShouldSerialize() {
+        var steps = new List<object>(180);
+        var warningCount = 0;
+        for (var index = 0; index < 180; index++) {
+            var status = index % 9 == 0 ? "warning" : "ok";
+            if (status == "warning") {
+                warningCount++;
+            }
+
+            var matrix = Array.CreateInstance(typeof(object), lengths: [2, 2], lowerBounds: [1, -1]);
+            matrix.SetValue(CreateDeepNode(12), [1, -1]);
+            matrix.SetValue(new Dictionary<string, object?>(StringComparer.Ordinal) {
+                ["phase"] = "collect",
+                ["step"] = index
+            }, [1, 0]);
+
+            var cyclic = new Dictionary<string, object?>(StringComparer.Ordinal) {
+                ["id"] = index
+            };
+            cyclic["self"] = cyclic;
+            matrix.SetValue(cyclic, [2, -1]);
+            matrix.SetValue(index % 2 == 0, [2, 0]);
+
+            steps.Add(new {
+                Step = index,
+                Status = status,
+                ScheduleMatrix = matrix
+            });
+        }
+
+        var json = ToolResponse.OkModel(new {
+            receipt = new {
+                steps,
+                summary = new { total_steps = steps.Count, warnings = warningCount }
+            }
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(180, root.GetProperty("receipt").GetProperty("steps").GetArrayLength());
+
+        var firstMatrix = root.GetProperty("receipt").GetProperty("steps")[0].GetProperty("schedule_matrix");
+        Assert.Equal(JsonValueKind.Object, firstMatrix.ValueKind);
+        Assert.Equal(2, firstMatrix.GetProperty("rank").GetInt32());
+        Assert.Equal(1, firstMatrix.GetProperty("lower_bounds")[0].GetInt32());
+        Assert.Equal(-1, firstMatrix.GetProperty("lower_bounds")[1].GetInt32());
+        Assert.Equal("[cycle]", firstMatrix.GetProperty("values")[1][0].GetProperty("self").GetString());
+    }
+
+    [Fact]
     public void AdReplicationConnectionsPayload_WithManyMappedRows_ShouldSerialize() {
         var rows = new List<object>(320);
         for (var i = 0; i < 320; i++) {


### PR DESCRIPTION
## Summary
- harden `ToolJson.ToJsonObjectSnakeCase` fallback trigger to include serializer `ArgumentException` failures
- preserve multidimensional source lower bounds in fallback shape via `lower_bounds` and use those bounds when reading array values
- document fallback contract near multidimensional sanitizer (`rank`, `lengths`, `lower_bounds`, `values`)
- add coverage for non-zero-lower-bound multidimensional arrays
- add stress coverage for long event-flow payloads that combine lower-bound matrices, deep objects, and cyclic dictionaries

## Why
We previously handled rank>1 arrays, but arrays with non-zero lower bounds still failed before fallback and the fallback output did not preserve lower-bound metadata. This caused fragile behavior for chat/tool chains that depend on stable, structured payloads.

## Testing
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolJsonSerializationSafetyTests|FullyQualifiedName~ToolSerializationStressTests"`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
