### PR TITLE
fix(chat): harden continuation intent and render-hint reliability

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
@@ -1,3 +1,4 @@
+using System;
 using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.App.Markdown;
 using Xunit;
@@ -128,5 +129,37 @@ public sealed class ToolRunMarkdownFormatterTests {
         Assert.Contains("\"kind\":\"ix_tool_dataview_v1\"", markdown);
         Assert.Contains("\"rows\":[[\"Rule\",\"Enabled\"],[\"rule_a\",\"true\"],[\"rule_b\",\"false\"]]", markdown);
         Assert.Contains("### TestimoX rules (preview)", markdown);
+    }
+
+    /// <summary>
+    /// Ensures render arrays can emit first-party visual fences and map visnetwork to ix-network.
+    /// </summary>
+    [Fact]
+    public void Format_EmitsVisualFencesFromRenderArrayAndSkipsCompletedFallback() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c5",
+                    Name = "visual_pack_report"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c5",
+                    Output =
+                        "{\"ok\":true,\"chart_payload\":{\"type\":\"bar\",\"data\":{\"labels\":[\"A\"],\"datasets\":[{\"data\":[1]}]}},\"network_payload\":{\"nodes\":[{\"id\":1,\"label\":\"A\"}],\"edges\":[]}}",
+                    RenderJson =
+                        "[{\"kind\":\"code\",\"language\":\"chart\",\"content_path\":\"chart_payload\"},{\"kind\":\"code\",\"language\":\"visnetwork\",\"content_path\":\"network_payload\"}]"
+                }
+            }
+        };
+
+        var markdown = ToolRunMarkdownFormatter.Format(tools, _ => "Visual Pack Report");
+
+        Assert.Contains("```ix-chart", markdown);
+        Assert.Contains("\"type\":\"bar\"", markdown);
+        Assert.Contains("```ix-network", markdown);
+        Assert.Contains("\"nodes\":[{\"id\":1,\"label\":\"A\"}]", markdown);
+        Assert.DoesNotContain("\ncompleted\n", markdown, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
@@ -353,7 +353,7 @@ public sealed class UiShellAssetsTests {
             "function resolveVisualExportBuildFailureMessage(visualType, format)",
             "function tryCaptureVisualViewCanvasPayload(visualType)",
             "function resolveDocxRenderSize(visualType, docxVisualMaxWidthPx)",
-            "var renderSize = resolveDocxRenderSize(fence.language, docxVisualMaxWidthPx);",
+            "var renderSize = resolveDocxRenderSize(normalizedFenceLanguage, docxVisualMaxWidthPx);",
             "convertSvgPayloadToPng(rendered, themeMode, renderSize)",
             "SVG export is only available for Mermaid diagrams.",
             "Visual export couldn't prepare the image payload before save.",
@@ -378,6 +378,8 @@ public sealed class UiShellAssetsTests {
             "host.style.width = String(exportWidth) + \"px\"",
             "(!parsedData || !parsedData.dataBase64) && canvas && typeof canvas.toDataURL === \"function\"",
             "window.requestAnimationFrame(function()",
+            "normalized === \"network\" || normalized === \"visnetwork\"",
+            "code.language-ix-network, code.language-visnetwork, code.language-network",
             "Object.prototype.hasOwnProperty.call(rawEdge, \"source\")",
             "Object.prototype.hasOwnProperty.call(rawEdge, \"target\")");
     }
@@ -392,7 +394,7 @@ public sealed class UiShellAssetsTests {
 
         Assert.Contains("pre.classList && pre.classList.contains(\"mermaid\")", script, StringComparison.Ordinal);
         Assert.Contains("pre.querySelector(\"code.language-ix-chart, code.language-chart\")", script, StringComparison.Ordinal);
-        Assert.Contains("pre.querySelector(\"code.language-ix-network\")", script, StringComparison.Ordinal);
+        Assert.Contains("pre.querySelector(\"code.language-ix-network, code.language-visnetwork, code.language-network\")", script, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.cs
@@ -12,6 +12,8 @@ namespace IntelligenceX.Chat.App.Markdown;
 internal static class ToolRunMarkdownFormatter {
     private const string DataViewPayloadFenceLanguage = "ix-dataview";
     private const string DataViewPayloadKind = "ix_tool_dataview_v1";
+    private const string ChartFenceLanguage = "ix-chart";
+    private const string NetworkFenceLanguage = "ix-network";
 
     /// <summary>
     /// Builds markdown for tool calls and outputs.
@@ -43,14 +45,16 @@ internal static class ToolRunMarkdownFormatter {
                 AppendFailureDescriptor(markdown, output);
             }
 
-            if (TryBuildDataViewPayload(output, out var dataViewPayloadJson)) {
-                markdown.CodeFence(DataViewPayloadFenceLanguage, dataViewPayloadJson);
+            var renderHintFences = BuildRenderHintFences(output);
+            for (var i = 0; i < renderHintFences.Count; i++) {
+                var fence = renderHintFences[i];
+                markdown.CodeFence(fence.Language, fence.Content);
             }
 
             var summary = NormalizeSummaryMarkdown(output.SummaryMarkdown, toolLabel);
             if (ShouldIncludeSummary(summary, hasError)) {
                 markdown.Raw(summary);
-            } else if (!hasError) {
+            } else if (!hasError && renderHintFences.Count == 0) {
                 markdown.Paragraph("completed");
             }
 
@@ -212,61 +216,207 @@ internal static class ToolRunMarkdownFormatter {
         return hasPipe;
     }
 
-    private static bool TryBuildDataViewPayload(ToolOutputDto output, out string payloadJson) {
-        payloadJson = string.Empty;
-        if (string.IsNullOrWhiteSpace(output.RenderJson) || string.IsNullOrWhiteSpace(output.Output)) {
-            return false;
+    private static List<(string Language, string Content)> BuildRenderHintFences(ToolOutputDto output) {
+        var fences = new List<(string Language, string Content)>();
+        if (string.IsNullOrWhiteSpace(output.RenderJson)) {
+            return fences;
         }
 
+        JsonDocument? outputDoc = null;
+        JsonElement outputRoot = default;
         try {
+            if (!string.IsNullOrWhiteSpace(output.Output)) {
+                outputDoc = JsonDocument.Parse(output.Output);
+                if (outputDoc.RootElement.ValueKind == JsonValueKind.Object) {
+                    outputRoot = outputDoc.RootElement;
+                }
+            }
+
             using var renderDoc = JsonDocument.Parse(output.RenderJson);
-            if (renderDoc.RootElement.ValueKind != JsonValueKind.Object) {
-                return false;
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var renderHint in EnumerateRenderHints(renderDoc.RootElement)) {
+                var normalizedKind = NormalizeRenderKind(ReadStringProperty(renderHint, "kind"));
+                if (normalizedKind.Length == 0) {
+                    continue;
+                }
+
+                if (string.Equals(normalizedKind, "table", StringComparison.Ordinal)) {
+                    if (!TryBuildDataViewPayload(
+                            renderHint,
+                            outputRoot,
+                            output.CallId ?? string.Empty,
+                            out var dataViewPayloadJson)) {
+                        continue;
+                    }
+
+                    var dedupeKey = DataViewPayloadFenceLanguage + "\n" + dataViewPayloadJson;
+                    if (seen.Add(dedupeKey)) {
+                        fences.Add((DataViewPayloadFenceLanguage, dataViewPayloadJson));
+                    }
+                    continue;
+                }
+
+                if (!TryBuildCodeRenderFence(
+                        renderHint,
+                        normalizedKind,
+                        outputRoot,
+                        out var language,
+                        out var content)) {
+                    continue;
+                }
+
+                var key = language + "\n" + content;
+                if (seen.Add(key)) {
+                    fences.Add((language, content));
+                }
             }
 
-            var render = renderDoc.RootElement;
-            var kind = ReadStringProperty(render, "kind");
-            if (!string.Equals(kind, "table", StringComparison.OrdinalIgnoreCase)) {
-                return false;
-            }
-
-            var rowsPath = ReadStringProperty(render, "rows_path");
-            if (string.IsNullOrWhiteSpace(rowsPath)) {
-                return false;
-            }
-
-            using var outputDoc = JsonDocument.Parse(output.Output);
-            if (outputDoc.RootElement.ValueKind != JsonValueKind.Object) {
-                return false;
-            }
-
-            if (!TryResolvePath(outputDoc.RootElement, rowsPath, out var rowsNode) || rowsNode.ValueKind != JsonValueKind.Array) {
-                return false;
-            }
-
-            var columns = ReadRenderColumns(render);
-            if (columns.Count == 0) {
-                columns = InferColumnsFromRows(rowsNode);
-            }
-            if (columns.Count == 0) {
-                return false;
-            }
-
-            var matrix = BuildRowsMatrix(rowsNode, columns);
-            if (matrix.Length == 0) {
-                return false;
-            }
-
-            var payload = new Dictionary<string, object?> {
-                ["kind"] = DataViewPayloadKind,
-                ["call_id"] = output.CallId ?? string.Empty,
-                ["rows"] = matrix
-            };
-            payloadJson = JsonSerializer.Serialize(payload);
-            return true;
+            return fences;
         } catch {
+            return fences;
+        } finally {
+            outputDoc?.Dispose();
+        }
+    }
+
+    private static IEnumerable<JsonElement> EnumerateRenderHints(JsonElement renderRoot) {
+        if (renderRoot.ValueKind == JsonValueKind.Object) {
+            yield return renderRoot;
+            yield break;
+        }
+
+        if (renderRoot.ValueKind != JsonValueKind.Array) {
+            yield break;
+        }
+
+        foreach (var item in renderRoot.EnumerateArray()) {
+            if (item.ValueKind == JsonValueKind.Object) {
+                yield return item;
+            }
+        }
+    }
+
+    private static string NormalizeRenderKind(string kind) {
+        var normalized = (kind ?? string.Empty).Trim().ToLowerInvariant();
+        return normalized switch {
+            "chart" => ChartFenceLanguage,
+            "network" => NetworkFenceLanguage,
+            "visnetwork" => NetworkFenceLanguage,
+            _ => normalized
+        };
+    }
+
+    private static string NormalizeRenderFenceLanguage(string language, string normalizedKind) {
+        var normalizedLanguage = (language ?? string.Empty).Trim().ToLowerInvariant();
+        if (normalizedLanguage.Length > 0) {
+            if (string.Equals(normalizedLanguage, "chart", StringComparison.Ordinal)) {
+                return ChartFenceLanguage;
+            }
+
+            if (string.Equals(normalizedLanguage, "network", StringComparison.Ordinal)
+                || string.Equals(normalizedLanguage, "visnetwork", StringComparison.Ordinal)) {
+                return NetworkFenceLanguage;
+            }
+
+            return normalizedLanguage;
+        }
+
+        if (string.Equals(normalizedKind, ChartFenceLanguage, StringComparison.Ordinal)
+            || string.Equals(normalizedKind, NetworkFenceLanguage, StringComparison.Ordinal)
+            || string.Equals(normalizedKind, "mermaid", StringComparison.Ordinal)) {
+            return normalizedKind;
+        }
+
+        return "text";
+    }
+
+    private static bool TryBuildCodeRenderFence(
+        JsonElement render,
+        string normalizedKind,
+        JsonElement outputRoot,
+        out string language,
+        out string content) {
+        language = string.Empty;
+        content = string.Empty;
+
+        if (!string.Equals(normalizedKind, "code", StringComparison.Ordinal)
+            && !string.Equals(normalizedKind, "mermaid", StringComparison.Ordinal)
+            && !string.Equals(normalizedKind, ChartFenceLanguage, StringComparison.Ordinal)
+            && !string.Equals(normalizedKind, NetworkFenceLanguage, StringComparison.Ordinal)) {
             return false;
         }
+
+        language = NormalizeRenderFenceLanguage(ReadStringProperty(render, "language"), normalizedKind);
+        if (language.Length == 0) {
+            return false;
+        }
+
+        if (TryGetPropertyValueCaseInsensitive(render, "content", out var inlineContentNode)
+            && inlineContentNode.ValueKind != JsonValueKind.Null
+            && inlineContentNode.ValueKind != JsonValueKind.Undefined) {
+            content = inlineContentNode.ValueKind == JsonValueKind.String
+                ? (inlineContentNode.GetString() ?? string.Empty)
+                : inlineContentNode.GetRawText();
+            content = content.Trim();
+            return content.Length > 0;
+        }
+
+        var contentPath = ReadStringProperty(render, "content_path");
+        if (string.IsNullOrWhiteSpace(contentPath)) {
+            return false;
+        }
+
+        if (outputRoot.ValueKind != JsonValueKind.Object
+            || !TryResolvePath(outputRoot, contentPath, out var contentNode)) {
+            return false;
+        }
+
+        content = contentNode.ValueKind == JsonValueKind.String
+            ? (contentNode.GetString() ?? string.Empty)
+            : contentNode.GetRawText();
+        content = content.Trim();
+        return content.Length > 0;
+    }
+
+    private static bool TryBuildDataViewPayload(
+        JsonElement render,
+        JsonElement outputRoot,
+        string callId,
+        out string payloadJson) {
+        payloadJson = string.Empty;
+        if (outputRoot.ValueKind != JsonValueKind.Object) {
+            return false;
+        }
+
+        var rowsPath = ReadStringProperty(render, "rows_path");
+        if (string.IsNullOrWhiteSpace(rowsPath)) {
+            return false;
+        }
+
+        if (!TryResolvePath(outputRoot, rowsPath, out var rowsNode) || rowsNode.ValueKind != JsonValueKind.Array) {
+            return false;
+        }
+
+        var columns = ReadRenderColumns(render);
+        if (columns.Count == 0) {
+            columns = InferColumnsFromRows(rowsNode);
+        }
+        if (columns.Count == 0) {
+            return false;
+        }
+
+        var matrix = BuildRowsMatrix(rowsNode, columns);
+        if (matrix.Length == 0) {
+            return false;
+        }
+
+        var payload = new Dictionary<string, object?> {
+            ["kind"] = DataViewPayloadKind,
+            ["call_id"] = callId,
+            ["rows"] = matrix
+        };
+        payloadJson = JsonSerializer.Serialize(payload);
+        return true;
     }
 
     private static string[][] BuildRowsMatrix(JsonElement rowsNode, IReadOnlyList<(string Key, string Label)> columns) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.18.core.tools.rendering.js
@@ -570,7 +570,7 @@
           return;
         }
 
-        if (pre.querySelector("code.language-ix-network")) {
+        if (pre.querySelector("code.language-ix-network, code.language-visnetwork, code.language-network")) {
           return;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.21.core.visuals.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.21.core.visuals.js
@@ -84,14 +84,14 @@
   }
 
   function getVisualKindLabel(kind) {
-    var normalized = String(kind || "").toLowerCase();
+    var normalized = normalizeVisualType(kind);
     if (normalized === "mermaid") {
       return "Mermaid Diagram";
     }
     if (normalized === "ix-chart" || normalized === "chart") {
       return "Chart";
     }
-    if (normalized === "ix-network") {
+    if (normalized === "ix-network" || normalized === "network" || normalized === "visnetwork") {
       return "Network Diagram";
     }
     return "Visual";
@@ -1503,7 +1503,7 @@
       return;
     }
 
-    var code = pre.querySelector("code.language-ix-network");
+    var code = pre.querySelector("code.language-ix-network, code.language-visnetwork, code.language-network");
     var source = pre.getAttribute("data-ix-network-source");
     if ((!source || source.length === 0) && code) {
       source = normalizeText(code.textContent || "");
@@ -1587,7 +1587,7 @@
   }
 
   function collectIxNetworkBlocks(root) {
-    var codeNodes = root.querySelectorAll(".bubble .markdown-body pre > code.language-ix-network");
+    var codeNodes = root.querySelectorAll(".bubble .markdown-body pre > code.language-ix-network, .bubble .markdown-body pre > code.language-visnetwork, .bubble .markdown-body pre > code.language-network");
     if (!codeNodes || codeNodes.length === 0) {
       return [];
     }
@@ -1841,6 +1841,9 @@
     var normalized = String(type || "").trim().toLowerCase();
     if (normalized === "chart") {
       return "ix-chart";
+    }
+    if (normalized === "network" || normalized === "visnetwork") {
+      return "ix-network";
     }
     return normalized;
   }
@@ -3698,7 +3701,7 @@
   }
 
   async function renderVisualFenceForExport(language, source, imageId, themeMode, renderSize) {
-    var normalized = String(language || "").trim().toLowerCase();
+    var normalized = normalizeVisualType(language);
     var content = normalizeText(source || "");
     if (!content) {
       return null;
@@ -3708,7 +3711,7 @@
       return renderMermaidForExport(content, imageId, themeMode);
     }
 
-    if (normalized === "ix-chart" || normalized === "chart") {
+    if (normalized === "ix-chart") {
       if (content.length > ixVisualChartState.maxSourceChars) {
         return null;
       }
@@ -3753,10 +3756,10 @@
         continue;
       }
 
-      var supportedLanguage = fence.language === "mermaid"
-        || fence.language === "ix-chart"
-        || fence.language === "chart"
-        || fence.language === "ix-network";
+      var normalizedFenceLanguage = normalizeVisualType(fence.language);
+      var supportedLanguage = normalizedFenceLanguage === "mermaid"
+        || normalizedFenceLanguage === "ix-chart"
+        || normalizedFenceLanguage === "ix-network";
       if (!supportedLanguage) {
         output.push(line);
         i += 1;
@@ -3777,8 +3780,8 @@
       }
 
       var source = lines.slice(i + 1, closingIndex).join("\n");
-      var renderSize = resolveDocxRenderSize(fence.language, docxVisualMaxWidthPx);
-      var rendered = await renderVisualFenceForExport(fence.language, source, imageCounter + 1, themeMode, renderSize);
+      var renderSize = resolveDocxRenderSize(normalizedFenceLanguage, docxVisualMaxWidthPx);
+      var rendered = await renderVisualFenceForExport(normalizedFenceLanguage, source, imageCounter + 1, themeMode, renderSize);
       if (rendered && rendered.mimeType === "image/svg+xml") {
         rendered = await convertSvgPayloadToPng(rendered, themeMode, renderSize);
       }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.StructuredNextAction.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.StructuredNextAction.cs
@@ -573,37 +573,7 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static bool TryParseFlexibleBoolean(string value, out bool parsed) {
-        parsed = false;
-        var normalized = (value ?? string.Empty).Trim();
-        if (normalized.Length == 0) {
-            return false;
-        }
-
-        if (bool.TryParse(normalized, out parsed)) {
-            return true;
-        }
-
-        if (string.Equals(normalized, "1", StringComparison.Ordinal)) {
-            parsed = true;
-            return true;
-        }
-
-        if (string.Equals(normalized, "0", StringComparison.Ordinal)) {
-            parsed = false;
-            return true;
-        }
-
-        if (FlexibleBooleanTrueTokens.Contains(normalized)) {
-            parsed = true;
-            return true;
-        }
-
-        if (FlexibleBooleanFalseTokens.Contains(normalized)) {
-            parsed = false;
-            return true;
-        }
-
-        return false;
+        return TryParseProtocolBoolean((value ?? string.Empty).Trim(), out parsed);
     }
 
     private static bool TryParseJsonArrayString(string value, out JsonArray parsedArray) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
@@ -29,19 +29,6 @@ internal sealed partial class ChatServiceSession {
     private const int FollowUpQuestionMaxTokens = 12;
     private static readonly char[] CallToActionCommaPunctuation = new[] { ',', '\uFF0C', '\u3001', '\u060C' };
     private static readonly char[] CallToActionColonPunctuation = new[] { ':', '\uFF1A', '\uFE13' };
-    // Keep this token set language-inclusive so boolean schema coercion does not depend on English-only replies.
-    private static readonly HashSet<string> FlexibleBooleanTrueTokens = new(StringComparer.OrdinalIgnoreCase) {
-        "yes", "on",
-        "si", "sí", "sim", "oui", "ja", "tak",
-        "да", "نعم", "是", "はい", "예",
-        "evet"
-    };
-    private static readonly HashSet<string> FlexibleBooleanFalseTokens = new(StringComparer.OrdinalIgnoreCase) {
-        "no", "off",
-        "non", "nein", "nie", "não", "nao",
-        "нет", "لا", "否", "いいえ", "아니요",
-        "hayir", "hayır"
-    };
     private enum ActionMutability {
         Unknown = 0,
         ReadOnly = 1,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
@@ -409,7 +409,9 @@ internal sealed partial class ChatServiceSession {
         }
 
         var normalized = (userRequest ?? string.Empty).Trim();
-        if (normalized.Length == 0 || LooksLikeContinuationFollowUp(normalized)) {
+        if (normalized.Length == 0
+            || LooksLikeContinuationFollowUp(normalized)
+            || LooksLikeStructuredIntentPayload(normalized)) {
             return;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.StatsAndTesting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.StatsAndTesting.cs
@@ -62,6 +62,16 @@ internal sealed partial class ChatServiceSession {
             }
         }
 
+        if (LooksLikeStructuredIntentPayload(intent!)) {
+            lock (_toolRoutingContextLock) {
+                _lastUserIntentByThreadId.Remove(normalizedThreadId);
+                _lastUserIntentSeenUtcTicks.Remove(normalizedThreadId);
+                TrimWeightedRoutingContextsNoLock();
+            }
+            RemoveUserIntentSnapshot(normalizedThreadId);
+            return raw;
+        }
+
         if (intentTicks > 0) {
             if (intentTicks < DateTime.MinValue.Ticks || intentTicks > DateTime.MaxValue.Ticks) {
                 // Defensive: avoid exceptions from ticks->DateTime conversion if ticks are corrupted/out of range.

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.TextNormalization.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.TextNormalization.cs
@@ -226,4 +226,28 @@ internal sealed partial class ChatServiceSession {
         return sb.ToString().Trim();
     }
 
+    private static bool LooksLikeStructuredIntentPayload(string text) {
+        var normalized = (text ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return false;
+        }
+
+        if (TryParseExplicitActSelection(normalized, out _, out _)
+            || TryReadActionSelectionIntent(normalized, out _, out _)
+            || TryParseDomainIntentMarkerSelection(normalized, DomainIntentMarker, out _)
+            || TryParseDomainIntentChoiceMarkerSelection(normalized, out _)
+            || TryParseDomainIntentFamilyFromActionSelectionPayload(normalized, out _)
+            || TryParseDomainIntentFamilyFromDomainScopePayload(normalized, out _)) {
+            return true;
+        }
+
+        if (TryExtractActionSelectionPayloadJson(normalized, out var payload)
+            && (TryParseDomainIntentFamilyFromActionSelectionPayload(payload, out _)
+                || TryParseDomainIntentFamilyFromDomainScopePayload(payload, out _))) {
+            return true;
+        }
+
+        return false;
+    }
+
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.WorkingMemoryCheckpoint.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.WorkingMemoryCheckpoint.cs
@@ -309,7 +309,9 @@ internal sealed partial class ChatServiceSession {
 
     private static string NormalizeWorkingMemoryIntentAnchor(string value) {
         var normalized = (value ?? string.Empty).Trim();
-        if (normalized.Length == 0 || LooksLikeContinuationFollowUp(normalized)) {
+        if (normalized.Length == 0
+            || LooksLikeContinuationFollowUp(normalized)
+            || LooksLikeStructuredIntentPayload(normalized)) {
             return string.Empty;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.BooleanParsing.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.BooleanParsing.cs
@@ -11,41 +11,35 @@ public sealed partial class ChatServiceRoutingTrimTests {
         ?? throw new InvalidOperationException("TryParseFlexibleBoolean not found.");
 
     [Theory]
-    [InlineData("sí")]
-    [InlineData("sim")]
-    [InlineData("oui")]
-    [InlineData("ja")]
-    [InlineData("tak")]
-    [InlineData("да")]
-    [InlineData("نعم")]
-    [InlineData("是")]
-    [InlineData("はい")]
-    [InlineData("예")]
-    [InlineData("evet")]
-    public void TryParseFlexibleBoolean_ParsesLanguageInclusiveTrueTokens(string input) {
+    [InlineData("true", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("1", true)]
+    [InlineData("false", false)]
+    [InlineData("FALSE", false)]
+    [InlineData("0", false)]
+    public void TryParseFlexibleBoolean_ParsesProtocolBooleanLiterals(string input, bool expected) {
         var args = new object?[] { input, false };
         var resolved = TryParseFlexibleBooleanMethod.Invoke(null, args);
 
         Assert.True(Assert.IsType<bool>(resolved));
-        Assert.True(Assert.IsType<bool>(args[1]));
+        Assert.Equal(expected, Assert.IsType<bool>(args[1]));
     }
 
     [Theory]
-    [InlineData("non")]
-    [InlineData("nein")]
-    [InlineData("nie")]
-    [InlineData("não")]
-    [InlineData("нет")]
-    [InlineData("لا")]
-    [InlineData("否")]
-    [InlineData("いいえ")]
-    [InlineData("아니요")]
-    [InlineData("hayır")]
-    public void TryParseFlexibleBoolean_ParsesLanguageInclusiveFalseTokens(string input) {
+    [InlineData("yes")]
+    [InlineData("no")]
+    [InlineData("on")]
+    [InlineData("off")]
+    [InlineData("sí")]
+    [InlineData("oui")]
+    [InlineData("да")]
+    [InlineData("نعم")]
+    [InlineData("はい")]
+    public void TryParseFlexibleBoolean_RejectsNaturalLanguageTokens(string input) {
         var args = new object?[] { input, true };
         var resolved = TryParseFlexibleBooleanMethod.Invoke(null, args);
 
-        Assert.True(Assert.IsType<bool>(resolved));
+        Assert.False(Assert.IsType<bool>(resolved));
         Assert.False(Assert.IsType<bool>(args[1]));
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.UserIntentPersistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.UserIntentPersistence.cs
@@ -38,4 +38,42 @@ public sealed partial class ChatServiceRoutingTrimTests {
             }
         }
     }
+
+    [Fact]
+    public void ExpandContinuationUserRequest_DoesNotRehydrateStructuredIntentPayloadAfterRestart() {
+        var root = Path.Combine(Path.GetTempPath(), "ix-chat-user-intent-structured-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var pendingActionsStorePath = Path.Combine(root, "pending-actions.json");
+        const string threadId = "thread-user-intent-structured-restart";
+        const string structuredIntent =
+            "{\"ix_action_selection\":{\"id\":\"act_domain_scope_public\",\"request\":{\"ix_domain_scope\":{\"family\":\"public_domain\"}},\"mutating\":false}}";
+
+        try {
+            var session1 = new ChatServiceSession(
+                new ServiceOptions { PendingActionsStorePath = pendingActionsStorePath },
+                Stream.Null);
+            RememberUserIntentMethod.Invoke(session1, new object?[] { threadId, structuredIntent });
+
+            var session2 = new ChatServiceSession(
+                new ServiceOptions { PendingActionsStorePath = pendingActionsStorePath },
+                Stream.Null);
+            var expandedObj = ExpandContinuationUserRequestMethod.Invoke(session2, new object?[] { threadId, "run now" });
+            var expanded = Assert.IsType<string>(expandedObj);
+            Assert.Equal("run now", expanded);
+
+            var userIntentPath = Assert.IsType<string>(ResolveUserIntentStorePathMethod.Invoke(session2, Array.Empty<object>()));
+            if (File.Exists(userIntentPath)) {
+                var persisted = File.ReadAllText(userIntentPath);
+                Assert.DoesNotContain(threadId, persisted, StringComparison.Ordinal);
+            }
+        } finally {
+            try {
+                if (Directory.Exists(root)) {
+                    Directory.Delete(root, recursive: true);
+                }
+            } catch {
+                // Best effort test cleanup only.
+            }
+        }
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.WorkingMemoryCheckpoint.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.WorkingMemoryCheckpoint.cs
@@ -115,4 +115,29 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.False(augmented);
         Assert.Equal("２", routedFromCheckpoint);
     }
+
+    [Fact]
+    public void WorkingMemoryCheckpoint_DropsStructuredIntentAnchorOnCheckpointWrite() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        const string threadId = "thread-working-memory-structured-anchor";
+        const string structuredAnchor =
+            "{\"ix_action_selection\":{\"id\":\"act_domain_scope_public\",\"request\":{\"ix_domain_scope\":{\"family\":\"public_domain\"}},\"mutating\":false}}";
+
+        session.RememberWorkingMemoryCheckpointForTesting(
+            threadId: threadId,
+            intentAnchor: structuredAnchor,
+            domainIntentFamily: "public_domain",
+            recentToolNames: new[] { "domaindetective_domain_summary" },
+            recentEvidenceSnippets: new[] { "domaindetective_domain_summary: SPF and DMARC are valid." });
+
+        var found = session.TryGetWorkingMemoryCheckpointForTesting(
+            threadId,
+            out var intentAnchor,
+            out _,
+            out _,
+            out _);
+
+        Assert.True(found);
+        Assert.Equal(string.Empty, intentAnchor);
+    }
 }


### PR DESCRIPTION
## Summary
This PR applies a targeted reliability hardening pass for IX Chat + IX Tools focused on three high-impact regressions that can degrade long conversations and tool UX:

1. **Continuation memory poisoning guard**
- Prevents structured action/domain payloads (for example `ix_action_selection`) from being persisted as user intent.
- Prunes previously persisted structured intent payloads during continuation expansion.
- Prevents structured payloads from becoming working-memory intent anchors.

2. **Language-neutral structured boolean coercion**
- Removes hardcoded natural-language boolean token lists from structured-next-action argument coercion.
- Uses strict protocol boolean parsing (`true/false/1/0`) for schema coercion.

3. **First-party render-hint reliability improvements**
- Tool render hints now support both **object and array** payloads.
- Adds automatic code-fence materialization for non-table render hints (`code`, `mermaid`, `chart`, `ix-chart`, `network`, `ix-network`, `visnetwork`).
- Normalizes `visnetwork`/`network` aliases to first-party `ix-network` in visual runtime and export flows.
- Avoids fallback `completed` text when render hints already produced meaningful output.

## Tests
### Passed
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "DisplayName~TryParseFlexibleBoolean|DisplayName~StructuredIntentPayload|DisplayName~WorkingMemoryCheckpoint_DropsStructuredIntentAnchorOnCheckpointWrite"`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release -p:NoWarn=1591 --filter "DisplayName~ToolRunMarkdownFormatter|DisplayName~UiShellAssetsTests"`

### Notes
- `-p:NoWarn=1591` was used for the app test run because XML-doc warning policy in unrelated public test file(s) otherwise blocks compilation in this environment.