### PR TITLE
Follow-up: address PR 712 bot blockers

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowEnsureConnectedInFlightTaskTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowEnsureConnectedInFlightTaskTests.cs
@@ -1,0 +1,29 @@
+using IntelligenceX.Chat.App;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Verifies lifecycle reset behavior for shared in-flight connect task tracking.
+/// </summary>
+public sealed class MainWindowEnsureConnectedInFlightTaskTests {
+    /// <summary>
+    /// Owner-created in-flight connect attempts must always clear in finally,
+    /// while joined in-flight attempts clear only after completion.
+    /// </summary>
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, true)]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, true)]
+    public void ShouldResetEnsureConnectedInFlightTask_ReturnsExpectedValue(
+        bool startedNewInFlightTask,
+        bool connectAttemptTaskCompleted,
+        bool expected) {
+        var shouldReset = MainWindow.ShouldResetEnsureConnectedInFlightTask(
+            startedNewInFlightTask,
+            connectAttemptTaskCompleted);
+
+        Assert.Equal(expected, shouldReset);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
@@ -50,7 +50,7 @@ public sealed partial class MainWindow : Window {
                         TranscriptMarkdownNormalizer.NormalizeForStreamingPreview(_assistantStreaming.ToString()));
                     requestConversation.UpdatedUtc = DateTime.UtcNow;
                     if (string.Equals(requestConversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
-                        _ = RenderTranscriptAsync();
+                        QueueTranscriptRender("chat_delta");
                     }
                     break;
                 case ChatStatusMessage status:
@@ -522,6 +522,7 @@ public sealed partial class MainWindow : Window {
 
         Task<bool> connectAttemptTask;
         var joinedExistingInFlight = false;
+        var startedNewInFlightTask = false;
         lock (_ensureConnectedSync) {
             if (_ensureConnectedInFlightTask is { IsCompleted: false } inFlightTask) {
                 connectAttemptTask = inFlightTask;
@@ -531,6 +532,7 @@ public sealed partial class MainWindow : Window {
                     connectBudget,
                     deferPostConnectMetadataSync: deferPostConnectMetadataSync);
                 _ensureConnectedInFlightTask = connectAttemptTask;
+                startedNewInFlightTask = true;
             }
         }
 
@@ -552,11 +554,28 @@ public sealed partial class MainWindow : Window {
             return await connectAttemptTask.ConfigureAwait(false);
         } finally {
             lock (_ensureConnectedSync) {
-                if (ReferenceEquals(_ensureConnectedInFlightTask, connectAttemptTask) && connectAttemptTask.IsCompleted) {
+                if (ReferenceEquals(_ensureConnectedInFlightTask, connectAttemptTask)
+                    && ShouldResetEnsureConnectedInFlightTask(
+                        startedNewInFlightTask: startedNewInFlightTask,
+                        connectAttemptTaskCompleted: connectAttemptTask.IsCompleted)) {
                     _ensureConnectedInFlightTask = null;
                 }
             }
         }
+    }
+
+    internal static bool ShouldResetEnsureConnectedInFlightTask(
+        bool startedNewInFlightTask,
+        bool connectAttemptTaskCompleted) {
+        if (startedNewInFlightTask) {
+            // Owner call must always clear in finally so a faulted/canceled attempt
+            // never pins stale in-flight state for subsequent reconnects.
+            return true;
+        }
+
+        // Joiners clear only after observing task completion; do not clear an active
+        // in-flight connect attempt while it is still running.
+        return connectAttemptTaskCompleted;
     }
 
     private async Task<bool> EnsureConnectedCoreAsync(TimeSpan connectBudget, bool deferPostConnectMetadataSync) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -61,7 +61,7 @@ public sealed partial class MainWindow : Window {
         _modelKickoffAttempted = false;
         _modelKickoffInProgress = false;
         _pendingLoginPrompt = null;
-        _ = RenderTranscriptAsync();
+        QueueTranscriptRender("clear_conversation");
         _ = PublishOptionsStateSafeAsync();
         QueuePersistAppState();
     }
@@ -75,7 +75,7 @@ public sealed partial class MainWindow : Window {
         conversation.Messages.Add(("System", text, DateTime.Now, null));
         conversation.UpdatedUtc = DateTime.UtcNow;
         if (string.Equals(conversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
-            _ = RenderTranscriptAsync();
+            QueueTranscriptRender("append_system");
         }
     }
 
@@ -85,6 +85,22 @@ public sealed partial class MainWindow : Window {
 
     private void AppendSystem(ConversationRuntime conversation, SystemNotice notice) {
         AppendSystem(conversation, SystemNoticeFormatter.Format(notice));
+    }
+
+    private void QueueTranscriptRender(string reason) {
+        _ = RenderTranscriptBestEffortAsync(reason);
+    }
+
+    private async Task RenderTranscriptBestEffortAsync(string reason) {
+        try {
+            await RenderTranscriptAsync().ConfigureAwait(false);
+        } catch (Exception ex) {
+            // Keep UI flow resilient; transcript failures should be visible in startup diagnostics.
+            StartupLog.Write("RenderTranscriptAsync failed (" + reason + "): " + ex.Message);
+            if (_debugMode) {
+                Debug.WriteLine("RenderTranscriptAsync failed (" + reason + "): " + ex);
+            }
+        }
     }
 
     private async Task RenderTranscriptAsync() {


### PR DESCRIPTION
## Summary
Follow-up cleanup for PR #712 to address IntelligenceX review bot merge blockers.

### Fixed
- replace fire-and-forget transcript calls with safe background wrapper
  - `QueueTranscriptRender(...)` now routes through `RenderTranscriptBestEffortAsync(...)`
  - render failures are caught and logged via `StartupLog` (and `Debug.WriteLine` in debug mode)
- make in-flight connect task reset deterministic
  - owner-created `_ensureConnectedInFlightTask` is always cleared in `finally`
  - joined callers clear only when the joined task has completed

### Added tests
- `MainWindowEnsureConnectedInFlightTaskTests`
  - verifies reset semantics for owner/joiner and completed/incomplete task states

## Bot blocker mapping (PR #712 comment)
- ✅ fire-and-forget `RenderTranscriptAsync()` is now safely observed/logged
- ✅ `_ensureConnectedInFlightTask` lifecycle now has explicit reset policy in `finally`

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Debug`
  - Passed: 475, Failed: 0
