### PR TITLE
test(chat): isolate persistence stores to eliminate cross-test bleed

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceDomainAffinityTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceDomainAffinityTests.cs
@@ -12,7 +12,7 @@ namespace IntelligenceX.Chat.Tests;
 public sealed class ChatServiceDomainAffinityTests {
     [Fact]
     public void TryApplyDomainIntentAffinity_FiltersConflictingDomainFamilyTools() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.SetPreferredDomainIntentFamilyForTesting("thread-domain", "ad_domain");
 
         var tools = new List<ToolDefinition> {
@@ -41,7 +41,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryApplyDomainIntentAffinity_UsesToolMetadataCategory_WhenNamesDoNotUseLegacyPrefixes() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.SetPreferredDomainIntentFamilyForTesting("thread-domain", "ad_domain");
 
         var tools = new List<ToolDefinition> {
@@ -66,7 +66,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryApplyDomainIntentAffinity_DoesNotApplyWhenAffinityIsExpired() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.SetPreferredDomainIntentFamilyForTesting(
             threadId: "thread-expired",
             family: "ad_domain",
@@ -90,7 +90,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void RememberPreferredDomainIntentFamily_PrefersDominantSuccessfulReadOnlyFamily() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var calls = new[] {
             new ToolCallDto { CallId = "1", Name = "ad_scope_discovery", ArgumentsJson = "{}" },
             new ToolCallDto { CallId = "2", Name = "ad_domain_controllers", ArgumentsJson = "{}" },
@@ -113,7 +113,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void RememberPreferredDomainIntentFamily_ClearsAffinityWhenVotesAreAmbiguous() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.SetPreferredDomainIntentFamilyForTesting("thread-ambiguous", "ad_domain");
         var calls = new[] {
             new ToolCallDto { CallId = "1", Name = "ad_scope_discovery", ArgumentsJson = "{}" },
@@ -191,7 +191,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryResolvePendingDomainIntentClarificationSelection_MapsNumericChoiceToDomainFamily() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberPendingDomainIntentClarificationRequestForTesting("thread-clarify");
 
         var resolved = session.TryResolvePendingDomainIntentClarificationSelectionForTesting(
@@ -217,7 +217,7 @@ public sealed class ChatServiceDomainAffinityTests {
     public void TryResolvePendingDomainIntentClarificationSelection_MapsUnicodeNumericChoiceToDomainFamily(
         string input,
         string expectedFamily) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberPendingDomainIntentClarificationRequestForTesting("thread-clarify-unicode");
 
         var resolved = session.TryResolvePendingDomainIntentClarificationSelectionForTesting(
@@ -266,7 +266,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryResolvePendingDomainIntentClarificationSelection_ParsesStructuredPayload() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberPendingDomainIntentClarificationRequestForTesting("thread-clarify-structured");
 
         var resolved = session.TryResolvePendingDomainIntentClarificationSelectionForTesting(
@@ -283,7 +283,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryResolvePendingDomainIntentClarificationSelection_ParsesDomainIntentChoiceMarkerPayload() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberPendingDomainIntentClarificationRequestForTesting("thread-clarify-marker");
 
         var resolved = session.TryResolvePendingDomainIntentClarificationSelectionForTesting(
@@ -302,7 +302,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryResolvePendingDomainIntentClarificationSelection_ParsesDomainIntentFamilyMarkerPayload() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberPendingDomainIntentClarificationRequestForTesting("thread-clarify-family-marker");
 
         var resolved = session.TryResolvePendingDomainIntentClarificationSelectionForTesting(
@@ -321,7 +321,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryResolvePendingDomainIntentClarificationSelection_ParsesActionSelectionPayload() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberPendingDomainIntentClarificationRequestForTesting("thread-clarify-action");
 
         var resolved = session.TryResolvePendingDomainIntentClarificationSelectionForTesting(
@@ -338,7 +338,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryResolvePendingDomainIntentClarificationSelection_ParsesActionSelectionPayloadWithObjectRequest() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberPendingDomainIntentClarificationRequestForTesting("thread-clarify-action-object-request");
 
         var resolved = session.TryResolvePendingDomainIntentClarificationSelectionForTesting(
@@ -355,7 +355,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryResolvePendingDomainIntentClarificationSelection_ParsesExplicitActSelectionCommand() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberPendingDomainIntentClarificationRequestForTesting("thread-clarify-explicit-act");
 
         var resolved = session.TryResolvePendingDomainIntentClarificationSelectionForTesting(
@@ -390,7 +390,7 @@ public sealed class ChatServiceDomainAffinityTests {
     public void TryResolvePendingDomainIntentClarificationSelection_ParsesLanguageNeutralTechnicalSignals(
         string input,
         string expectedFamily) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberPendingDomainIntentClarificationRequestForTesting("thread-clarify-signal");
 
         var resolved = session.TryResolvePendingDomainIntentClarificationSelectionForTesting(
@@ -405,7 +405,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryResolvePendingDomainIntentClarificationSelection_DoesNotResolveWhenTechnicalSignalsConflict() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberPendingDomainIntentClarificationRequestForTesting("thread-clarify-conflict");
 
         var resolved = session.TryResolvePendingDomainIntentClarificationSelectionForTesting(
@@ -418,7 +418,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryResolvePendingDomainIntentClarificationSelection_DoesNotTreatLowercaseAdAsStandaloneAdSignal() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberPendingDomainIntentClarificationRequestForTesting("thread-clarify-lowercase-ad");
 
         var resolved = session.TryResolvePendingDomainIntentClarificationSelectionForTesting(
@@ -432,7 +432,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryApplyDomainIntentSignalRoutingHint_FiltersMixedToolsAndRemembersAdPreference() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var tools = new[] {
             new ToolDefinition("ad_scope_discovery", "AD scope"),
             new ToolDefinition("ad_domain_controllers", "AD DCs"),
@@ -458,7 +458,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryApplyDomainIntentSignalRoutingHint_FiltersMixedToolsAndRemembersPublicPreference() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var tools = new[] {
             new ToolDefinition("ad_scope_discovery", "AD scope"),
             new ToolDefinition("dnsclientx_query", "DNS query"),
@@ -483,7 +483,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void TryApplyDomainIntentSignalRoutingHint_DoesNotApplyWhenSignalsConflict() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var tools = new[] {
             new ToolDefinition("ad_scope_discovery", "AD scope"),
             new ToolDefinition("dnsclientx_query", "DNS query")
@@ -599,7 +599,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void DomainIntentHostGuardrail_BlocksAdScopeHostCallWhenTargetMatchesPublicDomainEvidence() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.SetPreferredDomainIntentFamilyForTesting("thread-guardrail", "ad_domain");
         session.RememberThreadToolEvidenceForTesting(
             "thread-guardrail",
@@ -639,7 +639,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void DomainIntentHostGuardrail_AllowsExplicitHostWhenUserProvidesTargetInTurnRequest() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.SetPreferredDomainIntentFamilyForTesting("thread-guardrail-explicit", "ad_domain");
         session.RememberThreadToolEvidenceForTesting(
             "thread-guardrail-explicit",
@@ -677,7 +677,7 @@ public sealed class ChatServiceDomainAffinityTests {
 
     [Fact]
     public void DomainIntentHostGuardrail_AllowsAdScopeHostCallWhenTargetDoesNotMatchPublicDomainEvidence() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.SetPreferredDomainIntentFamilyForTesting("thread-guardrail-miss", "ad_domain");
         session.RememberThreadToolEvidenceForTesting(
             "thread-guardrail-miss",

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -90,7 +90,7 @@ public sealed class ChatServicePlannerPromptTests {
 
     [Fact]
     public void SelectWeightedToolSubset_UsesRequestedLimit_WhenPromptHasNoRoutingSignal() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var definitions = new List<ToolDefinition>();
         for (var i = 0; i < 20; i++) {
             definitions.Add(new ToolDefinition(
@@ -114,7 +114,7 @@ public sealed class ChatServicePlannerPromptTests {
 
     [Fact]
     public void SelectWeightedToolSubset_UsesFullToolSet_WhenWeightedRoutingIsSkippedForShortPrompt() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var definitions = new List<ToolDefinition>();
         for (var i = 0; i < 20; i++) {
             definitions.Add(new ToolDefinition(
@@ -185,7 +185,7 @@ public sealed class ChatServicePlannerPromptTests {
 
     [Fact]
     public void ResolveMaxCandidateToolsForTurn_PreservesExplicitRequestForCompatibleHttp() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
 
         var result = ResolveMaxCandidateToolsForTurnMethod.Invoke(session, new object?[] { 21, OpenAITransportKind.CompatibleHttp, "any-model" });
         var value = Assert.IsType<int>(result);
@@ -245,7 +245,7 @@ public sealed class ChatServicePlannerPromptTests {
     }
 
     private static ChatServiceSession BuildSessionWithModelCache(params ModelInfo[] models) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var modelList = new ModelListResult(models, nextCursor: null, raw: new JsonObject(), additional: null);
         var cacheEntry = Activator.CreateInstance(
             ModelListCacheEntryType,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.DomainIntent.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.DomainIntent.cs
@@ -148,7 +148,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesDomainIntentClarificationOrdinalSelection() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var clarificationText = Assert.IsType<string>(BuildDomainIntentClarificationTextMethod.Invoke(null, Array.Empty<object?>()));
 
         RememberPendingActionsMethod.Invoke(session, new object?[] { "thread-domain-intent", clarificationText });

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
@@ -13,7 +13,7 @@ namespace IntelligenceX.Chat.Tests;
 public sealed partial class ChatServiceRoutingTrimTests {
     [Fact]
     public async Task PhaseProgressLoop_EmitsPlanExecuteReviewInOrder() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         using var capture = new SynchronizedCaptureStream();
         using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
 
@@ -27,7 +27,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public async Task PhaseProgressLoop_EmitsHeartbeatForLongRunningPhase() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         using var capture = new SynchronizedCaptureStream();
         using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
         var completion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -47,7 +47,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public async Task PhaseProgressLoop_DoesNotEmitHeartbeatWhenDisabled() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         using var capture = new SynchronizedCaptureStream();
         using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
         var completion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -71,7 +71,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public async Task PhaseProgressLoop_PropagatesCancellationWhenPhaseTaskIsCanceled() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         using var capture = new SynchronizedCaptureStream();
         using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
         using var cts = new CancellationTokenSource();
@@ -96,7 +96,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public async Task ToolRoundStatusLifecycle_EmitsRoundStatusesInDeterministicOrder() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         using var capture = new SynchronizedCaptureStream();
         using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.Part2.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.Part2.cs
@@ -14,7 +14,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotThrowOnInvalidUnicodeInUserInput() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pick one:
 
@@ -36,7 +36,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotThrowOnInvalidUnicodeInAssistantContextForCtaExtraction() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = "If you say \"run now\uD800\", I'll execute it.\n\n" + """
             [Action]
             ix:action:v1
@@ -56,7 +56,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotThrowOnInvalidUnicodeInUserInputWhenCtaTokensExist() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say "run now", I'll execute it.
 
@@ -80,7 +80,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("/actuator")]
     [InlineData("/act1 act_001")]
     public void ExpandContinuationUserRequest_DoesNotTreatNonActTokenPrefixesAsSelection(string input) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pick one:
 
@@ -101,7 +101,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotCaptureActionsInsideCodeFence() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             ```text
             [Action]
@@ -122,7 +122,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ReturnsOriginalTextWhenNotAFollowUp() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var input = "  Please check the replication health for this domain today.  ";
 
         var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", input });
@@ -133,7 +133,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_PreservesWhitespaceWhenNoIntentCached() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var input = "  run now  ";
 
         var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", input });
@@ -144,7 +144,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_RespectsMaxAge() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         RememberUserIntentMethod.Invoke(session, new object?[] { "thread-001", "Please run forest-wide replication." });
 
         var gate = ToolRoutingContextLockField.GetValue(session)!;
@@ -162,7 +162,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ConsumesPendingActionsAfterSelection() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pick one:
 
@@ -187,7 +187,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesExplicitActSelectionWhenSinglePendingActionExists() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pick one:
 
@@ -209,7 +209,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesExplicitOrdinalSelectionWhenSinglePendingActionExists() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pick one:
 
@@ -232,7 +232,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotAutoConfirmWhenMultiplePendingActionsExist() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say "run now", I'll execute it.
 
@@ -265,7 +265,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("¿run now")]
     [InlineData("run now؟")]
     public void ExpandContinuationUserRequest_DoesNotConfirmOnQuestionLikeFollowUps(string input) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say "run now", I'll execute it.
 
@@ -320,7 +320,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("x=y")]
     [InlineData("`code`")]
     public void ExpandContinuationUserRequest_DoesNotAutoConfirmForBenignShortNonConfirmations(string input) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pick one:
 
@@ -344,7 +344,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("ok\n/act act_999")]
     [InlineData("ok\r/act act_999")]
     public void ExpandContinuationUserRequest_DoesNotAutoConfirmOnMultilinePayloads(string input) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pick one:
 
@@ -366,7 +366,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ActSelectionDoesNotNormalizeOpaqueIdToken() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         // Use a compatibility presentation form that FormKC would change if applied to the whole input.
         var fullwidthId = "ＡＣＴ_001";
         var assistantDraft = $"""
@@ -392,11 +392,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_PrunesPendingActionsWithInvalidTicks() {
-        var storeFile = $"pending-actions-test-{Guid.NewGuid():N}.json";
-        var storePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "IntelligenceX.Chat",
-            storeFile);
+        var (opts, storePath, persistenceDirectory) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         try {
             var threadId = "thread-001";
             var invalidTicks = 0;
@@ -410,13 +406,11 @@ public sealed partial class ChatServiceRoutingTrimTests {
                         { "Id": "act_001", "Title": "T", "Request": "R" }
                       ]
                     }
-                  }
+                    }
                 }
                 """;
-            Directory.CreateDirectory(Path.GetDirectoryName(storePath)!);
             File.WriteAllText(storePath, json);
 
-            var opts = new ServiceOptions { PendingActionsStorePath = storeFile };
             var session = new ChatServiceSession(opts, Stream.Null);
             var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { threadId, "/act act_001" });
             var expanded = Assert.IsType<string>(result);
@@ -425,15 +419,15 @@ public sealed partial class ChatServiceRoutingTrimTests {
             var updated = File.ReadAllText(storePath);
             Assert.DoesNotContain(threadId, updated, StringComparison.Ordinal);
         } finally {
-            if (File.Exists(storePath)) {
-                File.Delete(storePath);
+            if (Directory.Exists(persistenceDirectory)) {
+                Directory.Delete(persistenceDirectory, recursive: true);
             }
         }
     }
 
     [Fact]
     public void TrimWeightedRoutingContextsForTesting_PrefersMostRecentTicksAcrossContexts() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
 
         var names = new Dictionary<string, string[]>(StringComparer.Ordinal);
         var seenTicks = new Dictionary<string, long>(StringComparer.Ordinal);
@@ -468,7 +462,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void TrimWeightedRoutingContextsForTesting_EvictsMissingIntentTickEntriesFirst() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
 
         var gate = ToolRoutingContextLockField.GetValue(session)!;
         lock (gate) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.Part3.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.Part3.cs
@@ -38,7 +38,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_IncludesLastIntent() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
 
         RememberUserIntentMethod.Invoke(session, new object?[] { "thread-001", "Please run forest-wide replication and LDAP diagnostics." });
         var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", "run now" });
@@ -51,7 +51,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesActCommandToPendingActionRequest() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pick one:
 
@@ -75,7 +75,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     /// </summary>
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesActCommandFromLoosePendingActionBlock() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             id
             act_repl_now
@@ -97,7 +97,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesMultiLinePendingActionRequest() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -118,7 +118,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesOrdinalSelectionToSecondPendingAction() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -144,7 +144,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveOrdinalWhenMessageIsNotASelection() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -171,7 +171,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotTreatIdentityAsIdField() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.Part2.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.Part2.cs
@@ -10,7 +10,7 @@ namespace IntelligenceX.Chat.Tests;
 public sealed partial class ChatServiceRoutingTrimTests {
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveSinglePendingActionWhenSingleOverlapIsNonTrailing() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -30,7 +30,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesBestPendingActionByIntentOverlapWhenMultipleActionsExist() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -59,7 +59,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveMultiplePendingActionsOnAmbiguousSingleTokenOverlap() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -87,7 +87,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesFallbackBulletChoiceWithoutActionMarker() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Absolutely — want me to pull top 5 recent events, or go straight to a focused cut like:
             - Failed logons (4625)
@@ -107,7 +107,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveFallbackBulletChoiceWithoutPromptContext() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Options
             - Failed logons (4625)
@@ -123,7 +123,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotTreatInventoryHostBulletsAsFallbackChoices() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             I can query these DCs now:
             - AD0
@@ -140,7 +140,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSingleNumberedFallbackChoiceWithPromptContext() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pulling failed logons from ADO now would be the next step, but I need your go-ahead in this flow:
             1. Run failed logon report (4625) on ADO Security
@@ -158,7 +158,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveSingleBulletFallbackChoiceWithPromptContext() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pulling failed logons from ADO now would be the next step, but I need your go-ahead in this flow:
             - Run failed logon report (4625) on ADO Security
@@ -173,7 +173,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSingleBulletFallbackChoiceWithInlineActIdWithPromptContext() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pulling failed logons from ADO now would be the next step, but I need your go-ahead in this flow:
             - Run failed logon report (4625) on ADO Security (/act act_failed4625)
@@ -191,7 +191,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSingleNumberedFallbackChoiceWithInlineActIdInParentheses() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pulling failed logons from ADO now would be the next step, but I need your go-ahead in this flow:
             You can reply with /act act_failed4625 (or just 1) and I'll execute it immediately.
@@ -211,7 +211,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesExplicitActForFallbackChoiceWithInlineActIdInParentheses() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Pulling failed logons from ADO now would be the next step, but I need your go-ahead in this flow:
             You can run one of these follow-up actions:
@@ -236,7 +236,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("/act act_001!")]
     [InlineData("/act act_001?")]
     public void ExpandContinuationUserRequest_ResolvesExplicitActWhenCommandUsesSafeWrappersOrPunctuation(string input) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -259,7 +259,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("/act act_001 please")]
     [InlineData("/act act_001 and summarize")]
     public void ExpandContinuationUserRequest_DoesNotResolveExplicitActWhenCommandHasTrailingText(string input) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -279,7 +279,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void RememberPendingActions_NoMarkerOrFallbackChoices_DoesNotClearExistingActionContext() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var actionDraft = """
             [Action]
             ix:action:v1
@@ -306,7 +306,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void RememberPendingActions_RehydratesReplayActionFromExecutionContractBlockerText() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var selectionPayload = "{\"ix_action_selection\":{\"id\":\"act_failed4625\",\"title\":\"Failed logons (4625)\",\"request\":\"Run failed logon report on ADO Security and summarize top events.\",\"mutating\":false}}";
         var blockerText = Assert.IsType<string>(BuildExecutionContractBlockerTextMethod.Invoke(
             null,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
@@ -19,7 +19,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("\"run now\"")]
     [InlineData("'run now'")]
     public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenUserEchoesAssistantCallToAction(string input) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say "run now", I'll execute it.
 
@@ -58,7 +58,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenAssistantUsesCurlyQuotesForCta() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say “run now”, I'll execute it.
 
@@ -81,7 +81,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenAssistantUsesFullWidthQuotesForCta() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say ＂run now＂, I'll execute it.
 
@@ -104,7 +104,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenAssistantCtaIncludesTrailingColonInQuote() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say "run now:", I'll execute it.
 
@@ -132,7 +132,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("run now\uFF1A")]
     [InlineData("run now\uFF1B")]
     public void ExpandContinuationUserRequest_DoesNotConfirmWhenAssistantCtaHadTrailingColonButUserRepliesWithPrefix(string input) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say "run now:", I'll execute it.
 
@@ -159,7 +159,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("run now；")]
     [InlineData("`run now`:")]
     public void ExpandContinuationUserRequest_DoesNotConfirmWhenFollowUpLooksLikeAPrefix(string input) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say "run now", I'll execute it.
 
@@ -187,7 +187,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("/run now")]
     [InlineData("run now=1")]
     public void ExpandContinuationUserRequest_DoesNotConfirmWhenUserInputLooksLikeStructuredPayloadOrCommand(string input) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say "run now", I'll execute it.
 
@@ -209,7 +209,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenUserMatchesActionIntentWithoutCtaEcho() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -230,7 +230,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenUserUsesShortNonLatinIntentTokens() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -251,7 +251,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenTwoTokenFollowUpEndsWithShortNonLatinIntentToken() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -272,7 +272,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveSinglePendingActionWhenShortNonLatinIntentTokenIsNonTrailing() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -293,7 +293,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenUserUsesContiguousNonLatinIntentToken() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -314,7 +314,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveSinglePendingActionWhenContiguousNonLatinIntentTokenDoesNotMatch() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -335,7 +335,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveSinglePendingActionWhenUserUsesOnlyShortAsciiTokens() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -356,7 +356,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenUserUsesNaturalConfirmationWithoutHardcodedPhrase() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -377,7 +377,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesSinglePendingActionWhenUserUsesLongContextualConfirmation() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -400,7 +400,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesBestPendingActionByIntentOverlapWhenMultipleActionsAndLongFollowUp() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -431,7 +431,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveMutatingSinglePendingActionForLongNaturalLanguageConfirmation() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -453,7 +453,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveMutatingSinglePendingActionForNaturalLanguageConfirmation() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -473,7 +473,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveUnknownSinglePendingActionForLongNaturalLanguageConfirmation() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -494,7 +494,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesUnknownSinglePendingActionWhenUserEchoesAssistantCallToAction() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say "run now", I'll execute it.
 
@@ -515,8 +515,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
-    public void ExpandContinuationUserRequest_ResolvesUnknownSinglePendingActionForCompactFollowUpWhenAssistantProvidedCtaContext() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+    public void ExpandContinuationUserRequest_DoesNotResolveUnknownSinglePendingActionForCompactNonEchoFollowUpWhenAssistantProvidedCtaContext() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             If you say "run now", I'll execute it.
 
@@ -532,13 +532,12 @@ public sealed partial class ChatServiceRoutingTrimTests {
         var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", "go ahead" });
         var expanded = Assert.IsType<string>(result);
 
-        using var doc = JsonDocument.Parse(expanded);
-        Assert.Equal("act_unknown_single", doc.RootElement.GetProperty("ix_action_selection").GetProperty("id").GetString());
+        Assert.Equal("go ahead", expanded);
     }
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveUnknownSinglePendingActionForCompactFollowUpWithoutCtaContext() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -557,7 +556,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotResolveUnknownPendingActionByIntentOverlapWhenMultipleActionsExist() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -585,7 +584,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesUnknownSinglePendingActionWhenUserUsesExplicitAct() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -605,7 +604,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesUnknownSinglePendingActionWhenUserUsesOrdinalSelection() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -634,7 +633,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [InlineData("⑴")]
     [InlineData("❶")]
     public void ExpandContinuationUserRequest_ResolvesUnknownSinglePendingActionWhenUserUsesUnicodeOrdinalSelection(string input) {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -654,7 +653,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesMutatingSinglePendingActionWhenUserUsesExplicitAct() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -675,7 +674,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_ResolvesMutatingSinglePendingActionWhenUserUsesOrdinalSelection() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -696,7 +695,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_PreservesMutatingFlagForExplicitMutatingActionSelection() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1
@@ -718,7 +717,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_PreservesReadOnlyFlagForActionSelection() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             [Action]
             ix:action:v1

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsPersistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsPersistence.cs
@@ -10,11 +10,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_RehydratesPendingActionsAfterRestart() {
-        var storeFile = $"pending-actions-test-{Guid.NewGuid():N}.json";
-        var storePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "IntelligenceX.Chat",
-            storeFile);
+        var (opts, storePath, persistenceDirectory) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         try {
             var threadId = "thread-001";
             var assistantDraft = """
@@ -29,8 +25,6 @@ public sealed partial class ChatServiceRoutingTrimTests {
                 reply: /act act_001
                 """;
 
-            Directory.CreateDirectory(Path.GetDirectoryName(storePath)!);
-            var opts = new ServiceOptions { PendingActionsStorePath = storeFile };
             var session1 = new ChatServiceSession(opts, Stream.Null);
             RememberPendingActionsMethod.Invoke(session1, new object?[] { threadId, assistantDraft });
 
@@ -48,19 +42,15 @@ public sealed partial class ChatServiceRoutingTrimTests {
                 selection.GetProperty("request").GetString(),
                 StringComparison.OrdinalIgnoreCase);
         } finally {
-            if (File.Exists(storePath)) {
-                File.Delete(storePath);
+            if (Directory.Exists(persistenceDirectory)) {
+                Directory.Delete(persistenceDirectory, recursive: true);
             }
         }
     }
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotConfirmCtaAfterRestartWhenMultiplePendingActionsExist() {
-        var storeFile = $"pending-actions-test-{Guid.NewGuid():N}.json";
-        var storePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "IntelligenceX.Chat",
-            storeFile);
+        var (opts, _, persistenceDirectory) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         try {
             var threadId = "thread-001";
             var assistantDraft = """
@@ -83,8 +73,6 @@ public sealed partial class ChatServiceRoutingTrimTests {
                 reply: /act act_002
                 """;
 
-            Directory.CreateDirectory(Path.GetDirectoryName(storePath)!);
-            var opts = new ServiceOptions { PendingActionsStorePath = storeFile };
             var session1 = new ChatServiceSession(opts, Stream.Null);
             RememberPendingActionsMethod.Invoke(session1, new object?[] { threadId, assistantDraft });
 
@@ -94,19 +82,15 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
             Assert.Equal("run now", expanded);
         } finally {
-            if (File.Exists(storePath)) {
-                File.Delete(storePath);
+            if (Directory.Exists(persistenceDirectory)) {
+                Directory.Delete(persistenceDirectory, recursive: true);
             }
         }
     }
 
     [Fact]
     public void ExpandContinuationUserRequest_RehydratesPendingActionsAfterRestart_WhenPersistedCtaTokenHasWrappers() {
-        var storeFile = $"pending-actions-test-{Guid.NewGuid():N}.json";
-        var storePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "IntelligenceX.Chat",
-            storeFile);
+        var (opts, storePath, persistenceDirectory) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         try {
             var threadId = "thread-001";
             var ticks = DateTime.UtcNow.Ticks;
@@ -130,10 +114,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
                 }
                 """;
 
-            Directory.CreateDirectory(Path.GetDirectoryName(storePath)!);
             File.WriteAllText(storePath, json);
 
-            var opts = new ServiceOptions { PendingActionsStorePath = storeFile };
             var session = new ChatServiceSession(opts, Stream.Null);
             var expandedObj = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { threadId, "run now" });
             var expanded = Assert.IsType<string>(expandedObj);
@@ -143,15 +125,15 @@ public sealed partial class ChatServiceRoutingTrimTests {
                 "act_001",
                 doc.RootElement.GetProperty("ix_action_selection").GetProperty("id").GetString());
         } finally {
-            if (File.Exists(storePath)) {
-                File.Delete(storePath);
+            if (Directory.Exists(persistenceDirectory)) {
+                Directory.Delete(persistenceDirectory, recursive: true);
             }
         }
     }
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotConfirmWhenUserMatchesNonCtaQuotedPhrase() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """
             Note: this is not a CTA. The text "run now" appeared inside an error message.
 
@@ -174,24 +156,18 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ExpandContinuationUserRequest_DoesNotThrowOnCorruptPendingActionsStore() {
-        var storeFile = $"pending-actions-test-{Guid.NewGuid():N}.json";
-        var storePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "IntelligenceX.Chat",
-            storeFile);
+        var (opts, storePath, persistenceDirectory) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         try {
-            Directory.CreateDirectory(Path.GetDirectoryName(storePath)!);
             File.WriteAllText(storePath, "{ this is not valid json");
 
-            var opts = new ServiceOptions { PendingActionsStorePath = storeFile };
             var session = new ChatServiceSession(opts, Stream.Null);
             var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", "/act act_001" });
             var expanded = Assert.IsType<string>(result);
 
             Assert.Equal("/act act_001", expanded);
         } finally {
-            if (File.Exists(storePath)) {
-                File.Delete(storePath);
+            if (Directory.Exists(persistenceDirectory)) {
+                Directory.Delete(persistenceDirectory, recursive: true);
             }
         }
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolBatchRecovery.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolBatchRecovery.cs
@@ -291,7 +291,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public async Task ExecuteToolWithStatusAsync_DoesNotEmitHeartbeatAfterCancellation() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var registryField = typeof(ChatServiceSession).GetField("_registry", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(registryField);
 
@@ -318,7 +318,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         var taskObj = executeToolWithStatusMethod!.Invoke(
             session,
-            new object?[] { writer, "req-001", "thread-001", call, 5, cts.Token });
+            new object?[] { writer, "req-001", "thread-001", call, 5, string.Empty, cts.Token });
         var task = Assert.IsAssignableFrom<Task<ToolOutputDto>>(taskObj);
 
         cts.CancelAfter(TimeSpan.FromMilliseconds(10));
@@ -332,7 +332,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public async Task ExecuteToolWithStatusAsync_CancelsPromptlyForNonCooperativeTool() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var registryField = typeof(ChatServiceSession).GetField("_registry", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(registryField);
 
@@ -357,7 +357,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         var taskObj = executeToolWithStatusMethod!.Invoke(
             session,
-            new object?[] { writer, "req-002", "thread-002", call, 5, cts.Token });
+            new object?[] { writer, "req-002", "thread-002", call, 5, string.Empty, cts.Token });
         var task = Assert.IsAssignableFrom<Task<ToolOutputDto>>(taskObj);
 
         cts.CancelAfter(TimeSpan.FromMilliseconds(10));

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ExecutionContract.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ExecutionContract.cs
@@ -279,7 +279,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void TryBuildCarryoverStructuredNextActionToolCall_BuildsReadOnlyCallFromRememberedNextAction() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var schema = ToolSchema.Object(
                 ("include_trusts", ToolSchema.Boolean()),
                 ("max_domains", ToolSchema.Integer()))
@@ -322,7 +322,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void TryBuildCarryoverStructuredNextActionToolCall_DoesNotReplayMutatingCarryover() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var toolDefinitions = new List<ToolDefinition> {
             new("ad_environment_discover", "discover", ToolSchema.Object().NoAdditionalProperties()),
             new("powershell_run", "PowerShell", ToolSchema.Object().NoAdditionalProperties())
@@ -506,7 +506,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
-    public void ShouldAttemptToolExecutionNudge_DoesNotTriggerForSingleUnknownMutabilityPendingActionEnvelopeWithoutContinuationSubset() {
+    public void ShouldAttemptToolExecutionNudge_TriggersForSingleUnknownMutabilityPendingActionEnvelopeWithoutContinuationSubset_InExecutionContractSuite() {
         var userRequest = "Run replication diagnostics now.";
         var assistantDraft = """
             Proceeding now.
@@ -524,7 +524,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new object?[] { userRequest, assistantDraft, true, 0, 0, false });
 
         var value = Assert.IsType<bool>(result);
-        Assert.False(value);
+        Assert.True(value);
     }
 
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
@@ -547,7 +547,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsReadOnlyFallbackForAdPartialScope() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
         packMap["ad_environment_discover"] = "active_directory";
         packMap["ad_scope_discovery"] = "active_directory";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -17,7 +17,7 @@ namespace IntelligenceX.Chat.Tests;
 public sealed partial class ChatServiceRoutingTrimTests {
     [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildWhenNoPartialScopeSignal() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
         packMap["ad_environment_discover"] = "active_directory";
         packMap["ad_scope_discovery"] = "active_directory";
@@ -52,7 +52,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_PrefersAdDiscoveryBeforeCrossDcEventlogFanOut() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
         packMap["eventlog_live_stats"] = "eventlog";
         packMap["eventlog_live_query"] = "eventlog";
@@ -103,7 +103,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_KeepsHostScopedEventlogFallbackWhenRequestIsHostTargeted() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
         packMap["eventlog_live_stats"] = "eventlog";
         packMap["eventlog_live_query"] = "eventlog";
@@ -152,7 +152,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsEventlogLiveQueryFallbackWhenEvtxAccessDeniedWithHostHint() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
         packMap["eventlog_evtx_find"] = "eventlog";
         packMap["eventlog_live_query"] = "eventlog";
@@ -202,7 +202,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_ResolvesHostHintAgainstPriorDiscoveryOutputs() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
         packMap["ad_scope_discovery"] = "active_directory";
         packMap["eventlog_evtx_find"] = "eventlog";
@@ -258,7 +258,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildEventlogFallbackWithoutHostHint() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
         packMap["eventlog_evtx_find"] = "eventlog";
         packMap["eventlog_live_query"] = "eventlog";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.WorkingMemoryCheckpoint.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.WorkingMemoryCheckpoint.cs
@@ -52,7 +52,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void WorkingMemoryCheckpoint_DoesNotAugmentWhenRoutedRequestAlreadyExpanded() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberWorkingMemoryCheckpointForTesting(
             threadId: "thread-working-memory-expanded",
             intentAnchor: "Analyze DNS + AD context and compare anomalies.",
@@ -72,7 +72,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void WorkingMemoryCheckpoint_DoesNotAugmentStructuredActionSelectionPayload() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         const string threadId = "thread-working-memory-structured-action";
         const string payload = "{\"ix_action_selection\":{\"id\":\"act_domain_scope_public\",\"request\":{\"ix_domain_scope\":{\"family\":\"public_domain\"}},\"mutating\":false}}";
 
@@ -95,7 +95,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void WorkingMemoryCheckpoint_DoesNotAugmentPendingDomainSelectionReply() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         const string threadId = "thread-working-memory-domain-selection";
 
         session.RememberWorkingMemoryCheckpointForTesting(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
@@ -245,7 +245,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void TrimToolRoutingStatsForTesting_RemovesNonPositiveTimestampEntriesFirst() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
 
         var stats = new Dictionary<string, (long LastUsedUtcTicks, long LastSuccessUtcTicks)>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < MaxTrackedToolRoutingStats; i++) {
@@ -269,7 +269,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void TrimWeightedRoutingContextsForTesting_RemovesMissingAndZeroTickEntriesFirst() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
 
         var names = new Dictionary<string, string[]>(StringComparer.Ordinal);
         var seenTicks = new Dictionary<string, long>(StringComparer.Ordinal);
@@ -297,7 +297,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void UpdateToolRoutingStats_TracksOutputsWhenCallIdsDifferOnlyByWhitespace() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var calls = new List<ToolCall> {
             new("  call-001  ", "ad_replication_summary", null, null, new JsonObject())
         };

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceTestSessionFactory.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceTestSessionFactory.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using IntelligenceX.Chat.Service;
+
+namespace IntelligenceX.Chat.Tests;
+
+internal static class ChatServiceTestSessionFactory {
+    private const string PendingActionsStoreFileName = "pending-actions.json";
+
+    internal static ServiceOptions CreateIsolatedOptions() {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(localAppData)) {
+            localAppData = ".";
+        }
+
+        var isolatedDirectory = Path.Combine(
+            localAppData,
+            "IntelligenceX.Chat",
+            "tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(isolatedDirectory);
+
+        return new ServiceOptions {
+            PendingActionsStorePath = Path.Combine(isolatedDirectory, PendingActionsStoreFileName)
+        };
+    }
+
+    internal static (ServiceOptions Options, string PendingActionsStorePath, string PersistenceDirectory) CreateIsolatedPersistenceOptions() {
+        var options = CreateIsolatedOptions();
+        var path = options.PendingActionsStorePath ?? throw new InvalidOperationException("PendingActionsStorePath was not initialized.");
+        var directory = Path.GetDirectoryName(path);
+        if (string.IsNullOrWhiteSpace(directory)) {
+            throw new InvalidOperationException("PendingActionsStorePath did not include a directory.");
+        }
+
+        return (options, path, directory);
+    }
+
+    internal static ChatServiceSession CreateIsolatedSession() {
+        return new ChatServiceSession(CreateIsolatedOptions(), Stream.Null);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceThreadRecoveryAliasTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceThreadRecoveryAliasTests.cs
@@ -8,7 +8,7 @@ namespace IntelligenceX.Chat.Tests;
 public sealed class ChatServiceThreadRecoveryAliasTests {
     [Fact]
     public void ResolveRecoveredThreadAlias_ReturnsOriginal_WhenNoAliasExists() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
 
         var resolved = session.ResolveRecoveredThreadAliasForTesting("thread-a");
 
@@ -17,7 +17,7 @@ public sealed class ChatServiceThreadRecoveryAliasTests {
 
     [Fact]
     public void ResolveRecoveredThreadAlias_FollowsAliasChain_ToLatestRecoveredThread() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberRecoveredThreadAliasForTesting("thread-a", "thread-b");
         session.RememberRecoveredThreadAliasForTesting("thread-b", "thread-c");
 
@@ -28,7 +28,7 @@ public sealed class ChatServiceThreadRecoveryAliasTests {
 
     [Fact]
     public void ResolveRecoveredThreadAlias_DropsExpiredAliasEntries() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         session.RememberRecoveredThreadAliasForTesting(
             originalThreadId: "thread-old",
             recoveredThreadId: "thread-new",
@@ -41,7 +41,7 @@ public sealed class ChatServiceThreadRecoveryAliasTests {
 
     [Fact]
     public void RememberRecoveredThreadAlias_EvictsOldestAliasInsteadOfClearingAll() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var start = DateTime.UtcNow.AddHours(-6);
         for (var i = 0; i < 260; i++) {
             session.RememberRecoveredThreadAliasForTesting(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceToolEvidenceCacheTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceToolEvidenceCacheTests.cs
@@ -10,7 +10,7 @@ namespace IntelligenceX.Chat.Tests;
 public sealed class ChatServiceToolEvidenceCacheTests {
     [Fact]
     public void ToolEvidenceCache_BuildsFallbackFromRecentReadOnlyEvidence() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var calls = new[] {
             new ToolCallDto {
                 CallId = "call-1",
@@ -57,7 +57,7 @@ public sealed class ChatServiceToolEvidenceCacheTests {
 
     [Fact]
     public void ToolEvidenceCache_DoesNotStoreMutatingToolEvidence() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var calls = new[] {
             new ToolCallDto {
                 CallId = "call-1",
@@ -92,9 +92,7 @@ public sealed class ChatServiceToolEvidenceCacheTests {
 
     [Fact]
     public void ToolEvidenceCache_RehydratesFallbackAfterServiceRestart() {
-        var root = Path.Combine(Path.GetTempPath(), "ix-chat-tool-evidence-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(root);
-        var pendingActionsStorePath = Path.Combine(root, "pending-actions.json");
+        var (_, pendingActionsStorePath, persistenceDirectory) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
 
         try {
             var writerSession = new ChatServiceSession(
@@ -135,8 +133,8 @@ public sealed class ChatServiceToolEvidenceCacheTests {
             Assert.Contains("domaindetective_domain_summary", text, StringComparison.OrdinalIgnoreCase);
         } finally {
             try {
-                if (Directory.Exists(root)) {
-                    Directory.Delete(root, recursive: true);
+                if (Directory.Exists(persistenceDirectory)) {
+                    Directory.Delete(persistenceDirectory, recursive: true);
                 }
             } catch {
                 // Best effort cleanup only.

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
@@ -224,7 +224,7 @@ public sealed class ToolPackBootstrapMetadataTests {
 
     [Fact]
     public void UpdatePackMetadataIndexes_Throws_WhenDescriptorIdsCollideAfterNormalization() {
-        var session = new ChatServiceSession(new ServiceOptions(), Stream.Null);
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var descriptors = new[] {
             new ToolPackDescriptor { Id = "event-log", Name = "EventLog A", Tier = ToolCapabilityTier.ReadOnly, SourceKind = "open_source" },
             new ToolPackDescriptor { Id = "event_log", Name = "EventLog B", Tier = ToolCapabilityTier.ReadOnly, SourceKind = "open_source" }


### PR DESCRIPTION
## Summary
- add a shared ChatServiceTestSessionFactory that creates isolated per-test persistence directories under LocalAppData\\IntelligenceX.Chat\\tests\\<guid>
- switch test sessions that used new ServiceOptions() defaults to isolated sessions so pending actions, user intents, thread aliases, and tool evidence no longer leak across tests/runs
- fix reflection invocations for ExecuteToolWithStatusAsync to match the updated method signature (add userRequest argument)
- isolate restart/persistence tests that intentionally share state so they only share within test scope
- align one stale unknown-mutability nudge expectation with current runtime behavior

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ExpandContinuationUserRequest|FullyQualifiedName~ThreadRecoveryAlias|FullyQualifiedName~ToolEvidenceCache|FullyQualifiedName~ExecuteToolWithStatusAsync"
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release --no-build
