### PR TITLE
Harden tool replay pairing and transport recovery inputs

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -1269,6 +1269,7 @@ internal sealed partial class ChatServiceSession {
 
             var next = new ChatInput();
             var replayedToolCallIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var replayedToolOutputIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             for (var outputIndex = 0; outputIndex < executed.Count; outputIndex++) {
                 var output = executed[outputIndex];
                 var normalizedOutputCallId = ResolveToolOutputCallId(
@@ -1280,15 +1281,20 @@ internal sealed partial class ChatServiceSession {
                     continue;
                 }
 
-                if (executedCallsById.TryGetValue(normalizedOutputCallId, out var executedCall)
-                    && replayedToolCallIds.Add(normalizedOutputCallId)) {
+                if (!executedCallsById.TryGetValue(normalizedOutputCallId, out var executedCall)) {
+                    continue;
+                }
+
+                if (replayedToolCallIds.Add(normalizedOutputCallId)) {
                     next.AddToolCall(
                         executedCall.CallId,
                         executedCall.Name,
                         executedCall.Input);
                 }
 
-                next.AddToolOutput(normalizedOutputCallId, output.Output);
+                if (replayedToolOutputIds.Add(normalizedOutputCallId)) {
+                    next.AddToolOutput(normalizedOutputCallId, output.Output);
+                }
             }
             turn = await RunModelPhaseWithProgressAsync(
                     client,

--- a/IntelligenceX.Tests/Program.OpenAI.AppServerTransport.cs
+++ b/IntelligenceX.Tests/Program.OpenAI.AppServerTransport.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Reflection;
+using IntelligenceX.Json;
+using IntelligenceX.OpenAI;
+
+namespace IntelligenceX.Tests;
+
+internal static partial class Program {
+    private static void TestAppServerTransportNormalizesReplayInputItems() {
+        var ix = typeof(IntelligenceXClient).Assembly;
+        var transportType = ix.GetType("IntelligenceX.OpenAI.Transport.AppServerTransport", throwOnError: true)!;
+        var normalizeMethod = transportType.GetMethod(
+            "NormalizeAndFilterReplayInputItems",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        AssertNotNull(normalizeMethod, "AppServerTransport.NormalizeAndFilterReplayInputItems");
+
+        var replayItems = new JsonArray()
+            .Add(new JsonObject()
+                .Add("type", "custom_tool_call")
+                .Add("call_id", "call_dup")
+                .Add("name", "ad_scope_discovery")
+                .Add("input", "{\"domain\":\"ad.evotec.xyz\"}")
+                .Add("arguments", "{\"domain\":\"ad.evotec.xyz\"}"))
+            .Add(new JsonObject()
+                .Add("type", "tool_call")
+                .Add("call_id", "call_dup")
+                .Add("name", "ad_scope_discovery")
+                .Add("arguments", "{\"domain\":\"ad.evotec.xyz\"}"))
+            .Add(new JsonObject()
+                .Add("type", "custom_tool_call_output")
+                .Add("call_id", "call_dup")
+                .Add("output", "{\"ok\":true}"))
+            .Add(new JsonObject()
+                .Add("type", "diagnostic")
+                .Add("arguments", "{\"unexpected\":true}")
+                .Add("value", "kept"));
+
+        var normalizedObj = normalizeMethod!.Invoke(null, new object?[] { replayItems });
+        var normalized = normalizedObj as JsonArray;
+        AssertNotNull(normalized, "normalized replay items");
+        AssertEqual(3, normalized!.Count, "normalized replay item count");
+
+        var callCount = 0;
+        var outputCount = 0;
+        var diagnosticCount = 0;
+        for (var i = 0; i < normalized.Count; i++) {
+            var item = normalized[i].AsObject();
+            AssertNotNull(item, "normalized replay item");
+            var type = item!.GetString("type") ?? string.Empty;
+            if (string.Equals(type, "custom_tool_call", StringComparison.OrdinalIgnoreCase)) {
+                callCount++;
+                AssertEqual("call_dup", item.GetString("call_id") ?? string.Empty, "normalized call id");
+                AssertEqual(true, item.GetString("arguments") is null, "normalized call strips arguments");
+            } else if (string.Equals(type, "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+                outputCount++;
+                AssertEqual("call_dup", item.GetString("call_id") ?? string.Empty, "normalized output call id");
+            } else if (string.Equals(type, "diagnostic", StringComparison.OrdinalIgnoreCase)) {
+                diagnosticCount++;
+                AssertEqual(true, item.GetString("arguments") is null, "non-tool strips arguments");
+                AssertEqual("kept", item.GetString("value") ?? string.Empty, "non-tool value retained");
+            }
+        }
+
+        AssertEqual(1, callCount, "exactly one replay call retained");
+        AssertEqual(1, outputCount, "exactly one replay output retained");
+        AssertEqual(1, diagnosticCount, "diagnostic item retained");
+    }
+}

--- a/IntelligenceX.Tests/Program.OpenAI.NativeRequestBody.cs
+++ b/IntelligenceX.Tests/Program.OpenAI.NativeRequestBody.cs
@@ -237,4 +237,76 @@ internal static partial class Program {
         AssertEqual("shape_call_1", second.GetString("call_id") ?? string.Empty, "type-missing output normalized id");
         AssertEqual("{\"ok\":true}", second.GetString("output") ?? string.Empty, "type-missing output normalized payload");
     }
+
+    private static void TestNativeRequestBodyDeduplicatesReplayPairsAndStripsLegacyArguments() {
+        var ix = typeof(IntelligenceXClient).Assembly;
+        var optionsType = ix.GetType("IntelligenceX.OpenAI.Native.OpenAINativeOptions", throwOnError: true)!;
+        var transportType = ix.GetType("IntelligenceX.OpenAI.Native.OpenAINativeTransport", throwOnError: true)!;
+
+        var options = Activator.CreateInstance(optionsType);
+        AssertNotNull(options, "OpenAINativeOptions");
+
+        var transport = Activator.CreateInstance(transportType, options);
+        AssertNotNull(transport, "OpenAINativeTransport");
+
+        var wireEnum = transportType.GetNestedType("ToolWireFormat", BindingFlags.NonPublic);
+        AssertNotNull(wireEnum, "ToolWireFormat enum");
+        var customParameters = Enum.Parse(wireEnum!, "CustomParameters");
+
+        var method = transportType.GetMethod("BuildRequestBody", BindingFlags.Instance | BindingFlags.NonPublic);
+        AssertNotNull(method, "BuildRequestBody method");
+
+        var messages = new List<JsonObject> {
+            new JsonObject()
+                .Add("type", "custom_tool_call")
+                .Add("call_id", "call_dup")
+                .Add("name", "ad_scope_discovery")
+                .Add("input", "{\"domain\":\"ad.evotec.xyz\"}")
+                .Add("arguments", "{\"domain\":\"ad.evotec.xyz\"}"),
+            new JsonObject()
+                .Add("type", "tool_call")
+                .Add("call_id", "call_dup")
+                .Add("name", "ad_scope_discovery")
+                .Add("arguments", "{\"domain\":\"ad.evotec.xyz\"}"),
+            new JsonObject()
+                .Add("type", "custom_tool_call_output")
+                .Add("call_id", "call_dup")
+                .Add("output", "{\"ok\":true}"),
+            new JsonObject()
+                .Add("type", "diagnostic")
+                .Add("arguments", "{\"unexpected\":true}")
+                .Add("value", "kept")
+        };
+
+        var chatOptions = new ChatOptions();
+        var body = (JsonObject)method!.Invoke(transport, new object?[] { "gpt-5.3-codex", messages, "session", chatOptions, customParameters })!;
+        var input = body.GetArray("input");
+        AssertNotNull(input, "input array");
+        AssertEqual(3, input!.Count, "deduplicated input item count");
+
+        var callCount = 0;
+        var outputCount = 0;
+        var diagnosticCount = 0;
+        for (var i = 0; i < input.Count; i++) {
+            var item = input[i].AsObject();
+            AssertNotNull(item, "normalized replay item object");
+            var type = item!.GetString("type") ?? string.Empty;
+            if (string.Equals(type, "custom_tool_call", StringComparison.OrdinalIgnoreCase)) {
+                callCount++;
+                AssertEqual("call_dup", item.GetString("call_id") ?? string.Empty, "dedup call id");
+                AssertEqual(true, item.GetString("arguments") is null, "dedup call strips arguments field");
+            } else if (string.Equals(type, "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+                outputCount++;
+                AssertEqual("call_dup", item.GetString("call_id") ?? string.Empty, "dedup output call id");
+            } else if (string.Equals(type, "diagnostic", StringComparison.OrdinalIgnoreCase)) {
+                diagnosticCount++;
+                AssertEqual(true, item.GetString("arguments") is null, "non-tool replay strips legacy arguments");
+                AssertEqual("kept", item.GetString("value") ?? string.Empty, "non-tool replay keeps payload");
+            }
+        }
+
+        AssertEqual(1, callCount, "exactly one replay call retained");
+        AssertEqual(1, outputCount, "exactly one replay output retained");
+        AssertEqual(1, diagnosticCount, "diagnostic item retained");
+    }
 }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -78,6 +78,8 @@ internal static partial class Program {
         failed += Run("Native request body normalizes tool replay items", TestNativeRequestBodyNormalizesToolReplayInputItems);
         failed += Run("Native request body normalizes type-missing replay items", TestNativeRequestBodyNormalizesTypeMissingToolReplayItems);
         failed += Run("Native request body filters unpaired tool replay items", TestNativeRequestBodyFiltersUnpairedToolReplayItems);
+        failed += Run("Native request body deduplicates replay pairs", TestNativeRequestBodyDeduplicatesReplayPairsAndStripsLegacyArguments);
+        failed += Run("AppServer transport normalizes replay input items", TestAppServerTransportNormalizesReplayInputItems);
 #if !NET472
         failed += Run("Setup args reject skip+update", TestSetupArgsRejectSkipUpdate);
         failed += Run("Setup args include analysis options", TestSetupArgsIncludeAnalysisOptions);

--- a/IntelligenceX.UnitTests/OpenAICompatibleHttpTransportTests.cs
+++ b/IntelligenceX.UnitTests/OpenAICompatibleHttpTransportTests.cs
@@ -413,6 +413,84 @@ public sealed class OpenAICompatibleHttpTransportTests {
     }
 
     [Fact]
+    public async Task ReplayMessages_Deduplicate_DuplicateToolCallIds_ToSinglePair() {
+        var handler = new StubHandler()
+            .RespondJson(HttpStatusCode.OK, """
+                {
+                  "id": "chatcmpl_1",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [
+                          { "id": "call_dup", "type": "function", "function": { "name": "do_it", "arguments": "{}" } }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """)
+            .RespondJson(HttpStatusCode.OK, """
+                {
+                  "id": "chatcmpl_2",
+                  "choices": [
+                    { "index": 0, "message": { "role": "assistant", "content": "ok" } }
+                  ]
+                }
+                """);
+
+        using var http = new HttpClient(handler);
+        using var transport = new OpenAICompatibleHttpTransport(new OpenAICompatibleHttpOptions {
+            BaseUrl = "http://localhost:11434",
+            AllowInsecureHttp = true,
+            Streaming = false
+        }, http);
+
+        var thread = await transport.StartThreadAsync("local-model", null, null, null, CancellationToken.None);
+        var first = await transport.StartTurnAsync(thread.Id, ChatInput.FromText("hello"), new ChatOptions { Model = "local-model" }, null, null, null, CancellationToken.None);
+        var firstCall = Assert.Single(ToolCallParser.Extract(first));
+
+        var replayInput = new ChatInput()
+            .AddToolCall(firstCall.CallId, firstCall.Name, "{}")
+            .AddToolOutput(firstCall.CallId, """{"ok":true}""")
+            .AddText("continue");
+
+        _ = await transport.StartTurnAsync(thread.Id, replayInput, new ChatOptions { Model = "local-model" }, null, null, null, CancellationToken.None);
+
+        Assert.True(handler.RequestBodies.Count >= 2);
+        using var doc = JsonDocument.Parse(handler.RequestBodies[1]);
+        var messages = doc.RootElement.GetProperty("messages");
+
+        var callCount = 0;
+        var outputCount = 0;
+        for (var i = 0; i < messages.GetArrayLength(); i++) {
+            var msg = messages[i];
+            var role = msg.GetProperty("role").GetString() ?? string.Empty;
+            if (string.Equals(role, "assistant", StringComparison.OrdinalIgnoreCase)
+                && msg.TryGetProperty("tool_calls", out var toolCalls)) {
+                for (var j = 0; j < toolCalls.GetArrayLength(); j++) {
+                    var toolCall = toolCalls[j];
+                    var id = toolCall.GetProperty("id").GetString() ?? string.Empty;
+                    if (string.Equals(id, firstCall.CallId, StringComparison.OrdinalIgnoreCase)) {
+                        callCount++;
+                    }
+                }
+            } else if (string.Equals(role, "tool", StringComparison.OrdinalIgnoreCase)
+                       && msg.TryGetProperty("tool_call_id", out var toolCallId)) {
+                var id = toolCallId.GetString() ?? string.Empty;
+                if (string.Equals(id, firstCall.CallId, StringComparison.OrdinalIgnoreCase)) {
+                    outputCount++;
+                }
+            }
+        }
+
+        Assert.Equal(1, callCount);
+        Assert.Equal(1, outputCount);
+    }
+
+    [Fact]
     public async Task ChatCompletions_ContentArray_Is_Projected_To_TextOutput() {
         var handler = new StubHandler()
             .RespondJson(HttpStatusCode.OK, """

--- a/IntelligenceX/Providers/OpenAI/CompatibleHttp/OpenAICompatibleHttpTransport.Parsing.cs
+++ b/IntelligenceX/Providers/OpenAI/CompatibleHttp/OpenAICompatibleHttpTransport.Parsing.cs
@@ -425,4 +425,210 @@ internal sealed partial class OpenAICompatibleHttpTransport : IOpenAITransport {
         return messages;
     }
 
+    private static List<JsonObject> NormalizeToolReplayMessages(IReadOnlyList<JsonObject> messages) {
+        if (messages is null || messages.Count == 0) {
+            return new List<JsonObject>();
+        }
+
+        var callIndexesById = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
+        var outputIndexesById = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
+        var toolOutputCallIdByMessageIndex = new Dictionary<int, string>();
+        var hasReplayMessages = false;
+
+        for (var messageIndex = 0; messageIndex < messages.Count; messageIndex++) {
+            var message = messages[messageIndex];
+            if (message is null) {
+                continue;
+            }
+
+            var role = (message.GetString("role") ?? string.Empty).Trim();
+            if (string.Equals(role, "assistant", StringComparison.OrdinalIgnoreCase)
+                && message.GetArray("tool_calls") is { Count: > 0 } toolCalls) {
+                for (var i = 0; i < toolCalls.Count; i++) {
+                    var toolCall = toolCalls[i].AsObject();
+                    if (toolCall is null) {
+                        continue;
+                    }
+
+                    var callId = (toolCall.GetString("id") ?? string.Empty).Trim();
+                    if (callId.Length == 0) {
+                        continue;
+                    }
+
+                    hasReplayMessages = true;
+                    AddReplayIndex(callIndexesById, callId, messageIndex);
+                }
+            } else if (string.Equals(role, "tool", StringComparison.OrdinalIgnoreCase)) {
+                var callId = (message.GetString("tool_call_id") ?? string.Empty).Trim();
+                if (callId.Length == 0) {
+                    continue;
+                }
+
+                hasReplayMessages = true;
+                AddReplayIndex(outputIndexesById, callId, messageIndex);
+                toolOutputCallIdByMessageIndex[messageIndex] = callId;
+            }
+        }
+
+        if (!hasReplayMessages) {
+            return new List<JsonObject>(messages);
+        }
+
+        var selectedCallMessageIndexById = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var selectedOutputMessageIndexById = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in callIndexesById) {
+            if (!outputIndexesById.TryGetValue(pair.Key, out var outputIndexes)) {
+                continue;
+            }
+
+            if (!TrySelectReplayPairIndexes(pair.Value, outputIndexes, out var selectedCallIndex, out var selectedOutputIndex)) {
+                continue;
+            }
+
+            selectedCallMessageIndexById[pair.Key] = selectedCallIndex;
+            selectedOutputMessageIndexById[pair.Key] = selectedOutputIndex;
+        }
+
+        if (selectedCallMessageIndexById.Count == 0) {
+            var passthrough = new List<JsonObject>(messages.Count);
+            for (var i = 0; i < messages.Count; i++) {
+                var message = messages[i];
+                var role = (message.GetString("role") ?? string.Empty).Trim();
+                if (!string.Equals(role, "assistant", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(role, "tool", StringComparison.OrdinalIgnoreCase)) {
+                    passthrough.Add(message);
+                }
+            }
+
+            return passthrough;
+        }
+
+        var filtered = new List<JsonObject>(messages.Count);
+        for (var messageIndex = 0; messageIndex < messages.Count; messageIndex++) {
+            var message = messages[messageIndex];
+            if (message is null) {
+                continue;
+            }
+
+            var role = (message.GetString("role") ?? string.Empty).Trim();
+            if (string.Equals(role, "tool", StringComparison.OrdinalIgnoreCase)) {
+                if (!toolOutputCallIdByMessageIndex.TryGetValue(messageIndex, out var toolOutputCallId)) {
+                    continue;
+                }
+
+                if (selectedOutputMessageIndexById.TryGetValue(toolOutputCallId, out var selectedOutputIndex)
+                    && selectedOutputIndex == messageIndex) {
+                    filtered.Add(message);
+                }
+                continue;
+            }
+
+            if (string.Equals(role, "assistant", StringComparison.OrdinalIgnoreCase)
+                && message.GetArray("tool_calls") is { Count: > 0 } toolCalls) {
+                var filteredToolCalls = new JsonArray();
+                for (var i = 0; i < toolCalls.Count; i++) {
+                    var toolCall = toolCalls[i].AsObject();
+                    if (toolCall is null) {
+                        continue;
+                    }
+
+                    var callId = (toolCall.GetString("id") ?? string.Empty).Trim();
+                    if (callId.Length == 0) {
+                        continue;
+                    }
+
+                    if (selectedCallMessageIndexById.TryGetValue(callId, out var selectedCallIndex)
+                        && selectedCallIndex == messageIndex) {
+                        filteredToolCalls.Add(toolCall);
+                    }
+                }
+
+                if (filteredToolCalls.Count == 0) {
+                    var normalizedAssistantMessage = CloneMessageWithoutToolCalls(message);
+                    if (AssistantMessageHasUserVisibleContent(normalizedAssistantMessage)) {
+                        filtered.Add(normalizedAssistantMessage);
+                    }
+                    continue;
+                }
+
+                var replayMessage = CloneMessageWithoutToolCalls(message);
+                replayMessage.Add("tool_calls", filteredToolCalls);
+                filtered.Add(replayMessage);
+                continue;
+            }
+
+            filtered.Add(message);
+        }
+
+        return filtered;
+    }
+
+    private static void AddReplayIndex(IDictionary<string, List<int>> indexesById, string callId, int messageIndex) {
+        if (!indexesById.TryGetValue(callId, out var indexes)) {
+            indexes = new List<int>();
+            indexesById[callId] = indexes;
+        }
+
+        indexes.Add(messageIndex);
+    }
+
+    private static bool TrySelectReplayPairIndexes(
+        IReadOnlyList<int> callIndexes,
+        IReadOnlyList<int> outputIndexes,
+        out int selectedCallIndex,
+        out int selectedOutputIndex) {
+        selectedCallIndex = -1;
+        selectedOutputIndex = -1;
+        if (callIndexes is null || outputIndexes is null || callIndexes.Count == 0 || outputIndexes.Count == 0) {
+            return false;
+        }
+
+        var outputCursor = 0;
+        for (var i = 0; i < callIndexes.Count; i++) {
+            var callIndex = callIndexes[i];
+            while (outputCursor < outputIndexes.Count && outputIndexes[outputCursor] <= callIndex) {
+                outputCursor++;
+            }
+
+            if (outputCursor >= outputIndexes.Count) {
+                break;
+            }
+
+            selectedCallIndex = callIndex;
+            selectedOutputIndex = outputIndexes[outputCursor];
+        }
+
+        return selectedCallIndex >= 0 && selectedOutputIndex >= 0;
+    }
+
+    private static JsonObject CloneMessageWithoutToolCalls(JsonObject message) {
+        var clone = new JsonObject();
+        foreach (var pair in message) {
+            if (string.Equals(pair.Key, "tool_calls", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            clone.Add(pair.Key, pair.Value ?? JsonValue.Null);
+        }
+
+        return clone;
+    }
+
+    private static bool AssistantMessageHasUserVisibleContent(JsonObject message) {
+        if (message is null) {
+            return false;
+        }
+
+        if (!string.Equals((message.GetString("role") ?? string.Empty).Trim(), "assistant", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        if (message.GetArray("tool_calls") is { Count: > 0 }) {
+            return true;
+        }
+
+        var content = message.GetString("content");
+        return !string.IsNullOrWhiteSpace(content);
+    }
+
 }

--- a/IntelligenceX/Providers/OpenAI/CompatibleHttp/OpenAICompatibleHttpTransport.cs
+++ b/IntelligenceX/Providers/OpenAI/CompatibleHttp/OpenAICompatibleHttpTransport.cs
@@ -395,7 +395,8 @@ internal sealed partial class OpenAICompatibleHttpTransport : IOpenAITransport {
             requestMessages.AddRange(newMessages);
         }
 
-        var body = BuildChatCompletionsRequest(state.Model, requestMessages, options, streaming: _options.Streaming);
+        var normalizedRequestMessages = NormalizeToolReplayMessages(requestMessages);
+        var body = BuildChatCompletionsRequest(state.Model, normalizedRequestMessages, options, streaming: _options.Streaming);
         var rpcParams = JsonValue.From(body);
         RpcCallStarted?.Invoke(this, new RpcCallStartedEventArgs("chat.completions.create", rpcParams));
 
@@ -406,7 +407,8 @@ internal sealed partial class OpenAICompatibleHttpTransport : IOpenAITransport {
 
             // Update history with the messages we sent + the assistant message we received.
             lock (_threadsLock) {
-                state.Messages.AddRange(newMessages);
+                state.Messages.Clear();
+                state.Messages.AddRange(normalizedRequestMessages);
                 state.Messages.Add(response.AssistantMessageForHistory);
             }
 

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.Requests.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.Requests.cs
@@ -341,7 +341,7 @@ internal sealed partial class OpenAINativeTransport {
             return NormalizeToolOutputInputItem(message);
         }
 
-        return message;
+        return RemoveLegacyArgumentsFieldForNonToolInput(message);
     }
 
     private static IReadOnlyList<JsonObject> NormalizeAndFilterReplayInputItems(IReadOnlyList<JsonObject> messages) {
@@ -350,39 +350,64 @@ internal sealed partial class OpenAINativeTransport {
         }
 
         var normalized = new List<JsonObject>(messages.Count);
-        var callIdsWithCalls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var callIdsWithOutputs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var callIndexesById = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
+        var outputIndexesById = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
+        var hasToolReplayItems = false;
 
         for (var i = 0; i < messages.Count; i++) {
             var item = NormalizeInputItemForRequest(messages[i] ?? new JsonObject());
             normalized.Add(item);
 
             var type = (GetStringIgnoreCase(item, "type") ?? string.Empty).Trim();
+            var isToolCall = IsToolCallInputType(type);
+            var isToolOutput = IsToolOutputInputType(type);
+            if (!isToolCall && !isToolOutput) {
+                continue;
+            }
+
+            hasToolReplayItems = true;
             var callId = ExtractToolReplayCallId(item);
             if (string.IsNullOrWhiteSpace(callId)) {
                 continue;
             }
 
-            if (IsToolCallInputType(type)) {
-                callIdsWithCalls.Add(callId!);
-            } else if (IsToolOutputInputType(type)) {
-                callIdsWithOutputs.Add(callId!);
+            if (isToolCall) {
+                AddReplayIndex(callIndexesById, callId!, i);
+            } else if (isToolOutput) {
+                AddReplayIndex(outputIndexesById, callId!, i);
             }
         }
 
-        if (callIdsWithCalls.Count == 0 && callIdsWithOutputs.Count == 0) {
+        if (!hasToolReplayItems) {
             return normalized;
         }
 
-        var pairedCallIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var callId in callIdsWithCalls) {
-            if (callIdsWithOutputs.Contains(callId)) {
-                pairedCallIds.Add(callId);
+        var selectedCallIndexById = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var selectedOutputIndexById = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in callIndexesById) {
+            var callId = entry.Key;
+            if (!outputIndexesById.TryGetValue(callId, out var outputIndexes)) {
+                continue;
             }
+
+            if (!TrySelectReplayPairIndexes(entry.Value, outputIndexes, out var selectedCallIndex, out var selectedOutputIndex)) {
+                continue;
+            }
+
+            selectedCallIndexById[callId] = selectedCallIndex;
+            selectedOutputIndexById[callId] = selectedOutputIndex;
         }
 
-        if (pairedCallIds.Count == callIdsWithCalls.Count && pairedCallIds.Count == callIdsWithOutputs.Count) {
-            return normalized;
+        if (selectedCallIndexById.Count == 0) {
+            var noToolReplay = new List<JsonObject>(normalized.Count);
+            for (var i = 0; i < normalized.Count; i++) {
+                var item = normalized[i];
+                var type = (GetStringIgnoreCase(item, "type") ?? string.Empty).Trim();
+                if (!IsToolCallInputType(type) && !IsToolOutputInputType(type)) {
+                    noToolReplay.Add(item);
+                }
+            }
+            return noToolReplay;
         }
 
         var filtered = new List<JsonObject>(normalized.Count);
@@ -395,7 +420,20 @@ internal sealed partial class OpenAINativeTransport {
             }
 
             var callId = ExtractToolReplayCallId(item);
-            if (!string.IsNullOrWhiteSpace(callId) && pairedCallIds.Contains(callId!)) {
+            if (string.IsNullOrWhiteSpace(callId)) {
+                continue;
+            }
+
+            if (IsToolCallInputType(type)
+                && selectedCallIndexById.TryGetValue(callId!, out var selectedCallIndex)
+                && selectedCallIndex == i) {
+                filtered.Add(item);
+                continue;
+            }
+
+            if (IsToolOutputInputType(type)
+                && selectedOutputIndexById.TryGetValue(callId!, out var selectedOutputIndex)
+                && selectedOutputIndex == i) {
                 filtered.Add(item);
             }
         }
@@ -508,11 +546,64 @@ internal sealed partial class OpenAINativeTransport {
         return normalized;
     }
 
+    private static JsonObject RemoveLegacyArgumentsFieldForNonToolInput(JsonObject message) {
+        var removed = false;
+        var normalized = new JsonObject();
+        foreach (var pair in message) {
+            if (string.Equals(pair.Key, "arguments", StringComparison.OrdinalIgnoreCase)) {
+                removed = true;
+                continue;
+            }
+
+            normalized.Add(pair.Key, pair.Value ?? JsonValue.Null);
+        }
+
+        return removed ? normalized : message;
+    }
+
     private static string? ExtractToolReplayCallId(JsonObject message) {
         return FirstNonEmpty(
             GetStringIgnoreCase(message, "call_id"),
             GetStringIgnoreCase(message, "tool_call_id"),
             GetStringIgnoreCase(message, "id"));
+    }
+
+    private static void AddReplayIndex(IDictionary<string, List<int>> indexesById, string callId, int index) {
+        if (!indexesById.TryGetValue(callId, out var indexes)) {
+            indexes = new List<int>();
+            indexesById[callId] = indexes;
+        }
+
+        indexes.Add(index);
+    }
+
+    private static bool TrySelectReplayPairIndexes(
+        IReadOnlyList<int> callIndexes,
+        IReadOnlyList<int> outputIndexes,
+        out int selectedCallIndex,
+        out int selectedOutputIndex) {
+        selectedCallIndex = -1;
+        selectedOutputIndex = -1;
+        if (callIndexes is null || outputIndexes is null || callIndexes.Count == 0 || outputIndexes.Count == 0) {
+            return false;
+        }
+
+        var outputCursor = 0;
+        for (var i = 0; i < callIndexes.Count; i++) {
+            var callIndex = callIndexes[i];
+            while (outputCursor < outputIndexes.Count && outputIndexes[outputCursor] <= callIndex) {
+                outputCursor++;
+            }
+
+            if (outputCursor >= outputIndexes.Count) {
+                break;
+            }
+
+            selectedCallIndex = callIndex;
+            selectedOutputIndex = outputIndexes[outputCursor];
+        }
+
+        return selectedCallIndex >= 0 && selectedOutputIndex >= 0;
     }
 
     private static string BuildCustomToolCallWireId(string? sourceId, string? callId, string? name, string arguments) {

--- a/IntelligenceX/Providers/OpenAI/Transport/AppServerTransport.cs
+++ b/IntelligenceX/Providers/OpenAI/Transport/AppServerTransport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Json;
@@ -80,7 +81,8 @@ internal sealed class AppServerTransport : IOpenAITransport {
     public Task<TurnInfo> StartTurnAsync(string threadId, ChatInput input, ChatOptions? options, string? currentDirectory,
         string? approvalPolicy, SandboxPolicy? sandboxPolicy, CancellationToken cancellationToken) {
         var model = options?.Model;
-        return _client.StartTurnAsync(threadId, input.ToJson(), NormalizeModel(model), currentDirectory, approvalPolicy, sandboxPolicy, cancellationToken);
+        var normalizedInput = NormalizeAndFilterReplayInputItems(input.ToJson());
+        return _client.StartTurnAsync(threadId, normalizedInput, NormalizeModel(model), currentDirectory, approvalPolicy, sandboxPolicy, cancellationToken);
     }
 
     private void OnNotificationReceived(object? sender, JsonRpcNotificationEventArgs args) {
@@ -107,6 +109,228 @@ internal sealed class AppServerTransport : IOpenAITransport {
         }
         var slash = model!.IndexOf('/');
         return slash > -1 && slash + 1 < model.Length ? model.Substring(slash + 1) : model;
+    }
+
+    private static JsonArray NormalizeAndFilterReplayInputItems(JsonArray items) {
+        if (items is null || items.Count == 0) {
+            return new JsonArray();
+        }
+
+        var normalized = new List<JsonObject>(items.Count);
+        var callIndexesById = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
+        var outputIndexesById = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
+
+        for (var i = 0; i < items.Count; i++) {
+            var normalizedItem = NormalizeInputItem(items[i].AsObject() ?? new JsonObject());
+            normalized.Add(normalizedItem);
+
+            var type = (normalizedItem.GetString("type") ?? string.Empty).Trim();
+            if (!IsToolCallInputType(type) && !IsToolOutputInputType(type)) {
+                continue;
+            }
+
+            var callId = (normalizedItem.GetString("call_id") ?? normalizedItem.GetString("id") ?? string.Empty).Trim();
+            if (callId.Length == 0) {
+                continue;
+            }
+
+            if (IsToolCallInputType(type)) {
+                AddReplayIndex(callIndexesById, callId, i);
+            } else {
+                AddReplayIndex(outputIndexesById, callId, i);
+            }
+        }
+
+        var selectedCallIndexesById = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var selectedOutputIndexesById = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in callIndexesById) {
+            if (!outputIndexesById.TryGetValue(pair.Key, out var outputIndexes)) {
+                continue;
+            }
+
+            if (!TrySelectReplayPairIndexes(pair.Value, outputIndexes, out var selectedCallIndex, out var selectedOutputIndex)) {
+                continue;
+            }
+
+            selectedCallIndexesById[pair.Key] = selectedCallIndex;
+            selectedOutputIndexesById[pair.Key] = selectedOutputIndex;
+        }
+
+        var filtered = new JsonArray();
+        for (var i = 0; i < normalized.Count; i++) {
+            var item = normalized[i];
+            var type = (item.GetString("type") ?? string.Empty).Trim();
+            if (!IsToolCallInputType(type) && !IsToolOutputInputType(type)) {
+                filtered.Add(item);
+                continue;
+            }
+
+            var callId = (item.GetString("call_id") ?? item.GetString("id") ?? string.Empty).Trim();
+            if (callId.Length == 0) {
+                continue;
+            }
+
+            if (IsToolCallInputType(type)
+                && selectedCallIndexesById.TryGetValue(callId, out var selectedCallIndex)
+                && selectedCallIndex == i) {
+                filtered.Add(item);
+                continue;
+            }
+
+            if (IsToolOutputInputType(type)
+                && selectedOutputIndexesById.TryGetValue(callId, out var selectedOutputIndex)
+                && selectedOutputIndex == i) {
+                filtered.Add(item);
+            }
+        }
+
+        return filtered;
+    }
+
+    private static JsonObject NormalizeInputItem(JsonObject message) {
+        var type = (message.GetString("type") ?? string.Empty).Trim();
+        if (IsToolCallInputType(type) || LooksLikeToolCallInputShape(message)) {
+            var callId = FirstNonEmpty(
+                message.GetString("call_id"),
+                message.GetString("tool_call_id"),
+                message.GetString("id")) ?? string.Empty;
+            var name = FirstNonEmpty(
+                message.GetString("name"),
+                message.GetObject("function")?.GetString("name")) ?? string.Empty;
+            var input = FirstNonEmpty(
+                message.GetString("input"),
+                message.GetString("arguments"),
+                message.GetObject("function")?.GetString("arguments")) ?? "{}";
+
+            var normalized = new JsonObject()
+                .Add("type", "custom_tool_call")
+                .Add("id", callId.Trim().Length == 0 ? "call" : callId.Trim())
+                .Add("input", string.IsNullOrWhiteSpace(input) ? "{}" : input.Trim());
+            if (!string.IsNullOrWhiteSpace(callId)) {
+                normalized.Add("call_id", callId.Trim());
+            }
+            if (!string.IsNullOrWhiteSpace(name)) {
+                normalized.Add("name", name.Trim());
+            }
+            return normalized;
+        }
+
+        if (IsToolOutputInputType(type) || LooksLikeToolOutputInputShape(message)) {
+            var callId = FirstNonEmpty(
+                message.GetString("call_id"),
+                message.GetString("tool_call_id"),
+                message.GetString("id")) ?? string.Empty;
+            var output = FirstNonEmpty(
+                message.GetString("output"),
+                message.GetString("result"),
+                message.GetString("content")) ?? string.Empty;
+
+            var normalized = new JsonObject()
+                .Add("type", "custom_tool_call_output")
+                .Add("output", output);
+            if (!string.IsNullOrWhiteSpace(callId)) {
+                normalized.Add("call_id", callId.Trim());
+            }
+            return normalized;
+        }
+
+        var sanitized = new JsonObject();
+        foreach (var pair in message) {
+            if (string.Equals(pair.Key, "arguments", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            sanitized.Add(pair.Key, pair.Value ?? JsonValue.Null);
+        }
+        return sanitized;
+    }
+
+    private static bool IsToolCallInputType(string type) {
+        return string.Equals(type, "custom_tool_call", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(type, "tool_call", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(type, "function_call", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsToolOutputInputType(string type) {
+        return string.Equals(type, "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(type, "tool_call_output", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(type, "function_call_output", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool LooksLikeToolCallInputShape(JsonObject message) {
+        var callId = FirstNonEmpty(message.GetString("call_id"), message.GetString("tool_call_id"));
+        if (string.IsNullOrWhiteSpace(callId)) {
+            return false;
+        }
+
+        var hasName = !string.IsNullOrWhiteSpace(message.GetString("name"))
+                      || message.GetObject("function") is not null;
+        var hasInput = !string.IsNullOrWhiteSpace(message.GetString("input"))
+                       || !string.IsNullOrWhiteSpace(message.GetString("arguments"));
+        return hasName && hasInput;
+    }
+
+    private static bool LooksLikeToolOutputInputShape(JsonObject message) {
+        var callId = FirstNonEmpty(message.GetString("call_id"), message.GetString("tool_call_id"));
+        if (string.IsNullOrWhiteSpace(callId)) {
+            return false;
+        }
+
+        return !string.IsNullOrWhiteSpace(message.GetString("output"))
+               || !string.IsNullOrWhiteSpace(message.GetString("result"));
+    }
+
+    private static void AddReplayIndex(IDictionary<string, List<int>> indexesById, string callId, int index) {
+        if (!indexesById.TryGetValue(callId, out var indexes)) {
+            indexes = new List<int>();
+            indexesById[callId] = indexes;
+        }
+
+        indexes.Add(index);
+    }
+
+    private static bool TrySelectReplayPairIndexes(
+        IReadOnlyList<int> callIndexes,
+        IReadOnlyList<int> outputIndexes,
+        out int selectedCallIndex,
+        out int selectedOutputIndex) {
+        selectedCallIndex = -1;
+        selectedOutputIndex = -1;
+        if (callIndexes is null || outputIndexes is null || callIndexes.Count == 0 || outputIndexes.Count == 0) {
+            return false;
+        }
+
+        var outputCursor = 0;
+        for (var i = 0; i < callIndexes.Count; i++) {
+            var callIndex = callIndexes[i];
+            while (outputCursor < outputIndexes.Count && outputIndexes[outputCursor] <= callIndex) {
+                outputCursor++;
+            }
+
+            if (outputCursor >= outputIndexes.Count) {
+                break;
+            }
+
+            selectedCallIndex = callIndex;
+            selectedOutputIndex = outputIndexes[outputCursor];
+        }
+
+        return selectedCallIndex >= 0 && selectedOutputIndex >= 0;
+    }
+
+    private static string? FirstNonEmpty(params string?[] values) {
+        if (values is null || values.Length == 0) {
+            return null;
+        }
+
+        for (var i = 0; i < values.Length; i++) {
+            var value = values[i];
+            if (!string.IsNullOrWhiteSpace(value)) {
+                return value;
+            }
+        }
+
+        return null;
     }
 
     public void Dispose() {


### PR DESCRIPTION
## Summary
- Hardened replay input normalization for native transport to prevent malformed replay envelopes and orphaned call/output pairs.
- Added replay dedupe + pairing normalization for compatible-http requests so duplicate call_ids no longer produce unpaired function-call/tool-output chains.
- Added app-server transport input normalization for tool replay items (including legacy `arguments` stripping and pair filtering).
- Tightened chat service replay emission to only send tool outputs when the corresponding call is present, with duplicate output call_ids collapsed.
- Added regression tests for native replay dedupe/field sanitization, compatible-http duplicate call_id replay, and app-server replay normalization.

## Why
This addresses runtime failures seen in real chat turns:
- `No tool call found for custom tool call output with call_id ...`
- `No tool output found for function call ...`
- `Unknown parameter: 'input[n].arguments'`

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release --no-build`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
