### PR TITLE
Improve chat cold-start UX and latency diagnostics

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowAssistantTimestampTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowAssistantTimestampTests.cs
@@ -1,0 +1,62 @@
+using System;
+using IntelligenceX.Chat.App;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Guards assistant timestamp updates so transcript meta reflects first visible assistant output.
+/// </summary>
+public sealed class MainWindowAssistantTimestampTests {
+    /// <summary>
+    /// Ensures placeholder assistant timestamps move to the first visible assistant output time.
+    /// </summary>
+    [Fact]
+    public void ResolveAssistantTimestampForUpdate_UpdatesTimestampWhenAssistantTextFirstAppears() {
+        var current = new DateTime(2026, 2, 22, 9, 32, 30, DateTimeKind.Local);
+        var now = new DateTime(2026, 2, 22, 9, 32, 47, DateTimeKind.Local);
+
+        var resolved = MainWindow.ResolveAssistantTimestampForUpdate(
+            currentTimestamp: current,
+            existingText: string.Empty,
+            nextText: "Good morning, Przemek!",
+            nowLocal: now);
+
+        Assert.Equal(now, resolved);
+    }
+
+    /// <summary>
+    /// Ensures ongoing streaming updates keep the original first-output assistant timestamp.
+    /// </summary>
+    [Fact]
+    public void ResolveAssistantTimestampForUpdate_KeepsTimestampWhileStreamingSubsequentDeltas() {
+        var current = new DateTime(2026, 2, 22, 9, 32, 47, DateTimeKind.Local);
+        var now = new DateTime(2026, 2, 22, 9, 32, 50, DateTimeKind.Local);
+
+        var resolved = MainWindow.ResolveAssistantTimestampForUpdate(
+            currentTimestamp: current,
+            existingText: "Good morning,",
+            nextText: "Good morning, Przemek!",
+            nowLocal: now);
+
+        Assert.Equal(current, resolved);
+    }
+
+    /// <summary>
+    /// Ensures timestamp is unchanged when assistant text remains empty/whitespace.
+    /// </summary>
+    [Fact]
+    public void ResolveAssistantTimestampForUpdate_KeepsTimestampWhenNoAssistantTextIsAvailable() {
+        var current = new DateTime(2026, 2, 22, 9, 32, 30, DateTimeKind.Local);
+        var now = new DateTime(2026, 2, 22, 9, 32, 55, DateTimeKind.Local);
+
+        var resolved = MainWindow.ResolveAssistantTimestampForUpdate(
+            currentTimestamp: current,
+            existingText: string.Empty,
+            nextText: "   ",
+            nowLocal: now);
+
+        Assert.Equal(current, resolved);
+    }
+
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowStartupConnectTimeoutPolicyTests.cs
@@ -50,7 +50,7 @@ public sealed class MainWindowStartupConnectTimeoutPolicyTests {
     [InlineData(true, true, null)]
     [InlineData(true, false, null)]
     [InlineData(false, false, null)]
-    [InlineData(false, true, 4000)]
+    [InlineData(false, true, 6000)]
     public void ResolveStartupConnectBudget_ReturnsExpectedBudget(
         bool fromUserAction,
         bool captureStartupPhaseTelemetry,
@@ -338,5 +338,96 @@ public sealed class MainWindowStartupConnectTimeoutPolicyTests {
         bool expected) {
         var shouldDefer = MainWindow.ShouldDeferStartupWebViewPostInitialization(captureStartupPhaseTelemetry);
         Assert.Equal(expected, shouldDefer);
+    }
+
+    /// <summary>
+    /// Ensures startup dispatch prewarm auth probe only runs for native transport
+    /// when no authentication state is known and interactive login is not in progress.
+    /// </summary>
+    [Theory]
+    [InlineData(false, false, false, false)]
+    [InlineData(true, true, false, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(true, false, false, true)]
+    public void ShouldRunStartupDispatchAuthPrewarm_ReturnsExpectedValue(
+        bool requiresInteractiveSignIn,
+        bool isAuthenticated,
+        bool loginInProgress,
+        bool expected) {
+        var shouldRun = MainWindow.ShouldRunStartupDispatchAuthPrewarm(
+            requiresInteractiveSignIn,
+            isAuthenticated,
+            loginInProgress);
+        Assert.Equal(expected, shouldRun);
+    }
+
+    /// <summary>
+    /// Ensures dispatch auth probe can bypass network round-trips when an explicit
+    /// unauthenticated snapshot is already cached and current state is unauthenticated.
+    /// </summary>
+    [Theory]
+    [InlineData(true, false, true, true)]
+    [InlineData(true, true, true, false)]
+    [InlineData(true, false, false, false)]
+    [InlineData(false, false, true, false)]
+    public void ShouldBypassDispatchAuthProbeForKnownUnauthenticatedState_ReturnsExpectedValue(
+        bool requiresInteractiveSignIn,
+        bool isAuthenticated,
+        bool hasExplicitUnauthenticatedProbeSnapshot,
+        bool expected) {
+        var shouldBypass = MainWindow.ShouldBypassDispatchAuthProbeForKnownUnauthenticatedState(
+            requiresInteractiveSignIn,
+            isAuthenticated,
+            hasExplicitUnauthenticatedProbeSnapshot);
+        Assert.Equal(expected, shouldBypass);
+    }
+
+    /// <summary>
+    /// Ensures deferred startup metadata sync is skipped only for unauthenticated
+    /// native sessions where deferred mode is enabled and interactive login is idle.
+    /// </summary>
+    [Theory]
+    [InlineData(false, true, false, false, false)]
+    [InlineData(true, false, false, false, false)]
+    [InlineData(true, true, true, false, false)]
+    [InlineData(true, true, false, true, false)]
+    [InlineData(true, true, false, false, true)]
+    public void ShouldSkipDeferredStartupMetadataSyncForUnauthenticatedNative_ReturnsExpectedValue(
+        bool deferStartupMetadataSync,
+        bool requiresInteractiveSignIn,
+        bool isAuthenticated,
+        bool loginInProgress,
+        bool expected) {
+        var shouldSkip = MainWindow.ShouldSkipDeferredStartupMetadataSyncForUnauthenticatedNative(
+            deferStartupMetadataSync,
+            requiresInteractiveSignIn,
+            isAuthenticated,
+            loginInProgress);
+        Assert.Equal(expected, shouldSkip);
+    }
+
+    /// <summary>
+    /// Ensures startup dispatch prewarm system summary includes stable timing details.
+    /// </summary>
+    [Theory]
+    [InlineData(420, false, null, false, null, "Startup prewarm ready: runtime connected in 420ms (auth check deferred).")]
+    [InlineData(380, true, true, false, 95, "Startup prewarm ready: runtime connected in 380ms; account verified in 95ms.")]
+    [InlineData(510, true, false, false, 1200, "Startup prewarm ready: runtime connected in 510ms; sign-in still required (checked in 1200ms).")]
+    [InlineData(0, true, false, false, 1207, "Startup prewarm ready: runtime already connected; sign-in still required (checked in 1207ms).")]
+    [InlineData(0, true, null, true, 700, "Startup prewarm ready: runtime already connected; auth check inconclusive after 700ms (will verify on first message).")]
+    public void BuildStartupDispatchPrewarmSummary_ReturnsExpectedText(
+        long connectMs,
+        bool authProbeAttempted,
+        bool? authProbeAuthenticated,
+        bool authProbeInconclusive,
+        int? authProbeMs,
+        string expected) {
+        var summary = MainWindow.BuildStartupDispatchPrewarmSummary(
+            connectMs,
+            authProbeAttempted,
+            authProbeAuthenticated,
+            authProbeInconclusive,
+            authProbeMs.HasValue ? (long?)authProbeMs.Value : null);
+        Assert.Equal(expected, summary);
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowTurnLatencyNoticeTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowTurnLatencyNoticeTests.cs
@@ -1,0 +1,62 @@
+using IntelligenceX.Chat.App;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Verifies turn-latency notice thresholds and rendered diagnostics text.
+/// </summary>
+public sealed class MainWindowTurnLatencyNoticeTests {
+    /// <summary>
+    /// Ensures slow-turn and first-turn threshold policy stays stable.
+    /// </summary>
+    [Theory]
+    [InlineData(500, false, false)]
+    [InlineData(1100, true, false)]
+    [InlineData(1200, true, true)]
+    [InlineData(2000, true, true)]
+    [InlineData(4499, false, false)]
+    [InlineData(4500, false, true)]
+    public void ShouldEmitTurnLatencySystemNotice_ReturnsExpectedValue(
+        long durationMs,
+        bool emitForFirstTurn,
+        bool expected) {
+        var shouldEmit = MainWindow.ShouldEmitTurnLatencySystemNotice(durationMs, emitForFirstTurn);
+        Assert.Equal(expected, shouldEmit);
+    }
+
+    /// <summary>
+    /// Ensures first-turn diagnostics use dedicated prefix and dominant-phase classification.
+    /// </summary>
+    [Fact]
+    public void BuildTurnLatencySystemNotice_FormatsFirstTurnNotice() {
+        var text = MainWindow.BuildTurnLatencySystemNotice(
+            durationMs: 2400,
+            queueWaitMs: 80,
+            authProbeMs: 70,
+            connectMs: 50,
+            dispatchToFirstDeltaMs: 1400,
+            streamDurationMs: 700,
+            firstTurnNotice: true);
+
+        Assert.StartsWith("First turn latency: total 2400ms", text);
+        Assert.Contains("dominant: model/runtime.", text);
+    }
+
+    /// <summary>
+    /// Ensures slow-turn diagnostics keep the slow-turn prefix and classify preflight dominance.
+    /// </summary>
+    [Fact]
+    public void BuildTurnLatencySystemNotice_FormatsSlowTurnNotice() {
+        var text = MainWindow.BuildTurnLatencySystemNotice(
+            durationMs: 5000,
+            queueWaitMs: 300,
+            authProbeMs: 300,
+            connectMs: 300,
+            dispatchToFirstDeltaMs: 1000,
+            streamDurationMs: 3000);
+
+        Assert.StartsWith("Slow turn: total 5000ms", text);
+        Assert.Contains("dominant: preflight.", text);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
@@ -87,13 +87,6 @@ public sealed partial class MainWindow : Window {
             _availableModels);
         var assistantModelLabel = string.IsNullOrWhiteSpace(resolvedModel) ? "(auto)" : resolvedModel.Trim();
         conversation.ModelLabel = assistantModelLabel;
-        var now = DateTime.Now;
-        conversation.Messages.Add(("Assistant", string.Empty, now, assistantModelLabel));
-        conversation.Title = ComputeConversationTitle(conversation.Title, conversation.Messages);
-        conversation.UpdatedUtc = now.ToUniversalTime();
-        if (string.Equals(conversationId, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
-            await RenderTranscriptAsync().ConfigureAwait(false);
-        }
 
         // Keep the turn startup path responsive; state durability is still preserved via debounced persistence.
         QueuePersistAppState();
@@ -121,7 +114,8 @@ public sealed partial class MainWindow : Window {
         conversation.Title = ComputeConversationTitle(conversation.Title, conversation.Messages);
         conversation.UpdatedUtc = now.ToUniversalTime();
         if (string.Equals(conversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
-            await RenderTranscriptAsync().ConfigureAwait(false);
+            // Avoid waiting on WebView render before request dispatch.
+            _ = RenderTranscriptAsync();
         }
 
         // Avoid blocking request dispatch on storage I/O; debounce persistence instead.
@@ -132,7 +126,7 @@ public sealed partial class MainWindow : Window {
         try {
             var initialClient = _client;
             if (initialClient is null) {
-                if (await EnsureConnectedAsync().ConfigureAwait(false) && _client is { } reconnectClient) {
+                if (await EnsureConnectedAsync(deferPostConnectMetadataSync: true).ConfigureAwait(false) && _client is { } reconnectClient) {
                     try {
                         await ExecuteChatTurnWithThreadRecoveryAsync(reconnectClient, turn, cancellationToken).ConfigureAwait(false);
                         return;
@@ -151,7 +145,7 @@ public sealed partial class MainWindow : Window {
                 return;
             } catch (Exception ex) when (IsDisconnectedError(ex)) {
                 await DisposeClientAsync().ConfigureAwait(false);
-                if (await EnsureConnectedAsync().ConfigureAwait(false) && _client is { } retryClient) {
+                if (await EnsureConnectedAsync(deferPostConnectMetadataSync: true).ConfigureAwait(false) && _client is { } retryClient) {
                     try {
                         await ExecuteChatTurnWithThreadRecoveryAsync(retryClient, turn, cancellationToken).ConfigureAwait(false);
                         return;
@@ -279,6 +273,7 @@ public sealed partial class MainWindow : Window {
         var completion = CompleteTurnLatencyTracking(turn.RequestId, DateTime.UtcNow);
         if (completion is not null) {
             RegisterTurnSuccessReliability(completion);
+            AppendTurnLatencySystemNoticeIfNeeded(completion);
             lock (_turnDiagnosticsSync) {
                 if (_lastTurnMetrics is null
                     || !string.Equals(_lastTurnMetrics.RequestId, completion.RequestId, StringComparison.OrdinalIgnoreCase)) {
@@ -335,6 +330,7 @@ public sealed partial class MainWindow : Window {
         var completion = CompleteTurnLatencyTracking(turn.RequestId, DateTime.UtcNow);
         if (completion is not null) {
             RegisterTurnFailureReliability(completion, outcome);
+            AppendTurnLatencySystemNoticeIfNeeded(completion);
             lock (_turnDiagnosticsSync) {
                 _lastTurnMetrics = BuildTurnMetricsSnapshotFromCompletion(
                     completion,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Conversations.OnboardingAndKickoff.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Conversations.OnboardingAndKickoff.cs
@@ -188,7 +188,7 @@ public sealed partial class MainWindow : Window {
         }
 
         try {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+            using var cts = new CancellationTokenSource(KickoffCancelAckTimeout);
             var cancelRequest = new CancelChatRequest {
                 RequestId = NextId(),
                 ChatRequestId = kickoffRequestId

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
@@ -153,7 +153,21 @@ public sealed partial class MainWindow : Window {
         return captureStartupPhaseTelemetry;
     }
 
-    private async Task ConnectAsync(bool fromUserAction = false, TimeSpan? connectBudgetOverride = null) {
+    internal static bool ShouldSkipDeferredStartupMetadataSyncForUnauthenticatedNative(
+        bool deferStartupMetadataSync,
+        bool requiresInteractiveSignIn,
+        bool isAuthenticated,
+        bool loginInProgress) {
+        return deferStartupMetadataSync
+               && requiresInteractiveSignIn
+               && !isAuthenticated
+               && !loginInProgress;
+    }
+
+    private async Task ConnectAsync(
+        bool fromUserAction = false,
+        TimeSpan? connectBudgetOverride = null,
+        bool deferPostConnectMetadataSync = false) {
         await _connectGate.WaitAsync().ConfigureAwait(false);
         try {
             var captureStartupPhaseTelemetry = !fromUserAction && Volatile.Read(ref _startupFlowState) == 1;
@@ -450,13 +464,24 @@ public sealed partial class MainWindow : Window {
             StopAutoReconnectLoop();
             await SetStatusAsync(SessionStatus.Connected()).ConfigureAwait(false);
 
-            var deferStartupMetadataSync = ShouldDeferStartupHelloProbe(captureStartupPhaseTelemetry)
+            var deferStartupMetadataSync = deferPostConnectMetadataSync
+                                           || ShouldDeferStartupHelloProbe(captureStartupPhaseTelemetry)
                                            || ShouldDeferStartupToolCatalogSync(captureStartupPhaseTelemetry);
+            var skipDeferredMetadataUntilAuthenticated = ShouldSkipDeferredStartupMetadataSyncForUnauthenticatedNative(
+                deferStartupMetadataSync: deferStartupMetadataSync,
+                requiresInteractiveSignIn: RequiresInteractiveSignInForCurrentTransport(),
+                isAuthenticated: _isAuthenticated,
+                loginInProgress: _loginInProgress);
             if (deferStartupMetadataSync) {
                 _sessionPolicy = null;
-                LogStartupConnectPhase("hello", "deferred");
-                LogStartupConnectPhase("list_tools", "deferred");
-                QueueDeferredStartupConnectMetadataSync();
+                if (skipDeferredMetadataUntilAuthenticated) {
+                    LogStartupConnectPhase("hello", "skipped_unauthenticated");
+                    LogStartupConnectPhase("list_tools", "skipped_unauthenticated");
+                } else {
+                    LogStartupConnectPhase("hello", "deferred");
+                    LogStartupConnectPhase("list_tools", "deferred");
+                    QueueDeferredStartupConnectMetadataSync();
+                }
             } else {
                 try {
                     LogStartupConnectPhase("hello", "begin");
@@ -489,7 +514,9 @@ public sealed partial class MainWindow : Window {
             AppendStartupToolHealthWarningsFromPolicy();
             AppendUnavailablePacksFromPolicy();
 
-            if (ShouldDeferStartupAuthRefresh(captureStartupPhaseTelemetry)) {
+            if (skipDeferredMetadataUntilAuthenticated) {
+                LogStartupConnectPhase("auth_refresh", "skipped_unauthenticated");
+            } else if (deferPostConnectMetadataSync || ShouldDeferStartupAuthRefresh(captureStartupPhaseTelemetry)) {
                 LogStartupConnectPhase("auth_refresh", "deferred");
             } else {
                 LogStartupConnectPhase("auth_refresh", "begin");
@@ -501,7 +528,9 @@ public sealed partial class MainWindow : Window {
                     throw;
                 }
             }
-            if (ShouldDeferStartupModelProfileSync(captureStartupPhaseTelemetry)) {
+            if (skipDeferredMetadataUntilAuthenticated) {
+                LogStartupConnectPhase("model_profile_sync", "skipped_unauthenticated");
+            } else if (deferPostConnectMetadataSync || ShouldDeferStartupModelProfileSync(captureStartupPhaseTelemetry)) {
                 LogStartupConnectPhase("model_profile_sync", "deferred");
                 QueueDeferredStartupModelProfileSync();
             } else {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
@@ -84,6 +84,19 @@ public sealed partial class MainWindow : Window {
                     }
 
                     ApplyTurnMetrics(metrics);
+                    StartupLog.Write(
+                        "TurnMetrics request_id="
+                        + (metrics.RequestId ?? string.Empty).Trim()
+                        + " duration_ms="
+                        + metrics.DurationMs.ToString(CultureInfo.InvariantCulture)
+                        + " ttft_ms="
+                        + (metrics.TtftMs?.ToString(CultureInfo.InvariantCulture) ?? "null")
+                        + " outcome="
+                        + ((metrics.Outcome ?? string.Empty).Trim().Length == 0 ? "unknown" : metrics.Outcome!.Trim())
+                        + " tool_calls="
+                        + metrics.ToolCallsCount.ToString(CultureInfo.InvariantCulture)
+                        + " tool_rounds="
+                        + metrics.ToolRounds.ToString(CultureInfo.InvariantCulture));
                     RequestServiceDrivenSessionPublish();
                     if (VerboseServiceLogs || _debugMode) {
                         AppendSystem(FormatMetricsTrace(metrics));
@@ -489,7 +502,9 @@ public sealed partial class MainWindow : Window {
         });
     }
 
-    private async Task<bool> EnsureConnectedAsync(TimeSpan? connectBudgetOverride = null) {
+    private async Task<bool> EnsureConnectedAsync(
+        TimeSpan? connectBudgetOverride = null,
+        bool deferPostConnectMetadataSync = false) {
         if (_client is not null
             && await IsClientAliveAsync(
                     _client,
@@ -512,7 +527,9 @@ public sealed partial class MainWindow : Window {
                 connectAttemptTask = inFlightTask;
                 joinedExistingInFlight = true;
             } else {
-                connectAttemptTask = EnsureConnectedCoreAsync(connectBudget);
+                connectAttemptTask = EnsureConnectedCoreAsync(
+                    connectBudget,
+                    deferPostConnectMetadataSync: deferPostConnectMetadataSync);
                 _ensureConnectedInFlightTask = connectAttemptTask;
             }
         }
@@ -542,7 +559,7 @@ public sealed partial class MainWindow : Window {
         }
     }
 
-    private async Task<bool> EnsureConnectedCoreAsync(TimeSpan connectBudget) {
+    private async Task<bool> EnsureConnectedCoreAsync(TimeSpan connectBudget, bool deferPostConnectMetadataSync) {
         if (_client is not null
             && await IsClientAliveAsync(
                     _client,
@@ -559,7 +576,11 @@ public sealed partial class MainWindow : Window {
             return false;
         }
 
-        await ConnectAsync(fromUserAction: false, connectBudgetOverride: connectBudget).ConfigureAwait(false);
+        await ConnectAsync(
+                fromUserAction: false,
+                connectBudgetOverride: connectBudget,
+                deferPostConnectMetadataSync: deferPostConnectMetadataSync)
+            .ConfigureAwait(false);
         var connected = _client is not null;
         _isConnected = connected;
         if (!connected) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnQueue.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnQueue.cs
@@ -51,6 +51,8 @@ public sealed partial class MainWindow : Window {
 
         _turnStartupInProgress = true;
         var dispatchRequestId = string.Empty;
+        Task<bool>? connectWarmupTask = null;
+        DateTime? connectWarmupStartedUtc = null;
         try {
             long? queueWaitMs = null;
             if (queuedAtUtc.HasValue && queuedAtUtc.Value.Kind == DateTimeKind.Utc) {
@@ -58,6 +60,13 @@ public sealed partial class MainWindow : Window {
                 if (elapsed.TotalMilliseconds > 0) {
                     queueWaitMs = (long)Math.Round(elapsed.TotalMilliseconds);
                 }
+            }
+
+            // Start reconnect warm-up in parallel with turn preparation so auth checks
+            // and user bubble rendering do not wait on pipe/service startup.
+            if (_client is null || !_isConnected) {
+                connectWarmupStartedUtc = DateTime.UtcNow;
+                connectWarmupTask = EnsureConnectedAsync(deferPostConnectMetadataSync: true);
             }
 
             var turn = await PrepareChatTurnAsync(text, skipUserBubble).ConfigureAwait(false);
@@ -95,8 +104,15 @@ public sealed partial class MainWindow : Window {
 
             // Keep user bubble rendering immediate, but still validate connectivity
             // before we enter active send state.
-            var connectStartedUtc = DateTime.UtcNow;
-            var connected = await EnsureConnectedAsync().ConfigureAwait(false);
+            var connectStartedUtc = connectWarmupStartedUtc ?? DateTime.UtcNow;
+            var connected = connectWarmupTask is null
+                // Hot path: if we already have a connected client, avoid an eager liveness
+                // probe/reconnect before dispatch. Request-level recovery handles stale pipes.
+                ? (_client is not null && _isConnected
+                    ? true
+                    : await EnsureConnectedAsync(deferPostConnectMetadataSync: true).ConfigureAwait(false))
+                : await connectWarmupTask.ConfigureAwait(false);
+            connectWarmupTask = null;
             var connectCompletedUtc = DateTime.UtcNow;
             MarkTurnConnectStage(turn.RequestId, connectStartedUtc, connectCompletedUtc, connected);
             if (!connected) {
@@ -130,12 +146,8 @@ public sealed partial class MainWindow : Window {
                 }
                 ClearToolRoutingInsights();
                 await SetActivityAsync("Sending request to runtime...").ConfigureAwait(false);
-                try {
-                    await PublishSessionStateAsync().ConfigureAwait(false);
-                } finally {
-                    // Ensure tools state is refreshed after routing reset even if session publish faults.
-                    await PublishOptionsStateSafeAsync().ConfigureAwait(false);
-                }
+                // Keep dispatch path hot: publish state asynchronously while request starts.
+                _ = PublishTurnStartUiStateBestEffortAsync();
 
                 await ExecuteChatTurnWithReconnectAsync(turn, turnRequestCts.Token).ConfigureAwait(false);
             } finally {
@@ -184,6 +196,10 @@ public sealed partial class MainWindow : Window {
                 }
             }
         } finally {
+            if (connectWarmupTask is not null) {
+                _ = ObserveConnectWarmupCompletionAsync(connectWarmupTask);
+            }
+
             if (_turnStartupInProgress) {
                 _turnStartupInProgress = false;
                 try {
@@ -201,6 +217,31 @@ public sealed partial class MainWindow : Window {
                         await RestoreHeaderStatusAfterTurnIfNeededAsync(dispatchRequestId).ConfigureAwait(false);
                     }
                 }
+            }
+        }
+    }
+
+    private async Task ObserveConnectWarmupCompletionAsync(Task<bool> connectWarmupTask) {
+        try {
+            _ = await connectWarmupTask.ConfigureAwait(false);
+        } catch (Exception ex) {
+            if (VerboseServiceLogs || _debugMode) {
+                await AppendSystemBestEffortAsync("Background connect warm-up failed: " + ex.Message).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task PublishTurnStartUiStateBestEffortAsync() {
+        try {
+            try {
+                await PublishSessionStateAsync().ConfigureAwait(false);
+            } finally {
+                // Ensure tools state is refreshed after routing reset even if session publish faults.
+                await PublishOptionsStateSafeAsync().ConfigureAwait(false);
+            }
+        } catch (Exception ex) {
+            if (VerboseServiceLogs || _debugMode) {
+                await AppendSystemBestEffortAsync("Turn-start UI state publish failed: " + ex.Message).ConfigureAwait(false);
             }
         }
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ProfileUpdates.cs
@@ -44,12 +44,38 @@ public sealed partial class MainWindow : Window {
     }
 
     private static void ReplaceLastAssistantText(ConversationRuntime conversation, string text) {
-        for (var i = conversation.Messages.Count - 1; i >= 0; i--) {
-            if (string.Equals(conversation.Messages[i].Role, "Assistant", StringComparison.Ordinal)) {
-                conversation.Messages[i] = ("Assistant", text, conversation.Messages[i].Time, conversation.Messages[i].Model);
-                return;
-            }
+        var nowLocal = DateTime.Now;
+        if (conversation.Messages.Count > 0
+            && string.Equals(conversation.Messages[^1].Role, "Assistant", StringComparison.Ordinal)) {
+            var existing = conversation.Messages[^1];
+            var updatedTimestamp = ResolveAssistantTimestampForUpdate(
+                existing.Time,
+                existing.Text,
+                text,
+                nowLocal);
+            var updatedModel = string.IsNullOrWhiteSpace(existing.Model)
+                ? string.IsNullOrWhiteSpace(conversation.ModelLabel) ? null : conversation.ModelLabel.Trim()
+                : existing.Model;
+            conversation.Messages[^1] = ("Assistant", text, updatedTimestamp, updatedModel);
+            return;
         }
+
+        var modelLabel = string.IsNullOrWhiteSpace(conversation.ModelLabel) ? null : conversation.ModelLabel.Trim();
+        conversation.Messages.Add(("Assistant", text, nowLocal, modelLabel));
+    }
+
+    internal static DateTime ResolveAssistantTimestampForUpdate(
+        DateTime currentTimestamp,
+        string? existingText,
+        string? nextText,
+        DateTime nowLocal) {
+        var hadVisibleContent = !string.IsNullOrWhiteSpace(existingText);
+        var hasVisibleContent = !string.IsNullOrWhiteSpace(nextText);
+        if (!hadVisibleContent && hasVisibleContent) {
+            return nowLocal;
+        }
+
+        return currentTimestamp;
     }
 
     private void UpdateToolCatalog(ToolDefinitionDto[] tools) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Reliability.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Reliability.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading;
 using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.App.Conversation;
 using Microsoft.UI.Xaml;
@@ -563,6 +564,83 @@ public sealed partial class MainWindow : Window {
         return Math.Max(0L, (long)Math.Round(elapsed.TotalMilliseconds));
     }
 
+    internal static bool ShouldEmitTurnLatencySystemNotice(long durationMs) {
+        return ShouldEmitTurnLatencySystemNotice(durationMs, emitForFirstTurn: false);
+    }
+
+    internal static bool ShouldEmitTurnLatencySystemNotice(long durationMs, bool emitForFirstTurn) {
+        if (durationMs >= SlowTurnSystemNoticeThresholdMs) {
+            return true;
+        }
+
+        return emitForFirstTurn && durationMs >= FirstTurnLatencySystemNoticeThresholdMs;
+    }
+
+    internal static string BuildTurnLatencySystemNotice(
+        long durationMs,
+        long? queueWaitMs,
+        long? authProbeMs,
+        long? connectMs,
+        long? dispatchToFirstDeltaMs,
+        long? streamDurationMs,
+        bool firstTurnNotice = false) {
+        static long Normalize(long? value) {
+            return Math.Max(0L, value.GetValueOrDefault(0L));
+        }
+
+        var totalMs = Math.Max(0L, durationMs);
+        var queueMs = Normalize(queueWaitMs);
+        var authMs = Normalize(authProbeMs);
+        var connectStageMs = Normalize(connectMs);
+        var ttftMs = Normalize(dispatchToFirstDeltaMs);
+        var streamMs = Normalize(streamDurationMs);
+        var preflightMs = queueMs + authMs + connectStageMs;
+        var modelUntilFirstDeltaMs = ttftMs > preflightMs ? ttftMs - preflightMs : 0L;
+        var postFirstDeltaMs = totalMs > ttftMs ? totalMs - ttftMs : streamMs;
+        var dominantPhase = modelUntilFirstDeltaMs > preflightMs + 300
+            ? "model/runtime"
+            : preflightMs > modelUntilFirstDeltaMs + 300
+                ? "preflight"
+                : "mixed";
+
+        var noticePrefix = firstTurnNotice ? "First turn latency" : "Slow turn";
+        return noticePrefix + ": total "
+               + totalMs.ToString(CultureInfo.InvariantCulture)
+               + "ms | preflight "
+               + preflightMs.ToString(CultureInfo.InvariantCulture)
+               + "ms (queue "
+               + queueMs.ToString(CultureInfo.InvariantCulture)
+               + ", auth "
+               + authMs.ToString(CultureInfo.InvariantCulture)
+               + ", connect "
+               + connectStageMs.ToString(CultureInfo.InvariantCulture)
+               + ") | first-token "
+               + ttftMs.ToString(CultureInfo.InvariantCulture)
+               + "ms | model-pre-token ~"
+               + modelUntilFirstDeltaMs.ToString(CultureInfo.InvariantCulture)
+               + "ms | post-first-token ~"
+               + postFirstDeltaMs.ToString(CultureInfo.InvariantCulture)
+               + "ms | dominant: "
+               + dominantPhase
+               + ".";
+    }
+
+    private void AppendTurnLatencySystemNoticeIfNeeded(TurnLatencyCompletion completion) {
+        var emitForFirstTurn = Interlocked.CompareExchange(ref _startupFirstTurnLatencyNoticePending, 0, 1) == 1;
+        if (!ShouldEmitTurnLatencySystemNotice(completion.DurationMs, emitForFirstTurn)) {
+            return;
+        }
+
+        AppendSystem(BuildTurnLatencySystemNotice(
+            completion.DurationMs,
+            completion.QueueWaitMs,
+            completion.AuthProbeMs,
+            completion.ConnectMs,
+            completion.DispatchToFirstDeltaMs,
+            completion.StreamDurationMs,
+            firstTurnNotice: emitForFirstTurn));
+    }
+
     private static string MapOutcomeToMetricsToken(AssistantTurnOutcome outcome) {
         return outcome.Kind switch {
             AssistantTurnOutcomeKind.Canceled => "canceled",
@@ -631,4 +709,3 @@ public sealed partial class MainWindow : Window {
             EndpointHost: string.IsNullOrWhiteSpace(endpointHost) ? null : endpointHost.Trim());
     }
 }
-

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.cs
@@ -30,9 +30,9 @@ namespace IntelligenceX.Chat.App;
 public sealed partial class MainWindow : Window {
     private static readonly TimeSpan EnsureLoginProbeTimeout = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan EnsureLoginFreshProbeTimeout = TimeSpan.FromSeconds(2);
-    private static readonly TimeSpan EnsureLoginFastPathProbeTimeout = TimeSpan.FromMilliseconds(1200);
-    private static readonly TimeSpan EnsureLoginPostLoginProbeTimeout = TimeSpan.FromMilliseconds(1500);
-    private static readonly TimeSpan EnsureLoginProbeCacheTtl = TimeSpan.FromMilliseconds(900);
+    private static readonly TimeSpan EnsureLoginFastPathProbeTimeout = TimeSpan.FromMilliseconds(700);
+    private static readonly TimeSpan EnsureLoginPostLoginProbeTimeout = TimeSpan.FromMilliseconds(1200);
+    private static readonly TimeSpan EnsureLoginProbeCacheTtl = TimeSpan.FromSeconds(4);
     private static readonly TimeSpan EnsureLoginUnknownProbeRetryDelay = TimeSpan.FromMilliseconds(80);
     private static readonly TimeSpan RuntimeAccountPinResetTimeout = TimeSpan.FromSeconds(8);
     private static readonly TimeSpan RuntimeAccountPinResetFastTimeout = TimeSpan.FromSeconds(2);
@@ -62,6 +62,13 @@ public sealed partial class MainWindow : Window {
         Authenticated = 0,
         Unauthenticated = 1,
         Unknown = 2
+    }
+
+    internal static bool ShouldBypassDispatchAuthProbeForKnownUnauthenticatedState(
+        bool requiresInteractiveSignIn,
+        bool isAuthenticated,
+        bool hasExplicitUnauthenticatedProbeSnapshot) {
+        return requiresInteractiveSignIn && !isAuthenticated && hasExplicitUnauthenticatedProbeSnapshot;
     }
 
     private void ResetEnsureLoginProbeCache() {
@@ -293,7 +300,11 @@ public sealed partial class MainWindow : Window {
                 return;
             }
 
-            await ConnectAsync(fromUserAction: false, connectBudgetOverride: AutoReconnectConnectBudget).ConfigureAwait(false);
+            await ConnectAsync(
+                    fromUserAction: false,
+                    connectBudgetOverride: AutoReconnectConnectBudget,
+                    deferPostConnectMetadataSync: true)
+                .ConfigureAwait(false);
             attempt++;
 
             if (_client is not null && await IsClientAliveAsync(_client).ConfigureAwait(false)) {
@@ -392,6 +403,15 @@ public sealed partial class MainWindow : Window {
         if (!RequiresInteractiveSignInForCurrentTransport()) {
             ApplyNonNativeAuthenticationStateIfNeeded();
             return DispatchAuthenticationProbeOutcome.Authenticated;
+        }
+
+        if (ShouldBypassDispatchAuthProbeForKnownUnauthenticatedState(
+                requiresInteractiveSignIn: true,
+                isAuthenticated: _isAuthenticated,
+                hasExplicitUnauthenticatedProbeSnapshot: HasExplicitUnauthenticatedEnsureLoginProbeSnapshot())) {
+            _isAuthenticated = false;
+            _authenticatedAccountId = null;
+            return DispatchAuthenticationProbeOutcome.Unauthenticated;
         }
 
         var client = _client;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.cs
@@ -82,6 +82,9 @@ public sealed partial class MainWindow : Window {
             StartupLog.Write("StartupPhase.Onboarding deferred");
             QueueDeferredStartupOnboarding();
             Interlocked.Exchange(ref _startupFlowState, 2);
+            StartupLog.Write("StartupPhase.DispatchPrewarm deferred");
+            QueueDeferredStartupDispatchPrewarm();
+            QueueDeferredStartupBenchAutoSend();
             StartupLog.Write("MainWindow.StartupFlow done");
         } catch (Exception ex) {
             Interlocked.Exchange(ref _startupFlowState, 0);
@@ -224,12 +227,166 @@ public sealed partial class MainWindow : Window {
         });
     }
 
+    internal static bool ShouldRunStartupDispatchAuthPrewarm(
+        bool requiresInteractiveSignIn,
+        bool isAuthenticated,
+        bool loginInProgress) {
+        if (!requiresInteractiveSignIn) {
+            return false;
+        }
+
+        if (isAuthenticated) {
+            return false;
+        }
+
+        if (loginInProgress) {
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static string BuildStartupDispatchPrewarmSummary(
+        long connectMs,
+        bool authProbeAttempted,
+        bool? authProbeAuthenticated,
+        bool authProbeInconclusive,
+        long? authProbeMs) {
+        var safeConnectMs = Math.Max(0, connectMs);
+        var connectionSegment = safeConnectMs == 0
+            ? "runtime already connected"
+            : "runtime connected in " + safeConnectMs.ToString(CultureInfo.InvariantCulture) + "ms";
+        if (!authProbeAttempted) {
+            return "Startup prewarm ready: " + connectionSegment + " (auth check deferred).";
+        }
+
+        var safeAuthMs = Math.Max(0, authProbeMs.GetValueOrDefault(0));
+        if (authProbeInconclusive) {
+            return "Startup prewarm ready: " + connectionSegment
+                   + "; auth check inconclusive after "
+                   + safeAuthMs.ToString(CultureInfo.InvariantCulture)
+                   + "ms (will verify on first message).";
+        }
+
+        if (authProbeAuthenticated == true) {
+            return "Startup prewarm ready: " + connectionSegment
+                   + "; account verified in "
+                   + safeAuthMs.ToString(CultureInfo.InvariantCulture)
+                   + "ms.";
+        }
+
+        return "Startup prewarm ready: " + connectionSegment
+               + "; sign-in still required (checked in "
+               + safeAuthMs.ToString(CultureInfo.InvariantCulture)
+               + "ms).";
+    }
+
+    private void QueueDeferredStartupDispatchPrewarm() {
+        if (_shutdownRequested) {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _startupDispatchPrewarmDeferredQueued, 1, 0) != 0) {
+            return;
+        }
+
+        _ = Task.Run(async () => {
+            try {
+                await Task.Delay(StartupDeferredDispatchPrewarmDelay).ConfigureAwait(false);
+                if (_shutdownRequested) {
+                    return;
+                }
+
+                StartupLog.Write("StartupPhase.DispatchPrewarm begin");
+                var connectStartedUtc = DateTime.UtcNow;
+                var connected = false;
+                long connectMs;
+                if (_client is not null && _isConnected) {
+                    connected = true;
+                    connectMs = 0;
+                    StartupLog.Write("StartupPhase.DispatchPrewarm connect_reused");
+                } else {
+                    connected = await EnsureConnectedAsync(
+                            connectBudgetOverride: StartupDispatchPrewarmConnectBudget,
+                            deferPostConnectMetadataSync: true)
+                        .ConfigureAwait(false);
+                    connectMs = TryComputeElapsedMs(connectStartedUtc, DateTime.UtcNow);
+                }
+                if (!connected) {
+                    StartupLog.Write("StartupPhase.DispatchPrewarm connect_failed");
+                    await AppendSystemBestEffortAsync(
+                        "Startup prewarm couldn't connect to runtime. First message may need a reconnect.")
+                        .ConfigureAwait(false);
+                    return;
+                }
+
+                StartupLog.Write("StartupPhase.DispatchPrewarm connect_done");
+                var shouldProbeAuth = ShouldRunStartupDispatchAuthPrewarm(
+                    requiresInteractiveSignIn: RequiresInteractiveSignInForCurrentTransport(),
+                    isAuthenticated: _isAuthenticated,
+                    loginInProgress: _loginInProgress);
+                if (!shouldProbeAuth) {
+                    await AppendSystemBestEffortAsync(
+                        BuildStartupDispatchPrewarmSummary(
+                            connectMs: connectMs,
+                            authProbeAttempted: false,
+                            authProbeAuthenticated: null,
+                            authProbeInconclusive: false,
+                            authProbeMs: null)).ConfigureAwait(false);
+                    return;
+                }
+
+                var authProbeStartedUtc = DateTime.UtcNow;
+                var authOutcome = await ProbeAuthenticationStateForDispatchAsync(EnsureLoginFastPathProbeTimeout).ConfigureAwait(false);
+                var authProbeMs = TryComputeElapsedMs(authProbeStartedUtc, DateTime.UtcNow);
+                StartupLog.Write(
+                    "StartupPhase.DispatchPrewarm auth_probe="
+                    + authOutcome.ToString().ToLowerInvariant());
+                await AppendSystemBestEffortAsync(
+                    BuildStartupDispatchPrewarmSummary(
+                        connectMs: connectMs,
+                        authProbeAttempted: true,
+                        authProbeAuthenticated: authOutcome == DispatchAuthenticationProbeOutcome.Authenticated
+                            ? true
+                            : authOutcome == DispatchAuthenticationProbeOutcome.Unauthenticated
+                                ? false
+                                : null,
+                        authProbeInconclusive: authOutcome == DispatchAuthenticationProbeOutcome.Unknown,
+                        authProbeMs: authProbeMs)).ConfigureAwait(false);
+            } catch (Exception ex) {
+                StartupLog.Write("StartupPhase.DispatchPrewarm failed: " + ex.Message);
+                await AppendSystemBestEffortAsync("Startup prewarm failed: " + ex.Message).ConfigureAwait(false);
+            } finally {
+                Interlocked.Exchange(ref _startupDispatchPrewarmDeferredQueued, 0);
+            }
+        });
+    }
+
     private bool IsStartupInteractivePriorityRequested() {
         return Volatile.Read(ref _startupInteractivePriorityRequested) != 0;
     }
 
     private void MarkStartupInteractivePriorityRequested() {
         Interlocked.Exchange(ref _startupInteractivePriorityRequested, 1);
+    }
+
+    private async Task<bool> WaitForStartupDeferredBackgroundTurnIdleAsync(string phasePrefix) {
+        if (!IsStartupInteractivePriorityRequested() || !IsTurnDispatchInProgress()) {
+            return true;
+        }
+
+        StartupLog.Write(phasePrefix + " deferred_for_active_turn");
+        while (!_shutdownRequested && IsTurnDispatchInProgress()) {
+            await Task.Delay(StartupDeferredInteractiveBackgroundPollInterval).ConfigureAwait(false);
+        }
+
+        if (_shutdownRequested) {
+            StartupLog.Write(phasePrefix + " canceled_shutdown");
+            return false;
+        }
+
+        StartupLog.Write(phasePrefix + " resumed_after_turn");
+        return true;
     }
 
     private void QueueDeferredStartupModelProfileSync() {
@@ -247,8 +404,8 @@ public sealed partial class MainWindow : Window {
                 if (_shutdownRequested) {
                     return;
                 }
-                if (IsStartupInteractivePriorityRequested()) {
-                    StartupLog.Write("StartupConnect.model_profile_sync skipped_interactive_priority");
+
+                if (!await WaitForStartupDeferredBackgroundTurnIdleAsync("StartupConnect.model_profile_sync").ConfigureAwait(false)) {
                     return;
                 }
 
@@ -269,6 +426,34 @@ public sealed partial class MainWindow : Window {
         });
     }
 
+    private void QueueDeferredStartupBenchAutoSend() {
+        var prompt = (Environment.GetEnvironmentVariable("IXCHAT_BENCH_AUTOSEND_PROMPT") ?? string.Empty).Trim();
+        if (prompt.Length == 0 || _shutdownRequested) {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _startupBenchAutoSendQueued, 1, 0) != 0) {
+            return;
+        }
+
+        _ = Task.Run(async () => {
+            try {
+                await Task.Delay(350).ConfigureAwait(false);
+                if (_shutdownRequested) {
+                    return;
+                }
+
+                StartupLog.Write("StartupPhase.BenchAutoSend begin");
+                await RunOnUiThreadAsync(() => SendPromptAsync(prompt)).ConfigureAwait(false);
+                StartupLog.Write("StartupPhase.BenchAutoSend done");
+            } catch (Exception ex) {
+                StartupLog.Write("StartupPhase.BenchAutoSend failed: " + ex.Message);
+            } finally {
+                Interlocked.Exchange(ref _startupBenchAutoSendQueued, 0);
+            }
+        });
+    }
+
     private void QueueDeferredStartupConnectMetadataSync() {
         if (_shutdownRequested) {
             return;
@@ -284,8 +469,8 @@ public sealed partial class MainWindow : Window {
                 if (_shutdownRequested) {
                     return;
                 }
-                if (IsStartupInteractivePriorityRequested()) {
-                    StartupLog.Write("StartupConnect.metadata_sync skipped_interactive_priority");
+
+                if (!await WaitForStartupDeferredBackgroundTurnIdleAsync("StartupConnect.metadata_sync").ConfigureAwait(false)) {
                     return;
                 }
 
@@ -295,10 +480,6 @@ public sealed partial class MainWindow : Window {
                 }
 
                 try {
-                    if (IsStartupInteractivePriorityRequested()) {
-                        StartupLog.Write("StartupConnect.hello skipped_interactive_priority");
-                        return;
-                    }
                     StartupLog.Write("StartupConnect.hello begin");
                     var hello = await client.RequestAsync<HelloMessage>(new HelloRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
                     _sessionPolicy = hello.Policy;
@@ -314,10 +495,6 @@ public sealed partial class MainWindow : Window {
                 }
 
                 try {
-                    if (IsStartupInteractivePriorityRequested()) {
-                        StartupLog.Write("StartupConnect.list_tools skipped_interactive_priority");
-                        return;
-                    }
                     StartupLog.Write("StartupConnect.list_tools begin");
                     var toolList = await client.RequestAsync<ToolListMessage>(new ListToolsRequest { RequestId = NextId() }, CancellationToken.None).ConfigureAwait(false);
                     UpdateToolCatalog(toolList.Tools);
@@ -330,10 +507,6 @@ public sealed partial class MainWindow : Window {
                 }
 
                 try {
-                    if (IsStartupInteractivePriorityRequested()) {
-                        StartupLog.Write("StartupConnect.auth_refresh skipped_interactive_priority");
-                        return;
-                    }
                     StartupLog.Write("StartupConnect.auth_refresh begin");
                     _ = await RefreshAuthenticationStateAsync(updateStatus: true).ConfigureAwait(false);
                     StartupLog.Write("StartupConnect.auth_refresh done");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -67,8 +67,9 @@ public sealed partial class MainWindow : Window {
     private static readonly TimeSpan DragMoveWatchdogInterval = TimeSpan.FromMilliseconds(1200);
     private static readonly TimeSpan StartupInitialPipeConnectTimeout = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan StartupInitialPipeConnectColdStartTimeout = TimeSpan.FromMilliseconds(100);
-    private static readonly TimeSpan StartupConnectBudget = TimeSpan.FromSeconds(4);
+    private static readonly TimeSpan StartupConnectBudget = TimeSpan.FromSeconds(6);
     private static readonly TimeSpan DispatchConnectBudget = TimeSpan.FromSeconds(8);
+    private static readonly TimeSpan StartupDispatchPrewarmConnectBudget = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan DispatchConnectFailureCooldown = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan AutoReconnectConnectBudget = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan AutoReconnectBusyTurnDelay = TimeSpan.FromMilliseconds(400);
@@ -88,10 +89,13 @@ public sealed partial class MainWindow : Window {
         TimeSpan.FromSeconds(12),
         TimeSpan.FromSeconds(20)
     };
+    private static readonly TimeSpan KickoffCancelAckTimeout = TimeSpan.FromMilliseconds(450);
     private static readonly TimeSpan KickoffRecoverySettleDelay = TimeSpan.FromMilliseconds(60);
     private static readonly TimeSpan StartupWebViewBudget = TimeSpan.FromSeconds(4);
-    private static readonly TimeSpan StartupDeferredConnectMetadataDelay = TimeSpan.FromMilliseconds(750);
+    private static readonly TimeSpan StartupDeferredConnectMetadataDelay = TimeSpan.FromMilliseconds(1200);
     private static readonly TimeSpan StartupDeferredModelProfileSyncDelay = TimeSpan.FromMilliseconds(1250);
+    private static readonly TimeSpan StartupDeferredDispatchPrewarmDelay = TimeSpan.FromMilliseconds(60);
+    private static readonly TimeSpan StartupDeferredInteractiveBackgroundPollInterval = TimeSpan.FromMilliseconds(200);
     private const int StartupWebViewBudgetFastEnsureThresholdMs = 1200;
     private const int StartupWebViewBudgetMediumEnsureThresholdMs = 2000;
     private const int StartupWebViewBudgetSlowEnsureThresholdMs = 3000;
@@ -105,6 +109,8 @@ public sealed partial class MainWindow : Window {
     private const int StartupWebViewBudgetAdaptiveCooldownRunsAfterExhaustion = 2;
     private const int StartupWebViewBudgetAdaptiveMaxStableCompletions = 8;
     private const int StartupWebViewBudgetMaxConsecutiveExhaustions = 8;
+    private const long FirstTurnLatencySystemNoticeThresholdMs = 1200;
+    private const long SlowTurnSystemNoticeThresholdMs = 4500;
     private const string StartupWebViewBudgetCacheFileName = "startup-webview-budget-cache-v1.json";
     private const string StartupWebViewBudgetReasonCooldownConservative = "cooldown_conservative";
     private const string StartupWebViewBudgetReasonExhaustionConservative = "exhaustion_conservative";
@@ -246,6 +252,7 @@ public sealed partial class MainWindow : Window {
     private readonly object _startupWebViewBudgetCacheSync = new();
     private StartupWebViewBudgetCacheEntry _startupWebViewBudgetCache = StartupWebViewBudgetCacheEntry.Default;
     private int _startupWebViewBudgetExceededThisRun;
+    private int _startupBenchAutoSendQueued;
     private int _serviceStagingCleanupInFlight;
 
     private ChatServiceClient? _client;
@@ -361,6 +368,8 @@ public sealed partial class MainWindow : Window {
     private int _startupConnectMetadataDeferredQueued;
     private int _startupModelProfileSyncDeferredQueued;
     private int _startupWebViewPostInitDeferredQueued;
+    private int _startupDispatchPrewarmDeferredQueued;
+    private int _startupFirstTurnLatencyNoticePending = 1;
     private int _startupInteractivePriorityRequested;
     private string _themePreset = "default";
     private string? _sessionUserNameOverride;

--- a/scripts/profile-chat-first-turn.ps1
+++ b/scripts/profile-chat-first-turn.ps1
@@ -1,0 +1,465 @@
+[CmdletBinding()]
+param(
+    [string] $ExePath,
+    [ValidateRange(1, 20)]
+    [int] $Runs = 3,
+    [ValidateRange(10, 180)]
+    [int] $StartupTimeoutSeconds = 70,
+    [ValidateRange(10, 240)]
+    [int] $TurnTimeoutSeconds = 90,
+    [string] $ProfileName = "default",
+    [string] $OutFile
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not $IsWindows) {
+    throw "This script requires Windows."
+}
+
+$repoRoot = (Get-Item (Join-Path $PSScriptRoot "..")).FullName
+if ([string]::IsNullOrWhiteSpace($ExePath)) {
+    $ExePath = Join-Path $repoRoot "IntelligenceX.Chat\IntelligenceX.Chat.App\bin\Debug\net8.0-windows10.0.26100.0\win-x64\IntelligenceX.Chat.App.exe"
+}
+
+if (-not (Test-Path $ExePath)) {
+    throw "Chat app executable not found: $ExePath"
+}
+
+$dbPath = Join-Path $env:LOCALAPPDATA "IntelligenceX.Chat\app-state.db"
+$startupLogPath = Join-Path $env:TEMP "IntelligenceX.Chat\app-startup.log"
+$sqliteCorePath = "C:\Support\GitHub\DbaClientX\DbaClientX.Core\bin\Debug\net8.0\DbaClientX.Core.dll"
+$sqlitePath = "C:\Support\GitHub\DbaClientX\DbaClientX.SQLite\bin\Debug\net8.0\DbaClientX.SQLite.dll"
+
+if (-not (Test-Path $sqliteCorePath) -or -not (Test-Path $sqlitePath)) {
+    throw "DbaClientX assemblies not found. Build Debug first: $sqliteCorePath ; $sqlitePath"
+}
+
+Add-Type -AssemblyName Microsoft.VisualBasic
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -Path $sqliteCorePath
+Add-Type -Path $sqlitePath
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class IxChatWin32 {
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool SetCursorPos(int x, int y);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, UIntPtr dwExtraInfo);
+
+    public const int SW_RESTORE = 9;
+    public const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+    public const uint MOUSEEVENTF_LEFTUP = 0x0004;
+}
+"@
+
+function Stop-ChatProcesses {
+    Get-Process -Name "IntelligenceX.Chat.App", "IntelligenceX.Chat.Service" -ErrorAction SilentlyContinue |
+        Stop-Process -Force -ErrorAction SilentlyContinue
+}
+
+function Wait-StartupDone([int] $timeoutSeconds, [string] $startupLog) {
+    $deadline = (Get-Date).AddSeconds($timeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-Path $startupLog) {
+            $raw = Get-Content $startupLog -Raw -ErrorAction SilentlyContinue
+            if ($raw -match "MainWindow.StartupFlow done") {
+                return $true
+            }
+            if ($raw -match "MainWindow.StartupFlow failed") {
+                return $false
+            }
+        }
+        Start-Sleep -Milliseconds 150
+    }
+    return $false
+}
+
+function Get-StartupLogMarkerTime([string] $startupLog, [string] $marker) {
+    if (-not (Test-Path $startupLog)) {
+        return $null
+    }
+
+    try {
+        $line = Get-Content $startupLog -ErrorAction SilentlyContinue |
+            Where-Object { $_ -like "*$marker*" } |
+            Select-Object -Last 1
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            return $null
+        }
+
+        if ($line -match '^\[(?<ts>[^\]]+)\]') {
+            return [datetime]::Parse($Matches['ts'])
+        }
+    } catch {
+        return $null
+    }
+
+    return $null
+}
+
+function Get-LatestStartupTurnMetrics([string] $startupLog) {
+    if (-not (Test-Path $startupLog)) {
+        return $null
+    }
+
+    try {
+        $line = Get-Content $startupLog -ErrorAction SilentlyContinue |
+            Where-Object { $_ -like '*TurnMetrics request_id=*' } |
+            Select-Object -Last 1
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            return $null
+        }
+
+        if ($line -match '^\[(?<ts>[^\]]+)\]\s+TurnMetrics request_id=(?<requestId>\S+)\s+duration_ms=(?<duration>\d+)\s+ttft_ms=(?<ttft>null|\d+)\s+outcome=(?<outcome>\S+)\s+tool_calls=(?<toolCalls>\d+)\s+tool_rounds=(?<toolRounds>\d+)') {
+            $ttftValue = $null
+            if ($Matches['ttft'] -ne 'null') {
+                $ttftValue = [long]$Matches['ttft']
+            }
+
+            return [pscustomobject]@{
+                timestamp = [datetime]::Parse($Matches['ts'])
+                requestId = $Matches['requestId']
+                durationMs = [long]$Matches['duration']
+                ttftMs = $ttftValue
+                outcome = $Matches['outcome']
+                toolCalls = [int]$Matches['toolCalls']
+                toolRounds = [int]$Matches['toolRounds']
+            }
+        }
+    } catch {
+        return $null
+    }
+
+    return $null
+}
+
+function Wait-MainWindowHandle([System.Diagnostics.Process] $process, [int] $timeoutSeconds) {
+    $deadline = (Get-Date).AddSeconds($timeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $process.Refresh()
+        if ($process.MainWindowHandle -ne 0) {
+            return $process.MainWindowHandle
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    return [IntPtr]::Zero
+}
+
+function Focus-MainWindowPromptArea([System.IntPtr] $windowHandle) {
+    if ($windowHandle -eq [System.IntPtr]::Zero) {
+        return $false
+    }
+
+    [void][IxChatWin32]::ShowWindow($windowHandle, [IxChatWin32]::SW_RESTORE)
+    [void][IxChatWin32]::SetForegroundWindow($windowHandle)
+    Start-Sleep -Milliseconds 350
+
+    $rect = New-Object IxChatWin32+RECT
+    if (-not [IxChatWin32]::GetWindowRect($windowHandle, [ref]$rect)) {
+        return $false
+    }
+
+    $width = [Math]::Max(1, $rect.Right - $rect.Left)
+    $height = [Math]::Max(1, $rect.Bottom - $rect.Top)
+    $x = $rect.Left + [Math]::Floor($width / 2)
+    $y = $rect.Top + [Math]::Floor($height - 34)
+    [void][IxChatWin32]::SetCursorPos($x, $y)
+    Start-Sleep -Milliseconds 80
+    [IxChatWin32]::mouse_event([IxChatWin32]::MOUSEEVENTF_LEFTDOWN, 0, 0, 0, [UIntPtr]::Zero)
+    [IxChatWin32]::mouse_event([IxChatWin32]::MOUSEEVENTF_LEFTUP, 0, 0, 0, [UIntPtr]::Zero)
+    Start-Sleep -Milliseconds 120
+    return $true
+}
+
+function New-SqlParameters {
+    return (New-Object 'System.Collections.Generic.Dictionary[string,object]' ([StringComparer]::OrdinalIgnoreCase))
+}
+
+function Get-ProfileNames([string] $databasePath) {
+    $names = New-Object System.Collections.Generic.List[string]
+    if (-not (Test-Path $databasePath)) {
+        return $names
+    }
+
+    try {
+        $db = New-Object DBAClientX.SQLite
+        for ($offset = 0; $offset -lt 128; $offset++) {
+            $sql = "SELECT profile_name FROM ix_app_profiles ORDER BY profile_name LIMIT 1 OFFSET " + $offset
+            $name = $db.ExecuteScalar($databasePath, $sql, (New-SqlParameters))
+            $normalized = ([string]$name).Trim()
+            if ([string]::IsNullOrWhiteSpace($normalized)) {
+                break
+            }
+            [void]$names.Add($normalized)
+        }
+    } catch {
+        # best-effort discovery
+    }
+
+    return $names
+}
+
+function Get-ProfileJson([string] $databasePath, [string] $profileName) {
+    if (-not (Test-Path $databasePath)) {
+        return $null
+    }
+    try {
+        $db = New-Object DBAClientX.SQLite
+        $parameters = New-SqlParameters
+        $parameters["@name"] = $profileName
+        return $db.ExecuteScalar($databasePath, "SELECT json FROM ix_app_profiles WHERE profile_name = @name", $parameters)
+    } catch {
+        return $null
+    }
+}
+
+function Find-PromptObservationForState([object] $state, [string] $promptText) {
+    if ($null -eq $state -or $null -eq $state.conversations) {
+        return $null
+    }
+
+    $firstUserObservation = $null
+    foreach ($conversation in @($state.conversations)) {
+        $messages = @($conversation.messages)
+        if ($messages.Count -eq 0) {
+            continue
+        }
+        for ($i = 0; $i -lt $messages.Count; $i++) {
+            $entry = $messages[$i]
+            if ($entry.role -ne "User" -or $entry.text -ne $promptText) {
+                continue
+            }
+            $userTime = [datetime]$entry.time
+            if ($null -eq $firstUserObservation) {
+                $firstUserObservation = [pscustomobject]@{
+                    foundAssistant = $false
+                    conversationId = $conversation.id
+                    userAt = $userTime
+                    assistantAt = $null
+                    assistantPreview = $null
+                }
+            }
+            for ($j = $i + 1; $j -lt $messages.Count; $j++) {
+                $assistant = $messages[$j]
+                if ($assistant.role -ne "Assistant") {
+                    continue
+                }
+                if ([string]::IsNullOrWhiteSpace([string]$assistant.text)) {
+                    continue
+                }
+                return [pscustomobject]@{
+                    foundAssistant = $true
+                    conversationId = $conversation.id
+                    userAt = $userTime
+                    assistantAt = [datetime]$assistant.time
+                    assistantPreview = ([string]$assistant.text).Substring(0, [Math]::Min(120, ([string]$assistant.text).Length))
+                }
+            }
+        }
+    }
+
+    return $firstUserObservation
+}
+
+function Find-PromptObservationAcrossProfiles(
+    [string] $databasePath,
+    [System.Collections.Generic.List[string]] $profileNames,
+    [string] $promptText) {
+    $userOnly = $null
+    foreach ($profileName in @($profileNames)) {
+        $json = Get-ProfileJson -databasePath $databasePath -profileName $profileName
+        if ([string]::IsNullOrWhiteSpace($json)) {
+            continue
+        }
+
+        try {
+            $state = $json | ConvertFrom-Json -Depth 100
+            $observation = Find-PromptObservationForState -state $state -promptText $promptText
+            if ($null -eq $observation) {
+                continue
+            }
+
+            $withProfile = [pscustomobject]@{
+                profileName = $profileName
+                foundAssistant = $observation.foundAssistant
+                conversationId = $observation.conversationId
+                userAt = $observation.userAt
+                assistantAt = $observation.assistantAt
+                assistantPreview = $observation.assistantPreview
+            }
+
+            if ($withProfile.foundAssistant) {
+                return $withProfile
+            }
+
+            if ($null -eq $userOnly) {
+                $userOnly = $withProfile
+            }
+        } catch {
+            # best effort parsing while app is writing
+        }
+    }
+
+    return $userOnly
+}
+
+$runResults = New-Object System.Collections.Generic.List[object]
+
+for ($run = 1; $run -le $Runs; $run++) {
+    Stop-ChatProcesses
+    if (Test-Path $startupLogPath) {
+        Remove-Item $startupLogPath -Force
+    }
+
+    $message = "bench-first-turn-" + [Guid]::NewGuid().ToString("N").Substring(0, 8)
+    $previousAutoPrompt = $env:IXCHAT_BENCH_AUTOSEND_PROMPT
+    $env:IXCHAT_BENCH_AUTOSEND_PROMPT = $message
+    $launchAt = Get-Date
+    $process = Start-Process -FilePath $ExePath -PassThru
+    if ($null -eq $previousAutoPrompt) {
+        Remove-Item Env:IXCHAT_BENCH_AUTOSEND_PROMPT -ErrorAction SilentlyContinue
+    } else {
+        $env:IXCHAT_BENCH_AUTOSEND_PROMPT = $previousAutoPrompt
+    }
+    $startupDone = Wait-StartupDone -timeoutSeconds $StartupTimeoutSeconds -startupLog $startupLogPath
+    $startupDoneAt = Get-Date
+    $mainWindowHandle = Wait-MainWindowHandle -process $process -timeoutSeconds 20
+
+    $sendAttempted = $true
+    $sendAt = $null
+    $focusedPrompt = $false
+    if ($mainWindowHandle -ne [IntPtr]::Zero) {
+        # Optional focus click helps interactive observation while benchmark auto-send runs via env var.
+        $focusedPrompt = Focus-MainWindowPromptArea -windowHandle $mainWindowHandle
+    }
+
+    $response = $null
+    $benchAutoSendBeginAt = $null
+    $benchAutoSendDoneAt = $null
+    $turnMetrics = $null
+    if ($sendAttempted) {
+        $profileNames = New-Object System.Collections.Generic.List[string]
+        foreach ($profile in @(Get-ProfileNames -databasePath $dbPath)) {
+            $normalizedProfile = ([string]$profile).Trim()
+            if (-not [string]::IsNullOrWhiteSpace($normalizedProfile) -and -not $profileNames.Contains($normalizedProfile)) {
+                [void]$profileNames.Add($normalizedProfile)
+            }
+        }
+
+        $preferredProfile = ([string]$ProfileName).Trim()
+        if (-not [string]::IsNullOrWhiteSpace($preferredProfile) -and -not $profileNames.Contains($preferredProfile)) {
+            [void]$profileNames.Add($preferredProfile)
+        }
+        $deadline = (Get-Date).AddSeconds($TurnTimeoutSeconds)
+        while ((Get-Date) -lt $deadline) {
+            $response = Find-PromptObservationAcrossProfiles -databasePath $dbPath -profileNames $profileNames -promptText $message
+            if ($null -ne $response -and $response.foundAssistant) {
+                break
+            }
+
+            if ($null -eq $benchAutoSendBeginAt) {
+                $benchAutoSendBeginAt = Get-StartupLogMarkerTime -startupLog $startupLogPath -marker "StartupPhase.BenchAutoSend begin"
+            }
+            if ($null -eq $benchAutoSendDoneAt) {
+                $benchAutoSendDoneAt = Get-StartupLogMarkerTime -startupLog $startupLogPath -marker "StartupPhase.BenchAutoSend done"
+            }
+            if ($benchAutoSendBeginAt -and $benchAutoSendDoneAt) {
+                $turnMetrics = Get-LatestStartupTurnMetrics -startupLog $startupLogPath
+                # Benchmark hook completed; do not burn the full timeout waiting on DB parsing.
+                break
+            }
+
+            Start-Sleep -Milliseconds 250
+        }
+
+        if ($null -eq $turnMetrics) {
+            $turnMetrics = Get-LatestStartupTurnMetrics -startupLog $startupLogPath
+        }
+    }
+
+    $runResult = [ordered]@{
+        run = $run
+        processId = $process.Id
+        startupDone = $startupDone
+        startupMs = [Math]::Round(($startupDoneAt - $launchAt).TotalMilliseconds, 2)
+        sendAttempted = $sendAttempted
+        promptFocused = $focusedPrompt
+        prompt = $message
+        sendAt = if ($sendAt) { $sendAt.ToString("O") } else { $null }
+        profileName = if ($response) { $response.profileName } else { $null }
+        foundUser = $null -ne $response
+        foundAssistant = if ($response) { [bool]$response.foundAssistant } else { $false }
+        benchAutoSendBeginAt = if ($benchAutoSendBeginAt) { $benchAutoSendBeginAt.ToString("O") } else { $null }
+        benchAutoSendDoneAt = if ($benchAutoSendDoneAt) { $benchAutoSendDoneAt.ToString("O") } else { $null }
+        benchAutoSendMs = if ($benchAutoSendBeginAt -and $benchAutoSendDoneAt) { [Math]::Round(($benchAutoSendDoneAt - $benchAutoSendBeginAt).TotalMilliseconds, 2) } else { $null }
+        turnMetricsRequestId = if ($turnMetrics) { $turnMetrics.requestId } else { $null }
+        turnMetricsAt = if ($turnMetrics) { $turnMetrics.timestamp.ToString("O") } else { $null }
+        turnMetricsDurationMs = if ($turnMetrics) { $turnMetrics.durationMs } else { $null }
+        turnMetricsTtftMs = if ($turnMetrics) { $turnMetrics.ttftMs } else { $null }
+        turnMetricsOutcome = if ($turnMetrics) { $turnMetrics.outcome } else { $null }
+        turnMetricsToolCalls = if ($turnMetrics) { $turnMetrics.toolCalls } else { $null }
+        turnMetricsToolRounds = if ($turnMetrics) { $turnMetrics.toolRounds } else { $null }
+        userAt = if ($response) { $response.userAt.ToString("O") } else { $null }
+        assistantAt = if ($response -and $response.assistantAt) { $response.assistantAt.ToString("O") } else { $null }
+        firstTurnMs = if ($response -and $response.userAt -and $response.assistantAt) { [Math]::Round(($response.assistantAt - $response.userAt).TotalMilliseconds, 2) } else { $null }
+        assistantPreview = if ($response) { $response.assistantPreview } else { $null }
+    }
+    $runResults.Add([pscustomobject]$runResult)
+
+    Write-Host ("Run {0}/{1}: startupDone={2}, startupMs={3}, sendAttempted={4}, foundUser={5}, foundAssistant={6}, firstTurnMs={7}, benchAutoSendMs={8}, ttftMs={9}, durationMs={10}" -f
+        $run, $Runs, $runResult.startupDone, $runResult.startupMs, $runResult.sendAttempted, $runResult.foundUser, $runResult.foundAssistant, $runResult.firstTurnMs, $runResult.benchAutoSendMs, $runResult.turnMetricsTtftMs, $runResult.turnMetricsDurationMs)
+}
+
+$completed = @($runResults | Where-Object { $_.foundAssistant -eq $true -and $null -ne $_.firstTurnMs })
+$avgFirstTurn = if ($completed.Count -gt 0) {
+    [Math]::Round((($completed | Measure-Object -Property firstTurnMs -Average).Average), 2)
+} else {
+    $null
+}
+
+$report = [pscustomobject]@{
+    schema_version = "chat-first-turn-profile-v1"
+    generated_utc = [datetime]::UtcNow.ToString("O")
+    exe_path = $ExePath
+    db_path = $dbPath
+    startup_log_path = $startupLogPath
+    runs_requested = $Runs
+    runs_with_assistant = $completed.Count
+    avg_first_turn_ms = $avgFirstTurn
+    runs = $runResults
+}
+
+$jsonReport = $report | ConvertTo-Json -Depth 8
+if (-not [string]::IsNullOrWhiteSpace($OutFile)) {
+    $resolvedOut = [System.IO.Path]::GetFullPath($OutFile)
+    $outDir = [System.IO.Path]::GetDirectoryName($resolvedOut)
+    if (-not [string]::IsNullOrWhiteSpace($outDir) -and -not (Test-Path $outDir)) {
+        New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+    }
+    $jsonReport | Set-Content -Path $resolvedOut -Encoding UTF8
+    Write-Host "Saved report: $resolvedOut"
+}
+
+$jsonReport


### PR DESCRIPTION
## Summary
- improve first-turn cold-start flow by prewarming runtime connection during startup without blocking UI
- defer expensive startup metadata/auth/model sync off the critical dispatch path and avoid dropping deferred metadata when user sends quickly
- remove assistant pending placeholder bubble ("Working on it...") so normal turns no longer render a fake assistant message before real output
- preserve accurate assistant timestamps by setting timestamp on first visible assistant text
- add startup/turn latency diagnostics and a local benchmark script for repeatable first-turn measurements

## User-visible changes
- no assistant placeholder bubble before real model output
- startup prewarm system signal reflects runtime/auth prewarm state
- first-turn timing notices and startup logs better identify whether delay is preflight vs model/runtime
- tool metadata preload now waits for active turn to finish instead of being skipped permanently when user interacts early

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Debug`
  - Passed: 500, Failed: 0
