### PR TITLE
test(pr-babysit): harden monitor parse and explicit source handling

### DIFF
--- a/IntelligenceX.Cli/Todo/PrWatchMonitorRunner.cs
+++ b/IntelligenceX.Cli/Todo/PrWatchMonitorRunner.cs
@@ -14,6 +14,7 @@ namespace IntelligenceX.Cli.Todo;
 internal static class PrWatchMonitorRunner {
     private const string DefaultRepo = "EvotecIT/IntelligenceX";
     private static readonly JsonSerializerOptions CompactJson = new() { WriteIndented = false };
+    private readonly record struct GitHubEventContext(string? EventName, JsonObject? Payload);
 
     private sealed class Options {
         public string Repo { get; set; } = DefaultRepo;
@@ -125,12 +126,15 @@ internal static class PrWatchMonitorRunner {
     }
 
     private static void ApplyGitHubEventDefaults(Options options) {
+        var eventContext = ResolveGitHubEventContextFromEnvironment();
+        options.PrSpec = ResolvePrSpecWithEventDefaults(options.PrSpec, eventContext.Payload);
+        options.Source = ResolveSourceWithEventDefaults(options.Source, options.SourceExplicitlySet, eventContext.Payload, eventContext.EventName);
+    }
+
+    private static GitHubEventContext ResolveGitHubEventContextFromEnvironment() {
         var eventName = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME");
         var eventPath = Environment.GetEnvironmentVariable("GITHUB_EVENT_PATH");
-        var payload = LoadGitHubEventPayload(eventPath);
-
-        options.PrSpec = ResolvePrSpecWithEventDefaults(options.PrSpec, payload);
-        options.Source = ResolveSourceWithEventDefaults(options.Source, options.SourceExplicitlySet, payload, eventName);
+        return new GitHubEventContext(eventName, LoadGitHubEventPayload(eventPath));
     }
 
     internal static string ComposeSourceTag(string source, string action) {
@@ -139,9 +143,9 @@ internal static class PrWatchMonitorRunner {
         return string.IsNullOrWhiteSpace(normalizedAction) ? normalizedSource : $"{normalizedSource}:{normalizedAction}";
     }
 
-    internal static string ResolveSourceWithEventDefaults(string source, bool sourceExplicitlySet, JsonObject? payload, string? eventName) {
+    internal static string ResolveSourceWithEventDefaults(string? source, bool sourceExplicitlySet, JsonObject? payload, string? eventName) {
         if (sourceExplicitlySet) {
-            return source;
+            return ResolveDefaultSourceBase(source, eventName: null);
         }
 
         var action = ResolveEventActionFromGitHubEventPayload(payload);
@@ -149,7 +153,7 @@ internal static class PrWatchMonitorRunner {
         return ComposeSourceTag(fallbackSource, action);
     }
 
-    internal static string ResolveDefaultSourceBase(string source, string? eventName) {
+    internal static string ResolveDefaultSourceBase(string? source, string? eventName) {
         if (!string.IsNullOrWhiteSpace(source)) {
             return source.Trim();
         }
@@ -161,7 +165,7 @@ internal static class PrWatchMonitorRunner {
         return "manual_cli";
     }
 
-    internal static string ResolvePrSpecWithEventDefaults(string prSpec, JsonObject? payload) {
+    internal static string ResolvePrSpecWithEventDefaults(string? prSpec, JsonObject? payload) {
         if (!string.IsNullOrWhiteSpace(prSpec)) {
             return prSpec;
         }
@@ -186,7 +190,7 @@ internal static class PrWatchMonitorRunner {
         return number > 0 ? number.ToString(CultureInfo.InvariantCulture) : string.Empty;
     }
 
-    private static JsonObject? LoadGitHubEventPayload(string? eventPath) {
+    internal static JsonObject? LoadGitHubEventPayload(string? eventPath) {
         if (string.IsNullOrWhiteSpace(eventPath) || !File.Exists(eventPath)) {
             return null;
         }
@@ -194,7 +198,7 @@ internal static class PrWatchMonitorRunner {
         try {
             return JsonNode.Parse(File.ReadAllText(eventPath)) as JsonObject;
         } catch (Exception ex) {
-            Console.Error.WriteLine($"Warning: failed to parse GITHUB_EVENT_PATH payload '{eventPath}': {ex.Message}");
+            Console.Error.WriteLine($"Warning: failed to parse GITHUB_EVENT_PATH payload '{eventPath}': {ex.GetType().Name}: {ex.Message}");
             return null;
         }
     }

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -237,9 +237,11 @@ internal static partial class Program {
         failed += Run("Todo pr-watch monitor resolves event action from payload", TestPrWatchMonitorResolveEventActionFromPayload);
         failed += Run("Todo pr-watch monitor resolves PR spec from payload", TestPrWatchMonitorResolvePrSpecFromPayload);
         failed += Run("Todo pr-watch monitor resolves source defaults keeps explicit source", TestPrWatchMonitorResolveSourceWithEventDefaultsKeepsExplicitSource);
+        failed += Run("Todo pr-watch monitor resolves source defaults normalizes whitespace explicit source", TestPrWatchMonitorResolveSourceWithEventDefaultsNormalizesWhitespaceExplicitSource);
         failed += Run("Todo pr-watch monitor resolves source defaults uses event name when source empty", TestPrWatchMonitorResolveSourceWithEventDefaultsUsesEventNameWhenSourceEmpty);
         failed += Run("Todo pr-watch monitor resolves source defaults uses manual_cli when source and event name empty", TestPrWatchMonitorResolveSourceWithEventDefaultsUsesManualCliWhenSourceAndEventNameEmpty);
         failed += Run("Todo pr-watch monitor resolves PR defaults keeps explicit PR", TestPrWatchMonitorResolvePrSpecWithEventDefaultsKeepsExplicitPr);
+        failed += Run("Todo pr-watch monitor parse failure warns and defaults safely", TestPrWatchMonitorLoadGitHubEventPayloadParseFailureWarnsAndDefaultsSafely);
         failed += Run("Todo pr-watch monitor workflow review triggers include submitted and edited",
             TestPrWatchMonitorWorkflowReviewTriggersIncludeSubmittedAndEdited);
         failed += Run("Todo pr-watch monitor workflow excludes review comment trigger",

--- a/IntelligenceX.Tests/Program.Todo.PrWatch.cs
+++ b/IntelligenceX.Tests/Program.Todo.PrWatch.cs
@@ -288,6 +288,12 @@ internal static partial class Program {
         AssertEqual("workflow_dispatch", source, "explicit source should bypass action suffix auto-append");
     }
 
+    private static void TestPrWatchMonitorResolveSourceWithEventDefaultsNormalizesWhitespaceExplicitSource() {
+        var payload = global::System.Text.Json.Nodes.JsonNode.Parse("{\"action\":\"edited\"}") as global::System.Text.Json.Nodes.JsonObject;
+        var source = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ResolveSourceWithEventDefaults("   ", true, payload, "pull_request");
+        AssertEqual("manual_cli", source, "whitespace explicit source should normalize to manual_cli and bypass action suffix");
+    }
+
     private static void TestPrWatchMonitorResolveSourceWithEventDefaultsUsesEventNameWhenSourceEmpty() {
         var payload = global::System.Text.Json.Nodes.JsonNode.Parse("{\"action\":\"edited\"}") as global::System.Text.Json.Nodes.JsonObject;
         var source = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ResolveSourceWithEventDefaults(string.Empty, false, payload, "pull_request");
@@ -304,6 +310,33 @@ internal static partial class Program {
         var payload = global::System.Text.Json.Nodes.JsonNode.Parse("{\"pull_request\":{\"number\":742}}") as global::System.Text.Json.Nodes.JsonObject;
         var prSpec = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ResolvePrSpecWithEventDefaults("123", payload);
         AssertEqual("123", prSpec, "explicit PR should be preserved even when payload contains pull_request.number");
+    }
+
+    private static void TestPrWatchMonitorLoadGitHubEventPayloadParseFailureWarnsAndDefaultsSafely() {
+        var originalError = Console.Error;
+        using var errorWriter = new StringWriter();
+        var tempPath = Path.GetTempFileName();
+        try {
+            File.WriteAllText(tempPath, "{not-valid-json");
+            Console.SetError(errorWriter);
+
+            var payload = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.LoadGitHubEventPayload(tempPath);
+            var source = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ResolveSourceWithEventDefaults(string.Empty, false, payload, "pull_request");
+            var prSpec = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ResolvePrSpecWithEventDefaults(string.Empty, payload);
+
+            AssertEqual(true, payload is null, "invalid JSON payload should fail closed to null");
+            AssertEqual("pull_request", source, "source should safely default when payload parsing fails");
+            AssertEqual(string.Empty, prSpec, "PR spec should safely default when payload parsing fails");
+
+            var stderr = errorWriter.ToString();
+            AssertContainsText(stderr, "Warning: failed to parse GITHUB_EVENT_PATH payload", "parse warning prefix");
+            AssertContainsText(stderr, "JsonReaderException", "parse warning should include exception type");
+        } finally {
+            Console.SetError(originalError);
+            if (File.Exists(tempPath)) {
+                File.Delete(tempPath);
+            }
+        }
     }
 #endif
 }


### PR DESCRIPTION
## Summary
- follow up on #775 non-blocking review feedback with monitor-defaulting hardening
- extract GitHub event context loading into a dedicated helper so `ApplyGitHubEventDefaults` only coordinates default application
- harden explicit-source handling so whitespace explicit values normalize to `manual_cli` instead of persisting blank metadata
- improve payload parse diagnostics to include exception type for faster CI triage

## Tests
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`

## Added Coverage
- whitespace explicit source with `SourceExplicitlySet=true` normalizes safely
- invalid `GITHUB_EVENT_PATH` payload emits warning with exception type and defaults fail closed for source/PR resolution
