### PR TITLE
feat(chat): strict scenario guards for pairing, duplicates, and partial completion

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Scenario.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Scenario.cs
@@ -10,10 +10,22 @@ using System.Threading.Tasks;
 using IntelligenceX.OpenAI.Chat;
 using IntelligenceX.OpenAI.ToolCalling;
 using IntelligenceX.Tools;
+using JsonLite = IntelligenceX.Json.JsonLite;
 
 namespace IntelligenceX.Chat.Host;
 
 internal static partial class Program {
+    private static readonly string[] PartialCompletionMarkers = {
+        "partial response shown above",
+        "turn ended before completion",
+        "chat failed:",
+        "[execution blocked]",
+        "no tool call found for custom tool call output with call_id",
+        "no tool output found for function call",
+        "unknown parameter: 'input[",
+        "(chat_failed)"
+    };
+
     private static async Task<int> RunScenarioFileAsync(ReplSession session, ReplOptions options, CancellationToken cancellationToken) {
         if (session is null) {
             throw new ArgumentNullException(nameof(session));
@@ -223,6 +235,25 @@ internal static partial class Program {
                || MatchesPrefix(turn.RequireAnyTools, prefix);
     }
 
+    private static bool TurnHasToolContract(
+        int? minToolCalls,
+        int? minToolRounds,
+        IReadOnlyList<string> requireTools,
+        IReadOnlyList<string> requireAnyTools,
+        IReadOnlyList<string> assertToolOutputContains,
+        IReadOnlyList<string> assertToolOutputNotContains,
+        bool assertNoToolErrors,
+        IReadOnlyList<string> forbidToolErrorCodes) {
+        return Math.Max(0, minToolCalls ?? 0) > 0
+               || Math.Max(0, minToolRounds ?? 0) > 0
+               || requireTools.Count > 0
+               || requireAnyTools.Count > 0
+               || assertToolOutputContains.Count > 0
+               || assertToolOutputNotContains.Count > 0
+               || assertNoToolErrors
+               || forbidToolErrorCodes.Count > 0;
+    }
+
     private static ChatScenarioDefinition LoadChatScenarioDefinition(string scenarioPath) {
         if (string.IsNullOrWhiteSpace(scenarioPath)) {
             throw new ArgumentException("Scenario path cannot be empty.", nameof(scenarioPath));
@@ -302,7 +333,13 @@ internal static partial class Program {
                     assertToolOutputContains: Array.Empty<string>(),
                     assertToolOutputNotContains: Array.Empty<string>(),
                     assertNoToolErrors: false,
-                    forbidToolErrorCodes: Array.Empty<string>()));
+                    forbidToolErrorCodes: Array.Empty<string>(),
+                    assertCleanCompletion: true,
+                    assertToolCallOutputPairing: false,
+                    assertNoDuplicateToolCallIds: false,
+                    assertNoDuplicateToolOutputCallIds: false,
+                    maxNoToolExecutionRetries: null,
+                    maxDuplicateToolCallSignatures: null));
                 continue;
             }
 
@@ -331,6 +368,32 @@ internal static partial class Program {
             var assertToolOutputNotContains = ReadScenarioStringList(element, "assert_tool_output_not_contains");
             var assertNoToolErrors = ReadScenarioOptionalBoolean(element, "assert_no_tool_errors", defaultValue: false);
             var forbidToolErrorCodes = ReadScenarioStringList(element, "forbid_tool_error_codes");
+            var hasToolContract = TurnHasToolContract(
+                minToolCalls,
+                minToolRounds,
+                requireTools,
+                requireAnyTools,
+                assertToolOutputContains,
+                assertToolOutputNotContains,
+                assertNoToolErrors,
+                forbidToolErrorCodes);
+            var assertCleanCompletion = ReadScenarioOptionalBoolean(element, "assert_clean_completion", defaultValue: true);
+            var assertToolCallOutputPairing = ReadScenarioOptionalBoolean(
+                element,
+                "assert_tool_call_output_pairing",
+                defaultValue: hasToolContract);
+            var assertNoDuplicateToolCallIds = ReadScenarioOptionalBoolean(
+                element,
+                "assert_no_duplicate_tool_call_ids",
+                defaultValue: hasToolContract);
+            var assertNoDuplicateToolOutputCallIds = ReadScenarioOptionalBoolean(
+                element,
+                "assert_no_duplicate_tool_output_call_ids",
+                defaultValue: hasToolContract);
+            var maxNoToolExecutionRetries = ReadScenarioOptionalNonNegativeInt(element, "max_no_tool_execution_retries")
+                                            ?? (hasToolContract ? 0 : null);
+            var maxDuplicateToolCallSignatures = ReadScenarioOptionalNonNegativeInt(element, "max_duplicate_tool_call_signatures")
+                                                 ?? (hasToolContract ? 1 : null);
             turns.Add(new ChatScenarioTurn(
                 name,
                 user.Trim(),
@@ -346,7 +409,13 @@ internal static partial class Program {
                 assertToolOutputContains,
                 assertToolOutputNotContains,
                 assertNoToolErrors,
-                forbidToolErrorCodes));
+                forbidToolErrorCodes,
+                assertCleanCompletion,
+                assertToolCallOutputPairing,
+                assertNoDuplicateToolCallIds,
+                assertNoDuplicateToolOutputCallIds,
+                maxNoToolExecutionRetries,
+                maxDuplicateToolCallSignatures));
         }
 
         return turns;
@@ -384,7 +453,13 @@ internal static partial class Program {
                 assertToolOutputContains: Array.Empty<string>(),
                 assertToolOutputNotContains: Array.Empty<string>(),
                 assertNoToolErrors: false,
-                forbidToolErrorCodes: Array.Empty<string>()));
+                forbidToolErrorCodes: Array.Empty<string>(),
+                assertCleanCompletion: true,
+                assertToolCallOutputPairing: false,
+                assertNoDuplicateToolCallIds: false,
+                assertNoDuplicateToolOutputCallIds: false,
+                maxNoToolExecutionRetries: null,
+                maxDuplicateToolCallSignatures: null));
         }
         return turns;
     }
@@ -481,6 +556,7 @@ internal static partial class Program {
         var assistantText = turnResult?.Result.Text ?? string.Empty;
         var toolCalls = turnResult?.Result.ToolCalls ?? Array.Empty<ToolCall>();
         var toolOutputs = turnResult?.Result.ToolOutputs ?? Array.Empty<ToolOutput>();
+        var noToolExecutionRetries = turnResult?.Result.NoToolExecutionRetries ?? 0;
         var toolNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < toolCalls.Count; i++) {
             var toolName = (toolCalls[i].Name ?? string.Empty).Trim();
@@ -489,6 +565,13 @@ internal static partial class Program {
             }
         }
         var (toolErrorCount, toolErrorCodes) = SummarizeToolOutputErrors(toolOutputs);
+        var toolCallIdCounts = BuildToolCallIdCounts(toolCalls);
+        var toolOutputCallIdCounts = BuildToolOutputCallIdCounts(toolOutputs);
+        var toolCallSignatureCounts = BuildToolCallSignatureCounts(toolCalls);
+
+        if (turn.AssertCleanCompletion && ContainsPartialCompletionMarker(assistantText)) {
+            failures.Add("Expected clean completion, but assistant output contains partial/transport failure markers.");
+        }
 
         foreach (var expected in turn.AssertContains) {
             if (assistantText.IndexOf(expected, StringComparison.OrdinalIgnoreCase) >= 0) {
@@ -529,6 +612,11 @@ internal static partial class Program {
         var toolRounds = turnResult?.Metrics.ToolRounds ?? 0;
         if (turn.MinToolRounds.HasValue && toolRounds < turn.MinToolRounds.Value) {
             failures.Add($"Expected at least {turn.MinToolRounds.Value} tool round(s); observed {toolRounds}.");
+        }
+
+        if (turn.MaxNoToolExecutionRetries.HasValue && noToolExecutionRetries > turn.MaxNoToolExecutionRetries.Value) {
+            failures.Add(
+                $"Expected at most {turn.MaxNoToolExecutionRetries.Value} no-tool execution retry attempt(s); observed {noToolExecutionRetries}.");
         }
 
         foreach (var requiredTool in turn.RequireTools) {
@@ -594,7 +682,163 @@ internal static partial class Program {
             failures.Add($"Expected tool error code '{forbiddenErrorCode}' (exact or wildcard) to be absent, but it was observed.");
         }
 
+        if (turn.AssertNoDuplicateToolCallIds) {
+            var duplicateCallIds = toolCallIdCounts
+                .Where(static pair => pair.Value > 1)
+                .Select(static pair => pair.Key)
+                .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (duplicateCallIds.Length > 0) {
+                failures.Add("Expected unique tool call IDs, but duplicates were observed: " + FormatValuesForAssertion(duplicateCallIds) + ".");
+            }
+        }
+
+        if (turn.AssertNoDuplicateToolOutputCallIds) {
+            var duplicateOutputCallIds = toolOutputCallIdCounts
+                .Where(static pair => pair.Value > 1)
+                .Select(static pair => pair.Key)
+                .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (duplicateOutputCallIds.Length > 0) {
+                failures.Add("Expected unique tool output call IDs, but duplicates were observed: " + FormatValuesForAssertion(duplicateOutputCallIds) + ".");
+            }
+        }
+
+        if (turn.AssertToolCallOutputPairing) {
+            var callIds = new HashSet<string>(toolCallIdCounts.Keys, StringComparer.OrdinalIgnoreCase);
+            var outputCallIds = new HashSet<string>(toolOutputCallIdCounts.Keys, StringComparer.OrdinalIgnoreCase);
+            callIds.Remove(string.Empty);
+            outputCallIds.Remove(string.Empty);
+
+            var missingOutputs = callIds
+                .Where(id => !outputCallIds.Contains(id))
+                .OrderBy(static id => id, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (missingOutputs.Length > 0) {
+                failures.Add("Expected a tool output for each tool call ID; missing output(s) for: " + FormatValuesForAssertion(missingOutputs) + ".");
+            }
+
+            var orphanOutputs = outputCallIds
+                .Where(id => !callIds.Contains(id))
+                .OrderBy(static id => id, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (orphanOutputs.Length > 0) {
+                failures.Add("Expected tool outputs to map to in-turn tool calls; orphan output ID(s): " + FormatValuesForAssertion(orphanOutputs) + ".");
+            }
+
+            var emptyOutputCallIds = toolOutputs.Count(static output => string.IsNullOrWhiteSpace(output.CallId));
+            if (emptyOutputCallIds > 0) {
+                failures.Add($"Expected tool output call_id to be present; observed {emptyOutputCallIds} output(s) without call_id.");
+            }
+        }
+
+        if (turn.MaxDuplicateToolCallSignatures.HasValue) {
+            var maxAllowed = Math.Max(0, turn.MaxDuplicateToolCallSignatures.Value);
+            var duplicates = toolCallSignatureCounts
+                .Where(pair => pair.Value > maxAllowed)
+                .OrderByDescending(static pair => pair.Value)
+                .ThenBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(pair => $"{pair.Key} x{pair.Value}")
+                .ToArray();
+            if (duplicates.Length > 0) {
+                failures.Add(
+                    $"Expected each tool call signature to appear at most {maxAllowed} time(s), but observed duplicates: "
+                    + FormatValuesForAssertion(duplicates) + ".");
+            }
+        }
+
         return failures;
+    }
+
+    private static bool ContainsPartialCompletionMarker(string text) {
+        if (string.IsNullOrWhiteSpace(text)) {
+            return false;
+        }
+
+        var value = text.Trim();
+        for (var i = 0; i < PartialCompletionMarkers.Length; i++) {
+            if (value.IndexOf(PartialCompletionMarkers[i], StringComparison.OrdinalIgnoreCase) >= 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Dictionary<string, int> BuildToolCallIdCounts(IReadOnlyList<ToolCall> toolCalls) {
+        var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < toolCalls.Count; i++) {
+            var callId = (toolCalls[i].CallId ?? string.Empty).Trim();
+            if (!counts.TryGetValue(callId, out var count)) {
+                counts[callId] = 1;
+                continue;
+            }
+
+            counts[callId] = count + 1;
+        }
+
+        return counts;
+    }
+
+    private static Dictionary<string, int> BuildToolOutputCallIdCounts(IReadOnlyList<ToolOutput> toolOutputs) {
+        var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < toolOutputs.Count; i++) {
+            var callId = (toolOutputs[i].CallId ?? string.Empty).Trim();
+            if (!counts.TryGetValue(callId, out var count)) {
+                counts[callId] = 1;
+                continue;
+            }
+
+            counts[callId] = count + 1;
+        }
+
+        return counts;
+    }
+
+    private static Dictionary<string, int> BuildToolCallSignatureCounts(IReadOnlyList<ToolCall> toolCalls) {
+        var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < toolCalls.Count; i++) {
+            var signature = BuildToolCallSignature(toolCalls[i]);
+            if (signature.Length == 0) {
+                continue;
+            }
+
+            if (!counts.TryGetValue(signature, out var count)) {
+                counts[signature] = 1;
+                continue;
+            }
+
+            counts[signature] = count + 1;
+        }
+
+        return counts;
+    }
+
+    private static string BuildToolCallSignature(ToolCall call) {
+        var toolName = (call.Name ?? string.Empty).Trim();
+        if (toolName.Length == 0) {
+            return string.Empty;
+        }
+
+        var args = call.Arguments is null ? "{}" : JsonLite.Serialize(call.Arguments);
+        return toolName + " " + args;
+    }
+
+    private static string FormatValuesForAssertion(IReadOnlyList<string> values, int maxItems = 6) {
+        if (values.Count == 0) {
+            return "-";
+        }
+
+        var capped = values
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Take(Math.Max(1, maxItems))
+            .ToArray();
+        if (capped.Length == 0) {
+            return "-";
+        }
+
+        var suffix = values.Count > capped.Length ? ", ..." : string.Empty;
+        return string.Join(", ", capped) + suffix;
     }
 
     private static bool ToolNameSetContains(IReadOnlyCollection<string> toolNames, string expectedNameOrPattern) {
@@ -797,6 +1041,7 @@ internal static partial class Program {
                 sb.AppendLine($"- TTFT ms: {(turn.Result.Metrics.TtftMs.HasValue ? turn.Result.Metrics.TtftMs.Value.ToString() : "-")}");
                 sb.AppendLine($"- Tool calls: {turn.Result.Metrics.ToolCallsCount}");
                 sb.AppendLine($"- Tool rounds: {turn.Result.Metrics.ToolRounds}");
+                sb.AppendLine($"- No-tool retries: {turn.Result.Metrics.NoToolExecutionRetries}");
                 var toolNames = turn.Result.Result.ToolCalls
                     .Select(static c => (c.Name ?? string.Empty).Trim())
                     .Where(static n => n.Length > 0)
@@ -881,7 +1126,13 @@ internal static partial class Program {
             IReadOnlyList<string> assertToolOutputContains,
             IReadOnlyList<string> assertToolOutputNotContains,
             bool assertNoToolErrors,
-            IReadOnlyList<string> forbidToolErrorCodes) {
+            IReadOnlyList<string> forbidToolErrorCodes,
+            bool assertCleanCompletion,
+            bool assertToolCallOutputPairing,
+            bool assertNoDuplicateToolCallIds,
+            bool assertNoDuplicateToolOutputCallIds,
+            int? maxNoToolExecutionRetries,
+            int? maxDuplicateToolCallSignatures) {
             Name = name;
             User = user ?? string.Empty;
             AssertContains = assertContains ?? Array.Empty<string>();
@@ -897,6 +1148,12 @@ internal static partial class Program {
             AssertToolOutputNotContains = assertToolOutputNotContains ?? Array.Empty<string>();
             AssertNoToolErrors = assertNoToolErrors;
             ForbidToolErrorCodes = forbidToolErrorCodes ?? Array.Empty<string>();
+            AssertCleanCompletion = assertCleanCompletion;
+            AssertToolCallOutputPairing = assertToolCallOutputPairing;
+            AssertNoDuplicateToolCallIds = assertNoDuplicateToolCallIds;
+            AssertNoDuplicateToolOutputCallIds = assertNoDuplicateToolOutputCallIds;
+            MaxNoToolExecutionRetries = maxNoToolExecutionRetries;
+            MaxDuplicateToolCallSignatures = maxDuplicateToolCallSignatures;
         }
 
         public string? Name { get; }
@@ -914,6 +1171,12 @@ internal static partial class Program {
         public IReadOnlyList<string> AssertToolOutputNotContains { get; }
         public bool AssertNoToolErrors { get; }
         public IReadOnlyList<string> ForbidToolErrorCodes { get; }
+        public bool AssertCleanCompletion { get; }
+        public bool AssertToolCallOutputPairing { get; }
+        public bool AssertNoDuplicateToolCallIds { get; }
+        public bool AssertNoDuplicateToolOutputCallIds { get; }
+        public int? MaxNoToolExecutionRetries { get; }
+        public int? MaxDuplicateToolCallSignatures { get; }
     }
 
     private sealed class ScenarioTurnRun {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
@@ -78,7 +78,8 @@ internal static partial class Program {
                     ttftMs: ttftMs,
                     usage: result.Usage,
                     toolCallsCount: result.ToolCalls.Count,
-                    toolRounds: result.ToolRounds);
+                    toolRounds: result.ToolRounds,
+                    noToolExecutionRetries: result.NoToolExecutionRetries);
                 return new ReplTurnMetricsResult(result, metrics);
             } finally {
                 _client.DeltaReceived -= OnDelta;
@@ -144,7 +145,7 @@ internal static partial class Program {
                     }
 
                     _previousResponseId = TryGetResponseId(turn) ?? _previousResponseId;
-                    return new ReplTurnResult(finalText, calls, outputs, turn.Usage, toolRounds);
+                    return new ReplTurnResult(finalText, calls, outputs, turn.Usage, toolRounds, noToolExecutionRetryCount);
                 }
 
                 toolRounds++;
@@ -601,12 +602,13 @@ internal static partial class Program {
 
     private sealed class ReplTurnResult {
         public ReplTurnResult(string text, IReadOnlyList<ToolCall> toolCalls, IReadOnlyList<ToolOutput> toolOutputs,
-            TurnUsage? usage = null, int toolRounds = 0) {
+            TurnUsage? usage = null, int toolRounds = 0, int noToolExecutionRetries = 0) {
             Text = text ?? string.Empty;
             ToolCalls = toolCalls ?? Array.Empty<ToolCall>();
             ToolOutputs = toolOutputs ?? Array.Empty<ToolOutput>();
             Usage = usage;
             ToolRounds = Math.Max(0, toolRounds);
+            NoToolExecutionRetries = Math.Max(0, noToolExecutionRetries);
         }
 
         public string Text { get; }
@@ -614,11 +616,12 @@ internal static partial class Program {
         public IReadOnlyList<ToolOutput> ToolOutputs { get; }
         public TurnUsage? Usage { get; }
         public int ToolRounds { get; }
+        public int NoToolExecutionRetries { get; }
     }
 
     private sealed class ReplTurnMetrics {
         public ReplTurnMetrics(DateTime startedAtUtc, DateTime? firstDeltaAtUtc, DateTime completedAtUtc, long durationMs, long? ttftMs,
-            TurnUsage? usage, int toolCallsCount, int toolRounds) {
+            TurnUsage? usage, int toolCallsCount, int toolRounds, int noToolExecutionRetries) {
             StartedAtUtc = startedAtUtc;
             FirstDeltaAtUtc = firstDeltaAtUtc;
             CompletedAtUtc = completedAtUtc;
@@ -627,6 +630,7 @@ internal static partial class Program {
             Usage = usage;
             ToolCallsCount = Math.Max(0, toolCallsCount);
             ToolRounds = Math.Max(0, toolRounds);
+            NoToolExecutionRetries = Math.Max(0, noToolExecutionRetries);
         }
 
         public DateTime StartedAtUtc { get; }
@@ -637,6 +641,7 @@ internal static partial class Program {
         public TurnUsage? Usage { get; }
         public int ToolCallsCount { get; }
         public int ToolRounds { get; }
+        public int NoToolExecutionRetries { get; }
     }
 
     private sealed class ReplTurnMetricsResult {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioAssertionTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioAssertionTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class HostScenarioAssertionTests {
+    [Fact]
+    public void EvaluateScenarioAssertions_FailsStrictToolContract_OnPairingDuplicatesAndRetryChurn() {
+        const string json = """
+{
+  "name": "strict-check",
+  "turns": [
+    {
+      "name": "Strict Turn",
+      "user": "Check AD0 reboot evidence.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["eventlog_*query*"]
+    }
+  ]
+}
+""";
+        var turn = ParseSingleTurn(json);
+
+        var calls = new List<ToolCall> {
+            BuildToolCall("call_1", "eventlog_live_query", "{\"machine_name\":\"AD0\"}"),
+            BuildToolCall("call_1", "eventlog_live_query", "{\"machine_name\":\"AD0\"}")
+        };
+        var outputs = new List<ToolOutput> {
+            new("call_2", "{\"ok\":true}"),
+            new("call_2", "{\"ok\":true}")
+        };
+
+        var metricsResult = BuildMetricsResult(
+            assistantText: "Completed.",
+            toolCalls: calls,
+            toolOutputs: outputs,
+            toolRounds: 1,
+            noToolExecutionRetries: 1);
+
+        var failures = InvokeEvaluateScenarioAssertions(turn, metricsResult);
+
+        Assert.Contains(failures, value => value.Contains("no-tool execution retry", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(failures, value => value.Contains("unique tool call IDs", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(failures, value => value.Contains("unique tool output call IDs", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(failures, value => value.Contains("missing output", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(failures, value => value.Contains("orphan output", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(failures, value => value.Contains("tool call signature", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void EvaluateScenarioAssertions_FailsCleanCompletion_WhenPartialMarkerAppears() {
+        const string json = """
+{
+  "name": "clean-completion",
+  "turns": [
+    {
+      "name": "Turn 1",
+      "user": "Check AD status."
+    }
+  ]
+}
+""";
+        var turn = ParseSingleTurn(json);
+
+        var metricsResult = BuildMetricsResult(
+            assistantText: "Partial response shown above. The turn ended before completion.",
+            toolCalls: Array.Empty<ToolCall>(),
+            toolOutputs: Array.Empty<ToolOutput>(),
+            toolRounds: 0,
+            noToolExecutionRetries: 0);
+
+        var failures = InvokeEvaluateScenarioAssertions(turn, metricsResult);
+
+        Assert.Contains(failures, value => value.Contains("clean completion", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static object ParseSingleTurn(string json) {
+        var programType = ResolveHostProgramType();
+        var parseMethod = programType.GetMethod("ParseChatScenarioDefinition", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(parseMethod);
+
+        var scenario = parseMethod!.Invoke(null, new object?[] { json, "scenario" });
+        Assert.NotNull(scenario);
+
+        var turnsProperty = scenario!.GetType().GetProperty("Turns", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(turnsProperty);
+        var enumerable = Assert.IsAssignableFrom<IEnumerable>(turnsProperty!.GetValue(scenario));
+        var turns = enumerable.Cast<object>().ToList();
+        Assert.Single(turns);
+        return turns[0];
+    }
+
+    private static ToolCall BuildToolCall(string callId, string name, string jsonArgs) {
+        var args = JsonLite.Parse(jsonArgs)?.AsObject();
+        var raw = new JsonObject()
+            .Add("type", "custom_tool_call")
+            .Add("call_id", callId)
+            .Add("name", name)
+            .Add("input", jsonArgs);
+        return new ToolCall(callId, name, jsonArgs, args, raw);
+    }
+
+    private static object BuildMetricsResult(string assistantText, IReadOnlyList<ToolCall> toolCalls, IReadOnlyList<ToolOutput> toolOutputs,
+        int toolRounds, int noToolExecutionRetries) {
+        var programType = ResolveHostProgramType();
+        var hostAssembly = programType.Assembly;
+        var resultType = hostAssembly.GetType("IntelligenceX.Chat.Host.Program+ReplTurnResult", throwOnError: true);
+        var metricsType = hostAssembly.GetType("IntelligenceX.Chat.Host.Program+ReplTurnMetrics", throwOnError: true);
+        var metricsResultType = hostAssembly.GetType("IntelligenceX.Chat.Host.Program+ReplTurnMetricsResult", throwOnError: true);
+
+        Assert.NotNull(resultType);
+        Assert.NotNull(metricsType);
+        Assert.NotNull(metricsResultType);
+
+        var now = DateTime.UtcNow;
+        var result = Activator.CreateInstance(resultType!, new object?[] {
+            assistantText,
+            toolCalls,
+            toolOutputs,
+            null,
+            toolRounds,
+            noToolExecutionRetries
+        });
+        Assert.NotNull(result);
+
+        var metrics = Activator.CreateInstance(metricsType!, new object?[] {
+            now,
+            null,
+            now,
+            1L,
+            null,
+            null,
+            toolCalls.Count,
+            toolRounds,
+            noToolExecutionRetries
+        });
+        Assert.NotNull(metrics);
+
+        var metricsResult = Activator.CreateInstance(metricsResultType!, new[] { result, metrics });
+        Assert.NotNull(metricsResult);
+        return metricsResult!;
+    }
+
+    private static IReadOnlyList<string> InvokeEvaluateScenarioAssertions(object turn, object metricsResult) {
+        var programType = ResolveHostProgramType();
+        var method = programType.GetMethod("EvaluateScenarioAssertions", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var result = method!.Invoke(null, new[] { turn, metricsResult });
+        var enumerable = Assert.IsAssignableFrom<IEnumerable>(result);
+        return enumerable.Cast<object>().Select(value => value?.ToString() ?? string.Empty).ToList();
+    }
+
+    private static Type ResolveHostProgramType() {
+        var hostAssembly = Assembly.Load("IntelligenceX.Chat.Host");
+        var hostProgramType = hostAssembly.GetType("IntelligenceX.Chat.Host.Program", throwOnError: true);
+        Assert.NotNull(hostProgramType);
+        return hostProgramType!;
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioParsingTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioParsingTests.cs
@@ -31,7 +31,13 @@ public sealed class HostScenarioParsingTests {
       "assert_tool_output_contains": ["6008", "Kernel-Power"],
       "assert_tool_output_not_contains": ["schema_validation_failed"],
       "assert_no_tool_errors": true,
-      "forbid_tool_error_codes": ["invalid_argument", "query_*"]
+      "forbid_tool_error_codes": ["invalid_argument", "query_*"],
+      "assert_clean_completion": true,
+      "assert_tool_call_output_pairing": true,
+      "assert_no_duplicate_tool_call_ids": true,
+      "assert_no_duplicate_tool_output_call_ids": true,
+      "max_no_tool_execution_retries": 0,
+      "max_duplicate_tool_call_signatures": 1
     },
     "Check peer DCs"
   ]
@@ -57,6 +63,12 @@ public sealed class HostScenarioParsingTests {
         Assert.Single(ReadStringListProperty(turns[0], "AssertToolOutputNotContains"));
         Assert.True(ReadBooleanProperty(turns[0], "AssertNoToolErrors"));
         Assert.Equal(2, ReadStringListProperty(turns[0], "ForbidToolErrorCodes").Count);
+        Assert.True(ReadBooleanProperty(turns[0], "AssertCleanCompletion"));
+        Assert.True(ReadBooleanProperty(turns[0], "AssertToolCallOutputPairing"));
+        Assert.True(ReadBooleanProperty(turns[0], "AssertNoDuplicateToolCallIds"));
+        Assert.True(ReadBooleanProperty(turns[0], "AssertNoDuplicateToolOutputCallIds"));
+        Assert.Equal(0, ReadNullableIntProperty(turns[0], "MaxNoToolExecutionRetries"));
+        Assert.Equal(1, ReadNullableIntProperty(turns[0], "MaxDuplicateToolCallSignatures"));
         Assert.Equal("Check peer DCs", ReadStringProperty(turns[1], "User"));
         Assert.Empty(ReadStringListProperty(turns[1], "AssertContains"));
         Assert.Empty(ReadStringListProperty(turns[1], "AssertNotContains"));
@@ -71,6 +83,12 @@ public sealed class HostScenarioParsingTests {
         Assert.Empty(ReadStringListProperty(turns[1], "AssertToolOutputNotContains"));
         Assert.False(ReadBooleanProperty(turns[1], "AssertNoToolErrors"));
         Assert.Empty(ReadStringListProperty(turns[1], "ForbidToolErrorCodes"));
+        Assert.True(ReadBooleanProperty(turns[1], "AssertCleanCompletion"));
+        Assert.False(ReadBooleanProperty(turns[1], "AssertToolCallOutputPairing"));
+        Assert.False(ReadBooleanProperty(turns[1], "AssertNoDuplicateToolCallIds"));
+        Assert.False(ReadBooleanProperty(turns[1], "AssertNoDuplicateToolOutputCallIds"));
+        Assert.Null(ReadNullableIntProperty(turns[1], "MaxNoToolExecutionRetries"));
+        Assert.Null(ReadNullableIntProperty(turns[1], "MaxDuplicateToolCallSignatures"));
     }
 
     [Fact]
@@ -163,6 +181,32 @@ Check AD0 reboot
         Assert.Contains("first discovered/source DC", prompt, StringComparison.Ordinal);
         Assert.Contains("eventlog_pack_info alone is insufficient", prompt, StringComparison.Ordinal);
         Assert.Contains("Final response must include these literals: UTC.", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ParseChatScenarioDefinition_ToolContractTurn_AppliesStrictDefaultsWhenFieldsAreOmitted() {
+        const string json = """
+{
+  "name": "strict-defaults",
+  "turns": [
+    {
+      "name": "Strict Turn",
+      "user": "Check AD0 reboot evidence",
+      "min_tool_calls": 1,
+      "require_any_tools": ["eventlog_*query*"]
+    }
+  ]
+}
+""";
+        var scenario = InvokeParseScenarioDefinition(json, "strict-defaults");
+        var turn = ReadTurns(scenario).Single();
+
+        Assert.True(ReadBooleanProperty(turn, "AssertCleanCompletion"));
+        Assert.True(ReadBooleanProperty(turn, "AssertToolCallOutputPairing"));
+        Assert.True(ReadBooleanProperty(turn, "AssertNoDuplicateToolCallIds"));
+        Assert.True(ReadBooleanProperty(turn, "AssertNoDuplicateToolOutputCallIds"));
+        Assert.Equal(0, ReadNullableIntProperty(turn, "MaxNoToolExecutionRetries"));
+        Assert.Equal(1, ReadNullableIntProperty(turn, "MaxDuplicateToolCallSignatures"));
     }
 
     private static object InvokeParseScenarioDefinition(string raw, string fallbackName) {

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -53,6 +53,12 @@ Scenario file formats:
   - `assert_tool_output_not_contains` (string or array; disallowed content in tool output payloads)
   - `assert_no_tool_errors` (boolean; when true, fails turn if any tool output envelope has `ok=false`)
   - `forbid_tool_error_codes` (string or array; disallow specific tool `error_code` values; supports `*` and `?` wildcards)
+  - `assert_clean_completion` (boolean; default `true`; fails when assistant output includes partial/transport-failure markers)
+  - `assert_tool_call_output_pairing` (boolean; defaults to `true` for tool-contract turns; enforces call/output `call_id` pairing integrity)
+  - `assert_no_duplicate_tool_call_ids` (boolean; defaults to `true` for tool-contract turns)
+  - `assert_no_duplicate_tool_output_call_ids` (boolean; defaults to `true` for tool-contract turns)
+  - `max_no_tool_execution_retries` (integer >= 0; defaults to `0` for tool-contract turns)
+  - `max_duplicate_tool_call_signatures` (integer >= 0; defaults to `1` for tool-contract turns)
 - Plain text where each non-empty line is a user turn (`#` and `//` lines are ignored).
 
 The host writes a markdown run report under `artifacts/chat-scenarios` by default (or your `-ScenarioOutput` path).


### PR DESCRIPTION
## Summary
- add stricter chat scenario turn assertions for real regressions we observed in interactive runs:
  - clean completion markers (partial/transport failure text)
  - tool call/output `call_id` pairing integrity
  - duplicate tool call and tool output ID detection
  - duplicate tool-call signature caps
  - no-tool retry churn caps
- make strict integrity defaults auto-enable for tool-contract turns (`min_tool_calls` / required tools / tool-output assertions)
- surface `No-tool retries` in scenario markdown reports
- add host tests for strict default parsing and assertion behavior
- document the new scenario fields in `IntelligenceX.Chat/README.md`

## Validation
- `dotnet build IntelligenceX.sln -c Release --nologo`
- `dotnet test IntelligenceX.sln -c Release --no-build --nologo`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
