### PR TITLE
refactor(tests): replace reviewer reflection calls with test seams

### DIFF
--- a/IntelligenceX.Reviewer/ReviewRunner.TestSeams.cs
+++ b/IntelligenceX.Reviewer/ReviewRunner.TestSeams.cs
@@ -1,0 +1,13 @@
+using IntelligenceX.OpenAI.Native;
+
+namespace IntelligenceX.Reviewer;
+
+internal sealed partial class ReviewRunner {
+    internal Task PreflightNativeConnectivityForTestsAsync(OpenAINativeOptions options, TimeSpan timeout,
+        CancellationToken cancellationToken = default) =>
+        PreflightNativeConnectivityAsync(options, timeout, cancellationToken);
+
+    internal static Exception? MapPreflightConnectivityExceptionForTests(HttpRequestException ex, string host,
+        TimeSpan timeout, bool cancellationRequested) =>
+        MapPreflightConnectivityException(ex, host, timeout, cancellationRequested);
+}

--- a/IntelligenceX.Reviewer/ReviewerApp.TestSeams.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.TestSeams.cs
@@ -1,0 +1,68 @@
+namespace IntelligenceX.Reviewer;
+
+public static partial class ReviewerApp {
+    // Compile-time test seam to avoid brittle reflection against private methods.
+    internal static string TrimPatchForTests(string patch, int maxPatchChars) => TrimPatch(patch, maxPatchChars);
+
+    internal static (IReadOnlyList<PullRequestFile> Files, string BudgetNote) PrepareFilesForTests(
+        IReadOnlyList<PullRequestFile> files, int maxFiles, int maxPatchChars) =>
+        PrepareFiles(files, maxFiles, maxPatchChars);
+
+    internal static string FormatUsageSummaryForTests(ChatGptUsageSnapshot snapshot) => FormatUsageSummary(snapshot);
+
+    internal static string? EvaluateUsageBudgetGuardFailureForTests(ReviewSettings settings, ChatGptUsageSnapshot snapshot) =>
+        EvaluateUsageBudgetGuardFailure(settings, snapshot);
+
+    internal static Task<string?> TryBuildUsageBudgetGuardFailureForTestsAsync(ReviewSettings settings, ReviewProvider provider) =>
+        TryBuildUsageBudgetGuardFailureAsync(settings, provider);
+
+    internal static IReadOnlyList<string> OrderOpenAiAccountsForTests(IReadOnlyList<string> accountIds, string rotation,
+        string? stickyAccountId, long rotationSeed) =>
+        OrderOpenAiAccounts(accountIds, rotation, stickyAccountId, rotationSeed);
+
+    internal static Task<(bool Success, string? Error, bool BudgetGuardEvaluated)> TryResolveOpenAiAccountForTestsAsync(
+        ReviewSettings settings) =>
+        TryResolveOpenAiAccountAsync(settings);
+
+    internal static bool ShouldAutoResolveMissingInlineThreadsForTests(ReviewSettings settings, PullRequestContext context,
+        HashSet<string>? inlineKeys, int inlineCommentsCount) =>
+        ShouldAutoResolveMissingInlineThreads(settings, context, inlineKeys, inlineCommentsCount);
+
+    internal static Task<ReviewContextExtras> BuildExtrasForTestsAsync(GitHubClient github, PullRequestContext context,
+        ReviewSettings settings, bool forceReviewThreads, CancellationToken cancellationToken = default) {
+        var codeHostReader = new GitHubCodeHostReader(github);
+        return BuildExtrasAsync(codeHostReader, github, null, context, settings, cancellationToken, forceReviewThreads);
+    }
+
+    internal static Task AutoResolveMissingInlineThreadsForTestsAsync(GitHubClient github, PullRequestContext context,
+        HashSet<string>? expectedKeys, ReviewSettings settings, CancellationToken cancellationToken = default) {
+        var codeHostReader = new GitHubCodeHostReader(github);
+        return AutoResolveMissingInlineThreadsAsync(codeHostReader, github, null, context, expectedKeys, settings,
+            cancellationToken);
+    }
+
+    internal static Task AutoResolveStaleThreadsForTestsAsync(GitHubClient github, IReadOnlyList<PullRequestReviewThread> threads,
+        ReviewSettings settings, CancellationToken cancellationToken = default) =>
+        AutoResolveStaleThreadsAsync(github, null, threads, settings, cancellationToken);
+
+    internal static string BuildThreadAssessmentPromptForTests(PullRequestContext context,
+        IReadOnlyList<PullRequestReviewThread> threads, IReadOnlyList<PullRequestFile> files, ReviewSettings settings,
+        string? diffNote) =>
+        BuildThreadAssessmentPrompt(context, threads, files, settings, diffNote);
+
+    internal static bool HasValidResolveEvidenceForTests(string evidence, PullRequestReviewThread thread,
+        IReadOnlyList<PullRequestFile> files, int maxPatchChars) {
+        var patchIndex = BuildInlinePatchIndex(files);
+        var patchLookup = BuildPatchLookup(files, maxPatchChars);
+        return HasValidResolveEvidence(evidence, thread, patchIndex, patchLookup, maxPatchChars);
+    }
+
+    internal static string NormalizeResolveEvidenceForTests(string evidence) => NormalizeResolveEvidence(evidence);
+
+    internal static Task<(IReadOnlyList<PullRequestFile> Files, string DiffNote)> ResolveDiffRangeFilesForTestsAsync(
+        GitHubClient github, PullRequestContext context, string range, IReadOnlyList<PullRequestFile> currentFiles,
+        ReviewSettings settings, CancellationToken cancellationToken = default) {
+        var codeHostReader = new GitHubCodeHostReader(github);
+        return ResolveDiffRangeFilesAsync(codeHostReader, context, range, currentFiles, settings, cancellationToken);
+    }
+}

--- a/IntelligenceX.Tests/Program.Reviewer.InternalCalls.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.InternalCalls.cs
@@ -22,56 +22,24 @@ internal static partial class Program {
     }
 
     private static string CallTrimPatch(string patch, int maxChars) {
-        var method = typeof(ReviewerApp).GetMethod("TrimPatch", BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("TrimPatch method not found.");
-        }
-        var result = method.Invoke(null, new object?[] { patch, maxChars }) as string;
-        return result ?? string.Empty;
+        return ReviewerApp.TrimPatchForTests(patch, maxChars);
     }
 
     private static (IReadOnlyList<PullRequestFile> Files, string BudgetNote) CallPrepareFiles(IReadOnlyList<PullRequestFile> files,
         int maxFiles, int maxPatchChars) {
-        var method = typeof(ReviewerApp).GetMethod("PrepareFiles", BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("PrepareFiles method not found.");
-        }
-        var result = method.Invoke(null, new object?[] { files, maxFiles, maxPatchChars });
-        if (result is ValueTuple<IReadOnlyList<PullRequestFile>, string> tuple) {
-            return tuple;
-        }
-        throw new InvalidOperationException("PrepareFiles method returned unexpected result.");
+        return ReviewerApp.PrepareFilesForTests(files, maxFiles, maxPatchChars);
     }
 
     private static string CallFormatUsageSummary(ChatGptUsageSnapshot snapshot) {
-        var method = typeof(ReviewerApp).GetMethod("FormatUsageSummary", BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("FormatUsageSummary method not found.");
-        }
-        var result = method.Invoke(null, new object?[] { snapshot }) as string;
-        return result ?? string.Empty;
+        return ReviewerApp.FormatUsageSummaryForTests(snapshot);
     }
 
     private static string? CallEvaluateUsageBudgetGuardFailure(ReviewSettings settings, ChatGptUsageSnapshot snapshot) {
-        var method = typeof(ReviewerApp).GetMethod("EvaluateUsageBudgetGuardFailure",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("EvaluateUsageBudgetGuardFailure method not found.");
-        }
-        return method.Invoke(null, new object?[] { settings, snapshot }) as string;
+        return ReviewerApp.EvaluateUsageBudgetGuardFailureForTests(settings, snapshot);
     }
 
     private static string? CallTryBuildUsageBudgetGuardFailure(ReviewSettings settings, ReviewProvider provider) {
-        var method = typeof(ReviewerApp).GetMethod("TryBuildUsageBudgetGuardFailureAsync",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("TryBuildUsageBudgetGuardFailureAsync method not found.");
-        }
-        var task = method.Invoke(null, new object?[] { settings, provider });
-        if (task is Task<string?> typedTask) {
-            return typedTask.GetAwaiter().GetResult();
-        }
-        throw new InvalidOperationException("TryBuildUsageBudgetGuardFailureAsync returned unexpected result.");
+        return ReviewerApp.TryBuildUsageBudgetGuardFailureForTestsAsync(settings, provider).GetAwaiter().GetResult();
     }
 
     private static IReadOnlyList<string> CallOrderOpenAiAccounts(
@@ -79,220 +47,73 @@ internal static partial class Program {
         string rotation,
         string? stickyAccountId,
         long rotationSeed) {
-        var method = typeof(ReviewerApp).GetMethod("OrderOpenAiAccounts",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("OrderOpenAiAccounts method not found.");
-        }
-        var result = method.Invoke(null, new object?[] { accountIds, rotation, stickyAccountId, rotationSeed });
-        if (result is IReadOnlyList<string> ordered) {
-            return ordered;
-        }
-        throw new InvalidOperationException("OrderOpenAiAccounts returned unexpected result.");
+        return ReviewerApp.OrderOpenAiAccountsForTests(accountIds, rotation, stickyAccountId, rotationSeed);
     }
 
     private static (bool Success, string? Error, bool BudgetGuardEvaluated) CallTryResolveOpenAiAccount(ReviewSettings settings) {
-        var method = typeof(ReviewerApp).GetMethod("TryResolveOpenAiAccountAsync",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("TryResolveOpenAiAccountAsync method not found.");
-        }
-        var task = method.Invoke(null, new object?[] { settings });
-        if (task is Task<ValueTuple<bool, string?, bool>> typedTask) {
-            return typedTask.GetAwaiter().GetResult();
-        }
-        throw new InvalidOperationException("TryResolveOpenAiAccountAsync returned unexpected result.");
+        return ReviewerApp.TryResolveOpenAiAccountForTestsAsync(settings).GetAwaiter().GetResult();
     }
 
     private static void CallPreflightNativeConnectivity(OpenAINativeOptions options, TimeSpan timeout) {
         var runner = new ReviewRunner(new ReviewSettings());
-        var method = typeof(ReviewRunner).GetMethod("PreflightNativeConnectivityAsync",
-            BindingFlags.NonPublic | BindingFlags.Instance);
-        if (method is null) {
-            throw new InvalidOperationException("PreflightNativeConnectivityAsync method not found.");
-        }
-        var task = method.Invoke(runner, new object?[] { options, timeout, CancellationToken.None }) as Task;
-        if (task is null) {
-            throw new InvalidOperationException("PreflightNativeConnectivityAsync did not return a task.");
-        }
-        task.GetAwaiter().GetResult();
+        runner.PreflightNativeConnectivityForTestsAsync(options, timeout, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
     }
 
     private static Exception? CallMapPreflightConnectivityException(HttpRequestException ex, string host, TimeSpan timeout,
         bool cancellationRequested) {
-        var method = typeof(ReviewRunner).GetMethod("MapPreflightConnectivityException",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("MapPreflightConnectivityException method not found.");
-        }
-        var result = method.Invoke(null, new object?[] { ex, host, timeout, cancellationRequested });
-        return result as Exception;
+        return ReviewRunner.MapPreflightConnectivityExceptionForTests(ex, host, timeout, cancellationRequested);
     }
 
     private static bool CallShouldAutoResolveMissingInlineThreads(ReviewSettings settings, PullRequestContext context,
         HashSet<string>? inlineKeys, int inlineCommentsCount) {
-        var method = typeof(ReviewerApp).GetMethod("ShouldAutoResolveMissingInlineThreads",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("ShouldAutoResolveMissingInlineThreads method not found.");
-        }
-        var result = method.Invoke(null, new object?[] { settings, context, inlineKeys, inlineCommentsCount });
-        if (result is bool value) {
-            return value;
-        }
-        throw new InvalidOperationException("ShouldAutoResolveMissingInlineThreads returned unexpected result.");
+        return ReviewerApp.ShouldAutoResolveMissingInlineThreadsForTests(settings, context, inlineKeys, inlineCommentsCount);
     }
 
     private static ReviewContextExtras CallBuildExtrasAsync(GitHubClient github, PullRequestContext context,
         ReviewSettings settings, bool forceReviewThreads) {
-        var method = typeof(ReviewerApp).GetMethod("BuildExtrasAsync", BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("BuildExtrasAsync method not found.");
-        }
-        var codeHostReader = new GitHubCodeHostReader(github);
-        var task = method.Invoke(null, new object?[] {
-            codeHostReader,
-            github,
-            null,
-            context,
-            settings,
-            CancellationToken.None,
-            forceReviewThreads
-        }) as Task<ReviewContextExtras>;
-        if (task is null) {
-            throw new InvalidOperationException("BuildExtrasAsync did not return a task.");
-        }
-        return task.GetAwaiter().GetResult();
+        return ReviewerApp.BuildExtrasForTestsAsync(github, context, settings, forceReviewThreads, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
     }
 
     private static void CallAutoResolveMissingInlineThreads(GitHubClient github, PullRequestContext context,
         HashSet<string>? expectedKeys, ReviewSettings settings) {
-        var method = typeof(ReviewerApp).GetMethod("AutoResolveMissingInlineThreadsAsync",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("AutoResolveMissingInlineThreadsAsync method not found.");
-        }
-        var codeHostReader = new GitHubCodeHostReader(github);
-        var task = method.Invoke(null, new object?[] {
-            codeHostReader,
-            github,
-            null,
-            context,
-            expectedKeys,
-            settings,
-            CancellationToken.None
-        }) as Task;
-        if (task is null) {
-            throw new InvalidOperationException("AutoResolveMissingInlineThreadsAsync did not return a task.");
-        }
-        task.GetAwaiter().GetResult();
+        ReviewerApp.AutoResolveMissingInlineThreadsForTestsAsync(github, context, expectedKeys, settings, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
     }
 
     private static void CallAutoResolveStaleThreads(GitHubClient github, IReadOnlyList<PullRequestReviewThread> threads,
         ReviewSettings settings) {
-        var method = typeof(ReviewerApp).GetMethod("AutoResolveStaleThreadsAsync",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("AutoResolveStaleThreadsAsync method not found.");
-        }
-        var task = method.Invoke(null, new object?[] {
-            github,
-            null,
-            threads,
-            settings,
-            CancellationToken.None
-        }) as Task;
-        if (task is null) {
-            throw new InvalidOperationException("AutoResolveStaleThreadsAsync did not return a task.");
-        }
-        task.GetAwaiter().GetResult();
+        ReviewerApp.AutoResolveStaleThreadsForTestsAsync(github, threads, settings, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
     }
 
     private static string CallBuildThreadAssessmentPrompt(PullRequestContext context,
         IReadOnlyList<PullRequestReviewThread> threads, IReadOnlyList<PullRequestFile> files, ReviewSettings settings,
         string? diffNote) {
-        var method = typeof(ReviewerApp).GetMethod("BuildThreadAssessmentPrompt",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("BuildThreadAssessmentPrompt method not found.");
-        }
-        var result = method.Invoke(null, new object?[] { context, threads, files, settings, diffNote }) as string;
-        return result ?? string.Empty;
+        return ReviewerApp.BuildThreadAssessmentPromptForTests(context, threads, files, settings, diffNote);
     }
 
     private static bool CallHasValidResolveEvidence(string evidence, PullRequestReviewThread thread,
         IReadOnlyList<PullRequestFile> files, int maxPatchChars) {
-        var buildPatchIndexMethod = typeof(ReviewerApp).GetMethod("BuildInlinePatchIndex",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (buildPatchIndexMethod is null) {
-            throw new InvalidOperationException("BuildInlinePatchIndex method not found.");
-        }
-        var patchIndex = buildPatchIndexMethod.Invoke(null, new object?[] { files });
-        if (patchIndex is null) {
-            throw new InvalidOperationException("BuildInlinePatchIndex returned null.");
-        }
-
-        var buildPatchLookupMethod = typeof(ReviewerApp).GetMethod("BuildPatchLookup",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (buildPatchLookupMethod is null) {
-            throw new InvalidOperationException("BuildPatchLookup method not found.");
-        }
-        var patchLookup = buildPatchLookupMethod.Invoke(null, new object?[] { files, maxPatchChars });
-        if (patchLookup is null) {
-            throw new InvalidOperationException("BuildPatchLookup returned null.");
-        }
-
-        var method = typeof(ReviewerApp).GetMethod("HasValidResolveEvidence",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("HasValidResolveEvidence method not found.");
-        }
-        var result = method.Invoke(null, new object?[] { evidence, thread, patchIndex, patchLookup, maxPatchChars });
-        if (result is bool value) {
-            return value;
-        }
-        throw new InvalidOperationException("HasValidResolveEvidence returned unexpected result.");
+        return ReviewerApp.HasValidResolveEvidenceForTests(evidence, thread, files, maxPatchChars);
     }
 
     private static string CallNormalizeResolveEvidence(string evidence) {
-        var method = typeof(ReviewerApp).GetMethod("NormalizeResolveEvidence",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("NormalizeResolveEvidence method not found.");
-        }
-        var result = method.Invoke(null, new object?[] { evidence }) as string;
-        return result ?? string.Empty;
+        return ReviewerApp.NormalizeResolveEvidenceForTests(evidence);
     }
 
     private static (IReadOnlyList<PullRequestFile> Files, string Note) CallResolveDiffRangeFiles(GitHubClient github,
         PullRequestContext context, string range, IReadOnlyList<PullRequestFile> currentFiles, ReviewSettings settings) {
-        var method = typeof(ReviewerApp).GetMethod("ResolveDiffRangeFilesAsync",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        if (method is null) {
-            throw new InvalidOperationException("ResolveDiffRangeFilesAsync method not found.");
-        }
-        var codeHostReader = new GitHubCodeHostReader(github);
-        var task = method.Invoke(null, new object?[] {
-            codeHostReader,
-            context,
-            range,
-            currentFiles,
-            settings,
-            CancellationToken.None
-        }) as Task;
-        if (task is null) {
-            throw new InvalidOperationException("ResolveDiffRangeFilesAsync did not return a task.");
-        }
-        task.GetAwaiter().GetResult();
-        var resultProperty = task.GetType().GetProperty("Result");
-        if (resultProperty is null) {
-            throw new InvalidOperationException("ResolveDiffRangeFilesAsync Result not found.");
-        }
-        var result = resultProperty.GetValue(task);
-        if (result is ValueTuple<IReadOnlyList<PullRequestFile>, string> tuple) {
-            return tuple;
-        }
-        throw new InvalidOperationException("ResolveDiffRangeFilesAsync returned unexpected result.");
+        var result = ReviewerApp.ResolveDiffRangeFilesForTestsAsync(github, context, range, currentFiles, settings,
+                CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+        return (result.Files, result.DiffNote);
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- add explicit internal reviewer test seams (`...ForTests`) in `ReviewerApp` and `ReviewRunner`
- replace reflection-based calls in `IntelligenceX.Tests/Program.Reviewer.InternalCalls.cs` with compile-time calls to those seams
- keep test behavior unchanged while removing brittleness tied to private method names/signatures

## Why
This addresses maintainability feedback: tests should not rely on reflection over private method names/signatures when we already expose internals to `IntelligenceX.Tests`.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`