### PR TITLE
ci(website): roll forward default PowerForge pin

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
   # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
   POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'a9b7144f30da9edd6e06e644c3fc05535baec26a' }}
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || '83bb21dba0f8a102851c08cb7ed615d1cf061aa1' }}
 
 jobs:
   build:
@@ -196,3 +196,4 @@ jobs:
             --site-config "Website/site.json" \
             --warmup 1 \
             --allow-status "HIT,REVALIDATED,EXPIRED,STALE,DYNAMIC"
+

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
   POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'a9b7144f30da9edd6e06e644c3fc05535baec26a' }}
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || '83bb21dba0f8a102851c08cb7ed615d1cf061aa1' }}
 
 jobs:
   website-build:
@@ -66,3 +66,4 @@ jobs:
           if [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ] && [ -d "${PLAYWRIGHT_BROWSERS_PATH}" ]; then
             rm -rf "${PLAYWRIGHT_BROWSERS_PATH}"
           fi
+


### PR DESCRIPTION
## Summary
- update website workflow fallback POWERFORGE_REF to \\83bb21dba0f8a102851c08cb7ed615d1cf061aa1\\
- keep fallback aligned with current PSPublishModule main that includes Magick.NET vulnerability gate fix

## Why
Website CI/deploy could still resolve older fallback SHA if repo variable is missing/reset, causing intermittent NU1902/NU1903 failures when advisory feeds update.