### PR TITLE
Chat: enforce strict AD scenario defaults + add live harness suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,6 +375,7 @@ build/*
 !Build/Run-ChatApp.ps1
 !Build/Run-ChatScenarioSuite.ps1
 !Build/Run-ChatLiveConversation.ps1
+!Build/Run-ChatLiveConversationSuite.ps1
 !Build/Run-ChatQualityPreflight.ps1
 !Build/Compare-ChatScenarioReports.ps1
 !Build/Get-ChatScenarioCoverage.ps1

--- a/Build/Run-ChatLiveConversationSuite.ps1
+++ b/Build/Run-ChatLiveConversationSuite.ps1
@@ -1,0 +1,239 @@
+# Runs a repeatable batch of live chat conversations (real auth + real tools) and validates artifacts.
+
+[CmdletBinding()] param(
+    [string] $ScenarioDir = '.\IntelligenceX.Chat\scenarios',
+    [string] $Filter = 'ad-*-10-turn.json',
+    [string[]] $Tags = @('ad', 'strict', 'live'),
+    [int] $ExpectedTurns = 10,
+    [string] $OutDir = '.\artifacts\chat-live',
+    [string[]] $AllowRoot,
+    [switch] $NoBuild,
+    [switch] $StopOnFailure,
+    [bool] $ContinueOnError = $false,
+    [switch] $ParallelTools = $true,
+    [switch] $EchoToolOutputs = $true,
+    [switch] $EnablePowerShellPack,
+    [switch] $EnableTestimoXPack,
+    [switch] $EnableDnsClientXPack,
+    [switch] $DisableDnsClientXPack,
+    [switch] $EnableDomainDetectivePack,
+    [switch] $DisableDomainDetectivePack,
+    [string] $Model,
+    [string[]] $ExtraArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Header([string] $text) { Write-Host "`n=== $text ===" -ForegroundColor Cyan }
+function Write-Step([string] $text) { Write-Host "[+] $text" -ForegroundColor Yellow }
+function Write-Fail([string] $text) { Write-Host "[x] $text" -ForegroundColor Red }
+function Resolve-RepoRelativePath([string] $repoRoot, [string] $pathValue) {
+    if ([string]::IsNullOrWhiteSpace($pathValue)) {
+        throw "Path value is required."
+    }
+
+    if ([System.IO.Path]::IsPathRooted($pathValue)) {
+        return [System.IO.Path]::GetFullPath($pathValue)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $repoRoot $pathValue))
+}
+
+function Normalize-TagValues([string[]] $values) {
+    $result = New-Object System.Collections.Generic.List[string]
+    foreach ($value in @($values)) {
+        $candidate = "$value".Trim().ToLowerInvariant()
+        if ($candidate.Length -eq 0) {
+            continue
+        }
+        if (-not $result.Contains($candidate)) {
+            $result.Add($candidate) | Out-Null
+        }
+    }
+    return @($result.ToArray())
+}
+
+function Get-ScenarioTags([string] $path) {
+    try {
+        $raw = Get-Content -Path $path -Raw
+        $trimmed = $raw.TrimStart()
+        if (-not ($trimmed.StartsWith('{') -or $trimmed.StartsWith('['))) {
+            return @()
+        }
+
+        $json = $raw | ConvertFrom-Json -Depth 100
+        if ($null -eq $json) {
+            return @()
+        }
+
+        $tagsProperty = $json.PSObject.Properties['tags']
+        if ($null -eq $tagsProperty -or $null -eq $tagsProperty.Value) {
+            return @()
+        }
+
+        $rawTags = @($tagsProperty.Value | ForEach-Object { "$_" })
+        return Normalize-TagValues -values $rawTags
+    } catch {
+        return @()
+    }
+}
+
+function Test-ScenarioTagMatch([string[]] $scenarioTags, [string[]] $requiredTags) {
+    $required = @($requiredTags)
+    $scenario = @($scenarioTags)
+
+    if ($required.Count -eq 0) {
+        return $true
+    }
+    if ($scenario.Count -eq 0) {
+        return $false
+    }
+
+    foreach ($tag in $required) {
+        if (-not ($scenario -contains $tag)) {
+            return $false
+        }
+    }
+    return $true
+}
+
+$repoRoot = (Get-Item (Split-Path -Parent $MyInvocation.MyCommand.Path)).Parent.FullName
+$liveHarnessScript = Join-Path $repoRoot 'Build\Run-ChatLiveConversation.ps1'
+if (-not (Test-Path $liveHarnessScript)) {
+    throw "Live harness script not found: $liveHarnessScript"
+}
+
+$resolvedScenarioDir = Resolve-RepoRelativePath -repoRoot $repoRoot -pathValue $ScenarioDir
+if (-not (Test-Path $resolvedScenarioDir)) {
+    throw "Scenario directory not found: $resolvedScenarioDir"
+}
+
+$resolvedOutDir = Resolve-RepoRelativePath -repoRoot $repoRoot -pathValue $OutDir
+New-Item -ItemType Directory -Path $resolvedOutDir -Force | Out-Null
+
+$requiredTags = @(Normalize-TagValues -values $Tags)
+$candidateFiles = @(Get-ChildItem -Path $resolvedScenarioDir -File -Filter $Filter | Sort-Object Name)
+if ($candidateFiles.Count -eq 0) {
+    throw "No scenario files matched '$Filter' in '$resolvedScenarioDir'."
+}
+
+$scenarioRuns = New-Object System.Collections.Generic.List[object]
+foreach ($file in $candidateFiles) {
+    $scenarioTags = @(Get-ScenarioTags -path $file.FullName)
+    if (-not (Test-ScenarioTagMatch -scenarioTags $scenarioTags -requiredTags $requiredTags)) {
+        continue
+    }
+
+    $scenarioRuns.Add([pscustomobject]@{
+        File = $file
+        Tags = $scenarioTags
+    }) | Out-Null
+}
+
+if ($scenarioRuns.Count -eq 0) {
+    if ($requiredTags.Count -gt 0) {
+        throw "No scenario files matched '$Filter' and tags '$($requiredTags -join ',')' in '$resolvedScenarioDir'."
+    }
+    throw "No scenario files selected in '$resolvedScenarioDir'."
+}
+
+Write-Header 'Run Live Chat Conversation Suite'
+Write-Step ("Scenario dir: {0}" -f $resolvedScenarioDir)
+Write-Step ("Filter: {0}" -f $Filter)
+if ($requiredTags.Count -gt 0) {
+    Write-Step ("Required tags: {0}" -f ($requiredTags -join ', '))
+}
+Write-Step ("Scenarios: {0}" -f $scenarioRuns.Count)
+Write-Step ("Expected turns: {0}" -f $ExpectedTurns)
+Write-Step ("Output dir: {0}" -f $resolvedOutDir)
+
+$passed = 0
+$failed = 0
+$failedScenarios = New-Object System.Collections.Generic.List[string]
+
+for ($i = 0; $i -lt $scenarioRuns.Count; $i++) {
+    $scenarioRun = $scenarioRuns[$i]
+    $scenario = $scenarioRun.File
+    $scenarioNoBuild = $NoBuild -or ($i -gt 0)
+
+    Write-Header ("Live Scenario {0}/{1}: {2}" -f ($i + 1), $scenarioRuns.Count, $scenario.Name)
+    Write-Step ("NoBuild: {0}" -f $scenarioNoBuild)
+    $scenarioRunTags = @($scenarioRun.Tags)
+    if ($scenarioRunTags.Count -gt 0) {
+        Write-Step ("Tags: {0}" -f ($scenarioRunTags -join ', '))
+    }
+
+    $runParams = @{
+        ScenarioFile = $scenario.FullName
+        ExpectedTurns = $ExpectedTurns
+        OutDir = $resolvedOutDir
+        ContinueOnError = $ContinueOnError
+        ParallelTools = [bool]$ParallelTools
+        EchoToolOutputs = [bool]$EchoToolOutputs
+        NoBuild = $scenarioNoBuild
+    }
+
+    if ($AllowRoot -and $AllowRoot.Count -gt 0) {
+        $runParams['AllowRoot'] = $AllowRoot
+    }
+    if ($EnablePowerShellPack) {
+        $runParams['EnablePowerShellPack'] = $true
+    }
+    if ($EnableTestimoXPack) {
+        $runParams['EnableTestimoXPack'] = $true
+    }
+    if ($EnableDnsClientXPack) {
+        $runParams['EnableDnsClientXPack'] = $true
+    }
+    if ($DisableDnsClientXPack) {
+        $runParams['DisableDnsClientXPack'] = $true
+    }
+    if ($EnableDomainDetectivePack) {
+        $runParams['EnableDomainDetectivePack'] = $true
+    }
+    if ($DisableDomainDetectivePack) {
+        $runParams['DisableDomainDetectivePack'] = $true
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Model)) {
+        $runParams['Model'] = $Model
+    }
+    if ($ExtraArgs -and $ExtraArgs.Count -gt 0) {
+        $runParams['ExtraArgs'] = $ExtraArgs
+    }
+
+    $scenarioSucceeded = $true
+    try {
+        & $liveHarnessScript @runParams
+    } catch {
+        $scenarioSucceeded = $false
+        Write-Fail ("Live scenario failed: {0}" -f $scenario.Name)
+        Write-Fail $_.Exception.Message
+    }
+
+    if ($scenarioSucceeded) {
+        $passed++
+        Write-Step ("Live scenario passed: {0}" -f $scenario.Name)
+    } else {
+        $failed++
+        $failedScenarios.Add($scenario.Name) | Out-Null
+        if ($StopOnFailure) {
+            Write-Fail "Stopping early because -StopOnFailure is set."
+            break
+        }
+    }
+}
+
+Write-Header 'Live Suite Summary'
+Write-Step ("Passed: {0}" -f $passed)
+Write-Step ("Failed: {0}" -f $failed)
+if ($failedScenarios.Count -gt 0) {
+    Write-Fail ("Failed scenarios: {0}" -f ($failedScenarios -join ', '))
+}
+Write-Step ("Artifacts: {0}" -f $resolvedOutDir)
+
+if ($failed -gt 0) {
+    exit 1
+}
+
+exit 0

--- a/Build/Run-ChatQualityPreflight.ps1
+++ b/Build/Run-ChatQualityPreflight.ps1
@@ -1,6 +1,7 @@
 # Runs strict chat quality checks in one command.
 # - Strict scenario suite (required)
 # - Optional live harness smoke run (opt-in)
+# - Optional live harness suite run (opt-in, no hardcoded single scenario)
 
 [CmdletBinding()] param(
     [string] $ScenarioDir = '.\IntelligenceX.Chat\scenarios',
@@ -16,6 +17,12 @@
     [string] $LiveScenarioFile = '.\IntelligenceX.Chat\scenarios\ad-cross-dc-followthrough-10-turn.json',
     [int] $LiveExpectedTurns = 10,
     [string] $LiveOutDir = '.\artifacts\chat-live',
+    [switch] $RunLiveHarnessSuite,
+    [string] $LiveSuiteScenarioDir = '.\IntelligenceX.Chat\scenarios',
+    [string] $LiveSuiteFilter = 'ad-*-10-turn.json',
+    [string[]] $LiveSuiteTags = @('ad', 'strict', 'live'),
+    [int] $LiveSuiteExpectedTurns = 10,
+    [string] $LiveSuiteOutDir = '.\artifacts\chat-live-suite',
     [string[]] $AllowRoot,
     [switch] $NoBuild,
     [switch] $ParallelTools = $true,
@@ -39,12 +46,19 @@ function Write-Step([string] $text) { Write-Host "[+] $text" -ForegroundColor Ye
 $repoRoot = (Get-Item (Split-Path -Parent $MyInvocation.MyCommand.Path)).Parent.FullName
 $scenarioSuiteScript = Join-Path $repoRoot 'Build\Run-ChatScenarioSuite.ps1'
 $liveHarnessScript = Join-Path $repoRoot 'Build\Run-ChatLiveConversation.ps1'
+$liveHarnessSuiteScript = Join-Path $repoRoot 'Build\Run-ChatLiveConversationSuite.ps1'
 
 if (-not (Test-Path $scenarioSuiteScript)) {
     throw "Scenario suite script not found: $scenarioSuiteScript"
 }
 if (-not (Test-Path $liveHarnessScript)) {
     throw "Live harness script not found: $liveHarnessScript"
+}
+if (-not (Test-Path $liveHarnessSuiteScript)) {
+    throw "Live harness suite script not found: $liveHarnessSuiteScript"
+}
+if ($RunLiveHarness -and $RunLiveHarnessSuite) {
+    throw "Use only one live mode per run: -RunLiveHarness or -RunLiveHarnessSuite."
 }
 
 Write-Header 'IX Chat Quality Preflight'
@@ -171,9 +185,57 @@ if ($RunRecoveryUnitTests) {
     Write-Step "Recovery unit tests passed."
 }
 
-if (-not $RunLiveHarness) {
+if ((-not $RunLiveHarness) -and (-not $RunLiveHarnessSuite)) {
     Write-Step "Strict scenario suite passed."
-    Write-Step "Live harness smoke run skipped. Use -RunLiveHarness to include it."
+    Write-Step "Live harness run skipped. Use -RunLiveHarness (single scenario) or -RunLiveHarnessSuite (tag-driven suite)."
+    exit 0
+}
+
+if ($RunLiveHarnessSuite) {
+    Write-Step "Strict scenario suite passed."
+    Write-Step "Running live harness suite..."
+
+    $liveSuiteParams = @{
+        ScenarioDir = $LiveSuiteScenarioDir
+        Filter = $LiveSuiteFilter
+        Tags = $LiveSuiteTags
+        ExpectedTurns = $LiveSuiteExpectedTurns
+        OutDir = $LiveSuiteOutDir
+        ContinueOnError = $false
+        ParallelTools = [bool]$ParallelTools
+        EchoToolOutputs = [bool]$EchoToolOutputs
+        NoBuild = $true
+    }
+    if ($AllowRoot -and $AllowRoot.Count -gt 0) {
+        $liveSuiteParams['AllowRoot'] = $AllowRoot
+    }
+    if ($EnablePowerShellPack) {
+        $liveSuiteParams['EnablePowerShellPack'] = $true
+    }
+    if ($EnableTestimoXPack) {
+        $liveSuiteParams['EnableTestimoXPack'] = $true
+    }
+    if ($EnableDnsClientXPack) {
+        $liveSuiteParams['EnableDnsClientXPack'] = $true
+    }
+    if ($DisableDnsClientXPack) {
+        $liveSuiteParams['DisableDnsClientXPack'] = $true
+    }
+    if ($EnableDomainDetectivePack) {
+        $liveSuiteParams['EnableDomainDetectivePack'] = $true
+    }
+    if ($DisableDomainDetectivePack) {
+        $liveSuiteParams['DisableDomainDetectivePack'] = $true
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Model)) {
+        $liveSuiteParams['Model'] = $Model
+    }
+    if ($ExtraArgs -and $ExtraArgs.Count -gt 0) {
+        $liveSuiteParams['ExtraArgs'] = $ExtraArgs
+    }
+
+    & $liveHarnessSuiteScript @liveSuiteParams
+    Write-Step "Live harness suite passed."
     exit 0
 }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioCatalogStrictnessTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioCatalogStrictnessTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class HostScenarioCatalogStrictnessTests {
+    [Fact]
+    public void AdTenTurnScenarios_AreStrictByDefault() {
+        var scenarioDir = ResolveScenarioDirectory();
+        var scenarioFiles = Directory.GetFiles(scenarioDir, "ad-*-10-turn.json", SearchOption.TopDirectoryOnly)
+            .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Assert.NotEmpty(scenarioFiles);
+
+        foreach (var file in scenarioFiles) {
+            using var document = JsonDocument.Parse(File.ReadAllText(file));
+            var root = document.RootElement;
+
+            var turns = RequireProperty(root, "turns");
+            Assert.Equal(JsonValueKind.Array, turns.ValueKind);
+            Assert.Equal(10, turns.GetArrayLength());
+
+            var tags = ReadTagSet(root);
+            Assert.Contains("ad", tags);
+            Assert.Contains("strict", tags);
+            Assert.Contains("live", tags);
+
+            var defaults = RequireProperty(root, "defaults");
+            Assert.Equal(JsonValueKind.Object, defaults.ValueKind);
+            Assert.True(ReadRequiredBoolean(defaults, "assert_clean_completion"));
+            Assert.True(ReadRequiredBoolean(defaults, "assert_tool_call_output_pairing"));
+            Assert.True(ReadRequiredBoolean(defaults, "assert_no_duplicate_tool_call_ids"));
+            Assert.True(ReadRequiredBoolean(defaults, "assert_no_duplicate_tool_output_call_ids"));
+            Assert.Equal(0, ReadRequiredInt32(defaults, "max_no_tool_execution_retries"));
+            Assert.Equal(1, ReadRequiredInt32(defaults, "max_duplicate_tool_call_signatures"));
+        }
+    }
+
+    private static string ResolveScenarioDirectory() {
+        var current = Path.GetFullPath(AppContext.BaseDirectory);
+        while (!string.IsNullOrWhiteSpace(current)) {
+            var candidate = Path.Combine(current, "IntelligenceX.Chat", "scenarios");
+            if (Directory.Exists(candidate)) {
+                return candidate;
+            }
+
+            var parent = Directory.GetParent(current);
+            if (parent is null) {
+                break;
+            }
+
+            current = parent.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate 'IntelligenceX.Chat/scenarios' from test runtime path.");
+    }
+
+    private static HashSet<string> ReadTagSet(JsonElement root) {
+        if (!root.TryGetProperty("tags", out var tags) || tags.ValueKind != JsonValueKind.Array) {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var element in tags.EnumerateArray()) {
+            if (element.ValueKind != JsonValueKind.String) {
+                continue;
+            }
+
+            var value = (element.GetString() ?? string.Empty).Trim();
+            if (value.Length > 0) {
+                values.Add(value);
+            }
+        }
+
+        return values;
+    }
+
+    private static JsonElement RequireProperty(JsonElement root, string name) {
+        if (!root.TryGetProperty(name, out var value)) {
+            throw new InvalidDataException($"Missing required property '{name}'.");
+        }
+
+        return value;
+    }
+
+    private static bool ReadRequiredBoolean(JsonElement root, string name) {
+        var value = RequireProperty(root, name);
+        if (value.ValueKind is JsonValueKind.True or JsonValueKind.False) {
+            return value.GetBoolean();
+        }
+
+        throw new InvalidDataException($"Property '{name}' must be a boolean.");
+    }
+
+    private static int ReadRequiredInt32(JsonElement root, string name) {
+        var value = RequireProperty(root, name);
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var parsed)) {
+            return parsed;
+        }
+
+        throw new InvalidDataException($"Property '{name}' must be an integer.");
+    }
+}

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -47,6 +47,17 @@ pwsh .\Build\Run-ChatLiveConversation.ps1 `
   -OutDir .\artifacts\chat-live
 ```
 
+Live 10-turn harness suite run (tag-driven, no hardcoded single scenario):
+
+```powershell
+pwsh .\Build\Run-ChatLiveConversationSuite.ps1 `
+  -ScenarioDir .\IntelligenceX.Chat\scenarios `
+  -Filter "ad-*-10-turn.json" `
+  -Tags ad,strict,live `
+  -ExpectedTurns 10 `
+  -OutDir .\artifacts\chat-live-suite
+```
+
 Scenario file formats:
 - JSON object with `name` + `turns` (each turn can be a string or object with `user`/`name` and optional quality gates).
 - Optional scenario-level `tags` array (for example `["ad","replication","strict"]`) for suite filtering.
@@ -121,6 +132,15 @@ To include a live 10-turn smoke run in the same preflight:
 pwsh .\Build\Run-ChatQualityPreflight.ps1 `
   -ScenarioFilter "ad-*-10-turn.json" `
   -RunLiveHarness
+```
+
+To include a tag-driven live harness suite run in the same preflight:
+
+```powershell
+pwsh .\Build\Run-ChatQualityPreflight.ps1 `
+  -ScenarioFilter "ad-*-10-turn.json" `
+  -RunLiveHarnessSuite `
+  -LiveSuiteTags ad,strict,live
 ```
 
 To run only strict AD continuation scenarios in preflight:

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -23,7 +23,10 @@ Last validated: 2026-02-24
   - `Build/Run-ChatLiveConversation.ps1`
   - `Build/Run-ChatQualityPreflight.ps1`
 - Existing AD scenarios were made strict by default and one new cross-DC continuation scenario was added.
+- Added catalog-level strictness test coverage for `ad-*-10-turn.json` to enforce strict defaults and 10-turn shape.
 - Scenario suite now supports scenario-tag filtering (`-Tags`) and preflight forwards tags via `-ScenarioTags`.
+- Added live-suite runner (`Build/Run-ChatLiveConversationSuite.ps1`) so local live validation can run tag-driven batches without hardcoded single-scenario defaults.
+- Preflight now supports `-RunLiveHarnessSuite` for the same tag-driven live validation path.
 - App already supports debug toggles for turn trace and draft bubbles with distinct rendering channels.
 
 ## Scenario Coverage (Current)
@@ -108,6 +111,7 @@ Progress:
 - Added coverage summary helper:
   - `Build/Get-ChatScenarioCoverage.ps1`
 - Added scenario tag taxonomy (`ad`, `strict`, `continuation`, `cross-dc`, `eventlog`, etc.) and suite tag filtering.
+- Added live harness suite runner (tag-driven, repeatable) for real auth/tool runs without hardcoded single-scenario selection.
 - Hardened scenario duplicate-call detection by canonicalizing tool argument JSON before signature comparison
   (so key-order-only differences still count as duplicate signatures).
 


### PR DESCRIPTION
## Summary
- add `HostScenarioCatalogStrictnessTests` to enforce strict defaults + 10-turn shape for every `ad-*-10-turn.json` scenario
- add `Build/Run-ChatLiveConversationSuite.ps1` for tag-driven live harness batches (real auth/tools, repeatable, no hardcoded single scenario)
- extend `Build/Run-ChatQualityPreflight.ps1` with `-RunLiveHarnessSuite` and live-mode guardrails
- document new live-suite commands in `IntelligenceX.Chat/README.md`
- allow tracking the new script via `.gitignore` exception

## Why
This locks in strict scenario behavior and provides a repeatable live validation path that scales beyond one hardcoded smoke scenario.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~HostScenarioCatalogStrictnessTests|FullyQualifiedName~HostScenarioParsingTests"`
- PowerShell parser validation:
  - `Build/Run-ChatQualityPreflight.ps1`
  - `Build/Run-ChatLiveConversationSuite.ps1`
- `pwsh -File Build/Get-ChatScenarioCoverage.ps1 -Filter "ad-*-10-turn.json"`
