### PR TITLE
tests: split analysis tool-runner harness registration block

### DIFF
--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.AnalysisToolRunners.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.AnalysisToolRunners.cs
@@ -1,0 +1,50 @@
+namespace IntelligenceX.Tests;
+
+#if INTELLIGENCEX_REVIEWER
+internal static partial class Program {
+    private static int RunAnalyzeToolRunnerTests() {
+        var failed = 0;
+        failed += Run("Analyze run PowerShell script captures engine errors", TestAnalyzeRunPowerShellScriptCapturesEngineErrors);
+        failed += Run("Analyze run PowerShell strict args include fail switch", TestAnalyzeRunPowerShellStrictArgsIncludeFailSwitch);
+        failed += Run("Analyze run JavaScript args include configured rules", TestAnalyzeRunJavaScriptArgsIncludeConfiguredRules);
+        failed += Run("Analyze run Python args include select rule IDs", TestAnalyzeRunPythonArgsIncludeSelectRuleIds);
+        failed += Run("Analyze run Python args include output file when configured",
+            TestAnalyzeRunPythonArgsIncludeOutputFileWhenConfigured);
+        failed += Run("Analyze run Python output-file fallback detection",
+            TestAnalyzeRunPythonOutputFileFallbackDetection);
+        failed += Run("Analyze run process exception classification includes expected exceptions",
+            TestAnalyzeRunProcessExceptionClassificationIncludesExpectedExceptions);
+        failed += Run("Analyze run process exception classification excludes unexpected exceptions",
+            TestAnalyzeRunProcessExceptionClassificationExcludesUnexpectedExceptions);
+        failed += Run("Analyze run external runner missing command message classification",
+            TestAnalyzeRunExternalFailureMessageClassifiesMissingCommand);
+        failed += Run("Analyze run external runner recognizes tool-specific unavailable markers",
+            TestAnalyzeRunExternalFailureMessageRecognizesToolSpecificUnavailableMarkers);
+        failed += Run("Analyze run external runner supports configured unavailable markers",
+            TestAnalyzeRunExternalFailureMessageSupportsConfiguredUnavailableMarkers);
+        failed += Run("Analyze run external runner configured markers refresh on environment change",
+            TestAnalyzeRunExternalFailureMessageConfiguredMarkersRefreshOnEnvironmentChange);
+        failed += Run("Analyze run workspace source detection skips excluded directories",
+            TestAnalyzeRunWorkspaceSourceDetectionSkipsExcludedDirectories);
+        failed += Run("Analyze run workspace source detection diagnostics default to zero skipped",
+            TestAnalyzeRunWorkspaceSourceDetectionDiagnosticsDefaultToZeroSkipped);
+        failed += Run("Analyze run workspace source detection finds powershell module files",
+            TestAnalyzeRunWorkspaceSourceDetectionFindsPowerShellModuleFiles);
+        failed += Run("Analyze run workspace source inventory captures multiple extensions",
+            TestAnalyzeRunWorkspaceSourceInventoryCapturesMultipleExtensions);
+        failed += Run("Analyze run workspace source inventory keeps tracked extensions only",
+            TestAnalyzeRunWorkspaceSourceInventoryKeepsTrackedExtensionsOnly);
+        failed += Run("Analyze run shared source inventory falls back when scan limit reached",
+            TestAnalyzeRunSharedSourceInventoryFallsBackWhenScanLimitReached);
+        failed += Run("Analyze run shared source inventory fallback detects powershell sources",
+            TestAnalyzeRunSharedSourceInventoryFallbackDetectsPowerShellSources);
+        failed += Run("Analyze run shared source inventory fallback detects csharp sources",
+            TestAnalyzeRunSharedSourceInventoryFallbackDetectsCsharpSources);
+        failed += Run("Analyze run javascript selectors ignore mismatched tools",
+            TestAnalyzeRunJavaScriptSelectorsIgnoreMismatchedTools);
+        failed += Run("Analyze run python selected rule ids ignore mismatched tools",
+            TestAnalyzeRunPythonSelectedRuleIdsIgnoreMismatchedTools);
+        return failed;
+    }
+}
+#endif

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -391,46 +391,7 @@ internal static partial class Program {
         failed += Run("Todo project bootstrap parses issue url output", TestProjectBootstrapParseIssueNumberFromGhOutputParsesIssueUrl);
         failed += Run("Todo project bootstrap parses trailing issue number", TestProjectBootstrapParseIssueNumberFromGhOutputParsesTrailingInteger);
         failed += Run("Todo project bootstrap rejects conflicting control issue options", TestProjectBootstrapRejectsConflictingControlIssueOptions);
-        failed += Run("Analyze run PowerShell script captures engine errors", TestAnalyzeRunPowerShellScriptCapturesEngineErrors);
-        failed += Run("Analyze run PowerShell strict args include fail switch", TestAnalyzeRunPowerShellStrictArgsIncludeFailSwitch);
-        failed += Run("Analyze run JavaScript args include configured rules", TestAnalyzeRunJavaScriptArgsIncludeConfiguredRules);
-        failed += Run("Analyze run Python args include select rule IDs", TestAnalyzeRunPythonArgsIncludeSelectRuleIds);
-        failed += Run("Analyze run Python args include output file when configured",
-            TestAnalyzeRunPythonArgsIncludeOutputFileWhenConfigured);
-        failed += Run("Analyze run Python output-file fallback detection",
-            TestAnalyzeRunPythonOutputFileFallbackDetection);
-        failed += Run("Analyze run process exception classification includes expected exceptions",
-            TestAnalyzeRunProcessExceptionClassificationIncludesExpectedExceptions);
-        failed += Run("Analyze run process exception classification excludes unexpected exceptions",
-            TestAnalyzeRunProcessExceptionClassificationExcludesUnexpectedExceptions);
-        failed += Run("Analyze run external runner missing command message classification",
-            TestAnalyzeRunExternalFailureMessageClassifiesMissingCommand);
-        failed += Run("Analyze run external runner recognizes tool-specific unavailable markers",
-            TestAnalyzeRunExternalFailureMessageRecognizesToolSpecificUnavailableMarkers);
-        failed += Run("Analyze run external runner supports configured unavailable markers",
-            TestAnalyzeRunExternalFailureMessageSupportsConfiguredUnavailableMarkers);
-        failed += Run("Analyze run external runner configured markers refresh on environment change",
-            TestAnalyzeRunExternalFailureMessageConfiguredMarkersRefreshOnEnvironmentChange);
-        failed += Run("Analyze run workspace source detection skips excluded directories",
-            TestAnalyzeRunWorkspaceSourceDetectionSkipsExcludedDirectories);
-        failed += Run("Analyze run workspace source detection diagnostics default to zero skipped",
-            TestAnalyzeRunWorkspaceSourceDetectionDiagnosticsDefaultToZeroSkipped);
-        failed += Run("Analyze run workspace source detection finds powershell module files",
-            TestAnalyzeRunWorkspaceSourceDetectionFindsPowerShellModuleFiles);
-        failed += Run("Analyze run workspace source inventory captures multiple extensions",
-            TestAnalyzeRunWorkspaceSourceInventoryCapturesMultipleExtensions);
-        failed += Run("Analyze run workspace source inventory keeps tracked extensions only",
-            TestAnalyzeRunWorkspaceSourceInventoryKeepsTrackedExtensionsOnly);
-        failed += Run("Analyze run shared source inventory falls back when scan limit reached",
-            TestAnalyzeRunSharedSourceInventoryFallsBackWhenScanLimitReached);
-        failed += Run("Analyze run shared source inventory fallback detects powershell sources",
-            TestAnalyzeRunSharedSourceInventoryFallbackDetectsPowerShellSources);
-        failed += Run("Analyze run shared source inventory fallback detects csharp sources",
-            TestAnalyzeRunSharedSourceInventoryFallbackDetectsCsharpSources);
-        failed += Run("Analyze run javascript selectors ignore mismatched tools",
-            TestAnalyzeRunJavaScriptSelectorsIgnoreMismatchedTools);
-        failed += Run("Analyze run python selected rule ids ignore mismatched tools",
-            TestAnalyzeRunPythonSelectedRuleIdsIgnoreMismatchedTools);
+        failed += RunAnalyzeToolRunnerTests();
         failed += RunAnalyzeRunStrictBehaviorTests();
         failed += Run("Analyze run internal file size rule", TestAnalyzeRunInternalFileSizeRule);
         failed += Run("Analyze run internal findings use catalog tool metadata",


### PR DESCRIPTION
## Summary
- extract analysis tool-runner harness registrations from `Program.Reviewer.MainHarness.cs` into a dedicated partial file
- keep registration order and test names unchanged (pure maintainability refactor)
- reduce `MainHarness.cs` size to stay comfortably below `IXLOC001` threshold and lower future churn risk

## Validation
- `dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`