### PR TITLE
Tighten fallback contract and stress assertions

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolJsonSerializationSafetyTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolJsonSerializationSafetyTests.cs
@@ -63,6 +63,11 @@ public sealed class ToolJsonSerializationSafetyTests {
         Assert.Equal(JsonValueKind.Object, raw.ValueKind);
         Assert.Equal(2, raw.GetProperty("rank").GetInt32());
 
+        var lengths = raw.GetProperty("lengths");
+        Assert.Equal(2, lengths.GetArrayLength());
+        Assert.Equal(2, lengths[0].GetInt32());
+        Assert.Equal(2, lengths[1].GetInt32());
+
         var lowerBounds = raw.GetProperty("lower_bounds");
         Assert.Equal(2, lowerBounds.GetArrayLength());
         Assert.Equal(1, lowerBounds[0].GetInt32());

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSerializationStressTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSerializationStressTests.cs
@@ -122,6 +122,12 @@ public sealed class ToolSerializationStressTests {
         Assert.Equal(2, firstMatrix.GetProperty("rank").GetInt32());
         Assert.Equal(1, firstMatrix.GetProperty("lower_bounds")[0].GetInt32());
         Assert.Equal(-1, firstMatrix.GetProperty("lower_bounds")[1].GetInt32());
+
+        var deepNode = firstMatrix.GetProperty("values")[0][0];
+        Assert.Equal(JsonValueKind.Object, deepNode.ValueKind);
+        Assert.Equal("root", deepNode.GetProperty("name").GetString());
+        Assert.Equal("level-00", deepNode.GetProperty("child").GetProperty("name").GetString());
+
         Assert.Equal("[cycle]", firstMatrix.GetProperty("values")[1][0].GetProperty("self").GetString());
     }
 


### PR DESCRIPTION
## Summary
- add missing `lengths` assertions in non-zero-lower-bound multidimensional fallback safety test
- add deep-node preservation assertion in mixed event-flow stress test (`schedule_matrix.values`) to guard against subtree flattening/stringification regressions

## Why
This tightens fallback contract coverage around multidimensional array shape and verifies nested object preservation in long-flow payloads beyond cycle markers alone.

## Testing
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolJsonSerializationSafetyTests|FullyQualifiedName~ToolSerializationStressTests"`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
