### PR TITLE
fix(chat): harden turn lifecycle and channelize assistant drafts

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowAssistantTurnLifecycleTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowAssistantTurnLifecycleTests.cs
@@ -1,0 +1,72 @@
+using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.App;
+using IntelligenceX.Chat.App.Rendering;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Guards assistant turn lifecycle transitions so late streaming events cannot mutate finalized turns.
+/// </summary>
+public sealed class MainWindowAssistantTurnLifecycleTests {
+    /// <summary>
+    /// Ensures draft mutations are blocked once a turn is finalized or failed.
+    /// </summary>
+    [Fact]
+    public void CanApplyAssistantTurnDraftUpdate_DeniesTerminalStages() {
+        Assert.False(MainWindow.CanApplyAssistantTurnDraftUpdate(MainWindow.AssistantTurnLifecycleStage.Finalized));
+        Assert.False(MainWindow.CanApplyAssistantTurnDraftUpdate(MainWindow.AssistantTurnLifecycleStage.Failed));
+    }
+
+    /// <summary>
+    /// Ensures tool-related statuses promote lifecycle state from draft to tool phase.
+    /// </summary>
+    [Fact]
+    public void PromoteAssistantTurnLifecycleForStatus_PromotesToolStageForToolStatuses() {
+        var stage = MainWindow.PromoteAssistantTurnLifecycleForStatus(
+            MainWindow.AssistantTurnLifecycleStage.Draft,
+            ChatStatusCodes.ToolRunning);
+
+        Assert.Equal(MainWindow.AssistantTurnLifecycleStage.Tool, stage);
+    }
+
+    /// <summary>
+    /// Ensures terminal lifecycle stages remain immutable under late status updates.
+    /// </summary>
+    [Fact]
+    public void PromoteAssistantTurnLifecycleForStatus_LeavesTerminalStagesUntouched() {
+        var stage = MainWindow.PromoteAssistantTurnLifecycleForStatus(
+            MainWindow.AssistantTurnLifecycleStage.Finalized,
+            ChatStatusCodes.ToolRunning);
+
+        Assert.Equal(MainWindow.AssistantTurnLifecycleStage.Finalized, stage);
+    }
+
+    /// <summary>
+    /// Ensures terminal lifecycle transitions are idempotent and never regress from finalized to failed.
+    /// </summary>
+    [Fact]
+    public void ResolveAssistantTurnLifecycleTerminalTransition_IsIdempotentAfterFinalization() {
+        var first = MainWindow.ResolveAssistantTurnLifecycleTerminalTransition(
+            MainWindow.AssistantTurnLifecycleStage.Tool,
+            succeeded: true);
+        var second = MainWindow.ResolveAssistantTurnLifecycleTerminalTransition(
+            first,
+            succeeded: false);
+
+        Assert.Equal(MainWindow.AssistantTurnLifecycleStage.Finalized, first);
+        Assert.Equal(MainWindow.AssistantTurnLifecycleStage.Finalized, second);
+    }
+
+    /// <summary>
+    /// Ensures tool statuses promote assistant bubbles into the tool-activity channel.
+    /// </summary>
+    [Fact]
+    public void ResolveAssistantBubbleChannelForStatus_PromotesToolActivityChannel() {
+        var channel = MainWindow.ResolveAssistantBubbleChannelForStatus(
+            AssistantBubbleChannelKind.DraftThinking,
+            ChatStatusCodes.ToolBatchProgress);
+
+        Assert.Equal(AssistantBubbleChannelKind.ToolActivity, channel);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
@@ -156,6 +156,34 @@ public sealed class TranscriptHtmlFormatterTests {
     }
 
     /// <summary>
+    /// Ensures tool-activity decorations render a distinct channel style and trace affordance.
+    /// </summary>
+    [Fact]
+    public void Format_RendersToolActivityChannelWhenDecorationRequestsIt() {
+        var options = MarkdownRendererPresets.CreateChatStrictMinimal();
+        var now = new DateTime(2026, 2, 23, 7, 41, 0, DateTimeKind.Local);
+        var messages = new (string Role, string Text, DateTime Time, string? Model)[] {
+            ("Assistant", "Running cross-DC checks...", now, "gpt-5.3-codex")
+        };
+        var html = TranscriptHtmlFormatter.Format(
+            messages,
+            "HH:mm:ss",
+            options,
+            new Dictionary<int, TranscriptMessageDecoration> {
+                [0] = new TranscriptMessageDecoration {
+                    Channel = AssistantBubbleChannelKind.ToolActivity,
+                    Timeline = new[] { "run Eventlog Live Query", "done Eventlog Live Query" }
+                }
+            });
+
+        Assert.Contains("assistant-tool-meta-pill", html, StringComparison.Ordinal);
+        Assert.Contains("Tool Activity", html, StringComparison.Ordinal);
+        Assert.Contains("bubble-tool-activity", html, StringComparison.Ordinal);
+        Assert.Contains("assistant-turn-live-pill'>Tool</span>", html, StringComparison.Ordinal);
+        Assert.Contains("assistant-turn-trace-title'>Tool trace</span>", html, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Ensures trace sections can be suppressed while keeping provisional bubble styling.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.App.Conversation;
+using IntelligenceX.Chat.App.Rendering;
 using IntelligenceX.Chat.Client;
 using Microsoft.UI.Xaml;
 
@@ -282,6 +283,10 @@ public sealed partial class MainWindow : Window {
     }
 
     private async Task ApplyChatResultAsync(ChatTurnContext turn, ChatResultMessage result) {
+        if (!TryFinalizeActiveTurnAssistantState(turn.Conversation, succeeded: true)) {
+            return;
+        }
+
         var completion = CompleteTurnLatencyTracking(turn.RequestId, DateTime.UtcNow);
         if (completion is not null) {
             RegisterTurnSuccessReliability(completion);
@@ -339,6 +344,7 @@ public sealed partial class MainWindow : Window {
             ReplaceLastAssistantText(conversation, assistantText);
         }
         BindActiveTurnAssistantMessage(conversation);
+        SetActiveTurnAssistantChannel(conversation, AssistantBubbleChannelKind.Final);
         SetActiveTurnAssistantProvisional(conversation, provisional: false, preferProvisionalEvents: false);
         ApplyFinalAssistantTurnTimeline(conversation, result.TurnTimelineEvents);
         _assistantStreamingState.ClearReceivedDelta();
@@ -356,6 +362,10 @@ public sealed partial class MainWindow : Window {
     }
 
     private async Task ApplyTurnFailureAsync(ChatTurnContext turn, AssistantTurnOutcome outcome) {
+        if (!TryFinalizeActiveTurnAssistantState(turn.Conversation, succeeded: false)) {
+            return;
+        }
+
         var completion = CompleteTurnLatencyTracking(turn.RequestId, DateTime.UtcNow);
         if (completion is not null) {
             RegisterTurnFailureReliability(completion, outcome);
@@ -384,6 +394,7 @@ public sealed partial class MainWindow : Window {
             ReplaceLastAssistantText(turn.Conversation, AssistantTurnOutcomeFormatter.Format(outcome));
         }
         BindActiveTurnAssistantMessage(turn.Conversation);
+        SetActiveTurnAssistantChannel(turn.Conversation, AssistantBubbleChannelKind.Final);
         SetActiveTurnAssistantProvisional(turn.Conversation, provisional: false, preferProvisionalEvents: false);
 
         turn.Conversation.UpdatedUtc = DateTime.UtcNow;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using IntelligenceX.Chat.Abstractions.Policy;
 using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.App.Conversation;
+using IntelligenceX.Chat.App.Rendering;
 using IntelligenceX.Chat.Client;
 using Microsoft.UI;
 using Microsoft.UI.Dispatching;
@@ -89,6 +90,7 @@ public sealed partial class MainWindow : Window {
                     }
 
                     MarkTurnStatusStage(status);
+                    var assistantStatusSignalChanged = ApplyActiveTurnStatusSignal(requestConversation, status.Status);
                     var routingInsightUpdated = ApplyToolRoutingInsight(status);
                     var activityText = IsTerminalChatStatus(status.Status) ? null : FormatActivityText(status);
                     var timelineChanged = AppendActivityTimeline(status, activityText ?? string.Empty);
@@ -105,7 +107,7 @@ public sealed partial class MainWindow : Window {
                     if (timelineChanged) {
                         RequestServiceDrivenSessionPublish();
                     }
-                    if (assistantTimelineChanged
+                    if ((assistantTimelineChanged || assistantStatusSignalChanged)
                         && string.Equals(requestConversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
                         QueueTranscriptRender("chat_status_timeline");
                     }
@@ -194,6 +196,9 @@ public sealed partial class MainWindow : Window {
         if (delta.Length == 0) {
             return;
         }
+        if (!TryAcceptActiveTurnDraftMutation(conversation)) {
+            return;
+        }
 
         var normalizedPreview = _assistantStreamingState.AppendDeltaAndNormalizePreview(
             delta,
@@ -203,6 +208,7 @@ public sealed partial class MainWindow : Window {
             normalizedPreview);
         conversation.UpdatedUtc = DateTime.UtcNow;
         BindActiveTurnAssistantMessage(conversation);
+        SetActiveTurnAssistantChannel(conversation, AssistantBubbleChannelKind.DraftThinking);
         SetActiveTurnAssistantProvisional(conversation, provisional: true, preferProvisionalEvents);
         if (string.Equals(conversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
             QueueTranscriptRender(renderReason);
@@ -211,7 +217,7 @@ public sealed partial class MainWindow : Window {
 
     private void ApplyInterimAssistantResult(ConversationRuntime conversation, string? text) {
         var interimText = (text ?? string.Empty).Trim();
-        if (interimText.Length == 0 || !TryMarkActiveTurnInterimResult(interimText)) {
+        if (interimText.Length == 0 || !TryAcceptActiveTurnDraftMutation(conversation) || !TryMarkActiveTurnInterimResult(interimText)) {
             return;
         }
 
@@ -225,6 +231,7 @@ public sealed partial class MainWindow : Window {
         }
         conversation.UpdatedUtc = DateTime.UtcNow;
         BindActiveTurnAssistantMessage(conversation);
+        SetActiveTurnAssistantChannel(conversation, AssistantBubbleChannelKind.DraftThinking);
         // Interim snapshots are draft-by-definition and should stay visually distinct
         // from the finalized assistant response.
         SetActiveTurnAssistantProvisional(conversation, provisional: true, preferProvisionalEvents: false);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.AssistantTurnVisuals.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.AssistantTurnVisuals.cs
@@ -14,6 +14,12 @@ public sealed partial class MainWindow : Window {
             _activeTurnAssistantMessageIndex = -1;
             _activeTurnAssistantPendingTimeline.Clear();
             _activeTurnAssistantProvisional = false;
+            _activeTurnLifecycleStage = normalizedConversationId.Length == 0
+                ? AssistantTurnLifecycleStage.Idle
+                : AssistantTurnLifecycleStage.Draft;
+            _activeTurnAssistantChannel = normalizedConversationId.Length == 0
+                ? AssistantBubbleChannelKind.Final
+                : AssistantBubbleChannelKind.DraftThinking;
             _activeTurnUsesProvisionalEvents = false;
             _activeTurnInterimResultSeen = false;
             _activeTurnInterimFingerprint = null;
@@ -33,6 +39,8 @@ public sealed partial class MainWindow : Window {
                 _activeTurnAssistantMessageIndex = -1;
                 _activeTurnAssistantPendingTimeline.Clear();
                 _activeTurnAssistantProvisional = false;
+                _activeTurnLifecycleStage = AssistantTurnLifecycleStage.Idle;
+                _activeTurnAssistantChannel = AssistantBubbleChannelKind.Final;
                 _activeTurnUsesProvisionalEvents = false;
                 _activeTurnInterimResultSeen = false;
                 _activeTurnInterimFingerprint = null;
@@ -93,6 +101,7 @@ public sealed partial class MainWindow : Window {
             _activeTurnAssistantMessageIndex = messageIndex;
             var state = GetOrCreateAssistantVisualState(conversationId, messageIndex);
             state.IsProvisional = _activeTurnAssistantProvisional;
+            state.Channel = _activeTurnAssistantChannel;
             for (var i = 0; i < _activeTurnAssistantPendingTimeline.Count; i++) {
                 AppendTimelineLabel(state.Timeline, _activeTurnAssistantPendingTimeline[i]);
             }
@@ -115,6 +124,9 @@ public sealed partial class MainWindow : Window {
 
         lock (_turnDiagnosticsSync) {
             if (!string.Equals(_activeTurnAssistantConversationId, conversationId, StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+            if (IsAssistantTurnLifecycleTerminal(_activeTurnLifecycleStage)) {
                 return false;
             }
 
@@ -160,6 +172,35 @@ public sealed partial class MainWindow : Window {
         }
     }
 
+    private bool SetActiveTurnAssistantChannel(ConversationRuntime conversation, AssistantBubbleChannelKind channel) {
+        var conversationId = (conversation.Id ?? string.Empty).Trim();
+        if (conversationId.Length == 0) {
+            return false;
+        }
+
+        lock (_turnDiagnosticsSync) {
+            if (!string.Equals(_activeTurnAssistantConversationId, conversationId, StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            var changed = false;
+            if (_activeTurnAssistantChannel != channel) {
+                _activeTurnAssistantChannel = channel;
+                changed = true;
+            }
+
+            if (_activeTurnAssistantMessageIndex >= 0) {
+                var state = GetOrCreateAssistantVisualState(conversationId, _activeTurnAssistantMessageIndex);
+                if (state.Channel != channel) {
+                    state.Channel = channel;
+                    changed = true;
+                }
+            }
+
+            return changed;
+        }
+    }
+
     private bool ShouldUseProvisionalEventsForActiveTurn(ConversationRuntime conversation) {
         var conversationId = (conversation.Id ?? string.Empty).Trim();
         if (conversationId.Length == 0) {
@@ -183,6 +224,172 @@ public sealed partial class MainWindow : Window {
         return provisionalModePreferredForTurn && hasReceivedProvisionalFragment;
     }
 
+    internal static bool IsAssistantTurnLifecycleTerminal(AssistantTurnLifecycleStage stage) {
+        return stage is AssistantTurnLifecycleStage.Finalized or AssistantTurnLifecycleStage.Failed;
+    }
+
+    internal static bool CanApplyAssistantTurnDraftUpdate(AssistantTurnLifecycleStage stage) {
+        return !IsAssistantTurnLifecycleTerminal(stage);
+    }
+
+    internal static AssistantTurnLifecycleStage PromoteAssistantTurnLifecycleForStatus(
+        AssistantTurnLifecycleStage current,
+        string? status) {
+        if (IsAssistantTurnLifecycleTerminal(current)) {
+            return current;
+        }
+
+        if (IsToolActivityStatus(status)) {
+            return AssistantTurnLifecycleStage.Tool;
+        }
+
+        return current == AssistantTurnLifecycleStage.Idle
+            ? AssistantTurnLifecycleStage.Draft
+            : current;
+    }
+
+    internal static AssistantTurnLifecycleStage ResolveAssistantTurnLifecycleTerminalTransition(
+        AssistantTurnLifecycleStage current,
+        bool succeeded) {
+        if (IsAssistantTurnLifecycleTerminal(current)) {
+            return current;
+        }
+
+        return succeeded ? AssistantTurnLifecycleStage.Finalized : AssistantTurnLifecycleStage.Failed;
+    }
+
+    internal static bool IsToolActivityStatus(string? status) {
+        var normalized = (status ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return false;
+        }
+
+        return normalized.Equals(ChatStatusCodes.Routing, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.RoutingMeta, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.RoutingTool, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolCall, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolRunning, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolHeartbeat, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolCompleted, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolCanceled, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolRecovered, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolParallelMode, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolParallelForced, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolParallelSafetyOff, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolBatchStarted, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolBatchProgress, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolBatchHeartbeat, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolBatchRecovering, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolBatchRecovered, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolBatchCompleted, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolRoundStarted, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolRoundCompleted, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolRoundLimitReached, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.ToolRoundCapApplied, StringComparison.OrdinalIgnoreCase)
+               || normalized.Equals(ChatStatusCodes.PhaseExecute, StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static AssistantBubbleChannelKind ResolveAssistantBubbleChannelForStatus(
+        AssistantBubbleChannelKind current,
+        string? status) {
+        if (IsToolActivityStatus(status)) {
+            return AssistantBubbleChannelKind.ToolActivity;
+        }
+
+        return current;
+    }
+
+    private bool TryAcceptActiveTurnDraftMutation(ConversationRuntime conversation) {
+        var conversationId = (conversation.Id ?? string.Empty).Trim();
+        if (conversationId.Length == 0) {
+            return false;
+        }
+
+        lock (_turnDiagnosticsSync) {
+            if (!string.Equals(_activeTurnAssistantConversationId, conversationId, StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            if (!CanApplyAssistantTurnDraftUpdate(_activeTurnLifecycleStage)) {
+                return false;
+            }
+
+            if (_activeTurnLifecycleStage == AssistantTurnLifecycleStage.Idle) {
+                _activeTurnLifecycleStage = AssistantTurnLifecycleStage.Draft;
+            }
+
+            return true;
+        }
+    }
+
+    private bool ApplyActiveTurnStatusSignal(ConversationRuntime conversation, string? status) {
+        var conversationId = (conversation.Id ?? string.Empty).Trim();
+        if (conversationId.Length == 0) {
+            return false;
+        }
+
+        lock (_turnDiagnosticsSync) {
+            if (!string.Equals(_activeTurnAssistantConversationId, conversationId, StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            if (IsAssistantTurnLifecycleTerminal(_activeTurnLifecycleStage)) {
+                return false;
+            }
+
+            var changed = false;
+            var nextStage = PromoteAssistantTurnLifecycleForStatus(_activeTurnLifecycleStage, status);
+            if (nextStage != _activeTurnLifecycleStage) {
+                _activeTurnLifecycleStage = nextStage;
+                changed = true;
+            }
+
+            var nextChannel = ResolveAssistantBubbleChannelForStatus(_activeTurnAssistantChannel, status);
+            if (nextChannel != _activeTurnAssistantChannel) {
+                _activeTurnAssistantChannel = nextChannel;
+                changed = true;
+            }
+
+            if (_activeTurnAssistantMessageIndex >= 0) {
+                var state = GetOrCreateAssistantVisualState(conversationId, _activeTurnAssistantMessageIndex);
+                if (state.Channel != _activeTurnAssistantChannel) {
+                    state.Channel = _activeTurnAssistantChannel;
+                    changed = true;
+                }
+            }
+
+            return changed;
+        }
+    }
+
+    private bool TryFinalizeActiveTurnAssistantState(ConversationRuntime conversation, bool succeeded) {
+        var conversationId = (conversation.Id ?? string.Empty).Trim();
+        if (conversationId.Length == 0) {
+            return false;
+        }
+
+        lock (_turnDiagnosticsSync) {
+            if (!string.Equals(_activeTurnAssistantConversationId, conversationId, StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            var nextStage = ResolveAssistantTurnLifecycleTerminalTransition(_activeTurnLifecycleStage, succeeded);
+            if (nextStage == _activeTurnLifecycleStage && IsAssistantTurnLifecycleTerminal(nextStage)) {
+                return false;
+            }
+
+            _activeTurnLifecycleStage = nextStage;
+            _activeTurnAssistantChannel = AssistantBubbleChannelKind.Final;
+
+            if (_activeTurnAssistantMessageIndex >= 0) {
+                var state = GetOrCreateAssistantVisualState(conversationId, _activeTurnAssistantMessageIndex);
+                state.Channel = AssistantBubbleChannelKind.Final;
+            }
+
+            return true;
+        }
+    }
+
     private bool ApplyFinalAssistantTurnTimeline(ConversationRuntime conversation, IReadOnlyList<TurnTimelineEventDto>? timelineEvents) {
         var conversationId = (conversation.Id ?? string.Empty).Trim();
         if (conversationId.Length == 0) {
@@ -197,13 +404,15 @@ public sealed partial class MainWindow : Window {
             }
 
             var state = GetOrCreateAssistantVisualState(conversationId, messageIndex);
-            var changed = state.IsProvisional;
+            var changed = state.IsProvisional || state.Channel != AssistantBubbleChannelKind.Final;
             state.IsProvisional = false;
+            state.Channel = AssistantBubbleChannelKind.Final;
             changed |= MergeFinalTimeline(state.Timeline, normalizedTimeline);
 
             if (string.Equals(_activeTurnAssistantConversationId, conversationId, StringComparison.OrdinalIgnoreCase)) {
                 _activeTurnAssistantMessageIndex = messageIndex;
                 _activeTurnAssistantProvisional = false;
+                _activeTurnAssistantChannel = AssistantBubbleChannelKind.Final;
                 _activeTurnAssistantPendingTimeline.Clear();
             }
 
@@ -251,12 +460,15 @@ public sealed partial class MainWindow : Window {
                 }
 
                 var state = item.Value;
-                if (!state.IsProvisional && state.Timeline.Count == 0) {
+                if (!state.IsProvisional
+                    && state.Channel == AssistantBubbleChannelKind.Final
+                    && state.Timeline.Count == 0) {
                     continue;
                 }
 
                 snapshot[messageIndex] = new TranscriptMessageDecoration {
                     IsProvisional = state.IsProvisional,
+                    Channel = state.Channel,
                     Timeline = state.Timeline.Count == 0 ? Array.Empty<string>() : state.Timeline.ToArray()
                 };
             }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using IntelligenceX.Chat.Abstractions.Policy;
 using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.App.Conversation;
+using IntelligenceX.Chat.App.Rendering;
 using IntelligenceX.Chat.App.Theming;
 using IntelligenceX.Chat.Client;
 using Microsoft.UI.Input;
@@ -368,6 +369,8 @@ public sealed partial class MainWindow : Window {
     private int _activeTurnAssistantMessageIndex = -1;
     private readonly List<string> _activeTurnAssistantPendingTimeline = new();
     private bool _activeTurnAssistantProvisional;
+    private AssistantTurnLifecycleStage _activeTurnLifecycleStage = AssistantTurnLifecycleStage.Idle;
+    private AssistantBubbleChannelKind _activeTurnAssistantChannel = AssistantBubbleChannelKind.Final;
     private bool _activeTurnUsesProvisionalEvents;
     private bool _activeTurnInterimResultSeen;
     private string? _activeTurnInterimFingerprint;
@@ -474,7 +477,16 @@ public sealed partial class MainWindow : Window {
     private sealed class AssistantTurnVisualState {
         // Mutable state; always access under _turnDiagnosticsSync.
         public bool IsProvisional { get; set; }
+        public AssistantBubbleChannelKind Channel { get; set; } = AssistantBubbleChannelKind.Final;
         public List<string> Timeline { get; } = new();
+    }
+
+    internal enum AssistantTurnLifecycleStage {
+        Idle = 0,
+        Draft = 1,
+        Tool = 2,
+        Finalized = 3,
+        Failed = 4
     }
 
     private sealed record QueuedTurn(string Text, string? ConversationId, DateTime EnqueuedUtc, bool SkipUserBubbleOnDispatch = false);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptHtmlFormatter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptHtmlFormatter.cs
@@ -15,6 +15,7 @@ namespace IntelligenceX.Chat.App.Rendering;
 internal static class TranscriptHtmlFormatter {
     private const int MaxAssistantTurnTraceEntries = 8;
     private const string AssistantDraftBadgeText = "Draft/Thinking";
+    private const string AssistantToolBadgeText = "Tool Activity";
     private const string CopyButtonIconSvg =
         "<svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><rect x='9' y='9' width='13' height='13' rx='2'/><path d='M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1'/></svg>";
     private static readonly Regex AssistantOutcomePrefixRegex = new(
@@ -95,8 +96,15 @@ internal static class TranscriptHtmlFormatter {
             var isAssistantDraft = decoration is not null
                                    && decoration.IsProvisional
                                    && string.Equals(message.Role, "Assistant", StringComparison.OrdinalIgnoreCase);
+            var assistantChannel = decoration?.Channel ?? AssistantBubbleChannelKind.Final;
+            if (isAssistantDraft && assistantChannel == AssistantBubbleChannelKind.Final) {
+                assistantChannel = AssistantBubbleChannelKind.DraftThinking;
+            }
+            var isAssistantToolActivity = assistantChannel == AssistantBubbleChannelKind.ToolActivity
+                                          && string.Equals(message.Role, "Assistant", StringComparison.OrdinalIgnoreCase);
             var hideContinuationMeta = !string.Equals(role.RoleClass, "system", StringComparison.Ordinal)
-                                       && !isAssistantDraft;
+                                       && !isAssistantDraft
+                                       && !isAssistantToolActivity;
             var isContinuation = hideContinuationMeta
                 && string.Equals(previousRoleClass, role.RoleClass, StringComparison.Ordinal);
             if (!showAssistantDraftBubbles && isAssistantDraft) {
@@ -110,6 +118,9 @@ internal static class TranscriptHtmlFormatter {
             if (isAssistantDraft) {
                 bubbleClass += " bubble-provisional";
             }
+            if (isAssistantToolActivity) {
+                bubbleClass += " bubble-tool-activity";
+            }
             if (TryRenderOutcomeCallout(message.Role, normalizedText, markdownOptions, out var calloutHtml)) {
                 bodyHtml = calloutHtml;
                 bubbleClass = "bubble bubble-callout";
@@ -121,6 +132,9 @@ internal static class TranscriptHtmlFormatter {
             html.Append("<div class='msg-row ").Append(role.RoleClass);
             if (isAssistantDraft) {
                 html.Append(" assistant-draft");
+            }
+            if (isAssistantToolActivity) {
+                html.Append(" assistant-tool-activity");
             }
             if (isContinuation) {
                 html.Append(" cont");
@@ -135,6 +149,8 @@ internal static class TranscriptHtmlFormatter {
             html.Append("'>").Append(encoder.Encode(role.DisplayName)).Append(" &middot; ").Append(encoder.Encode(time));
             if (isAssistantDraft) {
                 html.Append(" <span class='assistant-draft-meta-pill'>").Append(encoder.Encode(AssistantDraftBadgeText)).Append("</span>");
+            } else if (isAssistantToolActivity) {
+                html.Append(" <span class='assistant-tool-meta-pill'>").Append(encoder.Encode(AssistantToolBadgeText)).Append("</span>");
             }
             html.Append("</div>")
                 .Append("<div class='").Append(bubbleClass).Append("'>").Append(bodyHtml).Append("</div>");
@@ -173,14 +189,25 @@ internal static class TranscriptHtmlFormatter {
         }
 
         var encoder = HtmlEncoder.Default;
-        var summaryLabel = decoration.IsProvisional ? "Draft trace" : hasTimeline ? "Turn trace" : "Live stream";
+        var channel = decoration.Channel;
+        if (decoration.IsProvisional && channel == AssistantBubbleChannelKind.Final) {
+            channel = AssistantBubbleChannelKind.DraftThinking;
+        }
+        var summaryLabel = channel switch {
+            AssistantBubbleChannelKind.DraftThinking => "Draft trace",
+            AssistantBubbleChannelKind.ToolActivity => "Tool trace",
+            _ => hasTimeline ? "Turn trace" : "Live stream"
+        };
         var countLabel = hasTimeline ? timeline.Count.ToString(CultureInfo.InvariantCulture) : string.Empty;
-        var detailsOpen = decoration.IsProvisional ? " open" : string.Empty;
+        var detailsOpen = channel is AssistantBubbleChannelKind.DraftThinking or AssistantBubbleChannelKind.ToolActivity
+            ? " open"
+            : string.Empty;
         var sb = new StringBuilder();
         sb.Append("<details class='assistant-turn-trace'").Append(detailsOpen).Append(">")
             .Append("<summary class='assistant-turn-trace-summary'>");
-        if (decoration.IsProvisional) {
-            sb.Append("<span class='assistant-turn-live-pill'>Live</span>");
+        if (channel is AssistantBubbleChannelKind.DraftThinking or AssistantBubbleChannelKind.ToolActivity) {
+            var liveLabel = channel == AssistantBubbleChannelKind.ToolActivity ? "Tool" : "Live";
+            sb.Append("<span class='assistant-turn-live-pill'>").Append(encoder.Encode(liveLabel)).Append("</span>");
         }
         sb.Append("<span class='assistant-turn-trace-title'>").Append(encoder.Encode(summaryLabel)).Append("</span>");
         if (countLabel.Length > 0) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMessageDecoration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptMessageDecoration.cs
@@ -3,10 +3,17 @@ using System.Collections.Generic;
 
 namespace IntelligenceX.Chat.App.Rendering;
 
+internal enum AssistantBubbleChannelKind {
+    Final = 0,
+    DraftThinking = 1,
+    ToolActivity = 2
+}
+
 /// <summary>
 /// Optional per-message transcript decorations (live/provisional + timeline details).
 /// </summary>
 internal sealed class TranscriptMessageDecoration {
     public bool IsProvisional { get; init; }
+    public AssistantBubbleChannelKind Channel { get; init; } = AssistantBubbleChannelKind.Final;
     public IReadOnlyList<string> Timeline { get; init; } = Array.Empty<string>();
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.chat.css
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.chat.css
@@ -111,6 +111,16 @@
   border: 1px dashed rgba(131, 202, 248, 0.7);
 }
 
+.msg-row.assistant.assistant-tool-activity .avatar {
+  background: #af7c1f;
+  color: #fff6df;
+}
+
+.msg-row.assistant.assistant-tool-activity .bubble {
+  background: rgba(85, 66, 22, 0.56);
+  border: 1px dashed rgba(238, 198, 109, 0.68);
+}
+
 .msg-row.user .bubble {
   background: var(--ix-bubble-user-bg);
   border: 1px solid var(--ix-bubble-user-border);
@@ -314,9 +324,28 @@
   letter-spacing: 0.01em;
 }
 
+.assistant-tool-meta-pill {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(238, 198, 109, 0.62);
+  background: rgba(140, 106, 33, 0.45);
+  color: #fff0cf;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
 .bubble.bubble-provisional {
   border-style: dashed;
   box-shadow: inset 0 0 0 1px rgba(129, 204, 255, 0.22);
+}
+
+.bubble.bubble-tool-activity {
+  border-style: dashed;
+  box-shadow: inset 0 0 0 1px rgba(238, 198, 109, 0.2);
 }
 
 .assistant-turn-trace {


### PR DESCRIPTION
## Summary
- add an explicit assistant turn lifecycle guard (`Idle/Draft/Tool/Finalized/Failed`) to prevent late deltas/interims/statuses from mutating already-finalized turns
- make final/failure application idempotent via lifecycle terminal transitions
- add transcript channel metadata (`Final`, `DraftThinking`, `ToolActivity`) so draft/thinking and tool-activity states are visually distinct from final assistant output
- wire status-driven channel promotion for tool phases and keep channel reset on terminal finalize/failure
- add UI styling for tool-activity bubbles and badges, while preserving existing draft toggle behavior
- extend tests with lifecycle transition coverage and formatter channel rendering coverage

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
