### PR TITLE
Harden analyzer marker caching and source inventory scan guardrails

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -379,6 +379,7 @@ Enable analysis summaries and inline findings sourced from SARIF or Intelligence
 - `failOnUnavailable`: fail when no result files match configured inputs or when result parsing fails.
 - `failOnNoEnabledRules`: fail when `analysis.packs` selects zero rules.
 - `includeOutsidePackRules`: when `true`, all findings from non-enabled rules can still fail the gate; explicit `ruleIds` always remain eligible.
+  Gate output `Outside-pack findings` included/ignored counts are post-filter scoped (after `types`/`ruleIds` gate filters).
 - `failOnHotspotsToReview`: when `true`, security hotspots in `to-review` state can fail the gate (after `minSeverity`/`types` filtering).
 
 `analysis.run.strict` controls `intelligencex analyze run` exit semantics:

--- a/Docs/reviewer/static-analysis.md
+++ b/Docs/reviewer/static-analysis.md
@@ -253,6 +253,7 @@ If you enable `intelligencex-maintainability-default` in an existing repository,
 `IXTOOL005` defaults to `warning` severity and is intended to keep EventLog `max_results` helper semantics explicit and stable.
 To gate specific contract rules without widening gate types, set `analysis.gate.ruleIds` (for example `["IXTOOL001","IXTOOL002","IXTOOL003","IXTOOL004","IXTOOL005"]`).
 Explicit gate rule IDs are still evaluated even when `analysis.gate.includeOutsidePackRules` is `false`.
+When gate output reports `Outside-pack findings: ... (included/ignored)`, those included/ignored counts are scoped to findings that remain in gate scope after type/ruleId filtering.
 Use `analysis.disabledRules` or `analysis.severityOverrides` in `.intelligencex/reviewer.json` to phase in enforcement.
 IntelligenceX does not push analysis configuration into existing user repositories; policy only changes when the repository configuration is updated explicitly.
 

--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ExternalRunnerHelpers.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ExternalRunnerHelpers.cs
@@ -8,6 +8,8 @@ namespace IntelligenceX.Cli.Analysis;
 internal static partial class AnalyzeRunCommand {
     private const string CommandUnavailableMarkersEnvVar = "INTELLIGENCEX_ANALYSIS_COMMAND_UNAVAILABLE_MARKERS";
     private const string CommandUnavailableMarkersEnvVarPrefix = "INTELLIGENCEX_ANALYSIS_COMMAND_UNAVAILABLE_MARKERS_";
+    private const string SourceInventoryMaxFilesEnvVar = "INTELLIGENCEX_ANALYSIS_SOURCE_SCAN_MAX_FILES";
+    private const int DefaultSourceInventoryMaxFiles = 200000;
     private static readonly string[] CommonCommandUnavailableMarkers = {
         "not recognized as an internal or external command",
         "is not recognized as an internal or external command",
@@ -26,19 +28,26 @@ internal static partial class AnalyzeRunCommand {
                 "no module named ruff"
             }
         };
+    private static readonly object CommandUnavailableMarkerCacheLock = new();
+    private static readonly Dictionary<string, (string RawValue, IReadOnlyList<string> Markers)> CommandUnavailableMarkerCache =
+        new(StringComparer.Ordinal);
     private static readonly char[] PathSeparators = {
         Path.DirectorySeparatorChar,
         Path.AltDirectorySeparatorChar
     };
 
     private sealed class WorkspaceSourceInventory {
-        public WorkspaceSourceInventory(HashSet<string> extensions, int skippedEnumerations) {
+        public WorkspaceSourceInventory(HashSet<string> extensions, int skippedEnumerations, bool scanLimitReached, int maxScannedFiles) {
             Extensions = extensions ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             SkippedEnumerations = Math.Max(0, skippedEnumerations);
+            ScanLimitReached = scanLimitReached;
+            MaxScannedFiles = Math.Max(0, maxScannedFiles);
         }
 
         public HashSet<string> Extensions { get; }
         public int SkippedEnumerations { get; }
+        public bool ScanLimitReached { get; }
+        public int MaxScannedFiles { get; }
     }
 
     private static string BuildExternalRunnerFailureMessage(string languageLabel, string command, string optionName, CommandResult result) {
@@ -82,10 +91,8 @@ internal static partial class AnalyzeRunCommand {
             }
         }
 
-        foreach (var marker in GetConfiguredCommandUnavailableMarkers(command)) {
-            if (text.Contains(marker, StringComparison.Ordinal)) {
-                return true;
-            }
+        if (ContainsAnyConfiguredCommandUnavailableMarker(command, text)) {
+            return true;
         }
 
         return false;
@@ -132,24 +139,24 @@ internal static partial class AnalyzeRunCommand {
         return Path.GetFileNameWithoutExtension(fileName).Trim().ToLowerInvariant();
     }
 
-    private static IEnumerable<string> GetConfiguredCommandUnavailableMarkers(string command) {
-        foreach (var marker in ParseCommandUnavailableMarkersFromEnvironment(CommandUnavailableMarkersEnvVar)) {
-            yield return marker;
+    private static bool ContainsAnyConfiguredCommandUnavailableMarker(string command, string text) {
+        var globalMarkers = GetCommandUnavailableMarkersFromEnvironment(CommandUnavailableMarkersEnvVar);
+        if (ContainsAnyMarker(text, globalMarkers)) {
+            return true;
         }
 
         var commandKey = ResolveCommandKey(command);
         if (string.IsNullOrWhiteSpace(commandKey)) {
-            yield break;
+            return false;
         }
 
         var envName = BuildCommandUnavailableMarkersEnvVarName(commandKey);
         if (string.IsNullOrWhiteSpace(envName)) {
-            yield break;
+            return false;
         }
 
-        foreach (var marker in ParseCommandUnavailableMarkersFromEnvironment(envName)) {
-            yield return marker;
-        }
+        var commandMarkers = GetCommandUnavailableMarkersFromEnvironment(envName);
+        return ContainsAnyMarker(text, commandMarkers);
     }
 
     private static string BuildCommandUnavailableMarkersEnvVarName(string commandKey) {
@@ -169,24 +176,68 @@ internal static partial class AnalyzeRunCommand {
         return CommandUnavailableMarkersEnvVarPrefix + normalized;
     }
 
-    private static IEnumerable<string> ParseCommandUnavailableMarkersFromEnvironment(string variableName) {
+    private static IReadOnlyList<string> GetCommandUnavailableMarkersFromEnvironment(string variableName) {
         if (string.IsNullOrWhiteSpace(variableName)) {
-            yield break;
+            return Array.Empty<string>();
         }
 
-        var raw = Environment.GetEnvironmentVariable(variableName);
+        var raw = Environment.GetEnvironmentVariable(variableName) ?? string.Empty;
+        lock (CommandUnavailableMarkerCacheLock) {
+            if (CommandUnavailableMarkerCache.TryGetValue(variableName, out var cached) &&
+                string.Equals(cached.RawValue, raw, StringComparison.Ordinal)) {
+                return cached.Markers;
+            }
+
+            var parsed = ParseCommandUnavailableMarkers(raw);
+            CommandUnavailableMarkerCache[variableName] = (raw, parsed);
+            return parsed;
+        }
+    }
+
+    private static IReadOnlyList<string> ParseCommandUnavailableMarkers(string raw) {
         if (string.IsNullOrWhiteSpace(raw)) {
-            yield break;
+            return Array.Empty<string>();
         }
 
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var parsed = new List<string>();
         var parts = raw.Split(new[] { '\r', '\n', ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
         foreach (var part in parts) {
             var normalized = (part ?? string.Empty).Trim().ToLowerInvariant();
-            if (string.IsNullOrWhiteSpace(normalized)) {
+            if (string.IsNullOrWhiteSpace(normalized) || !seen.Add(normalized)) {
                 continue;
             }
-            yield return normalized;
+            parsed.Add(normalized);
         }
+
+        return parsed;
+    }
+
+    private static bool ContainsAnyMarker(string text, IReadOnlyList<string> markers) {
+        if (string.IsNullOrWhiteSpace(text) || markers is null || markers.Count == 0) {
+            return false;
+        }
+
+        foreach (var marker in markers) {
+            if (text.Contains(marker, StringComparison.Ordinal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static int ResolveSourceInventoryMaxFiles() {
+        var raw = Environment.GetEnvironmentVariable(SourceInventoryMaxFilesEnvVar);
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return DefaultSourceInventoryMaxFiles;
+        }
+
+        if (!int.TryParse(raw.Trim(), out var parsedValue)) {
+            return DefaultSourceInventoryMaxFiles;
+        }
+
+        return Math.Max(0, parsedValue);
     }
 
     private static bool WorkspaceContainsAnySourceFile(string workspace, params string[] extensions) {
@@ -198,11 +249,26 @@ internal static partial class AnalyzeRunCommand {
         return WorkspaceContainsAnySourceFile(sourceInventory, out skippedEnumerations, extensions);
     }
 
+    private static bool WorkspaceContainsAnySourceFileWithoutScanLimit(string workspace, out int skippedEnumerations,
+        params string[] extensions) {
+        var sourceInventory = DiscoverWorkspaceSourceInventory(workspace, maxScannedFiles: int.MaxValue);
+        return WorkspaceContainsAnySourceFile(sourceInventory, out skippedEnumerations, extensions);
+    }
+
     private static bool WorkspaceContainsAnySourceFile(
         WorkspaceSourceInventory? sourceInventory,
         out int skippedEnumerations,
         params string[] extensions) {
+        return WorkspaceContainsAnySourceFile(sourceInventory, out skippedEnumerations, out _, extensions);
+    }
+
+    private static bool WorkspaceContainsAnySourceFile(
+        WorkspaceSourceInventory? sourceInventory,
+        out int skippedEnumerations,
+        out bool scanLimitReached,
+        params string[] extensions) {
         skippedEnumerations = sourceInventory?.SkippedEnumerations ?? 0;
+        scanLimitReached = sourceInventory?.ScanLimitReached ?? false;
         if (sourceInventory is null) {
             return false;
         }
@@ -222,16 +288,26 @@ internal static partial class AnalyzeRunCommand {
     }
 
     private static WorkspaceSourceInventory? DiscoverWorkspaceSourceInventory(string workspace) {
+        return DiscoverWorkspaceSourceInventory(workspace, ResolveSourceInventoryMaxFiles());
+    }
+
+    private static WorkspaceSourceInventory? DiscoverWorkspaceSourceInventory(string workspace, int maxScannedFiles) {
         if (string.IsNullOrWhiteSpace(workspace) || !Directory.Exists(workspace)) {
             return null;
         }
 
         var skippedEnumerations = 0;
         var discoveredExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        maxScannedFiles = Math.Max(0, maxScannedFiles);
+        var scanLimitReached = false;
+        var scannedFiles = 0;
+        if (maxScannedFiles == 0) {
+            return new WorkspaceSourceInventory(discoveredExtensions, skippedEnumerations, scanLimitReached: true, maxScannedFiles);
+        }
         var pending = new Stack<string>();
         pending.Push(workspace);
 
-        while (pending.Count > 0) {
+        while (pending.Count > 0 && !scanLimitReached) {
             var directory = pending.Pop();
 
             IEnumerable<string>? subdirectories = null;
@@ -267,6 +343,12 @@ internal static partial class AnalyzeRunCommand {
             }
 
             foreach (var path in files) {
+                if (scannedFiles >= maxScannedFiles) {
+                    scanLimitReached = true;
+                    break;
+                }
+                scannedFiles++;
+
                 if (IsPathUnderExcludedDirectorySegment(workspace, path)) {
                     continue;
                 }
@@ -278,7 +360,7 @@ internal static partial class AnalyzeRunCommand {
             }
         }
 
-        return new WorkspaceSourceInventory(discoveredExtensions, skippedEnumerations);
+        return new WorkspaceSourceInventory(discoveredExtensions, skippedEnumerations, scanLimitReached, maxScannedFiles);
     }
 
     private static HashSet<string> NormalizeSourceExtensions(params string[] extensions) {

--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.TestSeams.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.TestSeams.cs
@@ -67,17 +67,33 @@ internal static partial class AnalyzeRunCommand {
         return (found, skippedEnumerations);
     }
 
-    internal static (IReadOnlyList<string> Extensions, int SkippedEnumerations) DiscoverWorkspaceSourceInventoryForTests(
+    internal static (IReadOnlyList<string> Extensions, int SkippedEnumerations, bool ScanLimitReached, int MaxScannedFiles)
+        DiscoverWorkspaceSourceInventoryForTests(
         string workspace) {
         var inventory = DiscoverWorkspaceSourceInventory(workspace);
         if (inventory is null) {
-            return (Array.Empty<string>(), 0);
+            return (Array.Empty<string>(), 0, false, 0);
         }
 
         var extensions = inventory.Extensions
             .OrderBy(static extension => extension, StringComparer.OrdinalIgnoreCase)
             .ToArray();
-        return (extensions, inventory.SkippedEnumerations);
+        return (extensions, inventory.SkippedEnumerations, inventory.ScanLimitReached, inventory.MaxScannedFiles);
+    }
+
+    internal static (bool Found, int SkippedEnumerations, bool UsedDirectFallback, IReadOnlyList<string> Warnings)
+        TryDetectSourceFilesWithSharedInventoryForTests(string workspace, string languageLabel, params string[] extensions) {
+        var inventory = DiscoverWorkspaceSourceInventory(workspace);
+        var warnings = new List<string>();
+        var found = TryDetectSourceFiles(
+            workspace,
+            inventory,
+            languageLabel,
+            warnings,
+            out var skippedEnumerations,
+            out var usedDirectFallback,
+            extensions);
+        return (found, skippedEnumerations, usedDirectFallback, warnings);
     }
 
     internal static IReadOnlyList<string> BuildPowerShellRunnerArgsForTests(

--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.cs
@@ -271,12 +271,14 @@ internal static partial class AnalyzeRunCommand {
             warnings.Add("All JavaScript/TypeScript rules are disabled by policy severity; skipping ESLint analysis.");
             return new RunnerResult(true, string.Empty);
         }
-        var skippedSourceEnumerations = 0;
-        var hasJavaScriptSources = sourceInventory is null
-            ? WorkspaceContainsAnySourceFile(workspace, out skippedSourceEnumerations,
-                SourceLanguageConventions.JavaScriptSourceExtensions)
-            : WorkspaceContainsAnySourceFile(sourceInventory, out skippedSourceEnumerations,
-                SourceLanguageConventions.JavaScriptSourceExtensions);
+        var hasJavaScriptSources = TryDetectSourceFiles(
+            workspace,
+            sourceInventory,
+            "JavaScript/TypeScript",
+            warnings,
+            out var skippedSourceEnumerations,
+            out _,
+            SourceLanguageConventions.JavaScriptSourceExtensions);
         if (!hasJavaScriptSources) {
             if (skippedSourceEnumerations > 0) {
                 warnings.Add($"JavaScript/TypeScript source discovery skipped {skippedSourceEnumerations} path(s) due to access or IO errors.");
@@ -322,12 +324,14 @@ internal static partial class AnalyzeRunCommand {
             warnings.Add("All Python rules are disabled by policy severity; skipping Ruff analysis.");
             return new RunnerResult(true, string.Empty);
         }
-        var skippedSourceEnumerations = 0;
-        var hasPythonSources = sourceInventory is null
-            ? WorkspaceContainsAnySourceFile(workspace, out skippedSourceEnumerations,
-                SourceLanguageConventions.PythonSourceExtensions)
-            : WorkspaceContainsAnySourceFile(sourceInventory, out skippedSourceEnumerations,
-                SourceLanguageConventions.PythonSourceExtensions);
+        var hasPythonSources = TryDetectSourceFiles(
+            workspace,
+            sourceInventory,
+            "Python",
+            warnings,
+            out var skippedSourceEnumerations,
+            out _,
+            SourceLanguageConventions.PythonSourceExtensions);
         if (!hasPythonSources) {
             if (skippedSourceEnumerations > 0) {
                 warnings.Add($"Python source discovery skipped {skippedSourceEnumerations} path(s) due to access or IO errors.");
@@ -373,6 +377,31 @@ internal static partial class AnalyzeRunCommand {
 
         Console.WriteLine($"Ruff SARIF: {sarifPath}");
         return new RunnerResult(true, string.Empty);
+    }
+
+    private static bool TryDetectSourceFiles(
+        string workspace,
+        WorkspaceSourceInventory? sourceInventory,
+        string languageLabel,
+        List<string> warnings,
+        out int skippedSourceEnumerations,
+        out bool usedDirectFallback,
+        params string[] extensions) {
+        usedDirectFallback = false;
+        var scanLimitReached = false;
+        var found = sourceInventory is null
+            ? WorkspaceContainsAnySourceFile(workspace, out skippedSourceEnumerations, extensions)
+            : WorkspaceContainsAnySourceFile(sourceInventory, out skippedSourceEnumerations, out scanLimitReached, extensions);
+
+        if (!found && sourceInventory is not null && scanLimitReached) {
+            usedDirectFallback = true;
+            warnings.Add(
+                $"Shared source inventory reached the configured file limit ({sourceInventory.MaxScannedFiles}); falling back to direct {languageLabel} source detection.");
+            found = WorkspaceContainsAnySourceFileWithoutScanLimit(workspace, out var directSkipped, extensions);
+            skippedSourceEnumerations += directSkipped;
+        }
+
+        return found;
     }
 
     private static List<string> BuildJavaScriptRunnerArgs(string sarifPath, IReadOnlyList<ExternalToolRuleSelector> selectors) {

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
@@ -240,6 +240,46 @@ internal static partial class Program {
         }
     }
 
+    private static void TestAnalyzeRunExternalFailureMessageConfiguredMarkersRefreshOnEnvironmentChange() {
+        const string globalEnv = "INTELLIGENCEX_ANALYSIS_COMMAND_UNAVAILABLE_MARKERS";
+        var previousGlobal = Environment.GetEnvironmentVariable(globalEnv);
+        try {
+            Environment.SetEnvironmentVariable(globalEnv, "missing-marker-one");
+            var firstMessage = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.BuildExternalRunnerFailureMessageForTests(
+                languageLabel: "Python",
+                command: "ruff",
+                optionName: "--ruff-command",
+                exitCode: 2,
+                stdOut: string.Empty,
+                stdErr: "missing-marker-one");
+            AssertContainsText(firstMessage, "analysis command 'ruff' is unavailable",
+                "external runner configured markers classify first env marker");
+
+            Environment.SetEnvironmentVariable(globalEnv, "missing-marker-two");
+            var staleMarkerMessage = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.BuildExternalRunnerFailureMessageForTests(
+                languageLabel: "Python",
+                command: "ruff",
+                optionName: "--ruff-command",
+                exitCode: 2,
+                stdOut: string.Empty,
+                stdErr: "missing-marker-one");
+            AssertContainsText(staleMarkerMessage, "analysis returned exit code 2",
+                "external runner marker cache refresh drops stale env marker");
+
+            var updatedMarkerMessage = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.BuildExternalRunnerFailureMessageForTests(
+                languageLabel: "Python",
+                command: "ruff",
+                optionName: "--ruff-command",
+                exitCode: 2,
+                stdOut: string.Empty,
+                stdErr: "missing-marker-two");
+            AssertContainsText(updatedMarkerMessage, "analysis command 'ruff' is unavailable",
+                "external runner marker cache refresh picks up updated env marker");
+        } finally {
+            Environment.SetEnvironmentVariable(globalEnv, previousGlobal);
+        }
+    }
+
     private static void TestAnalyzeRunWorkspaceSourceDetectionSkipsExcludedDirectories() {
         var workspace = Path.Combine(Path.GetTempPath(), "ix-source-detect-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(workspace);
@@ -378,6 +418,40 @@ internal static partial class Program {
             AssertEqual(true, hasTypeScript, "source inventory retains tracked extension");
             AssertEqual(false, hasRandomExtension, "source inventory ignores untracked extensions");
         } finally {
+            try {
+                Directory.Delete(workspace, recursive: true);
+            } catch {
+                // Best-effort cleanup for temp harness directories.
+            }
+        }
+    }
+
+    private static void TestAnalyzeRunSharedSourceInventoryFallsBackWhenScanLimitReached() {
+        const string maxFilesEnv = "INTELLIGENCEX_ANALYSIS_SOURCE_SCAN_MAX_FILES";
+        var previousValue = Environment.GetEnvironmentVariable(maxFilesEnv);
+        var workspace = Path.Combine(Path.GetTempPath(), "ix-source-inventory-fallback-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspace);
+        try {
+            Environment.SetEnvironmentVariable(maxFilesEnv, "0");
+            var src = Path.Combine(workspace, "src");
+            Directory.CreateDirectory(src);
+            File.WriteAllText(Path.Combine(src, "main.ts"), "export const answer = 42;");
+
+            var inventory = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.DiscoverWorkspaceSourceInventoryForTests(workspace);
+            AssertEqual(true, inventory.ScanLimitReached, "source inventory reports scan-limit reached when max files is zero");
+            AssertEqual(0, inventory.MaxScannedFiles, "source inventory reports configured max files");
+
+            var fallbackResult = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.TryDetectSourceFilesWithSharedInventoryForTests(
+                workspace,
+                "JavaScript/TypeScript",
+                ".ts");
+            AssertEqual(true, fallbackResult.Found, "shared source inventory fallback finds source files when scan limit is reached");
+            AssertEqual(true, fallbackResult.UsedDirectFallback, "shared source inventory uses direct fallback when scan limit is reached");
+            AssertContainsText(string.Join("\n", fallbackResult.Warnings),
+                "Shared source inventory reached the configured file limit (0); falling back to direct JavaScript/TypeScript source detection.",
+                "shared source inventory fallback emits scan-limit warning");
+        } finally {
+            Environment.SetEnvironmentVariable(maxFilesEnv, previousValue);
             try {
                 Directory.Delete(workspace, recursive: true);
             } catch {

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -404,6 +404,8 @@ internal static partial class Program {
             TestAnalyzeRunExternalFailureMessageRecognizesToolSpecificUnavailableMarkers);
         failed += Run("Analyze run external runner supports configured unavailable markers",
             TestAnalyzeRunExternalFailureMessageSupportsConfiguredUnavailableMarkers);
+        failed += Run("Analyze run external runner configured markers refresh on environment change",
+            TestAnalyzeRunExternalFailureMessageConfiguredMarkersRefreshOnEnvironmentChange);
         failed += Run("Analyze run workspace source detection skips excluded directories",
             TestAnalyzeRunWorkspaceSourceDetectionSkipsExcludedDirectories);
         failed += Run("Analyze run workspace source detection diagnostics default to zero skipped",
@@ -414,6 +416,8 @@ internal static partial class Program {
             TestAnalyzeRunWorkspaceSourceInventoryCapturesMultipleExtensions);
         failed += Run("Analyze run workspace source inventory keeps tracked extensions only",
             TestAnalyzeRunWorkspaceSourceInventoryKeepsTrackedExtensionsOnly);
+        failed += Run("Analyze run shared source inventory falls back when scan limit reached",
+            TestAnalyzeRunSharedSourceInventoryFallsBackWhenScanLimitReached);
         failed += Run("Analyze run javascript selectors ignore mismatched tools",
             TestAnalyzeRunJavaScriptSelectorsIgnoreMismatchedTools);
         failed += Run("Analyze run python selected rule ids ignore mismatched tools",

--- a/InternalDocs/cli-commands/analyze.md
+++ b/InternalDocs/cli-commands/analyze.md
@@ -85,6 +85,7 @@ Gate behavior is configured by `analysis.gate` in `.intelligencex/reviewer.json`
 - `types`: optional type filter (for example `vulnerability`, `bug`).
 - `ruleIds`: optional explicit rule-ID filter (for example `IXTOOL001`). When both `types` and `ruleIds` are set, a finding is in-scope if it matches either filter.
 - `includeOutsidePackRules`: when true, findings outside enabled packs can fail the gate. Explicit `ruleIds` remain eligible even when this flag is false.
+  Gate output `Outside-pack findings` included/ignored counts are post-filter scoped (after `types`/`ruleIds` filtering).
 - `failOnHotspotsToReview`: when true, security hotspots in `to-review` state can fail the gate.
 - `newIssuesOnly` + `baselinePath`: baseline-aware finding gate mode.
 - `duplication.enabled`: enables duplication gate checks from `artifacts/intelligencex.duplication.json`.


### PR DESCRIPTION
## Summary
- cache configured command-unavailable marker parsing from environment to avoid reparsing/splitting on every external-runner classification call
- add shared source-inventory scan guardrails with configurable cap via `INTELLIGENCEX_ANALYSIS_SOURCE_SCAN_MAX_FILES` (default `200000`)
- add safe fallback behavior: when shared inventory hits cap and misses a language, run an unbounded direct language scan for correctness
- add tests for environment-marker cache refresh behavior and shared-inventory fallback semantics
- clarify gate docs that outside-pack included/ignored summary counts are post-filter scoped

## Validation
- `dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- analyze validate-catalog --workspace .`
- `dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj -c Release`
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.ps1 -Mode fast`
