### PR TITLE
Chat recovery: prefer latest explicit replay output + guard tests

### DIFF
--- a/Build/Run-ChatQualityPreflight.ps1
+++ b/Build/Run-ChatQualityPreflight.ps1
@@ -160,11 +160,15 @@ if ($RunTransportRecoveryProfile) {
 
 if ($RunRecoveryUnitTests) {
     Write-Step "Strict scenario suite passed."
-    Write-Step "Running recovery unit tests (transport/tool-pairing guards)..."
+    Write-Step "Running recovery unit tests (transport/tool-pairing + duplicate-bubble guards)..."
 
     $chatTestsProject = Join-Path $repoRoot 'IntelligenceX.Chat\IntelligenceX.Chat.Tests\IntelligenceX.Chat.Tests.csproj'
     if (-not (Test-Path $chatTestsProject)) {
         throw "Chat tests project not found: $chatTestsProject"
+    }
+    $chatAppTestsProject = Join-Path $repoRoot 'IntelligenceX.Chat\IntelligenceX.Chat.App.Tests\IntelligenceX.Chat.App.Tests.csproj'
+    if (-not (Test-Path $chatAppTestsProject)) {
+        throw "Chat app tests project not found: $chatAppTestsProject"
     }
 
     $testArgs = @(
@@ -180,6 +184,21 @@ if ($RunRecoveryUnitTests) {
     & dotnet @testArgs
     if ($LASTEXITCODE -ne 0) {
         throw "Recovery unit tests failed."
+    }
+
+    $appTestArgs = @(
+        'test',
+        $chatAppTestsProject,
+        '-c', 'Release',
+        '--filter', 'FullyQualifiedName~MainWindowNoTextWarningHandlingTests'
+    )
+    if ($NoBuild) {
+        $appTestArgs += '--no-build'
+    }
+
+    & dotnet @appTestArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Recovery unit tests failed (app duplicate-bubble guards)."
     }
 
     Write-Step "Recovery unit tests passed."

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -1398,7 +1398,8 @@ internal sealed partial class ChatServiceSession {
                 continue;
             }
 
-            if (!existingOutput.MatchedRawCallId && candidateOutput.MatchedRawCallId) {
+            if ((!existingOutput.MatchedRawCallId && candidateOutput.MatchedRawCallId)
+                || (existingOutput.MatchedRawCallId && candidateOutput.MatchedRawCallId)) {
                 selectedOutputsByCallId[normalizedOutputCallId] = candidateOutput;
             }
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
@@ -2196,7 +2196,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.Equal(2, toolCalls);
         Assert.Equal(2, toolOutputs);
-        Assert.Equal("out-a-first", callAOutput);
+        Assert.Equal("out-a-duplicate", callAOutput);
     }
 
     [Fact]
@@ -2296,6 +2296,96 @@ public sealed partial class ChatServiceRoutingTrimTests {
         }
 
         Assert.Equal("out-a-direct-delayed", outputByCallId["call_a"]);
+        Assert.Equal("out-b-indexed-fallback", outputByCallId["call_b"]);
+    }
+
+    [Fact]
+    public void BuildToolRoundReplayInput_PrefersLatestExplicitOutputWhenSameCallIdRepeats() {
+        var callA = new ToolCall(
+            callId: "call_a",
+            name: "eventlog_live_query",
+            input: "{\"machine_name\":\"AD0\"}",
+            arguments: null,
+            raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        var extracted = new List<ToolCall> { callA };
+        var byId = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase) {
+            ["call_a"] = callA
+        };
+        var outputs = new List<ToolOutputDto> {
+            new() { CallId = "call_a", Output = "out-a-direct-first", Ok = true },
+            new() { CallId = "call_a", Output = "out-a-direct-latest", Ok = true }
+        };
+
+        var inputObj = BuildToolRoundReplayInputMethod.Invoke(
+            null,
+            new object?[] { extracted, byId, outputs });
+        var input = Assert.IsType<ChatInput>(inputObj);
+        var items = GetChatInputItems(input);
+
+        Assert.Equal(2, items.Count);
+        var outputPayload = string.Empty;
+        for (var i = 0; i < items.Count; i++) {
+            var item = Assert.IsType<JsonObject>(items[i].AsObject());
+            if (!string.Equals(item.GetString("type"), "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            outputPayload = item.GetString("output") ?? string.Empty;
+            break;
+        }
+
+        Assert.Equal("out-a-direct-latest", outputPayload);
+    }
+
+    [Fact]
+    public void BuildToolRoundReplayInput_UsesLatestExplicitOutputAfterFallbackAndDirectDuplicates() {
+        var callA = new ToolCall(
+            callId: "call_a",
+            name: "eventlog_live_query",
+            input: "{\"machine_name\":\"AD0\"}",
+            arguments: null,
+            raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        var callB = new ToolCall(
+            callId: "call_b",
+            name: "eventlog_live_query",
+            input: "{\"machine_name\":\"AD1\"}",
+            arguments: null,
+            raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        var extracted = new List<ToolCall> { callA, callB };
+        var byId = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase) {
+            ["call_a"] = callA,
+            ["call_b"] = callB
+        };
+        var outputs = new List<ToolOutputDto> {
+            new() { CallId = "mismatch_0", Output = "out-a-indexed-fallback", Ok = true },
+            new() { CallId = "mismatch_1", Output = "out-b-indexed-fallback", Ok = true },
+            new() { CallId = "call_a", Output = "out-a-direct-first", Ok = true },
+            new() { CallId = "call_a", Output = "out-a-direct-latest", Ok = true }
+        };
+
+        var inputObj = BuildToolRoundReplayInputMethod.Invoke(
+            null,
+            new object?[] { extracted, byId, outputs });
+        var input = Assert.IsType<ChatInput>(inputObj);
+        var items = GetChatInputItems(input);
+
+        Assert.Equal(4, items.Count);
+        var outputByCallId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < items.Count; i++) {
+            var item = Assert.IsType<JsonObject>(items[i].AsObject());
+            if (!string.Equals(item.GetString("type"), "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            var callId = item.GetString("call_id");
+            if (string.IsNullOrWhiteSpace(callId)) {
+                continue;
+            }
+
+            outputByCallId[callId!] = item.GetString("output") ?? string.Empty;
+        }
+
+        Assert.Equal("out-a-direct-latest", outputByCallId["call_a"]);
         Assert.Equal("out-b-indexed-fallback", outputByCallId["call_b"]);
     }
 

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -87,6 +87,11 @@ Progress:
 - Added reconnect/final overlap boundary tests:
   - short suffix-only provisional/final differences stay replace-only (no duplicate bubble)
   - long suffix synthesized finals still append as a new final bubble
+- Hardened tool replay output selection for delayed/replayed duplicates:
+  - when multiple explicit outputs for the same `call_id` arrive, replay now uses the latest explicit output
+  - direct `call_id` matches still outrank indexed fallback matches
+- Extended preflight recovery unit tests to include app duplicate-bubble guards:
+  - `MainWindowNoTextWarningHandlingTests`
 
 ### WS2: Live Scenario Expansion (No Hardcoding)
 Status: in_progress  


### PR DESCRIPTION
## Summary
- make tool replay selection more resilient for delayed/replayed output streams
  - keep direct `call_id` matches prioritized over index fallback
  - when explicit outputs repeat for the same `call_id`, keep the latest explicit output
- extend replay regression coverage in `ChatServiceRoutingTrimTests.ToolNudge`
  - latest explicit output wins when duplicate explicit outputs exist
  - latest explicit output wins after fallback + delayed explicit duplicates
- expand recovery preflight unit coverage to include app duplicate-bubble guards (`MainWindowNoTextWarningHandlingTests`)

## Why
This directly hardens transport-break recovery behavior where delayed/replayed tool outputs previously risked replaying stale explicit payloads.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildToolRoundReplayInput_"`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~MainWindowNoTextWarningHandlingTests"`
- PowerShell parser check: `Build/Run-ChatQualityPreflight.ps1`
