### PR TITLE
Chat: extend transport recovery replay and retry tests

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatSchemaRecoveryFallbackTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatSchemaRecoveryFallbackTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Reflection;
 using System.Threading;
 using IntelligenceX.Chat.Tooling;
@@ -252,6 +253,40 @@ public sealed class ChatSchemaRecoveryFallbackTests {
             attempt: 1,
             maxAttempts: 2,
             cancellationToken: CancellationToken.None);
+
+        Assert.False(shouldRetry);
+    }
+
+    [Fact]
+    public void ServiceShouldRetryModelPhaseAttempt_RetriesOnNestedUnexpectedEndOfStreamAfterToolCall() {
+        var ex = new InvalidOperationException(
+            "model phase failed after tool call",
+            new InvalidOperationException(
+                "tool replay failed",
+                new IOException("unexpected end of stream while reading tool output payload")));
+
+        var shouldRetry = InvokeShouldRetryModelPhaseAttempt(
+            ServiceShouldRetryModelPhaseAttemptMethod,
+            ex,
+            attempt: 0,
+            maxAttempts: 2,
+            cancellationToken: CancellationToken.None);
+
+        Assert.True(shouldRetry);
+    }
+
+    [Fact]
+    public void ServiceShouldRetryModelPhaseAttempt_DoesNotRetryWhenCancellationAlreadyRequested() {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var ex = new InvalidOperationException("connection reset by peer");
+
+        var shouldRetry = InvokeShouldRetryModelPhaseAttempt(
+            ServiceShouldRetryModelPhaseAttemptMethod,
+            ex,
+            attempt: 0,
+            maxAttempts: 2,
+            cancellationToken: cts.Token);
 
         Assert.False(shouldRetry);
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
@@ -2200,6 +2200,63 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildToolRoundReplayInput_DropAfterToolCall_ReplaysOnlyCompletedPair() {
+        var callA = new ToolCall(
+            callId: "call_a",
+            name: "eventlog_live_query",
+            input: "{\"machine_name\":\"AD0\"}",
+            arguments: null,
+            raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        var callB = new ToolCall(
+            callId: "call_b",
+            name: "eventlog_live_query",
+            input: "{\"machine_name\":\"AD1\"}",
+            arguments: null,
+            raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        var extracted = new List<ToolCall> { callA, callB };
+        var byId = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase) {
+            ["call_a"] = callA,
+            ["call_b"] = callB
+        };
+        var outputs = new List<ToolOutputDto> {
+            new() { CallId = "call_a", Output = "out-a-complete", Ok = true }
+        };
+
+        var inputObj = BuildToolRoundReplayInputMethod.Invoke(
+            null,
+            new object?[] { extracted, byId, outputs });
+        var input = Assert.IsType<ChatInput>(inputObj);
+        var items = GetChatInputItems(input);
+
+        Assert.Equal(2, items.Count);
+
+        var replayedCallIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var outputCallIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < items.Count; i++) {
+            var item = Assert.IsType<JsonObject>(items[i].AsObject());
+            var type = item.GetString("type");
+            var callId = item.GetString("call_id");
+            if (string.IsNullOrWhiteSpace(callId)) {
+                continue;
+            }
+
+            if (string.Equals(type, "custom_tool_call", StringComparison.OrdinalIgnoreCase)) {
+                replayedCallIds.Add(callId!);
+                continue;
+            }
+
+            if (string.Equals(type, "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+                outputCallIds.Add(callId!);
+            }
+        }
+
+        Assert.Contains("call_a", replayedCallIds);
+        Assert.DoesNotContain("call_b", replayedCallIds);
+        Assert.Contains("call_a", outputCallIds);
+        Assert.DoesNotContain("call_b", outputCallIds);
+    }
+
+    [Fact]
     public void BuildToolRoundReplayInput_UsesIndexedFallbackWhenRawCallIdIsMismatched() {
         var callA = new ToolCall(
             callId: "call_a",
@@ -2463,6 +2520,62 @@ public sealed partial class ChatServiceRoutingTrimTests {
         }
 
         Assert.Equal("out-a-direct", outputPayload);
+    }
+
+    [Fact]
+    public void BuildToolRoundReplayInput_DelayedMixedReplay_EmitsSingleLatestOutputPerCall() {
+        var callA = new ToolCall(
+            callId: "call_a",
+            name: "eventlog_live_query",
+            input: "{\"machine_name\":\"AD0\"}",
+            arguments: null,
+            raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        var callB = new ToolCall(
+            callId: "call_b",
+            name: "eventlog_live_query",
+            input: "{\"machine_name\":\"AD1\"}",
+            arguments: null,
+            raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        var extracted = new List<ToolCall> { callA, callB };
+        var byId = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase) {
+            ["call_a"] = callA,
+            ["call_b"] = callB
+        };
+        var outputs = new List<ToolOutputDto> {
+            new() { CallId = "mismatch_0", Output = "out-a-fallback-first", Ok = true },
+            new() { CallId = "mismatch_1", Output = "out-b-fallback-first", Ok = true },
+            new() { CallId = "call_a", Output = "out-a-explicit-first", Ok = true },
+            new() { CallId = "call_a", Output = "out-a-explicit-latest", Ok = true },
+            new() { CallId = "mismatch_2", Output = "out-a-fallback-late", Ok = true },
+            new() { CallId = "call_b", Output = "out-b-explicit-latest", Ok = true },
+            new() { CallId = "orphan_call", Output = "out-orphan", Ok = true }
+        };
+
+        var inputObj = BuildToolRoundReplayInputMethod.Invoke(
+            null,
+            new object?[] { extracted, byId, outputs });
+        var input = Assert.IsType<ChatInput>(inputObj);
+        var items = GetChatInputItems(input);
+
+        Assert.Equal(4, items.Count);
+        var outputByCallId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < items.Count; i++) {
+            var item = Assert.IsType<JsonObject>(items[i].AsObject());
+            if (!string.Equals(item.GetString("type"), "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            var callId = item.GetString("call_id");
+            if (string.IsNullOrWhiteSpace(callId)) {
+                continue;
+            }
+
+            outputByCallId[callId!] = item.GetString("output") ?? string.Empty;
+        }
+
+        Assert.Equal(2, outputByCallId.Count);
+        Assert.Equal("out-a-explicit-latest", outputByCallId["call_a"]);
+        Assert.Equal("out-b-explicit-latest", outputByCallId["call_b"]);
     }
 
     [Fact]

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -93,6 +93,11 @@ Progress:
 - Refined replay fallback behavior:
   - when only fallback matches are available, replay now uses the latest fallback output
   - later fallback entries cannot overwrite an already selected explicit `call_id` match
+- Added additional transport-break replay and retry regression coverage:
+  - `BuildToolRoundReplayInput_DropAfterToolCall_ReplaysOnlyCompletedPair`
+  - `BuildToolRoundReplayInput_DelayedMixedReplay_EmitsSingleLatestOutputPerCall`
+  - `ServiceShouldRetryModelPhaseAttempt_RetriesOnNestedUnexpectedEndOfStreamAfterToolCall`
+  - `ServiceShouldRetryModelPhaseAttempt_DoesNotRetryWhenCancellationAlreadyRequested`
 - Extended preflight recovery unit tests to include app duplicate-bubble guards:
   - `MainWindowNoTextWarningHandlingTests`
 


### PR DESCRIPTION
## Summary
- extend transport-recovery replay coverage in `BuildToolRoundReplayInput_*` tests:
  - drop-after-tool-call only replays completed call/output pairs
  - delayed mixed fallback/direct outputs emit exactly one latest output per call
- extend model-phase retry coverage in `ServiceShouldRetryModelPhaseAttempt_*` tests:
  - retry on nested unexpected-end-of-stream transport failure after tool call
  - no retry when cancellation is already requested
- update WS1 roadmap progress with these new recovery regressions

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildToolRoundReplayInput_DropAfterToolCall_ReplaysOnlyCompletedPair|FullyQualifiedName~BuildToolRoundReplayInput_DelayedMixedReplay_EmitsSingleLatestOutputPerCall|FullyQualifiedName~ServiceShouldRetryModelPhaseAttempt_RetriesOnNestedUnexpectedEndOfStreamAfterToolCall|FullyQualifiedName~ServiceShouldRetryModelPhaseAttempt_DoesNotRetryWhenCancellationAlreadyRequested"
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildToolRoundReplayInput_|FullyQualifiedName~ServiceShouldRetryModelPhaseAttempt_"