### PR TITLE
Fix JsonMapper ulong overflow for tool/chat serialization

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/JsonMapperNumericSafetyTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/JsonMapperNumericSafetyTests.cs
@@ -1,0 +1,54 @@
+using System;
+using IntelligenceX.Json;
+using IntelligenceX.Tools.Common;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class JsonMapperNumericSafetyTests {
+    [Fact]
+    public void FromObject_WithLargeUnsignedLong_ShouldNotThrowOrOverflow() {
+        var mapped = JsonMapper.FromObject(ulong.MaxValue);
+
+        Assert.Equal(JsonValueKind.Number, mapped.Kind);
+        var numeric = mapped.AsDouble();
+        Assert.NotNull(numeric);
+        Assert.True(double.IsFinite(numeric!.Value));
+        Assert.True(numeric.Value > long.MaxValue);
+    }
+
+    [Fact]
+    public void FromObject_WithUnsignedLongWithinInt64Range_ShouldPreserveIntegerSemantics() {
+        var mapped = JsonMapper.FromObject((ulong)42);
+
+        Assert.Equal(JsonValueKind.Number, mapped.Kind);
+        Assert.Equal(42L, mapped.AsInt64());
+    }
+
+    [Fact]
+    public void ToolTableView_Apply_WithLargeUnsignedLongCell_ShouldSerializeRow() {
+        var rows = new[] { new UnsignedRow(ulong.MaxValue) };
+        var columns = new[] {
+            new ToolTableColumnSpec<UnsignedRow>(
+                column: new ToolColumn("counter", "Counter", "number"),
+                selector: static row => row.Counter)
+        };
+
+        var result = ToolTableView.Apply(
+            sourceRows: rows,
+            request: new ToolTableViewRequest(),
+            columnSpecs: columns,
+            previewMaxRows: 1);
+
+        Assert.Single(result.Rows);
+        var first = result.Rows[0].AsObject();
+        Assert.NotNull(first);
+
+        var numeric = first!.GetDouble("counter");
+        Assert.NotNull(numeric);
+        Assert.True(double.IsFinite(numeric!.Value));
+        Assert.True(numeric.Value > long.MaxValue);
+    }
+
+    private sealed record UnsignedRow(ulong Counter);
+}

--- a/IntelligenceX/Json/JsonMapper.cs
+++ b/IntelligenceX/Json/JsonMapper.cs
@@ -29,8 +29,14 @@ public static class JsonMapper {
                 return JsonValue.From(str);
             case bool b:
                 return JsonValue.From(b);
-            case byte or sbyte or short or ushort or int or uint or long or ulong:
+            case byte or sbyte or short or ushort or int or uint or long:
                 return JsonValue.From(Convert.ToInt64(value));
+            case ulong unsignedLong:
+                // JsonValue stores numbers as Int64/Double. Keep exact Int64 when possible;
+                // otherwise fall back to Double to avoid overflow exceptions.
+                return unsignedLong <= long.MaxValue
+                    ? JsonValue.From((long)unsignedLong)
+                    : JsonValue.From((double)unsignedLong);
             case float or double or decimal:
                 return JsonValue.From(Convert.ToDouble(value));
             case IDictionary dictionary:


### PR DESCRIPTION
## Summary
- fix `JsonMapper.FromObject` overflow path for `ulong` values above `long.MaxValue`
- preserve exact integer semantics for `ulong` values within `Int64` range
- add regression tests covering direct mapping and `ToolTableView` serialization for large unsigned values

## Why
Some tool/chat serialization paths can pass through `JsonMapper`. Previously, mapping a large `ulong` could throw via `Convert.ToInt64`, causing runtime serialization failures.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`