### PR TITLE
tools: preserve deeper fallback context for cyclic payloads

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolJson.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolJson.cs
@@ -13,7 +13,7 @@ namespace IntelligenceX.Tools.Common;
 /// Common JSON helpers shared by tool implementations.
 /// </summary>
 public static class ToolJson {
-    private const int MaxFallbackDepth = 8;
+    private const int MaxFallbackDepth = 16;
 
     private static readonly JsonSerializerOptions SnakeCaseSerializerOptions = new() {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolJsonSerializationSafetyTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolJsonSerializationSafetyTests.cs
@@ -94,8 +94,44 @@ public sealed class ToolJsonSerializationSafetyTests {
         Assert.Equal("[cycle]", root.GetProperty("next").GetString());
     }
 
+    [Fact]
+    public void OkModel_WhenFallbackHandlesCycle_ShouldPreserveDeepChildContext() {
+        var rootNode = new CycleNode { Name = "root" };
+        var current = rootNode;
+        for (var index = 0; index < 12; index++) {
+            var next = new CycleNode { Name = $"level-{index:00}" };
+            current.Child = next;
+            current = next;
+        }
+        rootNode.Next = rootNode;
+
+        var json = ToolResponse.OkModel(rootNode);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(
+            "level-09",
+            root.GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("name")
+                .GetString());
+        Assert.Equal("[cycle]", root.GetProperty("next").GetString());
+    }
+
     private sealed class CycleNode {
         public string Name { get; set; } = string.Empty;
+
+        public CycleNode? Child { get; set; }
 
         public CycleNode? Next { get; set; }
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSerializationStressTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSerializationStressTests.cs
@@ -129,18 +129,32 @@ public sealed class ToolSerializationStressTests {
         Assert.Equal(1, firstMatrix.GetProperty("lower_bounds")[0].GetInt32());
         Assert.Equal(-1, firstMatrix.GetProperty("lower_bounds")[1].GetInt32());
 
-        var deepNode = firstMatrix.GetProperty("values")[0][0];
+        var values = firstMatrix.GetProperty("values");
+        Assert.Equal(2, values.GetArrayLength());
+        Assert.Equal(2, values[0].GetArrayLength());
+        Assert.Equal(2, values[1].GetArrayLength());
+
+        var deepNode = values[0][0];
         Assert.Equal(JsonValueKind.Object, deepNode.ValueKind);
         Assert.Equal("root", deepNode.GetProperty("name").GetString());
         Assert.Equal("level-00", deepNode.GetProperty("child").GetProperty("name").GetString());
+        Assert.Equal(
+            "level-04",
+            deepNode.GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("child")
+                .GetProperty("name")
+                .GetString());
 
-        var collectNode = firstMatrix.GetProperty("values")[0][1];
+        var collectNode = values[0][1];
         Assert.Equal(JsonValueKind.Object, collectNode.ValueKind);
         Assert.Equal("collect", collectNode.GetProperty("phase").GetString());
         Assert.Equal(0, collectNode.GetProperty("step").GetInt32());
 
-        Assert.Equal("[cycle]", firstMatrix.GetProperty("values")[1][0].GetProperty("self").GetString());
-        Assert.True(firstMatrix.GetProperty("values")[1][1].GetBoolean());
+        Assert.Equal("[cycle]", values[1][0].GetProperty("self").GetString());
+        Assert.True(values[1][1].GetBoolean());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- increase `ToolJson` fallback depth budget from 8 to 16 so cyclic/unsupported payload fallback preserves deeper diagnostic context
- harden serialization stress assertions to verify matrix `values` shape before index-based checks
- add regression coverage that fallback mode preserves deep child chains while still emitting cycle markers

## Why
- improves chat-facing tool payload continuity for long event/step flows that include cycles and nested objects
- keeps multidimensional fallback contract checks more diagnosable when shape regressions happen

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~ToolJsonSerializationSafetyTests|FullyQualifiedName~ToolSerializationStressTests"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
