### PR TITLE
chore(pr-babysit): cover review edits and lock monitor trigger contract

### DIFF
--- a/.github/workflows/ix-pr-babysit-monitor.yml
+++ b/.github/workflows/ix-pr-babysit-monitor.yml
@@ -14,6 +14,7 @@ on:
     # Keep submitted reviews as the event-driven signal and avoid duplicate monitor runs.
     types:
       - submitted
+      - edited
   workflow_dispatch:
     inputs:
       pr:

--- a/Docs/reviewer/projects-pr-monitoring.md
+++ b/Docs/reviewer/projects-pr-monitoring.md
@@ -87,7 +87,7 @@ Observe-mode babysitter automation:
 
 - Workflow: `.github/workflows/ix-pr-babysit-monitor.yml`
 - Triggers:
-  - event-driven on PR lifecycle and submitted reviews (`pull_request`, `pull_request_review`)
+  - event-driven on PR lifecycle and submitted/edited reviews (`pull_request`, `pull_request_review`)
   - hourly observe-mode safety-net sweep
 - Engine command: `intelligencex todo pr-watch-monitor`
 - Behavior:
@@ -140,7 +140,7 @@ Weekly governance automation:
 
 | Cadence | Workflow | Phase | Purpose | Expected maintainer action |
 | --- | --- | --- | --- | --- |
-| Event-driven | `.github/workflows/ix-pr-babysit-monitor.yml` | `observe` | Immediate reaction to PR updates and submitted reviews | Validate newest blocker classification quickly and decide whether targeted assist is needed |
+| Event-driven | `.github/workflows/ix-pr-babysit-monitor.yml` | `observe` | Immediate reaction to PR updates and submitted/edited reviews | Validate newest blocker classification quickly and decide whether targeted assist is needed |
 | Hourly | `.github/workflows/ix-pr-babysit-monitor.yml` | `observe` | Fast detection of CI/review/mergeability drift on open PRs | Triage fresh blockers and decide whether to run assist retry on specific PRs |
 | Daily | `.github/workflows/ix-pr-babysit-nightly-consolidation.yml` | `observe` | Portfolio-level no-progress and stale-blocker rollup | Prioritize next-day unblock queue, review metrics deltas, and maintain source tracker issue |
 | Weekly | `.github/workflows/ix-pr-babysit-weekly-governance.yml` | `observe` | Wider-window governance snapshot (older stalls/churn classes) | Review systemic patterns, validate stale/no-progress trend direction, and adjust operational ownership |

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -232,6 +232,10 @@ internal static partial class Program {
         failed += Run("Todo pr-watch authenticated login fallback uses actor env", TestPrWatchResolveAuthenticatedLoginFallbackUsesActorEnv);
         failed += Run("Todo pr-watch authenticated login fallback prefers actor over triggering actor", TestPrWatchResolveAuthenticatedLoginFallbackPrefersActorOverTriggeringActor);
         failed += Run("Todo pr-watch authenticated login fallback empty when unset", TestPrWatchResolveAuthenticatedLoginFallbackReturnsEmptyWhenUnset);
+        failed += Run("Todo pr-watch monitor workflow review triggers include submitted and edited",
+            TestPrWatchMonitorWorkflowReviewTriggersIncludeSubmittedAndEdited);
+        failed += Run("Todo pr-watch monitor workflow excludes review comment trigger",
+            TestPrWatchMonitorWorkflowExcludesReviewCommentTrigger);
         failed += Run("Todo unknown command", TestTodoUnknownCommandShowsMessage);
         failed += Run("Todo bot feedback render LF", TestBotFeedbackRenderHonorsLfNewlines);
         failed += Run("Todo bot feedback parse existing", TestBotFeedbackParseExistingPrBlockExtractsTasks);

--- a/IntelligenceX.Tests/Program.Todo.PrWatch.WorkflowContracts.cs
+++ b/IntelligenceX.Tests/Program.Todo.PrWatch.WorkflowContracts.cs
@@ -1,0 +1,22 @@
+namespace IntelligenceX.Tests;
+
+internal static partial class Program {
+#if !NET472
+    private static void TestPrWatchMonitorWorkflowReviewTriggersIncludeSubmittedAndEdited() {
+        var workflowPath = Path.Combine(".github", "workflows", "ix-pr-babysit-monitor.yml");
+        var content = File.ReadAllText(workflowPath);
+
+        AssertContainsText(content, "pull_request_review:", "monitor workflow defines pull_request_review trigger");
+        AssertContainsText(content, "- submitted", "monitor workflow includes submitted review trigger");
+        AssertContainsText(content, "- edited", "monitor workflow includes edited review trigger");
+    }
+
+    private static void TestPrWatchMonitorWorkflowExcludesReviewCommentTrigger() {
+        var workflowPath = Path.Combine(".github", "workflows", "ix-pr-babysit-monitor.yml");
+        var content = File.ReadAllText(workflowPath);
+
+        AssertEqual(false, content.Contains("pull_request_review_comment:", StringComparison.Ordinal),
+            "monitor workflow should not define pull_request_review_comment trigger");
+    }
+#endif
+}

--- a/InternalDocs/cli-commands/todo.md
+++ b/InternalDocs/cli-commands/todo.md
@@ -135,7 +135,7 @@ Default outputs:
 
 Workflow automation:
 - `.github/workflows/ix-pr-babysit-monitor.yml` runs in observe mode with hybrid triggering using `todo pr-watch-monitor`:
-  - event-driven on `pull_request` and submitted `pull_request_review`,
+  - event-driven on `pull_request` and submitted/edited `pull_request_review`,
   - hourly scheduled sweep as a safety-net.
   - PR-triggered runs are forced to GitHub-hosted runners for untrusted-code safety.
   - `pull_request_review_comment` is intentionally excluded to avoid duplicate paired runs with review submission events.


### PR DESCRIPTION
## Summary
This PR continues the IX PR babysit monitor hardening by:
- adding `pull_request_review` `edited` as an event-driven monitor signal,
- keeping `pull_request_review_comment` excluded to avoid duplicate paired runs,
- adding workflow contract tests so this trigger policy does not regress.

## Why
After reducing duplicate monitor runs in the previous phase, the remaining review suggestion was to consider review edits as a valid signal. This keeps monitor reactions responsive to changed review state while preserving the run-volume reduction from excluding review-comment events.

## Changes
- Workflow
  - `.github/workflows/ix-pr-babysit-monitor.yml`
    - `pull_request_review.types` now includes:
      - `submitted`
      - `edited`
- Docs alignment
  - `Docs/reviewer/projects-pr-monitoring.md`
  - `InternalDocs/cli-commands/todo.md`
  - Updated wording from "submitted reviews" to "submitted/edited reviews".
- Test coverage
  - Added `IntelligenceX.Tests/Program.Todo.PrWatch.WorkflowContracts.cs` with assertions that:
    - monitor workflow includes `pull_request_review` + `submitted` + `edited`
    - monitor workflow does not define `pull_request_review_comment:` trigger
  - Wired tests into reviewer harness (`Program.Reviewer.MainHarness.cs`).

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
