### PR TITLE
Harden reviewer stale-inline matching with line window + signature keys

### DIFF
--- a/IntelligenceX.Reviewer/ReviewerApp.InlineSummary.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.InlineSummary.cs
@@ -1,18 +1,15 @@
 namespace IntelligenceX.Reviewer;
 
 public static partial class ReviewerApp {
+    private const int InlineLineWindowSize = 3;
+    private const string InlineSignatureMarkerPrefix = "<!-- intelligencex:inline-sig:v1 ";
+    private const string InlineSignatureMarkerSuffix = " -->";
+
     internal static bool TryGetInlineThreadKey(PullRequestReviewThread thread, ReviewSettings settings, out string key) {
         key = string.Empty;
-        if (thread.Comments.Count == 0) {
-            return false;
-        }
-        if (settings.ReviewThreadsAutoResolveBotsOnly && !ThreadHasOnlyBotComments(thread, settings)) {
-            return false;
-        }
-
-        var marker = thread.Comments.FirstOrDefault(comment =>
-            comment.Body.Contains(ReviewFormatter.InlineMarker, StringComparison.OrdinalIgnoreCase));
-        if (marker is null || string.IsNullOrWhiteSpace(marker.Path) || !marker.Line.HasValue) {
+        if (!TryGetInlineMarkerComment(thread, settings, out var marker) ||
+            string.IsNullOrWhiteSpace(marker.Path) ||
+            !marker.Line.HasValue) {
             return false;
         }
 
@@ -23,10 +20,32 @@ public static partial class ReviewerApp {
     private static bool TryGetInlineThreadMatchKeys(PullRequestReviewThread thread, ReviewSettings settings,
         out HashSet<string> keys) {
         keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (!TryGetInlineThreadKey(thread, settings, out var key)) {
+        if (!TryGetInlineMarkerComment(thread, settings, out var marker) ||
+            string.IsNullOrWhiteSpace(marker.Path) ||
+            !marker.Line.HasValue) {
             return false;
         }
-        keys.Add(key);
+
+        keys = BuildInlineMatchKeys(marker.Path!, marker.Line.Value, marker.Body, snippet: null, signatureSource: null);
+        return keys.Count > 0;
+    }
+
+    private static bool TryGetInlineMarkerComment(PullRequestReviewThread thread, ReviewSettings settings,
+        out PullRequestReviewThreadComment marker) {
+        marker = default!;
+        if (thread.Comments.Count == 0) {
+            return false;
+        }
+        if (settings.ReviewThreadsAutoResolveBotsOnly && !ThreadHasOnlyBotComments(thread, settings)) {
+            return false;
+        }
+
+        var candidate = thread.Comments.FirstOrDefault(comment =>
+            comment.Body.Contains(ReviewFormatter.InlineMarker, StringComparison.OrdinalIgnoreCase));
+        if (candidate is null) {
+            return false;
+        }
+        marker = candidate;
         return true;
     }
 
@@ -201,7 +220,11 @@ public static partial class ReviewerApp {
             if (!comment.Body.Contains(ReviewFormatter.InlineMarker, StringComparison.OrdinalIgnoreCase)) {
                 continue;
             }
-            existingKeys.Add(BuildInlineKey(comment.Path!, comment.Line.Value));
+            var matchKeys = BuildInlineMatchKeys(comment.Path!, comment.Line.Value, comment.Body, snippet: null,
+                signatureSource: null);
+            foreach (var matchKey in matchKeys) {
+                existingKeys.Add(matchKey);
+            }
         }
 
         var posted = 0;
@@ -227,12 +250,20 @@ public static partial class ReviewerApp {
             if (string.IsNullOrWhiteSpace(body)) {
                 continue;
             }
+            var signatureSource = ResolveInlineSignatureSource(normalizedPath, lineNumber, inline.Snippet, body, patchIndex);
+            var matchKeys = BuildInlineMatchKeys(normalizedPath, lineNumber, body, inline.Snippet, signatureSource);
+            foreach (var matchKey in matchKeys) {
+                expectedKeys.Add(matchKey);
+            }
             var key = BuildInlineKey(normalizedPath, lineNumber);
-            expectedKeys.Add(key);
-            if (!allowPost || existingKeys.Contains(key) || !seen.Add(key)) {
+            if (!allowPost || existingKeys.Overlaps(matchKeys) || !seen.Add(key)) {
                 continue;
             }
-            body = $"{ReviewFormatter.InlineMarker}\n{body}";
+            var signatureMarker = TryBuildInlineSignatureMarker(normalizedPath, lineNumber, body, inline.Snippet,
+                signatureSource);
+            body = string.IsNullOrWhiteSpace(signatureMarker)
+                ? $"{ReviewFormatter.InlineMarker}\n{body}"
+                : $"{ReviewFormatter.InlineMarker}\n{signatureMarker}\n{body}";
 
             try {
                 await github.CreatePullRequestReviewCommentAsync(context.Owner, context.Repo, context.Number, body,
@@ -462,6 +493,126 @@ public static partial class ReviewerApp {
         return normalized;
     }
 
+    private static string? ResolveInlineSignatureSource(string path, int line, string? snippet, string body,
+        IReadOnlyDictionary<string, List<PatchLine>> patchIndex) {
+        if (!string.IsNullOrWhiteSpace(snippet)) {
+            return snippet;
+        }
+        var normalizedPath = NormalizePath(path);
+        if (line > 0 &&
+            !string.IsNullOrWhiteSpace(normalizedPath) &&
+            patchIndex.TryGetValue(normalizedPath, out var lines) &&
+            lines.Count > 0) {
+            var patchLine = lines.FirstOrDefault(item => item.LineNumber == line);
+            if (patchLine is not null && !string.IsNullOrWhiteSpace(patchLine.NormalizedText)) {
+                return patchLine.NormalizedText;
+            }
+        }
+        return ExtractInlineBodySignatureSource(body);
+    }
+
+    private static string? ExtractInlineBodySignatureSource(string? body) {
+        if (string.IsNullOrWhiteSpace(body)) {
+            return null;
+        }
+        var lines = body.Replace("\r\n", "\n").Split('\n');
+        foreach (var line in lines) {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0) {
+                continue;
+            }
+            if (trimmed.Contains(ReviewFormatter.InlineMarker, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (trimmed.Contains(InlineSignatureMarkerPrefix, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            return trimmed;
+        }
+        return null;
+    }
+
+    private static string? TryBuildInlineSignatureMarker(string path, int line, string? body, string? snippet,
+        string? signatureSource) {
+        var signature = BuildInlineSignature(path, line, signatureSource ?? snippet ?? ExtractInlineBodySignatureSource(body));
+        if (string.IsNullOrWhiteSpace(signature)) {
+            return null;
+        }
+        return $"{InlineSignatureMarkerPrefix}{signature}{InlineSignatureMarkerSuffix}";
+    }
+
+    private static string? TryExtractInlineSignature(string? body) {
+        if (string.IsNullOrWhiteSpace(body)) {
+            return null;
+        }
+        var start = body.IndexOf(InlineSignatureMarkerPrefix, StringComparison.OrdinalIgnoreCase);
+        if (start < 0) {
+            return null;
+        }
+        start += InlineSignatureMarkerPrefix.Length;
+        var end = body.IndexOf(InlineSignatureMarkerSuffix, start, StringComparison.Ordinal);
+        if (end < 0 || end <= start) {
+            return null;
+        }
+        var signature = body.Substring(start, end - start).Trim();
+        if (signature.Length == 0 || signature.Length > 128) {
+            return null;
+        }
+        for (var i = 0; i < signature.Length; i++) {
+            if (!Uri.IsHexDigit(signature[i])) {
+                return null;
+            }
+        }
+        return signature.ToLowerInvariant();
+    }
+
+    private static string? BuildInlineSignature(string path, int line, string? source) {
+        var normalizedSource = NormalizeSnippetText(source ?? string.Empty);
+        if (string.IsNullOrWhiteSpace(normalizedSource) || normalizedSource.Length < 3) {
+            return null;
+        }
+        var normalizedPath = NormalizePath(path);
+        if (string.IsNullOrWhiteSpace(normalizedPath) || line <= 0) {
+            return null;
+        }
+        var input = $"{normalizedPath}|{normalizedSource}";
+        var digest = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(digest).ToLowerInvariant();
+    }
+
+    private static HashSet<string> BuildInlineMatchKeys(string path, int line, string? body, string? snippet,
+        string? signatureSource) {
+        var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var normalizedPath = NormalizePath(path);
+        if (string.IsNullOrWhiteSpace(normalizedPath) || line <= 0) {
+            return keys;
+        }
+
+        keys.Add(BuildInlineKey(normalizedPath, line));
+        var lower = Math.Max(1, line - InlineLineWindowSize);
+        var upper = line + InlineLineWindowSize;
+        for (var candidate = lower; candidate <= upper; candidate++) {
+            keys.Add(BuildInlineWindowKey(normalizedPath, candidate));
+        }
+
+        var signature = TryExtractInlineSignature(body);
+        if (string.IsNullOrWhiteSpace(signature)) {
+            signature = BuildInlineSignature(normalizedPath, line, signatureSource ?? snippet);
+        }
+        if (!string.IsNullOrWhiteSpace(signature)) {
+            keys.Add(BuildInlineSignatureKey(normalizedPath, signature));
+        }
+        return keys;
+    }
+
+    private static string BuildInlineWindowKey(string path, int line) {
+        return $"window:{NormalizePath(path)}:{line}";
+    }
+
+    private static string BuildInlineSignatureKey(string path, string signature) {
+        return $"signature:{NormalizePath(path)}:{signature}";
+    }
+
     private static string BuildInlineKey(string path, int line) {
         return $"{NormalizePath(path)}:{line}";
     }
@@ -589,4 +740,3 @@ public static partial class ReviewerApp {
     }
 
 }
-

--- a/IntelligenceX.Reviewer/ReviewerApp.TestSeams.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.TestSeams.cs
@@ -84,6 +84,16 @@ public static partial class ReviewerApp {
         return scannedPaths;
     }
 
+    /// <summary>Test-only helper that exposes inline composite matching keys used by missing-inline auto-resolve.</summary>
+    internal static IReadOnlySet<string> BuildInlineMatchKeysForTests(string path, int line, string? body, string? snippet,
+        string? signatureSource) =>
+        BuildInlineMatchKeys(path, line, body, snippet, signatureSource);
+
+    /// <summary>Test-only helper that exposes hidden inline signature marker formatting.</summary>
+    internal static string? BuildInlineSignatureMarkerForTests(string path, int line, string? body, string? snippet,
+        string? signatureSource) =>
+        TryBuildInlineSignatureMarker(path, line, body, snippet, signatureSource);
+
     /// <summary>Test-only forwarder for diff-range file resolution.</summary>
     internal static Task<(IReadOnlyList<PullRequestFile> Files, string DiffNote)> ResolveDiffRangeFilesForTestsAsync(
         GitHubClient github, PullRequestContext context, string range, IReadOnlyList<PullRequestFile> currentFiles,

--- a/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.cs
@@ -423,6 +423,77 @@ internal static partial class Program {
         AssertEqual(true, resolvedThreadIdObserved, "auto resolve missing inline targets thread1");
     }
 
+    private static void TestAutoResolveMissingInlineSkipsShiftedLineWithinWindow() {
+        var resolved = 0;
+        var resolvePayloadObserved = false;
+        var inlineBody = $"{ReviewFormatter.InlineMarker}\nLegacy wording.";
+        using var server = new LocalHttpServer(request => {
+            if (!request.Path.Equals("/graphql", StringComparison.OrdinalIgnoreCase)) {
+                return null;
+            }
+            if (TryGetResolveThreadIdFromGraphQlPayload(request.Body, out _)) {
+                resolvePayloadObserved = true;
+                resolved++;
+                return new HttpResponse("{\"data\":{\"resolveReviewThread\":{\"thread\":{\"id\":\"thread-shifted\",\"isResolved\":true}}}}");
+            }
+            return new HttpResponse(BuildGraphQlThreadsResponse(inlineBody, "src/Foo.cs", 12, "intelligencex-review",
+                "thread-shifted"));
+        });
+
+        using var github = new GitHubClient("token", server.BaseUri.ToString().TrimEnd('/'));
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Title", null, false, "head", "base",
+            Array.Empty<string>(), "owner/repo", false, null);
+        var settings = new ReviewSettings {
+            ReviewThreadsAutoResolveMax = 1,
+            ReviewThreadsMax = 1,
+            ReviewThreadsMaxComments = 1,
+            ReviewThreadsAutoResolveBotsOnly = false
+        };
+        var expected = new HashSet<string>(CallBuildInlineMatchKeys("src/Foo.cs", 10, "Updated wording", null,
+            "if (value == null) return;"), StringComparer.OrdinalIgnoreCase);
+
+        CallAutoResolveMissingInlineThreads(github, context, expected, settings);
+        AssertEqual(0, resolved, "auto resolve missing inline shifted line skipped");
+        AssertEqual(false, resolvePayloadObserved, "auto resolve missing inline shifted line no resolve payload");
+    }
+
+    private static void TestAutoResolveMissingInlineSkipsSignatureMatchForRewordedBody() {
+        var resolved = 0;
+        var resolvePayloadObserved = false;
+        var signatureMarker = CallBuildInlineSignatureMarker("src/Foo.cs", 24, "Original wording", null,
+            "if (value is null) return;");
+        AssertNotNull(signatureMarker, "signature marker");
+        var inlineBody = $"{ReviewFormatter.InlineMarker}\n{signatureMarker}\nOriginal wording";
+        using var server = new LocalHttpServer(request => {
+            if (!request.Path.Equals("/graphql", StringComparison.OrdinalIgnoreCase)) {
+                return null;
+            }
+            if (TryGetResolveThreadIdFromGraphQlPayload(request.Body, out _)) {
+                resolvePayloadObserved = true;
+                resolved++;
+                return new HttpResponse("{\"data\":{\"resolveReviewThread\":{\"thread\":{\"id\":\"thread-signature\",\"isResolved\":true}}}}");
+            }
+            return new HttpResponse(BuildGraphQlThreadsResponse(inlineBody, "src/Foo.cs", 31, "intelligencex-review",
+                "thread-signature"));
+        });
+
+        using var github = new GitHubClient("token", server.BaseUri.ToString().TrimEnd('/'));
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Title", null, false, "head", "base",
+            Array.Empty<string>(), "owner/repo", false, null);
+        var settings = new ReviewSettings {
+            ReviewThreadsAutoResolveMax = 1,
+            ReviewThreadsMax = 1,
+            ReviewThreadsMaxComments = 1,
+            ReviewThreadsAutoResolveBotsOnly = false
+        };
+        var expected = new HashSet<string>(CallBuildInlineMatchKeys("src/Foo.cs", 24, "Completely reworded comment",
+            null, "if (value is null) return;"), StringComparer.OrdinalIgnoreCase);
+
+        CallAutoResolveMissingInlineThreads(github, context, expected, settings);
+        AssertEqual(0, resolved, "auto resolve missing inline signature skipped");
+        AssertEqual(false, resolvePayloadObserved, "auto resolve missing inline signature no resolve payload");
+    }
+
     private static void TestResolveThreadPayloadParserRejectsInvalidJson() {
         var emptyPayloadResult = TryGetResolveThreadIdFromGraphQlPayload(string.Empty, out var emptyPayloadThreadId);
         AssertEqual(false, emptyPayloadResult, "resolve payload empty rejected");
@@ -689,4 +760,3 @@ internal static partial class Program {
 
 }
 #endif
-

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -475,9 +475,26 @@ internal static partial class Program {
     }
 
     private static string BuildGraphQlThreadsResponse(string body) {
-        return "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"nodes\":[{\"id\":\"thread1\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"totalCount\":1,\"nodes\":[{\"databaseId\":1,\"createdAt\":\"2024-01-01T00:00:00Z\",\"body\":\""
+        return BuildGraphQlThreadsResponse(body, "file.txt", 10, "bot", "thread1");
+    }
+
+    private static string BuildGraphQlThreadsResponse(string body, string path, int line, string author, string threadId,
+        bool isResolved = false, bool isOutdated = false) {
+        return "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"nodes\":[{\"id\":\""
+            + EscapeJson(threadId)
+            + "\",\"isResolved\":"
+            + (isResolved ? "true" : "false")
+            + ",\"isOutdated\":"
+            + (isOutdated ? "true" : "false")
+            + ",\"comments\":{\"totalCount\":1,\"nodes\":[{\"databaseId\":1,\"createdAt\":\"2024-01-01T00:00:00Z\",\"body\":\""
             + EscapeJson(body)
-            + "\",\"path\":\"file.txt\",\"line\":10,\"author\":{\"login\":\"bot\"}}]}}],\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null}}}}}}";
+            + "\",\"path\":\""
+            + EscapeJson(path)
+            + "\",\"line\":"
+            + line.ToString()
+            + ",\"author\":{\"login\":\""
+            + EscapeJson(author)
+            + "\"}}]}}],\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null}}}}}}";
     }
 
     private static string EscapeJson(string value) {

--- a/IntelligenceX.Tests/Program.Reviewer.InternalCalls.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.InternalCalls.cs
@@ -112,6 +112,16 @@ internal static partial class Program {
         return ReviewerApp.CollectEvidenceScanPathsForTests(files, evidence, preferredPath);
     }
 
+    private static IReadOnlySet<string> CallBuildInlineMatchKeys(string path, int line, string? body = null,
+        string? snippet = null, string? signatureSource = null) {
+        return ReviewerApp.BuildInlineMatchKeysForTests(path, line, body, snippet, signatureSource);
+    }
+
+    private static string? CallBuildInlineSignatureMarker(string path, int line, string? body = null,
+        string? snippet = null, string? signatureSource = null) {
+        return ReviewerApp.BuildInlineSignatureMarkerForTests(path, line, body, snippet, signatureSource);
+    }
+
     private static (IReadOnlyList<PullRequestFile> Files, string Note) CallResolveDiffRangeFiles(GitHubClient github,
         PullRequestContext context, string range, IReadOnlyList<PullRequestFile> currentFiles, ReviewSettings settings) {
         var result = ReviewerApp.ResolveDiffRangeFilesForTestsAsync(github, context, range, currentFiles, settings,
@@ -122,4 +132,3 @@ internal static partial class Program {
     }
 }
 #endif
-

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -30,6 +30,8 @@ internal static partial class Program {
         failed += Run("Thread assessment prompt smoke", TestThreadAssessmentPromptSmoke);
         failed += Run("Auto-resolve stale threads smoke", TestAutoResolveStaleThreadsSmoke);
         failed += Run("Auto-resolve missing inline empty keys", TestAutoResolveMissingInlineEmptyKeys);
+        failed += Run("Auto-resolve missing inline shifted line window", TestAutoResolveMissingInlineSkipsShiftedLineWithinWindow);
+        failed += Run("Auto-resolve missing inline signature match", TestAutoResolveMissingInlineSkipsSignatureMatchForRewordedBody);
         failed += Run("Resolve thread payload parser rejects invalid JSON", TestResolveThreadPayloadParserRejectsInvalidJson);
         failed += Run("Auto-resolve missing inline gate empty set", TestAutoResolveMissingInlineGateAllowsEmptySet);
         failed += Run("Auto-resolve missing inline gate null set", TestAutoResolveMissingInlineGateRejectsNull);
@@ -589,4 +591,3 @@ internal static partial class Program {
 #endif
     }
 }
-


### PR DESCRIPTION
## Summary\n- harden missing-inline thread matching by using composite keys instead of exact path:line only\n- add a small line-window tolerance for shifted inline positions\n- add hidden inline signature markers (<!-- intelligencex:inline-sig:v1 ... -->) so reworded comments can still match previously posted inline findings\n- reuse composite matching for expected vs existing inline comments to avoid duplicate posting and stale auto-resolve misses\n- add test seams and targeted reviewer regression tests for shifted-line and signature-match cases\n\n## Validation\n- dotnet build IntelligenceX.sln -c Release\n- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll\n- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll\n- dotnet test IntelligenceX.sln -c Release (known unrelated existing failure in IntelligenceX.Tools.Tests.ToolResponseContractGuardrailTests.ResponseContracts_ShouldNotIntroduceUnsafeDictionaryKeyValueProperties for IntelligenceX.Tools.Common.ToolNextActionModel.Arguments)\n