### PR TITLE
Chat: expose context-aware tool budget diagnostics

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ModelResolution.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ModelResolution.cs
@@ -249,21 +249,40 @@ internal sealed partial class ChatServiceSession {
     }
 
     private int? ResolveMaxCandidateToolsForTurn(int? requestedLimit, OpenAITransportKind transportKind, string? selectedModel) {
+        return ResolveMaxCandidateToolsDiagnosticsForTurn(requestedLimit, transportKind, selectedModel).EffectiveMaxCandidateTools;
+    }
+
+    private ToolCandidateBudgetDiagnostics ResolveMaxCandidateToolsDiagnosticsForTurn(
+        int? requestedLimit,
+        OpenAITransportKind transportKind,
+        string? selectedModel) {
         var resolved = ResolveMaxCandidateToolsSetting(requestedLimit, transportKind);
         if (transportKind != OpenAITransportKind.CompatibleHttp) {
-            return resolved;
+            return new ToolCandidateBudgetDiagnostics(
+                EffectiveMaxCandidateTools: resolved,
+                EffectiveContextLength: null,
+                ContextAwareBudgetApplied: false);
         }
 
         if (requestedLimit is > 0) {
-            return resolved;
+            return new ToolCandidateBudgetDiagnostics(
+                EffectiveMaxCandidateTools: resolved,
+                EffectiveContextLength: null,
+                ContextAwareBudgetApplied: false);
         }
 
         var effectiveContextLength = ResolveEffectiveModelContextLength(selectedModel);
         if (!effectiveContextLength.HasValue) {
-            return resolved;
+            return new ToolCandidateBudgetDiagnostics(
+                EffectiveMaxCandidateTools: resolved,
+                EffectiveContextLength: null,
+                ContextAwareBudgetApplied: false);
         }
 
-        return ResolveContextAwareCompatibleHttpDefaultMaxCandidateTools(effectiveContextLength.Value);
+        return new ToolCandidateBudgetDiagnostics(
+            EffectiveMaxCandidateTools: ResolveContextAwareCompatibleHttpDefaultMaxCandidateTools(effectiveContextLength.Value),
+            EffectiveContextLength: effectiveContextLength.Value,
+            ContextAwareBudgetApplied: true);
     }
 
     private long? ResolveEffectiveModelContextLength(string? selectedModel) {
@@ -337,6 +356,11 @@ internal sealed partial class ChatServiceSession {
 
         return null;
     }
+
+    private readonly record struct ToolCandidateBudgetDiagnostics(
+        int? EffectiveMaxCandidateTools,
+        long? EffectiveContextLength,
+        bool ContextAwareBudgetApplied);
 
     private bool ShouldDisableToolsForSelectedModel(OpenAITransportKind transportKind, string? selectedModel) {
         if (transportKind != OpenAITransportKind.CompatibleHttp) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -66,7 +66,9 @@ internal sealed partial class ChatServiceSession {
         var userIntent = ExtractIntentUserText(request.Text);
         RememberUserIntent(threadId, userIntent);
         var routedUserRequest = ExpandContinuationUserRequest(threadId, userRequest);
-        var maxCandidateTools = ResolveMaxCandidateToolsForTurn(request.Options?.MaxCandidateTools, client.TransportKind, selectedModel);
+        var requestedMaxCandidateTools = request.Options?.MaxCandidateTools;
+        var maxCandidateToolDiagnostics = ResolveMaxCandidateToolsDiagnosticsForTurn(requestedMaxCandidateTools, client.TransportKind, selectedModel);
+        var maxCandidateTools = maxCandidateToolDiagnostics.EffectiveMaxCandidateTools;
         var executionContractApplies = ShouldEnforceExecuteOrExplainContract(routedUserRequest);
         var proactiveModeEnabled = TryReadProactiveModeFromRequestText(request.Text, out var proactiveMode) && proactiveMode;
         var compactFollowUpTurn = LooksLikeContinuationFollowUp(userRequest);
@@ -144,7 +146,11 @@ internal sealed partial class ChatServiceSession {
                 selectedToolCount: routingSelectedToolCount,
                 totalToolCount: routingTotalToolCount,
                 insightCount: routingInsights.Count,
-                plannerInsightsDetected);
+                plannerInsightsDetected,
+                requestedMaxCandidateTools: requestedMaxCandidateTools,
+                effectiveMaxCandidateTools: maxCandidateTools,
+                effectiveContextLength: maxCandidateToolDiagnostics.EffectiveContextLength,
+                contextAwareBudgetApplied: maxCandidateToolDiagnostics.ContextAwareBudgetApplied);
             await TryWriteStatusAsync(
                     writer,
                     request.RequestId,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
@@ -211,8 +211,13 @@ internal sealed partial class ChatServiceSession {
         int selectedToolCount,
         int totalToolCount,
         int insightCount,
-        bool plannerInsightsDetected) {
+        bool plannerInsightsDetected,
+        int? requestedMaxCandidateTools,
+        int? effectiveMaxCandidateTools,
+        long? effectiveContextLength,
+        bool contextAwareBudgetApplied) {
         var (selected, total) = NormalizeRoutingToolCounts(selectedToolCount, totalToolCount);
+        var normalizedContextLength = effectiveContextLength is > 0 ? effectiveContextLength : null;
         return JsonSerializer.Serialize(new {
             strategy = (strategy ?? string.Empty).Trim(),
             weightedToolRouting,
@@ -222,7 +227,13 @@ internal sealed partial class ChatServiceSession {
             totalToolCount = total,
             reducedToolSet = selected > 0 && selected < total,
             insightCount = Math.Max(0, insightCount),
-            plannerInsightsDetected
+            plannerInsightsDetected,
+            toolCandidateBudget = new {
+                requested = requestedMaxCandidateTools,
+                effective = effectiveMaxCandidateTools,
+                contextAwareBudgetApplied,
+                effectiveModelContextLength = normalizedContextLength
+            }
         });
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingTransparency.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingTransparency.cs
@@ -101,6 +101,10 @@ public sealed partial class ChatServiceRoutingTrimTests {
             selectedToolCount,
             totalToolCount,
             0,
+            false,
+            null,
+            null,
+            null,
             false
         });
         var payload = Assert.IsType<string>(payloadResult);
@@ -121,7 +125,11 @@ public sealed partial class ChatServiceRoutingTrimTests {
             8,
             21,
             5,
-            true
+            true,
+            null,
+            null,
+            null,
+            false
         });
         var payload = Assert.IsType<string>(result);
 
@@ -145,6 +153,10 @@ public sealed partial class ChatServiceRoutingTrimTests {
             14,
             6,
             2,
+            false,
+            null,
+            null,
+            null,
             false
         });
         var payload = Assert.IsType<string>(result);
@@ -166,6 +178,10 @@ public sealed partial class ChatServiceRoutingTrimTests {
             5,
             0,
             0,
+            false,
+            null,
+            null,
+            null,
             false
         });
         var payload = Assert.IsType<string>(result);
@@ -176,5 +192,32 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Equal(0, root.GetProperty("selectedToolCount").GetInt32());
         Assert.Equal(0, root.GetProperty("totalToolCount").GetInt32());
         Assert.False(root.GetProperty("reducedToolSet").GetBoolean());
+    }
+
+    [Fact]
+    public void BuildRoutingMetaPayload_IncludesToolCandidateBudgetDiagnostics() {
+        var result = BuildRoutingMetaPayloadMethod.Invoke(null, new object?[] {
+            "weighted_heuristic",
+            true,
+            false,
+            false,
+            4,
+            19,
+            2,
+            false,
+            null,
+            4,
+            8192L,
+            true
+        });
+        var payload = Assert.IsType<string>(result);
+
+        using var doc = JsonDocument.Parse(payload);
+        var root = doc.RootElement;
+        var budget = root.GetProperty("toolCandidateBudget");
+        Assert.Equal(4, budget.GetProperty("effective").GetInt32());
+        Assert.True(budget.GetProperty("contextAwareBudgetApplied").GetBoolean());
+        Assert.Equal(8192L, budget.GetProperty("effectiveModelContextLength").GetInt64());
+        Assert.Equal(JsonValueKind.Null, budget.GetProperty("requested").ValueKind);
     }
 }

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -202,6 +202,10 @@ Progress:
   - explicit override precedence
   - matched model loaded/max context selection
   - single-model fallback and unknown-model multi-model fallback
+- Added routing-meta budget diagnostics so turn trace can expose budget decisions:
+  - requested vs effective `maxCandidateTools`
+  - context-aware budget application flag
+  - effective model context length when available
 
 ### WS6: Merge Gates
 Status: in_progress  


### PR DESCRIPTION
## Summary
- add context-aware tool-candidate budget diagnostics object to routing metadata payloads
- emit requested/effective max candidate tools, context-aware budget flag, and effective model context length (when available)
- refactor budget resolution to return diagnostic details in addition to the effective candidate limit
- keep roadmap tracking updated for WS5 visibility progress

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRoutingTrimTests.RoutingTransparency|FullyQualifiedName~ChatServicePlannerPromptTests"