### PR TITLE
Chat: tighten replay ordering and unicode duplicate-bubble guards

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowNoTextWarningHandlingTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowNoTextWarningHandlingTests.cs
@@ -116,6 +116,20 @@ public sealed class MainWindowNoTextWarningHandlingTests {
     }
 
     /// <summary>
+    /// Ensures Unicode punctuation-only differences do not create duplicate final bubbles after streaming.
+    /// </summary>
+    [Fact]
+    public void ShouldAppendFinalAssistantAfterStreamedDraft_DoesNotAppendForUnicodePunctuationOnlyDiffs() {
+        var append = MainWindow.ShouldAppendFinalAssistantAfterStreamedDraft(
+            activeTurnReceivedDelta: true,
+            activeTurnInterimResultSeen: false,
+            finalAssistantText: "Running checks now！",
+            streamedAssistantText: "running checks now");
+
+        Assert.False(append);
+    }
+
+    /// <summary>
     /// Ensures short suffix-only final updates are treated as near-duplicates after streamed drafts.
     /// </summary>
     [Fact]
@@ -190,6 +204,20 @@ public sealed class MainWindowNoTextWarningHandlingTests {
             activeTurnReceivedDelta: false,
             activeTurnBoundToConversation: true,
             interimAssistantText: "Running checks now!",
+            latestAssistantText: "running checks now");
+
+        Assert.False(append);
+    }
+
+    /// <summary>
+    /// Ensures Unicode punctuation-only interim/latest diffs stay replace-only during reconnect snapshots.
+    /// </summary>
+    [Fact]
+    public void ShouldAppendInterimAssistantResult_DoesNotAppendForUnicodePunctuationOnlyDiffs() {
+        var append = MainWindow.ShouldAppendInterimAssistantResult(
+            activeTurnReceivedDelta: false,
+            activeTurnBoundToConversation: true,
+            interimAssistantText: "Running checks now！",
             latestAssistantText: "running checks now");
 
         Assert.False(append);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
@@ -646,7 +646,7 @@ public sealed partial class MainWindow : Window {
         var compact = normalized.ToString().Trim();
         while (compact.Length > 0) {
             var tail = compact[^1];
-            if (tail is '.' or '!' or '?' or ':' or ';' or ',') {
+            if (IsAssistantSnapshotTerminalPunctuation(tail)) {
                 compact = compact[..^1].TrimEnd();
                 continue;
             }
@@ -655,6 +655,23 @@ public sealed partial class MainWindow : Window {
         }
 
         return compact;
+    }
+
+    private static bool IsAssistantSnapshotTerminalPunctuation(char value) {
+        return value is '.'
+            or '!'
+            or '?'
+            or ':'
+            or ';'
+            or ','
+            or '\u3002' // 。
+            or '\uFF01' // ！
+            or '\uFF1F' // ？
+            or '\uFF1A' // ：
+            or '\uFF1B' // ；
+            or '\uFF0C' // ，
+            or '\u061F' // ؟
+            or '\u060C'; // ،
     }
 
     private static bool AreNearDuplicateAssistantSnapshots(string finalText, string interimText) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatSchemaRecoveryFallbackTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatSchemaRecoveryFallbackTests.cs
@@ -276,6 +276,24 @@ public sealed class ChatSchemaRecoveryFallbackTests {
     }
 
     [Fact]
+    public void ServiceShouldRetryModelPhaseAttempt_DoesNotRetryOnNestedNonTransportFailure() {
+        var ex = new InvalidOperationException(
+            "model phase failed after tool call",
+            new InvalidOperationException(
+                "tool replay failed",
+                new FormatException("schema parse failure in recovered replay payload")));
+
+        var shouldRetry = InvokeShouldRetryModelPhaseAttempt(
+            ServiceShouldRetryModelPhaseAttemptMethod,
+            ex,
+            attempt: 0,
+            maxAttempts: 2,
+            cancellationToken: CancellationToken.None);
+
+        Assert.False(shouldRetry);
+    }
+
+    [Fact]
     public void ServiceShouldRetryModelPhaseAttempt_DoesNotRetryWhenCancellationAlreadyRequested() {
         using var cts = new CancellationTokenSource();
         cts.Cancel();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
@@ -2558,14 +2558,22 @@ public sealed partial class ChatServiceRoutingTrimTests {
         var items = GetChatInputItems(input);
 
         Assert.Equal(4, items.Count);
+        var sequence = new List<string>();
         var outputByCallId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < items.Count; i++) {
             var item = Assert.IsType<JsonObject>(items[i].AsObject());
-            if (!string.Equals(item.GetString("type"), "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+            var type = item.GetString("type");
+            var callId = item.GetString("call_id");
+            if (!string.IsNullOrWhiteSpace(callId)
+                && (string.Equals(type, "custom_tool_call", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(type, "custom_tool_call_output", StringComparison.OrdinalIgnoreCase))) {
+                sequence.Add(type + ":" + callId);
+            }
+
+            if (!string.Equals(type, "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
                 continue;
             }
 
-            var callId = item.GetString("call_id");
             if (string.IsNullOrWhiteSpace(callId)) {
                 continue;
             }
@@ -2576,6 +2584,14 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Equal(2, outputByCallId.Count);
         Assert.Equal("out-a-explicit-latest", outputByCallId["call_a"]);
         Assert.Equal("out-b-explicit-latest", outputByCallId["call_b"]);
+        Assert.Equal(
+            new[] {
+                "custom_tool_call:call_a",
+                "custom_tool_call_output:call_a",
+                "custom_tool_call:call_b",
+                "custom_tool_call_output:call_b"
+            },
+            sequence);
     }
 
     [Fact]

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -98,6 +98,10 @@ Progress:
   - `BuildToolRoundReplayInput_DelayedMixedReplay_EmitsSingleLatestOutputPerCall`
   - `ServiceShouldRetryModelPhaseAttempt_RetriesOnNestedUnexpectedEndOfStreamAfterToolCall`
   - `ServiceShouldRetryModelPhaseAttempt_DoesNotRetryWhenCancellationAlreadyRequested`
+- Tightened replay and reconnect quality checks:
+  - replay test now asserts stable `call -> output` sequencing for mixed delayed-output paths
+  - added negative retry-control test for nested non-transport failures
+  - expanded app duplicate-bubble normalization to include common Unicode terminal punctuation
 - Extended preflight recovery unit tests to include app duplicate-bubble guards:
   - `MainWindowNoTextWarningHandlingTests`
 


### PR DESCRIPTION
## Summary
- assert strict replay sequence for delayed mixed tool-call replay to prevent ordering regressions
- add a negative retry-control test to ensure nested non-transport failures do not trigger transport retries
- expand duplicate-bubble normalization to handle common Unicode terminal punctuation and add app tests for both final/interim paths
- record WS1 roadmap progress for these hardening items

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildToolRoundReplayInput_DelayedMixedReplay_EmitsSingleLatestOutputPerCall|FullyQualifiedName~ServiceShouldRetryModelPhaseAttempt_DoesNotRetryOnNestedNonTransportFailure|FullyQualifiedName~ServiceShouldRetryModelPhaseAttempt_RetriesOnNestedUnexpectedEndOfStreamAfterToolCall|FullyQualifiedName~ServiceShouldRetryModelPhaseAttempt_DoesNotRetryWhenCancellationAlreadyRequested"
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~UnicodePunctuationOnlyDiffs|FullyQualifiedName~ShouldAppendInterimAssistantResult|FullyQualifiedName~ShouldAppendFinalAssistantAfterStreamedDraft"