### PR TITLE
Chat recovery: latest fallback replay selection with explicit-match protection

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -1398,8 +1398,7 @@ internal sealed partial class ChatServiceSession {
                 continue;
             }
 
-            if ((!existingOutput.MatchedRawCallId && candidateOutput.MatchedRawCallId)
-                || (existingOutput.MatchedRawCallId && candidateOutput.MatchedRawCallId)) {
+            if (candidateOutput.MatchedRawCallId || !existingOutput.MatchedRawCallId) {
                 selectedOutputsByCallId[normalizedOutputCallId] = candidateOutput;
             }
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
@@ -2390,6 +2390,82 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildToolRoundReplayInput_PrefersLatestFallbackOutputWhenOnlyFallbackMatchesExist() {
+        var callA = new ToolCall(
+            callId: "call_a",
+            name: "eventlog_live_query",
+            input: "{\"machine_name\":\"AD0\"}",
+            arguments: null,
+            raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        var extracted = new List<ToolCall> { callA };
+        var byId = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase) {
+            ["call_a"] = callA
+        };
+        var outputs = new List<ToolOutputDto> {
+            new() { CallId = "mismatch_0", Output = "out-a-fallback-first", Ok = true },
+            new() { CallId = "mismatch_1", Output = "out-a-fallback-latest", Ok = true }
+        };
+
+        var inputObj = BuildToolRoundReplayInputMethod.Invoke(
+            null,
+            new object?[] { extracted, byId, outputs });
+        var input = Assert.IsType<ChatInput>(inputObj);
+        var items = GetChatInputItems(input);
+
+        Assert.Equal(2, items.Count);
+        var outputPayload = string.Empty;
+        for (var i = 0; i < items.Count; i++) {
+            var item = Assert.IsType<JsonObject>(items[i].AsObject());
+            if (!string.Equals(item.GetString("type"), "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            outputPayload = item.GetString("output") ?? string.Empty;
+            break;
+        }
+
+        Assert.Equal("out-a-fallback-latest", outputPayload);
+    }
+
+    [Fact]
+    public void BuildToolRoundReplayInput_DoesNotDowngradeExplicitOutputWhenLaterFallbackArrives() {
+        var callA = new ToolCall(
+            callId: "call_a",
+            name: "eventlog_live_query",
+            input: "{\"machine_name\":\"AD0\"}",
+            arguments: null,
+            raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        var extracted = new List<ToolCall> { callA };
+        var byId = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase) {
+            ["call_a"] = callA
+        };
+        var outputs = new List<ToolOutputDto> {
+            new() { CallId = "call_a", Output = "out-a-direct", Ok = true },
+            new() { CallId = "mismatch_1", Output = "out-a-fallback-later", Ok = true }
+        };
+
+        var inputObj = BuildToolRoundReplayInputMethod.Invoke(
+            null,
+            new object?[] { extracted, byId, outputs });
+        var input = Assert.IsType<ChatInput>(inputObj);
+        var items = GetChatInputItems(input);
+
+        Assert.Equal(2, items.Count);
+        var outputPayload = string.Empty;
+        for (var i = 0; i < items.Count; i++) {
+            var item = Assert.IsType<JsonObject>(items[i].AsObject());
+            if (!string.Equals(item.GetString("type"), "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            outputPayload = item.GetString("output") ?? string.Empty;
+            break;
+        }
+
+        Assert.Equal("out-a-direct", outputPayload);
+    }
+
+    [Fact]
     public void BuildNativeHostReplayReviewPrompt_IncludesToolIdentityAndEvidence() {
         var call = new ToolCall(
             callId: "host_carryover_next_action_123",

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -90,6 +90,9 @@ Progress:
 - Hardened tool replay output selection for delayed/replayed duplicates:
   - when multiple explicit outputs for the same `call_id` arrive, replay now uses the latest explicit output
   - direct `call_id` matches still outrank indexed fallback matches
+- Refined replay fallback behavior:
+  - when only fallback matches are available, replay now uses the latest fallback output
+  - later fallback entries cannot overwrite an already selected explicit `call_id` match
 - Extended preflight recovery unit tests to include app duplicate-bubble guards:
   - `MainWindowNoTextWarningHandlingTests`
 


### PR DESCRIPTION
## Summary
- refine replay output selection so fallback-only mappings also prefer the latest output candidate
- preserve explicit `call_id` authority: a later fallback candidate cannot replace an explicit match already selected for the same call
- add regression tests for both behaviors in `ChatServiceRoutingTrimTests.ToolNudge`

## Why
This closes a remaining delayed-output edge case where fallback-only replay could keep stale payloads when providers resend updated outputs without stable `call_id`s.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildToolRoundReplayInput_"`
