### PR TITLE
Model-aware replay compaction budgets + trace status

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Protocol/ChatContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Protocol/ChatContracts.cs
@@ -180,6 +180,11 @@ public static class ChatStatusCodes {
     public const string ToolRoundCompleted = "tool_round_completed";
 
     /// <summary>
+    /// Indicates replayed tool outputs were compacted to fit context budget.
+    /// </summary>
+    public const string ToolReplayCompacted = "tool_replay_compacted";
+
+    /// <summary>
     /// Indicates max tool rounds were reached.
     /// </summary>
     public const string ToolRoundLimitReached = "tool_round_limit_reached";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -297,6 +297,7 @@ internal sealed partial class ChatServiceSession {
         var isLocalCompatibleLoopback = _options.OpenAITransport == OpenAITransportKind.CompatibleHttp
                                         && IsLoopbackEndpoint(_options.OpenAIBaseUrl);
         var supportsSyntheticHostReplayItems = SupportsSyntheticHostReplayItems(_options.OpenAITransport);
+        var replayOutputCompactionBudget = ResolveReplayOutputCompactionBudgetForTurn(resolvedModel);
 
         var mutatingToolHints = BuildMutatingToolHintsByName(toolDefs);
         for (var round = 0; round < maxRounds; round++) {
@@ -1344,7 +1345,21 @@ internal sealed partial class ChatServiceSession {
             }
 
             var replayInputOutputs = MergeToolRoundReplayOutputs(executed, replayRecoveredOutputs);
-            var next = BuildToolRoundReplayInput(extracted, executedCallsById, replayInputOutputs);
+            var next = BuildToolRoundReplayInputWithBudget(
+                extracted,
+                executedCallsById,
+                replayInputOutputs,
+                replayOutputCompactionBudget,
+                out var replayOutputCompactionStats);
+            if (ShouldEmitReplayOutputCompactionStatus(replayOutputCompactionStats)) {
+                await TryWriteStatusAsync(
+                        writer,
+                        request.RequestId,
+                        threadId,
+                        status: ChatStatusCodes.ToolReplayCompacted,
+                        message: BuildReplayOutputCompactionStatusMessage(replayOutputCompactionBudget, replayOutputCompactionStats))
+                    .ConfigureAwait(false);
+            }
             turn = await RunModelPhaseWithProgressAsync(
                     client,
                     writer,
@@ -1381,11 +1396,81 @@ internal sealed partial class ChatServiceSession {
         return transport == OpenAITransportKind.CompatibleHttp;
     }
 
-    private const int MaxReplayToolOutputCharsPerCall = 6_000;
-    private const int MaxReplayToolOutputCharsTotal = 16_000;
+    private const int DefaultMaxReplayToolOutputCharsPerCall = 6_000;
+    private const int DefaultMaxReplayToolOutputCharsTotal = 16_000;
+    private const int SmallContextMaxReplayToolOutputCharsPerCall = 2_500;
+    private const int SmallContextMaxReplayToolOutputCharsTotal = 7_000;
+    private const int MediumContextMaxReplayToolOutputCharsPerCall = 4_000;
+    private const int MediumContextMaxReplayToolOutputCharsTotal = 11_000;
+    private const int LargeContextMaxReplayToolOutputCharsPerCall = 8_000;
+    private const int LargeContextMaxReplayToolOutputCharsTotal = 22_000;
     private const string ReplayOutputCompactionMarker = "ix:replay-output-compacted:v1";
+    private const string ReplayOutputBudgetStatusMarker = "ix:replay-output-budget:v1";
 
     private readonly record struct ReplayToolOutputSelection(string Output, bool MatchedRawCallId);
+    private readonly record struct ReplayOutputCompactionBudget(
+        int MaxOutputCharsPerCall,
+        int MaxOutputCharsTotal,
+        long? EffectiveContextLength,
+        bool ContextAwareBudgetApplied);
+    private readonly record struct ReplayOutputCompactionStats(
+        int ReplayedCallCount,
+        int OriginalTotalChars,
+        int CompactedTotalChars,
+        int CompactedCallCount);
+
+    private static readonly ReplayOutputCompactionBudget DefaultReplayOutputCompactionBudget = new(
+        MaxOutputCharsPerCall: DefaultMaxReplayToolOutputCharsPerCall,
+        MaxOutputCharsTotal: DefaultMaxReplayToolOutputCharsTotal,
+        EffectiveContextLength: null,
+        ContextAwareBudgetApplied: false);
+
+    private ReplayOutputCompactionBudget ResolveReplayOutputCompactionBudgetForTurn(string? selectedModel) {
+        var effectiveContextLength = ResolveEffectiveModelContextLength(selectedModel);
+        if (!effectiveContextLength.HasValue) {
+            return DefaultReplayOutputCompactionBudget;
+        }
+
+        var (maxOutputCharsPerCall, maxOutputCharsTotal) = ResolveContextAwareReplayOutputCharBudgets(effectiveContextLength.Value);
+        return new ReplayOutputCompactionBudget(
+            MaxOutputCharsPerCall: maxOutputCharsPerCall,
+            MaxOutputCharsTotal: maxOutputCharsTotal,
+            EffectiveContextLength: effectiveContextLength.Value,
+            ContextAwareBudgetApplied: true);
+    }
+
+    private static (int MaxOutputCharsPerCall, int MaxOutputCharsTotal) ResolveContextAwareReplayOutputCharBudgets(
+        long effectiveContextLength) {
+        if (effectiveContextLength <= 0) {
+            return (DefaultMaxReplayToolOutputCharsPerCall, DefaultMaxReplayToolOutputCharsTotal);
+        }
+
+        if (effectiveContextLength <= 8_192) {
+            return (SmallContextMaxReplayToolOutputCharsPerCall, SmallContextMaxReplayToolOutputCharsTotal);
+        }
+
+        if (effectiveContextLength <= 16_384) {
+            return (MediumContextMaxReplayToolOutputCharsPerCall, MediumContextMaxReplayToolOutputCharsTotal);
+        }
+
+        if (effectiveContextLength <= 32_768) {
+            return (DefaultMaxReplayToolOutputCharsPerCall, DefaultMaxReplayToolOutputCharsTotal);
+        }
+
+        return (LargeContextMaxReplayToolOutputCharsPerCall, LargeContextMaxReplayToolOutputCharsTotal);
+    }
+
+    private static bool ShouldEmitReplayOutputCompactionStatus(ReplayOutputCompactionStats stats) {
+        return stats.CompactedCallCount > 0 && stats.CompactedTotalChars < stats.OriginalTotalChars;
+    }
+
+    private static string BuildReplayOutputCompactionStatusMessage(
+        ReplayOutputCompactionBudget budget,
+        ReplayOutputCompactionStats stats) {
+        var contextLength = budget.EffectiveContextLength.HasValue ? budget.EffectiveContextLength.Value.ToString() : "unknown";
+        var contextAware = budget.ContextAwareBudgetApplied ? "true" : "false";
+        return $"[{ReplayOutputBudgetStatusMarker} compacted_calls={stats.CompactedCallCount} replayed_calls={stats.ReplayedCallCount} original_chars={stats.OriginalTotalChars} kept_chars={stats.CompactedTotalChars} per_call_budget={budget.MaxOutputCharsPerCall} total_budget={budget.MaxOutputCharsTotal} context_aware={contextAware} context_length={contextLength}]";
+    }
 
     private static string ResolveToolOutputCallId(
         IReadOnlyList<ToolCall> extractedCalls,
@@ -1481,6 +1566,20 @@ internal sealed partial class ChatServiceSession {
         IReadOnlyList<ToolCall> extractedCalls,
         IReadOnlyDictionary<string, ToolCall> extractedCallsById,
         IReadOnlyList<ToolOutputDto> outputs) {
+        return BuildToolRoundReplayInputWithBudget(
+            extractedCalls,
+            extractedCallsById,
+            outputs,
+            DefaultReplayOutputCompactionBudget,
+            out _);
+    }
+
+    private static ChatInput BuildToolRoundReplayInputWithBudget(
+        IReadOnlyList<ToolCall> extractedCalls,
+        IReadOnlyDictionary<string, ToolCall> extractedCallsById,
+        IReadOnlyList<ToolOutputDto> outputs,
+        ReplayOutputCompactionBudget compactionBudget,
+        out ReplayOutputCompactionStats compactionStats) {
         var next = new ChatInput();
         var replayedCallIdsInOrder = new List<string>();
         var replayedCallsById = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase);
@@ -1522,7 +1621,11 @@ internal sealed partial class ChatServiceSession {
             }
         }
 
-        selectedOutputsByCallId = CompactReplayOutputsByBudget(replayedCallIdsInOrder, selectedOutputsByCallId);
+        selectedOutputsByCallId = CompactReplayOutputsByBudget(
+            replayedCallIdsInOrder,
+            selectedOutputsByCallId,
+            compactionBudget,
+            out compactionStats);
 
         for (var replayIndex = 0; replayIndex < replayedCallIdsInOrder.Count; replayIndex++) {
             var replayCallId = replayedCallIdsInOrder[replayIndex];
@@ -1544,8 +1647,15 @@ internal sealed partial class ChatServiceSession {
 
     private static Dictionary<string, ReplayToolOutputSelection> CompactReplayOutputsByBudget(
         IReadOnlyList<string> replayedCallIdsInOrder,
-        IReadOnlyDictionary<string, ReplayToolOutputSelection> selectedOutputsByCallId) {
-        var remainingChars = MaxReplayToolOutputCharsTotal;
+        IReadOnlyDictionary<string, ReplayToolOutputSelection> selectedOutputsByCallId,
+        ReplayOutputCompactionBudget compactionBudget,
+        out ReplayOutputCompactionStats compactionStats) {
+        var remainingChars = Math.Max(0, compactionBudget.MaxOutputCharsTotal);
+        var maxOutputCharsPerCall = Math.Max(0, compactionBudget.MaxOutputCharsPerCall);
+        var replayedCallCount = 0;
+        var originalTotalChars = 0;
+        var compactedTotalChars = 0;
+        var compactedCallCount = 0;
         var compactedByCallId = new Dictionary<string, ReplayToolOutputSelection>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < replayedCallIdsInOrder.Count; i++) {
             var callId = replayedCallIdsInOrder[i];
@@ -1553,18 +1663,33 @@ internal sealed partial class ChatServiceSession {
                 continue;
             }
 
-            if (remainingChars <= 0) {
-                compactedByCallId[callId] = selectedOutput with { Output = string.Empty };
-                continue;
-            }
+            replayedCallCount++;
 
             var originalOutput = selectedOutput.Output ?? string.Empty;
-            var maxOutputChars = Math.Min(MaxReplayToolOutputCharsPerCall, remainingChars);
-            var compactedOutput = CompactReplayOutputText(originalOutput, maxOutputChars);
+            originalTotalChars += originalOutput.Length;
+
+            string compactedOutput;
+            if (remainingChars <= 0 || maxOutputCharsPerCall <= 0) {
+                compactedOutput = string.Empty;
+            } else {
+                var maxOutputChars = Math.Min(maxOutputCharsPerCall, remainingChars);
+                compactedOutput = CompactReplayOutputText(originalOutput, maxOutputChars);
+            }
+
             compactedByCallId[callId] = selectedOutput with { Output = compactedOutput };
+            compactedTotalChars += compactedOutput.Length;
+            if (compactedOutput.Length < originalOutput.Length) {
+                compactedCallCount++;
+            }
+
             remainingChars = Math.Max(0, remainingChars - compactedOutput.Length);
         }
 
+        compactionStats = new ReplayOutputCompactionStats(
+            ReplayedCallCount: replayedCallCount,
+            OriginalTotalChars: originalTotalChars,
+            CompactedTotalChars: compactedTotalChars,
+            CompactedCallCount: compactedCallCount);
         return compactedByCallId;
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
@@ -140,6 +140,7 @@ internal sealed partial class ChatServiceSession {
                     || string.Equals(status, ChatStatusCodes.ToolCompleted, StringComparison.OrdinalIgnoreCase)
                     || string.Equals(status, ChatStatusCodes.ToolRoundStarted, StringComparison.OrdinalIgnoreCase)
                     || string.Equals(status, ChatStatusCodes.ToolRoundCompleted, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(status, ChatStatusCodes.ToolReplayCompacted, StringComparison.OrdinalIgnoreCase)
                     || string.Equals(status, ChatStatusCodes.PhaseExecute, StringComparison.OrdinalIgnoreCase)
                     || string.Equals(status, ChatStatusCodes.ToolBatchStarted, StringComparison.OrdinalIgnoreCase)
                     || string.Equals(status, ChatStatusCodes.ToolBatchProgress, StringComparison.OrdinalIgnoreCase)

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatContractsProtocolStabilityTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatContractsProtocolStabilityTests.cs
@@ -34,6 +34,7 @@ public sealed class ChatContractsProtocolStabilityTests {
         Assert.Equal("tool_batch_completed", ChatStatusCodes.ToolBatchCompleted);
         Assert.Equal("tool_round_started", ChatStatusCodes.ToolRoundStarted);
         Assert.Equal("tool_round_completed", ChatStatusCodes.ToolRoundCompleted);
+        Assert.Equal("tool_replay_compacted", ChatStatusCodes.ToolReplayCompacted);
         Assert.Equal("tool_round_limit_reached", ChatStatusCodes.ToolRoundLimitReached);
         Assert.Equal("tool_round_cap_applied", ChatStatusCodes.ToolRoundCapApplied);
         Assert.Equal("review_passes_clamped", ChatStatusCodes.ReviewPassesClamped);
@@ -53,7 +54,7 @@ public sealed class ChatContractsProtocolStabilityTests {
             .Select(field => (string)field.GetRawConstantValue()!)
             .ToArray();
 
-        Assert.Equal(31, values.Length);
+        Assert.Equal(32, values.Length);
         Assert.Equal(values.Length, values.Distinct(StringComparer.Ordinal).Count());
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
@@ -2702,6 +2702,104 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ResolveContextAwareReplayOutputCharBudgets_AdjustsByContextWindow() {
+        var smallObj = ResolveContextAwareReplayOutputCharBudgetsMethod.Invoke(null, new object?[] { 8_192L });
+        var mediumObj = ResolveContextAwareReplayOutputCharBudgetsMethod.Invoke(null, new object?[] { 16_384L });
+        var defaultObj = ResolveContextAwareReplayOutputCharBudgetsMethod.Invoke(null, new object?[] { 32_768L });
+        var largeObj = ResolveContextAwareReplayOutputCharBudgetsMethod.Invoke(null, new object?[] { 65_536L });
+        var unknownObj = ResolveContextAwareReplayOutputCharBudgetsMethod.Invoke(null, new object?[] { 0L });
+
+        var small = Assert.IsType<ValueTuple<int, int>>(smallObj);
+        var medium = Assert.IsType<ValueTuple<int, int>>(mediumObj);
+        var @default = Assert.IsType<ValueTuple<int, int>>(defaultObj);
+        var large = Assert.IsType<ValueTuple<int, int>>(largeObj);
+        var unknown = Assert.IsType<ValueTuple<int, int>>(unknownObj);
+
+        Assert.Equal((2_500, 7_000), small);
+        Assert.Equal((4_000, 11_000), medium);
+        Assert.Equal((6_000, 16_000), @default);
+        Assert.Equal((8_000, 22_000), large);
+        Assert.Equal((6_000, 16_000), unknown);
+    }
+
+    [Fact]
+    public void BuildToolRoundReplayInputWithBudget_AppliesProvidedBudgetAndTracksStats() {
+        var callA = new ToolCall(
+            callId: "call_a",
+            name: "eventlog_live_query",
+            input: "{\"machine_name\":\"AD0\"}",
+            arguments: null,
+            raw: new JsonObject().Add("type", "tool_call").Add("name", "eventlog_live_query"));
+        var extracted = new List<ToolCall> { callA };
+        var byId = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase) {
+            ["call_a"] = callA
+        };
+        var oversized = new string('Z', 12_000);
+        var outputs = new List<ToolOutputDto> {
+            new() { CallId = "call_a", Output = oversized, Ok = true }
+        };
+        var smallBudget = CreateReplayOutputCompactionBudget(
+            maxOutputCharsPerCall: 2_500,
+            maxOutputCharsTotal: 7_000,
+            effectiveContextLength: 8_192L,
+            contextAwareBudgetApplied: true);
+
+        var invokeArgs = new object?[] { extracted, byId, outputs, smallBudget, null };
+        var inputObj = BuildToolRoundReplayInputWithBudgetMethod.Invoke(null, invokeArgs);
+        var input = Assert.IsType<ChatInput>(inputObj);
+        var items = GetChatInputItems(input);
+
+        Assert.Equal(2, items.Count);
+        string? outputPayload = null;
+        for (var i = 0; i < items.Count; i++) {
+            var item = Assert.IsType<JsonObject>(items[i].AsObject());
+            if (!string.Equals(item.GetString("type"), "custom_tool_call_output", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            outputPayload = item.GetString("output");
+            break;
+        }
+
+        var compacted = Assert.IsType<string>(outputPayload);
+        Assert.Contains("ix:replay-output-compacted:v1", compacted, StringComparison.OrdinalIgnoreCase);
+        Assert.True(compacted.Length <= 2_500);
+        Assert.True(compacted.Length < oversized.Length);
+
+        Assert.NotNull(invokeArgs[4]);
+        var statsObj = invokeArgs[4]!;
+        Assert.Equal(1, ReadIntRecordProperty(statsObj, "ReplayedCallCount"));
+        Assert.Equal(12_000, ReadIntRecordProperty(statsObj, "OriginalTotalChars"));
+        Assert.Equal(compacted.Length, ReadIntRecordProperty(statsObj, "CompactedTotalChars"));
+        Assert.Equal(1, ReadIntRecordProperty(statsObj, "CompactedCallCount"));
+    }
+
+    [Fact]
+    public void BuildReplayOutputCompactionStatusMessage_EmitsMarkerAndBudgetDetails() {
+        var budget = CreateReplayOutputCompactionBudget(
+            maxOutputCharsPerCall: 2_500,
+            maxOutputCharsTotal: 7_000,
+            effectiveContextLength: 8_192L,
+            contextAwareBudgetApplied: true);
+        var stats = CreateReplayOutputCompactionStats(
+            replayedCallCount: 2,
+            originalTotalChars: 24_000,
+            compactedTotalChars: 5_000,
+            compactedCallCount: 1);
+
+        var messageObj = BuildReplayOutputCompactionStatusMessageMethod.Invoke(null, new[] { budget, stats });
+        var message = Assert.IsType<string>(messageObj);
+
+        Assert.Contains("ix:replay-output-budget:v1", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("compacted_calls=1", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("replayed_calls=2", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("per_call_budget=2500", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("total_budget=7000", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("context_aware=true", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("context_length=8192", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildNativeHostReplayReviewPrompt_IncludesToolIdentityAndEvidence() {
         var call = new ToolCall(
             callId: "host_carryover_next_action_123",
@@ -2748,6 +2846,43 @@ public sealed partial class ChatServiceRoutingTrimTests {
         var result = ShouldSkipWeightedRoutingMethod.Invoke(null, new object?[] { "Show failed logons across all domain controllers for the last 24 hours with source IP breakdown." });
 
         Assert.False(Assert.IsType<bool>(result));
+    }
+
+    private static object CreateReplayOutputCompactionBudget(
+        int maxOutputCharsPerCall,
+        int maxOutputCharsTotal,
+        long? effectiveContextLength,
+        bool contextAwareBudgetApplied) {
+        var budgetType = BuildToolRoundReplayInputWithBudgetMethod.GetParameters()[3].ParameterType;
+        var value = Activator.CreateInstance(
+            budgetType,
+            maxOutputCharsPerCall,
+            maxOutputCharsTotal,
+            effectiveContextLength,
+            contextAwareBudgetApplied);
+        return value ?? throw new InvalidOperationException("ReplayOutputCompactionBudget instance could not be created.");
+    }
+
+    private static object CreateReplayOutputCompactionStats(
+        int replayedCallCount,
+        int originalTotalChars,
+        int compactedTotalChars,
+        int compactedCallCount) {
+        var statsType = BuildReplayOutputCompactionStatusMessageMethod.GetParameters()[1].ParameterType;
+        var value = Activator.CreateInstance(
+            statsType,
+            replayedCallCount,
+            originalTotalChars,
+            compactedTotalChars,
+            compactedCallCount);
+        return value ?? throw new InvalidOperationException("ReplayOutputCompactionStats instance could not be created.");
+    }
+
+    private static int ReadIntRecordProperty(object value, string propertyName) {
+        var property = value.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)
+                       ?? throw new InvalidOperationException($"Property '{propertyName}' not found.");
+        var raw = property.GetValue(value);
+        return Assert.IsType<int>(raw);
     }
 
     private static JsonArray GetChatInputItems(ChatInput input) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
@@ -92,6 +92,15 @@ public sealed partial class ChatServiceRoutingTrimTests {
     private static readonly MethodInfo BuildToolRoundReplayInputMethod =
         typeof(ChatServiceSession).GetMethod("BuildToolRoundReplayInput", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("BuildToolRoundReplayInput not found.");
+    private static readonly MethodInfo BuildToolRoundReplayInputWithBudgetMethod =
+        typeof(ChatServiceSession).GetMethod("BuildToolRoundReplayInputWithBudget", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildToolRoundReplayInputWithBudget not found.");
+    private static readonly MethodInfo ResolveContextAwareReplayOutputCharBudgetsMethod =
+        typeof(ChatServiceSession).GetMethod("ResolveContextAwareReplayOutputCharBudgets", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("ResolveContextAwareReplayOutputCharBudgets not found.");
+    private static readonly MethodInfo BuildReplayOutputCompactionStatusMessageMethod =
+        typeof(ChatServiceSession).GetMethod("BuildReplayOutputCompactionStatusMessage", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildReplayOutputCompactionStatusMessage not found.");
     private static readonly MethodInfo BuildNativeHostReplayReviewPromptMethod =
         typeof(ChatServiceSession).GetMethod("BuildNativeHostReplayReviewPrompt", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("BuildNativeHostReplayReviewPrompt not found.");


### PR DESCRIPTION
## Summary
- add model-aware replay output compaction budgets for tool-round replay inputs using discovered model context length
- keep existing replay compaction defaults when context length is unknown, but tighten small-context budgets and loosen large-context budgets
- emit `tool_replay_compacted` status with structured budget/size diagnostics when replay compaction is applied
- preserve existing `BuildToolRoundReplayInput(...)` test seam and add a budget-aware internal path used by runtime
- extend routing/contract tests for context-aware budget thresholds, budget-aware replay compaction stats, and new status token stability

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildToolRoundReplayInput|FullyQualifiedName~ResolveContextAwareReplayOutputCharBudgets|FullyQualifiedName~BuildReplayOutputCompactionStatusMessage|FullyQualifiedName~ChatStatusCodes_"`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~RunChatOnCurrentThreadAsync_"`