### PR TITLE
refactor(pr-babysit): move workflow defaults into CLI engine

### DIFF
--- a/.github/workflows/ix-pr-babysit-assist-retry.yml
+++ b/.github/workflows/ix-pr-babysit-assist-retry.yml
@@ -66,22 +66,19 @@ jobs:
       - name: Run guarded retry assist engine
         env:
           GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll \
-            todo pr-watch-assist-retry \
-            --repo "${{ github.repository }}" \
-            --pr "${{ inputs.pr }}" \
-            --max-flaky-retries "${{ inputs.max_flaky_retries }}" \
-            --retry-cooldown-minutes "${{ inputs.retry_cooldown_minutes }}" \
-            --approved-bots "${{ inputs.approved_bots }}" \
-            --confirm-apply-retries "${{ inputs.confirm_apply_retries }}" \
-            --source "${{ github.event_name }}" \
-            --run-link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --output-path "${PR_WATCH_ASSIST_OUTPUT_PATH}" \
-            --summary-path "${PR_WATCH_ASSIST_SUMMARY_PATH}"
+        run: >
+          dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll
+          todo pr-watch-assist-retry
+          --repo "${{ github.repository }}"
+          --pr "${{ inputs.pr }}"
+          --max-flaky-retries "${{ inputs.max_flaky_retries }}"
+          --retry-cooldown-minutes "${{ inputs.retry_cooldown_minutes }}"
+          --approved-bots "${{ inputs.approved_bots }}"
+          --confirm-apply-retries "${{ inputs.confirm_apply_retries }}"
+          --source "${{ github.event_name }}"
+          --run-link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          --output-path "${PR_WATCH_ASSIST_OUTPUT_PATH}"
+          --summary-path "${PR_WATCH_ASSIST_SUMMARY_PATH}"
 
       - name: Upload pr-watch assist artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/ix-pr-babysit-nightly-consolidation.yml
+++ b/.github/workflows/ix-pr-babysit-nightly-consolidation.yml
@@ -129,45 +129,26 @@ jobs:
       - name: Run nightly PR babysit consolidation engine
         env:
           GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          MAX_PRS="${{ inputs.max_prs }}"
-          STALE_DAYS="${{ inputs.stale_days }}"
-          INCLUDE_DRAFTS="${{ inputs.include_drafts }}"
-          APPROVED_BOTS="${{ inputs.approved_bots }}"
-          SOURCE_TAG="${{ inputs.source }}"
-          PUBLISH_TRACKING_ISSUE="${{ inputs.publish_tracking_issue }}"
-          TRACKER_ISSUE_TITLE="${{ inputs.tracker_issue_title }}"
-          TRACKER_ISSUE_LABELS="${{ inputs.tracker_issue_labels }}"
-
-          if [ -z "${MAX_PRS}" ]; then MAX_PRS="200"; fi
-          if [ -z "${STALE_DAYS}" ]; then STALE_DAYS="7"; fi
-          if [ -z "${INCLUDE_DRAFTS}" ]; then INCLUDE_DRAFTS="false"; fi
-          if [ -z "${APPROVED_BOTS}" ]; then APPROVED_BOTS="intelligencex-review,intelligencex-review[bot],chatgpt-codex-connector[bot]"; fi
-          if [ -z "${SOURCE_TAG}" ]; then SOURCE_TAG="${{ github.event_name }}"; fi
-          if [ -z "${PUBLISH_TRACKING_ISSUE}" ]; then PUBLISH_TRACKING_ISSUE="true"; fi
-
-          dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll \
-            todo pr-watch-consolidate \
-            --repo "${{ github.repository }}" \
-            --max-prs "${MAX_PRS}" \
-            --max-flaky-retries "3" \
-            --stale-days "${STALE_DAYS}" \
-            --include-drafts "${INCLUDE_DRAFTS}" \
-            --approved-bots "${APPROVED_BOTS}" \
-            --source "${SOURCE_TAG}" \
-            --run-link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --snapshot-dir "${PR_WATCH_NIGHTLY_DIR}" \
-            --rollup-path "${PR_WATCH_NIGHTLY_ROLLUP_PATH}" \
-            --summary-path "${PR_WATCH_NIGHTLY_SUMMARY_PATH}" \
-            --metrics-path "${PR_WATCH_NIGHTLY_METRICS_PATH}" \
-            --metrics-history-path "${PR_WATCH_METRICS_HISTORY_PATH}" \
-            --tracker-path "${PR_WATCH_NIGHTLY_TRACKER_PATH}" \
-            --publish-tracking-issue "${PUBLISH_TRACKING_ISSUE}" \
-            --tracker-issue-title "${TRACKER_ISSUE_TITLE}" \
-            --tracker-issue-labels "${TRACKER_ISSUE_LABELS}"
+        run: >
+          dotnet ./IntelligenceX.Cli/bin/Release/net8.0/IntelligenceX.Cli.dll
+          todo pr-watch-consolidate
+          --repo "${{ github.repository }}"
+          --max-prs "${{ inputs.max_prs }}"
+          --max-flaky-retries "3"
+          --stale-days "${{ inputs.stale_days }}"
+          --include-drafts "${{ inputs.include_drafts }}"
+          --approved-bots "${{ inputs.approved_bots }}"
+          --source "${{ inputs.source }}"
+          --run-link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          --snapshot-dir "${PR_WATCH_NIGHTLY_DIR}"
+          --rollup-path "${PR_WATCH_NIGHTLY_ROLLUP_PATH}"
+          --summary-path "${PR_WATCH_NIGHTLY_SUMMARY_PATH}"
+          --metrics-path "${PR_WATCH_NIGHTLY_METRICS_PATH}"
+          --metrics-history-path "${PR_WATCH_METRICS_HISTORY_PATH}"
+          --tracker-path "${PR_WATCH_NIGHTLY_TRACKER_PATH}"
+          --publish-tracking-issue "${{ inputs.publish_tracking_issue }}"
+          --tracker-issue-title "${{ inputs.tracker_issue_title }}"
+          --tracker-issue-labels "${{ inputs.tracker_issue_labels }}"
 
       - name: Upload nightly pr-watch artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/IntelligenceX.Cli/Todo/PrWatchConsolidationRunner.cs
+++ b/IntelligenceX.Cli/Todo/PrWatchConsolidationRunner.cs
@@ -150,6 +150,7 @@ internal static class PrWatchConsolidationRunner {
             }
         }
 
+        options.Source = ResolveSourceWithDefault(options.Source, Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME"));
         return options;
     }
 
@@ -590,7 +591,19 @@ internal static class PrWatchConsolidationRunner {
     }
 
     private static bool IsHelp(string value) => value.Equals("-h", StringComparison.OrdinalIgnoreCase) || value.Equals("--help", StringComparison.OrdinalIgnoreCase) || value.Equals("help", StringComparison.OrdinalIgnoreCase);
-    private static string ResolveDefaultSource() => Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME") ?? DefaultSource;
+    internal static string ResolveSourceWithDefault(string? source, string? eventName) {
+        if (!string.IsNullOrWhiteSpace(source)) {
+            return source.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(eventName)) {
+            return eventName.Trim();
+        }
+
+        return DefaultSource;
+    }
+
+    private static string ResolveDefaultSource() => ResolveSourceWithDefault(null, Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME"));
     private static string? ResolveDefaultRunLink() {
         var server = Environment.GetEnvironmentVariable("GITHUB_SERVER_URL");
         var repo = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -232,6 +232,9 @@ internal static partial class Program {
         failed += Run("Todo pr-watch authenticated login fallback uses actor env", TestPrWatchResolveAuthenticatedLoginFallbackUsesActorEnv);
         failed += Run("Todo pr-watch authenticated login fallback prefers actor over triggering actor", TestPrWatchResolveAuthenticatedLoginFallbackPrefersActorOverTriggeringActor);
         failed += Run("Todo pr-watch authenticated login fallback empty when unset", TestPrWatchResolveAuthenticatedLoginFallbackReturnsEmptyWhenUnset);
+        failed += Run("Todo pr-watch consolidation source default keeps trimmed explicit source", TestPrWatchConsolidationResolveSourceWithDefaultKeepsTrimmedExplicitSource);
+        failed += Run("Todo pr-watch consolidation source default uses event name when source empty", TestPrWatchConsolidationResolveSourceWithDefaultUsesEventNameWhenSourceEmpty);
+        failed += Run("Todo pr-watch consolidation source default uses manual_cli when source and event name empty", TestPrWatchConsolidationResolveSourceWithDefaultUsesManualCliWhenSourceAndEventEmpty);
         failed += Run("Todo pr-watch monitor compose source tag appends action", TestPrWatchMonitorComposeSourceTagAppendsActionWhenPresent);
         failed += Run("Todo pr-watch monitor compose source tag skips empty action", TestPrWatchMonitorComposeSourceTagSkipsEmptyAction);
         failed += Run("Todo pr-watch monitor resolves event action from payload", TestPrWatchMonitorResolveEventActionFromPayload);
@@ -246,6 +249,10 @@ internal static partial class Program {
             TestPrWatchMonitorWorkflowReviewTriggersIncludeSubmittedAndEdited);
         failed += Run("Todo pr-watch monitor workflow excludes review comment trigger",
             TestPrWatchMonitorWorkflowExcludesReviewCommentTrigger);
+        failed += Run("Todo pr-watch nightly workflow uses direct CLI invocation",
+            TestPrWatchNightlyConsolidationWorkflowUsesDirectCliInvocation);
+        failed += Run("Todo pr-watch assist workflow uses direct CLI invocation",
+            TestPrWatchAssistRetryWorkflowUsesDirectCliInvocation);
         failed += Run("Todo pr-watch workflow parser supports scalar types value",
             TestPrWatchWorkflowParserSupportsScalarTypesValue);
         failed += Run("Todo pr-watch workflow parser supports flow sequence types value",

--- a/IntelligenceX.Tests/Program.Todo.PrWatch.WorkflowContracts.cs
+++ b/IntelligenceX.Tests/Program.Todo.PrWatch.WorkflowContracts.cs
@@ -20,6 +20,26 @@ internal static partial class Program {
             "monitor workflow should not define pull_request_review_comment trigger");
     }
 
+    private static void TestPrWatchNightlyConsolidationWorkflowUsesDirectCliInvocation() {
+        var workflowPath = ResolveRepoFilePath(".github", "workflows", "ix-pr-babysit-nightly-consolidation.yml");
+        var content = File.ReadAllText(workflowPath);
+
+        AssertContainsText(content, "todo pr-watch-consolidate", "nightly workflow should invoke consolidation CLI command");
+        AssertEqual(false, content.Contains("set -euo pipefail", StringComparison.Ordinal),
+            "nightly workflow should avoid shell wrapper logic");
+        AssertEqual(false, content.Contains("if [ -z \"${MAX_PRS}\" ]", StringComparison.Ordinal),
+            "nightly workflow should keep defaulting logic in CLI, not YAML shell conditionals");
+    }
+
+    private static void TestPrWatchAssistRetryWorkflowUsesDirectCliInvocation() {
+        var workflowPath = ResolveRepoFilePath(".github", "workflows", "ix-pr-babysit-assist-retry.yml");
+        var content = File.ReadAllText(workflowPath);
+
+        AssertContainsText(content, "todo pr-watch-assist-retry", "assist workflow should invoke assist CLI command");
+        AssertEqual(false, content.Contains("set -euo pipefail", StringComparison.Ordinal),
+            "assist workflow should avoid shell wrapper logic");
+    }
+
     private static void TestPrWatchWorkflowParserSupportsScalarTypesValue() {
         var tempDir = Path.Combine(Path.GetTempPath(), "ix-prwatch-workflow-scalar-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);

--- a/IntelligenceX.Tests/Program.Todo.PrWatch.cs
+++ b/IntelligenceX.Tests/Program.Todo.PrWatch.cs
@@ -260,6 +260,21 @@ internal static partial class Program {
         }
     }
 
+    private static void TestPrWatchConsolidationResolveSourceWithDefaultKeepsTrimmedExplicitSource() {
+        var source = IntelligenceX.Cli.Todo.PrWatchConsolidationRunner.ResolveSourceWithDefault("  workflow_dispatch  ", "schedule");
+        AssertEqual("workflow_dispatch", source, "explicit source should be trimmed and preserved");
+    }
+
+    private static void TestPrWatchConsolidationResolveSourceWithDefaultUsesEventNameWhenSourceEmpty() {
+        var source = IntelligenceX.Cli.Todo.PrWatchConsolidationRunner.ResolveSourceWithDefault(string.Empty, "schedule");
+        AssertEqual("schedule", source, "empty source should use event name fallback");
+    }
+
+    private static void TestPrWatchConsolidationResolveSourceWithDefaultUsesManualCliWhenSourceAndEventEmpty() {
+        var source = IntelligenceX.Cli.Todo.PrWatchConsolidationRunner.ResolveSourceWithDefault(" ", null);
+        AssertEqual("manual_cli", source, "empty source and event name should fall back to manual_cli");
+    }
+
     private static void TestPrWatchMonitorComposeSourceTagAppendsActionWhenPresent() {
         var source = IntelligenceX.Cli.Todo.PrWatchMonitorRunner.ComposeSourceTag("pull_request_review", "submitted");
         AssertEqual("pull_request_review:submitted", source, "source tag should append action");


### PR DESCRIPTION
## Summary
- simplify PR-babysit workflows by removing shell wrapper/defaulting logic and invoking CLI commands directly
- move source fallback normalization into `PrWatchConsolidationRunner` so blank `--source` values resolve via event-name/default inside engine code
- add contract tests to prevent regression back to shell-heavy YAML wrappers for nightly and assist workflows
- add consolidation source-default unit coverage and wire it into harness

## Why
This keeps workflow YAML thin and pushes behavior/default semantics into tested internal code paths, matching the direction of previous PR-babysit refactors.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release --no-build -v minimal`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`

## Notes
A transient timing failure appeared once in `IntelligenceX.Chat.Tests` (`AwaitStartupToolHealthPrimingForHelloAsync_ReturnsAfterWaitBudget`), then passed on rerun within the same validation cycle.
