### PR TITLE
Chat: scale compatible-http tool routing by model context

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ModelResolution.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ModelResolution.cs
@@ -248,6 +248,74 @@ internal sealed partial class ChatServiceSession {
                && candidate.Contains("<|constrain|>", StringComparison.OrdinalIgnoreCase);
     }
 
+    private int? ResolveMaxCandidateToolsForTurn(int? requestedLimit, OpenAITransportKind transportKind, string? selectedModel) {
+        var resolved = ResolveMaxCandidateToolsSetting(requestedLimit, transportKind);
+        if (transportKind != OpenAITransportKind.CompatibleHttp) {
+            return resolved;
+        }
+
+        if (requestedLimit is > 0) {
+            return resolved;
+        }
+
+        var effectiveContextLength = ResolveEffectiveModelContextLength(selectedModel);
+        if (!effectiveContextLength.HasValue) {
+            return resolved;
+        }
+
+        return ResolveContextAwareCompatibleHttpDefaultMaxCandidateTools(effectiveContextLength.Value);
+    }
+
+    private long? ResolveEffectiveModelContextLength(string? selectedModel) {
+        ModelListResult? modelList = null;
+        lock (_modelListCacheLock) {
+            modelList = _modelListCache?.Result;
+        }
+
+        if (modelList is null || modelList.Models.Count == 0) {
+            return null;
+        }
+
+        var requestedModel = (selectedModel ?? string.Empty).Trim();
+        if (requestedModel.Length > 0) {
+            var modelInfo = FindModelInfo(modelList.Models, requestedModel);
+            if (modelInfo is not null) {
+                if (modelInfo.LoadedContextLength is > 0) {
+                    return modelInfo.LoadedContextLength.Value;
+                }
+
+                if (modelInfo.MaxContextLength is > 0) {
+                    return modelInfo.MaxContextLength.Value;
+                }
+            }
+        }
+
+        if (modelList.Models.Count == 1) {
+            var onlyModel = modelList.Models[0];
+            if (onlyModel.LoadedContextLength is > 0) {
+                return onlyModel.LoadedContextLength.Value;
+            }
+
+            if (onlyModel.MaxContextLength is > 0) {
+                return onlyModel.MaxContextLength.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static int ResolveContextAwareCompatibleHttpDefaultMaxCandidateTools(long effectiveContextLength) {
+        if (effectiveContextLength <= 8_192) {
+            return 4;
+        }
+
+        if (effectiveContextLength <= 16_384) {
+            return 6;
+        }
+
+        return 8;
+    }
+
     private static int? ResolveMaxCandidateToolsSetting(int? requestedLimit, OpenAITransportKind transportKind) {
         if (requestedLimit.HasValue) {
             var requested = requestedLimit.Value;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -62,11 +62,11 @@ internal sealed partial class ChatServiceSession {
         var originalToolCount = toolDefs.Count;
         var routingInsights = new List<ToolRoutingInsight>();
         var weightedToolRouting = request.Options?.WeightedToolRouting ?? true;
-        var maxCandidateTools = ResolveMaxCandidateToolsSetting(request.Options?.MaxCandidateTools, client.TransportKind);
         var userRequest = ExtractPrimaryUserRequest(request.Text);
         var userIntent = ExtractIntentUserText(request.Text);
         RememberUserIntent(threadId, userIntent);
         var routedUserRequest = ExpandContinuationUserRequest(threadId, userRequest);
+        var maxCandidateTools = ResolveMaxCandidateToolsForTurn(request.Options?.MaxCandidateTools, client.TransportKind, selectedModel);
         var executionContractApplies = ShouldEnforceExecuteOrExplainContract(routedUserRequest);
         var proactiveModeEnabled = TryReadProactiveModeFromRequestText(request.Text, out var proactiveMode) && proactiveMode;
         var compactFollowUpTurn = LooksLikeContinuationFollowUp(userRequest);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -29,6 +29,9 @@ public sealed class ChatServicePlannerPromptTests {
     private static readonly MethodInfo ResolveMaxCandidateToolsSettingMethod =
         typeof(ChatServiceSession).GetMethod("ResolveMaxCandidateToolsSetting", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("ResolveMaxCandidateToolsSetting not found.");
+    private static readonly MethodInfo ResolveContextAwareCompatibleHttpDefaultMaxCandidateToolsMethod =
+        typeof(ChatServiceSession).GetMethod("ResolveContextAwareCompatibleHttpDefaultMaxCandidateTools", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("ResolveContextAwareCompatibleHttpDefaultMaxCandidateTools not found.");
 
     [Fact]
     public void BuildModelPlannerPrompt_IncludesSchemaArgumentsRequiredAndTableViewTrait() {
@@ -154,5 +157,17 @@ public sealed class ChatServicePlannerPromptTests {
         var result = ResolveMaxCandidateToolsSettingMethod.Invoke(null, new object?[] { 999, OpenAITransportKind.CompatibleHttp });
         var value = Assert.IsType<int>(result);
         Assert.Equal(256, value);
+    }
+
+    [Theory]
+    [InlineData(4096L, 4)]
+    [InlineData(8192L, 4)]
+    [InlineData(12000L, 6)]
+    [InlineData(16384L, 6)]
+    [InlineData(32768L, 8)]
+    public void ResolveContextAwareCompatibleHttpDefaultMaxCandidateTools_UsesContextBands(long effectiveContextLength, int expected) {
+        var result = ResolveContextAwareCompatibleHttpDefaultMaxCandidateToolsMethod.Invoke(null, new object?[] { effectiveContextLength });
+        var value = Assert.IsType<int>(result);
+        Assert.Equal(expected, value);
     }
 }

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -160,7 +160,7 @@ Progress:
   - when weighted routing yields a mixed, non-dominant subset across `ad_*` and `dnsclientx_*`/`domaindetective_*`, Chat asks one clarifying turn before execution.
 
 ### WS5: Tool Count, Context Budget, Compaction
-Status: pending  
+Status: in_progress  
 Effort: L  
 Risk: High
 
@@ -171,6 +171,14 @@ Acceptance:
   - max retained tool rounds before compaction
 - Add deterministic compaction preserving `call_id`, failure/error envelopes, and evidence receipts.
 - Add long-run tests validating no partial endings under compaction.
+
+Progress:
+- Added context-aware default tool-candidate budgeting for compatible-http runtimes:
+  - loaded/max context `<= 8k` defaults to `4` candidates
+  - loaded/max context `<= 16k` defaults to `6` candidates
+  - larger contexts keep the `8` candidate default
+- Preserved explicit `maxCandidateTools` overrides and safety clamping.
+- Added regression tests for context-band budget selection logic.
 
 ### WS6: Merge Gates
 Status: in_progress  


### PR DESCRIPTION
## Summary
- add context-aware default candidate-tool budgeting for compatible-http transports
- when no explicit `maxCandidateTools` is requested, derive defaults from loaded/max model context:
  - <=8k context -> 4
  - <=16k context -> 6
  - >16k context -> 8
- keep explicit `maxCandidateTools` requests and safety clamps unchanged
- update roadmap WS5 progress with this context-budget step

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ResolveMaxCandidateToolsSetting|FullyQualifiedName~ResolveContextAwareCompatibleHttpDefaultMaxCandidateTools|FullyQualifiedName~ShouldRequestDomainIntentClarification|FullyQualifiedName~ResolvesDomainIntentClarificationOrdinalSelection"