### PR TITLE
Chat: add strict DNS scenarios and open-source routing guards

### DIFF
--- a/Build/Get-ChatScenarioCoverage.ps1
+++ b/Build/Get-ChatScenarioCoverage.ps1
@@ -2,7 +2,7 @@
 
 [CmdletBinding()] param(
     [string] $ScenarioDir = '.\IntelligenceX.Chat\scenarios',
-    [string] $Filter = 'ad-*-10-turn.json',
+    [string] $Filter = '*-10-turn.json',
     [string] $OutFile
 )
 
@@ -88,6 +88,16 @@ function Contains-ToolPattern([object] $turn, [string] $token) {
     return $false
 }
 
+function Contains-ForbiddenToolPattern([object] $turn, [string] $token) {
+    $forbidTools = @(Get-NormalizedStringList -rawValue (Get-JsonPropertyValue -instance $turn -propertyName 'forbid_tools'))
+    foreach ($pattern in $forbidTools) {
+        if ($pattern.IndexOf($token, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            return $true
+        }
+    }
+    return $false
+}
+
 function Is-StrictDefaultSet([object] $defaults) {
     if ($null -eq $defaults) {
         return $false
@@ -120,6 +130,9 @@ foreach ($file in $files) {
     $toolContractTurns = 0
     $adTurns = 0
     $eventLogTurns = 0
+    $dnsTurns = 0
+    $domainDetectiveTurns = 0
+    $publicDnsGuardTurns = 0
     $crossDcTurns = 0
 
     foreach ($turn in $turns) {
@@ -131,6 +144,15 @@ foreach ($file in $files) {
         }
         if (Contains-ToolPattern -turn $turn -token "eventlog_") {
             $eventLogTurns++
+        }
+        if (Contains-ToolPattern -turn $turn -token "dnsclientx_") {
+            $dnsTurns++
+        }
+        if (Contains-ToolPattern -turn $turn -token "domaindetective_") {
+            $domainDetectiveTurns++
+        }
+        if ((Contains-ForbiddenToolPattern -turn $turn -token "ad_") -or (Contains-ForbiddenToolPattern -turn $turn -token "eventlog_")) {
+            $publicDnsGuardTurns++
         }
         $user = "$(Get-JsonPropertyValue -instance $turn -propertyName 'user')"
         if ($user -match '(?i)all other|all remaining|every remaining|cross-DC|cross DC|those DCs') {
@@ -147,6 +169,9 @@ foreach ($file in $files) {
         ToolContractTurns = $toolContractTurns
         AdTurns = $adTurns
         EventLogTurns = $eventLogTurns
+        DnsTurns = $dnsTurns
+        DomainDetectiveTurns = $domainDetectiveTurns
+        PublicDnsGuardTurns = $publicDnsGuardTurns
         CrossDcTurns = $crossDcTurns
         StrictDefaults = $strictDefaults
         Tags = ($tags -join ',')
@@ -154,7 +179,7 @@ foreach ($file in $files) {
 }
 
 Write-Host "`n=== Chat Scenario Coverage ===" -ForegroundColor Cyan
-$rows | Format-Table ScenarioName, Turns, ToolContractTurns, AdTurns, EventLogTurns, CrossDcTurns, StrictDefaults, Tags -AutoSize
+$rows | Format-Table ScenarioName, Turns, ToolContractTurns, AdTurns, EventLogTurns, DnsTurns, DomainDetectiveTurns, PublicDnsGuardTurns, CrossDcTurns, StrictDefaults, Tags -AutoSize
 
 if (-not [string]::IsNullOrWhiteSpace($OutFile)) {
     $resolvedOutFile = Resolve-RepoRelativePath -repoRoot $repoRoot -pathValue $OutFile
@@ -166,16 +191,19 @@ if (-not [string]::IsNullOrWhiteSpace($OutFile)) {
     $lines = New-Object System.Collections.Generic.List[string]
     $lines.Add("# Chat Scenario Coverage") | Out-Null
     $lines.Add("") | Out-Null
-    $lines.Add("| Scenario | Turns | ToolContractTurns | AdTurns | EventLogTurns | CrossDcTurns | StrictDefaults | Tags |") | Out-Null
-    $lines.Add("|---|---:|---:|---:|---:|---:|:---:|---|") | Out-Null
+    $lines.Add("| Scenario | Turns | ToolContractTurns | AdTurns | EventLogTurns | DnsTurns | DomainDetectiveTurns | PublicDnsGuardTurns | CrossDcTurns | StrictDefaults | Tags |") | Out-Null
+    $lines.Add("|---|---:|---:|---:|---:|---:|---:|---:|---:|:---:|---|") | Out-Null
     foreach ($row in $rows) {
         $lines.Add(
-            ("| {0} | {1} | {2} | {3} | {4} | {5} | {6} | {7} |" -f
+            ("| {0} | {1} | {2} | {3} | {4} | {5} | {6} | {7} | {8} | {9} | {10} |" -f
                 $row.ScenarioName,
                 $row.Turns,
                 $row.ToolContractTurns,
                 $row.AdTurns,
                 $row.EventLogTurns,
+                $row.DnsTurns,
+                $row.DomainDetectiveTurns,
+                $row.PublicDnsGuardTurns,
                 $row.CrossDcTurns,
                 $(if ($row.StrictDefaults) { "yes" } else { "no" }),
                 $row.Tags)) | Out-Null

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioCatalogStrictnessTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioCatalogStrictnessTests.cs
@@ -9,9 +9,9 @@ namespace IntelligenceX.Chat.Tests;
 
 public sealed class HostScenarioCatalogStrictnessTests {
     [Fact]
-    public void AdTenTurnScenarios_AreStrictByDefault() {
+    public void TenTurnScenarios_AreStrictByDefault() {
         var scenarioDir = ResolveScenarioDirectory();
-        var scenarioFiles = Directory.GetFiles(scenarioDir, "ad-*-10-turn.json", SearchOption.TopDirectoryOnly)
+        var scenarioFiles = Directory.GetFiles(scenarioDir, "*-10-turn.json", SearchOption.TopDirectoryOnly)
             .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
@@ -20,15 +20,21 @@ public sealed class HostScenarioCatalogStrictnessTests {
         foreach (var file in scenarioFiles) {
             using var document = JsonDocument.Parse(File.ReadAllText(file));
             var root = document.RootElement;
+            var fileName = Path.GetFileName(file);
 
             var turns = RequireProperty(root, "turns");
             Assert.Equal(JsonValueKind.Array, turns.ValueKind);
             Assert.Equal(10, turns.GetArrayLength());
 
             var tags = ReadTagSet(root);
-            Assert.Contains("ad", tags);
             Assert.Contains("strict", tags);
             Assert.Contains("live", tags);
+            if (fileName.StartsWith("ad-", StringComparison.OrdinalIgnoreCase)) {
+                Assert.Contains("ad", tags);
+            }
+            if (fileName.StartsWith("dns-", StringComparison.OrdinalIgnoreCase)) {
+                Assert.Contains("dns", tags);
+            }
 
             var defaults = RequireProperty(root, "defaults");
             Assert.Equal(JsonValueKind.Object, defaults.ValueKind);
@@ -38,6 +44,43 @@ public sealed class HostScenarioCatalogStrictnessTests {
             Assert.True(ReadRequiredBoolean(defaults, "assert_no_duplicate_tool_output_call_ids"));
             Assert.Equal(0, ReadRequiredInt32(defaults, "max_no_tool_execution_retries"));
             Assert.Equal(1, ReadRequiredInt32(defaults, "max_duplicate_tool_call_signatures"));
+        }
+    }
+
+    [Fact]
+    public void DnsTenTurnScenarios_StayOnOpenSourceDnsToolingPath() {
+        var scenarioDir = ResolveScenarioDirectory();
+        var scenarioFiles = Directory.GetFiles(scenarioDir, "dns-*-10-turn.json", SearchOption.TopDirectoryOnly)
+            .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Assert.NotEmpty(scenarioFiles);
+
+        foreach (var file in scenarioFiles) {
+            using var document = JsonDocument.Parse(File.ReadAllText(file));
+            var root = document.RootElement;
+
+            var tags = ReadTagSet(root);
+            Assert.Contains("dns", tags);
+            Assert.Contains("strict", tags);
+            Assert.Contains("live", tags);
+
+            var turns = RequireProperty(root, "turns");
+            Assert.Equal(JsonValueKind.Array, turns.ValueKind);
+            Assert.Equal(10, turns.GetArrayLength());
+
+            var requiredPatterns = new List<string>();
+            var forbiddenPatterns = new List<string>();
+            foreach (var turn in turns.EnumerateArray()) {
+                requiredPatterns.AddRange(ReadStringList(turn, "require_tools"));
+                requiredPatterns.AddRange(ReadStringList(turn, "require_any_tools"));
+                forbiddenPatterns.AddRange(ReadStringList(turn, "forbid_tools"));
+            }
+
+            Assert.Contains(requiredPatterns, static pattern => pattern.StartsWith("dnsclientx_", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(requiredPatterns, static pattern => pattern.StartsWith("domaindetective_", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(forbiddenPatterns, static pattern => pattern.StartsWith("ad_", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(forbiddenPatterns, static pattern => pattern.StartsWith("eventlog_", StringComparison.OrdinalIgnoreCase));
         }
     }
 
@@ -78,6 +121,26 @@ public sealed class HostScenarioCatalogStrictnessTests {
         }
 
         return values;
+    }
+
+    private static IReadOnlyList<string> ReadStringList(JsonElement root, string propertyName) {
+        if (!root.TryGetProperty(propertyName, out var values) || values.ValueKind != JsonValueKind.Array) {
+            return Array.Empty<string>();
+        }
+
+        var result = new List<string>();
+        foreach (var value in values.EnumerateArray()) {
+            if (value.ValueKind != JsonValueKind.String) {
+                continue;
+            }
+
+            var candidate = (value.GetString() ?? string.Empty).Trim();
+            if (candidate.Length > 0) {
+                result.Add(candidate);
+            }
+        }
+
+        return result;
     }
 
     private static JsonElement RequireProperty(JsonElement root, string name) {

--- a/IntelligenceX.Chat/scenarios/dns-public-health-followthrough-10-turn.json
+++ b/IntelligenceX.Chat/scenarios/dns-public-health-followthrough-10-turn.json
@@ -1,0 +1,80 @@
+{
+  "name": "dns-public-health-followthrough-10-turn",
+  "tags": ["dns", "domaindetective", "continuation", "strict", "live", "open-source"],
+  "defaults": {
+    "assert_clean_completion": true,
+    "assert_tool_call_output_pairing": true,
+    "assert_no_duplicate_tool_call_ids": true,
+    "assert_no_duplicate_tool_output_call_ids": true,
+    "max_no_tool_execution_retries": 0,
+    "max_duplicate_tool_call_signatures": 1
+  },
+  "turns": [
+    {
+      "name": "Set scope to public DNS",
+      "user": "Treat this as a public DNS/domain troubleshooting task for contoso.com, not an AD DS domain-controller task.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["dnsclientx_pack_info", "domaindetective_pack_info", "dnsclientx_query"],
+      "forbid_tools": ["ad_*", "eventlog_*"]
+    },
+    {
+      "name": "Resolver baseline",
+      "user": "Collect baseline A/AAAA/NS evidence for contoso.com using explicit resolvers 1.1.1.1 and 8.8.8.8.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["dnsclientx_query"],
+      "forbid_tools": ["ad_*", "eventlog_*"]
+    },
+    {
+      "name": "Mail records",
+      "user": "Collect MX plus SPF and DMARC evidence for contoso.com and note gaps.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["dnsclientx_query"],
+      "forbid_tools": ["ad_*", "eventlog_*"]
+    },
+    {
+      "name": "Reachability probes",
+      "user": "Ping all discovered MX or authoritative DNS hosts in this same turn and do not stop after the first host.",
+      "min_tool_calls": 2,
+      "require_any_tools": ["dnsclientx_ping"],
+      "forbid_tools": ["ad_*", "eventlog_*"],
+      "assert_no_questions": true
+    },
+    {
+      "name": "DomainDetective posture",
+      "user": "Run a broad Domain Detective domain summary for contoso.com and surface highest-risk findings.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["domaindetective_domain_summary"],
+      "forbid_tools": ["ad_*", "eventlog_*"]
+    },
+    {
+      "name": "Resolver divergence",
+      "user": "Highlight resolver-to-resolver differences and likely caching/TTL causes.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["dnsclientx_query", "domaindetective_domain_summary"],
+      "forbid_tools": ["ad_*", "eventlog_*"]
+    },
+    {
+      "name": "Continue unresolved hosts",
+      "user": "If any hosts were unresolved or unreachable, continue with remaining hosts and return concrete blockers instead of stopping.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["dnsclientx_query", "dnsclientx_ping"],
+      "forbid_tools": ["ad_*", "eventlog_*"],
+      "assert_no_questions": true
+    },
+    {
+      "name": "Root cause families",
+      "user": "Classify likely root-cause families with confidence and strongest supporting evidence."
+    },
+    {
+      "name": "Immediate checklist",
+      "user": "Give a prioritized 30-minute DNS/domain validation checklist with no follow-up questions.",
+      "assert_no_questions": true
+    },
+    {
+      "name": "Compact summary",
+      "user": "Summarize final findings in 6 bullets with impacted records, affected hosts, and unresolved blockers.",
+      "assert_no_questions": true,
+      "assert_not_contains": ["Partial response shown above", "turn ended before completion"]
+    }
+  ]
+}

--- a/IntelligenceX.Chat/scenarios/dns-resolver-fallback-recovery-10-turn.json
+++ b/IntelligenceX.Chat/scenarios/dns-resolver-fallback-recovery-10-turn.json
@@ -1,0 +1,77 @@
+{
+  "name": "dns-resolver-fallback-recovery-10-turn",
+  "tags": ["dns", "continuation", "transport-recovery", "strict", "live", "open-source"],
+  "defaults": {
+    "assert_clean_completion": true,
+    "assert_tool_call_output_pairing": true,
+    "assert_no_duplicate_tool_call_ids": true,
+    "assert_no_duplicate_tool_output_call_ids": true,
+    "max_no_tool_execution_retries": 0,
+    "max_duplicate_tool_call_signatures": 1
+  },
+  "turns": [
+    {
+      "name": "Public DNS intent",
+      "user": "Investigate public DNS reliability for fabrikam.com and keep this on DNS/domain tooling only.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["dnsclientx_query", "dnsclientx_pack_info"],
+      "forbid_tools": ["ad_*", "eventlog_*"]
+    },
+    {
+      "name": "Resolver matrix",
+      "user": "Query A and NS records across 1.1.1.1, 8.8.8.8, and 9.9.9.9 and keep per-resolver evidence.",
+      "min_tool_calls": 2,
+      "require_any_tools": ["dnsclientx_query"],
+      "forbid_tools": ["ad_*", "eventlog_*"]
+    },
+    {
+      "name": "Retry failed resolvers once",
+      "user": "Retry failed resolver queries once with bounded timeout, then continue without duplicating successful resolver results.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["dnsclientx_query"],
+      "forbid_tools": ["ad_*", "eventlog_*"],
+      "assert_no_questions": true
+    },
+    {
+      "name": "Ping authoritative hosts",
+      "user": "Ping all authoritative DNS hosts and return packet-loss/latency notes for each host.",
+      "min_tool_calls": 2,
+      "require_any_tools": ["dnsclientx_ping"],
+      "forbid_tools": ["ad_*", "eventlog_*"]
+    },
+    {
+      "name": "Domain posture snapshot",
+      "user": "Run a Domain Detective summary and correlate DNS findings with email/security posture.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["domaindetective_domain_summary"],
+      "forbid_tools": ["ad_*", "eventlog_*"]
+    },
+    {
+      "name": "Continue remaining checks",
+      "user": "If any checks still failed, continue with unresolved resolvers/hosts only and preserve completed evidence.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["dnsclientx_query", "dnsclientx_ping", "domaindetective_domain_summary"],
+      "forbid_tools": ["ad_*", "eventlog_*"],
+      "assert_no_questions": true
+    },
+    {
+      "name": "Coverage matrix",
+      "user": "Return a resolver/host matrix showing success, failure class, and confidence for each evidence path."
+    },
+    {
+      "name": "Root causes",
+      "user": "Classify probable root causes and identify what is still unknown."
+    },
+    {
+      "name": "Action plan",
+      "user": "Provide a short execute-now plan to stabilize DNS reliability for this domain.",
+      "assert_no_questions": true
+    },
+    {
+      "name": "Final summary",
+      "user": "Summarize in 6 bullets with resolver coverage count, host coverage count, and unresolved blockers.",
+      "assert_no_questions": true,
+      "assert_not_contains": ["Partial response shown above", "turn ended before completion"]
+    }
+  ]
+}

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -24,6 +24,7 @@ Last validated: 2026-02-24
   - `Build/Run-ChatQualityPreflight.ps1`
 - Existing AD scenarios were made strict by default and one new cross-DC continuation scenario was added.
 - Added catalog-level strictness test coverage for `ad-*-10-turn.json` to enforce strict defaults and 10-turn shape.
+- Expanded catalog-level strictness coverage to all `*-10-turn.json` scenarios, including DNS/open-source domain paths.
 - Scenario suite now supports scenario-tag filtering (`-Tags`) and preflight forwards tags via `-ScenarioTags`.
 - Added live-suite runner (`Build/Run-ChatLiveConversationSuite.ps1`) so local live validation can run tag-driven batches without hardcoded single-scenario defaults.
 - Preflight now supports `-RunLiveHarnessSuite` for the same tag-driven live validation path.
@@ -36,6 +37,8 @@ Last validated: 2026-02-24
 - `ad-identity-correlation-przemyslaw-10-turn.json`: identity-centric AD correlation.
 - `ad-ldap-adws-health-10-turn.json`: LDAP/ADWS service health.
 - `ad-user-last-logon-przemyslaw-10-turn.json`: cross-DC user last-logon evidence.
+- `dns-public-health-followthrough-10-turn.json`: public DNS + Domain Detective follow-through with no AD/eventlog tool path.
+- `dns-resolver-fallback-recovery-10-turn.json`: resolver divergence/fallback recovery with bounded retries and no AD/eventlog tool path.
 
 ## Confirmed Gaps / Risks
 - High: missing explicit end-to-end tests for transport break right after tool call plus delayed/replayed tool output across service and app message handling.
@@ -131,6 +134,13 @@ Progress:
 - Added live harness suite runner (tag-driven, repeatable) for real auth/tool runs without hardcoded single-scenario selection.
 - Hardened scenario duplicate-call detection by canonicalizing tool argument JSON before signature comparison
   (so key-order-only differences still count as duplicate signatures).
+- Added DNS/open-source scenario coverage:
+  - `dns-public-health-followthrough-10-turn.json`
+  - `dns-resolver-fallback-recovery-10-turn.json`
+- Tightened scenario catalog tests for DNS routing safety:
+  - DNS scenarios must include strict/live tags and 10 turns
+  - DNS scenarios must include both `dnsclientx_*` and `domaindetective_*` tool contracts
+  - DNS scenarios must include `forbid_tools` guards for `ad_*` and `eventlog_*`
 
 ### WS3: UI Debug Visibility Modes
 Status: mostly_done  


### PR DESCRIPTION
## Summary
- add two strict 10-turn DNS/domain scenarios focused on open-source tooling paths:
  - dns-public-health-followthrough-10-turn
  - dns-resolver-fallback-recovery-10-turn
- keep those scenarios explicitly on public DNS/domain diagnostics by forbidding `ad_*` and `eventlog_*` tools per tool-contract turns
- expand scenario catalog strictness tests to all `*-10-turn.json` files and add DNS-specific routing guard assertions
- extend `Build/Get-ChatScenarioCoverage.ps1` to cover all 10-turn scenarios plus DNS/DomainDetective and public-DNS guard turn metrics
- update roadmap progress with the new DNS scenario/routing safety coverage

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~HostScenarioCatalogStrictnessTests"
- pwsh -NoLogo -NoProfile -File Build/Get-ChatScenarioCoverage.ps1 -ScenarioDir .\IntelligenceX.Chat\scenarios -Filter "*-10-turn.json"