### PR TITLE
feat(todo): add pr-watch audit records and workflow context

### DIFF
--- a/.github/workflows/ix-pr-babysit-assist-retry.yml
+++ b/.github/workflows/ix-pr-babysit-assist-retry.yml
@@ -60,7 +60,7 @@ jobs:
             ${{ env.PR_WATCH_STATE_CACHE_PREFIX }}-
 
       - name: Build CLI once
-        run: dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj -c Release /m:1
+        run: dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -c Release /m:1
 
       - name: Apply guarded retry assist for target PR
         env:
@@ -103,6 +103,9 @@ jobs:
             "--retry-cooldown-minutes" "${RETRY_COOLDOWN_MINUTES}"
             "--apply-retry"
             "--confirm-apply-retry" "${CONFIRM}"
+            "--phase" "assist"
+            "--source" "${{ github.event_name }}"
+            "--run-link" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           )
 
           IFS=',' read -r -a bot_parts <<< "${APPROVED_BOTS}"

--- a/.github/workflows/ix-pr-babysit-monitor.yml
+++ b/.github/workflows/ix-pr-babysit-monitor.yml
@@ -66,7 +66,7 @@ jobs:
             ${{ env.PR_WATCH_STATE_CACHE_PREFIX }}-
 
       - name: Build CLI once
-        run: dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj -c Release /m:1
+        run: dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -c Release /m:1
 
       - name: Run observe-mode PR watch sweep
         env:
@@ -142,6 +142,9 @@ jobs:
                 "--repo" "${{ github.repository }}"
                 "--pr" "${pr_spec}"
                 "--max-flaky-retries" "${MAX_FLAKY_RETRIES}"
+                "--phase" "observe"
+                "--source" "${{ github.event_name }}"
+                "--run-link" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
               )
 
               IFS=',' read -r -a bot_parts <<< "${APPROVED_BOTS}"

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -65,7 +65,7 @@ intelligencex todo project-view-checklist --config artifacts/triage/ix-project-c
 | `sync-bot-feedback` | Extract explicit bot checklist tasks and keep them tracked in `TODO.md` | Updated `TODO.md` (optional GitHub issues) |
 | `build-triage-index` | Build PR/issue inventory, duplicate clusters, and best PR ranking | `artifacts/triage/ix-triage-index.json`, `.md` |
 | `issue-review` | Detect stale/no-longer-applicable infra blocker issues and optionally auto-close | `artifacts/triage/ix-issue-review.json`, `.md` |
-| `pr-watch` | Observe PR CI/review/mergeability state and emit deterministic action recommendations | JSON snapshot + watcher state in `artifacts/pr-watch/` |
+| `pr-watch` | Observe PR CI/review/mergeability state and emit deterministic action recommendations | JSON snapshot + watcher state + audit JSONL in `artifacts/pr-watch/` |
 | `vision-check` | Compare backlog against `VISION.md` scope | `artifacts/triage/ix-vision-check.json`, `.md` |
 | `project-init` | Create/initialize GitHub Project fields + metadata | `artifacts/triage/ix-project-config.json` |
 | `project-sync` | Push triage/issue-review/vision signals to project items and optional labels/comments | Project field updates, optional comment/label updates |
@@ -88,7 +88,7 @@ Observe-mode babysitter automation:
 - Workflow: `.github/workflows/ix-pr-babysit-monitor.yml`
 - Schedule: hourly observe-mode sweep
 - Manual targeted run: `workflow_dispatch` with optional `pr` and policy inputs (`max_prs`, `max_flaky_retries`, `include_drafts`, `approved_bots`)
-- Outputs: per-PR snapshots + rollup summary in `artifacts/pr-watch/`
+- Outputs: per-PR snapshots + rollup summary + audit log (`ix-pr-watch-audit.jsonl`) in `artifacts/pr-watch/`
 
 Guarded retry assist automation:
 
@@ -96,6 +96,7 @@ Guarded retry assist automation:
 - Trigger: manual `workflow_dispatch` only (single PR target)
 - Safety: requires explicit confirmation token `RETRY_CHECKS`
 - Scope: retries failed checks only when `pr-watch` plans an eligible `retry_failed_checks` action (dedupe + cooldown aware)
+- Audit: emits execution outcomes (`success`/`skipped`/`failed`) into `artifacts/pr-watch/ix-pr-watch-audit.jsonl`
 
 ### Issue-review confidence signals
 

--- a/IntelligenceX.Cli/Todo/PrWatchRunner.cs
+++ b/IntelligenceX.Cli/Todo/PrWatchRunner.cs
@@ -15,6 +15,7 @@ internal static class PrWatchRunner {
     private const string DefaultRepo = "EvotecIT/IntelligenceX";
     private const string SnapshotSchema = "intelligencex.pr-watch.snapshot.v1";
     private const string StateSchema = "intelligencex.pr-watch.state.v1";
+    private const string AuditSchema = "intelligencex.pr-watch.audit.v1";
     private const string ReviewSourceTrustedHuman = "trusted_human";
     private const string ReviewSourceApprovedBot = "approved_bot";
     private const string ReviewSourceOther = "other";
@@ -29,6 +30,9 @@ internal static class PrWatchRunner {
     private const string StopReasonReadyToMerge = "ready_to_merge";
     private const string StopReasonRetryBudgetExhausted = "retry_budget_exhausted";
     private const string ConfirmApplyRetryToken = "RETRY_CHECKS";
+    private const string DefaultAuditLogPath = "artifacts/pr-watch/ix-pr-watch-audit.jsonl";
+    private const string DefaultPhase = "observe";
+    private const string DefaultSource = "manual_cli";
     private const int DefaultPollSeconds = 60;
     private const int DefaultRetryCooldownMinutes = 15;
     private const int MaxRetryCooldownMinutes = 24 * 60;
@@ -62,6 +66,11 @@ internal static class PrWatchRunner {
         "DIRTY",
         "DRAFT",
         "UNKNOWN"
+    };
+    private static readonly HashSet<string> AllowedPhases = new(StringComparer.OrdinalIgnoreCase) {
+        "observe",
+        "assist",
+        "repair"
     };
     private static readonly JsonSerializerOptions JsonOptions = new() {
         WriteIndented = false
@@ -119,6 +128,21 @@ internal static class PrWatchRunner {
         int MaxFlakyRetries
     );
 
+    internal sealed record AuditRecord(
+        string Schema,
+        DateTimeOffset TimestampUtc,
+        int PrNumber,
+        string Repo,
+        string HeadSha,
+        string Phase,
+        string Action,
+        string? DedupeKey,
+        string Source,
+        string Reason,
+        string Result,
+        string? RunLink
+    );
+
     internal sealed record WatchSnapshot(
         string Schema,
         DateTimeOffset CapturedAtUtc,
@@ -128,7 +152,8 @@ internal static class PrWatchRunner {
         IReadOnlyList<ReviewItem> NewReviewItems,
         IReadOnlyList<RecommendedAction> Actions,
         string? StopReason,
-        RetryState RetryState
+        RetryState RetryState,
+        IReadOnlyList<AuditRecord> Audit
     );
 
     private sealed class RunnerState {
@@ -153,6 +178,10 @@ internal static class PrWatchRunner {
         public int RetryCooldownMinutes { get; set; } = DefaultRetryCooldownMinutes;
         public bool ApplyRetry { get; set; }
         public string ConfirmApplyRetry { get; set; } = string.Empty;
+        public string Phase { get; set; } = DefaultPhase;
+        public string Source { get; set; } = DefaultSource;
+        public string? RunLink { get; set; }
+        public string AuditLogPath { get; set; } = DefaultAuditLogPath;
         public string? StateFilePath { get; set; }
         public bool Once { get; set; } = true;
         public bool Watch { get; set; }
@@ -166,6 +195,14 @@ internal static class PrWatchRunner {
     }
 
     private sealed record WatchCollectionResult(WatchSnapshot Snapshot, string StateFilePath, RunnerState State);
+
+    private sealed record RetryApplyOutcome(
+        bool Applied,
+        string Result,
+        string Reason,
+        string? DedupeKey,
+        string? ErrorMessage = null
+    );
 
     public static async Task<int> RunAsync(string[] args) {
         var options = ParseOptions(args);
@@ -205,9 +242,60 @@ internal static class PrWatchRunner {
 
         try {
             var result = await CollectSnapshotAsync(options, authenticatedLogin).ConfigureAwait(false);
+            var plannedAudit = BuildPlannedAuditRecords(
+                result.Snapshot,
+                options.Phase,
+                options.Source,
+                options.RunLink);
+            AppendAuditRecords(options.AuditLogPath, plannedAudit);
+            result = result with {
+                Snapshot = result.Snapshot with { Audit = plannedAudit }
+            };
+
             if (options.ApplyRetry) {
-                var applied = await TryApplyRetryActionAsync(result).ConfigureAwait(false);
-                if (applied) {
+                RetryApplyOutcome retryOutcome;
+                try {
+                    retryOutcome = await TryApplyRetryActionAsync(result).ConfigureAwait(false);
+                } catch (Exception ex) {
+                    var fallbackRetryAction = result.Snapshot.Actions
+                        .FirstOrDefault(action => action.Name.Equals(ActionRetryFailedChecks, StringComparison.OrdinalIgnoreCase));
+                    var failureAudit = BuildExecutionAuditRecord(
+                        result.Snapshot,
+                        options.Phase,
+                        options.Source,
+                        options.RunLink,
+                        ActionRetryFailedChecks,
+                        fallbackRetryAction?.DedupeKey,
+                        "failed",
+                        "retry_execution_exception");
+                    AppendAuditRecords(options.AuditLogPath, new[] { failureAudit });
+                    result = result with {
+                        Snapshot = result.Snapshot with { Audit = result.Snapshot.Audit.Concat(new[] { failureAudit }).ToList() }
+                    };
+                    Console.Error.WriteLine(ex.Message);
+                    return 1;
+                }
+
+                var retryAudit = BuildExecutionAuditRecord(
+                    result.Snapshot,
+                    options.Phase,
+                    options.Source,
+                    options.RunLink,
+                    ActionRetryFailedChecks,
+                    retryOutcome.DedupeKey,
+                    retryOutcome.Result,
+                    retryOutcome.Reason);
+                AppendAuditRecords(options.AuditLogPath, new[] { retryAudit });
+                result = result with {
+                    Snapshot = result.Snapshot with { Audit = result.Snapshot.Audit.Concat(new[] { retryAudit }).ToList() }
+                };
+
+                if (retryOutcome.Result.Equals("failed", StringComparison.OrdinalIgnoreCase)) {
+                    Console.Error.WriteLine(retryOutcome.ErrorMessage ?? "Retry rerun failed.");
+                    return 1;
+                }
+
+                if (retryOutcome.Applied) {
                     var refreshedRetryState = new RetryState(
                         CurrentShaRetriesUsed: GetRetriesUsed(result.State, result.Snapshot.Pr.HeadSha),
                         MaxFlakyRetries: options.MaxFlakyRetries
@@ -237,7 +325,8 @@ internal static class PrWatchRunner {
                             CapturedAtUtc = DateTimeOffset.UtcNow,
                             RetryState = refreshedRetryState,
                             Actions = refreshedActions,
-                            StopReason = refreshedStopReason
+                            StopReason = refreshedStopReason,
+                            Audit = result.Snapshot.Audit
                         }
                     };
                 }
@@ -352,6 +441,109 @@ internal static class PrWatchRunner {
         return false;
     }
 
+    internal static string NormalizePhase(string? phase) {
+        var value = (phase ?? string.Empty).Trim().ToLowerInvariant();
+        if (AllowedPhases.Contains(value)) {
+            return value;
+        }
+
+        return DefaultPhase;
+    }
+
+    internal static string NormalizeSource(string? source) {
+        var value = (source ?? string.Empty).Trim().ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(value)) {
+            return DefaultSource;
+        }
+
+        var sb = new StringBuilder(value.Length);
+        foreach (var ch in value) {
+            if ((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_' || ch == '.') {
+                sb.Append(ch);
+            } else {
+                sb.Append('-');
+            }
+        }
+
+        var normalized = sb.ToString().Trim('-');
+        return string.IsNullOrWhiteSpace(normalized) ? DefaultSource : normalized;
+    }
+
+    internal static IReadOnlyList<AuditRecord> BuildPlannedAuditRecords(WatchSnapshot snapshot, string phase, string source, string? runLink) {
+        var normalizedPhase = NormalizePhase(phase);
+        var normalizedSource = NormalizeSource(source);
+        var records = new List<AuditRecord>();
+        foreach (var action in snapshot.Actions) {
+            records.Add(BuildAuditRecord(
+                snapshot,
+                normalizedPhase,
+                normalizedSource,
+                runLink,
+                action.Name,
+                action.DedupeKey,
+                "planned",
+                ResolvePlannedActionReason(snapshot, action)));
+        }
+
+        return records;
+    }
+
+    internal static AuditRecord BuildExecutionAuditRecord(WatchSnapshot snapshot, string phase, string source, string? runLink,
+        string action, string? dedupeKey, string result, string reason) {
+        return BuildAuditRecord(
+            snapshot,
+            NormalizePhase(phase),
+            NormalizeSource(source),
+            runLink,
+            action,
+            dedupeKey,
+            result,
+            reason);
+    }
+
+    private static AuditRecord BuildAuditRecord(WatchSnapshot snapshot, string phase, string source, string? runLink,
+        string action, string? dedupeKey, string result, string reason) {
+        return new AuditRecord(
+            Schema: AuditSchema,
+            TimestampUtc: DateTimeOffset.UtcNow,
+            PrNumber: snapshot.Pr.Number,
+            Repo: snapshot.Pr.Repo,
+            HeadSha: snapshot.Pr.HeadSha,
+            Phase: phase,
+            Action: action,
+            DedupeKey: string.IsNullOrWhiteSpace(dedupeKey) ? null : dedupeKey,
+            Source: source,
+            Reason: reason,
+            Result: result,
+            RunLink: string.IsNullOrWhiteSpace(runLink) ? null : runLink);
+    }
+
+    private static string ResolvePlannedActionReason(WatchSnapshot snapshot, RecommendedAction action) {
+        if (action.Name.Equals(ActionRetryFailedChecks, StringComparison.OrdinalIgnoreCase)) {
+            return "retry_budget_available";
+        }
+
+        if (action.Name.Equals(ActionDiagnoseCiFailure, StringComparison.OrdinalIgnoreCase)) {
+            return "checks_failed";
+        }
+
+        if (action.Name.Equals(ActionProcessReviewComment, StringComparison.OrdinalIgnoreCase)) {
+            return "new_actionable_review_feedback";
+        }
+
+        if (action.Name.Equals(ActionIdleWait, StringComparison.OrdinalIgnoreCase)) {
+            return "no_actionable_changes";
+        }
+
+        if (action.Name.StartsWith("stop_", StringComparison.OrdinalIgnoreCase)) {
+            return string.IsNullOrWhiteSpace(snapshot.StopReason)
+                ? "terminal_state"
+                : $"stop:{snapshot.StopReason}";
+        }
+
+        return "planned_action";
+    }
+
     private static async Task<int> RunWatchAsync(Options options, string authenticatedLogin) {
         var pollSeconds = options.PollSeconds;
         string? lastChangeKey = null;
@@ -364,6 +556,16 @@ internal static class PrWatchRunner {
                 Console.Error.WriteLine(ex.Message);
                 return 1;
             }
+
+            var plannedAudit = BuildPlannedAuditRecords(
+                result.Snapshot,
+                options.Phase,
+                options.Source,
+                options.RunLink);
+            AppendAuditRecords(options.AuditLogPath, plannedAudit);
+            result = result with {
+                Snapshot = result.Snapshot with { Audit = plannedAudit }
+            };
 
             PrintJson(new {
                 @event = "snapshot",
@@ -456,7 +658,8 @@ internal static class PrWatchRunner {
             NewReviewItems: newReviewItems,
             Actions: actions,
             StopReason: stopReason,
-            RetryState: retryState
+            RetryState: retryState,
+            Audit: Array.Empty<AuditRecord>()
         );
         return new WatchCollectionResult(snapshot, statePath, state);
     }
@@ -508,6 +711,23 @@ internal static class PrWatchRunner {
         File.Delete(tempPath);
     }
 
+    private static void AppendAuditRecords(string path, IReadOnlyList<AuditRecord> records) {
+        if (string.IsNullOrWhiteSpace(path) || records.Count == 0) {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+        using var writer = new StreamWriter(stream, new UTF8Encoding(false));
+        foreach (var record in records) {
+            writer.WriteLine(JsonSerializer.Serialize(record, JsonOptions));
+        }
+    }
+
     private static int GetRetriesUsed(RunnerState state, string headSha) {
         if (string.IsNullOrWhiteSpace(headSha)) {
             return 0;
@@ -540,12 +760,16 @@ internal static class PrWatchRunner {
             : null;
     }
 
-    private static async Task<bool> TryApplyRetryActionAsync(WatchCollectionResult result) {
+    private static async Task<RetryApplyOutcome> TryApplyRetryActionAsync(WatchCollectionResult result) {
         var retryAction = result.Snapshot.Actions
             .FirstOrDefault(action => action.Name.Equals(ActionRetryFailedChecks, StringComparison.OrdinalIgnoreCase));
         if (retryAction is null) {
             Console.Error.WriteLine("Assist retry requested, but no eligible retry action was planned.");
-            return false;
+            return new RetryApplyOutcome(
+                Applied: false,
+                Result: "skipped",
+                Reason: "no_eligible_retry_action",
+                DedupeKey: null);
         }
 
         var runIds = result.Snapshot.FailedRuns
@@ -556,7 +780,11 @@ internal static class PrWatchRunner {
             .ToList();
         if (runIds.Count == 0) {
             Console.Error.WriteLine("Assist retry requested, but no failed run IDs are available.");
-            return false;
+            return new RetryApplyOutcome(
+                Applied: false,
+                Result: "skipped",
+                Reason: "no_failed_run_ids",
+                DedupeKey: retryAction.DedupeKey);
         }
 
         var failedReruns = new List<string>();
@@ -582,7 +810,12 @@ internal static class PrWatchRunner {
         }
 
         if (!rerunSucceeded) {
-            throw new InvalidOperationException("Retry rerun failed for all targeted workflow runs.");
+            return new RetryApplyOutcome(
+                Applied: false,
+                Result: "failed",
+                Reason: "rerun_all_failed",
+                DedupeKey: retryAction.DedupeKey,
+                ErrorMessage: "Retry rerun failed for all targeted workflow runs.");
         }
 
         var headSha = result.Snapshot.Pr.HeadSha;
@@ -599,11 +832,20 @@ internal static class PrWatchRunner {
             $"Applied retry_failed_checks for PR #{result.Snapshot.Pr.Number.ToString(CultureInfo.InvariantCulture)} on SHA {headSha} (runs={runIds.Count.ToString(CultureInfo.InvariantCulture)}).");
 
         if (failedReruns.Count > 0) {
-            throw new InvalidOperationException(
+            return new RetryApplyOutcome(
+                Applied: false,
+                Result: "failed",
+                Reason: "rerun_partial_failure",
+                DedupeKey: retryAction.DedupeKey,
+                ErrorMessage:
                 $"Retry rerun partially failed for PR #{result.Snapshot.Pr.Number.ToString(CultureInfo.InvariantCulture)}: {string.Join("; ", failedReruns)}");
         }
 
-        return true;
+        return new RetryApplyOutcome(
+            Applied: true,
+            Result: "success",
+            Reason: "rerun_applied",
+            DedupeKey: retryAction.DedupeKey);
     }
 
     private static async Task<string> GetAuthenticatedLoginAsync() {
@@ -1032,6 +1274,44 @@ internal static class PrWatchRunner {
                         options.ShowHelp = true;
                     }
                     break;
+                case "--phase":
+                    if (i + 1 < args.Length) {
+                        var phase = args[++i] ?? string.Empty;
+                        if (AllowedPhases.Contains(phase.Trim())) {
+                            options.Phase = NormalizePhase(phase);
+                        } else {
+                            options.ParseFailed = true;
+                            options.ShowHelp = true;
+                        }
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--source":
+                    if (i + 1 < args.Length) {
+                        options.Source = NormalizeSource(args[++i]);
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--run-link":
+                    if (i + 1 < args.Length) {
+                        options.RunLink = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
+                case "--audit-log-path":
+                    if (i + 1 < args.Length) {
+                        options.AuditLogPath = args[++i];
+                    } else {
+                        options.ParseFailed = true;
+                        options.ShowHelp = true;
+                    }
+                    break;
                 default:
                     Console.Error.WriteLine($"Unknown option: {arg}");
                     options.ParseFailed = true;
@@ -1060,6 +1340,12 @@ internal static class PrWatchRunner {
             options.ShowHelp = true;
         }
 
+        options.Phase = NormalizePhase(options.Phase);
+        options.Source = NormalizeSource(options.Source);
+        if (string.IsNullOrWhiteSpace(options.AuditLogPath)) {
+            options.AuditLogPath = DefaultAuditLogPath;
+        }
+
         return options;
     }
 
@@ -1079,6 +1365,10 @@ internal static class PrWatchRunner {
         Console.WriteLine("  --approved-bot <login>      Additional approved bot login (repeatable)");
         Console.WriteLine("  --apply-retry               Execute retry_failed_checks action if eligible (once mode only)");
         Console.WriteLine("  --confirm-apply-retry <v>   Required safety confirmation token (`RETRY_CHECKS`)");
+        Console.WriteLine("  --phase <observe|assist|repair> Audit phase marker (default: observe)");
+        Console.WriteLine("  --source <value>            Audit source marker (default: manual_cli)");
+        Console.WriteLine("  --run-link <url>            Optional workflow/job URL embedded in audit records");
+        Console.WriteLine("  --audit-log-path <path>     Audit JSONL output (default: artifacts/pr-watch/ix-pr-watch-audit.jsonl)");
     }
 
     private static void PrintJson(object value) {

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -226,6 +226,9 @@ internal static partial class Program {
         failed += Run("Todo pr-watch retry suppression by matching dedupe key", TestPrWatchRetrySuppressionByMatchingDedupeKey);
         failed += Run("Todo pr-watch retry suppression by cooldown", TestPrWatchRetrySuppressionByCooldown);
         failed += Run("Todo pr-watch retry suppression window expiry allows retry", TestPrWatchRetrySuppressionAllowsRetryWhenWindowExpired);
+        failed += Run("Todo pr-watch normalize phase fallback", TestPrWatchNormalizePhaseFallback);
+        failed += Run("Todo pr-watch normalize source sanitizes unsafe chars", TestPrWatchNormalizeSourceSanitizesUnsafeChars);
+        failed += Run("Todo pr-watch planned audit includes dedupe and reason", TestPrWatchBuildPlannedAuditRecordsIncludesDedupeAndReason);
         failed += Run("Todo unknown command", TestTodoUnknownCommandShowsMessage);
         failed += Run("Todo bot feedback render LF", TestBotFeedbackRenderHonorsLfNewlines);
         failed += Run("Todo bot feedback parse existing", TestBotFeedbackParseExistingPrBlockExtractsTasks);

--- a/IntelligenceX.Tests/Program.Todo.PrWatch.cs
+++ b/IntelligenceX.Tests/Program.Todo.PrWatch.cs
@@ -158,5 +158,64 @@ internal static partial class Program {
             nowUtc: now);
         AssertEqual(false, suppress, "retry should be allowed when dedupe changed and cooldown expired");
     }
+
+    private static void TestPrWatchNormalizePhaseFallback() {
+        var normalized = IntelligenceX.Cli.Todo.PrWatchRunner.NormalizePhase("unknown-phase");
+        AssertEqual("observe", normalized, "unknown phase should fall back to observe");
+    }
+
+    private static void TestPrWatchNormalizeSourceSanitizesUnsafeChars() {
+        var normalized = IntelligenceX.Cli.Todo.PrWatchRunner.NormalizeSource("Workflow Dispatch / Scheduler");
+        AssertEqual("workflow-dispatch---scheduler", normalized, "source should be normalized for audit metadata");
+    }
+
+    private static void TestPrWatchBuildPlannedAuditRecordsIncludesDedupeAndReason() {
+        var snapshot = new IntelligenceX.Cli.Todo.PrWatchRunner.WatchSnapshot(
+            Schema: "intelligencex.pr-watch.snapshot.v1",
+            CapturedAtUtc: new DateTimeOffset(2026, 2, 24, 8, 0, 0, TimeSpan.Zero),
+            Pr: new IntelligenceX.Cli.Todo.PrWatchRunner.PrState(
+                Number: 746,
+                Url: "https://github.com/EvotecIT/IntelligenceX/pull/746",
+                Repo: "EvotecIT/IntelligenceX",
+                HeadSha: "abc123",
+                HeadBranch: "feature/audit",
+                State: "OPEN",
+                Merged: false,
+                Closed: false,
+                Mergeable: "MERGEABLE",
+                MergeStateStatus: "CLEAN",
+                ReviewDecision: "APPROVED"),
+            Checks: new IntelligenceX.Cli.Todo.PrWatchRunner.CheckSummary(
+                PendingCount: 0,
+                FailedCount: 1,
+                PassedCount: 4,
+                AllTerminal: true),
+            FailedRuns: new[] {
+                new IntelligenceX.Cli.Todo.PrWatchRunner.FailedRun("100", "build", "completed", "failure", "https://example/run/100")
+            },
+            NewReviewItems: Array.Empty<IntelligenceX.Cli.Todo.PrWatchRunner.ReviewItem>(),
+            Actions: new[] {
+                new IntelligenceX.Cli.Todo.PrWatchRunner.RecommendedAction("diagnose_ci_failure"),
+                new IntelligenceX.Cli.Todo.PrWatchRunner.RecommendedAction("retry_failed_checks", "retry_failed_checks:deadbeef1234")
+            },
+            StopReason: null,
+            RetryState: new IntelligenceX.Cli.Todo.PrWatchRunner.RetryState(0, 3),
+            Audit: Array.Empty<IntelligenceX.Cli.Todo.PrWatchRunner.AuditRecord>());
+
+        var records = IntelligenceX.Cli.Todo.PrWatchRunner.BuildPlannedAuditRecords(
+            snapshot,
+            "assist",
+            "workflow_dispatch",
+            "https://github.com/EvotecIT/IntelligenceX/actions/runs/1");
+
+        AssertEqual(2, records.Count, "expected one planned audit record per action");
+        AssertEqual("assist", records[0].Phase, "phase should be preserved");
+        AssertEqual("workflow_dispatch", records[0].Source, "source should be preserved");
+        AssertEqual("diagnose_ci_failure", records[0].Action, "first action name");
+        AssertEqual("checks_failed", records[0].Reason, "diagnose reason");
+        AssertEqual("retry_failed_checks:deadbeef1234", records[1].DedupeKey, "retry dedupe key");
+        AssertEqual("retry_budget_available", records[1].Reason, "retry reason");
+        AssertEqual("planned", records[1].Result, "planned result");
+    }
 #endif
 }

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -118,14 +118,20 @@ Options:
 - `--approved-bot <login>` (repeatable approved bot allow-list extension)
 - `--apply-retry` (once mode only; executes `retry_failed_checks` if eligible)
 - `--confirm-apply-retry RETRY_CHECKS` (required with `--apply-retry`)
+- `--phase <observe|assist|repair>` (audit phase marker; default `observe`)
+- `--source <value>` (audit source marker; default `manual_cli`)
+- `--run-link <url>` (optional workflow/job URL in audit records)
+- `--audit-log-path <path>` (JSONL audit path; default `artifacts/pr-watch/ix-pr-watch-audit.jsonl`)
 
 Default approved bots include `intelligencex-review`, `intelligencex-review[bot]`, and `chatgpt-codex-connector[bot]`.
 
 Default outputs:
 - JSON snapshot on stdout with:
-  - `pr`, `checks`, `failedRuns`, `newReviewItems`, `retryState`, `actions`, `stopReason`
+  - `pr`, `checks`, `failedRuns`, `newReviewItems`, `retryState`, `actions`, `stopReason`, `audit`
 - Stateful tracker file at:
   - `artifacts/pr-watch/ix-pr-watch-<owner>-<repo>-pr<Number>.json`
+- Audit log (JSONL append-only) at:
+  - `artifacts/pr-watch/ix-pr-watch-audit.jsonl`
 
 Workflow automation:
 - `.github/workflows/ix-pr-babysit-monitor.yml` runs in observe mode on an hourly schedule.
@@ -142,7 +148,8 @@ Workflow automation:
 - Workflow artifacts:
   - per-PR snapshots under `artifacts/pr-watch/snapshots/`,
   - rollup JSON `artifacts/pr-watch/ix-pr-watch-rollup.json`,
-  - markdown summary `artifacts/pr-watch/ix-pr-watch-summary.md`.
+  - markdown summary `artifacts/pr-watch/ix-pr-watch-summary.md`,
+  - audit log JSONL `artifacts/pr-watch/ix-pr-watch-audit.jsonl`.
 
 ## Vision Check (Assistive)
 


### PR DESCRIPTION
## Summary
This PR advances PR-babysitter implementation by adding the RFC-aligned minimal audit contract for `todo pr-watch` cycles and wiring workflow context into those audit records.

## What changed
- Added `pr-watch` audit record schema and per-cycle audit emission:
  - Snapshot now includes `audit` records.
  - Append-only JSONL audit log (default): `artifacts/pr-watch/ix-pr-watch-audit.jsonl`.
- Added audit metadata options to `pr-watch`:
  - `--phase <observe|assist|repair>`
  - `--source <value>`
  - `--run-link <url>`
  - `--audit-log-path <path>`
- Added deterministic planned action reasons and execution outcomes:
  - planned reasons like `checks_failed`, `new_actionable_review_feedback`, `retry_budget_available`, `stop:<reason>`
  - assist retry execution records now emit `success` / `skipped` / `failed` outcomes.
- Updated babysitter workflows to pass audit context:
  - monitor runs with `--phase observe --source ${{ github.event_name }} --run-link ...`
  - assist runs with `--phase assist --source ${{ github.event_name }} --run-link ...`
- Reliability fix: CLI build step in both babysitter workflows now targets `--framework net8.0` explicitly.
- Added tests for:
  - phase normalization fallback,
  - source normalization sanitization,
  - planned audit record generation (dedupe + reason).
- Updated docs to include audit outputs/flags and artifact location.

## Validation
- `dotnet build IntelligenceX.sln -c Release /m:1`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- todo pr-watch --help`
- Smoke run:
  - `dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- todo pr-watch --repo EvotecIT/IntelligenceX --pr 746 --once --phase observe --source workflow_dispatch --run-link https://github.com/EvotecIT/IntelligenceX/actions/runs/1 --audit-log-path artifacts/pr-watch/ix-pr-watch-audit-smoke.jsonl`
  - Verified snapshot includes `audit` and JSONL log entries were written.
