### PR TITLE
Harden non-finite number handling in tool JSON serialization

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolJson.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolJson.cs
@@ -168,9 +168,9 @@ public static class ToolJson {
             case ulong n:
                 return n;
             case float n:
-                return n;
+                return float.IsNaN(n) || float.IsInfinity(n) ? null : n;
             case double n:
-                return n;
+                return double.IsNaN(n) || double.IsInfinity(n) ? null : n;
             case decimal n:
                 return n;
             case DateTime dt:

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolTableView.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Common/ToolTableView.cs
@@ -557,10 +557,10 @@ public static class ToolTableView {
                 case ulong ul:
                     number = ul;
                     return true;
-                case float f:
+                case float f when !(float.IsNaN(f) || float.IsInfinity(f)):
                     number = (decimal)f;
                     return true;
-                case double d:
+                case double d when !(double.IsNaN(d) || double.IsInfinity(d)):
                     number = (decimal)d;
                     return true;
                 case decimal dec:

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/JsonMapperNumericSafetyTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/JsonMapperNumericSafetyTests.cs
@@ -26,6 +26,28 @@ public sealed class JsonMapperNumericSafetyTests {
     }
 
     [Fact]
+    public void FromObject_WithNonFiniteDouble_ShouldMapToNull() {
+        Assert.Equal(JsonValueKind.Null, JsonMapper.FromObject(double.NaN).Kind);
+        Assert.Equal(JsonValueKind.Null, JsonMapper.FromObject(double.PositiveInfinity).Kind);
+        Assert.Equal(JsonValueKind.Null, JsonMapper.FromObject(double.NegativeInfinity).Kind);
+    }
+
+    [Fact]
+    public void JsonLiteSerialize_WithNonFiniteDoubles_ShouldEmitNullLiterals() {
+        var json = JsonLite.Serialize(
+            new JsonObject()
+                .Add("nan", double.NaN)
+                .Add("positive_infinity", double.PositiveInfinity)
+                .Add("negative_infinity", double.NegativeInfinity));
+
+        var parsed = JsonLite.Parse(json).AsObject();
+        Assert.NotNull(parsed);
+        Assert.Equal(JsonValueKind.Null, parsed!["nan"].Kind);
+        Assert.Equal(JsonValueKind.Null, parsed["positive_infinity"].Kind);
+        Assert.Equal(JsonValueKind.Null, parsed["negative_infinity"].Kind);
+    }
+
+    [Fact]
     public void ToolTableView_Apply_WithLargeUnsignedLongCell_ShouldSerializeRow() {
         var rows = new[] { new UnsignedRow(ulong.MaxValue) };
         var columns = new[] {
@@ -50,5 +72,29 @@ public sealed class JsonMapperNumericSafetyTests {
         Assert.True(numeric.Value > long.MaxValue);
     }
 
+    [Fact]
+    public void ToolTableView_Apply_WithNonFiniteDoubleCell_ShouldSerializeNull() {
+        var rows = new[] { new FloatingPointRow(double.NaN) };
+        var columns = new[] {
+            new ToolTableColumnSpec<FloatingPointRow>(
+                column: new ToolColumn("score", "Score", "number"),
+                selector: static row => row.Score)
+        };
+
+        var result = ToolTableView.Apply(
+            sourceRows: rows,
+            request: new ToolTableViewRequest(),
+            columnSpecs: columns,
+            previewMaxRows: 1);
+
+        Assert.Single(result.Rows);
+        var first = result.Rows[0].AsObject();
+        Assert.NotNull(first);
+        Assert.True(first!.TryGetValue("score", out var mapped));
+        Assert.NotNull(mapped);
+        Assert.Equal(JsonValueKind.Null, mapped!.Kind);
+    }
+
     private sealed record UnsignedRow(ulong Counter);
+    private sealed record FloatingPointRow(double Score);
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolJsonSerializationSafetyTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolJsonSerializationSafetyTests.cs
@@ -95,6 +95,44 @@ public sealed class ToolJsonSerializationSafetyTests {
     }
 
     [Fact]
+    public void OkModel_WhenPayloadContainsNonFiniteNumbers_ShouldEmitNulls() {
+        var json = ToolResponse.OkModel(new {
+            Name = "non-finite",
+            Score = double.NaN,
+            Ratio = double.PositiveInfinity,
+            Delta = float.NegativeInfinity
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("non-finite", root.GetProperty("name").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("score").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("ratio").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("delta").ValueKind);
+    }
+
+    [Fact]
+    public void OkModel_WhenFallbackPayloadContainsNonFiniteNumbers_ShouldEmitNulls() {
+        var node = new CycleNode {
+            Name = "root",
+            Score = double.NaN
+        };
+        node.Next = node;
+
+        var json = ToolResponse.OkModel(node);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal("root", root.GetProperty("name").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("score").ValueKind);
+        Assert.Equal("[cycle]", root.GetProperty("next").GetString());
+    }
+
+    [Fact]
     public void OkModel_WhenFallbackHandlesCycle_ShouldPreserveDeepChildContext() {
         var rootNode = new CycleNode { Name = "root" };
         var current = rootNode;
@@ -130,6 +168,7 @@ public sealed class ToolJsonSerializationSafetyTests {
 
     private sealed class CycleNode {
         public string Name { get; set; } = string.Empty;
+        public double Score { get; set; }
 
         public CycleNode? Child { get; set; }
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolTableViewTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolTableViewTests.cs
@@ -101,6 +101,35 @@ public class ToolTableViewTests {
     }
 
     [Fact]
+    public void Apply_WhenSortingWithNonFiniteNumbers_ShouldNotThrow() {
+        var rows = new[] {
+            new SortRow(3, double.NaN),
+            new SortRow(1, 1d),
+            new SortRow(2, 2d)
+        };
+
+        var specs = new[] {
+            new ToolTableColumnSpec<SortRow>(new ToolColumn("id", "ID", "int"), static x => x.Id),
+            new ToolTableColumnSpec<SortRow>(new ToolColumn("score", "Score", "number"), static x => x.Score)
+        };
+
+        var request = new ToolTableViewRequest {
+            SortBy = "score",
+            SortDirection = ToolTableSortDirection.Asc
+        };
+
+        var result = ToolTableView.Apply(rows, request, specs, previewMaxRows: 20);
+
+        Assert.Equal(3, result.Count);
+        var first = result.Rows[0].AsObject();
+        Assert.NotNull(first);
+        Assert.Equal(3, first!.GetInt64("id"));
+        Assert.True(first.TryGetValue("score", out var score));
+        Assert.NotNull(score);
+        Assert.Equal(JsonValueKind.Null, score!.Kind);
+    }
+
+    [Fact]
     public void AutoColumns_ShouldInferSnakeCaseAndPrimitiveTypes() {
         var specs = ToolAutoTableColumns.GetColumnSpecs<AutoRow>();
         var keys = ToolAutoTableColumns.GetColumnKeys<AutoRow>();
@@ -313,6 +342,7 @@ public class ToolTableViewTests {
     }
 
     private sealed record Row(int Id, string Name, long MemoryUsage);
+    private sealed record SortRow(int Id, double Score);
     private sealed record AutoRow(int Id, string DisplayName, DateTime StartTimeUtc, IReadOnlyList<string> Tags);
 
     private sealed class AutoModel {

--- a/IntelligenceX/Json/JsonLite.cs
+++ b/IntelligenceX/Json/JsonLite.cs
@@ -208,10 +208,18 @@ public static class JsonLite {
                 builder.Append(ul.ToString(CultureInfo.InvariantCulture));
                 break;
             case float f:
-                builder.Append(f.ToString("R", CultureInfo.InvariantCulture));
+                if (float.IsNaN(f) || float.IsInfinity(f)) {
+                    builder.Append("null");
+                } else {
+                    builder.Append(f.ToString("R", CultureInfo.InvariantCulture));
+                }
                 break;
             case double d:
-                builder.Append(d.ToString("R", CultureInfo.InvariantCulture));
+                if (double.IsNaN(d) || double.IsInfinity(d)) {
+                    builder.Append("null");
+                } else {
+                    builder.Append(d.ToString("R", CultureInfo.InvariantCulture));
+                }
                 break;
             case decimal dec:
                 builder.Append(dec.ToString(CultureInfo.InvariantCulture));

--- a/IntelligenceX/Json/JsonMapper.cs
+++ b/IntelligenceX/Json/JsonMapper.cs
@@ -37,8 +37,16 @@ public static class JsonMapper {
                 return unsignedLong <= long.MaxValue
                     ? JsonValue.From((long)unsignedLong)
                     : JsonValue.From((double)unsignedLong);
-            case float or double or decimal:
-                return JsonValue.From(Convert.ToDouble(value));
+            case float floatValue:
+                return float.IsNaN(floatValue) || float.IsInfinity(floatValue)
+                    ? JsonValue.Null
+                    : JsonValue.From((double)floatValue);
+            case double doubleValue:
+                return double.IsNaN(doubleValue) || double.IsInfinity(doubleValue)
+                    ? JsonValue.Null
+                    : JsonValue.From(doubleValue);
+            case decimal decimalValue:
+                return JsonValue.From(Convert.ToDouble(decimalValue));
             case IDictionary dictionary:
                 return JsonValue.From(FromDictionary(dictionary));
             case IEnumerable enumerable:


### PR DESCRIPTION
## Summary
- map non-finite floating-point values (`NaN`, `+Infinity`, `-Infinity`) to JSON `null` in `JsonMapper`
- ensure `JsonLite` serializer emits valid JSON for non-finite numeric values by writing `null` instead of named float literals
- harden `ToolJson` fallback sanitization to normalize non-finite floats/doubles to `null`
- prevent `ToolTableView` numeric comparer from attempting decimal conversion on non-finite values
- add regression tests for direct mapping/serialization, `ToolResponse.OkModel`, and table-view projection/sorting paths

## Why
Tool/chat payloads occasionally carry computed doubles. Non-finite values can produce invalid JSON or exception paths, especially in long-running analytical flows. This keeps outputs machine-parseable while preserving tool execution continuity.

## Validation
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~JsonMapperNumericSafetyTests|FullyQualifiedName~ToolJsonSerializationSafetyTests|FullyQualifiedName~ToolTableViewTests"`
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.sln -c Release`
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`