### PR TITLE
Fix Prism theme regression without breaking audit gate

### DIFF
--- a/Website/site.json
+++ b/Website/site.json
@@ -111,7 +111,7 @@
   "AssetRegistry": {
     "CssStrategy": "standard",
     "Bundles": [
-      { "Name": "global", "Css": ["/css/main.css", "/css/prism-theme.css"], "Js": ["/js/main.js"] },
+      { "Name": "global", "Css": ["/css/main.css"], "Js": ["/js/main.js"] },
       { "Name": "home", "Css": ["/css/home.css"], "Js": ["/js/main.js", "/assets/prism/prism-core.min.js", "/assets/prism/prism-autoloader.min.js"] },
       { "Name": "docs", "Css": ["/css/docs.css"], "Js": ["/js/main.js"] }
     ],

--- a/Website/static/js/main.js
+++ b/Website/static/js/main.js
@@ -401,6 +401,27 @@ document.addEventListener('DOMContentLoaded', function () {
     return null;
   }
 
+  function hasHomepageCodeExamples() {
+    return !!document.querySelector('.code-examples pre code[class*="language-"]');
+  }
+
+  function ensurePrismThemeLoaded() {
+    if (!hasHomepageCodeExamples()) {
+      return;
+    }
+
+    var existing = document.querySelector('link[data-prism-theme="true"], link[href*="/css/prism-theme"]');
+    if (existing) {
+      return;
+    }
+
+    var link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/css/prism-theme.css';
+    link.setAttribute('data-prism-theme', 'true');
+    document.head.appendChild(link);
+  }
+
   function ensurePrismLoaded() {
     if (window.Prism && (typeof window.Prism.highlightAllUnder === 'function' || typeof window.Prism.highlightAll === 'function')) {
       return Promise.resolve(true);
@@ -433,6 +454,8 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function highlightCodeBlocksWhenReady(scope, attemptsLeft) {
+    ensurePrismThemeLoaded();
+
     if (window.Prism) {
       highlightCodeBlocks(scope);
       return;


### PR DESCRIPTION
## Summary\n- keep Prism syntax highlighting resilient on homepage code examples\n- remove global prism-theme.css from the global bundle (this caused CI doctor render-blocking failures)\n- load Prism theme dynamically only when homepage code examples are present\n\n## Why\nThe previous fix restored Prism styling but introduced a third render-blocking stylesheet on docs pages, which failed the deploy workflow doctor gate. This keeps highlighting while preserving the CI render-blocking budget.