### PR TITLE
Chat: add mixed domain ambiguity scenario and clarify-first guard

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioCatalogStrictnessTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioCatalogStrictnessTests.cs
@@ -144,12 +144,12 @@ public sealed class HostScenarioCatalogStrictnessTests {
         Assert.Contains(clarifyForbidden, pattern => string.Equals(pattern, "*", StringComparison.Ordinal));
 
         var clarifyContains = ReadStringList(clarifyTurn, "assert_contains");
-        Assert.Contains(clarifyContains, pattern => pattern.IndexOf("ad", StringComparison.OrdinalIgnoreCase) >= 0);
+        Assert.Contains(clarifyContains, pattern => pattern.IndexOf("ad", StringComparison.OrdinalIgnoreCase) >= 0 || pattern.IndexOf("directory", StringComparison.OrdinalIgnoreCase) >= 0);
         Assert.Contains(clarifyContains, pattern => pattern.IndexOf("dns", StringComparison.OrdinalIgnoreCase) >= 0);
 
         var adPathTurnFound = false;
         var dnsPathTurnFound = false;
-        foreach (var turn in turnList) {
+        foreach (var turn in turnList.Skip(1)) {
             var requiredPatterns = ReadStringList(turn, "require_any_tools");
             var forbiddenPatterns = ReadStringList(turn, "forbid_tools");
             if (requiredPatterns.Count == 0) {
@@ -324,4 +324,6 @@ public sealed class HostScenarioCatalogStrictnessTests {
         throw new InvalidDataException($"Property '{name}' must be an integer.");
     }
 }
+
+
 

--- a/IntelligenceX.Chat/scenarios/mixed-domain-ambiguity-clarify-routing-10-turn.json
+++ b/IntelligenceX.Chat/scenarios/mixed-domain-ambiguity-clarify-routing-10-turn.json
@@ -14,7 +14,7 @@
       "name": "Clarify AD vs public DNS intent",
       "user": "Check domain health for corp.contoso.com and contoso.com.",
       "forbid_tools": ["*"],
-      "assert_contains": ["AD", "DNS"]
+      "assert_contains": ["Active Directory", "DNS"]
     },
     {
       "name": "User selects AD path",
@@ -73,7 +73,7 @@
     {
       "name": "Boundary comparison",
       "user": "Return two sections: AD internal findings and public DNS findings, with clear boundaries.",
-      "assert_contains": ["AD", "DNS"]
+      "assert_contains": ["Active Directory", "DNS"]
     },
     {
       "name": "Final compact checklist",
@@ -83,3 +83,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
## Summary
- add a new strict 10-turn live scenario: `mixed-domain-ambiguity-clarify-routing-10-turn.json`
- enforce a clarify-first contract for ambiguous "domain" requests by forbidding tools on turn 1 (`forbid_tools: ["*"]`) and requiring AD/DNS clarification context in response assertions
- model split execution paths in one scenario:
  - AD path turns require AD/EventLog tools and explicitly forbid DNS tools
  - DNS path turns require DnsClientX/DomainDetective tools and explicitly forbid AD/EventLog tools
- add catalog strictness test `MixedDomainAmbiguityScenario_RequiresClarifyBeforeSplitToolPaths` to prevent regressions

## Why
This captures the key routing risk where "domain" can mean AD domain health or public DNS/domain diagnostics. The scenario and guard test enforce explicit clarify-before-tools behavior and safe tool-path separation.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~HostScenarioCatalogStrictnessTests|FullyQualifiedName~HostScenarioParsingTests|FullyQualifiedName~HostScenarioAssertionTests"`
- `pwsh -NoProfile -File .github/scripts/test-chat-scenario-catalog-quality.ps1`

Both passed locally.
