### PR TITLE
Chat: add long-run compaction soak scenario coverage

### DIFF
--- a/Build/Run-ChatCompactionSoakSuite.ps1
+++ b/Build/Run-ChatCompactionSoakSuite.ps1
@@ -1,0 +1,77 @@
+# Runs long-run compaction/soak chat scenarios using the real host runtime.
+
+[CmdletBinding()] param(
+    [string] $ScenarioDir = '.\IntelligenceX.Chat\scenarios',
+    [string] $Filter = 'ad-compaction-soak-*.json',
+    [string[]] $Tags = @('ad', 'strict', 'compaction', 'soak'),
+    [string] $OutDir = '.\artifacts\chat-compaction-soak',
+    [string[]] $AllowRoot,
+    [switch] $NoBuild,
+    [switch] $StopOnFailure,
+    [bool] $ContinueOnError = $false,
+    [switch] $ParallelTools = $true,
+    [switch] $EchoToolOutputs = $true,
+    [switch] $EnablePowerShellPack,
+    [switch] $EnableTestimoXPack,
+    [switch] $EnableDnsClientXPack,
+    [switch] $DisableDnsClientXPack,
+    [switch] $EnableDomainDetectivePack,
+    [switch] $DisableDomainDetectivePack,
+    [string] $Model,
+    [string[]] $ExtraArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Get-Item (Split-Path -Parent $MyInvocation.MyCommand.Path)).Parent.FullName
+$scenarioSuiteScript = Join-Path $repoRoot 'Build\Run-ChatScenarioSuite.ps1'
+if (-not (Test-Path $scenarioSuiteScript)) {
+    throw "Scenario suite script not found: $scenarioSuiteScript"
+}
+
+$params = @{
+    ScenarioDir = $ScenarioDir
+    Filter = $Filter
+    Tags = $Tags
+    OutDir = $OutDir
+    ContinueOnError = $ContinueOnError
+    ParallelTools = [bool]$ParallelTools
+    EchoToolOutputs = [bool]$EchoToolOutputs
+}
+
+if ($AllowRoot -and $AllowRoot.Count -gt 0) {
+    $params['AllowRoot'] = $AllowRoot
+}
+if ($NoBuild) {
+    $params['NoBuild'] = $true
+}
+if ($StopOnFailure) {
+    $params['StopOnFailure'] = $true
+}
+if ($EnablePowerShellPack) {
+    $params['EnablePowerShellPack'] = $true
+}
+if ($EnableTestimoXPack) {
+    $params['EnableTestimoXPack'] = $true
+}
+if ($EnableDnsClientXPack) {
+    $params['EnableDnsClientXPack'] = $true
+}
+if ($DisableDnsClientXPack) {
+    $params['DisableDnsClientXPack'] = $true
+}
+if ($EnableDomainDetectivePack) {
+    $params['EnableDomainDetectivePack'] = $true
+}
+if ($DisableDomainDetectivePack) {
+    $params['DisableDomainDetectivePack'] = $true
+}
+if (-not [string]::IsNullOrWhiteSpace($Model)) {
+    $params['Model'] = $Model
+}
+if ($ExtraArgs -and $ExtraArgs.Count -gt 0) {
+    $params['ExtraArgs'] = $ExtraArgs
+}
+
+& $scenarioSuiteScript @params

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioCompactionSoakTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostScenarioCompactionSoakTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class HostScenarioCompactionSoakTests {
+    [Fact]
+    public void AdCompactionSoakScenarios_UseLongRunStrictContracts() {
+        var scenarioDir = ResolveScenarioDirectory();
+        var files = Directory.GetFiles(scenarioDir, "ad-compaction-soak-*.json", SearchOption.TopDirectoryOnly)
+            .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Assert.NotEmpty(files);
+
+        foreach (var file in files) {
+            using var document = JsonDocument.Parse(File.ReadAllText(file));
+            var root = document.RootElement;
+            var fileName = Path.GetFileName(file);
+
+            var tags = ReadTagSet(root);
+            Assert.Contains("ad", tags);
+            Assert.Contains("strict", tags);
+            Assert.Contains("live", tags);
+            Assert.Contains("compaction", tags);
+            Assert.Contains("soak", tags);
+
+            var defaults = RequireProperty(root, "defaults");
+            Assert.Equal(JsonValueKind.Object, defaults.ValueKind);
+            Assert.True(ReadRequiredBoolean(defaults, "assert_clean_completion"));
+            Assert.True(ReadRequiredBoolean(defaults, "assert_tool_call_output_pairing"));
+            Assert.True(ReadRequiredBoolean(defaults, "assert_no_duplicate_tool_call_ids"));
+            Assert.True(ReadRequiredBoolean(defaults, "assert_no_duplicate_tool_output_call_ids"));
+            Assert.Equal(0, ReadRequiredInt32(defaults, "max_no_tool_execution_retries"));
+            Assert.Equal(1, ReadRequiredInt32(defaults, "max_duplicate_tool_call_signatures"));
+
+            var turns = RequireProperty(root, "turns");
+            Assert.Equal(JsonValueKind.Array, turns.ValueKind);
+            var turnList = turns.EnumerateArray().ToArray();
+            Assert.True(turnList.Length >= 20, $"{fileName}: expected at least 20 turns.");
+
+            var toolContractTurnCount = 0;
+            var crossDcTurnCount = 0;
+            foreach (var turn in turnList) {
+                var user = ReadOptionalString(turn, "user");
+                Assert.False(string.IsNullOrWhiteSpace(user), $"{fileName}: every turn must include non-empty user text.");
+
+                if (HasToolContract(turn)) {
+                    toolContractTurnCount++;
+                }
+
+                var minToolCalls = ReadOptionalInt32(turn, "min_tool_calls");
+                if (minToolCalls < 2) {
+                    continue;
+                }
+
+                var minimumDistinctValues = ReadNonNegativeIntMap(turn, "min_distinct_tool_input_values");
+                if (minimumDistinctValues.TryGetValue("machine_name", out var minMachineNameValues) && minMachineNameValues >= 2) {
+                    crossDcTurnCount++;
+                }
+            }
+
+            Assert.True(toolContractTurnCount >= 10, $"{fileName}: expected at least 10 tool-contract turns.");
+            Assert.True(crossDcTurnCount >= 5, $"{fileName}: expected at least 5 cross-DC continuation turns with machine diversity.");
+
+            var finalTurn = turnList[^1];
+            Assert.True(ReadRequiredBoolean(finalTurn, "assert_no_questions"));
+
+            var finalNotContains = ReadStringList(finalTurn, "assert_not_contains");
+            Assert.Contains(finalNotContains, static value => value.IndexOf("Partial response shown above", StringComparison.OrdinalIgnoreCase) >= 0);
+            Assert.Contains(finalNotContains, static value => value.IndexOf("turn ended before completion", StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+    }
+
+    private static string ResolveScenarioDirectory() {
+        var current = Path.GetFullPath(AppContext.BaseDirectory);
+        while (!string.IsNullOrWhiteSpace(current)) {
+            var candidate = Path.Combine(current, "IntelligenceX.Chat", "scenarios");
+            if (Directory.Exists(candidate)) {
+                return candidate;
+            }
+
+            var parent = Directory.GetParent(current);
+            if (parent is null) {
+                break;
+            }
+
+            current = parent.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate 'IntelligenceX.Chat/scenarios' from test runtime path.");
+    }
+
+    private static JsonElement RequireProperty(JsonElement root, string name) {
+        if (!root.TryGetProperty(name, out var value)) {
+            throw new InvalidDataException($"Missing required property '{name}'.");
+        }
+
+        return value;
+    }
+
+    private static string ReadOptionalString(JsonElement root, string name) {
+        if (!root.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.String) {
+            return string.Empty;
+        }
+
+        return value.GetString() ?? string.Empty;
+    }
+
+    private static int ReadOptionalInt32(JsonElement root, string name) {
+        if (!root.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.Number || !value.TryGetInt32(out var parsed)) {
+            return 0;
+        }
+
+        return parsed;
+    }
+
+    private static bool ReadRequiredBoolean(JsonElement root, string name) {
+        var value = RequireProperty(root, name);
+        if (value.ValueKind is JsonValueKind.True or JsonValueKind.False) {
+            return value.GetBoolean();
+        }
+
+        throw new InvalidDataException($"Property '{name}' must be a boolean.");
+    }
+
+    private static int ReadRequiredInt32(JsonElement root, string name) {
+        var value = RequireProperty(root, name);
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var parsed)) {
+            return parsed;
+        }
+
+        throw new InvalidDataException($"Property '{name}' must be an integer.");
+    }
+
+    private static IReadOnlyDictionary<string, int> ReadNonNegativeIntMap(JsonElement root, string propertyName) {
+        if (!root.TryGetProperty(propertyName, out var values) || values.ValueKind == JsonValueKind.Null) {
+            return new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (values.ValueKind != JsonValueKind.Object) {
+            throw new InvalidDataException($"Property '{propertyName}' must be an object.");
+        }
+
+        var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var property in values.EnumerateObject()) {
+            var key = (property.Name ?? string.Empty).Trim();
+            if (key.Length == 0) {
+                continue;
+            }
+
+            var value = property.Value;
+            if (value.ValueKind != JsonValueKind.Number || !value.TryGetInt32(out var parsed)) {
+                throw new InvalidDataException($"Property '{propertyName}.{key}' must be an integer.");
+            }
+
+            if (parsed < 0) {
+                throw new InvalidDataException($"Property '{propertyName}.{key}' must be >= 0.");
+            }
+
+            result[key] = parsed;
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyList<string> ReadStringList(JsonElement root, string propertyName) {
+        if (!root.TryGetProperty(propertyName, out var values) || values.ValueKind != JsonValueKind.Array) {
+            return Array.Empty<string>();
+        }
+
+        var result = new List<string>();
+        foreach (var value in values.EnumerateArray()) {
+            if (value.ValueKind != JsonValueKind.String) {
+                continue;
+            }
+
+            var candidate = (value.GetString() ?? string.Empty).Trim();
+            if (candidate.Length > 0) {
+                result.Add(candidate);
+            }
+        }
+
+        return result;
+    }
+
+    private static HashSet<string> ReadTagSet(JsonElement root) {
+        if (!root.TryGetProperty("tags", out var tags) || tags.ValueKind != JsonValueKind.Array) {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var element in tags.EnumerateArray()) {
+            if (element.ValueKind != JsonValueKind.String) {
+                continue;
+            }
+
+            var value = (element.GetString() ?? string.Empty).Trim();
+            if (value.Length > 0) {
+                values.Add(value);
+            }
+        }
+
+        return values;
+    }
+
+    private static bool HasToolContract(JsonElement turn) {
+        if (ReadOptionalInt32(turn, "min_tool_calls") > 0 || ReadOptionalInt32(turn, "min_tool_rounds") > 0) {
+            return true;
+        }
+
+        return ReadStringList(turn, "require_tools").Count > 0
+               || ReadStringList(turn, "require_any_tools").Count > 0
+               || ReadStringList(turn, "assert_tool_output_contains").Count > 0
+               || ReadStringList(turn, "assert_tool_output_not_contains").Count > 0
+               || ReadStringList(turn, "forbid_tool_error_codes").Count > 0
+               || (turn.TryGetProperty("assert_no_tool_errors", out var noErrors)
+                   && noErrors.ValueKind is JsonValueKind.True or JsonValueKind.False
+                   && noErrors.GetBoolean());
+    }
+}

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -96,6 +96,7 @@ Included AD scenario seeds:
 - `IntelligenceX.Chat/scenarios/ad-reboot-local-10-turn.json`
 - `IntelligenceX.Chat/scenarios/ad-replication-health-10-turn.json`
 - `IntelligenceX.Chat/scenarios/ad-cross-dc-followthrough-10-turn.json`
+- `IntelligenceX.Chat/scenarios/ad-compaction-soak-cross-dc-24-turn.json`
 - `IntelligenceX.Chat/scenarios/ad-eventlog-correlation-partial-failures-10-turn.json`
 - `IntelligenceX.Chat/scenarios/ad-identity-correlation-przemyslaw-10-turn.json`
 - `IntelligenceX.Chat/scenarios/ad-ldap-adws-health-10-turn.json`
@@ -110,6 +111,14 @@ pwsh .\Build\Run-ChatScenarioSuite.ps1 `
   -ScenarioDir .\IntelligenceX.Chat\scenarios `
   -Filter "ad-*-10-turn.json" `
   -OutDir .\artifacts\chat-scenarios
+```
+
+Run long-run compaction soak scenarios (20+ turns) with strict contracts:
+
+```powershell
+pwsh .\Build\Run-ChatCompactionSoakSuite.ps1 `
+  -ScenarioDir .\IntelligenceX.Chat\scenarios `
+  -OutDir .\artifacts\chat-compaction-soak
 ```
 
 Optional flags:

--- a/IntelligenceX.Chat/scenarios/ad-compaction-soak-cross-dc-24-turn.json
+++ b/IntelligenceX.Chat/scenarios/ad-compaction-soak-cross-dc-24-turn.json
@@ -1,0 +1,173 @@
+{
+  "name": "ad-compaction-soak-cross-dc-24-turn",
+  "tags": ["ad", "strict", "live", "compaction", "soak", "continuation", "cross-dc", "long-run", "eventlog"],
+  "defaults": {
+    "assert_clean_completion": true,
+    "assert_tool_call_output_pairing": true,
+    "assert_no_duplicate_tool_call_ids": true,
+    "assert_no_duplicate_tool_output_call_ids": true,
+    "max_no_tool_execution_retries": 0,
+    "max_duplicate_tool_call_signatures": 1
+  },
+  "turns": [
+    {
+      "name": "Scope and discover DCs",
+      "user": "Discover all domain controllers for corp.fabrikam.com and lock this run to that scope.",
+      "assert_no_questions": true,
+      "min_tool_calls": 1,
+      "require_any_tools": ["ad_*discover*", "ad_*scope*"]
+    },
+    {
+      "name": "AD0 reboot baseline",
+      "user": "Start on AD0: gather reboot and startup markers (1074, 6008, 41, 6005, 6006) with UTC timestamps.",
+      "assert_no_questions": true,
+      "min_tool_calls": 1,
+      "require_any_tools": ["eventlog_*query*", "eventlog_*events*", "eventlog_*stats*", "eventlog_top_events"]
+    },
+    {
+      "name": "Cross-DC reboot continuation",
+      "user": "Continue the same reboot-marker query across all remaining discovered DCs in this turn.",
+      "assert_no_questions": true,
+      "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
+      "require_any_tools": ["eventlog_*query*", "eventlog_*events*", "eventlog_*stats*"]
+    },
+    {
+      "name": "Reboot correlation summary",
+      "user": "Summarize which reboot markers are shared across DCs versus host-local."
+    },
+    {
+      "name": "LDAP baseline on AD0",
+      "user": "Validate LDAP bind/search health on AD0 and capture concrete failures.",
+      "assert_no_questions": true,
+      "min_tool_calls": 1,
+      "require_any_tools": ["ad_*ldap*", "ad_ldap_query*"]
+    },
+    {
+      "name": "LDAP continuation on remaining DCs",
+      "user": "Continue the same LDAP validation across all remaining DCs in this turn.",
+      "assert_no_questions": true,
+      "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
+      "require_any_tools": ["ad_*ldap*", "ad_ldap_query*"]
+    },
+    {
+      "name": "ADWS baseline on AD0",
+      "user": "Validate ADWS health and responsiveness on AD0.",
+      "assert_no_questions": true,
+      "min_tool_calls": 1,
+      "require_any_tools": ["ad_*adws*", "ad_monitoring_probe_run"]
+    },
+    {
+      "name": "ADWS continuation on remaining DCs",
+      "user": "Continue ADWS validation across all remaining discovered DCs in this turn.",
+      "assert_no_questions": true,
+      "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
+      "require_any_tools": ["ad_*adws*", "ad_monitoring_probe_run"]
+    },
+    {
+      "name": "Replication baseline snapshot",
+      "user": "Collect replication health baseline and current replication blockers.",
+      "assert_no_questions": true,
+      "min_tool_calls": 1,
+      "require_any_tools": ["ad_*replication*", "ad_monitoring_probe_run"]
+    },
+    {
+      "name": "Replication continuation across DCs",
+      "user": "Continue replication checks across all remaining DCs in this turn and surface any lag or errors.",
+      "assert_no_questions": true,
+      "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
+      "require_any_tools": ["ad_*replication*", "ad_monitoring_probe_run"]
+    },
+    {
+      "name": "System and Directory Service failures on AD0",
+      "user": "On AD0, gather top System and Directory Service failure signatures for the same analysis window.",
+      "assert_no_questions": true,
+      "min_tool_calls": 1,
+      "require_any_tools": ["eventlog_*query*", "eventlog_*events*", "eventlog_top_events"]
+    },
+    {
+      "name": "System and Directory Service continuation",
+      "user": "Continue that failure-signature collection across all remaining DCs in this turn.",
+      "assert_no_questions": true,
+      "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
+      "require_any_tools": ["eventlog_*query*", "eventlog_*events*", "eventlog_top_events"]
+    },
+    {
+      "name": "Mid-run evidence ledger",
+      "user": "Return a mid-run evidence ledger grouped by DC and by signal type.",
+      "assert_contains": ["evidence", "DC"]
+    },
+    {
+      "name": "Recurring error baseline",
+      "user": "On AD0, query the top recurring errors over a longer lookback window.",
+      "assert_no_questions": true,
+      "min_tool_calls": 1,
+      "require_any_tools": ["eventlog_*stats*", "eventlog_top_events", "eventlog_*query*"]
+    },
+    {
+      "name": "Recurring error continuation",
+      "user": "Continue recurring-error analysis across all remaining DCs in this turn.",
+      "assert_no_questions": true,
+      "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
+      "require_any_tools": ["eventlog_*stats*", "eventlog_top_events", "eventlog_*query*"]
+    },
+    {
+      "name": "Role and scope refresh",
+      "user": "Refresh domain scope and controller-role context before final correlation.",
+      "assert_no_questions": true,
+      "min_tool_calls": 1,
+      "require_any_tools": ["ad_*scope*", "ad_*discover*"]
+    },
+    {
+      "name": "Long-window baseline on AD0",
+      "user": "On AD0, collect a seven-day baseline for reboot, LDAP, ADWS, and replication-related failures.",
+      "assert_no_questions": true,
+      "min_tool_calls": 1,
+      "require_any_tools": ["eventlog_*query*", "eventlog_*stats*", "ad_*replication*", "ad_*ldap*", "ad_*adws*"]
+    },
+    {
+      "name": "Long-window continuation on remaining DCs",
+      "user": "Continue that seven-day baseline collection across all remaining discovered DCs in this turn.",
+      "assert_no_questions": true,
+      "min_tool_calls": 2,
+      "min_distinct_tool_input_values": { "machine_name": 2 },
+      "require_any_tools": ["eventlog_*query*", "eventlog_*stats*", "ad_*replication*", "ad_*ldap*", "ad_*adws*"]
+    },
+    {
+      "name": "Before-after comparison",
+      "user": "Compare the pre-reboot and post-reboot behavior windows and call out material changes."
+    },
+    {
+      "name": "Top blockers by domain impact",
+      "user": "Rank current blockers by domain impact and confidence."
+    },
+    {
+      "name": "Targeted remediation sequence",
+      "user": "Provide a targeted remediation sequence with one fast validation per blocker.",
+      "assert_no_questions": true,
+      "assert_not_contains": ["Partial response shown above", "turn ended before completion"]
+    },
+    {
+      "name": "Operator handoff draft",
+      "user": "Prepare an operator handoff summary with what was checked and what remains.",
+      "assert_not_contains": ["Partial response shown above", "turn ended before completion"]
+    },
+    {
+      "name": "Final unresolved blockers",
+      "user": "List unresolved blockers only, with impacted DCs and evidence references.",
+      "assert_no_questions": true,
+      "assert_not_contains": ["Partial response shown above", "turn ended before completion"]
+    },
+    {
+      "name": "Compact final checklist",
+      "user": "Return a compact final checklist and confidence notes with no follow-up questions.",
+      "assert_no_questions": true,
+      "assert_not_contains": ["Partial response shown above", "turn ended before completion"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a new long-run AD compaction soak scenario (`ad-compaction-soak-cross-dc-24-turn.json`) with strict defaults and 24 turns to stress continuation behavior over extended conversations
- add dedicated catalog tests (`HostScenarioCompactionSoakTests`) to enforce soak contracts:
  - strict/live/ad/compaction/soak tags
  - 20+ turns
  - minimum tool-contract density
  - cross-DC machine diversity guards
  - clean final completion markers
- add `Build/Run-ChatCompactionSoakSuite.ps1` as a convenience runner for soak scenarios
- document soak scenario/runner usage in Chat README

## Validation
- `pwsh .github/scripts/test-chat-scenario-catalog-quality.ps1`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~HostScenarioCompactionSoakTests|FullyQualifiedName~HostScenarioCatalogStrictnessTests"`
- `pwsh -NoProfile -Command '& { $t=$null; $e=$null; [void][System.Management.Automation.Language.Parser]::ParseFile("Build/Run-ChatCompactionSoakSuite.ps1",[ref]$t,[ref]$e); if($e.Count -gt 0){ $e | ForEach-Object { $_.Message }; exit 1 } }'`