### PR TITLE
Chat: enforce distinct host coverage in AD continuation scenarios

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Scenario.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Scenario.cs
@@ -148,7 +148,8 @@ internal static partial class Program {
         var requiresToolExecution = minToolCalls > 0
                                     || minToolRounds > 0
                                     || turn.RequireTools.Count > 0
-                                    || turn.RequireAnyTools.Count > 0;
+                                    || turn.RequireAnyTools.Count > 0
+                                    || turn.MinDistinctToolInputValues.Count > 0;
         var requiresTimestampShape = turn.AssertContains.Any(static value => value.Contains("UTC", StringComparison.OrdinalIgnoreCase))
                                      || turn.AssertMatchesRegex.Any(static value => value.Contains(@"\d{4}-\d{2}-\d{2}", StringComparison.Ordinal));
         var requiresEventLogTool = TurnRequiresToolPrefix(turn, "eventlog_");
@@ -178,6 +179,14 @@ internal static partial class Program {
 
         if (turn.ForbidTools.Count > 0) {
             sb.AppendLine("- Forbidden tool calls: " + string.Join(", ", turn.ForbidTools) + ".");
+        }
+
+        if (turn.MinDistinctToolInputValues.Count > 0) {
+            var requirements = turn.MinDistinctToolInputValues
+                .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(static pair => pair.Key + ">=" + Math.Max(0, pair.Value))
+                .ToArray();
+            sb.AppendLine("- Distinct tool input value requirements: " + string.Join(", ", requirements) + ".");
         }
 
         sb.AppendLine("- Do not ask for permission/confirmation before the first required tool call.");
@@ -246,6 +255,7 @@ internal static partial class Program {
         int? minToolRounds,
         IReadOnlyList<string> requireTools,
         IReadOnlyList<string> requireAnyTools,
+        IReadOnlyDictionary<string, int> minDistinctToolInputValues,
         IReadOnlyList<string> assertToolOutputContains,
         IReadOnlyList<string> assertToolOutputNotContains,
         bool assertNoToolErrors,
@@ -254,6 +264,7 @@ internal static partial class Program {
                || Math.Max(0, minToolRounds ?? 0) > 0
                || requireTools.Count > 0
                || requireAnyTools.Count > 0
+               || minDistinctToolInputValues.Count > 0
                || assertToolOutputContains.Count > 0
                || assertToolOutputNotContains.Count > 0
                || assertNoToolErrors
@@ -357,6 +368,7 @@ internal static partial class Program {
                     requireTools: Array.Empty<string>(),
                     requireAnyTools: Array.Empty<string>(),
                     forbidTools: Array.Empty<string>(),
+                    minDistinctToolInputValues: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
                     assertToolOutputContains: Array.Empty<string>(),
                     assertToolOutputNotContains: Array.Empty<string>(),
                     assertNoToolErrors: false,
@@ -386,6 +398,7 @@ internal static partial class Program {
             var requireTools = ReadScenarioStringList(element, "require_tools");
             var requireAnyTools = ReadScenarioStringList(element, "require_any_tools");
             var forbidTools = ReadScenarioStringList(element, "forbid_tools");
+            var minDistinctToolInputValues = ReadScenarioMinDistinctToolInputValues(element, "min_distinct_tool_input_values");
             var assertToolOutputContains = ReadScenarioStringList(element, "assert_tool_output_contains");
             var assertToolOutputNotContains = ReadScenarioStringList(element, "assert_tool_output_not_contains");
             var assertNoToolErrors = ReadScenarioOptionalBoolean(element, "assert_no_tool_errors", defaultValue: false);
@@ -395,6 +408,7 @@ internal static partial class Program {
                 minToolRounds,
                 requireTools,
                 requireAnyTools,
+                minDistinctToolInputValues,
                 assertToolOutputContains,
                 assertToolOutputNotContains,
                 assertNoToolErrors,
@@ -431,6 +445,7 @@ internal static partial class Program {
                 requireTools,
                 requireAnyTools,
                 forbidTools,
+                minDistinctToolInputValues,
                 assertToolOutputContains,
                 assertToolOutputNotContains,
                 assertNoToolErrors,
@@ -475,6 +490,7 @@ internal static partial class Program {
                 requireTools: Array.Empty<string>(),
                 requireAnyTools: Array.Empty<string>(),
                 forbidTools: Array.Empty<string>(),
+                minDistinctToolInputValues: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
                 assertToolOutputContains: Array.Empty<string>(),
                 assertToolOutputNotContains: Array.Empty<string>(),
                 assertNoToolErrors: false,
@@ -496,6 +512,7 @@ internal static partial class Program {
         IReadOnlyList<string> requireTools,
         IReadOnlyList<string> requireAnyTools,
         IReadOnlyList<string> forbidTools,
+        IReadOnlyDictionary<string, int> minDistinctToolInputValues,
         IReadOnlyList<string> assertToolOutputContains,
         IReadOnlyList<string> assertToolOutputNotContains,
         bool assertNoToolErrors,
@@ -506,6 +523,7 @@ internal static partial class Program {
             minToolRounds,
             requireTools,
             requireAnyTools,
+            minDistinctToolInputValues,
             assertToolOutputContains,
             assertToolOutputNotContains,
             assertNoToolErrors,
@@ -523,6 +541,7 @@ internal static partial class Program {
             requireTools,
             requireAnyTools,
             forbidTools,
+            minDistinctToolInputValues,
             assertToolOutputContains,
             assertToolOutputNotContains,
             assertNoToolErrors,
@@ -582,6 +601,46 @@ internal static partial class Program {
             }
         }
         return assertions;
+    }
+
+    private static IReadOnlyDictionary<string, int> ReadScenarioMinDistinctToolInputValues(JsonElement element, string propertyName) {
+        if (!element.TryGetProperty(propertyName, out var valueElement)) {
+            return new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (valueElement.ValueKind == JsonValueKind.Null || valueElement.ValueKind == JsonValueKind.Undefined) {
+            return new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (valueElement.ValueKind != JsonValueKind.Object) {
+            throw new InvalidOperationException($"'{propertyName}' must be an object mapping input keys to integers >= 0.");
+        }
+
+        var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var property in valueElement.EnumerateObject()) {
+            var key = (property.Name ?? string.Empty).Trim();
+            if (key.Length == 0) {
+                continue;
+            }
+
+            int parsed;
+            if (property.Value.ValueKind == JsonValueKind.Number && property.Value.TryGetInt32(out var numberValue)) {
+                parsed = numberValue;
+            } else if (property.Value.ValueKind == JsonValueKind.String
+                       && int.TryParse(property.Value.GetString(), out var stringValue)) {
+                parsed = stringValue;
+            } else {
+                throw new InvalidOperationException($"'{propertyName}.{key}' must be an integer >= 0.");
+            }
+
+            if (parsed < 0) {
+                throw new InvalidOperationException($"'{propertyName}.{key}' must be >= 0.");
+            }
+
+            result[key] = parsed;
+        }
+
+        return result;
     }
 
     private static int? ReadScenarioOptionalNonNegativeInt(JsonElement element, string propertyName) {
@@ -697,6 +756,25 @@ internal static partial class Program {
         var toolRounds = turnResult?.Metrics.ToolRounds ?? 0;
         if (turn.MinToolRounds.HasValue && toolRounds < turn.MinToolRounds.Value) {
             failures.Add($"Expected at least {turn.MinToolRounds.Value} tool round(s); observed {toolRounds}.");
+        }
+
+        if (turn.MinDistinctToolInputValues.Count > 0) {
+            foreach (var requirement in turn.MinDistinctToolInputValues) {
+                var inputKey = requirement.Key;
+                var minDistinct = Math.Max(0, requirement.Value);
+                if (minDistinct == 0) {
+                    continue;
+                }
+
+                var observedValues = CollectDistinctToolInputValuesByKey(toolCalls, inputKey);
+                if (observedValues.Count >= minDistinct) {
+                    continue;
+                }
+
+                failures.Add(
+                    $"Expected at least {minDistinct} distinct '{inputKey}' tool input value(s); observed {observedValues.Count}."
+                    + " Values: " + FormatValuesForAssertion(observedValues.OrderBy(static value => value, StringComparer.OrdinalIgnoreCase).ToArray()) + ".");
+            }
         }
 
         if (turn.MaxNoToolExecutionRetries.HasValue && noToolExecutionRetries > turn.MaxNoToolExecutionRetries.Value) {
@@ -897,6 +975,72 @@ internal static partial class Program {
         }
 
         return counts;
+    }
+
+    private static HashSet<string> CollectDistinctToolInputValuesByKey(IReadOnlyList<ToolCall> toolCalls, string inputKey) {
+        var values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (toolCalls.Count == 0 || string.IsNullOrWhiteSpace(inputKey)) {
+            return values;
+        }
+
+        var normalizedKey = inputKey.Trim();
+        for (var i = 0; i < toolCalls.Count; i++) {
+            var args = toolCalls[i].Arguments;
+            if (args is null) {
+                continue;
+            }
+
+            if (!TryReadToolInputValueByKey(args, normalizedKey, out var value) || string.IsNullOrWhiteSpace(value)) {
+                continue;
+            }
+
+            values.Add(value.Trim());
+        }
+
+        return values;
+    }
+
+    private static bool TryReadToolInputValueByKey(IxJsonObject arguments, string inputKey, out string value) {
+        value = string.Empty;
+        if (arguments is null || string.IsNullOrWhiteSpace(inputKey)) {
+            return false;
+        }
+
+        var normalizedKey = inputKey.Trim();
+        if (arguments.TryGetValue(normalizedKey, out var exactValue) && TryNormalizeToolInputValue(exactValue, out value)) {
+            return true;
+        }
+
+        foreach (var pair in arguments) {
+            if (!string.Equals(pair.Key, normalizedKey, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            if (TryNormalizeToolInputValue(pair.Value, out value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryNormalizeToolInputValue(IxJsonValue? value, out string normalized) {
+        normalized = string.Empty;
+        if (value is null) {
+            return false;
+        }
+
+        switch (value.Kind) {
+            case IxJsonValueKind.String:
+                normalized = (value.AsString() ?? string.Empty).Trim();
+                return normalized.Length > 0;
+            case IxJsonValueKind.Number:
+            case IxJsonValueKind.Boolean:
+                normalized = value.ToString().Trim();
+                return normalized.Length > 0;
+            default:
+                return false;
+        }
     }
 
     private static string BuildToolCallSignature(ToolCall call) {
@@ -1363,6 +1507,7 @@ internal static partial class Program {
             IReadOnlyList<string> requireTools,
             IReadOnlyList<string> requireAnyTools,
             IReadOnlyList<string> forbidTools,
+            IReadOnlyDictionary<string, int> minDistinctToolInputValues,
             IReadOnlyList<string> assertToolOutputContains,
             IReadOnlyList<string> assertToolOutputNotContains,
             bool assertNoToolErrors,
@@ -1384,6 +1529,7 @@ internal static partial class Program {
             RequireTools = requireTools ?? Array.Empty<string>();
             RequireAnyTools = requireAnyTools ?? Array.Empty<string>();
             ForbidTools = forbidTools ?? Array.Empty<string>();
+            MinDistinctToolInputValues = minDistinctToolInputValues ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             AssertToolOutputContains = assertToolOutputContains ?? Array.Empty<string>();
             AssertToolOutputNotContains = assertToolOutputNotContains ?? Array.Empty<string>();
             AssertNoToolErrors = assertNoToolErrors;
@@ -1407,6 +1553,7 @@ internal static partial class Program {
         public IReadOnlyList<string> RequireTools { get; }
         public IReadOnlyList<string> RequireAnyTools { get; }
         public IReadOnlyList<string> ForbidTools { get; }
+        public IReadOnlyDictionary<string, int> MinDistinctToolInputValues { get; }
         public IReadOnlyList<string> AssertToolOutputContains { get; }
         public IReadOnlyList<string> AssertToolOutputNotContains { get; }
         public bool AssertNoToolErrors { get; }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioAssertionTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioAssertionTests.cs
@@ -120,6 +120,84 @@ public sealed class HostScenarioAssertionTests {
         Assert.DoesNotContain(failures, value => value.Contains("orphan output", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void EvaluateScenarioAssertions_FailsWhenDistinctToolInputCoverageIsInsufficient() {
+        const string json = """
+{
+  "name": "distinct-inputs",
+  "turns": [
+    {
+      "name": "Turn 1",
+      "user": "Continue on all remaining DCs.",
+      "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
+      "require_any_tools": ["eventlog_*query*"]
+    }
+  ]
+}
+""";
+        var turn = ParseSingleTurn(json);
+
+        var calls = new List<ToolCall> {
+            BuildToolCall("call_1", "eventlog_live_query", "{\"machine_name\":\"AD0\",\"window\":\"last_24_hours_utc\"}"),
+            BuildToolCall("call_2", "eventlog_live_query", "{\"machine_name\":\"AD0\",\"window\":\"last_8_hours_utc\"}")
+        };
+        var outputs = new List<ToolOutput> {
+            new("call_1", "{\"ok\":true}"),
+            new("call_2", "{\"ok\":true}")
+        };
+
+        var metricsResult = BuildMetricsResult(
+            assistantText: "Completed.",
+            toolCalls: calls,
+            toolOutputs: outputs,
+            toolRounds: 1,
+            noToolExecutionRetries: 0);
+
+        var failures = InvokeEvaluateScenarioAssertions(turn, metricsResult);
+
+        Assert.Contains(failures, value => value.Contains("distinct 'machine_name' tool input value", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void EvaluateScenarioAssertions_PassesWhenDistinctToolInputCoverageIsSatisfied() {
+        const string json = """
+{
+  "name": "distinct-inputs",
+  "turns": [
+    {
+      "name": "Turn 1",
+      "user": "Continue on all remaining DCs.",
+      "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
+      "require_any_tools": ["eventlog_*query*"]
+    }
+  ]
+}
+""";
+        var turn = ParseSingleTurn(json);
+
+        var calls = new List<ToolCall> {
+            BuildToolCall("call_1", "eventlog_live_query", "{\"machine_name\":\"AD1\"}"),
+            BuildToolCall("call_2", "eventlog_live_query", "{\"machine_name\":\"AD2\"}")
+        };
+        var outputs = new List<ToolOutput> {
+            new("call_1", "{\"ok\":true}"),
+            new("call_2", "{\"ok\":true}")
+        };
+
+        var metricsResult = BuildMetricsResult(
+            assistantText: "Completed.",
+            toolCalls: calls,
+            toolOutputs: outputs,
+            toolRounds: 1,
+            noToolExecutionRetries: 0);
+
+        var failures = InvokeEvaluateScenarioAssertions(turn, metricsResult);
+
+        Assert.DoesNotContain(failures, value => value.Contains("distinct 'machine_name' tool input value", StringComparison.OrdinalIgnoreCase));
+    }
+
     private static object ParseSingleTurn(string json) {
         var programType = ResolveHostProgramType();
         var parseMethod = programType.GetMethod("ParseChatScenarioDefinition", BindingFlags.NonPublic | BindingFlags.Static);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioCatalogStrictnessTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioCatalogStrictnessTests.cs
@@ -84,6 +84,39 @@ public sealed class HostScenarioCatalogStrictnessTests {
         }
     }
 
+    [Fact]
+    public void AdContinuationTurns_EnforceDistinctMachineCoverage() {
+        var scenarioDir = ResolveScenarioDirectory();
+        var scenarioFiles = Directory.GetFiles(scenarioDir, "ad-*-10-turn.json", SearchOption.TopDirectoryOnly)
+            .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Assert.NotEmpty(scenarioFiles);
+
+        var matchedContinuationTurns = 0;
+        foreach (var file in scenarioFiles) {
+            using var document = JsonDocument.Parse(File.ReadAllText(file));
+            var root = document.RootElement;
+            var turns = RequireProperty(root, "turns");
+            Assert.Equal(JsonValueKind.Array, turns.ValueKind);
+
+            foreach (var turn in turns.EnumerateArray()) {
+                if (turn.ValueKind != JsonValueKind.Object || !IsCrossDcContinuationTurn(turn)) {
+                    continue;
+                }
+
+                matchedContinuationTurns++;
+                Assert.True(ReadRequiredInt32(turn, "min_tool_calls") >= 2);
+
+                var minimumDistinctInputValues = ReadNonNegativeIntMap(turn, "min_distinct_tool_input_values");
+                Assert.True(minimumDistinctInputValues.TryGetValue("machine_name", out var minMachineNameValues));
+                Assert.True(minMachineNameValues >= 2);
+            }
+        }
+
+        Assert.True(matchedContinuationTurns >= 5);
+    }
+
     private static string ResolveScenarioDirectory() {
         var current = Path.GetFullPath(AppContext.BaseDirectory);
         while (!string.IsNullOrWhiteSpace(current)) {
@@ -141,6 +174,67 @@ public sealed class HostScenarioCatalogStrictnessTests {
         }
 
         return result;
+    }
+
+    private static IReadOnlyDictionary<string, int> ReadNonNegativeIntMap(JsonElement root, string propertyName) {
+        if (!root.TryGetProperty(propertyName, out var values) || values.ValueKind == JsonValueKind.Null) {
+            return new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (values.ValueKind != JsonValueKind.Object) {
+            throw new InvalidDataException($"Property '{propertyName}' must be an object.");
+        }
+
+        var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var property in values.EnumerateObject()) {
+            var key = (property.Name ?? string.Empty).Trim();
+            if (key.Length == 0) {
+                continue;
+            }
+
+            var value = property.Value;
+            if (value.ValueKind != JsonValueKind.Number || !value.TryGetInt32(out var parsed)) {
+                throw new InvalidDataException($"Property '{propertyName}.{key}' must be an integer.");
+            }
+
+            if (parsed < 0) {
+                throw new InvalidDataException($"Property '{propertyName}.{key}' must be >= 0.");
+            }
+
+            result[key] = parsed;
+        }
+
+        return result;
+    }
+
+    private static bool IsCrossDcContinuationTurn(JsonElement turn) {
+        if (!turn.TryGetProperty("min_tool_calls", out var minToolCallsElement)
+            || minToolCallsElement.ValueKind != JsonValueKind.Number
+            || !minToolCallsElement.TryGetInt32(out var minToolCalls)
+            || minToolCalls < 2) {
+            return false;
+        }
+
+        var name = turn.TryGetProperty("name", out var nameElement) && nameElement.ValueKind == JsonValueKind.String
+            ? (nameElement.GetString() ?? string.Empty)
+            : string.Empty;
+        var user = turn.TryGetProperty("user", out var userElement) && userElement.ValueKind == JsonValueKind.String
+            ? (userElement.GetString() ?? string.Empty)
+            : string.Empty;
+
+        if (name.Length == 0 && user.Length == 0) {
+            return false;
+        }
+
+        var combined = (name + " " + user).ToLowerInvariant();
+        var continuationSignal = combined.Contains("continue", StringComparison.Ordinal)
+                                 || combined.Contains("continuation", StringComparison.Ordinal);
+        var dcScopeSignal = combined.Contains("remaining dc", StringComparison.Ordinal)
+                            || combined.Contains("other discovered dc", StringComparison.Ordinal)
+                            || combined.Contains("remaining discovered dc", StringComparison.Ordinal)
+                            || combined.Contains("all other dc", StringComparison.Ordinal)
+                            || combined.Contains("all remaining dc", StringComparison.Ordinal);
+        return continuationSignal && dcScopeSignal;
     }
 
     private static JsonElement RequireProperty(JsonElement root, string name) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioParsingTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioParsingTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Xunit;
@@ -28,6 +29,7 @@ public sealed class HostScenarioParsingTests {
       "require_tools": ["eventlog_live_query"],
       "require_any_tools": ["eventlog_live_query", "eventlog_live_stats"],
       "forbid_tools": ["eventlog_evtx_query"],
+      "min_distinct_tool_input_values": { "machine_name": 2 },
       "assert_tool_output_contains": ["6008", "Kernel-Power"],
       "assert_tool_output_not_contains": ["schema_validation_failed"],
       "assert_no_tool_errors": true,
@@ -59,6 +61,9 @@ public sealed class HostScenarioParsingTests {
         Assert.Single(ReadStringListProperty(turns[0], "RequireTools"));
         Assert.Equal(2, ReadStringListProperty(turns[0], "RequireAnyTools").Count);
         Assert.Single(ReadStringListProperty(turns[0], "ForbidTools"));
+        var minDistinctInputValues = ReadIntDictionaryProperty(turns[0], "MinDistinctToolInputValues");
+        Assert.True(minDistinctInputValues.TryGetValue("machine_name", out var minMachineNameValues));
+        Assert.Equal(2, minMachineNameValues);
         Assert.Equal(2, ReadStringListProperty(turns[0], "AssertToolOutputContains").Count);
         Assert.Single(ReadStringListProperty(turns[0], "AssertToolOutputNotContains"));
         Assert.True(ReadBooleanProperty(turns[0], "AssertNoToolErrors"));
@@ -79,6 +84,7 @@ public sealed class HostScenarioParsingTests {
         Assert.Empty(ReadStringListProperty(turns[1], "RequireTools"));
         Assert.Empty(ReadStringListProperty(turns[1], "RequireAnyTools"));
         Assert.Empty(ReadStringListProperty(turns[1], "ForbidTools"));
+        Assert.Empty(ReadIntDictionaryProperty(turns[1], "MinDistinctToolInputValues"));
         Assert.Empty(ReadStringListProperty(turns[1], "AssertToolOutputContains"));
         Assert.Empty(ReadStringListProperty(turns[1], "AssertToolOutputNotContains"));
         Assert.False(ReadBooleanProperty(turns[1], "AssertNoToolErrors"));
@@ -318,5 +324,29 @@ Check AD0 reboot
         Assert.NotNull(property);
         var value = property!.GetValue(instance);
         return value is bool b && b;
+    }
+
+    private static IReadOnlyDictionary<string, int> ReadIntDictionaryProperty(object instance, string propertyName) {
+        var property = instance.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(property);
+        var raw = property!.GetValue(instance);
+        var dictionary = Assert.IsAssignableFrom<IEnumerable>(raw);
+        var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in dictionary) {
+            var type = entry.GetType();
+            var keyProperty = type.GetProperty("Key", BindingFlags.Instance | BindingFlags.Public);
+            var valueProperty = type.GetProperty("Value", BindingFlags.Instance | BindingFlags.Public);
+            Assert.NotNull(keyProperty);
+            Assert.NotNull(valueProperty);
+            var key = (keyProperty!.GetValue(entry)?.ToString() ?? string.Empty).Trim();
+            if (key.Length == 0) {
+                continue;
+            }
+
+            var parsed = Convert.ToInt32(valueProperty!.GetValue(entry));
+            result[key] = parsed;
+        }
+
+        return result;
     }
 }

--- a/IntelligenceX.Chat/scenarios/ad-ad0-then-all-dcs-followthrough-10-turn.json
+++ b/IntelligenceX.Chat/scenarios/ad-ad0-then-all-dcs-followthrough-10-turn.json
@@ -28,6 +28,7 @@
       "name": "Continue all remaining DCs in same turn",
       "user": "Now continue with all other discovered DCs in this same turn. Do not stop after AD0 and do not return partial output.",
       "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
       "require_any_tools": ["ad_replication_*", "eventlog_*query*", "eventlog_*events*", "ad_monitoring_probe_run"],
       "assert_no_questions": true,
       "assert_not_contains": ["partial", "stopped after AD0"]

--- a/IntelligenceX.Chat/scenarios/ad-cross-dc-followthrough-10-turn.json
+++ b/IntelligenceX.Chat/scenarios/ad-cross-dc-followthrough-10-turn.json
@@ -29,6 +29,7 @@
       "name": "Continue across all other DCs",
       "user": "Now continue and run the same check for all other discovered DCs in this turn. Do not stop after the first host.",
       "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
       "require_any_tools": ["eventlog_*query*", "eventlog_*events*", "eventlog_*stats*"],
       "assert_no_questions": true
     },

--- a/IntelligenceX.Chat/scenarios/ad-eventlog-correlation-partial-failures-10-turn.json
+++ b/IntelligenceX.Chat/scenarios/ad-eventlog-correlation-partial-failures-10-turn.json
@@ -34,6 +34,7 @@
       "name": "Continue across remaining DCs",
       "user": "Continue the same event correlation for every remaining discovered DC in this turn. Do not stop after the first failure.",
       "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
       "require_any_tools": ["eventlog_*query*", "eventlog_*events*", "ad_monitoring_probe_run"],
       "assert_no_questions": true
     },

--- a/IntelligenceX.Chat/scenarios/ad-long-continuation-no-partials-10-turn.json
+++ b/IntelligenceX.Chat/scenarios/ad-long-continuation-no-partials-10-turn.json
@@ -27,6 +27,7 @@
       "name": "Continue all remaining DCs",
       "user": "Continue now with all remaining discovered DCs in this same turn and keep results grouped per host.",
       "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
       "require_any_tools": ["eventlog_*query*", "eventlog_*events*", "ad_monitoring_probe_run"],
       "assert_no_questions": true
     },

--- a/IntelligenceX.Chat/scenarios/ad-mixed-ad-eventlog-retry-recovery-10-turn.json
+++ b/IntelligenceX.Chat/scenarios/ad-mixed-ad-eventlog-retry-recovery-10-turn.json
@@ -34,6 +34,7 @@
       "name": "Continue all remaining DCs",
       "user": "Continue AD + EventLog correlation for all remaining discovered DCs in this same turn. Do not stop after first failure.",
       "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
       "require_any_tools": ["ad_replication_*", "eventlog_*query*", "ad_monitoring_probe_run"],
       "assert_no_questions": true
     },

--- a/IntelligenceX.Chat/scenarios/ad-transport-recovery-no-duplicate-replay-10-turn.json
+++ b/IntelligenceX.Chat/scenarios/ad-transport-recovery-no-duplicate-replay-10-turn.json
@@ -28,6 +28,7 @@
       "name": "Continue all remaining DCs",
       "user": "Continue with all remaining discovered DCs in this same turn. Do not stop after first host.",
       "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
       "require_any_tools": ["eventlog_*query*", "eventlog_*events*", "ad_monitoring_probe_run"],
       "assert_no_questions": true
     },


### PR DESCRIPTION
## Summary
- add host-scenario support for `min_distinct_tool_input_values` so turns can require coverage across distinct tool input values (for example distinct `machine_name` values)
- enforce this constraint in AD continuation scenarios where user intent is "continue on all remaining/other DCs"
- add parser/assertion/catalog strictness tests to prevent regressions and ensure continuation turns keep cross-DC coverage guarantees

## Why
We had continuation cases where the agent kept querying a single DC even after prompts to continue across remaining DCs. `min_tool_calls` alone did not guarantee host diversity; this closes that gap.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`

All passed locally.
