### PR TITLE
Chat: remove AD-only defaults from live suite preflight

### DIFF
--- a/Build/Run-ChatLiveConversationSuite.ps1
+++ b/Build/Run-ChatLiveConversationSuite.ps1
@@ -2,8 +2,8 @@
 
 [CmdletBinding()] param(
     [string] $ScenarioDir = '.\IntelligenceX.Chat\scenarios',
-    [string] $Filter = 'ad-*-10-turn.json',
-    [string[]] $Tags = @('ad', 'strict', 'live'),
+    [string] $Filter = '*-10-turn.json',
+    [string[]] $Tags = @('strict', 'live'),
     [int] $ExpectedTurns = 10,
     [string] $OutDir = '.\artifacts\chat-live',
     [string[]] $AllowRoot,

--- a/Build/Run-ChatQualityPreflight.ps1
+++ b/Build/Run-ChatQualityPreflight.ps1
@@ -5,7 +5,7 @@
 
 [CmdletBinding()] param(
     [string] $ScenarioDir = '.\IntelligenceX.Chat\scenarios',
-    [string] $ScenarioFilter = 'ad-*-10-turn.json',
+    [string] $ScenarioFilter = '*-10-turn.json',
     [string[]] $ScenarioTags,
     [string] $ScenarioOutDir = '.\artifacts\chat-scenarios',
     [switch] $RunTransportRecoveryProfile,
@@ -19,8 +19,8 @@
     [string] $LiveOutDir = '.\artifacts\chat-live',
     [switch] $RunLiveHarnessSuite,
     [string] $LiveSuiteScenarioDir = '.\IntelligenceX.Chat\scenarios',
-    [string] $LiveSuiteFilter = 'ad-*-10-turn.json',
-    [string[]] $LiveSuiteTags = @('ad', 'strict', 'live'),
+    [string] $LiveSuiteFilter = '*-10-turn.json',
+    [string[]] $LiveSuiteTags = @('strict', 'live'),
     [int] $LiveSuiteExpectedTurns = 10,
     [string] $LiveSuiteOutDir = '.\artifacts\chat-live-suite',
     [string[]] $AllowRoot,

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -52,8 +52,8 @@ Live 10-turn harness suite run (tag-driven, no hardcoded single scenario):
 ```powershell
 pwsh .\Build\Run-ChatLiveConversationSuite.ps1 `
   -ScenarioDir .\IntelligenceX.Chat\scenarios `
-  -Filter "ad-*-10-turn.json" `
-  -Tags ad,strict,live `
+  -Filter "*-10-turn.json" `
+  -Tags strict,live `
   -ExpectedTurns 10 `
   -OutDir .\artifacts\chat-live-suite
 ```
@@ -123,14 +123,14 @@ One-command local quality preflight (strict scenario suite + optional live smoke
 
 ```powershell
 pwsh .\Build\Run-ChatQualityPreflight.ps1 `
-  -ScenarioFilter "ad-*-10-turn.json"
+  -ScenarioFilter "*-10-turn.json"
 ```
 
 To include a live 10-turn smoke run in the same preflight:
 
 ```powershell
 pwsh .\Build\Run-ChatQualityPreflight.ps1 `
-  -ScenarioFilter "ad-*-10-turn.json" `
+  -ScenarioFilter "*-10-turn.json" `
   -RunLiveHarness
 ```
 
@@ -138,9 +138,9 @@ To include a tag-driven live harness suite run in the same preflight:
 
 ```powershell
 pwsh .\Build\Run-ChatQualityPreflight.ps1 `
-  -ScenarioFilter "ad-*-10-turn.json" `
+  -ScenarioFilter "*-10-turn.json" `
   -RunLiveHarnessSuite `
-  -LiveSuiteTags ad,strict,live
+  -LiveSuiteTags strict,live
 ```
 
 To run only strict AD continuation scenarios in preflight:
@@ -155,7 +155,7 @@ To include recovery unit tests (tool-pairing/transport retry guards) in prefligh
 
 ```powershell
 pwsh .\Build\Run-ChatQualityPreflight.ps1 `
-  -ScenarioFilter "ad-*-10-turn.json" `
+  -ScenarioFilter "*-10-turn.json" `
   -RunRecoveryUnitTests
 ```
 
@@ -163,7 +163,7 @@ To add a dedicated strict transport-recovery gate run (tags: `ad,strict,transpor
 
 ```powershell
 pwsh .\Build\Run-ChatQualityPreflight.ps1 `
-  -ScenarioFilter "ad-*-10-turn.json" `
+  -ScenarioFilter "*-10-turn.json" `
   -RunTransportRecoveryProfile `
   -RunRecoveryUnitTests
 ```

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -28,6 +28,9 @@ Last validated: 2026-02-24
 - Scenario suite now supports scenario-tag filtering (`-Tags`) and preflight forwards tags via `-ScenarioTags`.
 - Added live-suite runner (`Build/Run-ChatLiveConversationSuite.ps1`) so local live validation can run tag-driven batches without hardcoded single-scenario defaults.
 - Preflight now supports `-RunLiveHarnessSuite` for the same tag-driven live validation path.
+- Updated live-suite/preflight defaults to remove AD-only hardcoding:
+  - default filter now targets all `*-10-turn.json` scenarios
+  - default live-suite tags now target `strict,live` across AD + DNS/domain paths
 - App already supports debug toggles for turn trace and draft bubbles with distinct rendering channels.
 
 ## Scenario Coverage (Current)


### PR DESCRIPTION
## Summary
- remove AD-only default hardcoding from `Run-ChatLiveConversationSuite.ps1`
  - default filter now `*-10-turn.json`
  - default tags now `strict,live`
- align `Run-ChatQualityPreflight.ps1` defaults for strict suite + live-suite mode with the same cross-scenario behavior
- update README examples and roadmap notes to reflect the new defaults

## Why
- keeps the live runner truly tag-driven/no single-domain hardcoding by default
- ensures DNS/domain strict-live scenarios are included in default live-suite validation paths

## Validation
- PowerShell parser validation:
  - `Build/Run-ChatLiveConversationSuite.ps1`
  - `Build/Run-ChatQualityPreflight.ps1`
- `pwsh -NoLogo -NoProfile -File .github/scripts/test-chat-scenario-catalog-quality.ps1`
