### PR TITLE
feat(todo): add guarded manual assist retry workflow

### DIFF
--- a/.github/workflows/ix-pr-babysit-assist-retry.yml
+++ b/.github/workflows/ix-pr-babysit-assist-retry.yml
@@ -1,0 +1,152 @@
+name: IX PR Babysit Assist Retry
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number or URL to assist"
+        required: true
+      max_flaky_retries:
+        description: "Per-SHA retry budget ceiling"
+        required: false
+        default: "3"
+      retry_cooldown_minutes:
+        description: "Cooldown before re-planning retry for same SHA"
+        required: false
+        default: "15"
+      approved_bots:
+        description: "Comma-separated approved bot logins for source classification"
+        required: false
+        default: "intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"
+      confirm_apply_retries:
+        description: "Required confirmation token: RETRY_CHECKS"
+        required: true
+        default: ""
+
+permissions:
+  actions: write
+  contents: read
+  issues: read
+  pull-requests: read
+
+env:
+  PR_WATCH_STATE_DIR: artifacts/pr-watch
+  PR_WATCH_ASSIST_DIR: artifacts/pr-watch/assist
+  PR_WATCH_STATE_CACHE_PREFIX: ix-pr-watch-state-${{ github.repository }}-${{ github.ref_name }}
+  PR_WATCH_STATE_CACHE_KEY: ix-pr-watch-state-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_id }}
+
+jobs:
+  assist-retry:
+    # While private, prefer self-hosted runners to avoid GitHub-hosted spend limits.
+    # Set repository variable IX_FORCE_GITHUB_HOSTED=true to bypass self-hosted runners temporarily.
+    # When public, use GitHub-hosted runners by default.
+    runs-on: ${{ fromJSON((github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","ubuntu"]' || '["ubuntu-latest"]') }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore pr-watch state cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.PR_WATCH_STATE_DIR }}/ix-pr-watch-*.json
+          key: ${{ env.PR_WATCH_STATE_CACHE_KEY }}
+          restore-keys: |
+            ${{ env.PR_WATCH_STATE_CACHE_PREFIX }}-
+
+      - name: Build CLI once
+        run: dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj -c Release /m:1
+
+      - name: Apply guarded retry assist for target PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "jq is required for assist summary rendering."
+            exit 1
+          fi
+
+          CONFIRM="${{ github.event.inputs.confirm_apply_retries }}"
+          if [ "${CONFIRM}" != "RETRY_CHECKS" ]; then
+            echo "confirm_apply_retries must equal RETRY_CHECKS"
+            exit 1
+          fi
+
+          PR_INPUT="${{ github.event.inputs.pr }}"
+          MAX_FLAKY_RETRIES="${{ github.event.inputs.max_flaky_retries }}"
+          RETRY_COOLDOWN_MINUTES="${{ github.event.inputs.retry_cooldown_minutes }}"
+          APPROVED_BOTS="${{ github.event.inputs.approved_bots }}"
+
+          if [ -z "${MAX_FLAKY_RETRIES}" ]; then MAX_FLAKY_RETRIES="3"; fi
+          if [ -z "${RETRY_COOLDOWN_MINUTES}" ]; then RETRY_COOLDOWN_MINUTES="15"; fi
+          if [ -z "${APPROVED_BOTS}" ]; then APPROVED_BOTS="intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"; fi
+
+          mkdir -p "${PR_WATCH_STATE_DIR}"
+          mkdir -p "${PR_WATCH_ASSIST_DIR}"
+
+          OUTPUT_PATH="${PR_WATCH_ASSIST_DIR}/ix-pr-watch-assist-pr.json"
+
+          ARGS=(
+            "todo" "pr-watch"
+            "--repo" "${{ github.repository }}"
+            "--pr" "${PR_INPUT}"
+            "--once"
+            "--max-flaky-retries" "${MAX_FLAKY_RETRIES}"
+            "--retry-cooldown-minutes" "${RETRY_COOLDOWN_MINUTES}"
+            "--apply-retry"
+            "--confirm-apply-retry" "${CONFIRM}"
+          )
+
+          IFS=',' read -r -a bot_parts <<< "${APPROVED_BOTS}"
+          for raw in "${bot_parts[@]}"; do
+            bot="$(echo "${raw}" | xargs)"
+            if [ -n "${bot}" ]; then
+              ARGS+=("--approved-bot" "${bot}")
+            fi
+          done
+
+          dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll "${ARGS[@]}" > "${OUTPUT_PATH}"
+
+          {
+            echo "# IX PR Babysit Assist Retry"
+            echo
+            echo "- Generated: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+            echo "- Repo: \`${{ github.repository }}\`"
+            echo "- Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo
+            echo "## Snapshot"
+            jq -r '"- PR: #\(.pr.number) (\(.pr.url))"' "${OUTPUT_PATH}"
+            jq -r '"- Head SHA: `\(.pr.headSha)`"' "${OUTPUT_PATH}"
+            jq -r '"- Stop reason: `\((.stopReason // "none"))`"' "${OUTPUT_PATH}"
+            jq -r '"- Retry usage: \(.retryState.currentShaRetriesUsed)/\(.retryState.maxFlakyRetries)"' "${OUTPUT_PATH}"
+            echo
+            echo "## Planned actions"
+            jq -r '
+              if (.actions | length) == 0 then
+                "- none"
+              else
+                .actions | map("- `\(.name)`\((if .dedupeKey then " (`\(.dedupeKey)`)" else "" end)") | .[]
+              end
+            ' "${OUTPUT_PATH}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload pr-watch assist artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ix-pr-watch-assist
+          path: artifacts/pr-watch
+
+      - name: Save pr-watch state cache
+        if: ${{ always() && hashFiles('artifacts/pr-watch/ix-pr-watch-*.json') != '' }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.PR_WATCH_STATE_DIR }}/ix-pr-watch-*.json
+          key: ${{ env.PR_WATCH_STATE_CACHE_KEY }}

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -90,6 +90,13 @@ Observe-mode babysitter automation:
 - Manual targeted run: `workflow_dispatch` with optional `pr` and policy inputs (`max_prs`, `max_flaky_retries`, `include_drafts`, `approved_bots`)
 - Outputs: per-PR snapshots + rollup summary in `artifacts/pr-watch/`
 
+Guarded retry assist automation:
+
+- Workflow: `.github/workflows/ix-pr-babysit-assist-retry.yml`
+- Trigger: manual `workflow_dispatch` only (single PR target)
+- Safety: requires explicit confirmation token `RETRY_CHECKS`
+- Scope: retries failed checks only when `pr-watch` plans an eligible `retry_failed_checks` action (dedupe + cooldown aware)
+
 ### Issue-review confidence signals
 
 `issue-review` now emits a proposed action and confidence score for each issue:

--- a/IntelligenceX.Cli/Todo/PrWatchRunner.cs
+++ b/IntelligenceX.Cli/Todo/PrWatchRunner.cs
@@ -28,7 +28,10 @@ internal static class PrWatchRunner {
     private const string StopReasonPrClosed = "pr_closed";
     private const string StopReasonReadyToMerge = "ready_to_merge";
     private const string StopReasonRetryBudgetExhausted = "retry_budget_exhausted";
+    private const string ConfirmApplyRetryToken = "RETRY_CHECKS";
     private const int DefaultPollSeconds = 60;
+    private const int DefaultRetryCooldownMinutes = 15;
+    private const int MaxRetryCooldownMinutes = 24 * 60;
     private const int MaxPollSeconds = 60 * 60;
     private static readonly HashSet<string> PendingCheckStates = new(StringComparer.OrdinalIgnoreCase) {
         "QUEUED",
@@ -135,6 +138,8 @@ internal static class PrWatchRunner {
         public DateTimeOffset UpdatedAtUtc { get; set; } = DateTimeOffset.UtcNow;
         public string LastSeenHeadSha { get; set; } = string.Empty;
         public Dictionary<string, int> RetriesBySha { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, string> LastRetryDedupeBySha { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, DateTimeOffset> LastRetryAtBySha { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public List<string> SeenIssueCommentIds { get; set; } = new();
         public List<string> SeenReviewCommentIds { get; set; } = new();
         public List<string> SeenReviewIds { get; set; } = new();
@@ -145,6 +150,9 @@ internal static class PrWatchRunner {
         public string PrSpec { get; set; } = "auto";
         public int PollSeconds { get; set; } = DefaultPollSeconds;
         public int MaxFlakyRetries { get; set; } = 3;
+        public int RetryCooldownMinutes { get; set; } = DefaultRetryCooldownMinutes;
+        public bool ApplyRetry { get; set; }
+        public string ConfirmApplyRetry { get; set; } = string.Empty;
         public string? StateFilePath { get; set; }
         public bool Once { get; set; } = true;
         public bool Watch { get; set; }
@@ -157,7 +165,7 @@ internal static class PrWatchRunner {
         };
     }
 
-    private sealed record WatchCollectionResult(WatchSnapshot Snapshot, string StateFilePath);
+    private sealed record WatchCollectionResult(WatchSnapshot Snapshot, string StateFilePath, RunnerState State);
 
     public static async Task<int> RunAsync(string[] args) {
         var options = ParseOptions(args);
@@ -181,13 +189,61 @@ internal static class PrWatchRunner {
             return 1;
         }
 
+        if (options.ApplyRetry && !options.Once) {
+            Console.Error.WriteLine("`--apply-retry` is supported only in `--once` mode.");
+            return 1;
+        }
+
+        if (options.ApplyRetry && !string.Equals(options.ConfirmApplyRetry, ConfirmApplyRetryToken, StringComparison.Ordinal)) {
+            Console.Error.WriteLine("`--apply-retry` requires `--confirm-apply-retry RETRY_CHECKS`.");
+            return 1;
+        }
+
         if (options.Watch) {
             return await RunWatchAsync(options, authenticatedLogin).ConfigureAwait(false);
         }
 
         try {
-            var snapshot = await CollectSnapshotAsync(options, authenticatedLogin).ConfigureAwait(false);
-            PrintJson(snapshot.Snapshot);
+            var result = await CollectSnapshotAsync(options, authenticatedLogin).ConfigureAwait(false);
+            if (options.ApplyRetry) {
+                var applied = await TryApplyRetryActionAsync(result).ConfigureAwait(false);
+                if (applied) {
+                    var refreshedRetryState = new RetryState(
+                        CurrentShaRetriesUsed: GetRetriesUsed(result.State, result.Snapshot.Pr.HeadSha),
+                        MaxFlakyRetries: options.MaxFlakyRetries
+                    );
+                    var retryDedupeKey = BuildRetryActionDedupeKey(
+                        result.Snapshot.Pr.Repo,
+                        result.Snapshot.Pr.Number,
+                        result.Snapshot.Pr.HeadSha,
+                        result.Snapshot.FailedRuns.Select(item => item.RunId));
+                    var allowRetryAction = !ShouldSuppressRetryAction(
+                        GetLastRetryDedupeKey(result.State, result.Snapshot.Pr.HeadSha),
+                        GetLastRetryAt(result.State, result.Snapshot.Pr.HeadSha),
+                        retryDedupeKey,
+                        options.RetryCooldownMinutes,
+                        DateTimeOffset.UtcNow);
+                    var refreshedActions = RecommendActions(
+                        result.Snapshot.Pr,
+                        result.Snapshot.Checks,
+                        result.Snapshot.FailedRuns,
+                        result.Snapshot.NewReviewItems,
+                        refreshedRetryState,
+                        out var refreshedStopReason,
+                        allowRetryAction);
+
+                    result = result with {
+                        Snapshot = result.Snapshot with {
+                            CapturedAtUtc = DateTimeOffset.UtcNow,
+                            RetryState = refreshedRetryState,
+                            Actions = refreshedActions,
+                            StopReason = refreshedStopReason
+                        }
+                    };
+                }
+            }
+
+            PrintJson(result.Snapshot);
             return 0;
         } catch (Exception ex) {
             Console.Error.WriteLine(ex.Message);
@@ -230,7 +286,8 @@ internal static class PrWatchRunner {
     }
 
     internal static IReadOnlyList<RecommendedAction> RecommendActions(PrState pr, CheckSummary checks,
-        IReadOnlyList<FailedRun> failedRuns, IReadOnlyList<ReviewItem> newReviewItems, RetryState retryState, out string? stopReason) {
+        IReadOnlyList<FailedRun> failedRuns, IReadOnlyList<ReviewItem> newReviewItems, RetryState retryState, out string? stopReason,
+        bool allowRetryAction = true) {
         var actions = new List<RecommendedAction>();
         stopReason = null;
 
@@ -265,7 +322,7 @@ internal static class PrWatchRunner {
             }
 
             actions.Add(new RecommendedAction(ActionDiagnoseCiFailure));
-            if (checks.AllTerminal && failedRuns.Count > 0 && retryState.CurrentShaRetriesUsed < retryState.MaxFlakyRetries) {
+            if (allowRetryAction && checks.AllTerminal && failedRuns.Count > 0 && retryState.CurrentShaRetriesUsed < retryState.MaxFlakyRetries) {
                 var dedupeKey = BuildRetryActionDedupeKey(pr.Repo, pr.Number, pr.HeadSha, failedRuns.Select(item => item.RunId));
                 actions.Add(new RecommendedAction(ActionRetryFailedChecks, dedupeKey));
             }
@@ -275,6 +332,24 @@ internal static class PrWatchRunner {
             actions.Add(new RecommendedAction(ActionIdleWait));
         }
         return actions;
+    }
+
+    internal static bool ShouldSuppressRetryAction(string? lastRetryDedupeKey, DateTimeOffset? lastRetryAtUtc,
+        string currentRetryDedupeKey, int retryCooldownMinutes, DateTimeOffset nowUtc) {
+        if (!string.IsNullOrWhiteSpace(lastRetryDedupeKey) &&
+            !string.IsNullOrWhiteSpace(currentRetryDedupeKey) &&
+            string.Equals(lastRetryDedupeKey, currentRetryDedupeKey, StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        if (lastRetryAtUtc.HasValue && retryCooldownMinutes > 0) {
+            var elapsed = nowUtc - lastRetryAtUtc.Value;
+            if (elapsed < TimeSpan.FromMinutes(retryCooldownMinutes)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static async Task<int> RunWatchAsync(Options options, string authenticatedLogin) {
@@ -357,7 +432,14 @@ internal static class PrWatchRunner {
             CurrentShaRetriesUsed: GetRetriesUsed(state, pr.HeadSha),
             MaxFlakyRetries: options.MaxFlakyRetries
         );
-        var actions = RecommendActions(pr, checksSummary, failedRuns, newReviewItems, retryState, out var stopReason);
+        var retryDedupeKey = BuildRetryActionDedupeKey(pr.Repo, pr.Number, pr.HeadSha, failedRuns.Select(item => item.RunId));
+        var allowRetryAction = !ShouldSuppressRetryAction(
+            GetLastRetryDedupeKey(state, pr.HeadSha),
+            GetLastRetryAt(state, pr.HeadSha),
+            retryDedupeKey,
+            options.RetryCooldownMinutes,
+            DateTimeOffset.UtcNow);
+        var actions = RecommendActions(pr, checksSummary, failedRuns, newReviewItems, retryState, out var stopReason, allowRetryAction);
 
         state.Repo = pr.Repo;
         state.PrNumber = pr.Number;
@@ -376,7 +458,7 @@ internal static class PrWatchRunner {
             StopReason: stopReason,
             RetryState: retryState
         );
-        return new WatchCollectionResult(snapshot, statePath);
+        return new WatchCollectionResult(snapshot, statePath, state);
     }
 
     private static string ResolveStatePath(Options options, PrState pr) {
@@ -400,6 +482,8 @@ internal static class PrWatchRunner {
                 return new RunnerState();
             }
             value.RetriesBySha ??= new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            value.LastRetryDedupeBySha ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            value.LastRetryAtBySha ??= new Dictionary<string, DateTimeOffset>(StringComparer.OrdinalIgnoreCase);
             value.SeenIssueCommentIds ??= new List<string>();
             value.SeenReviewCommentIds ??= new List<string>();
             value.SeenReviewIds ??= new List<string>();
@@ -434,6 +518,92 @@ internal static class PrWatchRunner {
         }
 
         return Math.Max(0, count);
+    }
+
+    private static string? GetLastRetryDedupeKey(RunnerState state, string headSha) {
+        if (string.IsNullOrWhiteSpace(headSha)) {
+            return null;
+        }
+
+        return state.LastRetryDedupeBySha.TryGetValue(headSha, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value
+            : null;
+    }
+
+    private static DateTimeOffset? GetLastRetryAt(RunnerState state, string headSha) {
+        if (string.IsNullOrWhiteSpace(headSha)) {
+            return null;
+        }
+
+        return state.LastRetryAtBySha.TryGetValue(headSha, out var value)
+            ? value
+            : null;
+    }
+
+    private static async Task<bool> TryApplyRetryActionAsync(WatchCollectionResult result) {
+        var retryAction = result.Snapshot.Actions
+            .FirstOrDefault(action => action.Name.Equals(ActionRetryFailedChecks, StringComparison.OrdinalIgnoreCase));
+        if (retryAction is null) {
+            Console.Error.WriteLine("Assist retry requested, but no eligible retry action was planned.");
+            return false;
+        }
+
+        var runIds = result.Snapshot.FailedRuns
+            .Select(item => item.RunId)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (runIds.Count == 0) {
+            Console.Error.WriteLine("Assist retry requested, but no failed run IDs are available.");
+            return false;
+        }
+
+        var failedReruns = new List<string>();
+        var rerunSucceeded = false;
+        foreach (var runId in runIds) {
+            var (code, _, stderr) = await GhCli.RunAsync(
+                TimeSpan.FromSeconds(90),
+                "run",
+                "rerun",
+                runId,
+                "--repo",
+                result.Snapshot.Pr.Repo,
+                "--failed").ConfigureAwait(false);
+            if (code == 0) {
+                rerunSucceeded = true;
+                continue;
+            }
+
+            var failure = string.IsNullOrWhiteSpace(stderr)
+                ? $"run:{runId}"
+                : $"run:{runId}:{stderr.Trim()}";
+            failedReruns.Add(failure);
+        }
+
+        if (!rerunSucceeded) {
+            throw new InvalidOperationException("Retry rerun failed for all targeted workflow runs.");
+        }
+
+        var headSha = result.Snapshot.Pr.HeadSha;
+        var currentCount = GetRetriesUsed(result.State, headSha);
+        result.State.RetriesBySha[headSha] = currentCount + 1;
+        if (!string.IsNullOrWhiteSpace(retryAction.DedupeKey)) {
+            result.State.LastRetryDedupeBySha[headSha] = retryAction.DedupeKey!;
+        }
+        result.State.LastRetryAtBySha[headSha] = DateTimeOffset.UtcNow;
+        result.State.UpdatedAtUtc = DateTimeOffset.UtcNow;
+        SaveState(result.StateFilePath, result.State);
+
+        Console.Error.WriteLine(
+            $"Applied retry_failed_checks for PR #{result.Snapshot.Pr.Number.ToString(CultureInfo.InvariantCulture)} on SHA {headSha} (runs={runIds.Count.ToString(CultureInfo.InvariantCulture)}).");
+
+        if (failedReruns.Count > 0) {
+            throw new InvalidOperationException(
+                $"Retry rerun partially failed for PR #{result.Snapshot.Pr.Number.ToString(CultureInfo.InvariantCulture)}: {string.Join("; ", failedReruns)}");
+        }
+
+        return true;
     }
 
     private static async Task<string> GetAuthenticatedLoginAsync() {
@@ -811,6 +981,16 @@ internal static class PrWatchRunner {
                         options.ShowHelp = true;
                     }
                     break;
+                case "--retry-cooldown-minutes":
+                    if (i + 1 < args.Length &&
+                        int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var retryCooldownMinutes) &&
+                        retryCooldownMinutes >= 0) {
+                        options.RetryCooldownMinutes = Math.Min(MaxRetryCooldownMinutes, retryCooldownMinutes);
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
                 case "--state-file":
                     if (i + 1 < args.Length) {
                         options.StateFilePath = args[++i];
@@ -841,6 +1021,17 @@ internal static class PrWatchRunner {
                         options.ShowHelp = true;
                     }
                     break;
+                case "--apply-retry":
+                    options.ApplyRetry = true;
+                    break;
+                case "--confirm-apply-retry":
+                    if (i + 1 < args.Length) {
+                        options.ConfirmApplyRetry = args[++i] ?? string.Empty;
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
                 default:
                     Console.Error.WriteLine($"Unknown option: {arg}");
                     options.ParseFailed = true;
@@ -864,6 +1055,11 @@ internal static class PrWatchRunner {
             options.ShowHelp = true;
         }
 
+        if (options.ApplyRetry && options.Watch) {
+            options.ParseFailed = true;
+            options.ShowHelp = true;
+        }
+
         return options;
     }
 
@@ -878,8 +1074,11 @@ internal static class PrWatchRunner {
         Console.WriteLine("  --watch                     Emit continuous snapshots until terminal state");
         Console.WriteLine("  --poll-seconds <n>          Base poll interval in watch mode (default: 60)");
         Console.WriteLine("  --max-flaky-retries <n>     Retry budget for recommendation classification (default: 3)");
+        Console.WriteLine("  --retry-cooldown-minutes <n> Suppress repeated retry recommendations during cooldown (default: 15)");
         Console.WriteLine("  --state-file <path>         Optional watcher state file path");
         Console.WriteLine("  --approved-bot <login>      Additional approved bot login (repeatable)");
+        Console.WriteLine("  --apply-retry               Execute retry_failed_checks action if eligible (once mode only)");
+        Console.WriteLine("  --confirm-apply-retry <v>   Required safety confirmation token (`RETRY_CHECKS`)");
     }
 
     private static void PrintJson(object value) {

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -223,6 +223,9 @@ internal static partial class Program {
         failed += Run("Todo pr-watch prioritizes review before retry", TestPrWatchRecommendActionsPrioritizesReviewBeforeRetry);
         failed += Run("Todo pr-watch source precedence", TestPrWatchDetermineReviewSourceTypeUsesPrecedence);
         failed += Run("Todo pr-watch retry dedupe key stability", TestPrWatchRetryDedupeKeyIsStableAcrossRunOrdering);
+        failed += Run("Todo pr-watch retry suppression by matching dedupe key", TestPrWatchRetrySuppressionByMatchingDedupeKey);
+        failed += Run("Todo pr-watch retry suppression by cooldown", TestPrWatchRetrySuppressionByCooldown);
+        failed += Run("Todo pr-watch retry suppression window expiry allows retry", TestPrWatchRetrySuppressionAllowsRetryWhenWindowExpired);
         failed += Run("Todo unknown command", TestTodoUnknownCommandShowsMessage);
         failed += Run("Todo bot feedback render LF", TestBotFeedbackRenderHonorsLfNewlines);
         failed += Run("Todo bot feedback parse existing", TestBotFeedbackParseExistingPrBlockExtractsTasks);

--- a/IntelligenceX.Tests/Program.Todo.PrWatch.cs
+++ b/IntelligenceX.Tests/Program.Todo.PrWatch.cs
@@ -125,5 +125,38 @@ internal static partial class Program {
         AssertEqual(keyA, keyB, "dedupe key should be stable regardless of input order");
         AssertContainsText(keyA, "retry_failed_checks:", "dedupe key prefix");
     }
+
+    private static void TestPrWatchRetrySuppressionByMatchingDedupeKey() {
+        var now = new DateTimeOffset(2026, 2, 24, 8, 0, 0, TimeSpan.Zero);
+        var suppress = IntelligenceX.Cli.Todo.PrWatchRunner.ShouldSuppressRetryAction(
+            lastRetryDedupeKey: "retry_failed_checks:abc123",
+            lastRetryAtUtc: now.AddMinutes(-20),
+            currentRetryDedupeKey: "retry_failed_checks:abc123",
+            retryCooldownMinutes: 15,
+            nowUtc: now);
+        AssertEqual(true, suppress, "matching dedupe key should suppress retry");
+    }
+
+    private static void TestPrWatchRetrySuppressionByCooldown() {
+        var now = new DateTimeOffset(2026, 2, 24, 8, 0, 0, TimeSpan.Zero);
+        var suppress = IntelligenceX.Cli.Todo.PrWatchRunner.ShouldSuppressRetryAction(
+            lastRetryDedupeKey: "retry_failed_checks:old",
+            lastRetryAtUtc: now.AddMinutes(-5),
+            currentRetryDedupeKey: "retry_failed_checks:new",
+            retryCooldownMinutes: 15,
+            nowUtc: now);
+        AssertEqual(true, suppress, "active cooldown should suppress retry");
+    }
+
+    private static void TestPrWatchRetrySuppressionAllowsRetryWhenWindowExpired() {
+        var now = new DateTimeOffset(2026, 2, 24, 8, 0, 0, TimeSpan.Zero);
+        var suppress = IntelligenceX.Cli.Todo.PrWatchRunner.ShouldSuppressRetryAction(
+            lastRetryDedupeKey: "retry_failed_checks:old",
+            lastRetryAtUtc: now.AddMinutes(-30),
+            currentRetryDedupeKey: "retry_failed_checks:new",
+            retryCooldownMinutes: 15,
+            nowUtc: now);
+        AssertEqual(false, suppress, "retry should be allowed when dedupe changed and cooldown expired");
+    }
 #endif
 }

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -113,8 +113,11 @@ Options:
 - `--watch` (continuous snapshots with adaptive backoff until terminal stop reason)
 - `--poll-seconds <n>` (watch mode base interval; default `60`)
 - `--max-flaky-retries <n>` (classification budget ceiling; default `3`)
+- `--retry-cooldown-minutes <n>` (suppress repeat retry recommendation during cooldown; default `15`)
 - `--state-file <path>` (override watcher-state file path)
 - `--approved-bot <login>` (repeatable approved bot allow-list extension)
+- `--apply-retry` (once mode only; executes `retry_failed_checks` if eligible)
+- `--confirm-apply-retry RETRY_CHECKS` (required with `--apply-retry`)
 
 Default approved bots include `intelligencex-review`, `intelligencex-review[bot]`, and `chatgpt-codex-connector[bot]`.
 
@@ -132,6 +135,10 @@ Workflow automation:
   - `max_flaky_retries`,
   - `include_drafts`,
   - `approved_bots`.
+- `.github/workflows/ix-pr-babysit-assist-retry.yml` provides manual guarded retry assist for one PR:
+  - requires `confirm_apply_retries=RETRY_CHECKS`,
+  - executes `pr-watch --apply-retry` in once mode,
+  - persists retry state and cooldown metadata in `artifacts/pr-watch/ix-pr-watch-*.json`.
 - Workflow artifacts:
   - per-PR snapshots under `artifacts/pr-watch/snapshots/`,
   - rollup JSON `artifacts/pr-watch/ix-pr-watch-rollup.json`,


### PR DESCRIPTION
## Summary
This PR adds the first guarded **assist** path for PR babysitting: a manual workflow that can rerun failed checks for one PR when `todo pr-watch` plans an eligible `retry_failed_checks` action.

## What this adds
- `todo pr-watch` assist flags and safety gates:
  - `--apply-retry`
  - `--confirm-apply-retry RETRY_CHECKS` (required)
  - `--retry-cooldown-minutes <n>` (default 15)
- Retry suppression state to prevent churn:
  - dedupe-by-action-key per SHA
  - cooldown timestamp per SHA
- Assist execution path:
  - reruns failed runs with `gh run rerun <id> --failed`
  - persists retry usage + suppression metadata in pr-watch state
- New manual workflow:
  - `.github/workflows/ix-pr-babysit-assist-retry.yml`
  - `workflow_dispatch` only
  - single-PR target + explicit confirmation token
  - uploads artifacts and preserves state cache
- Test coverage for retry suppression behavior (dedupe match, cooldown, cooldown expiry).
- Docs updates in internal command docs and public reviewer monitoring docs.

## Why this shape
- Keeps current reviewer behavior (review per PR) unchanged.
- Adds a separate, guarded operator-assist loop for flaky CI recovery.
- No autonomous merge, no policy mutation, no automatic background retries.

## Ops model
- Observe loop remains scheduled (`hourly`) for detection and recommendations.
- Assist loop is operator-triggered (`workflow_dispatch`) for now.
- After rollout telemetry, we can decide whether to introduce optional scheduled assist windows.

## Validation
- `dotnet build IntelligenceX.sln -c Release /m:1`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- todo pr-watch --help`
- `dotnet test IntelligenceX.sln -c Release /m:1` shows an existing unrelated failure in `IntelligenceX.Tools.Tests.ToolResponseContractGuardrailTests.ResponseContracts_ShouldNotIntroduceUnsafeDictionaryKeyValueProperties` (`IntelligenceX.Tools.Common.ToolNextActionModel.Arguments`).

## Follow-ups
- Add assist rollback/failure protocol details to RFC + runbook.
- Define success metrics and decision owners/dates for open rollout decisions.
