### PR TITLE
Use visibility-aware runner selection for issue-review workflow

### DIFF
--- a/.github/workflows/issue-review.yml
+++ b/.github/workflows/issue-review.yml
@@ -59,7 +59,10 @@ env:
 
 jobs:
   issue-review:
-    runs-on: ubuntu-latest
+    # While private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
+    # Set repository variable IX_FORCE_GITHUB_HOSTED=true to bypass self-hosted runners temporarily.
+    # When public, use GitHub-hosted runners by default.
+    runs-on: ${{ fromJSON((github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- update `.github/workflows/issue-review.yml` to use the same visibility-aware runner policy used by other workflows
- private repo: prefer self-hosted (`[self-hosted, ubuntu]`) unless `IX_FORCE_GITHUB_HOSTED=true`
- public repo: always use `ubuntu-latest` by default

## Why
- keeps behavior consistent across workflows after open-sourcing
- avoids accidentally running private runner capacity for public default cases
