### PR TITLE
fix(chat): harden render-hint fence parsing resilience

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
@@ -9,6 +9,21 @@ namespace IntelligenceX.Chat.App.Tests;
 /// Tests for tool-run markdown formatting.
 /// </summary>
 public sealed class ToolRunMarkdownFormatterTests {
+    private static int CountOccurrences(string text, string token) {
+        if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(token)) {
+            return 0;
+        }
+
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(token, index, StringComparison.Ordinal)) >= 0) {
+            count++;
+            index += token.Length;
+        }
+
+        return count;
+    }
+
     /// <summary>
     /// Ensures tool summaries render with headings and without list-heading corruption.
     /// </summary>
@@ -161,5 +176,86 @@ public sealed class ToolRunMarkdownFormatterTests {
         Assert.Contains("```ix-network", markdown);
         Assert.Contains("\"nodes\":[{\"id\":1,\"label\":\"A\"}]", markdown);
         Assert.DoesNotContain("\ncompleted\n", markdown, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Ensures malformed output payload JSON does not block inline render-hint code fences.
+    /// </summary>
+    [Fact]
+    public void Format_UsesInlineRenderContentWhenOutputPayloadIsMalformedJson() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c6",
+                    Name = "inline_renderer"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c6",
+                    Output = "not-json",
+                    RenderJson = "{\"kind\":\"code\",\"language\":\"text\",\"content\":\"inline-render-content\"}"
+                }
+            }
+        };
+
+        var markdown = ToolRunMarkdownFormatter.Format(tools, _ => "Inline Renderer");
+
+        Assert.Contains("```text", markdown);
+        Assert.Contains("inline-render-content", markdown);
+    }
+
+    /// <summary>
+    /// Ensures code render-hint content preserves leading/trailing whitespace from source payload strings.
+    /// </summary>
+    [Fact]
+    public void Format_PreservesWhitespaceForCodeRenderHintContentPath() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c7",
+                    Name = "whitespace_renderer"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c7",
+                    Output = "{\"snippet\":\"  keep-leading\\nkeep-trailing  \"}",
+                    RenderJson = "{\"kind\":\"code\",\"language\":\"text\",\"content_path\":\"snippet\"}"
+                }
+            }
+        };
+
+        var markdown = ToolRunMarkdownFormatter.Format(tools, _ => "Whitespace Renderer");
+
+        Assert.Contains("```text", markdown);
+        Assert.Contains("  keep-leading", markdown, StringComparison.Ordinal);
+        Assert.Contains("keep-trailing  ", markdown, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Ensures duplicate render-hint entries do not emit duplicate first-party visual fences.
+    /// </summary>
+    [Fact]
+    public void Format_DeduplicatesDuplicateRenderHintEntries() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c8",
+                    Name = "duplicate_visuals"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c8",
+                    Output = "{\"chart_payload\":{\"type\":\"bar\",\"data\":{\"labels\":[\"A\"],\"datasets\":[{\"data\":[1]}]}}}",
+                    RenderJson = "[{\"kind\":\"code\",\"language\":\"chart\",\"content_path\":\"chart_payload\"},{\"kind\":\"code\",\"language\":\"chart\",\"content_path\":\"chart_payload\"}]"
+                }
+            }
+        };
+
+        var markdown = ToolRunMarkdownFormatter.Format(tools, _ => "Duplicate Visuals");
+
+        Assert.Equal(1, CountOccurrences(markdown, "```ix-chart"));
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using IntelligenceX.Chat.Abstractions.Protocol;
@@ -226,53 +228,68 @@ internal static class ToolRunMarkdownFormatter {
         JsonElement outputRoot = default;
         try {
             if (!string.IsNullOrWhiteSpace(output.Output)) {
-                outputDoc = JsonDocument.Parse(output.Output);
-                if (outputDoc.RootElement.ValueKind == JsonValueKind.Object) {
-                    outputRoot = outputDoc.RootElement;
+                try {
+                    outputDoc = JsonDocument.Parse(output.Output);
+                    if (outputDoc.RootElement.ValueKind == JsonValueKind.Object) {
+                        outputRoot = outputDoc.RootElement;
+                    }
+                } catch (Exception ex) {
+                    TraceRenderHintWarning(output.CallId, "Failed to parse tool output JSON while building render fences.", ex);
                 }
             }
 
-            using var renderDoc = JsonDocument.Parse(output.RenderJson);
-            var seen = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var renderHint in EnumerateRenderHints(renderDoc.RootElement)) {
-                var normalizedKind = NormalizeRenderKind(ReadStringProperty(renderHint, "kind"));
-                if (normalizedKind.Length == 0) {
-                    continue;
-                }
+            JsonDocument renderDoc;
+            try {
+                renderDoc = JsonDocument.Parse(output.RenderJson);
+            } catch (Exception ex) {
+                TraceRenderHintWarning(output.CallId, "Failed to parse render hints JSON.", ex);
+                return fences;
+            }
 
-                if (string.Equals(normalizedKind, "table", StringComparison.Ordinal)) {
-                    if (!TryBuildDataViewPayload(
-                            renderHint,
-                            outputRoot,
-                            output.CallId ?? string.Empty,
-                            out var dataViewPayloadJson)) {
-                        continue;
+            using (renderDoc) {
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var renderHint in EnumerateRenderHints(renderDoc.RootElement)) {
+                    try {
+                        var normalizedKind = NormalizeRenderKind(ReadStringProperty(renderHint, "kind"));
+                        if (normalizedKind.Length == 0) {
+                            continue;
+                        }
+
+                        if (string.Equals(normalizedKind, "table", StringComparison.Ordinal)) {
+                            if (!TryBuildDataViewPayload(
+                                    renderHint,
+                                    outputRoot,
+                                    output.CallId ?? string.Empty,
+                                    out var dataViewPayloadJson)) {
+                                continue;
+                            }
+
+                            var dedupeKey = BuildRenderHintDeduplicationKey(DataViewPayloadFenceLanguage, dataViewPayloadJson);
+                            if (seen.Add(dedupeKey)) {
+                                fences.Add((DataViewPayloadFenceLanguage, dataViewPayloadJson));
+                            }
+                            continue;
+                        }
+
+                        if (!TryBuildCodeRenderFence(
+                                renderHint,
+                                normalizedKind,
+                                outputRoot,
+                                out var language,
+                                out var content)) {
+                            continue;
+                        }
+
+                        var key = BuildRenderHintDeduplicationKey(language, content);
+                        if (seen.Add(key)) {
+                            fences.Add((language, content));
+                        }
+                    } catch (Exception ex) {
+                        TraceRenderHintWarning(output.CallId, "Failed to process a render hint entry.", ex);
                     }
-
-                    var dedupeKey = DataViewPayloadFenceLanguage + "\n" + dataViewPayloadJson;
-                    if (seen.Add(dedupeKey)) {
-                        fences.Add((DataViewPayloadFenceLanguage, dataViewPayloadJson));
-                    }
-                    continue;
-                }
-
-                if (!TryBuildCodeRenderFence(
-                        renderHint,
-                        normalizedKind,
-                        outputRoot,
-                        out var language,
-                        out var content)) {
-                    continue;
-                }
-
-                var key = language + "\n" + content;
-                if (seen.Add(key)) {
-                    fences.Add((language, content));
                 }
             }
 
-            return fences;
-        } catch {
             return fences;
         } finally {
             outputDoc?.Dispose();
@@ -357,8 +374,7 @@ internal static class ToolRunMarkdownFormatter {
             content = inlineContentNode.ValueKind == JsonValueKind.String
                 ? (inlineContentNode.GetString() ?? string.Empty)
                 : inlineContentNode.GetRawText();
-            content = content.Trim();
-            return content.Length > 0;
+            return !string.IsNullOrWhiteSpace(content);
         }
 
         var contentPath = ReadStringProperty(render, "content_path");
@@ -374,8 +390,21 @@ internal static class ToolRunMarkdownFormatter {
         content = contentNode.ValueKind == JsonValueKind.String
             ? (contentNode.GetString() ?? string.Empty)
             : contentNode.GetRawText();
-        content = content.Trim();
-        return content.Length > 0;
+        return !string.IsNullOrWhiteSpace(content);
+    }
+
+    private static string BuildRenderHintDeduplicationKey(string language, string content) {
+        var normalizedLanguage = (language ?? string.Empty).Trim().ToLowerInvariant();
+        var value = content ?? string.Empty;
+        var payload = Encoding.UTF8.GetBytes(value);
+        var hash = Convert.ToHexString(SHA256.HashData(payload));
+        return normalizedLanguage + ":" + hash + ":" + value.Length;
+    }
+
+    private static void TraceRenderHintWarning(string? callId, string message, Exception ex) {
+        var id = string.IsNullOrWhiteSpace(callId) ? "<unknown>" : callId.Trim();
+        Trace.TraceWarning(
+            $"Tool render hint warning (call_id={id}): {message} ({ex.GetType().Name}: {ex.Message})");
     }
 
     private static bool TryBuildDataViewPayload(


### PR DESCRIPTION
## Summary
Follow-up reliability hardening for IX Chat render-hint handling.

This PR improves robustness and operability in `ToolRunMarkdownFormatter` by:

1. **Per-stage/per-item failure isolation**
- Malformed `output` JSON no longer blocks all render-hint processing.
- Malformed `render` JSON now exits cleanly with a warning (instead of silent fail-all).
- Individual broken render-hint entries are isolated so valid siblings still render.

2. **Operational diagnostics for render-hint failures**
- Adds `Trace.TraceWarning` diagnostics with `call_id`, error type, and failure stage.
- Improves production troubleshooting without changing user-facing behavior.

3. **Non-destructive code content handling**
- Removes unconditional `.Trim()` for code render hint content.
- Preserves meaningful leading/trailing whitespace in string code payloads.

4. **Lower-retention dedupe keys for large fence content**
- Deduplication now uses hashed keys (`SHA256`) instead of full `language + content` key strings.
- Reduces retained memory footprint for large render-hint payloads.

## Tests
### Added / Updated
- `Format_UsesInlineRenderContentWhenOutputPayloadIsMalformedJson`
- `Format_PreservesWhitespaceForCodeRenderHintContentPath`
- `Format_DeduplicatesDuplicateRenderHintEntries`

### Passed
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release -p:NoWarn=1591 --filter "DisplayName~ToolRunMarkdownFormatter|DisplayName~UiShellAssetsTests"`

## Notes
- `-p:NoWarn=1591` is still used in this environment due existing XML-doc warning policy in unrelated public test files.