### PR TITLE
Skip AI review for Dependabot PRs by default

### DIFF
--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -18,7 +18,9 @@ jobs:
   # INTELLIGENCEX:BEGIN
   review:
     # Do not run secret-dependent review on any forked pull requests.
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    # Skip Dependabot PRs by default to avoid unnecessary LLM usage/budget burn.
+    # Maintainers can opt-in per PR by adding the `needs-ai-review` label.
+    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || (github.actor != 'dependabot[bot]' && github.actor != 'app/dependabot') || contains(github.event.pull_request.labels.*.name, 'needs-ai-review')) }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- skip `review / review` for Dependabot PRs by default
- keep AI review enabled for normal PRs and manual workflow dispatch
- allow maintainers to opt-in on a Dependabot PR by adding `needs-ai-review`

## Why
Dependabot runs do not consistently provide the reviewer auth secret path used by the AI reviewer, which can block safe dependency PRs and burn credits unnecessarily.

## Tracking
- relates to #729