### PR TITLE
improve(reviewer): add triage observability and dedup scan coverage

### DIFF
--- a/IntelligenceX.Reviewer/ReviewRunner.TestSeams.cs
+++ b/IntelligenceX.Reviewer/ReviewRunner.TestSeams.cs
@@ -3,10 +3,14 @@ using IntelligenceX.OpenAI.Native;
 namespace IntelligenceX.Reviewer;
 
 internal sealed partial class ReviewRunner {
+    // Test-only forwarders: keep connectivity behavior tests compile-time bound without private reflection.
+
+    /// <summary>Test-only forwarder for native connectivity preflight.</summary>
     internal Task PreflightNativeConnectivityForTestsAsync(OpenAINativeOptions options, TimeSpan timeout,
         CancellationToken cancellationToken = default) =>
         PreflightNativeConnectivityAsync(options, timeout, cancellationToken);
 
+    /// <summary>Test-only forwarder for preflight exception mapping.</summary>
     internal static Exception? MapPreflightConnectivityExceptionForTests(HttpRequestException ex, string host,
         TimeSpan timeout, bool cancellationRequested) =>
         MapPreflightConnectivityException(ex, host, timeout, cancellationRequested);

--- a/IntelligenceX.Reviewer/ReviewerApp.FileContext.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.FileContext.cs
@@ -285,17 +285,31 @@ public static partial class ReviewerApp {
     private static async Task AutoResolveStaleThreadsAsync(GitHubClient github, GitHubClient? fallbackGithub,
         IReadOnlyList<PullRequestReviewThread> threads, ReviewSettings settings, CancellationToken cancellationToken) {
         var resolved = 0;
+        var scanned = 0;
+        var skippedResolved = 0;
+        var skippedNotOutdated = 0;
+        var skippedNonBot = 0;
+        var skippedPartialBotView = 0;
+        var failed = 0;
         foreach (var thread in threads) {
+            scanned++;
             if (resolved >= settings.ReviewThreadsAutoResolveMax) {
                 break;
             }
-            if (thread.IsResolved || !thread.IsOutdated) {
+            if (thread.IsResolved) {
+                skippedResolved++;
+                continue;
+            }
+            if (!thread.IsOutdated) {
+                skippedNotOutdated++;
                 continue;
             }
             if (settings.ReviewThreadsAutoResolveBotsOnly && !ThreadHasOnlyBotComments(thread, settings)) {
+                skippedNonBot++;
                 continue;
             }
             if (settings.ReviewThreadsAutoResolveBotsOnly && thread.TotalComments > thread.Comments.Count) {
+                skippedPartialBotView++;
                 continue;
             }
 
@@ -304,7 +318,15 @@ public static partial class ReviewerApp {
                 resolved++;
                 continue;
             }
+            failed++;
             Console.Error.WriteLine($"Failed to resolve review thread {thread.Id}: {result.Error ?? "unknown error"}");
+        }
+
+        if (scanned > 0) {
+            Console.Error.WriteLine(
+                $"Thread auto-resolve (stale): scanned={scanned}; resolved={resolved}; failed={failed}; " +
+                $"skip_resolved={skippedResolved}; skip_not_outdated={skippedNotOutdated}; " +
+                $"skip_non_bot={skippedNonBot}; skip_partial_view={skippedPartialBotView}.");
         }
     }
 
@@ -322,20 +344,31 @@ public static partial class ReviewerApp {
             .ConfigureAwait(false);
 
         var resolved = 0;
+        var scanned = 0;
+        var skippedResolved = 0;
+        var skippedPartialBotView = 0;
+        var skippedNoInlineKey = 0;
+        var skippedExpectedMatch = 0;
+        var failed = 0;
         foreach (var thread in threads) {
+            scanned++;
             if (resolved >= settings.ReviewThreadsAutoResolveMax) {
                 break;
             }
             if (thread.IsResolved) {
+                skippedResolved++;
                 continue;
             }
             if (settings.ReviewThreadsAutoResolveBotsOnly && thread.TotalComments > thread.Comments.Count) {
+                skippedPartialBotView++;
                 continue;
             }
-            if (!TryGetInlineThreadKey(thread, settings, out var key)) {
+            if (!TryGetInlineThreadMatchKeys(thread, settings, out var threadKeys) || threadKeys.Count == 0) {
+                skippedNoInlineKey++;
                 continue;
             }
-            if (keys.Contains(key)) {
+            if (threadKeys.Any(keys.Contains)) {
+                skippedExpectedMatch++;
                 continue;
             }
 
@@ -344,7 +377,15 @@ public static partial class ReviewerApp {
                 resolved++;
                 continue;
             }
+            failed++;
             Console.Error.WriteLine($"Failed to resolve review thread {thread.Id}: {result.Error ?? "unknown error"}");
+        }
+
+        if (scanned > 0) {
+            Console.Error.WriteLine(
+                $"Thread auto-resolve (missing-inline): expected_keys={keys.Count}; scanned={scanned}; resolved={resolved}; failed={failed}; " +
+                $"skip_resolved={skippedResolved}; skip_partial_view={skippedPartialBotView}; " +
+                $"skip_no_inline_key={skippedNoInlineKey}; skip_expected_match={skippedExpectedMatch}.");
         }
     }
 
@@ -427,3 +468,5 @@ public static partial class ReviewerApp {
     }
 
 }
+
+

--- a/IntelligenceX.Reviewer/ReviewerApp.InlineSummary.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.InlineSummary.cs
@@ -20,6 +20,16 @@ public static partial class ReviewerApp {
         return true;
     }
 
+    private static bool TryGetInlineThreadMatchKeys(PullRequestReviewThread thread, ReviewSettings settings,
+        out HashSet<string> keys) {
+        keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!TryGetInlineThreadKey(thread, settings, out var key)) {
+            return false;
+        }
+        keys.Add(key);
+        return true;
+    }
+
     private static string BuildRelatedPrsSection(PullRequestContext context, IReadOnlyList<RelatedPullRequest> related) {
         if (related.Count == 0) {
             return string.Empty;
@@ -579,3 +589,4 @@ public static partial class ReviewerApp {
     }
 
 }
+

--- a/IntelligenceX.Reviewer/ReviewerApp.TestSeams.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.TestSeams.cs
@@ -1,39 +1,50 @@
 namespace IntelligenceX.Reviewer;
 
 public static partial class ReviewerApp {
-    // Compile-time test seam to avoid brittle reflection against private methods.
+    // Test-only forwarders: keep tests compile-time bound to internal behavior without private reflection.
+
+    /// <summary>Test-only forwarder for patch trimming behavior.</summary>
     internal static string TrimPatchForTests(string patch, int maxPatchChars) => TrimPatch(patch, maxPatchChars);
 
+    /// <summary>Test-only forwarder for file preparation limits.</summary>
     internal static (IReadOnlyList<PullRequestFile> Files, string BudgetNote) PrepareFilesForTests(
         IReadOnlyList<PullRequestFile> files, int maxFiles, int maxPatchChars) =>
         PrepareFiles(files, maxFiles, maxPatchChars);
 
+    /// <summary>Test-only forwarder for usage summary formatting.</summary>
     internal static string FormatUsageSummaryForTests(ChatGptUsageSnapshot snapshot) => FormatUsageSummary(snapshot);
 
+    /// <summary>Test-only forwarder for usage budget guard evaluation.</summary>
     internal static string? EvaluateUsageBudgetGuardFailureForTests(ReviewSettings settings, ChatGptUsageSnapshot snapshot) =>
         EvaluateUsageBudgetGuardFailure(settings, snapshot);
 
+    /// <summary>Test-only forwarder for async usage budget guard construction.</summary>
     internal static Task<string?> TryBuildUsageBudgetGuardFailureForTestsAsync(ReviewSettings settings, ReviewProvider provider) =>
         TryBuildUsageBudgetGuardFailureAsync(settings, provider);
 
+    /// <summary>Test-only forwarder for OpenAI account ordering.</summary>
     internal static IReadOnlyList<string> OrderOpenAiAccountsForTests(IReadOnlyList<string> accountIds, string rotation,
         string? stickyAccountId, long rotationSeed) =>
         OrderOpenAiAccounts(accountIds, rotation, stickyAccountId, rotationSeed);
 
+    /// <summary>Test-only forwarder for OpenAI account resolution.</summary>
     internal static Task<(bool Success, string? Error, bool BudgetGuardEvaluated)> TryResolveOpenAiAccountForTestsAsync(
         ReviewSettings settings) =>
         TryResolveOpenAiAccountAsync(settings);
 
+    /// <summary>Test-only forwarder for missing-inline auto-resolve gate logic.</summary>
     internal static bool ShouldAutoResolveMissingInlineThreadsForTests(ReviewSettings settings, PullRequestContext context,
         HashSet<string>? inlineKeys, int inlineCommentsCount) =>
         ShouldAutoResolveMissingInlineThreads(settings, context, inlineKeys, inlineCommentsCount);
 
+    /// <summary>Test-only forwarder for review context extra loading.</summary>
     internal static Task<ReviewContextExtras> BuildExtrasForTestsAsync(GitHubClient github, PullRequestContext context,
         ReviewSettings settings, bool forceReviewThreads, CancellationToken cancellationToken = default) {
         var codeHostReader = new GitHubCodeHostReader(github);
         return BuildExtrasAsync(codeHostReader, github, null, context, settings, cancellationToken, forceReviewThreads);
     }
 
+    /// <summary>Test-only forwarder for missing-inline thread auto-resolution.</summary>
     internal static Task AutoResolveMissingInlineThreadsForTestsAsync(GitHubClient github, PullRequestContext context,
         HashSet<string>? expectedKeys, ReviewSettings settings, CancellationToken cancellationToken = default) {
         var codeHostReader = new GitHubCodeHostReader(github);
@@ -41,15 +52,18 @@ public static partial class ReviewerApp {
             cancellationToken);
     }
 
+    /// <summary>Test-only forwarder for stale-thread auto-resolution.</summary>
     internal static Task AutoResolveStaleThreadsForTestsAsync(GitHubClient github, IReadOnlyList<PullRequestReviewThread> threads,
         ReviewSettings settings, CancellationToken cancellationToken = default) =>
         AutoResolveStaleThreadsAsync(github, null, threads, settings, cancellationToken);
 
+    /// <summary>Test-only forwarder for thread assessment prompt rendering.</summary>
     internal static string BuildThreadAssessmentPromptForTests(PullRequestContext context,
         IReadOnlyList<PullRequestReviewThread> threads, IReadOnlyList<PullRequestFile> files, ReviewSettings settings,
         string? diffNote) =>
         BuildThreadAssessmentPrompt(context, threads, files, settings, diffNote);
 
+    /// <summary>Test-only forwarder for resolve evidence validation.</summary>
     internal static bool HasValidResolveEvidenceForTests(string evidence, PullRequestReviewThread thread,
         IReadOnlyList<PullRequestFile> files, int maxPatchChars) {
         var patchIndex = BuildInlinePatchIndex(files);
@@ -57,8 +71,20 @@ public static partial class ReviewerApp {
         return HasValidResolveEvidence(evidence, thread, patchIndex, patchLookup, maxPatchChars);
     }
 
+    /// <summary>Test-only forwarder for resolve evidence normalization.</summary>
     internal static string NormalizeResolveEvidenceForTests(string evidence) => NormalizeResolveEvidence(evidence);
 
+    /// <summary>Test-only helper that exposes evidence scan traversal order for dedup regression tests.</summary>
+    internal static IReadOnlyList<string> CollectEvidenceScanPathsForTests(IReadOnlyList<PullRequestFile> files,
+        string evidence, string? preferredPath = null) {
+        var patchIndex = BuildInlinePatchIndex(files);
+        var patchLookup = BuildPatchLookup(files, int.MaxValue);
+        var scannedPaths = new List<string>();
+        _ = HasEvidenceInAnyDiffContext(patchIndex, patchLookup, evidence, preferredPath, scannedPaths);
+        return scannedPaths;
+    }
+
+    /// <summary>Test-only forwarder for diff-range file resolution.</summary>
     internal static Task<(IReadOnlyList<PullRequestFile> Files, string DiffNote)> ResolveDiffRangeFilesForTestsAsync(
         GitHubClient github, PullRequestContext context, string range, IReadOnlyList<PullRequestFile> currentFiles,
         ReviewSettings settings, CancellationToken cancellationToken = default) {

--- a/IntelligenceX.Reviewer/ReviewerApp.ThreadResolution.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.ThreadResolution.cs
@@ -610,12 +610,15 @@ public static partial class ReviewerApp {
     }
 
     private static bool HasEvidenceInAnyDiffContext(Dictionary<string, List<PatchLine>> patchIndex,
-        IReadOnlyDictionary<string, string> patchLookup, string evidence, string? preferredPath = null) {
+        IReadOnlyDictionary<string, string> patchLookup, string evidence, string? preferredPath = null,
+        List<string>? scannedPaths = null) {
         var preferred = string.IsNullOrWhiteSpace(preferredPath) ? string.Empty : NormalizePath(preferredPath);
         if (!string.IsNullOrWhiteSpace(preferred) &&
-            TryGetPatchContextForPath(preferred, patchIndex, patchLookup, out var preferredContext) &&
-            HasEvidenceInContext(preferredContext, evidence)) {
-            return true;
+            TryGetPatchContextForPath(preferred, patchIndex, patchLookup, out var preferredContext)) {
+            scannedPaths?.Add(preferred);
+            if (HasEvidenceInContext(preferredContext, evidence)) {
+                return true;
+            }
         }
 
         var visitedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -627,6 +630,7 @@ public static partial class ReviewerApp {
             if (!visitedPaths.Add(path) || lines.Count == 0) {
                 continue;
             }
+            scannedPaths?.Add(path);
             var context = string.Join("\n", lines.Select(static line => $"{line.LineNumber}: {line.Text}"));
             if (HasEvidenceInContext(context, evidence)) {
                 return true;
@@ -637,6 +641,7 @@ public static partial class ReviewerApp {
             if (!visitedPaths.Add(path) || string.IsNullOrWhiteSpace(patch)) {
                 continue;
             }
+            scannedPaths?.Add(path);
             var context = $"<file patch>\n{patch}";
             if (HasEvidenceInContext(context, evidence)) {
                 return true;
@@ -807,3 +812,4 @@ public static partial class ReviewerApp {
     }
 
 }
+

--- a/IntelligenceX.Reviewer/ReviewerApp.UsageThreadsPrompt.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.UsageThreadsPrompt.cs
@@ -65,6 +65,9 @@ public static partial class ReviewerApp {
         var resolved = new List<ThreadAssessment>();
         var kept = new List<ThreadAssessment>();
         var failed = new List<ThreadAssessment>();
+        var evidenceRejected = 0;
+        var resolveAttempts = 0;
+        var sweepResolved = 0;
         foreach (var assessment in assessments) {
             switch (assessment.Action) {
                 case "comment":
@@ -89,12 +92,14 @@ public static partial class ReviewerApp {
             }
             if (settings.ReviewThreadsAutoResolveRequireEvidence &&
                 !HasValidResolveEvidence(assessment.Evidence, thread, patchIndex, patchLookup, settings.MaxPatchChars)) {
+                evidenceRejected++;
                 var missingEvidence = new ThreadAssessment(assessment.Id, "keep",
                     $"{assessment.Reason} (missing diff evidence)", assessment.Evidence);
                 kept.Add(missingEvidence);
                 replyMap[normalizedThreadId] = missingEvidence;
                 continue;
             }
+            resolveAttempts++;
             var result = await TryResolveThreadAsync(github, fallbackGithub, thread.Id, cancellationToken).ConfigureAwait(false);
             if (result.Resolved) {
                 resolvedCount++;
@@ -117,6 +122,7 @@ public static partial class ReviewerApp {
             var extraResolved = await TryResolveKeptBotThreadsAfterNoBlockersAsync(github, fallbackGithub, candidates, resolved, kept,
                     settings, cancellationToken)
                 .ConfigureAwait(false);
+            sweepResolved = extraResolved;
             resolvedCount += extraResolved;
         }
 
@@ -143,7 +149,11 @@ public static partial class ReviewerApp {
         if (resolvedCount == 0 && kept.Count == 0) {
             return ThreadTriageResult.Empty;
         }
-        var summary = $"Auto-resolve (AI): {resolvedCount} resolved, {kept.Count} kept.";
+        var summary =
+            $"Auto-resolve (AI): {resolvedCount} resolved, {kept.Count} kept " +
+            $"(candidates {candidates.Count}, assessments {assessments.Count}, attempts {resolveAttempts}, " +
+            $"evidence_rejected {evidenceRejected}, resolve_failed {failed.Count}, sweep_resolved {sweepResolved}, " +
+            $"missing_ids {missingIdCount}, duplicate_ids {duplicateIdCount}).";
         if (commentPosted) {
             summary += " Triage comment posted.";
         }
@@ -570,3 +580,8 @@ public static partial class ReviewerApp {
     }
 
 }
+
+
+
+
+

--- a/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.cs
@@ -304,6 +304,19 @@ internal static partial class Program {
         AssertEqual("\"42: fixed null check`", normalized, "unbalanced delimiters preserved");
     }
 
+    private static void TestThreadResolveEvidenceDeduplicatesPatchPathScans() {
+        var files = new[] {
+            new PullRequestFile("src/Foo.cs", "modified", "@@ -1,1 +1,2 @@\n- return oldValue;\n+ return newValue;\n+ return oldValue;"),
+            new PullRequestFile("src/Bar.cs", "modified", "@@ -5,1 +5,2 @@\n- old();\n+ updated();\n+ old();")
+        };
+
+        var scanned = CallCollectEvidenceScanPaths(files, "not-present-evidence", "src/Foo.cs");
+        AssertEqual(2, scanned.Count, "scan count with preferred path");
+        AssertEqual(2, scanned.Distinct(StringComparer.OrdinalIgnoreCase).Count(), "scan paths are unique");
+        AssertEqual(1, scanned.Count(path => path.Equals("src/Foo.cs", StringComparison.OrdinalIgnoreCase)),
+            "preferred path scanned once");
+    }
+
     private static void TestThreadTriageEmbedPlacement() {
         var method = typeof(ReviewerApp).GetMethod("ApplyEmbedPlacement", BindingFlags.NonPublic | BindingFlags.Static);
         if (method is null) {
@@ -676,3 +689,4 @@ internal static partial class Program {
 
 }
 #endif
+

--- a/IntelligenceX.Tests/Program.Reviewer.InternalCalls.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.InternalCalls.cs
@@ -107,6 +107,11 @@ internal static partial class Program {
         return ReviewerApp.NormalizeResolveEvidenceForTests(evidence);
     }
 
+    private static IReadOnlyList<string> CallCollectEvidenceScanPaths(IReadOnlyList<PullRequestFile> files, string evidence,
+        string? preferredPath = null) {
+        return ReviewerApp.CollectEvidenceScanPathsForTests(files, evidence, preferredPath);
+    }
+
     private static (IReadOnlyList<PullRequestFile> Files, string Note) CallResolveDiffRangeFiles(GitHubClient github,
         PullRequestContext context, string range, IReadOnlyList<PullRequestFile> currentFiles, ReviewSettings settings) {
         var result = ReviewerApp.ResolveDiffRangeFilesForTestsAsync(github, context, range, currentFiles, settings,
@@ -117,3 +122,4 @@ internal static partial class Program {
     }
 }
 #endif
+

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -25,6 +25,7 @@ internal static partial class Program {
         failed += Run("Thread resolve evidence cross-file fallback stale-only", TestThreadResolveEvidenceCrossFileFallbackOnlyForStaleThreads);
         failed += Run("Thread resolve evidence normalize single wrapper", TestThreadResolveEvidenceNormalizeSingleWrapperOnly);
         failed += Run("Thread resolve evidence normalize preserves unbalanced delimiters", TestThreadResolveEvidenceNormalizePreservesUnbalancedDelimiters);
+        failed += Run("Thread resolve evidence deduplicates patch path scans", TestThreadResolveEvidenceDeduplicatesPatchPathScans);
         failed += Run("Thread triage embed placement", TestThreadTriageEmbedPlacement);
         failed += Run("Thread assessment prompt smoke", TestThreadAssessmentPromptSmoke);
         failed += Run("Auto-resolve stale threads smoke", TestAutoResolveStaleThreadsSmoke);
@@ -588,3 +589,4 @@ internal static partial class Program {
 #endif
     }
 }
+


### PR DESCRIPTION
## Summary
- add reviewer triage observability counters in AI auto-resolve summary lines (`candidates`, `assessments`, `attempts`, `evidence_rejected`, `resolve_failed`, `sweep_resolved`, id hygiene counts)
- add structured stderr summaries for stale-thread and missing-inline auto-resolve sweeps (scanned/resolved/skip/fail counters)
- add dedup regression coverage for evidence scan traversal to ensure a path is not scanned twice when present in both patch index and patch lookup
- add explicit test-only XML docs on `...ForTests` seam methods for long-term hygiene

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `dotnet test IntelligenceX.sln -c Release` (known unrelated failure in `IntelligenceX.Tools.Tests.ToolResponseContractGuardrailTests.ResponseContracts_ShouldNotIntroduceUnsafeDictionaryKeyValueProperties`)