### PR TITLE
feat(todo): add observe-mode pr babysit monitor workflow

### DIFF
--- a/.github/workflows/ix-pr-babysit-monitor.yml
+++ b/.github/workflows/ix-pr-babysit-monitor.yml
@@ -1,0 +1,250 @@
+name: IX PR Babysit Monitor
+
+on:
+  schedule:
+    - cron: "23 * * * *"
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Optional PR number or URL to monitor (otherwise scans open PRs)"
+        required: false
+        default: ""
+      max_prs:
+        description: "Max open PRs to scan when pr is not provided"
+        required: false
+        default: "100"
+      max_flaky_retries:
+        description: "Retry budget classification ceiling for pr-watch snapshots"
+        required: false
+        default: "3"
+      include_drafts:
+        description: "Include draft PRs in scan mode"
+        required: false
+        default: false
+        type: boolean
+      approved_bots:
+        description: "Comma-separated approved bot logins for source classification"
+        required: false
+        default: "intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"
+
+permissions:
+  actions: read
+  contents: read
+  issues: read
+  pull-requests: read
+
+env:
+  PR_WATCH_STATE_DIR: artifacts/pr-watch
+  PR_WATCH_SNAPSHOT_DIR: artifacts/pr-watch/snapshots
+  PR_WATCH_SUMMARY_PATH: artifacts/pr-watch/ix-pr-watch-summary.md
+  PR_WATCH_ROLLUP_PATH: artifacts/pr-watch/ix-pr-watch-rollup.json
+  PR_WATCH_STATE_CACHE_PREFIX: ix-pr-watch-state-${{ github.repository }}-${{ github.ref_name }}
+  PR_WATCH_STATE_CACHE_KEY: ix-pr-watch-state-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_id }}
+
+jobs:
+  monitor:
+    # While private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
+    # Set repository variable IX_FORCE_GITHUB_HOSTED=true to bypass self-hosted runners temporarily.
+    # When public, use GitHub-hosted runners by default.
+    runs-on: ${{ fromJSON((github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore pr-watch state cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.PR_WATCH_STATE_DIR }}/ix-pr-watch-*.json
+          key: ${{ env.PR_WATCH_STATE_CACHE_KEY }}
+          restore-keys: |
+            ${{ env.PR_WATCH_STATE_CACHE_PREFIX }}-
+
+      - name: Build CLI once
+        run: dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj -c Release /m:1
+
+      - name: Run observe-mode PR watch sweep
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "jq is required for ix-pr-babysit-monitor workflow rollup generation."
+            exit 1
+          fi
+
+          mkdir -p "${PR_WATCH_STATE_DIR}"
+          rm -rf "${PR_WATCH_SNAPSHOT_DIR}"
+          mkdir -p "${PR_WATCH_SNAPSHOT_DIR}"
+
+          TARGETS_FILE="${PR_WATCH_STATE_DIR}/ix-pr-watch-targets.txt"
+          : > "${TARGETS_FILE}"
+
+          PR_INPUT="${{ github.event.inputs.pr }}"
+          MAX_PRS="${{ github.event.inputs.max_prs }}"
+          MAX_FLAKY_RETRIES="${{ github.event.inputs.max_flaky_retries }}"
+          INCLUDE_DRAFTS="${{ github.event.inputs.include_drafts }}"
+          APPROVED_BOTS="${{ github.event.inputs.approved_bots }}"
+
+          if [ -z "${MAX_PRS}" ]; then MAX_PRS="100"; fi
+          if [ -z "${MAX_FLAKY_RETRIES}" ]; then MAX_FLAKY_RETRIES="3"; fi
+          if [ -z "${INCLUDE_DRAFTS}" ]; then INCLUDE_DRAFTS="false"; fi
+          if [ -z "${APPROVED_BOTS}" ]; then APPROVED_BOTS="intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"; fi
+
+          if [ -n "${PR_INPUT}" ]; then
+            echo "${PR_INPUT}" >> "${TARGETS_FILE}"
+          else
+            if [ "${INCLUDE_DRAFTS}" = "true" ]; then
+              gh pr list \
+                --repo "${{ github.repository }}" \
+                --state open \
+                --limit "${MAX_PRS}" \
+                --json number \
+                --jq '.[].number' >> "${TARGETS_FILE}"
+            else
+              gh pr list \
+                --repo "${{ github.repository }}" \
+                --state open \
+                --limit "${MAX_PRS}" \
+                --json number,isDraft \
+                --jq '.[] | select(.isDraft == false) | .number' >> "${TARGETS_FILE}"
+            fi
+          fi
+
+          if [ ! -s "${TARGETS_FILE}" ]; then
+            printf '%s\n' '{"schema":"intelligencex.pr-watch.rollup.v1","repo":"","generatedAtUtc":"","totalSnapshots":0,"stopReasons":[],"actionCounts":[],"prs":[]}' > "${PR_WATCH_ROLLUP_PATH}"
+            jq \
+              --arg repo "${{ github.repository }}" \
+              --arg generatedAt "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+              '.repo = $repo | .generatedAtUtc = $generatedAt' \
+              "${PR_WATCH_ROLLUP_PATH}" > "${PR_WATCH_ROLLUP_PATH}.tmp"
+            mv "${PR_WATCH_ROLLUP_PATH}.tmp" "${PR_WATCH_ROLLUP_PATH}"
+          else
+            sort -u "${TARGETS_FILE}" -o "${TARGETS_FILE}"
+            while IFS= read -r pr_spec; do
+              [ -z "${pr_spec}" ] && continue
+
+              safe_spec="$(printf '%s' "${pr_spec}" | tr '/:#?&=' '-' | tr -cd 'A-Za-z0-9._-')"
+              if [ -z "${safe_spec}" ]; then
+                safe_spec="target"
+              fi
+              output_path="${PR_WATCH_SNAPSHOT_DIR}/pr-${safe_spec}.json"
+
+              ARGS=(
+                "todo" "pr-watch"
+                "--repo" "${{ github.repository }}"
+                "--pr" "${pr_spec}"
+                "--max-flaky-retries" "${MAX_FLAKY_RETRIES}"
+              )
+
+              IFS=',' read -r -a bot_parts <<< "${APPROVED_BOTS}"
+              for raw in "${bot_parts[@]}"; do
+                bot="$(echo "${raw}" | xargs)"
+                if [ -n "${bot}" ]; then
+                  ARGS+=("--approved-bot" "${bot}")
+                fi
+              done
+
+              dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll "${ARGS[@]}" > "${output_path}"
+
+              pr_number="$(jq -r '.pr.number // empty' "${output_path}")"
+              if [ -n "${pr_number}" ]; then
+                mv "${output_path}" "${PR_WATCH_SNAPSHOT_DIR}/pr-${pr_number}.json"
+              fi
+            done < "${TARGETS_FILE}"
+
+            jq -s '
+              {
+                schema: "intelligencex.pr-watch.rollup.v1",
+                repo: env.GITHUB_REPOSITORY,
+                generatedAtUtc: (now | gmtime | strftime("%Y-%m-%dT%H:%M:%SZ")),
+                totalSnapshots: length,
+                stopReasons: (
+                  map(.stopReason // "none")
+                  | group_by(.)
+                  | map({ reason: .[0], count: length })
+                ),
+                actionCounts: (
+                  map(.actions[]?.name)
+                  | group_by(.)
+                  | map({ action: .[0], count: length })
+                ),
+                prs: (
+                  map({
+                    number: .pr.number,
+                    url: .pr.url,
+                    headSha: .pr.headSha,
+                    stopReason: (.stopReason // ""),
+                    actions: (.actions | map(.name)),
+                    checks: {
+                      passedCount: .checks.passedCount,
+                      failedCount: .checks.failedCount,
+                      pendingCount: .checks.pendingCount
+                    }
+                  })
+                  | sort_by(.number)
+                )
+              }
+            ' "${PR_WATCH_SNAPSHOT_DIR}"/pr-*.json > "${PR_WATCH_ROLLUP_PATH}"
+          fi
+
+          {
+            echo "# IX PR Babysit Monitor (Observe)"
+            echo
+            echo "- Generated: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+            echo "- Repo: \`${{ github.repository }}\`"
+            echo "- Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo
+            echo "## Snapshot counts"
+            jq -r '"- PRs scanned: \(.totalSnapshots)"' "${PR_WATCH_ROLLUP_PATH}"
+            echo
+            echo "## Stop reasons"
+            jq -r '
+              if (.stopReasons | length) == 0 then
+                "- none"
+              else
+                .stopReasons | map("- `\(.reason)`: \(.count)") | .[]
+              end
+            ' "${PR_WATCH_ROLLUP_PATH}"
+            echo
+            echo "## Actions"
+            jq -r '
+              if (.actionCounts | length) == 0 then
+                "- none"
+              else
+                .actionCounts | map("- `\(.action)`: \(.count)") | .[]
+              end
+            ' "${PR_WATCH_ROLLUP_PATH}"
+            echo
+            echo "## Per PR"
+            jq -r '
+              if (.prs | length) == 0 then
+                "- none"
+              else
+                .prs[]
+                | "- #\(.number) | stop=`\((if (.stopReason | length) == 0 then "none" else .stopReason end))` | actions=`\((.actions | join(",")))` | checks pass/fail/pending=\(.checks.passedCount)/\(.checks.failedCount)/\(.checks.pendingCount)"
+              end
+            ' "${PR_WATCH_ROLLUP_PATH}"
+          } > "${PR_WATCH_SUMMARY_PATH}"
+
+          cat "${PR_WATCH_SUMMARY_PATH}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload pr-watch artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ix-pr-watch
+          path: artifacts/pr-watch
+
+      - name: Save pr-watch state cache
+        if: ${{ always() && hashFiles('artifacts/pr-watch/ix-pr-watch-*.json') != '' }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.PR_WATCH_STATE_DIR }}/ix-pr-watch-*.json
+          key: ${{ env.PR_WATCH_STATE_CACHE_KEY }}

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -16,6 +16,7 @@ These commands are assistive. They are not an autonomous production decision sys
 - Backlog indexing and duplicate clustering across open PRs/issues (`build-triage-index`).
 - Scope alignment checks against `VISION.md` (`vision-check`).
 - Issue applicability review for stale/no-longer-applicable infra blockers (`issue-review`).
+- Observe-mode PR babysitter snapshots and action recommendations (`pr-watch`).
 - Issue applicability proposed actions (`close`, `keep-open`, `needs-human-review`) with confidence scoring and safety signals.
 - GitHub Project field sync for triage at scale (`project-init`, `project-sync`, `project-bootstrap`).
 - Maintainer-assist view checklist and apply plan generation (`project-view-checklist`, `project-view-apply`).
@@ -64,6 +65,7 @@ intelligencex todo project-view-checklist --config artifacts/triage/ix-project-c
 | `sync-bot-feedback` | Extract explicit bot checklist tasks and keep them tracked in `TODO.md` | Updated `TODO.md` (optional GitHub issues) |
 | `build-triage-index` | Build PR/issue inventory, duplicate clusters, and best PR ranking | `artifacts/triage/ix-triage-index.json`, `.md` |
 | `issue-review` | Detect stale/no-longer-applicable infra blocker issues and optionally auto-close | `artifacts/triage/ix-issue-review.json`, `.md` |
+| `pr-watch` | Observe PR CI/review/mergeability state and emit deterministic action recommendations | JSON snapshot + watcher state in `artifacts/pr-watch/` |
 | `vision-check` | Compare backlog against `VISION.md` scope | `artifacts/triage/ix-vision-check.json`, `.md` |
 | `project-init` | Create/initialize GitHub Project fields + metadata | `artifacts/triage/ix-project-config.json` |
 | `project-sync` | Push triage/issue-review/vision signals to project items and optional labels/comments | Project field updates, optional comment/label updates |
@@ -80,6 +82,13 @@ intelligencex todo project-view-checklist --config artifacts/triage/ix-project-c
   - `confirm_apply_close=CLOSE_ISSUES`
   - `min_auto_close_confidence` (default `80`)
   - optional label policy (`allow_labels`, `deny_labels`)
+
+Observe-mode babysitter automation:
+
+- Workflow: `.github/workflows/ix-pr-babysit-monitor.yml`
+- Schedule: hourly observe-mode sweep
+- Manual targeted run: `workflow_dispatch` with optional `pr` and policy inputs (`max_prs`, `max_flaky_retries`, `include_drafts`, `approved_bots`)
+- Outputs: per-PR snapshots + rollup summary in `artifacts/pr-watch/`
 
 ### Issue-review confidence signals
 

--- a/IntelligenceX.Cli/Todo/PrWatchRunner.cs
+++ b/IntelligenceX.Cli/Todo/PrWatchRunner.cs
@@ -152,6 +152,7 @@ internal static class PrWatchRunner {
         public bool ParseFailed { get; set; }
         public HashSet<string> ApprovedBots { get; } = new(StringComparer.OrdinalIgnoreCase) {
             "intelligencex-review",
+            "intelligencex-review[bot]",
             "chatgpt-codex-connector[bot]"
         };
     }

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -98,6 +98,45 @@ Workflow automation:
   - `confirm_apply_close=CLOSE_ISSUES`
   - `min_auto_close_confidence` tune threshold for mutation runs
 
+## PR Watch (Observe Mode Babysitter Snapshot)
+
+Capture deterministic PR babysitter snapshots for a single PR:
+
+```bash
+intelligencex todo pr-watch --repo EvotecIT/IntelligenceX --pr 744
+```
+
+Options:
+- `--repo <owner/name>` (default `EvotecIT/IntelligenceX`)
+- `--pr <auto|number|url>` (default `auto`; current branch PR)
+- `--once` (default; capture one snapshot and exit)
+- `--watch` (continuous snapshots with adaptive backoff until terminal stop reason)
+- `--poll-seconds <n>` (watch mode base interval; default `60`)
+- `--max-flaky-retries <n>` (classification budget ceiling; default `3`)
+- `--state-file <path>` (override watcher-state file path)
+- `--approved-bot <login>` (repeatable approved bot allow-list extension)
+
+Default approved bots include `intelligencex-review`, `intelligencex-review[bot]`, and `chatgpt-codex-connector[bot]`.
+
+Default outputs:
+- JSON snapshot on stdout with:
+  - `pr`, `checks`, `failedRuns`, `newReviewItems`, `retryState`, `actions`, `stopReason`
+- Stateful tracker file at:
+  - `artifacts/pr-watch/ix-pr-watch-<owner>-<repo>-pr<Number>.json`
+
+Workflow automation:
+- `.github/workflows/ix-pr-babysit-monitor.yml` runs in observe mode on an hourly schedule.
+- Manual targeted run via `workflow_dispatch` supports:
+  - `pr` (specific PR number/URL),
+  - `max_prs`,
+  - `max_flaky_retries`,
+  - `include_drafts`,
+  - `approved_bots`.
+- Workflow artifacts:
+  - per-PR snapshots under `artifacts/pr-watch/snapshots/`,
+  - rollup JSON `artifacts/pr-watch/ix-pr-watch-rollup.json`,
+  - markdown summary `artifacts/pr-watch/ix-pr-watch-summary.md`.
+
 ## Vision Check (Assistive)
 
 Evaluate PR backlog alignment against `VISION.md`:


### PR DESCRIPTION
## Summary
Phase 2 scheduler slice for the PR babysitter RFC:
- adds an observe-mode scheduled workflow to run `todo pr-watch` across open PRs,
- keeps runs non-mutating,
- persists watcher state between runs,
- emits deterministic rollup artifacts for maintainer visibility.

## What this adds
- New workflow: `.github/workflows/ix-pr-babysit-monitor.yml`
  - Hourly schedule (`23 * * * *`) + `workflow_dispatch`
  - Inputs: `pr`, `max_prs`, `max_flaky_retries`, `include_drafts`, `approved_bots`
  - Observe-mode sweep (no retries/push/merge mutations)
  - State cache restore/save for `artifacts/pr-watch/ix-pr-watch-*.json`
  - Artifacts:
    - per-PR snapshots in `artifacts/pr-watch/snapshots/`
    - rollup JSON: `artifacts/pr-watch/ix-pr-watch-rollup.json`
    - markdown summary: `artifacts/pr-watch/ix-pr-watch-summary.md`
- `PrWatchRunner` default approved-bot list now includes `intelligencex-review[bot]` in addition to existing values.
- Docs updates:
  - `InternalDocs/cli-commands/todo.md`
  - `Docs/reviewer/projects-pr-monitoring.md`

## Safety / governance
- Observe mode only in this PR.
- No autonomous merge.
- No workflow/secret/policy mutation behavior.
- No CI rerun/push behavior in workflow.

## Validation
- `dotnet build IntelligenceX.sln -c Release /m:1`
- `dotnet test IntelligenceX.sln -c Release /m:1`
  - Known unrelated pre-existing failure persists:
    - `IntelligenceX.Tools.Tests.ToolResponseContractGuardrailTests.ResponseContracts_ShouldNotIntroduceUnsafeDictionaryKeyValueProperties`
    - (`IntelligenceX.Tools.Common.ToolNextActionModel.Arguments`)
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- Smoke: `todo pr-watch` with fresh state confirms `intelligencex-review[bot]` classifies as `approved_bot`.
