### PR TITLE
Chat: add mixed replay mismatch transport E2E

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
@@ -877,6 +877,120 @@ public sealed partial class ChatServiceRoutingTrimTests {
         }
     }
 
+    [Fact]
+    public async Task RunChatOnCurrentThreadAsync_ExecutesReplayMismatchAndFreshCalls_WhenRetryReturnsMixedBatch() {
+        using var server = new DeterministicCompatibleHttpServer(
+            dropChatCompletionResponseOnRequestIndices: new[] { 2 },
+            emitReplayMixedMismatchedAndFreshToolCallsAfterDrop: true);
+
+        var serviceOptions = new ServiceOptions {
+            OpenAITransport = OpenAITransportKind.CompatibleHttp,
+            OpenAIBaseUrl = server.BaseUrl,
+            OpenAIAllowInsecureHttp = true,
+            OpenAIStreaming = false,
+            Model = "mock-local-model",
+            MaxToolRounds = 4,
+            EnableTestimoXPack = false,
+            EnableOfficeImoPack = false
+        };
+        var session = new ChatServiceSession(serviceOptions, Stream.Null);
+        var registry = new ToolRegistry();
+
+        var invokedSteps = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var invokedStepsSync = new object();
+        registry.Register(new RoundTripStubTool(
+            "mock_round_tool",
+            (arguments, _) => {
+                var step = arguments?.GetString("step") ?? "unknown";
+                lock (invokedStepsSync) {
+                    if (invokedSteps.TryGetValue(step, out var current)) {
+                        invokedSteps[step] = current + 1;
+                    } else {
+                        invokedSteps[step] = 1;
+                    }
+                }
+
+                return Task.FromResult(JsonSerializer.Serialize(new { ok = true, step }));
+            }));
+        RegistryField.SetValue(session, registry);
+
+        var clientOptions = new IntelligenceXClientOptions {
+            TransportKind = OpenAITransportKind.CompatibleHttp,
+            AutoInitialize = false,
+            DefaultModel = "mock-local-model"
+        };
+        clientOptions.CompatibleHttpOptions.BaseUrl = server.BaseUrl;
+        clientOptions.CompatibleHttpOptions.AuthMode = OpenAICompatibleHttpAuthMode.None;
+        clientOptions.CompatibleHttpOptions.Streaming = false;
+        clientOptions.CompatibleHttpOptions.AllowInsecureHttp = true;
+
+        using var client = await IntelligenceXClient.ConnectAsync(clientOptions);
+        var thread = await client.StartNewThreadAsync("mock-local-model");
+
+        var request = new ChatRequest {
+            RequestId = "req-e2e-replay-mismatch-fresh-mixed",
+            ThreadId = thread.Id,
+            Text = "Run the diagnostics workflow to completion.",
+            Options = new ChatRequestOptions {
+                WeightedToolRouting = false,
+                MaxToolRounds = 4,
+                ParallelTools = false,
+                PlanExecuteReviewLoop = true,
+                MaxReviewPasses = 0,
+                ModelHeartbeatSeconds = 0
+            }
+        };
+
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+        var runResult = await InvokeRunChatOnCurrentThreadAsync(
+            session,
+            client,
+            writer,
+            request,
+            thread.Id,
+            CancellationToken.None);
+
+        var statuses = ParseStatuses(capture.Snapshot());
+        Assert.Equal(2, statuses.Count(static s => string.Equals(s, "tool_round_started", StringComparison.OrdinalIgnoreCase)));
+        Assert.Equal(2, statuses.Count(static s => string.Equals(s, "tool_round_completed", StringComparison.OrdinalIgnoreCase)));
+        Assert.Equal(3, statuses.Count(static s => string.Equals(s, "tool_call", StringComparison.OrdinalIgnoreCase)));
+
+        Assert.Equal(4, server.ChatCompletionRequestCount);
+        Assert.Equal(1, server.DroppedChatCompletionRequestCount);
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(1), "call_round_1"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(2), "call_round_1"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(3), "call_round_1"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(3), "call_round_2"));
+
+        Assert.Equal(2, GetPropertyValue<int>(runResult, "ToolRounds"));
+        Assert.Equal(3, GetPropertyValue<int>(runResult, "ToolCallsCount"));
+        var resultMessage = GetPropertyValue<ChatResultMessage>(runResult, "Result");
+        Assert.Equal("Final answer after mixed replay mismatch recovery.", resultMessage.Text);
+        Assert.NotNull(resultMessage.Tools);
+        Assert.Equal(3, resultMessage.Tools!.Calls.Count);
+        Assert.Equal(3, resultMessage.Tools.Outputs.Count);
+
+        var normalizedCallIds = resultMessage.Tools.Calls
+            .Select(static call => (call.CallId ?? string.Empty).Trim())
+            .Where(static callId => callId.Length > 0)
+            .ToArray();
+        var normalizedOutputIds = resultMessage.Tools.Outputs
+            .Select(static output => (output.CallId ?? string.Empty).Trim())
+            .Where(static callId => callId.Length > 0)
+            .ToArray();
+
+        var normalizedCallIdSet = new HashSet<string>(normalizedCallIds, StringComparer.OrdinalIgnoreCase);
+        Assert.All(normalizedOutputIds, outputCallId => Assert.Contains(outputCallId, normalizedCallIdSet));
+
+        lock (invokedStepsSync) {
+            Assert.Equal(3, invokedSteps.Values.Sum());
+            Assert.True(invokedSteps.TryGetValue("one", out var oneCount) && oneCount == 1);
+            Assert.True(invokedSteps.TryGetValue("two", out var twoCount) && twoCount == 1);
+            Assert.True(invokedSteps.TryGetValue("three", out var threeCount) && threeCount == 1);
+        }
+    }
+
     private static async Task<object> InvokeRunChatOnCurrentThreadAsync(ChatServiceSession session, IntelligenceXClient client, StreamWriter writer,
         ChatRequest request, string threadId, CancellationToken cancellationToken) {
         var taskObj = RunChatOnCurrentThreadAsyncMethod.Invoke(session, new object?[] { client, writer, request, threadId, cancellationToken });
@@ -984,6 +1098,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
         private readonly bool _emitReplayMixedToolCallsAfterDrop;
         private readonly bool _emitReplayMixedToolCallsAfterDropReordered;
         private readonly bool _emitReplayMismatchedToolCallArgumentsAfterDrop;
+        private readonly bool _emitReplayMixedMismatchedAndFreshToolCallsAfterDrop;
         private readonly List<int> _droppedChatCompletionRequests = new();
         private volatile bool _disposed;
         private int _successfulChatCompletionResponses;
@@ -993,7 +1108,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
             bool emitReplayDuplicateToolCallAfterDrop = false,
             bool emitReplayMixedToolCallsAfterDrop = false,
             bool emitReplayMixedToolCallsAfterDropReordered = false,
-            bool emitReplayMismatchedToolCallArgumentsAfterDrop = false) {
+            bool emitReplayMismatchedToolCallArgumentsAfterDrop = false,
+            bool emitReplayMixedMismatchedAndFreshToolCallsAfterDrop = false) {
             _listener = new TcpListener(IPAddress.Loopback, 0);
             _listener.Start();
             var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
@@ -1005,6 +1121,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             _emitReplayMixedToolCallsAfterDrop = emitReplayMixedToolCallsAfterDrop;
             _emitReplayMixedToolCallsAfterDropReordered = emitReplayMixedToolCallsAfterDropReordered;
             _emitReplayMismatchedToolCallArgumentsAfterDrop = emitReplayMismatchedToolCallArgumentsAfterDrop;
+            _emitReplayMixedMismatchedAndFreshToolCallsAfterDrop = emitReplayMixedMismatchedAndFreshToolCallsAfterDrop;
             _acceptLoop = Task.Run(AcceptLoopAsync);
         }
 
@@ -1215,6 +1332,17 @@ public sealed partial class ChatServiceRoutingTrimTests {
                         1 => BuildToolCallCompletionBody("call_round_1", "one"),
                         2 => BuildToolCallCompletionBody("call_round_1", "two"),
                         3 => BuildTextCompletionBody("Final answer after replay mismatch recovery."),
+                        _ => BuildTextCompletionBody("Unexpected extra chat request.")
+                    };
+                }
+
+                if (_emitReplayMixedMismatchedAndFreshToolCallsAfterDrop) {
+                    return responseIndex switch {
+                        1 => BuildToolCallCompletionBody("call_round_1", "one"),
+                        2 => BuildMultiToolCallCompletionBody(
+                            ("call_round_1", "two"),
+                            ("call_round_2", "three")),
+                        3 => BuildTextCompletionBody("Final answer after mixed replay mismatch recovery."),
                         _ => BuildTextCompletionBody("Unexpected extra chat request.")
                     };
                 }


### PR DESCRIPTION
## Summary
- add a new end-to-end transport recovery test for a mixed replay batch where retry returns:
  - one call-id that reuses a prior id with changed arguments
  - one fresh call-id in the same tool-call batch
- extend the deterministic compatible-http test server with a dedicated mode for this replay shape
- assert recovery behavior stays clean: expected rounds/statuses, no orphan outputs, and deterministic execution counts

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~RunChatOnCurrentThreadAsync_ExecutesReplayMismatchAndFreshCalls_WhenRetryReturnsMixedBatch|FullyQualifiedName~RunChatOnCurrentThreadAsync_ExecutesReplayCall_WhenCallIdMatchesButArgumentsDiffer"`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~RunChatOnCurrentThreadAsync_"`