### PR TITLE
test(pr-babysit): harden monitor event defaulting edges

### DIFF
--- a/IntelligenceX.Cli/Todo/PrWatchMonitorRunner.cs
+++ b/IntelligenceX.Cli/Todo/PrWatchMonitorRunner.cs
@@ -125,25 +125,48 @@ internal static class PrWatchMonitorRunner {
     }
 
     private static void ApplyGitHubEventDefaults(Options options) {
+        var eventName = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME");
         var eventPath = Environment.GetEnvironmentVariable("GITHUB_EVENT_PATH");
         var payload = LoadGitHubEventPayload(eventPath);
 
-        if (string.IsNullOrWhiteSpace(options.PrSpec)) {
-            options.PrSpec = ResolvePrSpecFromGitHubEventPayload(payload);
-        }
-
-        if (!options.SourceExplicitlySet) {
-            var action = ResolveEventActionFromGitHubEventPayload(payload);
-            options.Source = ComposeSourceTag(options.Source, action);
-        }
+        options.PrSpec = ResolvePrSpecWithEventDefaults(options.PrSpec, payload);
+        options.Source = ResolveSourceWithEventDefaults(options.Source, options.SourceExplicitlySet, payload, eventName);
     }
 
     internal static string ComposeSourceTag(string source, string action) {
-        var normalizedSource = string.IsNullOrWhiteSpace(source)
-            ? (Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME") ?? "manual_cli")
-            : source.Trim();
+        var normalizedSource = string.IsNullOrWhiteSpace(source) ? "manual_cli" : source.Trim();
         var normalizedAction = string.IsNullOrWhiteSpace(action) ? string.Empty : action.Trim();
         return string.IsNullOrWhiteSpace(normalizedAction) ? normalizedSource : $"{normalizedSource}:{normalizedAction}";
+    }
+
+    internal static string ResolveSourceWithEventDefaults(string source, bool sourceExplicitlySet, JsonObject? payload, string? eventName) {
+        if (sourceExplicitlySet) {
+            return source;
+        }
+
+        var action = ResolveEventActionFromGitHubEventPayload(payload);
+        var fallbackSource = ResolveDefaultSourceBase(source, eventName);
+        return ComposeSourceTag(fallbackSource, action);
+    }
+
+    internal static string ResolveDefaultSourceBase(string source, string? eventName) {
+        if (!string.IsNullOrWhiteSpace(source)) {
+            return source.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(eventName)) {
+            return eventName.Trim();
+        }
+
+        return "manual_cli";
+    }
+
+    internal static string ResolvePrSpecWithEventDefaults(string prSpec, JsonObject? payload) {
+        if (!string.IsNullOrWhiteSpace(prSpec)) {
+            return prSpec;
+        }
+
+        return ResolvePrSpecFromGitHubEventPayload(payload);
     }
 
     internal static string ResolveEventActionFromGitHubEventPayload(JsonObject? payload) {
@@ -170,7 +193,8 @@ internal static class PrWatchMonitorRunner {
 
         try {
             return JsonNode.Parse(File.ReadAllText(eventPath)) as JsonObject;
-        } catch {
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Warning: failed to parse GITHUB_EVENT_PATH payload '{eventPath}': {ex.Message}");
             return null;
         }
     }

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -236,8 +236,10 @@ internal static partial class Program {
         failed += Run("Todo pr-watch monitor compose source tag skips empty action", TestPrWatchMonitorComposeSourceTagSkipsEmptyAction);
         failed += Run("Todo pr-watch monitor resolves event action from payload", TestPrWatchMonitorResolveEventActionFromPayload);
         failed += Run("Todo pr-watch monitor resolves PR spec from payload", TestPrWatchMonitorResolvePrSpecFromPayload);
-        failed += Run("Todo pr-watch monitor compose source tag uses event name when source empty", TestPrWatchMonitorComposeSourceTagUsesEventNameWhenSourceEmpty);
-        failed += Run("Todo pr-watch monitor compose source tag uses manual_cli when source and event name empty", TestPrWatchMonitorComposeSourceTagUsesManualCliWhenSourceAndEventNameEmpty);
+        failed += Run("Todo pr-watch monitor resolves source defaults keeps explicit source", TestPrWatchMonitorResolveSourceWithEventDefaultsKeepsExplicitSource);
+        failed += Run("Todo pr-watch monitor resolves source defaults uses event name when source empty", TestPrWatchMonitorResolveSourceWithEventDefaultsUsesEventNameWhenSourceEmpty);
+        failed += Run("Todo pr-watch monitor resolves source defaults uses manual_cli when source and event name empty", TestPrWatchMonitorResolveSourceWithEventDefaultsUsesManualCliWhenSourceAndEventNameEmpty);
+        failed += Run("Todo pr-watch monitor resolves PR defaults keeps explicit PR", TestPrWatchMonitorResolvePrSpecWithEventDefaultsKeepsExplicitPr);
         failed += Run("Todo pr-watch monitor workflow review triggers include submitted and edited",
             TestPrWatchMonitorWorkflowReviewTriggersIncludeSubmittedAndEdited);
         failed += Run("Todo pr-watch monitor workflow excludes review comment trigger",

--- a/IntelligenceX.Tests/Program.Todo.PrWatch.cs
+++ b/IntelligenceX.Tests/Program.Todo.PrWatch.cs
@@ -282,26 +282,28 @@ internal static partial class Program {
         AssertEqual("742", prSpec, "PR spec should resolve from event payload pull_request.number");
     }
 
-    private static void TestPrWatchMonitorComposeSourceTagUsesEventNameWhenSourceEmpty() {
-        var originalEventName = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME");
-        try {
-            Environment.SetEnvironmentVariable("GITHUB_EVENT_NAME", "pull_request");
-            var source = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ComposeSourceTag(string.Empty, "edited");
-            AssertEqual("pull_request:edited", source, "empty source should fall back to GITHUB_EVENT_NAME before appending action");
-        } finally {
-            Environment.SetEnvironmentVariable("GITHUB_EVENT_NAME", originalEventName);
-        }
+    private static void TestPrWatchMonitorResolveSourceWithEventDefaultsKeepsExplicitSource() {
+        var payload = global::System.Text.Json.Nodes.JsonNode.Parse("{\"action\":\"edited\"}") as global::System.Text.Json.Nodes.JsonObject;
+        var source = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ResolveSourceWithEventDefaults("workflow_dispatch", true, payload, "pull_request");
+        AssertEqual("workflow_dispatch", source, "explicit source should bypass action suffix auto-append");
     }
 
-    private static void TestPrWatchMonitorComposeSourceTagUsesManualCliWhenSourceAndEventNameEmpty() {
-        var originalEventName = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME");
-        try {
-            Environment.SetEnvironmentVariable("GITHUB_EVENT_NAME", null);
-            var source = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ComposeSourceTag(string.Empty, "edited");
-            AssertEqual("manual_cli:edited", source, "empty source should fall back to manual_cli when event name is unavailable");
-        } finally {
-            Environment.SetEnvironmentVariable("GITHUB_EVENT_NAME", originalEventName);
-        }
+    private static void TestPrWatchMonitorResolveSourceWithEventDefaultsUsesEventNameWhenSourceEmpty() {
+        var payload = global::System.Text.Json.Nodes.JsonNode.Parse("{\"action\":\"edited\"}") as global::System.Text.Json.Nodes.JsonObject;
+        var source = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ResolveSourceWithEventDefaults(string.Empty, false, payload, "pull_request");
+        AssertEqual("pull_request:edited", source, "empty source should fall back to event name before appending action");
+    }
+
+    private static void TestPrWatchMonitorResolveSourceWithEventDefaultsUsesManualCliWhenSourceAndEventNameEmpty() {
+        var payload = global::System.Text.Json.Nodes.JsonNode.Parse("{\"action\":\"edited\"}") as global::System.Text.Json.Nodes.JsonObject;
+        var source = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ResolveSourceWithEventDefaults(string.Empty, false, payload, null);
+        AssertEqual("manual_cli:edited", source, "empty source should fall back to manual_cli when event name is unavailable");
+    }
+
+    private static void TestPrWatchMonitorResolvePrSpecWithEventDefaultsKeepsExplicitPr() {
+        var payload = global::System.Text.Json.Nodes.JsonNode.Parse("{\"pull_request\":{\"number\":742}}") as global::System.Text.Json.Nodes.JsonObject;
+        var prSpec = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ResolvePrSpecWithEventDefaults("123", payload);
+        AssertEqual("123", prSpec, "explicit PR should be preserved even when payload contains pull_request.number");
     }
 #endif
 }


### PR DESCRIPTION
## Summary
- harden monitor event defaulting internals with explicit helper boundaries:
  - `ResolveSourceWithEventDefaults(...)`
  - `ResolveDefaultSourceBase(...)`
  - `ResolvePrSpecWithEventDefaults(...)`
- remove ambient env dependency from `ComposeSourceTag(...)` and keep env fallback resolution in `ApplyGitHubEventDefaults(...)`
- add warning output when `GITHUB_EVENT_PATH` payload parsing fails (instead of silent swallow)
- add targeted tests for:
  - explicit source bypassing action suffix auto-append
  - source fallback to event name/manual_cli
  - explicit PR preserving precedence over payload PR number

## Why
- follows up on reviewer non-blocking concerns with deterministic helper logic and edge-case coverage
- improves diagnosability when event payload parsing fails

## Validation
- dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
