### PR TITLE
analysis: add js/python tiers and source-aware runner diagnostics

### DIFF
--- a/Analysis/Packs/README.md
+++ b/Analysis/Packs/README.md
@@ -26,9 +26,12 @@ Packs are curated rule sets built from rule IDs and optional includes/overrides.
 - Language tiers:
   - `csharp-50`, `csharp-100`, `csharp-500`
   - `powershell-50`, `powershell-100`, `powershell-500`
+  - `javascript-50`, `javascript-100`, `javascript-500`
+  - `python-50`, `python-100`, `python-500`
   - `intelligencex-maintainability-50`, `intelligencex-maintainability-100`, `intelligencex-maintainability-500`
 - Cross-language tiers:
   - `all-50`, `all-100`, `all-500`
+  - Note: `all-*` currently targets core tiers (`csharp-*`, `powershell-*`, `intelligencex-maintainability-*`); add `javascript-*` / `python-*` explicitly when desired.
 - Compatibility alias:
   - `all-default` (currently includes `all-50`)
 
@@ -48,6 +51,8 @@ For C#, tiers are generated from built-in NetAnalyzers metadata:
 Regenerate C# catalog + C# tiers with:
 
 `./scripts/update_analysis_catalog.py --repo-root .`
+
+For JavaScript and Python, current `*-50|100|500` tiers are intentionally stable aliases that expand as catalog coverage grows.
 
 ## JavaScript/Python catalog
 

--- a/Analysis/Packs/all-100.json
+++ b/Analysis/Packs/all-100.json
@@ -1,7 +1,7 @@
 {
   "id": "all-100",
   "label": "All Standard (100)",
-  "description": "Cross-language standard pack. Includes each language standard tier.",
+  "description": "Cross-language standard pack. Includes core standard tiers (C#, PowerShell, internal maintainability).",
   "includes": [
     "csharp-100",
     "powershell-100",

--- a/Analysis/Packs/all-50.json
+++ b/Analysis/Packs/all-50.json
@@ -1,7 +1,7 @@
 {
   "id": "all-50",
   "label": "All Essentials (50)",
-  "description": "Cross-language baseline pack. Includes each language essentials tier.",
+  "description": "Cross-language baseline pack. Includes core essentials tiers (C#, PowerShell, internal maintainability).",
   "includes": [
     "csharp-50",
     "powershell-50",

--- a/Analysis/Packs/all-500.json
+++ b/Analysis/Packs/all-500.json
@@ -1,7 +1,7 @@
 {
   "id": "all-500",
   "label": "All Strict (500)",
-  "description": "Cross-language strict pack. Includes each language strict tier.",
+  "description": "Cross-language strict pack. Includes core strict tiers (C#, PowerShell, internal maintainability).",
   "includes": [
     "csharp-500",
     "powershell-500",

--- a/Analysis/Packs/javascript-100.json
+++ b/Analysis/Packs/javascript-100.json
@@ -1,0 +1,10 @@
+{
+  "id": "javascript-100",
+  "label": "JavaScript Standard (100)",
+  "description": "JavaScript/TypeScript standard tier. Builds on javascript-50 while preserving stable IDs.",
+  "includes": [
+    "javascript-50"
+  ],
+  "rules": []
+}
+

--- a/Analysis/Packs/javascript-50.json
+++ b/Analysis/Packs/javascript-50.json
@@ -1,0 +1,10 @@
+{
+  "id": "javascript-50",
+  "label": "JavaScript Essentials (50)",
+  "description": "JavaScript/TypeScript essentials tier. Includes javascript-default and expands as the catalog grows.",
+  "includes": [
+    "javascript-default"
+  ],
+  "rules": []
+}
+

--- a/Analysis/Packs/javascript-500.json
+++ b/Analysis/Packs/javascript-500.json
@@ -1,0 +1,10 @@
+{
+  "id": "javascript-500",
+  "label": "JavaScript Strict (500)",
+  "description": "JavaScript/TypeScript strict tier. Builds on javascript-100 and expands as catalog coverage increases.",
+  "includes": [
+    "javascript-100"
+  ],
+  "rules": []
+}
+

--- a/Analysis/Packs/python-100.json
+++ b/Analysis/Packs/python-100.json
@@ -1,0 +1,10 @@
+{
+  "id": "python-100",
+  "label": "Python Standard (100)",
+  "description": "Python standard tier. Builds on python-50 while preserving stable IDs.",
+  "includes": [
+    "python-50"
+  ],
+  "rules": []
+}
+

--- a/Analysis/Packs/python-50.json
+++ b/Analysis/Packs/python-50.json
@@ -1,0 +1,10 @@
+{
+  "id": "python-50",
+  "label": "Python Essentials (50)",
+  "description": "Python essentials tier. Includes python-default and expands as the catalog grows.",
+  "includes": [
+    "python-default"
+  ],
+  "rules": []
+}
+

--- a/Analysis/Packs/python-500.json
+++ b/Analysis/Packs/python-500.json
@@ -1,0 +1,10 @@
+{
+  "id": "python-500",
+  "label": "Python Strict (500)",
+  "description": "Python strict tier. Builds on python-100 and expands as catalog coverage increases.",
+  "includes": [
+    "python-100"
+  ],
+  "rules": []
+}
+

--- a/Docs/reviewer/static-analysis.md
+++ b/Docs/reviewer/static-analysis.md
@@ -124,6 +124,12 @@ Pack layout:
 - `Analysis/Packs/powershell-50.json`
 - `Analysis/Packs/powershell-100.json`
 - `Analysis/Packs/powershell-500.json`
+- `Analysis/Packs/javascript-50.json`
+- `Analysis/Packs/javascript-100.json`
+- `Analysis/Packs/javascript-500.json`
+- `Analysis/Packs/python-50.json`
+- `Analysis/Packs/python-100.json`
+- `Analysis/Packs/python-500.json`
 - `Analysis/Packs/intelligencex-maintainability-50.json`
 - `Analysis/Packs/intelligencex-maintainability-100.json`
 - `Analysis/Packs/intelligencex-maintainability-500.json`
@@ -158,6 +164,7 @@ Recommended tier selection:
 - `all-50`: baseline/default onboarding tier.
 - `all-100`: broader coverage with higher review noise.
 - `all-500`: strict tier for mature repositories and dedicated cleanup cycles.
+- For JavaScript/TypeScript and Python coverage, add `javascript-50|100|500` and/or `python-50|100|500` explicitly to `analysis.packs`.
 
 The built-in catalog now contains hundreds of C# rules plus PowerShell, JavaScript, Python, and internal rules, and
 tier IDs remain stable for policy compatibility as coverage evolves.
@@ -184,6 +191,7 @@ Current built-in runners in `analyze run`:
 - JS/TS: ESLint via `npx` when JavaScript/TypeScript rules are selected (SARIF output).
   - ESLint severity mapping is normalized to ESLint's 3-level model: `critical|error|high -> error`, `warning|warn|medium|info|information|low|suggestion -> warn`, `none -> off`.
 - Python: Ruff via `ruff` when Python rules are selected (SARIF output).
+- External runners are source-aware: if a language has no matching source files in the workspace, that runner is skipped with a warning.
 - Internal: IntelligenceX maintainability checks (for example `IXLOC001`).
   - `IXLOC001` reads `max-lines:<n>` rule tags (default `700`) and supports configurable generated suffix tags (`generated-suffix:<value>`), generated header marker tags (`generated-marker:<value>`), optional generated header scan depth tags (`generated-header-lines:<n>`, `0` disables header scanning), and additional excluded directory segments (`exclude-dir:<segment>`).
   - `IXDUP001` measures per-file duplicated significant-line percentage and supports `max-duplication-percent:<0-100>` (default `25`), `dup-window-lines:<n>` (default `8`), and optional language-specific thresholds `max-duplication-percent-<language>:<0-100>` (`language`: `csharp|powershell|javascript|typescript|python` plus short aliases `cs|ps|js|ts|py`).

--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.cs
@@ -12,7 +12,23 @@ namespace IntelligenceX.Cli.Analysis;
 
 internal static partial class AnalyzeRunCommand {
     private static async Task<RunnerResult> RunCsharpAsync(AnalyzeRunOptions options, string workspace, string outputDirectory,
-        AnalysisSettings settings, string? generatedEditorConfig, List<string> warnings) {
+        WorkspaceSourceInventory? sourceInventory, AnalysisSettings settings, string? generatedEditorConfig, List<string> warnings) {
+        var hasCsharpSources = TryDetectSourceFiles(
+            workspace,
+            sourceInventory,
+            "C#",
+            warnings,
+            out var skippedSourceEnumerations,
+            out _,
+            SourceLanguageConventions.CSharpSourceExtensions);
+        if (!hasCsharpSources) {
+            if (skippedSourceEnumerations > 0) {
+                warnings.Add($"C# source discovery skipped {skippedSourceEnumerations} path(s) due to access or IO errors.");
+            }
+            warnings.Add("No C# source files detected; skipping Roslyn analysis.");
+            return new RunnerResult(true, string.Empty);
+        }
+
         var sarifPath = Path.Combine(outputDirectory, "intelligencex.roslyn.sarif");
         using var overrideScope = PrepareEditorConfigOverride(settings, workspace, generatedEditorConfig, warnings);
 
@@ -221,9 +237,17 @@ internal static partial class AnalyzeRunCommand {
     }
 
     private static async Task<PowerShellRunnerResult> RunPowerShellAsync(AnalyzeRunOptions options, string workspace,
-        string findingsPath, AnalysisSettings settings, string? generatedSettingsPath, List<string> warnings) {
-        if (!WorkspaceContainsAnySourceFile(workspace, out var skippedSourceEnumerations,
-                SourceLanguageConventions.PowerShellSourceExtensions)) {
+        string findingsPath, WorkspaceSourceInventory? sourceInventory, AnalysisSettings settings, string? generatedSettingsPath,
+        List<string> warnings) {
+        var hasPowerShellSources = TryDetectSourceFiles(
+            workspace,
+            sourceInventory,
+            "PowerShell",
+            warnings,
+            out var skippedSourceEnumerations,
+            out _,
+            SourceLanguageConventions.PowerShellSourceExtensions);
+        if (!hasPowerShellSources) {
             if (skippedSourceEnumerations > 0) {
                 warnings.Add($"PowerShell source discovery skipped {skippedSourceEnumerations} path(s) due to access or IO errors.");
             }

--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.cs
@@ -106,14 +106,27 @@ internal static partial class AnalyzeRunCommand {
         var javascriptRules = policy.SelectByLanguage("javascript", "js", "typescript", "ts");
         var pythonRules = policy.SelectByLanguage("python", "py");
         var internalRules = policy.SelectByLanguage("internal");
+        var externalLanguageRuleSelected = csharpRules.Count > 0 ||
+                                           powershellRules.Count > 0 ||
+                                           javascriptRules.Count > 0 ||
+                                           pythonRules.Count > 0;
         WorkspaceSourceInventory? sourceInventory = null;
-        if (javascriptRules.Count > 0 && pythonRules.Count > 0) {
+        if (externalLanguageRuleSelected) {
             sourceInventory = DiscoverWorkspaceSourceInventory(workspace);
         }
         var runWarnings = new List<string>();
         var runFailures = new List<string>();
         var findings = new List<AnalysisFindingItem>();
         var duplicationRuleMetrics = new List<DuplicationRuleMetrics>();
+        if (sourceInventory is not null && sourceInventory.SkippedEnumerations > 0) {
+            runWarnings.Add(
+                $"Shared source inventory skipped {sourceInventory.SkippedEnumerations} path(s) due to access or IO errors.");
+        }
+        if (sourceInventory is not null && sourceInventory.ScanLimitReached) {
+            runWarnings.Add(
+                $"Shared source inventory reached the configured file limit ({sourceInventory.MaxScannedFiles}); " +
+                "direct per-language fallback detection will run when needed.");
+        }
 
         var tempConfigDirectory = Path.Combine(Path.GetTempPath(), "ix-analysis-run-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempConfigDirectory);
@@ -129,7 +142,7 @@ internal static partial class AnalyzeRunCommand {
                 Path.GetFileName(file).Equals("PSScriptAnalyzerSettings.psd1", StringComparison.OrdinalIgnoreCase));
 
             if (csharpRules.Count > 0) {
-                var csharpResult = await RunCsharpAsync(options, workspace, outputDirectory, settings,
+                var csharpResult = await RunCsharpAsync(options, workspace, outputDirectory, sourceInventory, settings,
                     generatedEditorConfig, runWarnings).ConfigureAwait(false);
                 if (!csharpResult.Success) {
                     runFailures.Add(csharpResult.Message);
@@ -137,7 +150,7 @@ internal static partial class AnalyzeRunCommand {
             }
 
             if (powershellRules.Count > 0) {
-                var psResult = await RunPowerShellAsync(options, workspace, findingsPath, settings,
+                var psResult = await RunPowerShellAsync(options, workspace, findingsPath, sourceInventory, settings,
                     generatedPowerShellSettings, runWarnings).ConfigureAwait(false);
                 if (!psResult.Success) {
                     runFailures.Add(psResult.Message);
@@ -394,7 +407,7 @@ internal static partial class AnalyzeRunCommand {
                 continue;
             }
             if (!PackIdRegex.IsMatch(value)) {
-                error = $"Invalid pack id '{value}'. Use comma-separated ids like all-50, all-security-default, powershell-50.";
+                error = $"Invalid pack id '{value}'. Use comma-separated ids like all-50, all-security-default, powershell-50, javascript-50, python-50.";
                 return false;
             }
             if (!packs.Contains(value, StringComparer.OrdinalIgnoreCase)) {

--- a/IntelligenceX.Cli/Setup/SetupAnalysisPacks.cs
+++ b/IntelligenceX.Cli/Setup/SetupAnalysisPacks.cs
@@ -35,7 +35,7 @@ internal static class SetupAnalysisPacks {
                 continue;
             }
             if (!PackIdRegex.IsMatch(part)) {
-                error = $"Invalid pack id '{part}'. Use comma-separated ids like all-50, all-security-default, powershell-50.";
+                error = $"Invalid pack id '{part}'. Use comma-separated ids like all-50, all-security-default, powershell-50, javascript-50, python-50.";
                 return false;
             }
             if (seen.Add(part)) {
@@ -61,4 +61,3 @@ internal static class SetupAnalysisPacks {
         return true;
     }
 }
-

--- a/IntelligenceX.Cli/Setup/Web/Assets/index.html
+++ b/IntelligenceX.Cli/Setup/Web/Assets/index.html
@@ -347,7 +347,7 @@
             </div>
             <label>Analysis pack ids (comma-separated)</label>
             <input id="analysisPacks" placeholder="(default: all-50)" />
-            <p class="hint" id="analysisHint">Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50. Browse packs: `intelligencex analyze list-rules --workspace &lt;repo-root&gt; --format markdown`. Gate semantics/docs: Docs/reviewer/static-analysis.md</p>
+            <p class="hint" id="analysisHint">Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50, javascript-50, python-50. Browse packs: `intelligencex analyze list-rules --workspace &lt;repo-root&gt; --format markdown`. Gate semantics/docs: Docs/reviewer/static-analysis.md</p>
             <label>Analyzer export path for IDE support (optional)</label>
             <input id="analysisExportPath" placeholder=".intelligencex/analyzers" />
             <p class="hint">Explicit opt-in only. When set, setup PR also exports analyzer configs into this repo path.</p>

--- a/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
+++ b/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
@@ -1779,7 +1779,7 @@ function updateAnalysisControls() {
   const hint = $('analysisHint');
   if (hint) {
     hint.textContent = applicable
-      ? 'Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50. Browse packs: intelligencex analyze list-rules --workspace <repo-root> --format markdown. Gate semantics/docs: Docs/reviewer/static-analysis.md'
+      ? 'Leave empty to use defaults. Examples: all-50, all-100, all-500, all-security-default, powershell-50, javascript-50, python-50. Browse packs: intelligencex analyze list-rules --workspace <repo-root> --format markdown. Gate semantics/docs: Docs/reviewer/static-analysis.md'
       : 'Static analysis settings apply only when generating config from presets (no Config JSON/path override).';
   }
 }

--- a/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/WizardPrompts.cs
@@ -284,6 +284,8 @@ internal static class WizardPrompts {
                 "none (disable static analysis)",
                 "all-security-default",
                 "powershell-50",
+                "javascript-50",
+                "python-50",
                 "list available packs",
                 "custom (enter pack ids)"
             };

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisAndPatch.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisAndPatch.cs
@@ -131,6 +131,11 @@ internal static partial class Program {
         AssertEqual(0, exit, "analyze run pack override skips configured csharp runner failure");
     }
 
+    private static void TestAnalyzeRunStrictSkipsCsharpRunnerWithoutCsharpSources() {
+        var exit = RunAnalyzeRunWithMissingDotnet(strict: true, includeCsharpSource: false);
+        AssertEqual(0, exit, "analyze run strict skips csharp runner when no csharp sources are present");
+    }
+
     private static void TestAnalyzeRunInvalidPackOverrideFails() {
         var exit = RunAnalyzeRunWithMissingDotnet(strict: false, packsOverride: "all-50,--force");
         AssertEqual(1, exit, "analyze run invalid pack override fails");
@@ -144,7 +149,8 @@ internal static partial class Program {
         bool strictBeforePacks = false,
         string? strictOverrideRawValue = null,
         bool strictBeforeFramework = false,
-        string? frameworkOverride = null) {
+        string? frameworkOverride = null,
+        bool includeCsharpSource = true) {
         var temp = Path.Combine(Path.GetTempPath(), "ix-analyze-run-strict-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(temp);
         try {
@@ -210,6 +216,11 @@ internal static partial class Program {
   "rules": ["IXINT001"]
 }
 """);
+            if (includeCsharpSource) {
+                var src = Path.Combine(temp, "src");
+                Directory.CreateDirectory(src);
+                File.WriteAllText(Path.Combine(src, "Program.cs"), "public static class Program { public static void Main() { } }");
+            }
 
             var output = Path.Combine(temp, "artifacts");
             var args = new List<string> {

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisPacks.BuiltIn.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisPacks.BuiltIn.cs
@@ -83,6 +83,58 @@ internal static partial class Program {
         }
     }
 
+    private static void TestAnalysisPacksExternalLanguageTiersResolve() {
+        var workspace = ResolveWorkspaceRoot();
+        var catalog = IntelligenceX.Analysis.AnalysisCatalogLoader.LoadFromWorkspace(workspace);
+
+        AssertEqual(true, catalog.Packs.ContainsKey("javascript-50"), "pack javascript-50 exists");
+        AssertEqual(true, catalog.Packs.ContainsKey("javascript-100"), "pack javascript-100 exists");
+        AssertEqual(true, catalog.Packs.ContainsKey("javascript-500"), "pack javascript-500 exists");
+        AssertEqual(true, catalog.Packs.ContainsKey("python-50"), "pack python-50 exists");
+        AssertEqual(true, catalog.Packs.ContainsKey("python-100"), "pack python-100 exists");
+        AssertEqual(true, catalog.Packs.ContainsKey("python-500"), "pack python-500 exists");
+
+        var jsDefaultPolicy = IntelligenceX.Analysis.AnalysisPolicyBuilder.Build(
+            new IntelligenceX.Analysis.AnalysisSettings { Packs = new[] { "javascript-default" } },
+            catalog);
+        var js50Policy = IntelligenceX.Analysis.AnalysisPolicyBuilder.Build(
+            new IntelligenceX.Analysis.AnalysisSettings { Packs = new[] { "javascript-50" } },
+            catalog);
+        AssertEqual(true, js50Policy.Rules.Count >= jsDefaultPolicy.Rules.Count,
+            "javascript-50 resolves at least javascript-default coverage");
+
+        var pyDefaultPolicy = IntelligenceX.Analysis.AnalysisPolicyBuilder.Build(
+            new IntelligenceX.Analysis.AnalysisSettings { Packs = new[] { "python-default" } },
+            catalog);
+        var py50Policy = IntelligenceX.Analysis.AnalysisPolicyBuilder.Build(
+            new IntelligenceX.Analysis.AnalysisSettings { Packs = new[] { "python-50" } },
+            catalog);
+        AssertEqual(true, py50Policy.Rules.Count >= pyDefaultPolicy.Rules.Count,
+            "python-50 resolves at least python-default coverage");
+
+        var js100Policy = IntelligenceX.Analysis.AnalysisPolicyBuilder.Build(
+            new IntelligenceX.Analysis.AnalysisSettings { Packs = new[] { "javascript-100" } },
+            catalog);
+        var js500Policy = IntelligenceX.Analysis.AnalysisPolicyBuilder.Build(
+            new IntelligenceX.Analysis.AnalysisSettings { Packs = new[] { "javascript-500" } },
+            catalog);
+        AssertEqual(true, js100Policy.Rules.Count >= js50Policy.Rules.Count,
+            "javascript-100 expands javascript-50");
+        AssertEqual(true, js500Policy.Rules.Count >= js100Policy.Rules.Count,
+            "javascript-500 expands javascript-100");
+
+        var py100Policy = IntelligenceX.Analysis.AnalysisPolicyBuilder.Build(
+            new IntelligenceX.Analysis.AnalysisSettings { Packs = new[] { "python-100" } },
+            catalog);
+        var py500Policy = IntelligenceX.Analysis.AnalysisPolicyBuilder.Build(
+            new IntelligenceX.Analysis.AnalysisSettings { Packs = new[] { "python-500" } },
+            catalog);
+        AssertEqual(true, py100Policy.Rules.Count >= py50Policy.Rules.Count,
+            "python-100 expands python-50");
+        AssertEqual(true, py500Policy.Rules.Count >= py100Policy.Rules.Count,
+            "python-500 expands python-100");
+    }
+
     private static void TestAnalysisPacksPowerShell50ResolvesTo50Rules() {
         var workspace = ResolveWorkspaceRoot();
         var catalog = IntelligenceX.Analysis.AnalysisCatalogLoader.LoadFromWorkspace(workspace);

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
@@ -460,6 +460,68 @@ internal static partial class Program {
         }
     }
 
+    private static void TestAnalyzeRunSharedSourceInventoryFallbackDetectsPowerShellSources() {
+        const string maxFilesEnv = "INTELLIGENCEX_ANALYSIS_SOURCE_SCAN_MAX_FILES";
+        var previousValue = Environment.GetEnvironmentVariable(maxFilesEnv);
+        var workspace = Path.Combine(Path.GetTempPath(), "ix-source-inventory-fallback-ps-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspace);
+        try {
+            Environment.SetEnvironmentVariable(maxFilesEnv, "0");
+            var scripts = Path.Combine(workspace, "scripts");
+            Directory.CreateDirectory(scripts);
+            File.WriteAllText(Path.Combine(scripts, "tool.ps1"), "Write-Host 'ok'");
+
+            var fallbackResult = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.TryDetectSourceFilesWithSharedInventoryForTests(
+                workspace,
+                "PowerShell",
+                ".ps1",
+                ".psm1",
+                ".psd1");
+            AssertEqual(true, fallbackResult.Found, "shared source inventory fallback finds PowerShell sources when scan limit is reached");
+            AssertEqual(true, fallbackResult.UsedDirectFallback, "shared source inventory fallback uses direct detection for PowerShell");
+            AssertContainsText(string.Join("\n", fallbackResult.Warnings),
+                "Shared source inventory reached the configured file limit (0); falling back to direct PowerShell source detection.",
+                "shared source inventory fallback emits PowerShell scan-limit warning");
+        } finally {
+            Environment.SetEnvironmentVariable(maxFilesEnv, previousValue);
+            try {
+                Directory.Delete(workspace, recursive: true);
+            } catch {
+                // Best-effort cleanup for temp harness directories.
+            }
+        }
+    }
+
+    private static void TestAnalyzeRunSharedSourceInventoryFallbackDetectsCsharpSources() {
+        const string maxFilesEnv = "INTELLIGENCEX_ANALYSIS_SOURCE_SCAN_MAX_FILES";
+        var previousValue = Environment.GetEnvironmentVariable(maxFilesEnv);
+        var workspace = Path.Combine(Path.GetTempPath(), "ix-source-inventory-fallback-cs-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspace);
+        try {
+            Environment.SetEnvironmentVariable(maxFilesEnv, "0");
+            var src = Path.Combine(workspace, "src");
+            Directory.CreateDirectory(src);
+            File.WriteAllText(Path.Combine(src, "Program.cs"), "public static class Program { }");
+
+            var fallbackResult = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.TryDetectSourceFilesWithSharedInventoryForTests(
+                workspace,
+                "C#",
+                ".cs");
+            AssertEqual(true, fallbackResult.Found, "shared source inventory fallback finds csharp sources when scan limit is reached");
+            AssertEqual(true, fallbackResult.UsedDirectFallback, "shared source inventory fallback uses direct detection for csharp");
+            AssertContainsText(string.Join("\n", fallbackResult.Warnings),
+                "Shared source inventory reached the configured file limit (0); falling back to direct C# source detection.",
+                "shared source inventory fallback emits csharp scan-limit warning");
+        } finally {
+            Environment.SetEnvironmentVariable(maxFilesEnv, previousValue);
+            try {
+                Directory.Delete(workspace, recursive: true);
+            } catch {
+                // Best-effort cleanup for temp harness directories.
+            }
+        }
+    }
+
     private static void TestAnalyzeRunJavaScriptSelectorsIgnoreMismatchedTools() {
         var rules = new[] {
             new IntelligenceX.Analysis.AnalysisPolicyRule(

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -78,6 +78,7 @@ internal static partial class Program {
         failed += Run("Analysis packs: all-security includes language security packs", TestAnalysisPacksAllSecurityIncludesPowerShell);
         failed += Run("Analysis packs: powershell-default resolves", TestAnalysisPacksPowerShellDefaultResolves);
         failed += Run("Analysis packs: external defaults resolve", TestAnalysisPacksExternalDefaultsResolve);
+        failed += Run("Analysis packs: external language tiers resolve", TestAnalysisPacksExternalLanguageTiersResolve);
         failed += Run("Analysis packs: powershell-50 resolves to 50 rules", TestAnalysisPacksPowerShell50ResolvesTo50Rules);
         failed += Run("Analysis catalog rule overrides apply", TestAnalysisCatalogRuleOverridesApply);
         failed += Run("Analysis catalog PowerShell overrides apply", () => TestAnalysisCatalogPowerShellOverridesApply());
@@ -418,6 +419,10 @@ internal static partial class Program {
             TestAnalyzeRunWorkspaceSourceInventoryKeepsTrackedExtensionsOnly);
         failed += Run("Analyze run shared source inventory falls back when scan limit reached",
             TestAnalyzeRunSharedSourceInventoryFallsBackWhenScanLimitReached);
+        failed += Run("Analyze run shared source inventory fallback detects powershell sources",
+            TestAnalyzeRunSharedSourceInventoryFallbackDetectsPowerShellSources);
+        failed += Run("Analyze run shared source inventory fallback detects csharp sources",
+            TestAnalyzeRunSharedSourceInventoryFallbackDetectsCsharpSources);
         failed += Run("Analyze run javascript selectors ignore mismatched tools",
             TestAnalyzeRunJavaScriptSelectorsIgnoreMismatchedTools);
         failed += Run("Analyze run python selected rule ids ignore mismatched tools",
@@ -443,6 +448,8 @@ internal static partial class Program {
             TestAnalyzeRunStrictFlagAllowsKnownOptionLookaheadWithFrameworkValue);
         failed += Run("Analyze run pack override skips configured csharp runner failure",
             TestAnalyzeRunPacksOverrideSkipsConfiguredCsharpFailure);
+        failed += Run("Analyze run strict skips csharp runner without csharp sources",
+            TestAnalyzeRunStrictSkipsCsharpRunnerWithoutCsharpSources);
         failed += Run("Analyze run invalid pack override fails", TestAnalyzeRunInvalidPackOverrideFails);
         failed += Run("Analyze run internal file size rule", TestAnalyzeRunInternalFileSizeRule);
         failed += Run("Analyze run internal findings use catalog tool metadata",


### PR DESCRIPTION
## Summary
- Add opt-in JavaScript and Python tier packs: `javascript-50/100/500` and `python-50/100/500`.
- Keep default `all-50/100/500` behavior stable (core tiers only) while documenting and surfacing JS/Python tier usage in docs/setup hints.
- Improve analyzer execution with source-aware runner behavior:
  - C# runner now skips Roslyn cleanly when no C# sources are present.
  - PowerShell runner now uses shared source inventory/fallback detection path for consistent diagnostics.
  - Shared source inventory is discovered once when any external-language rules are selected, with explicit diagnostics for skipped paths and scan-limit reach.
- Expand tests for:
  - C# no-source strict-mode skip behavior,
  - shared inventory fallback for C# and PowerShell,
  - JS/Python tier pack resolution and monotonic expansion.

## Validation
- `dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj --framework net8.0 -- analyze validate-catalog --workspace .` ✅
- `dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj -c Release` ✅
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release` ✅
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll` ✅
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll` ✅
- `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.ps1 -Mode fast` ✅
- `dotnet test IntelligenceX.sln -c Release` ⚠️ fails in this environment due existing private dependency gaps in unrelated projects (`IntelligenceX.Tools.TestimoX`, `IntelligenceX.Tools.ADPlayground` missing external types), not from this diff.
