### PR TITLE
Fix prism-theme.css 404 on homepage code examples

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -168,7 +168,7 @@
       "imageEnhanceTags": true,
       "hashAssets": true,
       "hashExtensions": [".css", ".js"],
-      "hashExclude": ["**/assets/prism/components/**"],
+      "hashExclude": ["**/assets/prism/components/**", "**/css/prism-theme.css"],
       "reportPath": "./_reports/optimize-report.json",
       "cacheHeaders": true,
       "cacheHeadersOut": "_headers"

--- a/Website/site.json
+++ b/Website/site.json
@@ -130,7 +130,7 @@
     "Hashing": {
       "Enabled": true,
       "Extensions": [".css", ".js"],
-      "Exclude": ["**/assets/prism/components/**"]
+      "Exclude": ["**/assets/prism/components/**", "**/css/prism-theme.css"]
     },
     "CacheHeaders": {
       "Enabled": true,


### PR DESCRIPTION
## Summary\n- fix homepage Prism CSS 404 (/css/prism-theme.css)\n- exclude prism-theme.css from hashing in both site and optimize pipeline settings\n- keep other CSS/JS hashing intact\n\n## Root cause\nmain.js dynamically injects /css/prism-theme.css, but optimize hashing renamed the file to prism-theme.<hash>.css, leaving the non-hashed path missing in production.\n\n## Validation\n- local CI pipeline passed (pipeline --mode ci)\n- output now contains Website/_site/css/prism-theme.css\n- doctor/verify remain green