### PR TITLE
Skip IX reviewer on all fork PRs

### DIFF
--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -17,8 +17,8 @@ on:
 jobs:
   # INTELLIGENCEX:BEGIN
   review:
-    # Do not run secret-dependent review on forked PRs in public repos.
-    if: ${{ github.event_name != 'pull_request' || github.event.repository.private || !github.event.pull_request.head.repo.fork }}
+    # Do not run secret-dependent review on any forked pull requests.
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- tighten reviewer guard to skip all fork-based pull requests
- keep review workflow enabled for same-repo PRs and workflow_dispatch runs
- aligns with ownership model: each org/repo should run its own IX reviewer app/secrets

## Validation
- `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.ps1 .github/workflows/review-intelligencex.yml`