### PR TITLE
feat(workflows): define weekly governance cadence for PR babysit

### DIFF
--- a/.github/workflows/ix-pr-babysit-nightly-consolidation.yml
+++ b/.github/workflows/ix-pr-babysit-nightly-consolidation.yml
@@ -3,6 +3,33 @@ name: IX PR Babysit Nightly Consolidation
 on:
   schedule:
     - cron: "17 2 * * *"
+  workflow_call:
+    inputs:
+      max_prs:
+        description: "Max open PRs to scan"
+        required: false
+        default: "200"
+        type: string
+      stale_days:
+        description: "Age threshold (days) used for stale/no-progress buckets"
+        required: false
+        default: "7"
+        type: string
+      include_drafts:
+        description: "Include draft PRs in nightly scan"
+        required: false
+        default: false
+        type: boolean
+      approved_bots:
+        description: "Comma-separated approved bot logins for source classification"
+        required: false
+        default: "intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"
+        type: string
+      source:
+        description: "Source tag written into pr-watch snapshots"
+        required: false
+        default: ""
+        type: string
   workflow_dispatch:
     inputs:
       max_prs:
@@ -22,6 +49,10 @@ on:
         description: "Comma-separated approved bot logins for source classification"
         required: false
         default: "intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"
+      source:
+        description: "Optional source tag override for pr-watch snapshots"
+        required: false
+        default: ""
 
 permissions:
   actions: read
@@ -86,15 +117,17 @@ jobs:
           : > "${TARGETS_FILE}"
           : > "${FAILED_TARGETS_FILE}"
 
-          MAX_PRS="${{ github.event.inputs.max_prs }}"
-          STALE_DAYS="${{ github.event.inputs.stale_days }}"
-          INCLUDE_DRAFTS="${{ github.event.inputs.include_drafts }}"
-          APPROVED_BOTS="${{ github.event.inputs.approved_bots }}"
+          MAX_PRS="${{ inputs.max_prs }}"
+          STALE_DAYS="${{ inputs.stale_days }}"
+          INCLUDE_DRAFTS="${{ inputs.include_drafts }}"
+          APPROVED_BOTS="${{ inputs.approved_bots }}"
+          SOURCE_TAG="${{ inputs.source }}"
 
           if [ -z "${MAX_PRS}" ]; then MAX_PRS="200"; fi
           if [ -z "${STALE_DAYS}" ]; then STALE_DAYS="7"; fi
           if [ -z "${INCLUDE_DRAFTS}" ]; then INCLUDE_DRAFTS="false"; fi
           if [ -z "${APPROVED_BOTS}" ]; then APPROVED_BOTS="intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"; fi
+          if [ -z "${SOURCE_TAG}" ]; then SOURCE_TAG="${{ github.event_name }}"; fi
 
           if [ "${INCLUDE_DRAFTS}" = "true" ]; then
             gh pr list \
@@ -145,7 +178,7 @@ jobs:
                 "--pr" "${pr_spec}"
                 "--max-flaky-retries" "3"
                 "--phase" "observe"
-                "--source" "${{ github.event_name }}"
+                "--source" "${SOURCE_TAG}"
                 "--run-link" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
               )
 

--- a/.github/workflows/ix-pr-babysit-weekly-governance.yml
+++ b/.github/workflows/ix-pr-babysit-weekly-governance.yml
@@ -1,0 +1,23 @@
+name: IX PR Babysit Weekly Governance
+
+on:
+  schedule:
+    - cron: "41 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  weekly-consolidation:
+    uses: ./.github/workflows/ix-pr-babysit-nightly-consolidation.yml
+    with:
+      max_prs: "300"
+      stale_days: "14"
+      include_drafts: false
+      approved_bots: "intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"
+      source: "weekly-governance"
+    secrets: inherit

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -101,7 +101,7 @@ Guarded retry assist automation:
 Nightly consolidation automation:
 
 - Workflow: `.github/workflows/ix-pr-babysit-nightly-consolidation.yml`
-- Schedule: daily consolidation sweep (plus `workflow_dispatch`)
+- Schedule: daily consolidation sweep (plus `workflow_dispatch` and reusable `workflow_call`)
 - Inputs: `max_prs`, `stale_days`, `include_drafts`, `approved_bots`
 - Outputs:
   - rollup JSON: `artifacts/pr-watch/ix-pr-watch-nightly-rollup.json`
@@ -111,6 +111,27 @@ Nightly consolidation automation:
   - review-required/stuck PRs,
   - retry-budget-exhausted PRs,
   - no-progress PRs grouped by age/churn class.
+
+Weekly governance automation:
+
+- Workflow: `.github/workflows/ix-pr-babysit-weekly-governance.yml`
+- Schedule: weekly consolidation sweep (Monday)
+- Implementation: calls the nightly consolidation workflow via `workflow_call` with weekly profile defaults (`max_prs=300`, `stale_days=14`, `source=weekly-governance`)
+- Outputs: same artifact schema as nightly consolidation for comparable trend analysis
+
+### Cadence matrix
+
+| Cadence | Workflow | Phase | Purpose | Expected maintainer action |
+| --- | --- | --- | --- | --- |
+| Hourly | `.github/workflows/ix-pr-babysit-monitor.yml` | `observe` | Fast detection of CI/review/mergeability drift on open PRs | Triage fresh blockers and decide whether to run assist retry on specific PRs |
+| Daily | `.github/workflows/ix-pr-babysit-nightly-consolidation.yml` | `observe` | Portfolio-level no-progress and stale-blocker rollup | Prioritize the next-day unblock queue using bucket summaries |
+| Weekly | `.github/workflows/ix-pr-babysit-weekly-governance.yml` | `observe` | Wider-window governance snapshot (older stalls/churn classes) | Review systemic patterns, update runbooks/SLO targets, and assign owners for repeated blockers |
+
+This cadence keeps mutation guarded and targeted:
+
+- observe runs are scheduled (hourly/daily/weekly),
+- retry assist remains explicit/manual per PR (`ix-pr-babysit-assist-retry.yml`),
+- no autonomous merge or policy mutation is introduced.
 
 ### Issue-review confidence signals
 

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -145,11 +145,15 @@ Workflow automation:
   - requires `confirm_apply_retries=RETRY_CHECKS`,
   - executes `pr-watch --apply-retry` in once mode,
   - persists retry state and cooldown metadata in `artifacts/pr-watch/ix-pr-watch-*.json`.
-- `.github/workflows/ix-pr-babysit-nightly-consolidation.yml` runs daily consolidation (and supports `workflow_dispatch`) with:
+- `.github/workflows/ix-pr-babysit-nightly-consolidation.yml` runs daily consolidation (supports `workflow_dispatch` and reusable `workflow_call`) with:
   - `max_prs`,
   - `stale_days`,
   - `include_drafts`,
   - `approved_bots`.
+- `.github/workflows/ix-pr-babysit-weekly-governance.yml` runs weekly governance consolidation by calling nightly consolidation with weekly defaults:
+  - `max_prs=300`,
+  - `stale_days=14`,
+  - `source=weekly-governance`.
 - Workflow artifacts:
   - per-PR snapshots under `artifacts/pr-watch/snapshots/`,
   - rollup JSON `artifacts/pr-watch/ix-pr-watch-rollup.json`,
@@ -157,6 +161,14 @@ Workflow automation:
   - audit log JSONL `artifacts/pr-watch/ix-pr-watch-audit.jsonl`,
   - nightly rollup JSON `artifacts/pr-watch/ix-pr-watch-nightly-rollup.json`,
   - nightly markdown summary `artifacts/pr-watch/ix-pr-watch-nightly-summary.md`.
+
+Cadence matrix:
+
+| Cadence | Workflow | Defaults | Goal |
+| --- | --- | --- | --- |
+| Hourly | `ix-pr-babysit-monitor.yml` | `max_prs=100`, observe mode | detect fresh CI/review regressions quickly |
+| Daily | `ix-pr-babysit-nightly-consolidation.yml` | `stale_days=7`, `max_prs=200` | build no-progress backlog for next-day triage |
+| Weekly | `ix-pr-babysit-weekly-governance.yml` | `stale_days=14`, `max_prs=300` | governance review of persistent blockers/churn patterns |
 
 ## Vision Check (Assistive)
 


### PR DESCRIPTION
## Summary
This PR adds the **hourly/daily/weekly PR babysit cadence layer** so operating rhythm is explicit and automated.

### Workflow changes
- Extended `.github/workflows/ix-pr-babysit-nightly-consolidation.yml` to support reusable `workflow_call`
- Added optional `source` input for audit/source tagging
- Added `.github/workflows/ix-pr-babysit-weekly-governance.yml` (scheduled weekly, plus manual dispatch)
- Weekly workflow reuses nightly consolidation logic with weekly defaults:
  - `max_prs=300`
  - `stale_days=14`
  - `include_drafts=false`
  - `source=weekly-governance`

### Docs changes
- `Docs/reviewer/projects-pr-monitoring.md`
  - Added weekly governance automation section
  - Added explicit hourly/daily/weekly cadence matrix
  - Clarified guarded mutation boundary (observe scheduled, retry assist manual)
- `InternalDocs/cli-commands/todo.md`
  - Added weekly workflow and cadence matrix documentation

## Why
We already had hourly observe and daily consolidation, but weekly governance cadence was not codified in YAML. This closes that gap and defines how the system should run over time without introducing autonomous mutation.

## Safety / non-goals
- No autonomous merge
- No policy mutation
- No additional auto-fix surface beyond existing guarded assist retry flow

## Validation
- `dotnet build IntelligenceX.sln -c Release /m:1` ✅
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll` ✅
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll` ✅
- `dotnet test IntelligenceX.sln -c Release /m:1` ❌ (existing unrelated guardrail failure observed in `IntelligenceX.Tools.Tests.ToolResponseContractGuardrailTests` for `IntelligenceX.Tools.Common.ToolNextActionModel.Arguments`)
