### PR TITLE
chore(pr-babysit): polish dispatch args and fallback edge tests

### DIFF
--- a/.github/workflows/ix-pr-babysit-monitor.yml
+++ b/.github/workflows/ix-pr-babysit-monitor.yml
@@ -109,19 +109,24 @@ jobs:
             SOURCE_TAG="${SOURCE_TAG}:${EVENT_ACTION}"
           fi
 
-          dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll \
-            todo pr-watch-monitor \
-            --repo "${{ github.repository }}" \
-            --pr "${PR_SPEC}" \
-            --max-prs "${MAX_PRS}" \
-            --max-flaky-retries "${MAX_FLAKY_RETRIES}" \
-            --include-drafts "${INCLUDE_DRAFTS}" \
-            --approved-bots "${APPROVED_BOTS}" \
-            --source "${SOURCE_TAG}" \
-            --run-link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --snapshot-dir "${PR_WATCH_SNAPSHOT_DIR}" \
-            --rollup-path "${PR_WATCH_ROLLUP_PATH}" \
-            --summary-path "${PR_WATCH_SUMMARY_PATH}"
+          ARGS=(
+            "todo" "pr-watch-monitor"
+            "--repo" "${{ github.repository }}"
+            "--max-prs" "${MAX_PRS}"
+            "--max-flaky-retries" "${MAX_FLAKY_RETRIES}"
+            "--include-drafts" "${INCLUDE_DRAFTS}"
+            "--approved-bots" "${APPROVED_BOTS}"
+            "--source" "${SOURCE_TAG}"
+            "--run-link" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            "--snapshot-dir" "${PR_WATCH_SNAPSHOT_DIR}"
+            "--rollup-path" "${PR_WATCH_ROLLUP_PATH}"
+            "--summary-path" "${PR_WATCH_SUMMARY_PATH}"
+          )
+          if [ -n "${PR_SPEC}" ]; then
+            ARGS+=("--pr" "${PR_SPEC}")
+          fi
+
+          dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll "${ARGS[@]}"
 
       - name: Upload pr-watch artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -230,6 +230,8 @@ internal static partial class Program {
         failed += Run("Todo pr-watch normalize source sanitizes unsafe chars", TestPrWatchNormalizeSourceSanitizesUnsafeChars);
         failed += Run("Todo pr-watch planned audit includes dedupe and reason", TestPrWatchBuildPlannedAuditRecordsIncludesDedupeAndReason);
         failed += Run("Todo pr-watch authenticated login fallback uses actor env", TestPrWatchResolveAuthenticatedLoginFallbackUsesActorEnv);
+        failed += Run("Todo pr-watch authenticated login fallback prefers actor over triggering actor", TestPrWatchResolveAuthenticatedLoginFallbackPrefersActorOverTriggeringActor);
+        failed += Run("Todo pr-watch authenticated login fallback empty when unset", TestPrWatchResolveAuthenticatedLoginFallbackReturnsEmptyWhenUnset);
         failed += Run("Todo unknown command", TestTodoUnknownCommandShowsMessage);
         failed += Run("Todo bot feedback render LF", TestBotFeedbackRenderHonorsLfNewlines);
         failed += Run("Todo bot feedback parse existing", TestBotFeedbackParseExistingPrBlockExtractsTasks);

--- a/IntelligenceX.Tests/Program.Todo.PrWatch.cs
+++ b/IntelligenceX.Tests/Program.Todo.PrWatch.cs
@@ -231,5 +231,33 @@ internal static partial class Program {
             Environment.SetEnvironmentVariable("GITHUB_TRIGGERING_ACTOR", originalTriggeringActor);
         }
     }
+
+    private static void TestPrWatchResolveAuthenticatedLoginFallbackPrefersActorOverTriggeringActor() {
+        var originalActor = Environment.GetEnvironmentVariable("GITHUB_ACTOR");
+        var originalTriggeringActor = Environment.GetEnvironmentVariable("GITHUB_TRIGGERING_ACTOR");
+        try {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", "primary-actor");
+            Environment.SetEnvironmentVariable("GITHUB_TRIGGERING_ACTOR", "secondary-actor");
+            var login = IntelligenceX.Cli.Todo.PrWatchRunner.ResolveAuthenticatedLoginFallback();
+            AssertEqual("primary-actor", login, "fallback should prefer GITHUB_ACTOR over GITHUB_TRIGGERING_ACTOR");
+        } finally {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", originalActor);
+            Environment.SetEnvironmentVariable("GITHUB_TRIGGERING_ACTOR", originalTriggeringActor);
+        }
+    }
+
+    private static void TestPrWatchResolveAuthenticatedLoginFallbackReturnsEmptyWhenUnset() {
+        var originalActor = Environment.GetEnvironmentVariable("GITHUB_ACTOR");
+        var originalTriggeringActor = Environment.GetEnvironmentVariable("GITHUB_TRIGGERING_ACTOR");
+        try {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", null);
+            Environment.SetEnvironmentVariable("GITHUB_TRIGGERING_ACTOR", null);
+            var login = IntelligenceX.Cli.Todo.PrWatchRunner.ResolveAuthenticatedLoginFallback();
+            AssertEqual(string.Empty, login, "fallback should return empty string when actor env vars are missing");
+        } finally {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", originalActor);
+            Environment.SetEnvironmentVariable("GITHUB_TRIGGERING_ACTOR", originalTriggeringActor);
+        }
+    }
 #endif
 }


### PR DESCRIPTION
## Summary
Small follow-up polish after PR babysitter phase 7 merge.

## Changes
- Workflow arg handling hardening (`.github/workflows/ix-pr-babysit-monitor.yml`):
  - builds CLI args in an array,
  - appends `--pr` only when `PR_SPEC` is non-empty,
  - keeps behavior explicit for schedule/event runs without manual PR targeting.
- Added fallback edge-case tests for `ResolveAuthenticatedLoginFallback()`:
  - prefer `GITHUB_ACTOR` when both actor env vars are set,
  - return empty string when both are unset.
- Registered both tests in harness (`Program.Reviewer.MainHarness.cs`).

## Why
- Removes ambiguity around passing an empty `--pr` value.
- Locks auth fallback behavior with explicit precedence/empty-state regression tests.

## Validation
- `dotnet test IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release /m:1`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
