### PR TITLE
Add deterministic replay-output compaction for chat replays

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -1381,6 +1381,10 @@ internal sealed partial class ChatServiceSession {
         return transport == OpenAITransportKind.CompatibleHttp;
     }
 
+    private const int MaxReplayToolOutputCharsPerCall = 6_000;
+    private const int MaxReplayToolOutputCharsTotal = 16_000;
+    private const string ReplayOutputCompactionMarker = "ix:replay-output-compacted:v1";
+
     private readonly record struct ReplayToolOutputSelection(string Output, bool MatchedRawCallId);
 
     private static string ResolveToolOutputCallId(
@@ -1518,6 +1522,8 @@ internal sealed partial class ChatServiceSession {
             }
         }
 
+        selectedOutputsByCallId = CompactReplayOutputsByBudget(replayedCallIdsInOrder, selectedOutputsByCallId);
+
         for (var replayIndex = 0; replayIndex < replayedCallIdsInOrder.Count; replayIndex++) {
             var replayCallId = replayedCallIdsInOrder[replayIndex];
             if (!replayedCallsById.TryGetValue(replayCallId, out var replayCall)) {
@@ -1534,6 +1540,71 @@ internal sealed partial class ChatServiceSession {
         }
 
         return next;
+    }
+
+    private static Dictionary<string, ReplayToolOutputSelection> CompactReplayOutputsByBudget(
+        IReadOnlyList<string> replayedCallIdsInOrder,
+        IReadOnlyDictionary<string, ReplayToolOutputSelection> selectedOutputsByCallId) {
+        var remainingChars = MaxReplayToolOutputCharsTotal;
+        var compactedByCallId = new Dictionary<string, ReplayToolOutputSelection>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < replayedCallIdsInOrder.Count; i++) {
+            var callId = replayedCallIdsInOrder[i];
+            if (string.IsNullOrWhiteSpace(callId) || !selectedOutputsByCallId.TryGetValue(callId, out var selectedOutput)) {
+                continue;
+            }
+
+            if (remainingChars <= 0) {
+                compactedByCallId[callId] = selectedOutput with { Output = string.Empty };
+                continue;
+            }
+
+            var originalOutput = selectedOutput.Output ?? string.Empty;
+            var maxOutputChars = Math.Min(MaxReplayToolOutputCharsPerCall, remainingChars);
+            var compactedOutput = CompactReplayOutputText(originalOutput, maxOutputChars);
+            compactedByCallId[callId] = selectedOutput with { Output = compactedOutput };
+            remainingChars = Math.Max(0, remainingChars - compactedOutput.Length);
+        }
+
+        return compactedByCallId;
+    }
+
+    private static string CompactReplayOutputText(string output, int maxOutputChars) {
+        var source = output ?? string.Empty;
+        if (maxOutputChars <= 0) {
+            return string.Empty;
+        }
+
+        if (source.Length <= maxOutputChars) {
+            return source;
+        }
+
+        var markerLine = $"[{ReplayOutputCompactionMarker} original_chars={source.Length} kept_chars={maxOutputChars}]";
+        var budgetForContent = maxOutputChars - markerLine.Length - 2;
+        if (budgetForContent < 16) {
+            var headOnlyLength = Math.Max(0, maxOutputChars - markerLine.Length - 1);
+            if (headOnlyLength <= 0) {
+                return markerLine.Length > maxOutputChars ? markerLine[..maxOutputChars] : markerLine;
+            }
+
+            var headOnly = source[..Math.Min(source.Length, headOnlyLength)];
+            return headOnly + "\n" + markerLine;
+        }
+
+        var prefixLength = budgetForContent / 2;
+        var suffixLength = budgetForContent - prefixLength;
+        var prefix = source[..prefixLength];
+        var suffix = source[^suffixLength..];
+        return BuildReplayCompactedOutputEnvelope(prefix + suffix, source.Length, maxOutputChars, prefix, suffix);
+    }
+
+    private static string BuildReplayCompactedOutputEnvelope(string output, int originalLength, int maxOutputChars, string? prefix = null,
+        string? suffix = null) {
+        var markerLine = $"[{ReplayOutputCompactionMarker} original_chars={originalLength} kept_chars={maxOutputChars}]";
+        if (prefix is null || suffix is null) {
+            return output.Length == 0 ? markerLine : output + "\n" + markerLine;
+        }
+
+        return prefix + "\n" + markerLine + "\n" + suffix;
     }
 
     private static ChatInput BuildHostReplayReviewInput(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
@@ -2595,6 +2595,113 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildToolRoundReplayInput_CompactsOversizedOutput_WithReplayCompactionMarker() {
+        var callA = new ToolCall(
+            callId: "call_a",
+            name: "eventlog_live_query",
+            input: "{\"machine_name\":\"AD0\"}",
+            arguments: null,
+            raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        var extracted = new List<ToolCall> { callA };
+        var byId = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase) {
+            ["call_a"] = callA
+        };
+        var oversized = new string('X', 20_000);
+        var outputs = new List<ToolOutputDto> {
+            new() { CallId = "call_a", Output = oversized, Ok = true }
+        };
+
+        var inputObj = BuildToolRoundReplayInputMethod.Invoke(
+            null,
+            new object?[] { extracted, byId, outputs });
+        var input = Assert.IsType<ChatInput>(inputObj);
+        var items = GetChatInputItems(input);
+
+        Assert.Equal(2, items.Count);
+        string? outputPayload = null;
+        for (var i = 0; i < items.Count; i++) {
+            var item = Assert.IsType<JsonObject>(items[i].AsObject());
+            if (!string.Equals(item.GetString("type"), "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            outputPayload = item.GetString("output");
+            break;
+        }
+
+        var compacted = Assert.IsType<string>(outputPayload);
+        Assert.Contains("ix:replay-output-compacted:v1", compacted, StringComparison.OrdinalIgnoreCase);
+        Assert.True(compacted.Length <= 6000);
+        Assert.True(compacted.Length < oversized.Length);
+    }
+
+    [Fact]
+    public void BuildToolRoundReplayInput_EnforcesTotalReplayOutputBudgetAcrossCalls() {
+        static ToolCall BuildCall(string callId, string machineName) {
+            return new ToolCall(
+                callId: callId,
+                name: "eventlog_live_query",
+                input: "{\"machine_name\":\"" + machineName + "\"}",
+                arguments: null,
+                raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        }
+
+        var callA = BuildCall("call_a", "AD0");
+        var callB = BuildCall("call_b", "AD1");
+        var callC = BuildCall("call_c", "AD2");
+        var callD = BuildCall("call_d", "AD3");
+        var extracted = new List<ToolCall> { callA, callB, callC, callD };
+        var byId = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase) {
+            ["call_a"] = callA,
+            ["call_b"] = callB,
+            ["call_c"] = callC,
+            ["call_d"] = callD
+        };
+        var oversized = new string('Y', 20_000);
+        var outputs = new List<ToolOutputDto> {
+            new() { CallId = "call_a", Output = oversized, Ok = true },
+            new() { CallId = "call_b", Output = oversized, Ok = true },
+            new() { CallId = "call_c", Output = oversized, Ok = true },
+            new() { CallId = "call_d", Output = oversized, Ok = true }
+        };
+
+        var inputObj = BuildToolRoundReplayInputMethod.Invoke(
+            null,
+            new object?[] { extracted, byId, outputs });
+        var input = Assert.IsType<ChatInput>(inputObj);
+        var items = GetChatInputItems(input);
+
+        Assert.Equal(8, items.Count);
+        var totalReplayOutputChars = 0;
+        var outputsByCallId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < items.Count; i++) {
+            var item = Assert.IsType<JsonObject>(items[i].AsObject());
+            if (!string.Equals(item.GetString("type"), "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            var callId = item.GetString("call_id");
+            if (string.IsNullOrWhiteSpace(callId)) {
+                continue;
+            }
+
+            var outputPayload = item.GetString("output") ?? string.Empty;
+            outputsByCallId[callId!] = outputPayload;
+            totalReplayOutputChars += outputPayload.Length;
+        }
+
+        Assert.Equal(4, outputsByCallId.Count);
+        Assert.True(outputsByCallId["call_a"].Length <= 6000);
+        Assert.True(outputsByCallId["call_b"].Length <= 6000);
+        Assert.True(outputsByCallId["call_c"].Length <= 6000);
+        Assert.Equal(string.Empty, outputsByCallId["call_d"]);
+        Assert.True(totalReplayOutputChars <= 16_000);
+        Assert.Contains("ix:replay-output-compacted:v1", outputsByCallId["call_a"], StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ix:replay-output-compacted:v1", outputsByCallId["call_b"], StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ix:replay-output-compacted:v1", outputsByCallId["call_c"], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildNativeHostReplayReviewPrompt_IncludesToolIdentityAndEvidence() {
         var call = new ToolCall(
             callId: "host_carryover_next_action_123",

--- a/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
+++ b/InternalDocs/roadmaps/ix-chat-hardening-and-tooling-plan-2026-02-24.md
@@ -223,6 +223,11 @@ Progress:
   - requested vs effective `maxCandidateTools`
   - context-aware budget application flag
   - effective model context length when available
+- Added deterministic replay-output compaction in tool-round replay inputs:
+  - per-call replay output cap (`6,000` chars)
+  - total replay-output cap per replay payload (`16,000` chars)
+  - compaction marker (`ix:replay-output-compacted:v1`) preserved in replayed evidence text
+  - unit coverage for per-call and total-budget compaction behavior
 
 ### WS6: Merge Gates
 Status: in_progress  


### PR DESCRIPTION
## Summary
- add deterministic replay-output compaction for tool-round replay inputs to reduce context pressure on long runs
- enforce replay output budgets:
  - per-call cap: `6000` chars
  - total replay-output cap per replay payload: `16000` chars
- preserve pairing/evidence continuity by keeping replayed `call_id` links and embedding compaction marker `ix:replay-output-compacted:v1`
- add replay helper tests covering per-call compaction marker behavior and total-budget enforcement across multiple calls
- update roadmap progress for WS5 compaction implementation

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildToolRoundReplayInput_"`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~RunChatOnCurrentThreadAsync_"`
