### PR TITLE
test(pr-babysit): assert exact flow types count

### DIFF
--- a/IntelligenceX.Tests/Program.Todo.PrWatch.WorkflowContracts.cs
+++ b/IntelligenceX.Tests/Program.Todo.PrWatch.WorkflowContracts.cs
@@ -65,6 +65,7 @@ internal static partial class Program {
             var eventTypes = ParseWorkflowOnEventTypes(workflowPath);
             AssertEqual(true, eventTypes.TryGetValue("pull_request_review", out var reviewTypes),
                 "flow sequence parser event key");
+            AssertEqual(2, reviewTypes!.Count, "flow sequence parser type count");
             AssertContains(reviewTypes!, "submitted", "flow sequence parser submitted");
             AssertContains(reviewTypes!, "edited", "flow sequence parser edited");
         } finally {


### PR DESCRIPTION
## Summary
- tighten the flow-sequence workflow parser contract test by asserting exact type count
- keep existing containment assertions for `submitted` and `edited`

## Why
- addresses reviewer suggestion to catch unexpected extra parsed values early
- strengthens parser contract strictness with minimal/no-behavior-risk test change

## Validation
- dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
