### PR TITLE
Harden chat replay recovery when call_id is reused with changed args

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -1223,11 +1223,12 @@ internal sealed partial class ChatServiceSession {
             }
 
             var priorOutputsByCallId = BuildLatestToolOutputsByCallId(toolOutputs);
+            var priorToolCallsByCallId = BuildLatestToolCallContractsByCallId(toolCalls);
             var callsToExecute = new List<ToolCall>(extracted.Count);
             var replayRecoveredOutputs = new List<ToolOutputDto>(extracted.Count);
             for (var callIndex = 0; callIndex < extracted.Count; callIndex++) {
                 var call = extracted[callIndex];
-                if (TryGetReplayRecoveredOutputForCall(call, priorOutputsByCallId, out var replayRecoveredOutput)) {
+                if (TryGetReplayRecoveredOutputForCall(call, priorOutputsByCallId, priorToolCallsByCallId, out var replayRecoveredOutput)) {
                     replayRecoveredOutputs.Add(replayRecoveredOutput);
                     continue;
                 }
@@ -1407,6 +1408,7 @@ internal sealed partial class ChatServiceSession {
     private const string ReplayOutputCompactionMarker = "ix:replay-output-compacted:v1";
     private const string ReplayOutputBudgetStatusMarker = "ix:replay-output-budget:v1";
 
+    private readonly record struct PriorToolCallContract(string Name, string ArgumentsJson);
     private readonly record struct ReplayToolOutputSelection(string Output, bool MatchedRawCallId);
     private readonly record struct ReplayOutputCompactionBudget(
         int MaxOutputCharsPerCall,
@@ -1538,10 +1540,61 @@ internal sealed partial class ChatServiceSession {
         return byCallId;
     }
 
+    private static Dictionary<string, PriorToolCallContract> BuildLatestToolCallContractsByCallId(IReadOnlyList<ToolCallDto> calls) {
+        var byCallId = new Dictionary<string, PriorToolCallContract>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < calls.Count; i++) {
+            var callId = (calls[i].CallId ?? string.Empty).Trim();
+            if (callId.Length == 0) {
+                continue;
+            }
+
+            var callName = (calls[i].Name ?? string.Empty).Trim();
+            var argumentsJson = NormalizeArgumentsJsonForReplayContract(calls[i].ArgumentsJson);
+            byCallId[callId] = new PriorToolCallContract(callName, argumentsJson);
+        }
+
+        return byCallId;
+    }
+
+    private static string NormalizeArgumentsJsonForReplayContract(string? argumentsJson) {
+        var value = (argumentsJson ?? string.Empty).Trim();
+        if (value.Length == 0) {
+            return "{}";
+        }
+
+        try {
+            var parsed = JsonLite.Parse(value);
+            if (parsed is null) {
+                return "{}";
+            }
+
+            return JsonLite.Serialize(parsed);
+        } catch {
+            return value;
+        }
+    }
+
+    private static bool CallMatchesReplayRecoveredContract(ToolCall call, PriorToolCallContract priorContract) {
+        var currentName = (call.Name ?? string.Empty).Trim();
+        if (priorContract.Name.Length > 0
+            && currentName.Length > 0
+            && !string.Equals(currentName, priorContract.Name, StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        var currentArgumentsJson = call.Arguments is null
+            ? "{}"
+            : NormalizeArgumentsJsonForReplayContract(JsonLite.Serialize(call.Arguments));
+        return string.Equals(currentArgumentsJson, priorContract.ArgumentsJson, StringComparison.Ordinal);
+    }
+
     private static bool TryGetReplayRecoveredOutputForCall(ToolCall call, IReadOnlyDictionary<string, ToolOutputDto> outputsByCallId,
+        IReadOnlyDictionary<string, PriorToolCallContract> priorCallsByCallId,
         out ToolOutputDto replayRecoveredOutput) {
         var callId = (call.CallId ?? string.Empty).Trim();
-        if (callId.Length > 0 && outputsByCallId.TryGetValue(callId, out var priorOutput)) {
+        if (callId.Length > 0
+            && outputsByCallId.TryGetValue(callId, out var priorOutput)
+            && (!priorCallsByCallId.TryGetValue(callId, out var priorCall) || CallMatchesReplayRecoveredContract(call, priorCall))) {
             replayRecoveredOutput = priorOutput with { CallId = callId };
             return true;
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
@@ -777,6 +777,106 @@ public sealed partial class ChatServiceRoutingTrimTests {
         }
     }
 
+    [Fact]
+    public async Task RunChatOnCurrentThreadAsync_ExecutesReplayCall_WhenCallIdMatchesButArgumentsDiffer() {
+        using var server = new DeterministicCompatibleHttpServer(
+            dropChatCompletionResponseOnRequestIndices: new[] { 2 },
+            emitReplayMismatchedToolCallArgumentsAfterDrop: true);
+
+        var serviceOptions = new ServiceOptions {
+            OpenAITransport = OpenAITransportKind.CompatibleHttp,
+            OpenAIBaseUrl = server.BaseUrl,
+            OpenAIAllowInsecureHttp = true,
+            OpenAIStreaming = false,
+            Model = "mock-local-model",
+            MaxToolRounds = 4,
+            EnableTestimoXPack = false,
+            EnableOfficeImoPack = false
+        };
+        var session = new ChatServiceSession(serviceOptions, Stream.Null);
+        var registry = new ToolRegistry();
+
+        var invokedSteps = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var invokedStepsSync = new object();
+        registry.Register(new RoundTripStubTool(
+            "mock_round_tool",
+            (arguments, _) => {
+                var step = arguments?.GetString("step") ?? "unknown";
+                lock (invokedStepsSync) {
+                    if (invokedSteps.TryGetValue(step, out var current)) {
+                        invokedSteps[step] = current + 1;
+                    } else {
+                        invokedSteps[step] = 1;
+                    }
+                }
+
+                return Task.FromResult(JsonSerializer.Serialize(new { ok = true, step }));
+            }));
+        RegistryField.SetValue(session, registry);
+
+        var clientOptions = new IntelligenceXClientOptions {
+            TransportKind = OpenAITransportKind.CompatibleHttp,
+            AutoInitialize = false,
+            DefaultModel = "mock-local-model"
+        };
+        clientOptions.CompatibleHttpOptions.BaseUrl = server.BaseUrl;
+        clientOptions.CompatibleHttpOptions.AuthMode = OpenAICompatibleHttpAuthMode.None;
+        clientOptions.CompatibleHttpOptions.Streaming = false;
+        clientOptions.CompatibleHttpOptions.AllowInsecureHttp = true;
+
+        using var client = await IntelligenceXClient.ConnectAsync(clientOptions);
+        var thread = await client.StartNewThreadAsync("mock-local-model");
+
+        var request = new ChatRequest {
+            RequestId = "req-e2e-replay-call-id-argument-mismatch",
+            ThreadId = thread.Id,
+            Text = "Run the diagnostics workflow to completion.",
+            Options = new ChatRequestOptions {
+                WeightedToolRouting = false,
+                MaxToolRounds = 4,
+                ParallelTools = false,
+                PlanExecuteReviewLoop = true,
+                MaxReviewPasses = 0,
+                ModelHeartbeatSeconds = 0
+            }
+        };
+
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+        var runResult = await InvokeRunChatOnCurrentThreadAsync(
+            session,
+            client,
+            writer,
+            request,
+            thread.Id,
+            CancellationToken.None);
+
+        var statuses = ParseStatuses(capture.Snapshot());
+        Assert.Equal(2, statuses.Count(static s => string.Equals(s, "tool_round_started", StringComparison.OrdinalIgnoreCase)));
+        Assert.Equal(2, statuses.Count(static s => string.Equals(s, "tool_round_completed", StringComparison.OrdinalIgnoreCase)));
+        Assert.Equal(2, statuses.Count(static s => string.Equals(s, "tool_call", StringComparison.OrdinalIgnoreCase)));
+
+        Assert.Equal(4, server.ChatCompletionRequestCount);
+        Assert.Equal(1, server.DroppedChatCompletionRequestCount);
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(1), "call_round_1"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(2), "call_round_1"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(3), "call_round_1"));
+
+        Assert.Equal(2, GetPropertyValue<int>(runResult, "ToolRounds"));
+        Assert.Equal(2, GetPropertyValue<int>(runResult, "ToolCallsCount"));
+        var resultMessage = GetPropertyValue<ChatResultMessage>(runResult, "Result");
+        Assert.Equal("Final answer after replay mismatch recovery.", resultMessage.Text);
+        Assert.NotNull(resultMessage.Tools);
+        Assert.Equal(2, resultMessage.Tools!.Calls.Count);
+        Assert.Equal(2, resultMessage.Tools.Outputs.Count);
+
+        lock (invokedStepsSync) {
+            Assert.Equal(2, invokedSteps.Values.Sum());
+            Assert.True(invokedSteps.TryGetValue("one", out var oneCount) && oneCount == 1);
+            Assert.True(invokedSteps.TryGetValue("two", out var twoCount) && twoCount == 1);
+        }
+    }
+
     private static async Task<object> InvokeRunChatOnCurrentThreadAsync(ChatServiceSession session, IntelligenceXClient client, StreamWriter writer,
         ChatRequest request, string threadId, CancellationToken cancellationToken) {
         var taskObj = RunChatOnCurrentThreadAsyncMethod.Invoke(session, new object?[] { client, writer, request, threadId, cancellationToken });
@@ -883,6 +983,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
         private readonly bool _emitReplayDuplicateToolCallAfterDrop;
         private readonly bool _emitReplayMixedToolCallsAfterDrop;
         private readonly bool _emitReplayMixedToolCallsAfterDropReordered;
+        private readonly bool _emitReplayMismatchedToolCallArgumentsAfterDrop;
         private readonly List<int> _droppedChatCompletionRequests = new();
         private volatile bool _disposed;
         private int _successfulChatCompletionResponses;
@@ -891,7 +992,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
             IEnumerable<int>? dropChatCompletionResponseOnRequestIndices = null,
             bool emitReplayDuplicateToolCallAfterDrop = false,
             bool emitReplayMixedToolCallsAfterDrop = false,
-            bool emitReplayMixedToolCallsAfterDropReordered = false) {
+            bool emitReplayMixedToolCallsAfterDropReordered = false,
+            bool emitReplayMismatchedToolCallArgumentsAfterDrop = false) {
             _listener = new TcpListener(IPAddress.Loopback, 0);
             _listener.Start();
             var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
@@ -902,6 +1004,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             _emitReplayDuplicateToolCallAfterDrop = emitReplayDuplicateToolCallAfterDrop;
             _emitReplayMixedToolCallsAfterDrop = emitReplayMixedToolCallsAfterDrop;
             _emitReplayMixedToolCallsAfterDropReordered = emitReplayMixedToolCallsAfterDropReordered;
+            _emitReplayMismatchedToolCallArgumentsAfterDrop = emitReplayMismatchedToolCallArgumentsAfterDrop;
             _acceptLoop = Task.Run(AcceptLoopAsync);
         }
 
@@ -1103,6 +1206,15 @@ public sealed partial class ChatServiceRoutingTrimTests {
                         2 => BuildToolCallCompletionBody("call_round_1", "one"),
                         3 => BuildToolCallCompletionBody("call_round_2", "two"),
                         4 => BuildTextCompletionBody("Final answer after two tool rounds."),
+                        _ => BuildTextCompletionBody("Unexpected extra chat request.")
+                    };
+                }
+
+                if (_emitReplayMismatchedToolCallArgumentsAfterDrop) {
+                    return responseIndex switch {
+                        1 => BuildToolCallCompletionBody("call_round_1", "one"),
+                        2 => BuildToolCallCompletionBody("call_round_1", "two"),
+                        3 => BuildTextCompletionBody("Final answer after replay mismatch recovery."),
                         _ => BuildTextCompletionBody("Unexpected extra chat request.")
                     };
                 }


### PR DESCRIPTION
Summary:\n- Reuse replay outputs only when call_id and tool contract still match.\n- Prevent stale replay output reuse when retried tool call changes args/name.\n- Add end-to-end regression for drop/retry call_id reuse with argument mismatch.\n\nValidation:\n- dotnet build IntelligenceX.sln -c Release\n- dotnet test IntelligenceX.sln -c Release\n- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll\n- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll\n- targeted Chat replay tests