### PR TITLE
Add strict mixed AD+EventLog retry-recovery live scenario

### DIFF
--- a/IntelligenceX.Chat/scenarios/ad-mixed-ad-eventlog-retry-recovery-10-turn.json
+++ b/IntelligenceX.Chat/scenarios/ad-mixed-ad-eventlog-retry-recovery-10-turn.json
@@ -1,0 +1,77 @@
+{
+  "name": "ad-mixed-ad-eventlog-retry-recovery-10-turn",
+  "tags": ["ad", "eventlog", "cross-dc", "transport-recovery", "continuation", "strict", "live"],
+  "defaults": {
+    "assert_clean_completion": true,
+    "assert_tool_call_output_pairing": true,
+    "assert_no_duplicate_tool_call_ids": true,
+    "assert_no_duplicate_tool_output_call_ids": true,
+    "max_no_tool_execution_retries": 0,
+    "max_duplicate_tool_call_signatures": 1
+  },
+  "turns": [
+    {
+      "name": "Discover scope",
+      "user": "Discover AD scope for this run and list reachable DCs.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["ad_*discover*", "ad_*scope*"],
+      "forbid_tool_error_codes": ["invalid_argument", "schema_*"]
+    },
+    {
+      "name": "AD replication baseline",
+      "user": "Run replication baseline first and identify most impacted DCs with strongest AD evidence.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["ad_replication_*", "ad_monitoring_probe_run"]
+    },
+    {
+      "name": "EventLog correlation pass",
+      "user": "Correlate impacted DCs with Directory Service/System event evidence in the same UTC window.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["eventlog_*query*", "eventlog_*events*", "eventlog_*stats*"],
+      "assert_contains": ["UTC"]
+    },
+    {
+      "name": "Continue all remaining DCs",
+      "user": "Continue AD + EventLog correlation for all remaining discovered DCs in this same turn. Do not stop after first failure.",
+      "min_tool_calls": 2,
+      "require_any_tools": ["ad_replication_*", "eventlog_*query*", "ad_monitoring_probe_run"],
+      "assert_no_questions": true
+    },
+    {
+      "name": "Recovery continuation contract",
+      "user": "If this pass was interrupted, continue from already collected evidence and avoid rerunning identical successful host queries.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["ad_replication_*", "eventlog_*query*", "ad_monitoring_probe_run"],
+      "assert_no_questions": true
+    },
+    {
+      "name": "Retry only failed targets once",
+      "user": "Retry only failed or unreachable targets once with narrower scope, then continue with remaining hosts.",
+      "min_tool_calls": 1,
+      "require_any_tools": ["eventlog_*query*", "ad_monitoring_probe_run"],
+      "assert_no_questions": true
+    },
+    {
+      "name": "Cross-DC AD+Event matrix",
+      "user": "Return per-DC matrix with replication state, event evidence present/missing, earliest UTC, latest UTC, confidence.",
+      "assert_contains": ["UTC"],
+      "assert_not_contains": ["Partial response shown above", "turn ended before completion"]
+    },
+    {
+      "name": "Root cause families",
+      "user": "Classify likely root-cause families with confidence and strongest supporting AD/Event evidence."
+    },
+    {
+      "name": "Execute-now checklist",
+      "user": "Provide a prioritized 30-minute execute-now validation checklist with no follow-up questions.",
+      "assert_no_questions": true
+    },
+    {
+      "name": "Final compact summary",
+      "user": "Summarize in 6 bullets with UTC markers, DC coverage count, unresolved blockers, and rerun trigger.",
+      "assert_contains": ["UTC"],
+      "assert_no_questions": true,
+      "assert_not_contains": ["Partial response shown above", "turn ended before completion"]
+    }
+  ]
+}

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -40,6 +40,7 @@ Last validated: 2026-02-24
 - `ad-cross-dc-followthrough-10-turn.json`: AD0-first then continue all DCs in same turn (anti-stuck guard).
 - `ad-identity-correlation-przemyslaw-10-turn.json`: identity-centric AD correlation.
 - `ad-ldap-adws-health-10-turn.json`: LDAP/ADWS service health.
+- `ad-mixed-ad-eventlog-retry-recovery-10-turn.json`: mixed AD + EventLog retry-recovery path with strict no-partials completion.
 - `ad-user-last-logon-przemyslaw-10-turn.json`: cross-DC user last-logon evidence.
 - `dns-public-health-followthrough-10-turn.json`: public DNS + Domain Detective follow-through with no AD/eventlog tool path.
 - `dns-resolver-fallback-recovery-10-turn.json`: resolver divergence/fallback recovery with bounded retries and no AD/eventlog tool path.
@@ -132,6 +133,7 @@ Acceptance:
 Progress:
 - Added scenarios:
   - `ad-ad0-then-all-dcs-followthrough-10-turn.json`
+  - `ad-mixed-ad-eventlog-retry-recovery-10-turn.json`
   - `ad-eventlog-correlation-partial-failures-10-turn.json`
   - `ad-long-continuation-no-partials-10-turn.json`
   - `ad-transport-recovery-no-duplicate-replay-10-turn.json`


### PR DESCRIPTION
## Summary
- add a strict/live 10-turn scenario for mixed AD + EventLog retry-recovery flow
- enforce continuation and no-partial behavior with bounded retries and cross-DC evidence matrix checks
- refresh roadmap scenario inventory to include the new mixed recovery scenario

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~HostScenarioCatalogStrictnessTests|FullyQualifiedName~HostScenarioParsingTests"`
- `pwsh -NoProfile -File .github/scripts/test-chat-scenario-catalog-quality.ps1`
