### PR TITLE
Chat: tighten AD vs public-domain clarification boundary

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
@@ -25,6 +25,8 @@ using IntelligenceX.Tools.Common;
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
+    private const int DomainIntentClarificationMinRelevantCandidates = 3;
+    private const double DomainIntentClarificationMaxDominantShare = 0.80d;
 
     private static List<ToolRoutingInsight> BuildContinuationRoutingInsights(IReadOnlyList<ToolDefinition> selectedDefs) {
         var list = new List<ToolRoutingInsight>(selectedDefs.Count);
@@ -178,12 +180,12 @@ internal sealed partial class ChatServiceSession {
         }
 
         var relevantCandidates = adCandidates + publicDomainCandidates;
-        if (relevantCandidates < 3) {
+        if (relevantCandidates < DomainIntentClarificationMinRelevantCandidates) {
             return false;
         }
 
         var dominantShare = Math.Max(adCandidates, publicDomainCandidates) / (double)relevantCandidates;
-        return dominantShare <= 0.80d;
+        return dominantShare < DomainIntentClarificationMaxDominantShare;
     }
 
     private static bool IsAdDomainIntentTool(string toolName) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.DomainIntentClarification.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.DomainIntentClarification.cs
@@ -1,0 +1,70 @@
+using System;
+using IntelligenceX.Tools;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed partial class ChatServiceRoutingTrimTests {
+    [Fact]
+    public void ShouldRequestDomainIntentClarification_ReturnsTrueForMixedNonDominantSubset() {
+        var selectedTools = new[] {
+            new ToolDefinition("ad_object_get", "stub"),
+            new ToolDefinition("ad_replication_summary", "stub"),
+            new ToolDefinition("dnsclientx_query", "stub"),
+            new ToolDefinition("domaindetective_domain_summary", "stub")
+        };
+
+        var result = ShouldRequestDomainIntentClarificationMethod.Invoke(
+            null,
+            new object?[] { true, false, false, 4, 10, selectedTools });
+
+        Assert.True(Assert.IsType<bool>(result));
+    }
+
+    [Fact]
+    public void ShouldRequestDomainIntentClarification_DoesNotTriggerAtDominantShareBoundary() {
+        var selectedTools = new[] {
+            new ToolDefinition("ad_object_get", "stub"),
+            new ToolDefinition("ad_replication_summary", "stub"),
+            new ToolDefinition("ad_search", "stub"),
+            new ToolDefinition("ad_domain_discover", "stub"),
+            new ToolDefinition("dnsclientx_query", "stub")
+        };
+
+        var result = ShouldRequestDomainIntentClarificationMethod.Invoke(
+            null,
+            new object?[] { true, false, false, 5, 12, selectedTools });
+
+        Assert.False(Assert.IsType<bool>(result));
+    }
+
+    [Fact]
+    public void ShouldRequestDomainIntentClarification_ReturnsFalseWhenWeightedRoutingDisabled() {
+        var selectedTools = new[] {
+            new ToolDefinition("ad_object_get", "stub"),
+            new ToolDefinition("dnsclientx_query", "stub"),
+            new ToolDefinition("domaindetective_domain_summary", "stub")
+        };
+
+        var result = ShouldRequestDomainIntentClarificationMethod.Invoke(
+            null,
+            new object?[] { false, false, false, 3, 8, selectedTools });
+
+        Assert.False(Assert.IsType<bool>(result));
+    }
+
+    [Fact]
+    public void ShouldRequestDomainIntentClarification_ReturnsFalseWhenSelectionIsFullToolset() {
+        var selectedTools = new[] {
+            new ToolDefinition("ad_object_get", "stub"),
+            new ToolDefinition("dnsclientx_query", "stub"),
+            new ToolDefinition("domaindetective_domain_summary", "stub")
+        };
+
+        var result = ShouldRequestDomainIntentClarificationMethod.Invoke(
+            null,
+            new object?[] { true, false, false, 3, 3, selectedTools });
+
+        Assert.False(Assert.IsType<bool>(result));
+    }
+}

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -177,6 +177,10 @@ Progress:
 - Added metadata regression test coverage for disabled-by-configuration behavior and source-kind classification.
 - Added a routing ambiguity guard for mixed AD-domain and public DNS/domain candidate sets:
   - when weighted routing yields a mixed, non-dominant subset across `ad_*` and `dnsclientx_*`/`domaindetective_*`, Chat asks one clarifying turn before execution.
+- Tightened ambiguity threshold behavior to reduce over-clarification:
+  - extracted named constants for minimum relevant candidates and dominant-share threshold
+  - clarification now triggers only for strictly non-dominant mixes (not at the 80% dominance boundary)
+  - added targeted regression tests for mixed-positive and boundary-negative cases
 
 ### WS5: Tool Count, Context Budget, Compaction
 Status: in_progress  


### PR DESCRIPTION
## Summary
- extract named constants for domain-intent clarification thresholds
- only trigger AD/public-domain clarification for strictly non-dominant mixed subsets (no clarification at exactly 80% dominance)
- add targeted boundary and guard regression tests for clarification eligibility
- update roadmap progress notes for WS4

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Service/IntelligenceX.Chat.Service.csproj -c Release /p:BuildProjectReferences=false`
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release /p:BuildProjectReferences=false`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~DomainIntent|FullyQualifiedName~RoutingTransparency"`
- `pwsh -NoLogo -NoProfile -File .github/scripts/test-chat-scenario-catalog-quality.ps1`

## Notes
- local full project-reference test builds currently hit an unrelated sibling-repo compile issue in `C:\Support\GitHub\TestimoX` (outside this PR scope); targeted chat validation above is included and CI will run clean-environment checks.
