### PR TITLE
analysis: narrow process exception handling for runner execution

### DIFF
--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.Infrastructure.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.Infrastructure.cs
@@ -127,8 +127,14 @@ internal static partial class AnalyzeRunCommand {
             return new CommandResult(process.ExitCode, stdOut, stdErr);
         } catch (Win32Exception ex) {
             return new CommandResult(127, string.Empty, ex.Message);
-        } catch (Exception ex) {
+        } catch (Exception ex) when (IsExpectedProcessExecutionException(ex)) {
             return new CommandResult(1, string.Empty, ex.Message);
         }
+    }
+
+    private static bool IsExpectedProcessExecutionException(Exception ex) {
+        return ex is InvalidOperationException or
+            IOException or
+            UnauthorizedAccessException;
     }
 }

--- a/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.TestSeams.cs
+++ b/IntelligenceX.Cli/Analysis/AnalyzeRunCommand.ToolRunners.TestSeams.cs
@@ -104,4 +104,8 @@ internal static partial class AnalyzeRunCommand {
         bool strict) {
         return BuildPowerShellRunnerArgs(tempScript, workspace, findingsPath, settingsPath, strict);
     }
+
+    internal static bool IsExpectedProcessExecutionExceptionForTests(Exception ex) {
+        return IsExpectedProcessExecutionException(ex);
+    }
 }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisToolRunners.cs
@@ -140,6 +140,28 @@ internal static partial class Program {
         AssertEqual(false, otherError, "python output-file fallback detection ignores unrelated errors");
     }
 
+    private static void TestAnalyzeRunProcessExceptionClassificationIncludesExpectedExceptions() {
+        AssertEqual(true,
+            IntelligenceX.Cli.Analysis.AnalyzeRunCommand.IsExpectedProcessExecutionExceptionForTests(
+                new InvalidOperationException("test")),
+            "process exception classifier includes invalid operation");
+        AssertEqual(true,
+            IntelligenceX.Cli.Analysis.AnalyzeRunCommand.IsExpectedProcessExecutionExceptionForTests(
+                new IOException("test")),
+            "process exception classifier includes io exception");
+        AssertEqual(true,
+            IntelligenceX.Cli.Analysis.AnalyzeRunCommand.IsExpectedProcessExecutionExceptionForTests(
+                new UnauthorizedAccessException("test")),
+            "process exception classifier includes unauthorized access");
+    }
+
+    private static void TestAnalyzeRunProcessExceptionClassificationExcludesUnexpectedExceptions() {
+        AssertEqual(false,
+            IntelligenceX.Cli.Analysis.AnalyzeRunCommand.IsExpectedProcessExecutionExceptionForTests(
+                new NullReferenceException("test")),
+            "process exception classifier excludes unexpected exceptions");
+    }
+
     private static void TestAnalyzeRunExternalFailureMessageClassifiesMissingCommand() {
         var unavailableMessage = IntelligenceX.Cli.Analysis.AnalyzeRunCommand.BuildExternalRunnerFailureMessageForTests(
             languageLabel: "Python",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -399,6 +399,10 @@ internal static partial class Program {
             TestAnalyzeRunPythonArgsIncludeOutputFileWhenConfigured);
         failed += Run("Analyze run Python output-file fallback detection",
             TestAnalyzeRunPythonOutputFileFallbackDetection);
+        failed += Run("Analyze run process exception classification includes expected exceptions",
+            TestAnalyzeRunProcessExceptionClassificationIncludesExpectedExceptions);
+        failed += Run("Analyze run process exception classification excludes unexpected exceptions",
+            TestAnalyzeRunProcessExceptionClassificationExcludesUnexpectedExceptions);
         failed += Run("Analyze run external runner missing command message classification",
             TestAnalyzeRunExternalFailureMessageClassifiesMissingCommand);
         failed += Run("Analyze run external runner recognizes tool-specific unavailable markers",


### PR DESCRIPTION
## Summary
- narrow runner process execution exception handling to expected runtime/process exceptions only (`InvalidOperationException`, `IOException`, `UnauthorizedAccessException`) while keeping `Win32Exception` as command-unavailable (`exit 127`)
- avoid swallowing unexpected exceptions in `RunProcessAsync` by using an explicit exception classifier
- expose the classifier through test seams and add harness tests for expected vs unexpected exception classes

## Why
- this reduces risk of masking unrelated logic defects behind generic external-runner exit-code failures
- keeps external-runner behavior stable for known process/runtime error conditions

## Validation
- `dotnet build IntelligenceX.Cli/IntelligenceX.Cli.csproj -c Release`
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`
- `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.ps1 -Mode fast`