### PR TITLE
Add compaction soak baseline flow and delayed replay transport coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -374,6 +374,8 @@ build/*
 !Build/Run-Chat.ps1
 !Build/Run-ChatApp.ps1
 !Build/Run-ChatScenarioSuite.ps1
+!Build/Run-ChatCompactionSoakSuite.ps1
+!Build/Run-ChatCompactionSoakBaseline.ps1
 !Build/Run-ChatLiveConversation.ps1
 !Build/Run-ChatLiveConversationSuite.ps1
 !Build/Run-ChatQualityPreflight.ps1

--- a/Build/Run-ChatCompactionSoakBaseline.ps1
+++ b/Build/Run-ChatCompactionSoakBaseline.ps1
@@ -1,0 +1,252 @@
+# Runs compaction soak scenarios and compares latest run artifacts against golden baselines.
+
+[CmdletBinding()] param(
+    [string] $ScenarioDir = '.\IntelligenceX.Chat\scenarios',
+    [string] $Filter = 'ad-compaction-soak-*.json',
+    [string[]] $Tags = @('ad', 'strict', 'compaction', 'soak'),
+    [string] $OutDir = '.\artifacts\chat-compaction-soak',
+    [string] $GoldenDir = '.\artifacts\chat-compaction-soak\golden',
+    [switch] $UpdateGolden,
+    [switch] $AllowMissingGolden,
+    [switch] $NoCompare,
+    [string[]] $AllowRoot,
+    [switch] $NoBuild,
+    [switch] $StopOnFailure,
+    [bool] $ContinueOnError = $false,
+    [switch] $ParallelTools = $true,
+    [switch] $EchoToolOutputs = $true,
+    [switch] $EnablePowerShellPack,
+    [switch] $EnableTestimoXPack,
+    [switch] $EnableDnsClientXPack,
+    [switch] $DisableDnsClientXPack,
+    [switch] $EnableDomainDetectivePack,
+    [switch] $DisableDomainDetectivePack,
+    [string] $Model,
+    [string[]] $ExtraArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Header([string] $text) { Write-Host "`n=== $text ===" -ForegroundColor Cyan }
+function Write-Step([string] $text) { Write-Host "[+] $text" -ForegroundColor Yellow }
+function Write-Fail([string] $text) { Write-Host "[x] $text" -ForegroundColor Red }
+
+function Resolve-RepoRelativePath([string] $repoRoot, [string] $pathValue) {
+    if ([string]::IsNullOrWhiteSpace($pathValue)) {
+        throw "Path value is required."
+    }
+
+    if ([System.IO.Path]::IsPathRooted($pathValue)) {
+        return [System.IO.Path]::GetFullPath($pathValue)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $repoRoot $pathValue))
+}
+
+function Get-ScenarioStem([string] $scenarioName) {
+    $name = if ([string]::IsNullOrWhiteSpace($scenarioName)) { 'scenario' } else { $scenarioName.Trim() }
+    $builder = New-Object System.Text.StringBuilder
+    foreach ($c in $name.ToCharArray()) {
+        if ([char]::IsLetterOrDigit($c)) {
+            [void]$builder.Append([char]::ToLowerInvariant($c))
+        } else {
+            [void]$builder.Append('-')
+        }
+    }
+
+    $compact = $builder.ToString().Trim('-')
+    if ($compact.Length -eq 0) {
+        $compact = 'scenario'
+    }
+    while ($compact.Contains('--')) {
+        $compact = $compact.Replace('--', '-')
+    }
+    return $compact
+}
+
+$repoRoot = (Get-Item (Split-Path -Parent $MyInvocation.MyCommand.Path)).Parent.FullName
+$soakScript = Join-Path $repoRoot 'Build\Run-ChatCompactionSoakSuite.ps1'
+$compareScript = Join-Path $repoRoot 'Build\Compare-ChatScenarioReports.ps1'
+
+if (-not (Test-Path $soakScript)) {
+    throw "Compaction soak suite script not found: $soakScript"
+}
+if (-not (Test-Path $compareScript)) {
+    throw "Scenario report compare script not found: $compareScript"
+}
+
+$resolvedOutDir = Resolve-RepoRelativePath -repoRoot $repoRoot -pathValue $OutDir
+$resolvedGoldenDir = Resolve-RepoRelativePath -repoRoot $repoRoot -pathValue $GoldenDir
+New-Item -ItemType Directory -Path $resolvedOutDir -Force | Out-Null
+New-Item -ItemType Directory -Path $resolvedGoldenDir -Force | Out-Null
+
+$beforeJson = @{}
+Get-ChildItem -Path $resolvedOutDir -File -Filter '*.json' | ForEach-Object {
+    $beforeJson[$_.FullName] = $_.LastWriteTimeUtc.Ticks
+}
+
+Write-Header 'Run Chat Compaction Soak Baseline'
+Write-Step ("Scenario dir: {0}" -f (Resolve-RepoRelativePath -repoRoot $repoRoot -pathValue $ScenarioDir))
+Write-Step ("Filter: {0}" -f $Filter)
+Write-Step ("Tags: {0}" -f (@($Tags) -join ', '))
+Write-Step ("Output dir: {0}" -f $resolvedOutDir)
+Write-Step ("Golden dir: {0}" -f $resolvedGoldenDir)
+Write-Step ("Compare enabled: {0}" -f (-not $NoCompare))
+Write-Step ("Update golden: {0}" -f [bool]$UpdateGolden)
+Write-Step ("Allow missing golden: {0}" -f [bool]$AllowMissingGolden)
+
+$soakParams = @{
+    ScenarioDir = $ScenarioDir
+    Filter = $Filter
+    Tags = $Tags
+    OutDir = $resolvedOutDir
+    ContinueOnError = $ContinueOnError
+    ParallelTools = [bool]$ParallelTools
+    EchoToolOutputs = [bool]$EchoToolOutputs
+}
+if ($AllowRoot -and $AllowRoot.Count -gt 0) {
+    $soakParams['AllowRoot'] = $AllowRoot
+}
+if ($NoBuild) {
+    $soakParams['NoBuild'] = $true
+}
+if ($StopOnFailure) {
+    $soakParams['StopOnFailure'] = $true
+}
+if ($EnablePowerShellPack) {
+    $soakParams['EnablePowerShellPack'] = $true
+}
+if ($EnableTestimoXPack) {
+    $soakParams['EnableTestimoXPack'] = $true
+}
+if ($EnableDnsClientXPack) {
+    $soakParams['EnableDnsClientXPack'] = $true
+}
+if ($DisableDnsClientXPack) {
+    $soakParams['DisableDnsClientXPack'] = $true
+}
+if ($EnableDomainDetectivePack) {
+    $soakParams['EnableDomainDetectivePack'] = $true
+}
+if ($DisableDomainDetectivePack) {
+    $soakParams['DisableDomainDetectivePack'] = $true
+}
+if (-not [string]::IsNullOrWhiteSpace($Model)) {
+    $soakParams['Model'] = $Model
+}
+if ($ExtraArgs -and $ExtraArgs.Count -gt 0) {
+    $soakParams['ExtraArgs'] = $ExtraArgs
+}
+
+& $soakScript @soakParams
+
+$newReports = @(Get-ChildItem -Path $resolvedOutDir -File -Filter '*.json' |
+    Where-Object {
+        if (-not $beforeJson.ContainsKey($_.FullName)) {
+            return $true
+        }
+
+        $previousTicks = [long]$beforeJson[$_.FullName]
+        return $_.LastWriteTimeUtc.Ticks -gt $previousTicks
+    } |
+    Sort-Object LastWriteTimeUtc -Descending)
+if ($newReports.Count -eq 0) {
+    throw "No new scenario JSON artifacts found in '$resolvedOutDir' for this run."
+}
+
+$latestByScenario = @{}
+foreach ($file in $newReports) {
+    $report = Get-Content -Path $file.FullName -Raw | ConvertFrom-Json -Depth 100
+    if ($null -eq $report) {
+        continue
+    }
+
+    $scenarioName = "$($report.name)".Trim()
+    if ($scenarioName.Length -eq 0) {
+        $scenarioName = [System.IO.Path]::GetFileNameWithoutExtension($file.Name)
+    }
+    $scenarioKey = $scenarioName.ToLowerInvariant()
+    if ($latestByScenario.ContainsKey($scenarioKey)) {
+        continue
+    }
+
+    $latestByScenario[$scenarioKey] = [pscustomobject]@{
+        Name = $scenarioName
+        Path = $file.FullName
+        StartedUtc = "$($report.started_utc)"
+        PassedTurns = [int]$report.passed_turns
+        TotalTurns = [int]$report.total_turns
+    }
+}
+
+$selectedReports = @($latestByScenario.Values | Sort-Object Name)
+if ($selectedReports.Count -eq 0) {
+    throw "No parseable scenario JSON artifacts were produced in '$resolvedOutDir'."
+}
+
+Write-Header 'Selected Scenario Reports'
+foreach ($entry in $selectedReports) {
+    Write-Step ("{0}: {1}/{2} turns passed ({3})" -f $entry.Name, $entry.PassedTurns, $entry.TotalTurns, $entry.Path)
+}
+
+$comparisonRegressions = New-Object System.Collections.Generic.List[string]
+$missingGoldenScenarios = New-Object System.Collections.Generic.List[string]
+$updatedGoldenScenarios = New-Object System.Collections.Generic.List[string]
+$skippedComparisons = New-Object System.Collections.Generic.List[string]
+
+foreach ($entry in $selectedReports) {
+    $scenarioStem = Get-ScenarioStem -scenarioName $entry.Name
+    $goldenPath = Join-Path $resolvedGoldenDir ($scenarioStem + '.json')
+    $hasGolden = Test-Path $goldenPath
+
+    if ($NoCompare) {
+        $skippedComparisons.Add($entry.Name) | Out-Null
+    } elseif (-not $hasGolden) {
+        if ($AllowMissingGolden -or $UpdateGolden) {
+            Write-Step ("Missing golden (allowed): {0}" -f $entry.Name)
+            $skippedComparisons.Add($entry.Name) | Out-Null
+        } else {
+            $missingGoldenScenarios.Add($entry.Name) | Out-Null
+        }
+    } else {
+        Write-Header ("Compare: {0}" -f $entry.Name)
+        $compareParams = @{
+            BaseReport = $goldenPath
+            CurrentReport = $entry.Path
+        }
+        if (-not $UpdateGolden) {
+            $compareParams['FailOnRegression'] = $true
+        }
+
+        & $compareScript @compareParams
+        if ($LASTEXITCODE -ne 0) {
+            $comparisonRegressions.Add($entry.Name) | Out-Null
+        }
+    }
+
+    if ($UpdateGolden) {
+        Copy-Item -Path $entry.Path -Destination $goldenPath -Force
+        $updatedGoldenScenarios.Add($entry.Name) | Out-Null
+        Write-Step ("Golden updated: {0} -> {1}" -f $entry.Name, $goldenPath)
+    }
+}
+
+Write-Header 'Compaction Soak Baseline Summary'
+Write-Step ("Compared scenarios: {0}" -f ($selectedReports.Count - $skippedComparisons.Count))
+Write-Step ("Skipped comparisons: {0}" -f $skippedComparisons.Count)
+Write-Step ("Golden updates: {0}" -f $updatedGoldenScenarios.Count)
+
+if ($missingGoldenScenarios.Count -gt 0) {
+    Write-Fail ("Missing golden baselines: {0}" -f ($missingGoldenScenarios -join ', '))
+}
+if ($comparisonRegressions.Count -gt 0) {
+    Write-Fail ("Regressions detected: {0}" -f ($comparisonRegressions -join ', '))
+}
+
+if ($missingGoldenScenarios.Count -gt 0 -or $comparisonRegressions.Count -gt 0) {
+    exit 1
+}
+
+Write-Step "Compaction soak baseline checks passed."
+exit 0

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -1407,6 +1407,8 @@ internal sealed partial class ChatServiceSession {
     private const int LargeContextMaxReplayToolOutputCharsTotal = 22_000;
     private const string ReplayOutputCompactionMarker = "ix:replay-output-compacted:v1";
     private const string ReplayOutputBudgetStatusMarker = "ix:replay-output-budget:v1";
+    private const string ReplayOutputBudgetStatusWhere = "tool_replay_input";
+    private const string ReplayOutputBudgetStatusReason = "output_budget_compaction";
 
     private readonly record struct PriorToolCallContract(string Name, string ArgumentsJson);
     private readonly record struct ReplayToolOutputSelection(string Output, bool MatchedRawCallId);
@@ -1471,7 +1473,28 @@ internal sealed partial class ChatServiceSession {
         ReplayOutputCompactionStats stats) {
         var contextLength = budget.EffectiveContextLength.HasValue ? budget.EffectiveContextLength.Value.ToString() : "unknown";
         var contextAware = budget.ContextAwareBudgetApplied ? "true" : "false";
-        return $"[{ReplayOutputBudgetStatusMarker} compacted_calls={stats.CompactedCallCount} replayed_calls={stats.ReplayedCallCount} original_chars={stats.OriginalTotalChars} kept_chars={stats.CompactedTotalChars} per_call_budget={budget.MaxOutputCharsPerCall} total_budget={budget.MaxOutputCharsTotal} context_aware={contextAware} context_length={contextLength}]";
+        var contextTier = ResolveReplayOutputCompactionContextTier(budget.EffectiveContextLength);
+        return $"[{ReplayOutputBudgetStatusMarker} where={ReplayOutputBudgetStatusWhere} reason={ReplayOutputBudgetStatusReason} compacted_calls={stats.CompactedCallCount} replayed_calls={stats.ReplayedCallCount} original_chars={stats.OriginalTotalChars} kept_chars={stats.CompactedTotalChars} per_call_budget={budget.MaxOutputCharsPerCall} total_budget={budget.MaxOutputCharsTotal} context_aware={contextAware} context_tier={contextTier} context_length={contextLength}]";
+    }
+
+    private static string ResolveReplayOutputCompactionContextTier(long? effectiveContextLength) {
+        if (!effectiveContextLength.HasValue || effectiveContextLength.Value <= 0) {
+            return "unknown";
+        }
+
+        if (effectiveContextLength.Value <= 8_192) {
+            return "small";
+        }
+
+        if (effectiveContextLength.Value <= 16_384) {
+            return "medium";
+        }
+
+        if (effectiveContextLength.Value <= 32_768) {
+            return "default";
+        }
+
+        return "large";
     }
 
     private static string ResolveToolOutputCallId(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
@@ -991,6 +991,128 @@ public sealed partial class ChatServiceRoutingTrimTests {
         }
     }
 
+    [Fact]
+    public async Task RunChatOnCurrentThreadAsync_ReusesPriorOutput_WhenReplayDuplicateArrivesInLaterMixedBatch() {
+        using var server = new DeterministicCompatibleHttpServer(
+            dropChatCompletionResponseOnRequestIndices: new[] { 2 },
+            emitReplayDelayedMixedToolCallsAfterDrop: true);
+
+        var serviceOptions = new ServiceOptions {
+            OpenAITransport = OpenAITransportKind.CompatibleHttp,
+            OpenAIBaseUrl = server.BaseUrl,
+            OpenAIAllowInsecureHttp = true,
+            OpenAIStreaming = false,
+            Model = "mock-local-model",
+            MaxToolRounds = 5,
+            EnableTestimoXPack = false,
+            EnableOfficeImoPack = false
+        };
+        var session = new ChatServiceSession(serviceOptions, Stream.Null);
+        var registry = new ToolRegistry();
+
+        var invokedSteps = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var invokedStepsSync = new object();
+        registry.Register(new RoundTripStubTool(
+            "mock_round_tool",
+            (arguments, _) => {
+                var step = arguments?.GetString("step") ?? "unknown";
+                lock (invokedStepsSync) {
+                    if (invokedSteps.TryGetValue(step, out var current)) {
+                        invokedSteps[step] = current + 1;
+                    } else {
+                        invokedSteps[step] = 1;
+                    }
+                }
+
+                return Task.FromResult(JsonSerializer.Serialize(new { ok = true, step }));
+            }));
+        RegistryField.SetValue(session, registry);
+
+        var clientOptions = new IntelligenceXClientOptions {
+            TransportKind = OpenAITransportKind.CompatibleHttp,
+            AutoInitialize = false,
+            DefaultModel = "mock-local-model"
+        };
+        clientOptions.CompatibleHttpOptions.BaseUrl = server.BaseUrl;
+        clientOptions.CompatibleHttpOptions.AuthMode = OpenAICompatibleHttpAuthMode.None;
+        clientOptions.CompatibleHttpOptions.Streaming = false;
+        clientOptions.CompatibleHttpOptions.AllowInsecureHttp = true;
+
+        using var client = await IntelligenceXClient.ConnectAsync(clientOptions);
+        var thread = await client.StartNewThreadAsync("mock-local-model");
+
+        var request = new ChatRequest {
+            RequestId = "req-e2e-replay-delayed-mixed-duplicate-and-fresh",
+            ThreadId = thread.Id,
+            Text = "Run the diagnostics workflow to completion.",
+            Options = new ChatRequestOptions {
+                WeightedToolRouting = false,
+                MaxToolRounds = 5,
+                ParallelTools = false,
+                PlanExecuteReviewLoop = true,
+                MaxReviewPasses = 0,
+                ModelHeartbeatSeconds = 0
+            }
+        };
+
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+        var runResult = await InvokeRunChatOnCurrentThreadAsync(
+            session,
+            client,
+            writer,
+            request,
+            thread.Id,
+            CancellationToken.None);
+
+        var statuses = ParseStatuses(capture.Snapshot());
+        Assert.Equal(3, statuses.Count(static s => string.Equals(s, "tool_round_started", StringComparison.OrdinalIgnoreCase)));
+        Assert.Equal(3, statuses.Count(static s => string.Equals(s, "tool_round_completed", StringComparison.OrdinalIgnoreCase)));
+        Assert.Equal(3, statuses.Count(static s => string.Equals(s, "tool_call", StringComparison.OrdinalIgnoreCase)));
+
+        Assert.Equal(5, server.ChatCompletionRequestCount);
+        Assert.Equal(1, server.DroppedChatCompletionRequestCount);
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(1), "call_round_1"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(2), "call_round_1"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(3), "call_round_1"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(3), "call_round_2"));
+        Assert.True(ContainsToolMessageForCallId(server.GetChatRequestBody(4), "call_round_3"));
+
+        Assert.Equal(3, GetPropertyValue<int>(runResult, "ToolRounds"));
+        Assert.Equal(3, GetPropertyValue<int>(runResult, "ToolCallsCount"));
+        var resultMessage = GetPropertyValue<ChatResultMessage>(runResult, "Result");
+        Assert.Equal("Final answer after delayed mixed replay recovery.", resultMessage.Text);
+        Assert.NotNull(resultMessage.Tools);
+        Assert.Equal(3, resultMessage.Tools!.Calls.Count);
+        Assert.Equal(3, resultMessage.Tools.Outputs.Count);
+
+        var normalizedCallIds = resultMessage.Tools.Calls
+            .Select(static call => (call.CallId ?? string.Empty).Trim())
+            .Where(static callId => callId.Length > 0)
+            .ToArray();
+        var normalizedOutputIds = resultMessage.Tools.Outputs
+            .Select(static output => (output.CallId ?? string.Empty).Trim())
+            .Where(static callId => callId.Length > 0)
+            .ToArray();
+
+        Assert.Equal(
+            normalizedCallIds.Length,
+            normalizedCallIds.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.Equal(
+            normalizedOutputIds.Length,
+            normalizedOutputIds.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+
+        var normalizedCallIdSet = new HashSet<string>(normalizedCallIds, StringComparer.OrdinalIgnoreCase);
+        Assert.All(normalizedOutputIds, outputCallId => Assert.Contains(outputCallId, normalizedCallIdSet));
+
+        lock (invokedStepsSync) {
+            Assert.Equal(3, invokedSteps.Values.Sum());
+            Assert.True(invokedSteps.TryGetValue("one", out var oneCount) && oneCount == 1);
+            Assert.True(invokedSteps.TryGetValue("two", out var twoCount) && twoCount == 1);
+            Assert.True(invokedSteps.TryGetValue("three", out var threeCount) && threeCount == 1);
+        }
+    }
+
     private static async Task<object> InvokeRunChatOnCurrentThreadAsync(ChatServiceSession session, IntelligenceXClient client, StreamWriter writer,
         ChatRequest request, string threadId, CancellationToken cancellationToken) {
         var taskObj = RunChatOnCurrentThreadAsyncMethod.Invoke(session, new object?[] { client, writer, request, threadId, cancellationToken });
@@ -1097,6 +1219,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
         private readonly bool _emitReplayDuplicateToolCallAfterDrop;
         private readonly bool _emitReplayMixedToolCallsAfterDrop;
         private readonly bool _emitReplayMixedToolCallsAfterDropReordered;
+        private readonly bool _emitReplayDelayedMixedToolCallsAfterDrop;
         private readonly bool _emitReplayMismatchedToolCallArgumentsAfterDrop;
         private readonly bool _emitReplayMixedMismatchedAndFreshToolCallsAfterDrop;
         private readonly List<int> _droppedChatCompletionRequests = new();
@@ -1108,6 +1231,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             bool emitReplayDuplicateToolCallAfterDrop = false,
             bool emitReplayMixedToolCallsAfterDrop = false,
             bool emitReplayMixedToolCallsAfterDropReordered = false,
+            bool emitReplayDelayedMixedToolCallsAfterDrop = false,
             bool emitReplayMismatchedToolCallArgumentsAfterDrop = false,
             bool emitReplayMixedMismatchedAndFreshToolCallsAfterDrop = false) {
             _listener = new TcpListener(IPAddress.Loopback, 0);
@@ -1120,6 +1244,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             _emitReplayDuplicateToolCallAfterDrop = emitReplayDuplicateToolCallAfterDrop;
             _emitReplayMixedToolCallsAfterDrop = emitReplayMixedToolCallsAfterDrop;
             _emitReplayMixedToolCallsAfterDropReordered = emitReplayMixedToolCallsAfterDropReordered;
+            _emitReplayDelayedMixedToolCallsAfterDrop = emitReplayDelayedMixedToolCallsAfterDrop;
             _emitReplayMismatchedToolCallArgumentsAfterDrop = emitReplayMismatchedToolCallArgumentsAfterDrop;
             _emitReplayMixedMismatchedAndFreshToolCallsAfterDrop = emitReplayMixedMismatchedAndFreshToolCallsAfterDrop;
             _acceptLoop = Task.Run(AcceptLoopAsync);
@@ -1313,6 +1438,18 @@ public sealed partial class ChatServiceRoutingTrimTests {
                             ("call_round_1", "one"),
                             ("call_round_2", "two")),
                         3 => BuildTextCompletionBody("Final answer after two tool rounds."),
+                        _ => BuildTextCompletionBody("Unexpected extra chat request.")
+                    };
+                }
+
+                if (_emitReplayDelayedMixedToolCallsAfterDrop) {
+                    return responseIndex switch {
+                        1 => BuildToolCallCompletionBody("call_round_1", "one"),
+                        2 => BuildToolCallCompletionBody("call_round_2", "two"),
+                        3 => BuildMultiToolCallCompletionBody(
+                            ("call_round_1", "one"),
+                            ("call_round_3", "three")),
+                        4 => BuildTextCompletionBody("Final answer after delayed mixed replay recovery."),
                         _ => BuildTextCompletionBody("Unexpected extra chat request.")
                     };
                 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
@@ -2791,11 +2791,14 @@ public sealed partial class ChatServiceRoutingTrimTests {
         var message = Assert.IsType<string>(messageObj);
 
         Assert.Contains("ix:replay-output-budget:v1", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("where=tool_replay_input", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("reason=output_budget_compaction", message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("compacted_calls=1", message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("replayed_calls=2", message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("per_call_budget=2500", message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("total_budget=7000", message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("context_aware=true", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("context_tier=small", message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("context_length=8192", message, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/IntelligenceX.Chat/README.md
+++ b/IntelligenceX.Chat/README.md
@@ -136,6 +136,25 @@ pwsh .\Build\Run-ChatCompactionSoakSuite.ps1 `
   -OutDir .\artifacts\chat-compaction-soak
 ```
 
+Run compaction soak with golden-baseline comparison (real host runtime + strict regression gate):
+
+```powershell
+pwsh .\Build\Run-ChatCompactionSoakBaseline.ps1 `
+  -ScenarioDir .\IntelligenceX.Chat\scenarios `
+  -OutDir .\artifacts\chat-compaction-soak `
+  -GoldenDir .\artifacts\chat-compaction-soak\golden
+```
+
+To refresh golden baselines after an intentional behavior change:
+
+```powershell
+pwsh .\Build\Run-ChatCompactionSoakBaseline.ps1 `
+  -ScenarioDir .\IntelligenceX.Chat\scenarios `
+  -OutDir .\artifacts\chat-compaction-soak `
+  -GoldenDir .\artifacts\chat-compaction-soak\golden `
+  -UpdateGolden
+```
+
 Optional flags:
 - `-NoBuild` to skip restore/build in repeated local runs.
 - `-StopOnFailure` to stop on first failed scenario.


### PR DESCRIPTION
## Summary
- add Build/Run-ChatCompactionSoakBaseline.ps1 to run real compaction soak scenarios and compare latest JSON artifacts against golden baselines (with optional -UpdateGolden refresh)
- add delayed mixed replay transport E2E that validates replay recovery when a duplicate call id reappears in a later mixed batch alongside a fresh call
- enrich replay-output compaction status marker payload with explicit observability fields (where, eason, context_tier) and extend unit assertions
- document the new compaction soak baseline runner in Chat README
- unignore new/related build scripts in .gitignore to keep Build entrypoints trackable

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~RunChatOnCurrentThreadAsync_ReusesPriorOutput_WhenReplayDuplicateArrivesInLaterMixedBatch|FullyQualifiedName~BuildReplayOutputCompactionStatusMessage_EmitsMarkerAndBudgetDetails"
- PowerShell parse check: [System.Management.Automation.Language.Parser]::ParseFile('Build/Run-ChatCompactionSoakBaseline.ps1', ...)

## Notes
- The baseline script is intentionally strict by default: it fails when golden files are missing unless -AllowMissingGolden or -UpdateGolden is used.