### PR TITLE
feat(pr-babysit): move babysit workflow logic into CLI engine

### DIFF
--- a/.github/workflows/ix-pr-babysit-assist-retry.yml
+++ b/.github/workflows/ix-pr-babysit-assist-retry.yml
@@ -31,7 +31,8 @@ permissions:
 
 env:
   PR_WATCH_STATE_DIR: artifacts/pr-watch
-  PR_WATCH_ASSIST_DIR: artifacts/pr-watch/assist
+  PR_WATCH_ASSIST_OUTPUT_PATH: artifacts/pr-watch/assist/ix-pr-watch-assist-pr.json
+  PR_WATCH_ASSIST_SUMMARY_PATH: artifacts/pr-watch/ix-pr-watch-assist-summary.md
   PR_WATCH_STATE_CACHE_PREFIX: ix-pr-watch-state-${{ github.repository }}-${{ github.ref_name }}
   PR_WATCH_STATE_CACHE_KEY: ix-pr-watch-state-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_id }}
 
@@ -62,84 +63,25 @@ jobs:
       - name: Build CLI once
         run: dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -c Release /m:1
 
-      - name: Apply guarded retry assist for target PR
+      - name: Run guarded retry assist engine
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
 
-          if ! command -v jq >/dev/null 2>&1; then
-            echo "jq is required for assist summary rendering."
-            exit 1
-          fi
-
-          CONFIRM="${{ github.event.inputs.confirm_apply_retries }}"
-          if [ "${CONFIRM}" != "RETRY_CHECKS" ]; then
-            echo "confirm_apply_retries must equal RETRY_CHECKS"
-            exit 1
-          fi
-
-          PR_INPUT="${{ github.event.inputs.pr }}"
-          MAX_FLAKY_RETRIES="${{ github.event.inputs.max_flaky_retries }}"
-          RETRY_COOLDOWN_MINUTES="${{ github.event.inputs.retry_cooldown_minutes }}"
-          APPROVED_BOTS="${{ github.event.inputs.approved_bots }}"
-
-          if [ -z "${MAX_FLAKY_RETRIES}" ]; then MAX_FLAKY_RETRIES="3"; fi
-          if [ -z "${RETRY_COOLDOWN_MINUTES}" ]; then RETRY_COOLDOWN_MINUTES="15"; fi
-          if [ -z "${APPROVED_BOTS}" ]; then APPROVED_BOTS="intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"; fi
-
-          mkdir -p "${PR_WATCH_STATE_DIR}"
-          mkdir -p "${PR_WATCH_ASSIST_DIR}"
-
-          OUTPUT_PATH="${PR_WATCH_ASSIST_DIR}/ix-pr-watch-assist-pr.json"
-
-          ARGS=(
-            "todo" "pr-watch"
-            "--repo" "${{ github.repository }}"
-            "--pr" "${PR_INPUT}"
-            "--once"
-            "--max-flaky-retries" "${MAX_FLAKY_RETRIES}"
-            "--retry-cooldown-minutes" "${RETRY_COOLDOWN_MINUTES}"
-            "--apply-retry"
-            "--confirm-apply-retry" "${CONFIRM}"
-            "--phase" "assist"
-            "--source" "${{ github.event_name }}"
-            "--run-link" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          )
-
-          IFS=',' read -r -a bot_parts <<< "${APPROVED_BOTS}"
-          for raw in "${bot_parts[@]}"; do
-            bot="$(echo "${raw}" | xargs)"
-            if [ -n "${bot}" ]; then
-              ARGS+=("--approved-bot" "${bot}")
-            fi
-          done
-
-          dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll "${ARGS[@]}" > "${OUTPUT_PATH}"
-
-          {
-            echo "# IX PR Babysit Assist Retry"
-            echo
-            echo "- Generated: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
-            echo "- Repo: \`${{ github.repository }}\`"
-            echo "- Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            echo
-            echo "## Snapshot"
-            jq -r '"- PR: #\(.pr.number) (\(.pr.url))"' "${OUTPUT_PATH}"
-            jq -r '"- Head SHA: `\(.pr.headSha)`"' "${OUTPUT_PATH}"
-            jq -r '"- Stop reason: `\((.stopReason // "none"))`"' "${OUTPUT_PATH}"
-            jq -r '"- Retry usage: \(.retryState.currentShaRetriesUsed)/\(.retryState.maxFlakyRetries)"' "${OUTPUT_PATH}"
-            echo
-            echo "## Planned actions"
-            jq -r '
-              if (.actions | length) == 0 then
-                "- none"
-              else
-                .actions | map("- `\(.name)`\((if .dedupeKey then " (`\(.dedupeKey)`)" else "" end)") | .[]
-              end
-            ' "${OUTPUT_PATH}"
-          } >> "${GITHUB_STEP_SUMMARY}"
+          dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll \
+            todo pr-watch-assist-retry \
+            --repo "${{ github.repository }}" \
+            --pr "${{ inputs.pr }}" \
+            --max-flaky-retries "${{ inputs.max_flaky_retries }}" \
+            --retry-cooldown-minutes "${{ inputs.retry_cooldown_minutes }}" \
+            --approved-bots "${{ inputs.approved_bots }}" \
+            --confirm-apply-retries "${{ inputs.confirm_apply_retries }}" \
+            --source "${{ github.event_name }}" \
+            --run-link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --output-path "${PR_WATCH_ASSIST_OUTPUT_PATH}" \
+            --summary-path "${PR_WATCH_ASSIST_SUMMARY_PATH}"
 
       - name: Upload pr-watch assist artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/ix-pr-babysit-monitor.yml
+++ b/.github/workflows/ix-pr-babysit-monitor.yml
@@ -68,176 +68,26 @@ jobs:
       - name: Build CLI once
         run: dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -c Release /m:1
 
-      - name: Run observe-mode PR watch sweep
+      - name: Run observe-mode PR watch monitor engine
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
 
-          if ! command -v jq >/dev/null 2>&1; then
-            echo "jq is required for ix-pr-babysit-monitor workflow rollup generation."
-            exit 1
-          fi
-
-          mkdir -p "${PR_WATCH_STATE_DIR}"
-          rm -rf "${PR_WATCH_SNAPSHOT_DIR}"
-          mkdir -p "${PR_WATCH_SNAPSHOT_DIR}"
-
-          TARGETS_FILE="${PR_WATCH_STATE_DIR}/ix-pr-watch-targets.txt"
-          : > "${TARGETS_FILE}"
-
-          PR_INPUT="${{ github.event.inputs.pr }}"
-          MAX_PRS="${{ github.event.inputs.max_prs }}"
-          MAX_FLAKY_RETRIES="${{ github.event.inputs.max_flaky_retries }}"
-          INCLUDE_DRAFTS="${{ github.event.inputs.include_drafts }}"
-          APPROVED_BOTS="${{ github.event.inputs.approved_bots }}"
-
-          if [ -z "${MAX_PRS}" ]; then MAX_PRS="100"; fi
-          if [ -z "${MAX_FLAKY_RETRIES}" ]; then MAX_FLAKY_RETRIES="3"; fi
-          if [ -z "${INCLUDE_DRAFTS}" ]; then INCLUDE_DRAFTS="false"; fi
-          if [ -z "${APPROVED_BOTS}" ]; then APPROVED_BOTS="intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"; fi
-
-          if [ -n "${PR_INPUT}" ]; then
-            echo "${PR_INPUT}" >> "${TARGETS_FILE}"
-          else
-            if [ "${INCLUDE_DRAFTS}" = "true" ]; then
-              gh pr list \
-                --repo "${{ github.repository }}" \
-                --state open \
-                --limit "${MAX_PRS}" \
-                --json number \
-                --jq '.[].number' >> "${TARGETS_FILE}"
-            else
-              gh pr list \
-                --repo "${{ github.repository }}" \
-                --state open \
-                --limit "${MAX_PRS}" \
-                --json number,isDraft \
-                --jq '.[] | select(.isDraft == false) | .number' >> "${TARGETS_FILE}"
-            fi
-          fi
-
-          if [ ! -s "${TARGETS_FILE}" ]; then
-            printf '%s\n' '{"schema":"intelligencex.pr-watch.rollup.v1","repo":"","generatedAtUtc":"","totalSnapshots":0,"stopReasons":[],"actionCounts":[],"prs":[]}' > "${PR_WATCH_ROLLUP_PATH}"
-            jq \
-              --arg repo "${{ github.repository }}" \
-              --arg generatedAt "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-              '.repo = $repo | .generatedAtUtc = $generatedAt' \
-              "${PR_WATCH_ROLLUP_PATH}" > "${PR_WATCH_ROLLUP_PATH}.tmp"
-            mv "${PR_WATCH_ROLLUP_PATH}.tmp" "${PR_WATCH_ROLLUP_PATH}"
-          else
-            sort -u "${TARGETS_FILE}" -o "${TARGETS_FILE}"
-            while IFS= read -r pr_spec; do
-              [ -z "${pr_spec}" ] && continue
-
-              safe_spec="$(printf '%s' "${pr_spec}" | tr '/:#?&=' '-' | tr -cd 'A-Za-z0-9._-')"
-              if [ -z "${safe_spec}" ]; then
-                safe_spec="target"
-              fi
-              output_path="${PR_WATCH_SNAPSHOT_DIR}/pr-${safe_spec}.json"
-
-              ARGS=(
-                "todo" "pr-watch"
-                "--repo" "${{ github.repository }}"
-                "--pr" "${pr_spec}"
-                "--max-flaky-retries" "${MAX_FLAKY_RETRIES}"
-                "--phase" "observe"
-                "--source" "${{ github.event_name }}"
-                "--run-link" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              )
-
-              IFS=',' read -r -a bot_parts <<< "${APPROVED_BOTS}"
-              for raw in "${bot_parts[@]}"; do
-                bot="$(echo "${raw}" | xargs)"
-                if [ -n "${bot}" ]; then
-                  ARGS+=("--approved-bot" "${bot}")
-                fi
-              done
-
-              dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll "${ARGS[@]}" > "${output_path}"
-
-              pr_number="$(jq -r '.pr.number // empty' "${output_path}")"
-              if [ -n "${pr_number}" ]; then
-                mv "${output_path}" "${PR_WATCH_SNAPSHOT_DIR}/pr-${pr_number}.json"
-              fi
-            done < "${TARGETS_FILE}"
-
-            jq -s '
-              {
-                schema: "intelligencex.pr-watch.rollup.v1",
-                repo: env.GITHUB_REPOSITORY,
-                generatedAtUtc: (now | gmtime | strftime("%Y-%m-%dT%H:%M:%SZ")),
-                totalSnapshots: length,
-                stopReasons: (
-                  map(.stopReason // "none")
-                  | group_by(.)
-                  | map({ reason: .[0], count: length })
-                ),
-                actionCounts: (
-                  map(.actions[]?.name)
-                  | group_by(.)
-                  | map({ action: .[0], count: length })
-                ),
-                prs: (
-                  map({
-                    number: .pr.number,
-                    url: .pr.url,
-                    headSha: .pr.headSha,
-                    stopReason: (.stopReason // ""),
-                    actions: (.actions | map(.name)),
-                    checks: {
-                      passedCount: .checks.passedCount,
-                      failedCount: .checks.failedCount,
-                      pendingCount: .checks.pendingCount
-                    }
-                  })
-                  | sort_by(.number)
-                )
-              }
-            ' "${PR_WATCH_SNAPSHOT_DIR}"/pr-*.json > "${PR_WATCH_ROLLUP_PATH}"
-          fi
-
-          {
-            echo "# IX PR Babysit Monitor (Observe)"
-            echo
-            echo "- Generated: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
-            echo "- Repo: \`${{ github.repository }}\`"
-            echo "- Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            echo
-            echo "## Snapshot counts"
-            jq -r '"- PRs scanned: \(.totalSnapshots)"' "${PR_WATCH_ROLLUP_PATH}"
-            echo
-            echo "## Stop reasons"
-            jq -r '
-              if (.stopReasons | length) == 0 then
-                "- none"
-              else
-                .stopReasons | map("- `\(.reason)`: \(.count)") | .[]
-              end
-            ' "${PR_WATCH_ROLLUP_PATH}"
-            echo
-            echo "## Actions"
-            jq -r '
-              if (.actionCounts | length) == 0 then
-                "- none"
-              else
-                .actionCounts | map("- `\(.action)`: \(.count)") | .[]
-              end
-            ' "${PR_WATCH_ROLLUP_PATH}"
-            echo
-            echo "## Per PR"
-            jq -r '
-              if (.prs | length) == 0 then
-                "- none"
-              else
-                .prs[]
-                | "- #\(.number) | stop=`\((if (.stopReason | length) == 0 then "none" else .stopReason end))` | actions=`\((.actions | join(",")))` | checks pass/fail/pending=\(.checks.passedCount)/\(.checks.failedCount)/\(.checks.pendingCount)"
-              end
-            ' "${PR_WATCH_ROLLUP_PATH}"
-          } > "${PR_WATCH_SUMMARY_PATH}"
-
-          cat "${PR_WATCH_SUMMARY_PATH}" >> "${GITHUB_STEP_SUMMARY}"
+          dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll \
+            todo pr-watch-monitor \
+            --repo "${{ github.repository }}" \
+            --pr "${{ inputs.pr }}" \
+            --max-prs "${{ inputs.max_prs }}" \
+            --max-flaky-retries "${{ inputs.max_flaky_retries }}" \
+            --include-drafts "${{ inputs.include_drafts }}" \
+            --approved-bots "${{ inputs.approved_bots }}" \
+            --source "${{ github.event_name }}" \
+            --run-link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --snapshot-dir "${PR_WATCH_SNAPSHOT_DIR}" \
+            --rollup-path "${PR_WATCH_ROLLUP_PATH}" \
+            --summary-path "${PR_WATCH_SUMMARY_PATH}"
 
       - name: Upload pr-watch artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/ix-pr-babysit-nightly-consolidation.yml
+++ b/.github/workflows/ix-pr-babysit-nightly-consolidation.yml
@@ -30,6 +30,21 @@ on:
         required: false
         default: ""
         type: string
+      publish_tracking_issue:
+        description: "When true, create/update a source-specific tracker issue with latest rollup"
+        required: false
+        default: true
+        type: boolean
+      tracker_issue_title:
+        description: "Optional explicit tracker issue title (defaults to source-specific title)"
+        required: false
+        default: ""
+        type: string
+      tracker_issue_labels:
+        description: "Comma-separated labels to apply on tracker issue create/update (optional)"
+        required: false
+        default: ""
+        type: string
   workflow_dispatch:
     inputs:
       max_prs:
@@ -53,11 +68,24 @@ on:
         description: "Optional source tag override for pr-watch snapshots"
         required: false
         default: ""
+      publish_tracking_issue:
+        description: "When true, create/update a source-specific tracker issue with latest rollup"
+        required: false
+        default: false
+        type: boolean
+      tracker_issue_title:
+        description: "Optional explicit tracker issue title (defaults to source-specific title)"
+        required: false
+        default: ""
+      tracker_issue_labels:
+        description: "Comma-separated labels to apply on tracker issue create/update (optional)"
+        required: false
+        default: ""
 
 permissions:
   actions: read
   contents: read
-  issues: read
+  issues: write
   pull-requests: read
 
 env:
@@ -65,6 +93,9 @@ env:
   PR_WATCH_NIGHTLY_DIR: artifacts/pr-watch/nightly
   PR_WATCH_NIGHTLY_SUMMARY_PATH: artifacts/pr-watch/ix-pr-watch-nightly-summary.md
   PR_WATCH_NIGHTLY_ROLLUP_PATH: artifacts/pr-watch/ix-pr-watch-nightly-rollup.json
+  PR_WATCH_NIGHTLY_METRICS_PATH: artifacts/pr-watch/ix-pr-watch-nightly-metrics.json
+  PR_WATCH_METRICS_HISTORY_PATH: artifacts/pr-watch/ix-pr-watch-nightly-metrics-history.json
+  PR_WATCH_NIGHTLY_TRACKER_PATH: artifacts/pr-watch/ix-pr-watch-nightly-tracker.md
   PR_WATCH_STATE_CACHE_PREFIX: ix-pr-watch-state-${{ github.repository }}-${{ github.ref_name }}
   PR_WATCH_STATE_CACHE_KEY: ix-pr-watch-state-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_id }}
 
@@ -95,265 +126,48 @@ jobs:
       - name: Build CLI once
         run: dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -c Release /m:1
 
-      - name: Run nightly PR babysit consolidation
+      - name: Run nightly PR babysit consolidation engine
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
 
-          if ! command -v jq >/dev/null 2>&1; then
-            echo "jq is required for ix-pr-babysit-nightly-consolidation workflow."
-            exit 1
-          fi
-
-          mkdir -p "${PR_WATCH_STATE_DIR}"
-          rm -rf "${PR_WATCH_NIGHTLY_DIR}"
-          mkdir -p "${PR_WATCH_NIGHTLY_DIR}"
-
-          TARGETS_FILE="${PR_WATCH_STATE_DIR}/ix-pr-watch-nightly-targets.txt"
-          META_FILE="${PR_WATCH_STATE_DIR}/ix-pr-watch-nightly-meta.json"
-          FAILED_TARGETS_FILE="${PR_WATCH_STATE_DIR}/ix-pr-watch-nightly-failed-targets.txt"
-          : > "${TARGETS_FILE}"
-          : > "${FAILED_TARGETS_FILE}"
-
           MAX_PRS="${{ inputs.max_prs }}"
           STALE_DAYS="${{ inputs.stale_days }}"
           INCLUDE_DRAFTS="${{ inputs.include_drafts }}"
           APPROVED_BOTS="${{ inputs.approved_bots }}"
           SOURCE_TAG="${{ inputs.source }}"
+          PUBLISH_TRACKING_ISSUE="${{ inputs.publish_tracking_issue }}"
+          TRACKER_ISSUE_TITLE="${{ inputs.tracker_issue_title }}"
+          TRACKER_ISSUE_LABELS="${{ inputs.tracker_issue_labels }}"
 
           if [ -z "${MAX_PRS}" ]; then MAX_PRS="200"; fi
           if [ -z "${STALE_DAYS}" ]; then STALE_DAYS="7"; fi
           if [ -z "${INCLUDE_DRAFTS}" ]; then INCLUDE_DRAFTS="false"; fi
           if [ -z "${APPROVED_BOTS}" ]; then APPROVED_BOTS="intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"; fi
           if [ -z "${SOURCE_TAG}" ]; then SOURCE_TAG="${{ github.event_name }}"; fi
+          if [ -z "${PUBLISH_TRACKING_ISSUE}" ]; then PUBLISH_TRACKING_ISSUE="true"; fi
 
-          if [ "${INCLUDE_DRAFTS}" = "true" ]; then
-            gh pr list \
-              --repo "${{ github.repository }}" \
-              --state open \
-              --limit "${MAX_PRS}" \
-              --json number,updatedAt,isDraft > "${META_FILE}"
-          else
-            gh pr list \
-              --repo "${{ github.repository }}" \
-              --state open \
-              --limit "${MAX_PRS}" \
-              --json number,updatedAt,isDraft \
-              --jq '[.[] | select(.isDraft == false)]' > "${META_FILE}"
-          fi
-
-          jq -r '.[].number' "${META_FILE}" > "${TARGETS_FILE}"
-          sort -u "${TARGETS_FILE}" -o "${TARGETS_FILE}"
-          TOTAL_TARGETS="$(wc -l < "${TARGETS_FILE}" | tr -d ' ')"
-
-          if [ "${TOTAL_TARGETS}" -eq 0 ]; then
-            jq -n \
-              --arg repo "${{ github.repository }}" \
-              --arg generatedAt "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-              --argjson staleDays "${STALE_DAYS}" \
-              '{
-                schema: "intelligencex.pr-watch.nightly.v1",
-                repo: $repo,
-                generatedAtUtc: $generatedAt,
-                staleDaysThreshold: $staleDays,
-                totalTargets: 0,
-                totalSnapshots: 0,
-                failedTargets: [],
-                staleInfraBlocked: [],
-                reviewRequired: [],
-                retryBudgetExhausted: [],
-                noProgressByAgeClass: [],
-                prs: []
-              }' > "${PR_WATCH_NIGHTLY_ROLLUP_PATH}"
-          else
-            while IFS= read -r pr_spec; do
-              [ -z "${pr_spec}" ] && continue
-
-              output_path="${PR_WATCH_NIGHTLY_DIR}/pr-${pr_spec}.json"
-              ARGS=(
-                "todo" "pr-watch"
-                "--repo" "${{ github.repository }}"
-                "--pr" "${pr_spec}"
-                "--max-flaky-retries" "3"
-                "--phase" "observe"
-                "--source" "${SOURCE_TAG}"
-                "--run-link" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              )
-
-              IFS=',' read -r -a bot_parts <<< "${APPROVED_BOTS}"
-              for raw in "${bot_parts[@]}"; do
-                bot="$(echo "${raw}" | xargs)"
-                if [ -n "${bot}" ]; then
-                  ARGS+=("--approved-bot" "${bot}")
-                fi
-              done
-
-              if ! dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll "${ARGS[@]}" > "${output_path}"; then
-                echo "${pr_spec}" >> "${FAILED_TARGETS_FILE}"
-                rm -f "${output_path}"
-              fi
-            done < "${TARGETS_FILE}"
-
-            shopt -s nullglob
-            snapshot_files=("${PR_WATCH_NIGHTLY_DIR}"/pr-*.json)
-            failed_targets_json="$(jq -Rn '[inputs | select(length > 0)]' < "${FAILED_TARGETS_FILE}")"
-
-            if [ ${#snapshot_files[@]} -eq 0 ]; then
-              jq -n \
-                --arg repo "${{ github.repository }}" \
-                --arg generatedAt "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-                --argjson staleDays "${STALE_DAYS}" \
-                --argjson totalTargets "${TOTAL_TARGETS}" \
-                --argjson failedTargets "${failed_targets_json}" \
-                '{
-                  schema: "intelligencex.pr-watch.nightly.v1",
-                  repo: $repo,
-                  generatedAtUtc: $generatedAt,
-                  staleDaysThreshold: $staleDays,
-                  totalTargets: $totalTargets,
-                  totalSnapshots: 0,
-                  failedTargets: $failedTargets,
-                  staleInfraBlocked: [],
-                  reviewRequired: [],
-                  retryBudgetExhausted: [],
-                  noProgressByAgeClass: [],
-                  prs: []
-                }' > "${PR_WATCH_NIGHTLY_ROLLUP_PATH}"
-            else
-              jq -s \
-                --arg repo "${{ github.repository }}" \
-                --arg generatedAt "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-                --argjson staleDays "${STALE_DAYS}" \
-                --argjson totalTargets "${TOTAL_TARGETS}" \
-                --argjson failedTargets "${failed_targets_json}" \
-                --slurpfile meta "${META_FILE}" \
-                '
-                  def age_class(days):
-                    if days >= 30 then "30d_plus"
-                    elif days >= 14 then "14_29d"
-                    elif days >= 7 then "7_13d"
-                    else "under_7d"
-                    end;
-                  def progress_class(item):
-                    if item.stopReason == "retry_budget_exhausted" then "retry_budget_exhausted"
-                    elif (item.pr.reviewDecision == "REVIEW_REQUIRED" or item.pr.reviewDecision == "CHANGES_REQUESTED") then "review_required"
-                    elif ((item.actions | map(.name) | index("idle_wait")) != null) then "idle_wait"
-                    elif ((item.actions | map(.name) | index("diagnose_ci_failure")) != null) then "ci_failure"
-                    else "other"
-                    end;
-                  def pr_row(item):
-                    {
-                      number: item.pr.number,
-                      url: item.pr.url,
-                      daysSinceUpdate: item.daysSinceUpdate,
-                      stopReason: (item.stopReason // ""),
-                      reviewDecision: item.pr.reviewDecision,
-                      mergeStateStatus: item.pr.mergeStateStatus,
-                      actions: (item.actions | map(.name)),
-                      checks: {
-                        passedCount: item.checks.passedCount,
-                        failedCount: item.checks.failedCount,
-                        pendingCount: item.checks.pendingCount
-                      }
-                    };
-                  ($meta[0] // [] | map({ key: (.number | tostring), value: .updatedAt }) | from_entries) as $updatedMap
-                  | map(
-                      . + {
-                        updatedAt: ($updatedMap[(.pr.number | tostring)] // null),
-                        daysSinceUpdate: (
-                          if (($updatedMap[(.pr.number | tostring)] // null) == null) then null
-                          else (((now - (($updatedMap[(.pr.number | tostring)] | fromdateiso8601))) / 86400) | floor)
-                          end
-                        )
-                      }
-                    ) as $rows
-                  | ($rows | map(select(
-                      .pr.state == "OPEN"
-                      and ((.daysSinceUpdate // -1) >= $staleDays)
-                      and .checks.pendingCount > 0
-                      and ((.actions | map(.name) | index("idle_wait")) != null)
-                    ))) as $staleInfra
-                  | ($rows | map(select(
-                      .pr.state == "OPEN"
-                      and (.pr.reviewDecision == "REVIEW_REQUIRED" or .pr.reviewDecision == "CHANGES_REQUESTED")
-                    ))) as $reviewRequired
-                  | ($rows | map(select(.stopReason == "retry_budget_exhausted"))) as $retryBudgetExhausted
-                  | ($rows | map(select(
-                      .pr.state == "OPEN"
-                      and ((.daysSinceUpdate // -1) >= $staleDays)
-                      and (
-                        ((.actions | map(.name) | index("idle_wait")) != null)
-                        or .stopReason == "retry_budget_exhausted"
-                        or .pr.reviewDecision == "REVIEW_REQUIRED"
-                        or .pr.reviewDecision == "CHANGES_REQUESTED"
-                      )
-                    ))) as $noProgress
-                  | {
-                      schema: "intelligencex.pr-watch.nightly.v1",
-                      repo: $repo,
-                      generatedAtUtc: $generatedAt,
-                      staleDaysThreshold: $staleDays,
-                      totalTargets: $totalTargets,
-                      totalSnapshots: ($rows | length),
-                      failedTargets: $failedTargets,
-                      staleInfraBlocked: ($staleInfra | map(pr_row(.)) | sort_by(.number)),
-                      reviewRequired: ($reviewRequired | map(pr_row(.)) | sort_by(.number)),
-                      retryBudgetExhausted: ($retryBudgetExhausted | map(pr_row(.)) | sort_by(.number)),
-                      noProgressByAgeClass: (
-                        $noProgress
-                        | map({ ageClass: age_class(.daysSinceUpdate), progressClass: progress_class(.), number: .pr.number })
-                        | group_by(.ageClass + ":" + .progressClass)
-                        | map({
-                            ageClass: .[0].ageClass,
-                            progressClass: .[0].progressClass,
-                            count: length,
-                            prs: (map(.number) | sort)
-                          })
-                        | sort_by(.ageClass, .progressClass)
-                      ),
-                      prs: ($rows | map(pr_row(.)) | sort_by(.number))
-                    }
-                ' "${snapshot_files[@]}" > "${PR_WATCH_NIGHTLY_ROLLUP_PATH}"
-            fi
-          fi
-
-          {
-            echo "# IX PR Babysit Nightly Consolidation"
-            echo
-            echo "- Generated: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
-            echo "- Repo: \`${{ github.repository }}\`"
-            echo "- Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            echo
-            echo "## Totals"
-            jq -r '"- Targets scanned: \(.totalTargets)"; "- Snapshots captured: \(.totalSnapshots)"; "- Failed targets: \(.failedTargets | length)"' "${PR_WATCH_NIGHTLY_ROLLUP_PATH}"
-            echo
-            echo "## Buckets"
-            jq -r '"- Stale infra blockers: \(.staleInfraBlocked | length)"; "- Stuck review-required: \(.reviewRequired | length)"; "- Retry budget exhausted: \(.retryBudgetExhausted | length)"' "${PR_WATCH_NIGHTLY_ROLLUP_PATH}"
-            echo
-            echo "## No-progress by age/churn class"
-            jq -r '
-              if (.noProgressByAgeClass | length) == 0 then
-                "- none"
-              else
-                .noProgressByAgeClass
-                | map("- `\(.ageClass)` + `\(.progressClass)`: \(.count) PR(s) [#\(.prs | join(", #"))]")
-                | .[]
-              end
-            ' "${PR_WATCH_NIGHTLY_ROLLUP_PATH}"
-            echo
-            echo "## Failed target scans"
-            jq -r '
-              if (.failedTargets | length) == 0 then
-                "- none"
-              else
-                .failedTargets | map("- #\(.)") | .[]
-              end
-            ' "${PR_WATCH_NIGHTLY_ROLLUP_PATH}"
-          } > "${PR_WATCH_NIGHTLY_SUMMARY_PATH}"
-
-          cat "${PR_WATCH_NIGHTLY_SUMMARY_PATH}" >> "${GITHUB_STEP_SUMMARY}"
+          dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll \
+            todo pr-watch-consolidate \
+            --repo "${{ github.repository }}" \
+            --max-prs "${MAX_PRS}" \
+            --max-flaky-retries "3" \
+            --stale-days "${STALE_DAYS}" \
+            --include-drafts "${INCLUDE_DRAFTS}" \
+            --approved-bots "${APPROVED_BOTS}" \
+            --source "${SOURCE_TAG}" \
+            --run-link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --snapshot-dir "${PR_WATCH_NIGHTLY_DIR}" \
+            --rollup-path "${PR_WATCH_NIGHTLY_ROLLUP_PATH}" \
+            --summary-path "${PR_WATCH_NIGHTLY_SUMMARY_PATH}" \
+            --metrics-path "${PR_WATCH_NIGHTLY_METRICS_PATH}" \
+            --metrics-history-path "${PR_WATCH_METRICS_HISTORY_PATH}" \
+            --tracker-path "${PR_WATCH_NIGHTLY_TRACKER_PATH}" \
+            --publish-tracking-issue "${PUBLISH_TRACKING_ISSUE}" \
+            --tracker-issue-title "${TRACKER_ISSUE_TITLE}" \
+            --tracker-issue-labels "${TRACKER_ISSUE_LABELS}"
 
       - name: Upload nightly pr-watch artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/ix-pr-babysit-weekly-governance.yml
+++ b/.github/workflows/ix-pr-babysit-weekly-governance.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   actions: read
   contents: read
-  issues: read
+  issues: write
   pull-requests: read
 
 jobs:
@@ -20,4 +20,5 @@ jobs:
       include_drafts: false
       approved_bots: "intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"
       source: "weekly-governance"
+      publish_tracking_issue: true
     secrets: inherit

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -87,6 +87,7 @@ Observe-mode babysitter automation:
 
 - Workflow: `.github/workflows/ix-pr-babysit-monitor.yml`
 - Schedule: hourly observe-mode sweep
+- Engine command: `intelligencex todo pr-watch-monitor`
 - Manual targeted run: `workflow_dispatch` with optional `pr` and policy inputs (`max_prs`, `max_flaky_retries`, `include_drafts`, `approved_bots`)
 - Outputs: per-PR snapshots + rollup summary + audit log (`ix-pr-watch-audit.jsonl`) in `artifacts/pr-watch/`
 
@@ -94,6 +95,7 @@ Guarded retry assist automation:
 
 - Workflow: `.github/workflows/ix-pr-babysit-assist-retry.yml`
 - Trigger: manual `workflow_dispatch` only (single PR target)
+- Engine command: `intelligencex todo pr-watch-assist-retry`
 - Safety: requires explicit confirmation token `RETRY_CHECKS`
 - Scope: retries failed checks only when `pr-watch` plans an eligible `retry_failed_checks` action (dedupe + cooldown aware)
 - Audit: emits execution outcomes (`success`/`skipped`/`failed`) into `artifacts/pr-watch/ix-pr-watch-audit.jsonl`
@@ -102,30 +104,39 @@ Nightly consolidation automation:
 
 - Workflow: `.github/workflows/ix-pr-babysit-nightly-consolidation.yml`
 - Schedule: daily consolidation sweep (plus `workflow_dispatch` and reusable `workflow_call`)
-- Inputs: `max_prs`, `stale_days`, `include_drafts`, `approved_bots`
+- Engine command: `intelligencex todo pr-watch-consolidate`
+- Inputs: `max_prs`, `stale_days`, `include_drafts`, `approved_bots`, `source`
+- Optional tracker issue inputs: `publish_tracking_issue`, `tracker_issue_title`, `tracker_issue_labels`
 - Outputs:
   - rollup JSON: `artifacts/pr-watch/ix-pr-watch-nightly-rollup.json`
   - markdown summary: `artifacts/pr-watch/ix-pr-watch-nightly-summary.md`
+  - metrics JSON: `artifacts/pr-watch/ix-pr-watch-nightly-metrics.json`
+  - metrics history JSON: `artifacts/pr-watch/ix-pr-watch-nightly-metrics-history.json`
+  - tracker issue body markdown: `artifacts/pr-watch/ix-pr-watch-nightly-tracker.md`
 - Consolidation buckets include:
   - stale infra-like blockers,
   - review-required/stuck PRs,
   - retry-budget-exhausted PRs,
   - no-progress PRs grouped by age/churn class.
+- Tracker issue behavior:
+  - source-scoped upsert using marker `<!-- intelligencex:pr-watch-rollup-tracker:<source> -->`,
+  - auto-enabled for scheduled/reusable runs, opt-in for manual dispatch.
 
 Weekly governance automation:
 
 - Workflow: `.github/workflows/ix-pr-babysit-weekly-governance.yml`
 - Schedule: weekly consolidation sweep (Monday)
 - Implementation: calls the nightly consolidation workflow via `workflow_call` with weekly profile defaults (`max_prs=300`, `stale_days=14`, `source=weekly-governance`)
-- Outputs: same artifact schema as nightly consolidation for comparable trend analysis
+- Outputs: same rollup/summary/metrics schema as nightly consolidation for comparable trend analysis
+- Tracker issue: enabled by default (`publish_tracking_issue=true`) for weekly governance runs
 
 ### Cadence matrix
 
 | Cadence | Workflow | Phase | Purpose | Expected maintainer action |
 | --- | --- | --- | --- | --- |
 | Hourly | `.github/workflows/ix-pr-babysit-monitor.yml` | `observe` | Fast detection of CI/review/mergeability drift on open PRs | Triage fresh blockers and decide whether to run assist retry on specific PRs |
-| Daily | `.github/workflows/ix-pr-babysit-nightly-consolidation.yml` | `observe` | Portfolio-level no-progress and stale-blocker rollup | Prioritize the next-day unblock queue using bucket summaries |
-| Weekly | `.github/workflows/ix-pr-babysit-weekly-governance.yml` | `observe` | Wider-window governance snapshot (older stalls/churn classes) | Review systemic patterns, update runbooks/SLO targets, and assign owners for repeated blockers |
+| Daily | `.github/workflows/ix-pr-babysit-nightly-consolidation.yml` | `observe` | Portfolio-level no-progress and stale-blocker rollup | Prioritize next-day unblock queue, review metrics deltas, and maintain source tracker issue |
+| Weekly | `.github/workflows/ix-pr-babysit-weekly-governance.yml` | `observe` | Wider-window governance snapshot (older stalls/churn classes) | Review systemic patterns, validate stale/no-progress trend direction, and adjust operational ownership |
 
 This cadence keeps mutation guarded and targeted:
 

--- a/IntelligenceX.Cli/Program.Help.cs
+++ b/IntelligenceX.Cli/Program.Help.cs
@@ -74,6 +74,9 @@ internal static partial class Program {
         Console.WriteLine("  todo project-view-checklist  Build maintainer checklist for missing/default GitHub Project views");
         Console.WriteLine("  todo project-view-apply  Generate deterministic apply plan for missing GitHub Project views");
         Console.WriteLine("  todo pr-watch            Observe PR CI/review/mergeability state with deterministic action recommendations");
+        Console.WriteLine("  todo pr-watch-monitor    Run observe-mode PR babysit sweep and emit monitor rollup artifacts");
+        Console.WriteLine("  todo pr-watch-assist-retry   Run guarded retry assist for a single PR and emit assist artifacts");
+        Console.WriteLine("  todo pr-watch-consolidate Build nightly/weekly PR-babysit rollups, metrics, and tracker issue updates");
         Console.WriteLine();
         Console.WriteLine("Release commands:");
         Console.WriteLine("  release notes    Generate release notes from git tags/commits");

--- a/IntelligenceX.Cli/Todo/PrWatchAssistRetryRunner.cs
+++ b/IntelligenceX.Cli/Todo/PrWatchAssistRetryRunner.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace IntelligenceX.Cli.Todo;
+
+internal static class PrWatchAssistRetryRunner {
+    private const string DefaultRepo = "EvotecIT/IntelligenceX";
+    private static readonly JsonSerializerOptions CompactJson = new() { WriteIndented = false };
+
+    private sealed class Options {
+        public string Repo { get; set; } = DefaultRepo;
+        public string PrSpec { get; set; } = string.Empty;
+        public int MaxFlakyRetries { get; set; } = 3;
+        public int RetryCooldownMinutes { get; set; } = 15;
+        public string ConfirmApplyRetries { get; set; } = string.Empty;
+        public string Source { get; set; } = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME") ?? "manual_cli";
+        public string? RunLink { get; set; } = ResolveRunLink();
+        public string OutputPath { get; set; } = Path.Combine("artifacts", "pr-watch", "assist", "ix-pr-watch-assist-pr.json");
+        public string SummaryPath { get; set; } = Path.Combine("artifacts", "pr-watch", "ix-pr-watch-assist-summary.md");
+        public HashSet<string> ApprovedBots { get; } = new(StringComparer.OrdinalIgnoreCase) {
+            "intelligencex-review",
+            "intelligencex-review[bot]",
+            "chatgpt-codex-connector[bot]"
+        };
+    }
+
+    public static async Task<int> RunAsync(string[] args) {
+        try {
+            var options = ParseOptions(args);
+            if (options is null) {
+                PrintHelp();
+                return 0;
+            }
+
+            if (string.IsNullOrWhiteSpace(options.PrSpec)) {
+                throw new InvalidOperationException("--pr is required.");
+            }
+            if (!string.Equals(options.ConfirmApplyRetries, "RETRY_CHECKS", StringComparison.Ordinal)) {
+                throw new InvalidOperationException("--confirm-apply-retries must equal RETRY_CHECKS.");
+            }
+
+            var snapshot = await PrWatchConsolidationRunner.RunPrWatchSnapshotAsync(
+                repo: options.Repo,
+                prSpec: options.PrSpec,
+                maxFlakyRetries: options.MaxFlakyRetries,
+                phase: "assist",
+                source: options.Source,
+                runLink: options.RunLink,
+                approvedBots: options.ApprovedBots,
+                applyRetry: true,
+                retryCooldownMinutes: options.RetryCooldownMinutes,
+                confirmApplyRetry: options.ConfirmApplyRetries).ConfigureAwait(false);
+
+            WriteJson(options.OutputPath, snapshot);
+            WriteText(options.SummaryPath, BuildSummary(options, snapshot));
+            AppendStepSummary(options.SummaryPath);
+            return 0;
+        } catch (Exception ex) {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+    }
+
+    private static Options? ParseOptions(string[] args) {
+        if (args.Length > 0 && IsHelp(args[0])) {
+            return null;
+        }
+        var options = new Options();
+        for (var i = 0; i < args.Length; i++) {
+            var arg = args[i];
+            switch (arg) {
+                case "--repo": options.Repo = Next(args, ref i, arg); break;
+                case "--pr": options.PrSpec = Next(args, ref i, arg); break;
+                case "--max-flaky-retries": options.MaxFlakyRetries = ParseInt(Next(args, ref i, arg), options.MaxFlakyRetries, arg, 1, 50); break;
+                case "--retry-cooldown-minutes": options.RetryCooldownMinutes = ParseInt(Next(args, ref i, arg), options.RetryCooldownMinutes, arg, 1, 1440); break;
+                case "--confirm-apply-retries": options.ConfirmApplyRetries = Next(args, ref i, arg); break;
+                case "--approved-bot": options.ApprovedBots.Add(Next(args, ref i, arg)); break;
+                case "--approved-bots": AddCsv(options.ApprovedBots, Next(args, ref i, arg)); break;
+                case "--source": options.Source = Next(args, ref i, arg); break;
+                case "--run-link": options.RunLink = Next(args, ref i, arg); break;
+                case "--output-path": options.OutputPath = Next(args, ref i, arg); break;
+                case "--summary-path": options.SummaryPath = Next(args, ref i, arg); break;
+                default: throw new InvalidOperationException($"Unknown option: {arg}");
+            }
+        }
+        return options;
+    }
+
+    private static string BuildSummary(Options options, JsonObject snapshot) {
+        var pr = snapshot["pr"] as JsonObject ?? new JsonObject();
+        var retryState = snapshot["retryState"] as JsonObject ?? new JsonObject();
+        var actions = (snapshot["actions"] as JsonArray ?? new JsonArray())
+            .OfType<JsonObject>()
+            .Select(static action => ReadString(action, "name"))
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .ToList();
+        var builder = new StringBuilder();
+        builder.AppendLine("# IX PR Babysit Assist Retry");
+        builder.AppendLine();
+        builder.AppendLine($"- Generated: {DateTimeOffset.UtcNow.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture)}");
+        builder.AppendLine($"- Repo: `{options.Repo}`");
+        if (!string.IsNullOrWhiteSpace(options.RunLink)) {
+            builder.AppendLine($"- Workflow run: {options.RunLink}");
+        }
+        builder.AppendLine();
+        builder.AppendLine("## Snapshot");
+        builder.AppendLine($"- PR: #{ReadInt(pr, "number")} ({ReadString(pr, "url")})");
+        builder.AppendLine($"- Head SHA: `{ReadString(pr, "headSha")}`");
+        builder.AppendLine($"- Stop reason: `{ReadString(snapshot, "stopReason")}`");
+        builder.AppendLine($"- Retry usage: {ReadInt(retryState, "currentShaRetriesUsed")}/{ReadInt(retryState, "maxFlakyRetries")}");
+        builder.AppendLine();
+        builder.AppendLine("## Planned actions");
+        if (actions.Count == 0) {
+            builder.AppendLine("- none");
+        } else {
+            foreach (var action in actions) {
+                builder.AppendLine($"- `{action}`");
+            }
+        }
+        return builder.ToString();
+    }
+
+    private static string? ResolveRunLink() {
+        var server = Environment.GetEnvironmentVariable("GITHUB_SERVER_URL");
+        var repo = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+        var runId = Environment.GetEnvironmentVariable("GITHUB_RUN_ID");
+        return string.IsNullOrWhiteSpace(server) || string.IsNullOrWhiteSpace(repo) || string.IsNullOrWhiteSpace(runId) ? null : $"{server.TrimEnd('/')}/{repo}/actions/runs/{runId}";
+    }
+
+    private static string Next(string[] args, ref int index, string optionName) { if (index + 1 >= args.Length) throw new InvalidOperationException($"{optionName} requires a value."); return args[++index]; }
+    private static int ParseInt(string raw, int current, string optionName, int min, int max) { if (string.IsNullOrWhiteSpace(raw)) return current; if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v) || v < min || v > max) throw new InvalidOperationException($"{optionName} must be between {min} and {max}."); return v; }
+    private static void AddCsv(HashSet<string> values, string csv) { foreach (var part in csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)) values.Add(part); }
+    private static bool IsHelp(string value) => value.Equals("-h", StringComparison.OrdinalIgnoreCase) || value.Equals("--help", StringComparison.OrdinalIgnoreCase) || value.Equals("help", StringComparison.OrdinalIgnoreCase);
+    private static int ReadInt(JsonObject node, string name) => node.TryGetPropertyValue(name, out var value) && value is JsonValue jv && jv.TryGetValue<int>(out var v) ? v : 0;
+    private static string ReadString(JsonObject node, string name) => node.TryGetPropertyValue(name, out var value) && value is JsonValue jv && jv.TryGetValue<string>(out var text) ? text ?? string.Empty : string.Empty;
+    private static void WriteJson(string path, JsonNode node) { EnsureDirectory(path); File.WriteAllText(path, node.ToJsonString(CompactJson)); }
+    private static void WriteText(string path, string text) { EnsureDirectory(path); File.WriteAllText(path, text, Encoding.UTF8); }
+    private static void EnsureDirectory(string path) { var dir = Path.GetDirectoryName(path); if (!string.IsNullOrWhiteSpace(dir)) Directory.CreateDirectory(dir); }
+    private static void AppendStepSummary(string path) { var step = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY"); if (!string.IsNullOrWhiteSpace(step) && File.Exists(path)) File.AppendAllText(step, File.ReadAllText(path) + Environment.NewLine, Encoding.UTF8); }
+
+    private static void PrintHelp() {
+        Console.WriteLine("Usage: intelligencex todo pr-watch-assist-retry [options]");
+        Console.WriteLine("  --repo <owner/name>");
+        Console.WriteLine("  --pr <number|url>");
+        Console.WriteLine("  --max-flaky-retries <n>");
+        Console.WriteLine("  --retry-cooldown-minutes <n>");
+        Console.WriteLine("  --confirm-apply-retries RETRY_CHECKS");
+        Console.WriteLine("  --approved-bot <login> (repeatable)");
+        Console.WriteLine("  --approved-bots <csv>");
+        Console.WriteLine("  --source <value>");
+        Console.WriteLine("  --run-link <url>");
+        Console.WriteLine("  --output-path <path>");
+        Console.WriteLine("  --summary-path <path>");
+    }
+}

--- a/IntelligenceX.Cli/Todo/PrWatchConsolidationRunner.cs
+++ b/IntelligenceX.Cli/Todo/PrWatchConsolidationRunner.cs
@@ -1,0 +1,659 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Cli.GitHub;
+
+namespace IntelligenceX.Cli.Todo;
+
+internal static class PrWatchConsolidationRunner {
+    private const string DefaultRepo = "EvotecIT/IntelligenceX";
+    private const string DefaultSource = "manual_cli";
+    private const string ConfirmSchema = "intelligencex.pr-watch.snapshot.v1";
+    private static readonly SemaphoreSlim ConsoleCaptureGate = new(1, 1);
+    private static readonly JsonSerializerOptions CompactJson = new() { WriteIndented = false };
+
+    private sealed class Options {
+        public string Repo { get; set; } = DefaultRepo;
+        public int MaxPrs { get; set; } = 200;
+        public int MaxFlakyRetries { get; set; } = 3;
+        public int StaleDays { get; set; } = 7;
+        public bool IncludeDrafts { get; set; }
+        public string Source { get; set; } = ResolveDefaultSource();
+        public string? RunLink { get; set; } = ResolveDefaultRunLink();
+        public string SnapshotDir { get; set; } = Path.Combine("artifacts", "pr-watch", "nightly");
+        public string RollupPath { get; set; } = Path.Combine("artifacts", "pr-watch", "ix-pr-watch-nightly-rollup.json");
+        public string SummaryPath { get; set; } = Path.Combine("artifacts", "pr-watch", "ix-pr-watch-nightly-summary.md");
+        public string MetricsPath { get; set; } = Path.Combine("artifacts", "pr-watch", "ix-pr-watch-nightly-metrics.json");
+        public string MetricsHistoryPath { get; set; } = Path.Combine("artifacts", "pr-watch", "ix-pr-watch-nightly-metrics-history.json");
+        public string TrackerPath { get; set; } = Path.Combine("artifacts", "pr-watch", "ix-pr-watch-nightly-tracker.md");
+        public bool PublishTrackingIssue { get; set; } = true;
+        public string TrackerIssueTitle { get; set; } = string.Empty;
+        public HashSet<string> TrackerIssueLabels { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public HashSet<string> ApprovedBots { get; } = new(StringComparer.OrdinalIgnoreCase) {
+            "intelligencex-review",
+            "intelligencex-review[bot]",
+            "chatgpt-codex-connector[bot]"
+        };
+    }
+
+    private sealed record PrMeta(int Number, DateTimeOffset? UpdatedAtUtc);
+
+    private sealed record RowData(
+        int Number,
+        string Url,
+        string HeadSha,
+        string State,
+        string ReviewDecision,
+        string MergeStateStatus,
+        string StopReason,
+        int PassedCount,
+        int FailedCount,
+        int PendingCount,
+        int? DaysSinceUpdate,
+        List<string> Actions
+    );
+
+    public static async Task<int> RunAsync(string[] args) {
+        try {
+            var options = ParseOptions(args);
+            if (options is null) {
+                PrintHelp();
+                return 0;
+            }
+
+            Directory.CreateDirectory(options.SnapshotDir);
+            foreach (var existing in Directory.EnumerateFiles(options.SnapshotDir)) {
+                File.Delete(existing);
+            }
+
+            var metas = await ListOpenPrsAsync(options).ConfigureAwait(false);
+            var rows = new List<RowData>();
+            var failedTargets = new List<int>();
+
+            foreach (var meta in metas) {
+                try {
+                    var snapshot = await RunPrWatchSnapshotAsync(
+                        repo: options.Repo,
+                        prSpec: meta.Number.ToString(CultureInfo.InvariantCulture),
+                        maxFlakyRetries: options.MaxFlakyRetries,
+                        phase: "observe",
+                        source: options.Source,
+                        runLink: options.RunLink,
+                        approvedBots: options.ApprovedBots).ConfigureAwait(false);
+                    var row = BuildRow(snapshot, meta.UpdatedAtUtc);
+                    rows.Add(row);
+                    WriteJson(Path.Combine(options.SnapshotDir, $"pr-{row.Number.ToString(CultureInfo.InvariantCulture)}.json"), snapshot);
+                } catch {
+                    failedTargets.Add(meta.Number);
+                }
+            }
+
+            var rollup = BuildRollup(options, metas.Count, rows, failedTargets);
+            WriteJson(options.RollupPath, rollup);
+
+            var previousMetrics = LoadPreviousMetrics(options.MetricsHistoryPath);
+            var metrics = BuildMetrics(options, rollup, rows, previousMetrics);
+            WriteJson(options.MetricsPath, metrics);
+            UpdateMetricsHistory(options.MetricsHistoryPath, metrics);
+
+            WriteText(options.TrackerPath, BuildTrackerBody(options, rollup, metrics));
+            var trackerUrl = options.PublishTrackingIssue
+                ? await UpsertTrackerIssueAsync(options).ConfigureAwait(false)
+                : string.Empty;
+
+            var summary = BuildSummary(options, rollup, metrics, trackerUrl);
+            WriteText(options.SummaryPath, summary);
+            AppendStepSummaryIfPresent(options.SummaryPath);
+            return 0;
+        } catch (Exception ex) {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+    }
+
+    private static Options? ParseOptions(string[] args) {
+        if (args.Length > 0 && IsHelp(args[0])) {
+            return null;
+        }
+
+        var options = new Options();
+        for (var i = 0; i < args.Length; i++) {
+            var arg = args[i];
+            switch (arg) {
+                case "--repo": options.Repo = Next(args, ref i, arg); break;
+                case "--max-prs": options.MaxPrs = ParseInt(Next(args, ref i, arg), options.MaxPrs, arg, 1, 2000); break;
+                case "--max-flaky-retries": options.MaxFlakyRetries = ParseInt(Next(args, ref i, arg), options.MaxFlakyRetries, arg, 1, 50); break;
+                case "--stale-days": options.StaleDays = ParseInt(Next(args, ref i, arg), options.StaleDays, arg, 1, 3650); break;
+                case "--include-drafts": options.IncludeDrafts = ParseBool(Next(args, ref i, arg), options.IncludeDrafts, arg); break;
+                case "--approved-bot": options.ApprovedBots.Add(Next(args, ref i, arg)); break;
+                case "--approved-bots": AddCsv(options.ApprovedBots, Next(args, ref i, arg)); break;
+                case "--source": options.Source = Next(args, ref i, arg); break;
+                case "--run-link": options.RunLink = Next(args, ref i, arg); break;
+                case "--snapshot-dir": options.SnapshotDir = Next(args, ref i, arg); break;
+                case "--rollup-path": options.RollupPath = Next(args, ref i, arg); break;
+                case "--summary-path": options.SummaryPath = Next(args, ref i, arg); break;
+                case "--metrics-path": options.MetricsPath = Next(args, ref i, arg); break;
+                case "--metrics-history-path": options.MetricsHistoryPath = Next(args, ref i, arg); break;
+                case "--tracker-path": options.TrackerPath = Next(args, ref i, arg); break;
+                case "--publish-tracking-issue": options.PublishTrackingIssue = ParseBool(Next(args, ref i, arg), options.PublishTrackingIssue, arg); break;
+                case "--tracker-issue-title": options.TrackerIssueTitle = Next(args, ref i, arg); break;
+                case "--tracker-issue-label": options.TrackerIssueLabels.Add(Next(args, ref i, arg)); break;
+                case "--tracker-issue-labels": AddCsv(options.TrackerIssueLabels, Next(args, ref i, arg)); break;
+                default: throw new InvalidOperationException($"Unknown option: {arg}");
+            }
+        }
+
+        return options;
+    }
+
+    private static async Task<List<PrMeta>> ListOpenPrsAsync(Options options) {
+        var (exitCode, stdOut, stdErr) = await GhCli.RunAsync(
+            "pr", "list",
+            "--repo", options.Repo,
+            "--state", "open",
+            "--limit", options.MaxPrs.ToString(CultureInfo.InvariantCulture),
+            "--json", "number,updatedAt,isDraft").ConfigureAwait(false);
+        if (exitCode != 0) {
+            throw new InvalidOperationException($"gh pr list failed: {stdErr.Trim()}");
+        }
+
+        var result = new List<PrMeta>();
+        var root = JsonNode.Parse(stdOut) as JsonArray ?? new JsonArray();
+        foreach (var node in root) {
+            if (node is not JsonObject item) {
+                continue;
+            }
+            var number = ReadInt(item, "number");
+            var isDraft = ReadBool(item, "isDraft");
+            if (!options.IncludeDrafts && isDraft) {
+                continue;
+            }
+            var updatedAt = ReadDate(item, "updatedAt");
+            if (number > 0) {
+                result.Add(new PrMeta(number, updatedAt));
+            }
+        }
+        return result.OrderBy(static m => m.Number).ToList();
+    }
+
+    internal static async Task<JsonObject> RunPrWatchSnapshotAsync(
+        string repo,
+        string prSpec,
+        int maxFlakyRetries,
+        string phase,
+        string source,
+        string? runLink,
+        IEnumerable<string> approvedBots,
+        bool applyRetry = false,
+        int retryCooldownMinutes = 15,
+        string confirmApplyRetry = "") {
+        var args = new List<string> {
+            "--repo", repo,
+            "--pr", prSpec,
+            "--max-flaky-retries", maxFlakyRetries.ToString(CultureInfo.InvariantCulture),
+            "--phase", phase,
+            "--source", source,
+            "--once"
+        };
+        if (!string.IsNullOrWhiteSpace(runLink)) {
+            args.Add("--run-link");
+            args.Add(runLink!);
+        }
+        foreach (var bot in approvedBots) {
+            args.Add("--approved-bot");
+            args.Add(bot);
+        }
+        if (applyRetry) {
+            args.Add("--retry-cooldown-minutes");
+            args.Add(retryCooldownMinutes.ToString(CultureInfo.InvariantCulture));
+            args.Add("--apply-retry");
+            args.Add("--confirm-apply-retry");
+            args.Add(confirmApplyRetry);
+        }
+
+        await ConsoleCaptureGate.WaitAsync().ConfigureAwait(false);
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+        var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+        var errWriter = new StringWriter(CultureInfo.InvariantCulture);
+        try {
+            Console.SetOut(outWriter);
+            Console.SetError(errWriter);
+            var code = await PrWatchRunner.RunAsync(args.ToArray()).ConfigureAwait(false);
+            if (code != 0) {
+                var err = string.IsNullOrWhiteSpace(errWriter.ToString()) ? outWriter.ToString() : errWriter.ToString();
+                throw new InvalidOperationException($"pr-watch failed for {prSpec}: {err.Trim()}");
+            }
+        } finally {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+            ConsoleCaptureGate.Release();
+        }
+
+        var line = outWriter.ToString()
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault(static value => value.StartsWith("{", StringComparison.Ordinal));
+        if (string.IsNullOrWhiteSpace(line)) {
+            throw new InvalidOperationException($"Missing JSON snapshot for PR {prSpec}.");
+        }
+
+        var snapshot = JsonNode.Parse(line) as JsonObject;
+        if (snapshot is null || !string.Equals(ReadString(snapshot, "schema"), ConfirmSchema, StringComparison.OrdinalIgnoreCase)) {
+            throw new InvalidOperationException($"Invalid snapshot payload for PR {prSpec}.");
+        }
+        return snapshot;
+    }
+
+    private static RowData BuildRow(JsonObject snapshot, DateTimeOffset? updatedAt) {
+        var pr = snapshot["pr"] as JsonObject ?? new JsonObject();
+        var checks = snapshot["checks"] as JsonObject ?? new JsonObject();
+        var actions = (snapshot["actions"] as JsonArray ?? new JsonArray())
+            .OfType<JsonObject>()
+            .Select(static action => ReadString(action, "name"))
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .ToList();
+        int? daysSinceUpdate = null;
+        if (updatedAt.HasValue) {
+            daysSinceUpdate = (int)Math.Floor((DateTimeOffset.UtcNow - updatedAt.Value).TotalDays);
+        }
+
+        return new RowData(
+            Number: ReadInt(pr, "number"),
+            Url: ReadString(pr, "url"),
+            HeadSha: ReadString(pr, "headSha"),
+            State: ReadString(pr, "state"),
+            ReviewDecision: ReadString(pr, "reviewDecision"),
+            MergeStateStatus: ReadString(pr, "mergeStateStatus"),
+            StopReason: ReadString(snapshot, "stopReason"),
+            PassedCount: ReadInt(checks, "passedCount"),
+            FailedCount: ReadInt(checks, "failedCount"),
+            PendingCount: ReadInt(checks, "pendingCount"),
+            DaysSinceUpdate: daysSinceUpdate,
+            Actions: actions);
+    }
+
+    private static JsonObject BuildRollup(Options options, int totalTargets, IReadOnlyList<RowData> rows, IReadOnlyList<int> failedTargets) {
+        var staleInfra = rows.Where(row => IsOpen(row) && (row.DaysSinceUpdate ?? -1) >= options.StaleDays && row.PendingCount > 0 && row.Actions.Contains("idle_wait", StringComparer.OrdinalIgnoreCase)).ToList();
+        var reviewRequired = rows.Where(row => IsOpen(row) && IsReviewBlocking(row.ReviewDecision)).ToList();
+        var retryBudgetExhausted = rows.Where(static row => string.Equals(row.StopReason, "retry_budget_exhausted", StringComparison.OrdinalIgnoreCase)).ToList();
+        var noProgress = rows.Where(row => IsOpen(row) && (row.DaysSinceUpdate ?? -1) >= options.StaleDays && (row.Actions.Contains("idle_wait", StringComparer.OrdinalIgnoreCase) || string.Equals(row.StopReason, "retry_budget_exhausted", StringComparison.OrdinalIgnoreCase) || IsReviewBlocking(row.ReviewDecision))).ToList();
+
+        var noProgressBuckets = noProgress
+            .GroupBy(row => $"{AgeClass(row.DaysSinceUpdate)}::{ProgressClass(row)}", StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static group => group.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(group => (JsonNode)new JsonObject {
+                ["ageClass"] = group.Key.Split("::")[0],
+                ["progressClass"] = group.Key.Split("::")[1],
+                ["count"] = group.Count(),
+                ["prs"] = new JsonArray(group.Select(static row => (JsonNode)row.Number).OrderBy(static n => n).ToArray())
+            }).ToArray();
+
+        return new JsonObject {
+            ["schema"] = "intelligencex.pr-watch.nightly.v1",
+            ["repo"] = options.Repo,
+            ["generatedAtUtc"] = DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture),
+            ["staleDaysThreshold"] = options.StaleDays,
+            ["totalTargets"] = totalTargets,
+            ["totalSnapshots"] = rows.Count,
+            ["failedTargets"] = new JsonArray(failedTargets.OrderBy(static n => n).Select(static n => (JsonNode)n).ToArray()),
+            ["staleInfraBlocked"] = BuildPrArray(staleInfra),
+            ["reviewRequired"] = BuildPrArray(reviewRequired),
+            ["retryBudgetExhausted"] = BuildPrArray(retryBudgetExhausted),
+            ["noProgressByAgeClass"] = new JsonArray(noProgressBuckets),
+            ["prs"] = BuildPrArray(rows)
+        };
+    }
+
+    private static JsonArray BuildPrArray(IEnumerable<RowData> rows) {
+        var nodes = rows
+            .OrderBy(static row => row.Number)
+            .Select(static row => (JsonNode)new JsonObject {
+                ["number"] = row.Number,
+                ["url"] = row.Url,
+                ["headSha"] = row.HeadSha,
+                ["daysSinceUpdate"] = row.DaysSinceUpdate,
+                ["stopReason"] = row.StopReason,
+                ["reviewDecision"] = row.ReviewDecision,
+                ["mergeStateStatus"] = row.MergeStateStatus,
+                ["actions"] = new JsonArray(row.Actions.Select(static action => (JsonNode)action).ToArray()),
+                ["checks"] = new JsonObject {
+                    ["passedCount"] = row.PassedCount,
+                    ["failedCount"] = row.FailedCount,
+                    ["pendingCount"] = row.PendingCount
+                }
+            }).ToArray();
+        return new JsonArray(nodes);
+    }
+
+    private static bool IsOpen(RowData row) => string.Equals(row.State, "OPEN", StringComparison.OrdinalIgnoreCase);
+    private static bool IsReviewBlocking(string value) => string.Equals(value, "REVIEW_REQUIRED", StringComparison.OrdinalIgnoreCase) || string.Equals(value, "CHANGES_REQUESTED", StringComparison.OrdinalIgnoreCase);
+    private static string AgeClass(int? days) => !days.HasValue ? "unknown" : days >= 30 ? "30d_plus" : days >= 14 ? "14_29d" : days >= 7 ? "7_13d" : "under_7d";
+    private static string ProgressClass(RowData row) => string.Equals(row.StopReason, "retry_budget_exhausted", StringComparison.OrdinalIgnoreCase) ? "retry_budget_exhausted" : IsReviewBlocking(row.ReviewDecision) ? "review_required" : row.Actions.Contains("idle_wait", StringComparer.OrdinalIgnoreCase) ? "idle_wait" : row.Actions.Contains("diagnose_ci_failure", StringComparer.OrdinalIgnoreCase) ? "ci_failure" : "other";
+
+    private static JsonObject BuildMetrics(Options options, JsonObject rollup, IReadOnlyList<RowData> rows, JsonObject? previousMetrics) {
+        var totalSnapshots = rows.Count;
+        var staleOpenPrs = rows.Count(row => (row.DaysSinceUpdate ?? -1) >= options.StaleDays);
+        var reviewRequiredPrs = rows.Count(row => IsReviewBlocking(row.ReviewDecision) && IsOpen(row));
+        var retryBudgetExhaustedPrs = rows.Count(row => string.Equals(row.StopReason, "retry_budget_exhausted", StringComparison.OrdinalIgnoreCase));
+        var noProgressSet = new HashSet<int>(
+            rows.Where(row => IsOpen(row) && (row.DaysSinceUpdate ?? -1) >= options.StaleDays && (row.Actions.Contains("idle_wait", StringComparer.OrdinalIgnoreCase) || IsReviewBlocking(row.ReviewDecision) || string.Equals(row.StopReason, "retry_budget_exhausted", StringComparison.OrdinalIgnoreCase)))
+                .Select(static row => row.Number));
+        var noProgressPrs = noProgressSet.Count;
+
+        var allDays = rows.Where(static row => row.DaysSinceUpdate.HasValue).Select(static row => row.DaysSinceUpdate!.Value).OrderBy(static v => v).ToList();
+        var noProgressDays = rows.Where(row => noProgressSet.Contains(row.Number) && row.DaysSinceUpdate.HasValue).Select(static row => row.DaysSinceUpdate!.Value).OrderBy(static v => v).ToList();
+
+        var staleRatio = Ratio(staleOpenPrs, totalSnapshots);
+        var reviewRatio = Ratio(reviewRequiredPrs, totalSnapshots);
+        var retryRatio = Ratio(retryBudgetExhaustedPrs, totalSnapshots);
+        var noProgressRatio = Ratio(noProgressPrs, totalSnapshots);
+
+        var previousTotals = previousMetrics?["totals"] as JsonObject;
+        var previousRatios = previousMetrics?["ratiosPct"] as JsonObject;
+        var previousStale = ReadIntNullable(previousTotals, "staleOpenPrs");
+        var previousReview = ReadIntNullable(previousTotals, "reviewRequiredPrs");
+        var previousNoProgress = ReadIntNullable(previousTotals, "noProgressPrs");
+        var previousStaleRatio = ReadDoubleNullable(previousRatios, "staleOpenPrs");
+
+        return new JsonObject {
+            ["schema"] = "intelligencex.pr-watch.metrics.v1",
+            ["repo"] = options.Repo,
+            ["generatedAtUtc"] = ReadString(rollup, "generatedAtUtc"),
+            ["source"] = options.Source,
+            ["runLink"] = options.RunLink,
+            ["staleDaysThreshold"] = options.StaleDays,
+            ["totals"] = new JsonObject {
+                ["targetsScanned"] = ReadInt(rollup, "totalTargets"),
+                ["snapshotsCaptured"] = totalSnapshots,
+                ["failedTargets"] = (rollup["failedTargets"] as JsonArray)?.Count ?? 0,
+                ["staleOpenPrs"] = staleOpenPrs,
+                ["reviewRequiredPrs"] = reviewRequiredPrs,
+                ["retryBudgetExhaustedPrs"] = retryBudgetExhaustedPrs,
+                ["noProgressPrs"] = noProgressPrs
+            },
+            ["ratiosPct"] = new JsonObject {
+                ["staleOpenPrs"] = staleRatio,
+                ["reviewRequiredPrs"] = reviewRatio,
+                ["retryBudgetExhaustedPrs"] = retryRatio,
+                ["noProgressPrs"] = noProgressRatio
+            },
+            ["mediansDays"] = new JsonObject {
+                ["medianAllDaysSinceUpdate"] = Median(allDays),
+                ["medianNoProgressDaysSinceUpdate"] = Median(noProgressDays)
+            },
+            ["deltas"] = new JsonObject {
+                ["staleOpenPrs"] = previousStale.HasValue ? staleOpenPrs - previousStale.Value : null,
+                ["reviewRequiredPrs"] = previousReview.HasValue ? reviewRequiredPrs - previousReview.Value : null,
+                ["noProgressPrs"] = previousNoProgress.HasValue ? noProgressPrs - previousNoProgress.Value : null,
+                ["staleOpenPrsPctPoints"] = previousStaleRatio.HasValue ? Math.Round(staleRatio - previousStaleRatio.Value, 2, MidpointRounding.AwayFromZero) : null
+            },
+            ["successMetrics"] = new JsonObject {
+                ["medianTimeToUnblockProxyDays"] = Median(noProgressDays),
+                ["stalePrReductionSincePrevious"] = previousStale.HasValue ? previousStale.Value - staleOpenPrs : null
+            }
+        };
+    }
+
+    private static JsonObject? LoadPreviousMetrics(string historyPath) {
+        if (!File.Exists(historyPath)) {
+            return null;
+        }
+
+        try {
+            var history = JsonNode.Parse(File.ReadAllText(historyPath)) as JsonArray;
+            return history?.LastOrDefault() as JsonObject;
+        } catch {
+            return null;
+        }
+    }
+
+    private static void UpdateMetricsHistory(string historyPath, JsonObject metrics) {
+        JsonArray history;
+        if (File.Exists(historyPath)) {
+            try {
+                history = JsonNode.Parse(File.ReadAllText(historyPath)) as JsonArray ?? new JsonArray();
+            } catch {
+                history = new JsonArray();
+            }
+        } else {
+            history = new JsonArray();
+        }
+
+        history.Add(JsonNode.Parse(metrics.ToJsonString(CompactJson)));
+        while (history.Count > 120) {
+            history.RemoveAt(0);
+        }
+        WriteJson(historyPath, history);
+    }
+
+    private static string BuildTrackerBody(Options options, JsonObject rollup, JsonObject metrics) {
+        var builder = new StringBuilder();
+        builder.AppendLine(TrackerMarker(options.Source));
+        builder.AppendLine("# IX PR Babysit Rollup Tracker");
+        builder.AppendLine();
+        builder.AppendLine($"- Generated: {DateTimeOffset.UtcNow.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture)}");
+        builder.AppendLine($"- Repo: `{options.Repo}`");
+        builder.AppendLine($"- Source: `{options.Source}`");
+        if (!string.IsNullOrWhiteSpace(options.RunLink)) {
+            builder.AppendLine($"- Workflow run: {options.RunLink}");
+        }
+        builder.AppendLine();
+        builder.AppendLine("## Metrics");
+        builder.AppendLine($"- Median time-to-unblock proxy (days): {FormatNullable(metrics["successMetrics"] as JsonObject, "medianTimeToUnblockProxyDays")}");
+        builder.AppendLine($"- Stale open PR ratio: {ReadNumberText(metrics["ratiosPct"] as JsonObject, "staleOpenPrs")}%");
+        builder.AppendLine($"- Review-required ratio: {ReadNumberText(metrics["ratiosPct"] as JsonObject, "reviewRequiredPrs")}%");
+        builder.AppendLine($"- No-progress ratio: {ReadNumberText(metrics["ratiosPct"] as JsonObject, "noProgressPrs")}%");
+        builder.AppendLine();
+        builder.AppendLine("## Buckets");
+        builder.AppendLine($"- Stale infra blockers: {(rollup["staleInfraBlocked"] as JsonArray)?.Count ?? 0}");
+        builder.AppendLine($"- Stuck review-required: {(rollup["reviewRequired"] as JsonArray)?.Count ?? 0}");
+        builder.AppendLine($"- Retry budget exhausted: {(rollup["retryBudgetExhausted"] as JsonArray)?.Count ?? 0}");
+        return builder.ToString();
+    }
+
+    private static string BuildSummary(Options options, JsonObject rollup, JsonObject metrics, string trackerIssueUrl) {
+        var builder = new StringBuilder();
+        builder.AppendLine("# IX PR Babysit Nightly Consolidation");
+        builder.AppendLine();
+        builder.AppendLine($"- Generated: {DateTimeOffset.UtcNow.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture)}");
+        builder.AppendLine($"- Repo: `{options.Repo}`");
+        if (!string.IsNullOrWhiteSpace(options.RunLink)) {
+            builder.AppendLine($"- Workflow run: {options.RunLink}");
+        }
+        builder.AppendLine();
+        builder.AppendLine("## Totals");
+        builder.AppendLine($"- Targets scanned: {ReadInt(rollup, "totalTargets")}");
+        builder.AppendLine($"- Snapshots captured: {ReadInt(rollup, "totalSnapshots")}");
+        builder.AppendLine($"- Failed targets: {(rollup["failedTargets"] as JsonArray)?.Count ?? 0}");
+        builder.AppendLine();
+        builder.AppendLine("## Buckets");
+        builder.AppendLine($"- Stale infra blockers: {(rollup["staleInfraBlocked"] as JsonArray)?.Count ?? 0}");
+        builder.AppendLine($"- Stuck review-required: {(rollup["reviewRequired"] as JsonArray)?.Count ?? 0}");
+        builder.AppendLine($"- Retry budget exhausted: {(rollup["retryBudgetExhausted"] as JsonArray)?.Count ?? 0}");
+        builder.AppendLine();
+        builder.AppendLine("## Success metrics");
+        builder.AppendLine($"- Median time-to-unblock proxy (days): {FormatNullable(metrics["successMetrics"] as JsonObject, "medianTimeToUnblockProxyDays")}");
+        builder.AppendLine($"- Stale open PR ratio: {ReadNumberText(metrics["ratiosPct"] as JsonObject, "staleOpenPrs")}%");
+        builder.AppendLine($"- Review-required ratio: {ReadNumberText(metrics["ratiosPct"] as JsonObject, "reviewRequiredPrs")}%");
+        builder.AppendLine($"- No-progress ratio: {ReadNumberText(metrics["ratiosPct"] as JsonObject, "noProgressPrs")}%");
+        if (!string.IsNullOrWhiteSpace(trackerIssueUrl)) {
+            builder.AppendLine();
+            builder.AppendLine("## Tracker issue");
+            builder.AppendLine($"- {trackerIssueUrl}");
+        }
+        return builder.ToString();
+    }
+
+    private static async Task<string> UpsertTrackerIssueAsync(Options options) {
+        var marker = TrackerMarker(options.Source);
+        var title = string.IsNullOrWhiteSpace(options.TrackerIssueTitle)
+            ? $"IX PR Babysit Rollup Tracker ({options.Source})"
+            : options.TrackerIssueTitle;
+
+        var (listCode, listOut, listErr) = await GhCli.RunAsync(
+            "issue", "list",
+            "--repo", options.Repo,
+            "--state", "open",
+            "--limit", "200",
+            "--json", "number,url,body").ConfigureAwait(false);
+        if (listCode != 0) {
+            throw new InvalidOperationException($"gh issue list failed: {listErr.Trim()}");
+        }
+
+        var issues = JsonNode.Parse(listOut) as JsonArray ?? new JsonArray();
+        var existing = issues
+            .OfType<JsonObject>()
+            .FirstOrDefault(issue => ReadString(issue, "body").Contains(marker, StringComparison.Ordinal));
+
+        string issueUrl;
+        int issueNumber;
+        if (existing is null) {
+            var createArgs = new List<string> {
+                "issue", "create",
+                "--repo", options.Repo,
+                "--title", title,
+                "--body-file", options.TrackerPath
+            };
+            var (createCode, createOut, createErr) = await GhCli.RunAsync(createArgs.ToArray()).ConfigureAwait(false);
+            if (createCode != 0) {
+                throw new InvalidOperationException($"gh issue create failed: {createErr.Trim()}");
+            }
+            issueUrl = createOut.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).LastOrDefault() ?? string.Empty;
+            issueNumber = ParseIssueNumber(issueUrl);
+        } else {
+            issueNumber = ReadInt(existing, "number");
+            issueUrl = ReadString(existing, "url");
+            var (editCode, _, editErr) = await GhCli.RunAsync(
+                "issue", "edit", issueNumber.ToString(CultureInfo.InvariantCulture),
+                "--repo", options.Repo,
+                "--title", title,
+                "--body-file", options.TrackerPath).ConfigureAwait(false);
+            if (editCode != 0) {
+                throw new InvalidOperationException($"gh issue edit failed: {editErr.Trim()}");
+            }
+        }
+
+        foreach (var label in options.TrackerIssueLabels) {
+            var (labelCode, _, labelErr) = await GhCli.RunAsync(
+                "issue", "edit", issueNumber.ToString(CultureInfo.InvariantCulture),
+                "--repo", options.Repo,
+                "--add-label", label).ConfigureAwait(false);
+            if (labelCode != 0) {
+                Console.Error.WriteLine($"Warning: failed to add tracker label '{label}': {labelErr.Trim()}");
+            }
+        }
+
+        return issueUrl;
+    }
+
+    private static string TrackerMarker(string source) => $"<!-- intelligencex:pr-watch-rollup-tracker:{SanitizeSource(source)} -->";
+    private static string SanitizeSource(string source) => string.IsNullOrWhiteSpace(source) ? "default" : new string(source.Select(static c => char.IsLetterOrDigit(c) || c == '-' || c == '_' || c == '.' ? c : '-').ToArray()).Trim('-');
+
+    private static string Next(string[] args, ref int index, string argName) {
+        if (index + 1 >= args.Length) {
+            throw new InvalidOperationException($"{argName} requires a value.");
+        }
+        return args[++index];
+    }
+
+    private static int ParseInt(string raw, int current, string optionName, int min, int max) {
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return current;
+        }
+        if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) || value < min || value > max) {
+            throw new InvalidOperationException($"{optionName} must be between {min} and {max}.");
+        }
+        return value;
+    }
+
+    private static bool ParseBool(string raw, bool current, string optionName) {
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return current;
+        }
+        if (bool.TryParse(raw, out var value)) {
+            return value;
+        }
+        throw new InvalidOperationException($"{optionName} must be true/false.");
+    }
+
+    private static void AddCsv(HashSet<string> values, string csv) {
+        foreach (var part in csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)) {
+            values.Add(part);
+        }
+    }
+
+    private static bool IsHelp(string value) => value.Equals("-h", StringComparison.OrdinalIgnoreCase) || value.Equals("--help", StringComparison.OrdinalIgnoreCase) || value.Equals("help", StringComparison.OrdinalIgnoreCase);
+    private static string ResolveDefaultSource() => Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME") ?? DefaultSource;
+    private static string? ResolveDefaultRunLink() {
+        var server = Environment.GetEnvironmentVariable("GITHUB_SERVER_URL");
+        var repo = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+        var runId = Environment.GetEnvironmentVariable("GITHUB_RUN_ID");
+        return string.IsNullOrWhiteSpace(server) || string.IsNullOrWhiteSpace(repo) || string.IsNullOrWhiteSpace(runId) ? null : $"{server.TrimEnd('/')}/{repo}/actions/runs/{runId}";
+    }
+
+    private static void WriteJson(string path, JsonNode node) { EnsureDirectory(path); File.WriteAllText(path, node.ToJsonString(CompactJson)); }
+    private static void WriteText(string path, string text) { EnsureDirectory(path); File.WriteAllText(path, text, Encoding.UTF8); }
+    private static void EnsureDirectory(string path) { var dir = Path.GetDirectoryName(path); if (!string.IsNullOrWhiteSpace(dir)) { Directory.CreateDirectory(dir); } }
+
+    private static void AppendStepSummaryIfPresent(string summaryPath) {
+        var target = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
+        if (string.IsNullOrWhiteSpace(target) || !File.Exists(summaryPath)) {
+            return;
+        }
+        File.AppendAllText(target, File.ReadAllText(summaryPath) + Environment.NewLine, Encoding.UTF8);
+    }
+
+    private static int ReadInt(JsonObject node, string name) {
+        if (!node.TryGetPropertyValue(name, out var value) || value is null) { return 0; }
+        return value is JsonValue jv && jv.TryGetValue<int>(out var intValue) ? intValue : 0;
+    }
+
+    private static int? ReadIntNullable(JsonObject? node, string name) {
+        if (node is null || !node.TryGetPropertyValue(name, out var value) || value is null) { return null; }
+        return value is JsonValue jv && jv.TryGetValue<int>(out var intValue) ? intValue : null;
+    }
+
+    private static bool ReadBool(JsonObject node, string name) => node.TryGetPropertyValue(name, out var value) && value is JsonValue jv && jv.TryGetValue<bool>(out var boolValue) && boolValue;
+    private static string ReadString(JsonObject node, string name) => node.TryGetPropertyValue(name, out var value) && value is JsonValue jv && jv.TryGetValue<string>(out var text) ? text ?? string.Empty : string.Empty;
+    private static DateTimeOffset? ReadDate(JsonObject node, string name) => DateTimeOffset.TryParse(ReadString(node, name), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var value) ? value.ToUniversalTime() : null;
+    private static double? ReadDoubleNullable(JsonObject? node, string name) => node is not null && node.TryGetPropertyValue(name, out var value) && value is JsonValue jv && jv.TryGetValue<double>(out var doubleValue) ? doubleValue : null;
+    private static string ReadNumberText(JsonObject? node, string name) => node is not null && node.TryGetPropertyValue(name, out var value) && value is not null ? value.ToString() : "0";
+    private static string FormatNullable(JsonObject? node, string name) => node is not null && node.TryGetPropertyValue(name, out var value) && value is not null ? value.ToString() : "n/a";
+    private static double Ratio(int numerator, int denominator) => denominator <= 0 ? 0 : Math.Round((double)numerator * 100.0 / denominator, 2, MidpointRounding.AwayFromZero);
+    private static double? Median(IReadOnlyList<int> values) => values.Count == 0 ? null : values.Count % 2 == 1 ? values[values.Count / 2] : (values[(values.Count / 2) - 1] + values[values.Count / 2]) / 2.0;
+
+    private static int ParseIssueNumber(string url) {
+        var token = url.TrimEnd('/').Split('/').LastOrDefault();
+        return int.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number) ? number : 0;
+    }
+
+    private static void PrintHelp() {
+        Console.WriteLine("Usage: intelligencex todo pr-watch-consolidate [options]");
+        Console.WriteLine("  --repo <owner/name>");
+        Console.WriteLine("  --max-prs <n>");
+        Console.WriteLine("  --max-flaky-retries <n>");
+        Console.WriteLine("  --stale-days <n>");
+        Console.WriteLine("  --include-drafts <bool>");
+        Console.WriteLine("  --approved-bot <login> (repeatable)");
+        Console.WriteLine("  --approved-bots <csv>");
+        Console.WriteLine("  --source <value>");
+        Console.WriteLine("  --run-link <url>");
+        Console.WriteLine("  --snapshot-dir <path>");
+        Console.WriteLine("  --rollup-path <path>");
+        Console.WriteLine("  --summary-path <path>");
+        Console.WriteLine("  --metrics-path <path>");
+        Console.WriteLine("  --metrics-history-path <path>");
+        Console.WriteLine("  --tracker-path <path>");
+        Console.WriteLine("  --publish-tracking-issue <bool>");
+        Console.WriteLine("  --tracker-issue-title <text>");
+        Console.WriteLine("  --tracker-issue-label <label> (repeatable)");
+        Console.WriteLine("  --tracker-issue-labels <csv>");
+    }
+}

--- a/IntelligenceX.Cli/Todo/PrWatchMonitorRunner.cs
+++ b/IntelligenceX.Cli/Todo/PrWatchMonitorRunner.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using IntelligenceX.Cli.GitHub;
+
+namespace IntelligenceX.Cli.Todo;
+
+internal static class PrWatchMonitorRunner {
+    private const string DefaultRepo = "EvotecIT/IntelligenceX";
+    private static readonly JsonSerializerOptions CompactJson = new() { WriteIndented = false };
+
+    private sealed class Options {
+        public string Repo { get; set; } = DefaultRepo;
+        public string PrSpec { get; set; } = string.Empty;
+        public int MaxPrs { get; set; } = 100;
+        public int MaxFlakyRetries { get; set; } = 3;
+        public bool IncludeDrafts { get; set; }
+        public string Source { get; set; } = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME") ?? "manual_cli";
+        public string? RunLink { get; set; } = ResolveRunLink();
+        public string SnapshotDir { get; set; } = Path.Combine("artifacts", "pr-watch", "snapshots");
+        public string RollupPath { get; set; } = Path.Combine("artifacts", "pr-watch", "ix-pr-watch-rollup.json");
+        public string SummaryPath { get; set; } = Path.Combine("artifacts", "pr-watch", "ix-pr-watch-summary.md");
+        public HashSet<string> ApprovedBots { get; } = new(StringComparer.OrdinalIgnoreCase) {
+            "intelligencex-review",
+            "intelligencex-review[bot]",
+            "chatgpt-codex-connector[bot]"
+        };
+    }
+
+    public static async Task<int> RunAsync(string[] args) {
+        try {
+            var options = ParseOptions(args);
+            if (options is null) {
+                PrintHelp();
+                return 0;
+            }
+
+            Directory.CreateDirectory(options.SnapshotDir);
+            foreach (var file in Directory.EnumerateFiles(options.SnapshotDir)) {
+                File.Delete(file);
+            }
+
+            var targets = await ResolveTargetsAsync(options).ConfigureAwait(false);
+            var rows = new List<JsonObject>();
+            foreach (var target in targets) {
+                var snapshot = await PrWatchConsolidationRunner.RunPrWatchSnapshotAsync(
+                    repo: options.Repo,
+                    prSpec: target,
+                    maxFlakyRetries: options.MaxFlakyRetries,
+                    phase: "observe",
+                    source: options.Source,
+                    runLink: options.RunLink,
+                    approvedBots: options.ApprovedBots).ConfigureAwait(false);
+
+                var pr = snapshot["pr"] as JsonObject ?? new JsonObject();
+                var checks = snapshot["checks"] as JsonObject ?? new JsonObject();
+                var actions = (snapshot["actions"] as JsonArray ?? new JsonArray())
+                    .OfType<JsonObject>()
+                    .Select(static action => ReadString(action, "name"))
+                    .Where(static name => !string.IsNullOrWhiteSpace(name))
+                    .ToArray();
+
+                var number = ReadInt(pr, "number");
+                WriteJson(Path.Combine(options.SnapshotDir, $"pr-{number.ToString(CultureInfo.InvariantCulture)}.json"), snapshot);
+                rows.Add(new JsonObject {
+                    ["number"] = number,
+                    ["url"] = ReadString(pr, "url"),
+                    ["headSha"] = ReadString(pr, "headSha"),
+                    ["stopReason"] = ReadString(snapshot, "stopReason"),
+                    ["actions"] = new JsonArray(actions.Select(static action => (JsonNode)action).ToArray()),
+                    ["checks"] = new JsonObject {
+                        ["passedCount"] = ReadInt(checks, "passedCount"),
+                        ["failedCount"] = ReadInt(checks, "failedCount"),
+                        ["pendingCount"] = ReadInt(checks, "pendingCount")
+                    }
+                });
+            }
+
+            var rollup = BuildRollup(options, rows);
+            WriteJson(options.RollupPath, rollup);
+            WriteText(options.SummaryPath, BuildSummary(options, rollup));
+            AppendStepSummary(options.SummaryPath);
+            return 0;
+        } catch (Exception ex) {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+    }
+
+    private static Options? ParseOptions(string[] args) {
+        if (args.Length > 0 && IsHelp(args[0])) {
+            return null;
+        }
+        var options = new Options();
+        for (var i = 0; i < args.Length; i++) {
+            var arg = args[i];
+            switch (arg) {
+                case "--repo": options.Repo = Next(args, ref i, arg); break;
+                case "--pr": options.PrSpec = Next(args, ref i, arg); break;
+                case "--max-prs": options.MaxPrs = ParseInt(Next(args, ref i, arg), options.MaxPrs, arg, 1, 2000); break;
+                case "--max-flaky-retries": options.MaxFlakyRetries = ParseInt(Next(args, ref i, arg), options.MaxFlakyRetries, arg, 1, 50); break;
+                case "--include-drafts": options.IncludeDrafts = ParseBool(Next(args, ref i, arg), options.IncludeDrafts, arg); break;
+                case "--approved-bot": options.ApprovedBots.Add(Next(args, ref i, arg)); break;
+                case "--approved-bots": AddCsv(options.ApprovedBots, Next(args, ref i, arg)); break;
+                case "--source": options.Source = Next(args, ref i, arg); break;
+                case "--run-link": options.RunLink = Next(args, ref i, arg); break;
+                case "--snapshot-dir": options.SnapshotDir = Next(args, ref i, arg); break;
+                case "--rollup-path": options.RollupPath = Next(args, ref i, arg); break;
+                case "--summary-path": options.SummaryPath = Next(args, ref i, arg); break;
+                default: throw new InvalidOperationException($"Unknown option: {arg}");
+            }
+        }
+        return options;
+    }
+
+    private static async Task<List<string>> ResolveTargetsAsync(Options options) {
+        if (!string.IsNullOrWhiteSpace(options.PrSpec)) {
+            return new List<string> { options.PrSpec };
+        }
+        var (exitCode, stdOut, stdErr) = await GhCli.RunAsync(
+            "pr", "list",
+            "--repo", options.Repo,
+            "--state", "open",
+            "--limit", options.MaxPrs.ToString(CultureInfo.InvariantCulture),
+            "--json", "number,isDraft").ConfigureAwait(false);
+        if (exitCode != 0) {
+            throw new InvalidOperationException($"gh pr list failed: {stdErr.Trim()}");
+        }
+        var list = new List<string>();
+        var root = JsonNode.Parse(stdOut) as JsonArray ?? new JsonArray();
+        foreach (var node in root.OfType<JsonObject>()) {
+            if (!options.IncludeDrafts && ReadBool(node, "isDraft")) {
+                continue;
+            }
+            var number = ReadInt(node, "number");
+            if (number > 0) {
+                list.Add(number.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+        return list.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    private static JsonObject BuildRollup(Options options, IReadOnlyList<JsonObject> rows) {
+        var stopReasons = rows
+            .Select(static row => ReadString(row, "stopReason"))
+            .Select(static reason => string.IsNullOrWhiteSpace(reason) ? "none" : reason)
+            .GroupBy(static reason => reason, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static group => group.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(group => (JsonNode)new JsonObject { ["reason"] = group.Key, ["count"] = group.Count() }).ToArray();
+        var actionCounts = rows
+            .SelectMany(static row => (row["actions"] as JsonArray ?? new JsonArray()).Select(static action => action?.ToString() ?? string.Empty))
+            .Where(static action => !string.IsNullOrWhiteSpace(action))
+            .GroupBy(static action => action, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static group => group.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(group => (JsonNode)new JsonObject { ["action"] = group.Key, ["count"] = group.Count() }).ToArray();
+
+        return new JsonObject {
+            ["schema"] = "intelligencex.pr-watch.rollup.v1",
+            ["repo"] = options.Repo,
+            ["generatedAtUtc"] = DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture),
+            ["totalSnapshots"] = rows.Count,
+            ["stopReasons"] = new JsonArray(stopReasons),
+            ["actionCounts"] = new JsonArray(actionCounts),
+            ["prs"] = new JsonArray(rows.OrderBy(static row => ReadInt(row, "number")).Select(static row => (JsonNode)row).ToArray())
+        };
+    }
+
+    private static string BuildSummary(Options options, JsonObject rollup) {
+        var builder = new StringBuilder();
+        builder.AppendLine("# IX PR Babysit Monitor (Observe)");
+        builder.AppendLine();
+        builder.AppendLine($"- Generated: {DateTimeOffset.UtcNow.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture)}");
+        builder.AppendLine($"- Repo: `{options.Repo}`");
+        if (!string.IsNullOrWhiteSpace(options.RunLink)) {
+            builder.AppendLine($"- Workflow run: {options.RunLink}");
+        }
+        builder.AppendLine();
+        builder.AppendLine("## Snapshot counts");
+        builder.AppendLine($"- PRs scanned: {ReadInt(rollup, "totalSnapshots")}");
+        return builder.ToString();
+    }
+
+    private static string? ResolveRunLink() {
+        var server = Environment.GetEnvironmentVariable("GITHUB_SERVER_URL");
+        var repo = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+        var runId = Environment.GetEnvironmentVariable("GITHUB_RUN_ID");
+        return string.IsNullOrWhiteSpace(server) || string.IsNullOrWhiteSpace(repo) || string.IsNullOrWhiteSpace(runId) ? null : $"{server.TrimEnd('/')}/{repo}/actions/runs/{runId}";
+    }
+
+    private static string Next(string[] args, ref int index, string optionName) { if (index + 1 >= args.Length) throw new InvalidOperationException($"{optionName} requires a value."); return args[++index]; }
+    private static int ParseInt(string raw, int current, string optionName, int min, int max) { if (string.IsNullOrWhiteSpace(raw)) return current; if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v) || v < min || v > max) throw new InvalidOperationException($"{optionName} must be between {min} and {max}."); return v; }
+    private static bool ParseBool(string raw, bool current, string optionName) { if (string.IsNullOrWhiteSpace(raw)) return current; if (bool.TryParse(raw, out var v)) return v; throw new InvalidOperationException($"{optionName} must be true/false."); }
+    private static void AddCsv(HashSet<string> values, string csv) { foreach (var part in csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)) values.Add(part); }
+    private static bool IsHelp(string value) => value.Equals("-h", StringComparison.OrdinalIgnoreCase) || value.Equals("--help", StringComparison.OrdinalIgnoreCase) || value.Equals("help", StringComparison.OrdinalIgnoreCase);
+    private static int ReadInt(JsonObject node, string name) => node.TryGetPropertyValue(name, out var value) && value is JsonValue jv && jv.TryGetValue<int>(out var v) ? v : 0;
+    private static bool ReadBool(JsonObject node, string name) => node.TryGetPropertyValue(name, out var value) && value is JsonValue jv && jv.TryGetValue<bool>(out var v) && v;
+    private static string ReadString(JsonObject node, string name) => node.TryGetPropertyValue(name, out var value) && value is JsonValue jv && jv.TryGetValue<string>(out var text) ? text ?? string.Empty : string.Empty;
+    private static void WriteJson(string path, JsonNode node) { EnsureDirectory(path); File.WriteAllText(path, node.ToJsonString(CompactJson)); }
+    private static void WriteText(string path, string text) { EnsureDirectory(path); File.WriteAllText(path, text, Encoding.UTF8); }
+    private static void EnsureDirectory(string path) { var dir = Path.GetDirectoryName(path); if (!string.IsNullOrWhiteSpace(dir)) Directory.CreateDirectory(dir); }
+    private static void AppendStepSummary(string path) { var step = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY"); if (!string.IsNullOrWhiteSpace(step) && File.Exists(path)) File.AppendAllText(step, File.ReadAllText(path) + Environment.NewLine, Encoding.UTF8); }
+
+    private static void PrintHelp() {
+        Console.WriteLine("Usage: intelligencex todo pr-watch-monitor [options]");
+        Console.WriteLine("  --repo <owner/name>");
+        Console.WriteLine("  --pr <number|url>");
+        Console.WriteLine("  --max-prs <n>");
+        Console.WriteLine("  --max-flaky-retries <n>");
+        Console.WriteLine("  --include-drafts <bool>");
+        Console.WriteLine("  --approved-bot <login> (repeatable)");
+        Console.WriteLine("  --approved-bots <csv>");
+        Console.WriteLine("  --source <value>");
+        Console.WriteLine("  --run-link <url>");
+        Console.WriteLine("  --snapshot-dir <path>");
+        Console.WriteLine("  --rollup-path <path>");
+        Console.WriteLine("  --summary-path <path>");
+    }
+}

--- a/IntelligenceX.Cli/Todo/TodoRunner.cs
+++ b/IntelligenceX.Cli/Todo/TodoRunner.cs
@@ -27,6 +27,9 @@ internal static class TodoRunner {
             "project-view-checklist" => ProjectViewChecklistRunner.RunAsync(rest),
             "project-view-apply" => ProjectViewApplyRunner.RunAsync(rest),
             "pr-watch" => PrWatchRunner.RunAsync(rest),
+            "pr-watch-monitor" => PrWatchMonitorRunner.RunAsync(rest),
+            "pr-watch-assist-retry" => PrWatchAssistRetryRunner.RunAsync(rest),
+            "pr-watch-consolidate" => PrWatchConsolidationRunner.RunAsync(rest),
             _ => Task.FromResult(PrintHelpReturn(command))
         };
     }
@@ -58,6 +61,9 @@ internal static class TodoRunner {
         Console.WriteLine("  intelligencex todo project-view-checklist [options]");
         Console.WriteLine("  intelligencex todo project-view-apply [options]");
         Console.WriteLine("  intelligencex todo pr-watch [options]");
+        Console.WriteLine("  intelligencex todo pr-watch-monitor [options]");
+        Console.WriteLine("  intelligencex todo pr-watch-assist-retry [options]");
+        Console.WriteLine("  intelligencex todo pr-watch-consolidate [options]");
         Console.WriteLine();
         Console.WriteLine("Use `intelligencex todo sync-bot-feedback --help` for options.");
         Console.WriteLine("Use `intelligencex todo build-triage-index --help` for options.");
@@ -70,5 +76,8 @@ internal static class TodoRunner {
         Console.WriteLine("Use `intelligencex todo project-view-checklist --help` for options.");
         Console.WriteLine("Use `intelligencex todo project-view-apply --help` for options.");
         Console.WriteLine("Use `intelligencex todo pr-watch --help` for options.");
+        Console.WriteLine("Use `intelligencex todo pr-watch-monitor --help` for options.");
+        Console.WriteLine("Use `intelligencex todo pr-watch-assist-retry --help` for options.");
+        Console.WriteLine("Use `intelligencex todo pr-watch-consolidate --help` for options.");
     }
 }

--- a/IntelligenceX.Tests/Program.Todo.cs
+++ b/IntelligenceX.Tests/Program.Todo.cs
@@ -27,6 +27,9 @@ internal static partial class Program {
             AssertContainsText(output, "project-view-checklist", "todo help includes project view checklist command");
             AssertContainsText(output, "project-view-apply", "todo help includes project view apply command");
             AssertContainsText(output, "pr-watch", "todo help includes pr-watch command");
+            AssertContainsText(output, "pr-watch-monitor", "todo help includes pr-watch-monitor command");
+            AssertContainsText(output, "pr-watch-assist-retry", "todo help includes pr-watch-assist-retry command");
+            AssertContainsText(output, "pr-watch-consolidate", "todo help includes pr-watch-consolidate command");
         } finally {
             Console.SetOut(originalOut);
             Console.SetError(originalError);

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -134,41 +134,54 @@ Default outputs:
   - `artifacts/pr-watch/ix-pr-watch-audit.jsonl`
 
 Workflow automation:
-- `.github/workflows/ix-pr-babysit-monitor.yml` runs in observe mode on an hourly schedule.
+- `.github/workflows/ix-pr-babysit-monitor.yml` runs in observe mode on an hourly schedule using `todo pr-watch-monitor`.
 - Manual targeted run via `workflow_dispatch` supports:
   - `pr` (specific PR number/URL),
   - `max_prs`,
   - `max_flaky_retries`,
   - `include_drafts`,
   - `approved_bots`.
-- `.github/workflows/ix-pr-babysit-assist-retry.yml` provides manual guarded retry assist for one PR:
+- `.github/workflows/ix-pr-babysit-assist-retry.yml` provides manual guarded retry assist for one PR using `todo pr-watch-assist-retry`:
   - requires `confirm_apply_retries=RETRY_CHECKS`,
   - executes `pr-watch --apply-retry` in once mode,
   - persists retry state and cooldown metadata in `artifacts/pr-watch/ix-pr-watch-*.json`.
-- `.github/workflows/ix-pr-babysit-nightly-consolidation.yml` runs daily consolidation (supports `workflow_dispatch` and reusable `workflow_call`) with:
+- `.github/workflows/ix-pr-babysit-nightly-consolidation.yml` runs daily consolidation using `todo pr-watch-consolidate` (supports `workflow_dispatch` and reusable `workflow_call`) with:
   - `max_prs`,
   - `stale_days`,
   - `include_drafts`,
-  - `approved_bots`.
+  - `approved_bots`,
+  - `source`.
+- Optional tracker issue controls:
+  - `publish_tracking_issue`,
+  - `tracker_issue_title`,
+  - `tracker_issue_labels`.
 - `.github/workflows/ix-pr-babysit-weekly-governance.yml` runs weekly governance consolidation by calling nightly consolidation with weekly defaults:
   - `max_prs=300`,
   - `stale_days=14`,
-  - `source=weekly-governance`.
+  - `source=weekly-governance`,
+  - `publish_tracking_issue=true`.
 - Workflow artifacts:
   - per-PR snapshots under `artifacts/pr-watch/snapshots/`,
   - rollup JSON `artifacts/pr-watch/ix-pr-watch-rollup.json`,
   - markdown summary `artifacts/pr-watch/ix-pr-watch-summary.md`,
   - audit log JSONL `artifacts/pr-watch/ix-pr-watch-audit.jsonl`,
   - nightly rollup JSON `artifacts/pr-watch/ix-pr-watch-nightly-rollup.json`,
-  - nightly markdown summary `artifacts/pr-watch/ix-pr-watch-nightly-summary.md`.
+  - nightly markdown summary `artifacts/pr-watch/ix-pr-watch-nightly-summary.md`,
+  - nightly metrics JSON `artifacts/pr-watch/ix-pr-watch-nightly-metrics.json`,
+  - nightly metrics history JSON `artifacts/pr-watch/ix-pr-watch-nightly-metrics-history.json`,
+  - nightly tracker issue body markdown `artifacts/pr-watch/ix-pr-watch-nightly-tracker.md`.
+- Tracker issue automation:
+  - source-scoped upsert marker: `<!-- intelligencex:pr-watch-rollup-tracker:<source> -->`
+  - create/update open issue per source with latest bucket/metric snapshot
+  - manual dispatch defaults to tracker publishing off unless explicitly enabled
 
 Cadence matrix:
 
 | Cadence | Workflow | Defaults | Goal |
 | --- | --- | --- | --- |
 | Hourly | `ix-pr-babysit-monitor.yml` | `max_prs=100`, observe mode | detect fresh CI/review regressions quickly |
-| Daily | `ix-pr-babysit-nightly-consolidation.yml` | `stale_days=7`, `max_prs=200` | build no-progress backlog for next-day triage |
-| Weekly | `ix-pr-babysit-weekly-governance.yml` | `stale_days=14`, `max_prs=300` | governance review of persistent blockers/churn patterns |
+| Daily | `ix-pr-babysit-nightly-consolidation.yml` | `stale_days=7`, `max_prs=200` | build no-progress backlog, publish daily tracker snapshot, and watch metric deltas |
+| Weekly | `ix-pr-babysit-weekly-governance.yml` | `stale_days=14`, `max_prs=300` | governance review of persistent blockers/churn patterns and weekly trend validation |
 
 ## Vision Check (Assistive)
 


### PR DESCRIPTION
## Summary
This PR converts PR babysit automation from large shell-heavy workflow steps into internal CLI engine commands.

New engine commands:
- `intelligencex todo pr-watch-monitor`
- `intelligencex todo pr-watch-assist-retry`
- `intelligencex todo pr-watch-consolidate`

Workflows are now thin orchestration wrappers that restore cache, build the CLI once, invoke the engine command, and publish artifacts.

## Why this change
- Reduces YAML complexity and shell/jq drift.
- Moves logic into typed, testable C# code paths.
- Keeps behavior consistent between local runs and CI workflow runs.
- Creates a clearer maintainability boundary: workflows orchestrate, engine computes.

## What this adds
- Monitor sweep runner for observe-mode snapshots + rollup summary.
- Guarded assist-retry runner for single PR retry execution with explicit confirmation token.
- Consolidation runner for nightly/weekly rollups, metrics, metrics history, and optional source-scoped tracker issue upsert.
- Tracker issue label handling on both create and update flows.
- Updated docs and CLI help for cadence, command usage, and artifact contracts.
- TODO help test coverage for new command names.

## Cadence model (implemented)
- Hourly: `ix-pr-babysit-monitor.yml` (observe sweep)
- Daily: `ix-pr-babysit-nightly-consolidation.yml` (rollup + metrics + optional tracker upsert)
- Weekly: `ix-pr-babysit-weekly-governance.yml` (calls nightly workflow with weekly defaults)
- Manual assist: `ix-pr-babysit-assist-retry.yml` (single PR, guarded)

## Safety / non-goals
- No autonomous merge behavior.
- No autonomous policy mutation.
- Retry mutation remains explicit/manual and confirmation-gated.
- Observe/consolidation paths remain non-mutating except optional tracker issue upsert.

## Validation
- `dotnet build IntelligenceX.sln -c Release /m:1`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `dotnet test IntelligenceX.sln -c Release /m:1` *(known existing baseline failure in `IntelligenceX.Tools.Tests.ToolResponseContractGuardrailTests` for `IntelligenceX.Tools.Common.ToolNextActionModel.Arguments`; unrelated to this PR)*
