### PR TITLE
Harden transport retry replay for duplicate tool call IDs

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -1221,58 +1221,92 @@ internal sealed partial class ChatServiceSession {
                     ResolvedModel: resolvedModel);
             }
 
-            toolRounds++;
-            var roundNumber = round + 1;
-            await WriteToolRoundStartedStatusAsync(
-                    writer,
-                    request.RequestId,
-                    threadId,
-                    roundNumber,
-                    maxRounds,
-                    extracted.Count,
-                    parallelTools,
-                    allowMutatingParallel)
-                .ConfigureAwait(false);
-            if (planExecuteReviewLoop) {
-                await TryWriteStatusAsync(
+            var priorOutputsByCallId = BuildLatestToolOutputsByCallId(toolOutputs);
+            var callsToExecute = new List<ToolCall>(extracted.Count);
+            var replayRecoveredOutputs = new List<ToolOutputDto>(extracted.Count);
+            for (var callIndex = 0; callIndex < extracted.Count; callIndex++) {
+                var call = extracted[callIndex];
+                if (TryGetReplayRecoveredOutputForCall(call, priorOutputsByCallId, out var replayRecoveredOutput)) {
+                    replayRecoveredOutputs.Add(replayRecoveredOutput);
+                    continue;
+                }
+
+                callsToExecute.Add(call);
+            }
+
+            var hasFreshCallsToExecute = callsToExecute.Count > 0;
+            var roundNumber = 0;
+            if (hasFreshCallsToExecute) {
+                toolRounds++;
+                roundNumber = toolRounds;
+                await WriteToolRoundStartedStatusAsync(
                         writer,
                         request.RequestId,
                         threadId,
-                        status: ChatStatusCodes.PhaseExecute,
-                        message: $"Executing {extracted.Count} planned tool call(s)...")
+                        roundNumber,
+                        maxRounds,
+                        callsToExecute.Count,
+                        parallelTools,
+                        allowMutatingParallel)
                     .ConfigureAwait(false);
+                if (planExecuteReviewLoop) {
+                    await TryWriteStatusAsync(
+                            writer,
+                            request.RequestId,
+                            threadId,
+                            status: ChatStatusCodes.PhaseExecute,
+                            message: $"Executing {callsToExecute.Count} planned tool call(s)...")
+                        .ConfigureAwait(false);
+                }
+
+                foreach (var call in callsToExecute) {
+                    await TryWriteStatusAsync(
+                            writer,
+                            request.RequestId,
+                            threadId,
+                            status: ChatStatusCodes.ToolCall,
+                            toolName: call.Name,
+                            toolCallId: call.CallId)
+                        .ConfigureAwait(false);
+                    toolCalls.Add(new ToolCallDto {
+                        CallId = call.CallId,
+                        Name = call.Name,
+                        ArgumentsJson = call.Arguments is null ? "{}" : JsonLite.Serialize(call.Arguments)
+                    });
+                }
             }
 
-            foreach (var call in extracted) {
-                await TryWriteStatusAsync(
+            IReadOnlyList<ToolOutputDto> executed;
+            if (hasFreshCallsToExecute) {
+                executed = await ExecuteToolsAsync(
                         writer,
                         request.RequestId,
                         threadId,
-                        status: ChatStatusCodes.ToolCall,
-                        toolName: call.Name,
-                        toolCallId: call.CallId)
+                        callsToExecute,
+                        parallelTools,
+                        allowMutatingParallel,
+                        mutatingToolHints,
+                        toolTimeoutSeconds,
+                        turnToken)
                     .ConfigureAwait(false);
-                toolCalls.Add(new ToolCallDto {
-                    CallId = call.CallId,
-                    Name = call.Name,
-                    ArgumentsJson = call.Arguments is null ? "{}" : JsonLite.Serialize(call.Arguments)
-                });
+            } else {
+                executed = Array.Empty<ToolOutputDto>();
             }
 
-            var executed = await ExecuteToolsAsync(writer, request.RequestId, threadId, extracted, parallelTools, allowMutatingParallel,
-                    mutatingToolHints, toolTimeoutSeconds, turnToken)
-                .ConfigureAwait(false);
-            var failedCallsThisRound = CountFailedToolOutputs(executed);
-            await WriteToolRoundCompletedStatusAsync(
-                    writer,
-                    request.RequestId,
-                    threadId,
-                    roundNumber,
-                    maxRounds,
-                    executed.Count,
-                    failedCallsThisRound)
-                .ConfigureAwait(false);
-            UpdateToolRoutingStats(extracted, executed);
+            if (hasFreshCallsToExecute) {
+                var failedCallsThisRound = CountFailedToolOutputs(executed);
+                await WriteToolRoundCompletedStatusAsync(
+                        writer,
+                        request.RequestId,
+                        threadId,
+                        roundNumber,
+                        maxRounds,
+                        executed.Count,
+                        failedCallsThisRound)
+                    .ConfigureAwait(false);
+            }
+
+            UpdateToolRoutingStats(callsToExecute, executed);
             var executedCallsById = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase);
             foreach (var call in extracted) {
                 var normalizedCallId = (call.CallId ?? string.Empty).Trim();
@@ -1309,7 +1343,8 @@ internal sealed partial class ChatServiceSession {
                 });
             }
 
-            var next = BuildToolRoundReplayInput(extracted, executedCallsById, executed);
+            var replayInputOutputs = MergeToolRoundReplayOutputs(executed, replayRecoveredOutputs);
+            var next = BuildToolRoundReplayInput(extracted, executedCallsById, replayInputOutputs);
             turn = await RunModelPhaseWithProgressAsync(
                     client,
                     writer,
@@ -1398,6 +1433,44 @@ internal sealed partial class ChatServiceSession {
         }
 
         return false;
+    }
+
+    private static Dictionary<string, ToolOutputDto> BuildLatestToolOutputsByCallId(IReadOnlyList<ToolOutputDto> outputs) {
+        var byCallId = new Dictionary<string, ToolOutputDto>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < outputs.Count; i++) {
+            var callId = (outputs[i].CallId ?? string.Empty).Trim();
+            if (callId.Length == 0) {
+                continue;
+            }
+
+            byCallId[callId] = outputs[i];
+        }
+
+        return byCallId;
+    }
+
+    private static bool TryGetReplayRecoveredOutputForCall(ToolCall call, IReadOnlyDictionary<string, ToolOutputDto> outputsByCallId,
+        out ToolOutputDto replayRecoveredOutput) {
+        var callId = (call.CallId ?? string.Empty).Trim();
+        if (callId.Length > 0 && outputsByCallId.TryGetValue(callId, out var priorOutput)) {
+            replayRecoveredOutput = priorOutput with { CallId = callId };
+            return true;
+        }
+
+        replayRecoveredOutput = default!;
+        return false;
+    }
+
+    private static IReadOnlyList<ToolOutputDto> MergeToolRoundReplayOutputs(IReadOnlyList<ToolOutputDto> executed,
+        IReadOnlyList<ToolOutputDto> replayRecoveredOutputs) {
+        if (replayRecoveredOutputs.Count == 0) {
+            return executed;
+        }
+
+        var merged = new List<ToolOutputDto>(executed.Count + replayRecoveredOutputs.Count);
+        merged.AddRange(executed);
+        merged.AddRange(replayRecoveredOutputs);
+        return merged;
     }
 
     private static ChatInput BuildToolRoundReplayInput(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
@@ -417,6 +417,126 @@ public sealed partial class ChatServiceRoutingTrimTests {
         }
     }
 
+    [Fact]
+    public async Task RunChatOnCurrentThreadAsync_ReusesPriorOutput_WhenTransportRetryReplaysCompletedToolCallId() {
+        using var server = new DeterministicCompatibleHttpServer(
+            dropChatCompletionResponseOnRequestIndices: new[] { 2 },
+            emitReplayDuplicateToolCallAfterDrop: true);
+
+        var serviceOptions = new ServiceOptions {
+            OpenAITransport = OpenAITransportKind.CompatibleHttp,
+            OpenAIBaseUrl = server.BaseUrl,
+            OpenAIAllowInsecureHttp = true,
+            OpenAIStreaming = false,
+            Model = "mock-local-model",
+            MaxToolRounds = 4,
+            EnableTestimoXPack = false,
+            EnableOfficeImoPack = false
+        };
+        var session = new ChatServiceSession(serviceOptions, Stream.Null);
+        var registry = new ToolRegistry();
+
+        var invokedSteps = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var invokedStepsSync = new object();
+        registry.Register(new RoundTripStubTool(
+            "mock_round_tool",
+            (arguments, _) => {
+                var step = arguments?.GetString("step") ?? "unknown";
+                lock (invokedStepsSync) {
+                    if (invokedSteps.TryGetValue(step, out var current)) {
+                        invokedSteps[step] = current + 1;
+                    } else {
+                        invokedSteps[step] = 1;
+                    }
+                }
+
+                return Task.FromResult(JsonSerializer.Serialize(new { ok = true, step }));
+            }));
+        RegistryField.SetValue(session, registry);
+
+        var clientOptions = new IntelligenceXClientOptions {
+            TransportKind = OpenAITransportKind.CompatibleHttp,
+            AutoInitialize = false,
+            DefaultModel = "mock-local-model"
+        };
+        clientOptions.CompatibleHttpOptions.BaseUrl = server.BaseUrl;
+        clientOptions.CompatibleHttpOptions.AuthMode = OpenAICompatibleHttpAuthMode.None;
+        clientOptions.CompatibleHttpOptions.Streaming = false;
+        clientOptions.CompatibleHttpOptions.AllowInsecureHttp = true;
+
+        using var client = await IntelligenceXClient.ConnectAsync(clientOptions);
+        var thread = await client.StartNewThreadAsync("mock-local-model");
+
+        var request = new ChatRequest {
+            RequestId = "req-e2e-replay-duplicate-call-id",
+            ThreadId = thread.Id,
+            Text = "Run the diagnostics workflow to completion.",
+            Options = new ChatRequestOptions {
+                WeightedToolRouting = false,
+                MaxToolRounds = 4,
+                ParallelTools = false,
+                PlanExecuteReviewLoop = true,
+                MaxReviewPasses = 0,
+                ModelHeartbeatSeconds = 0
+            }
+        };
+
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+        var runResult = await InvokeRunChatOnCurrentThreadAsync(
+            session,
+            client,
+            writer,
+            request,
+            thread.Id,
+            CancellationToken.None);
+
+        var statuses = ParseStatuses(capture.Snapshot());
+        Assert.Equal(2, statuses.Count(static s => string.Equals(s, "tool_round_started", StringComparison.OrdinalIgnoreCase)));
+        Assert.Equal(2, statuses.Count(static s => string.Equals(s, "tool_round_completed", StringComparison.OrdinalIgnoreCase)));
+        Assert.Equal(2, statuses.Count(static s => string.Equals(s, "tool_call", StringComparison.OrdinalIgnoreCase)));
+
+        Assert.Equal(5, server.ChatCompletionRequestCount);
+        Assert.Equal(1, server.DroppedChatCompletionRequestCount);
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(1), "call_round_1"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(2), "call_round_1"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(3), "call_round_1"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(4), "call_round_2"));
+
+        Assert.Equal(2, GetPropertyValue<int>(runResult, "ToolRounds"));
+        Assert.Equal(2, GetPropertyValue<int>(runResult, "ToolCallsCount"));
+        var resultMessage = GetPropertyValue<ChatResultMessage>(runResult, "Result");
+        Assert.Equal("Final answer after two tool rounds.", resultMessage.Text);
+        Assert.NotNull(resultMessage.Tools);
+        Assert.Equal(2, resultMessage.Tools!.Calls.Count);
+        Assert.Equal(2, resultMessage.Tools.Outputs.Count);
+
+        var normalizedCallIds = resultMessage.Tools.Calls
+            .Select(static call => (call.CallId ?? string.Empty).Trim())
+            .Where(static callId => callId.Length > 0)
+            .ToArray();
+        var normalizedOutputIds = resultMessage.Tools.Outputs
+            .Select(static output => (output.CallId ?? string.Empty).Trim())
+            .Where(static callId => callId.Length > 0)
+            .ToArray();
+
+        Assert.Equal(
+            normalizedCallIds.Length,
+            normalizedCallIds.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.Equal(
+            normalizedOutputIds.Length,
+            normalizedOutputIds.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+
+        var normalizedCallIdSet = new HashSet<string>(normalizedCallIds, StringComparer.OrdinalIgnoreCase);
+        Assert.All(normalizedOutputIds, outputCallId => Assert.Contains(outputCallId, normalizedCallIdSet));
+
+        lock (invokedStepsSync) {
+            Assert.Equal(2, invokedSteps.Values.Sum());
+            Assert.True(invokedSteps.TryGetValue("one", out var oneCount) && oneCount == 1);
+            Assert.True(invokedSteps.TryGetValue("two", out var twoCount) && twoCount == 1);
+        }
+    }
+
     private static async Task<object> InvokeRunChatOnCurrentThreadAsync(ChatServiceSession session, IntelligenceXClient client, StreamWriter writer,
         ChatRequest request, string threadId, CancellationToken cancellationToken) {
         var taskObj = RunChatOnCurrentThreadAsyncMethod.Invoke(session, new object?[] { client, writer, request, threadId, cancellationToken });
@@ -520,11 +640,14 @@ public sealed partial class ChatServiceRoutingTrimTests {
         private readonly object _sync = new();
         private readonly List<string> _chatCompletionRequestBodies = new();
         private readonly HashSet<int> _dropChatCompletionResponseOnRequestIndices;
+        private readonly bool _emitReplayDuplicateToolCallAfterDrop;
         private readonly List<int> _droppedChatCompletionRequests = new();
         private volatile bool _disposed;
         private int _successfulChatCompletionResponses;
 
-        public DeterministicCompatibleHttpServer(IEnumerable<int>? dropChatCompletionResponseOnRequestIndices = null) {
+        public DeterministicCompatibleHttpServer(
+            IEnumerable<int>? dropChatCompletionResponseOnRequestIndices = null,
+            bool emitReplayDuplicateToolCallAfterDrop = false) {
             _listener = new TcpListener(IPAddress.Loopback, 0);
             _listener.Start();
             var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
@@ -532,6 +655,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             _dropChatCompletionResponseOnRequestIndices = dropChatCompletionResponseOnRequestIndices is null
                 ? new HashSet<int>()
                 : new HashSet<int>(dropChatCompletionResponseOnRequestIndices.Where(static index => index > 0));
+            _emitReplayDuplicateToolCallAfterDrop = emitReplayDuplicateToolCallAfterDrop;
             _acceptLoop = Task.Run(AcceptLoopAsync);
         }
 
@@ -705,6 +829,16 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
                 code = 200;
                 status = "OK";
+                if (_emitReplayDuplicateToolCallAfterDrop) {
+                    return responseIndex switch {
+                        1 => BuildToolCallCompletionBody("call_round_1", "one"),
+                        2 => BuildToolCallCompletionBody("call_round_1", "one"),
+                        3 => BuildToolCallCompletionBody("call_round_2", "two"),
+                        4 => BuildTextCompletionBody("Final answer after two tool rounds."),
+                        _ => BuildTextCompletionBody("Unexpected extra chat request.")
+                    };
+                }
+
                 return responseIndex switch {
                     1 => BuildToolCallCompletionBody("call_round_1", "one"),
                     2 => BuildToolCallCompletionBody("call_round_2", "two"),


### PR DESCRIPTION
## Summary
- harden chat transport-recovery behavior when a retry replay includes a previously-completed tool `call_id`
- avoid re-executing duplicate replayed calls by reusing the latest prior output for that `call_id`
- keep tool ledgers clean (no duplicate call entries / no duplicate outputs) while still replaying evidence back to the model
- add deterministic E2E coverage for drop + duplicate-call replay + clean final completion

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~RunChatOnCurrentThreadAsync_"`
