### PR TITLE
Chat: surface first-party tool visuals outside debug mode

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowPostLoginQueueRecoveryTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowPostLoginQueueRecoveryTests.cs
@@ -3,7 +3,13 @@ using Xunit;
 
 namespace IntelligenceX.Chat.App.Tests;
 
+/// <summary>
+/// Tests for queued prompt recovery decisions after post-login verification failures.
+/// </summary>
 public sealed class MainWindowPostLoginQueueRecoveryTests {
+    /// <summary>
+    /// Ensures queued prompts are retried when sign-in is required, at least one prompt is queued, and login is idle.
+    /// </summary>
     [Fact]
     public void ShouldAttemptQueuedPromptDispatchAfterVerificationFailure_ReturnsTrue_WhenQueuedPromptExistsAndLoginIsIdle() {
         var shouldDispatch = MainWindow.ShouldAttemptQueuedPromptDispatchAfterVerificationFailure(
@@ -14,6 +20,9 @@ public sealed class MainWindowPostLoginQueueRecoveryTests {
         Assert.True(shouldDispatch);
     }
 
+    /// <summary>
+    /// Ensures retry is skipped when no queued prompt exists.
+    /// </summary>
     [Fact]
     public void ShouldAttemptQueuedPromptDispatchAfterVerificationFailure_ReturnsFalse_WhenNoQueuedPromptExists() {
         var shouldDispatch = MainWindow.ShouldAttemptQueuedPromptDispatchAfterVerificationFailure(
@@ -24,6 +33,9 @@ public sealed class MainWindowPostLoginQueueRecoveryTests {
         Assert.False(shouldDispatch);
     }
 
+    /// <summary>
+    /// Ensures retry is skipped while login is still in progress.
+    /// </summary>
     [Fact]
     public void ShouldAttemptQueuedPromptDispatchAfterVerificationFailure_ReturnsFalse_WhenLoginIsStillInProgress() {
         var shouldDispatch = MainWindow.ShouldAttemptQueuedPromptDispatchAfterVerificationFailure(
@@ -34,6 +46,9 @@ public sealed class MainWindowPostLoginQueueRecoveryTests {
         Assert.False(shouldDispatch);
     }
 
+    /// <summary>
+    /// Ensures final assistant responses replace interim bubbles by default instead of appending a second final bubble.
+    /// </summary>
     [Fact]
     public void ShouldRenderFinalAssistantAsSeparateBubbleAfterInterim_ReturnsFalse() {
         Assert.False(MainWindow.ShouldRenderFinalAssistantAsSeparateBubbleAfterInterim());

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowToolTranscriptMarkdownTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowToolTranscriptMarkdownTests.cs
@@ -1,0 +1,75 @@
+using System;
+using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.App;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Tests for debug vs non-debug tool transcript markdown selection.
+/// </summary>
+public sealed class MainWindowToolTranscriptMarkdownTests {
+    /// <summary>
+    /// Ensures debug-mode transcript formatting keeps failure diagnostics.
+    /// </summary>
+    [Fact]
+    public void BuildToolRunTranscriptMarkdown_UsesDebugFormatterWhenDebugModeEnabled() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c1",
+                    Name = "diag"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c1",
+                    Output = "{}",
+                    Ok = false,
+                    ErrorCode = "tool_timeout",
+                    Error = "Tool timed out after 60s.",
+                    Hints = new[] { "Retry later." },
+                    SummaryMarkdown = "### Debug summary"
+                }
+            }
+        };
+
+        var markdown = MainWindow.BuildToolRunTranscriptMarkdown(tools, debugMode: true, _ => "Diagnostic Tool");
+
+        Assert.Contains("**Tool outputs:**", markdown);
+        Assert.Contains("failure descriptor:", markdown);
+        Assert.Contains("Tool timed out after 60s.", markdown);
+        Assert.Contains("Retry later.", markdown);
+    }
+
+    /// <summary>
+    /// Ensures non-debug transcript formatting emits only first-party visual markdown.
+    /// </summary>
+    [Fact]
+    public void BuildToolRunTranscriptMarkdown_UsesVisualsOnlyFormatterWhenDebugModeDisabled() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c2",
+                    Name = "chart_pack"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c2",
+                    Output = "{\"chart\":{\"type\":\"line\",\"data\":{\"labels\":[\"A\"],\"datasets\":[{\"data\":[1]}]}}}",
+                    RenderJson = "{\"kind\":\"code\",\"language\":\"chart\",\"content_path\":\"chart\"}",
+                    Ok = false,
+                    Error = "debug-only error"
+                }
+            }
+        };
+
+        var markdown = MainWindow.BuildToolRunTranscriptMarkdown(tools, debugMode: false, _ => "Chart Pack");
+
+        Assert.Contains("**Tool visuals:**", markdown);
+        Assert.Contains("```ix-chart", markdown);
+        Assert.DoesNotContain("failure descriptor:", markdown);
+        Assert.DoesNotContain("debug-only error", markdown, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
@@ -258,4 +258,71 @@ public sealed class ToolRunMarkdownFormatterTests {
 
         Assert.Equal(1, CountOccurrences(markdown, "```ix-chart"));
     }
+
+    /// <summary>
+    /// Ensures visual-only formatting emits first-party visual fences and excludes debug diagnostics.
+    /// </summary>
+    [Fact]
+    public void FormatVisualsOnly_EmitsFirstPartyVisualsWithoutDebugDiagnostics() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c9",
+                    Name = "visuals_only_report"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c9",
+                    Output = "{\"chart\":{\"type\":\"bar\",\"data\":{\"labels\":[\"A\"],\"datasets\":[{\"data\":[1]}]}},\"rows\":[{\"name\":\"A\",\"score\":1}]}",
+                    RenderJson =
+                        "[{\"kind\":\"code\",\"language\":\"ix-chart\",\"content_path\":\"chart\"},{\"kind\":\"table\",\"rows_path\":\"rows\",\"columns\":[{\"key\":\"name\",\"label\":\"Name\"},{\"key\":\"score\",\"label\":\"Score\"}]},{\"kind\":\"code\",\"language\":\"text\",\"content\":\"hidden\"}]",
+                    Ok = false,
+                    ErrorCode = "tool_timeout",
+                    Error = "debug-only error",
+                    Hints = new[] { "debug-only hint" },
+                    SummaryMarkdown = "### Debug Summary\n\nshould-not-leak"
+                }
+            }
+        };
+
+        var markdown = ToolRunMarkdownFormatter.FormatVisualsOnly(tools, _ => "Visuals Only Report");
+
+        Assert.Contains("**Tool visuals:**", markdown);
+        Assert.Contains("#### Visuals Only Report", markdown);
+        Assert.Contains("```ix-chart", markdown);
+        Assert.Contains("```ix-dataview", markdown);
+        Assert.DoesNotContain("```text", markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("failure descriptor", markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("debug-only error", markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("debug-only hint", markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Debug Summary", markdown, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Ensures visual-only formatting returns empty markdown when no first-party visuals are present.
+    /// </summary>
+    [Fact]
+    public void FormatVisualsOnly_ReturnsEmptyWhenNoFirstPartyVisualsPresent() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c10",
+                    Name = "text_renderer"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c10",
+                    Output = "{\"snippet\":\"hello\"}",
+                    RenderJson = "{\"kind\":\"code\",\"language\":\"text\",\"content_path\":\"snippet\"}",
+                    SummaryMarkdown = "### Text summary"
+                }
+            }
+        };
+
+        var markdown = ToolRunMarkdownFormatter.FormatVisualsOnly(tools, _ => "Text Renderer");
+
+        Assert.Equal(string.Empty, markdown);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
@@ -349,8 +349,11 @@ public sealed partial class MainWindow : Window {
         SetActiveTurnAssistantProvisional(conversation, provisional: false, preferProvisionalEvents: false);
         ApplyFinalAssistantTurnTimeline(conversation, result.TurnTimelineEvents);
         _assistantStreamingState.ClearReceivedDelta();
-        if (_debugMode && result.Tools is not null && (result.Tools.Calls.Count > 0 || result.Tools.Outputs.Count > 0)) {
-            conversation.Messages.Add(("Tools", BuildToolRunMarkdown(result.Tools), DateTime.Now, turn.AssistantModelLabel));
+        if (result.Tools is not null && (result.Tools.Calls.Count > 0 || result.Tools.Outputs.Count > 0)) {
+            var toolMarkdown = BuildToolRunTranscriptMarkdown(result.Tools);
+            if (!string.IsNullOrWhiteSpace(toolMarkdown)) {
+                conversation.Messages.Add(("Tools", toolMarkdown, DateTime.Now, turn.AssistantModelLabel));
+            }
         }
 
         conversation.UpdatedUtc = DateTime.UtcNow;
@@ -486,4 +489,3 @@ public sealed partial class MainWindow : Window {
             : AssistantTurnOutcome.Error(ex.Message);
     }
 }
-

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.ToolPresentation.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.ToolPresentation.cs
@@ -13,6 +13,25 @@ public sealed partial class MainWindow : Window {
         return ToolRunMarkdownFormatter.Format(tools, ResolveToolDisplayName);
     }
 
+    private string BuildToolRunVisualMarkdown(ToolRunDto tools) {
+        return ToolRunMarkdownFormatter.FormatVisualsOnly(tools, ResolveToolDisplayName);
+    }
+
+    internal static string BuildToolRunTranscriptMarkdown(
+        ToolRunDto tools,
+        bool debugMode,
+        Func<string?, string> resolveToolDisplayName) {
+        ArgumentNullException.ThrowIfNull(tools);
+        ArgumentNullException.ThrowIfNull(resolveToolDisplayName);
+        return debugMode
+            ? ToolRunMarkdownFormatter.Format(tools, resolveToolDisplayName)
+            : ToolRunMarkdownFormatter.FormatVisualsOnly(tools, resolveToolDisplayName);
+    }
+
+    private string BuildToolRunTranscriptMarkdown(ToolRunDto tools) {
+        return BuildToolRunTranscriptMarkdown(tools, _debugMode, ResolveToolDisplayName);
+    }
+
     private string ResolveToolDisplayName(string? name) {
         if (!string.IsNullOrWhiteSpace(name)) {
             var key = name.Trim();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.cs
@@ -66,6 +66,47 @@ internal static class ToolRunMarkdownFormatter {
         return markdown.Build();
     }
 
+    /// <summary>
+    /// Builds markdown containing first-party visual fences only.
+    /// </summary>
+    /// <param name="tools">Tool run payload.</param>
+    /// <param name="resolveToolDisplayName">Display-name resolver callback.</param>
+    /// <returns>Markdown containing visual fences or empty when none are available.</returns>
+    public static string FormatVisualsOnly(ToolRunDto tools, Func<string?, string> resolveToolDisplayName) {
+        ArgumentNullException.ThrowIfNull(tools);
+        ArgumentNullException.ThrowIfNull(resolveToolDisplayName);
+
+        var markdown = new MarkdownComposer()
+            .Paragraph("**Tool visuals:**")
+            .BlankLine();
+
+        var namesByCallId = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var call in tools.Calls) {
+            namesByCallId[call.CallId] = resolveToolDisplayName(call.Name);
+        }
+
+        var hasVisualFences = false;
+        foreach (var output in tools.Outputs) {
+            var visualFences = ExtractFirstPartyVisualFences(BuildRenderHintFences(output));
+            if (visualFences.Count == 0) {
+                continue;
+            }
+
+            hasVisualFences = true;
+            var toolLabel = namesByCallId.TryGetValue(output.CallId, out var name)
+                ? name
+                : $"Call {output.CallId}";
+            markdown.Heading(toolLabel, 4);
+            for (var i = 0; i < visualFences.Count; i++) {
+                var fence = visualFences[i];
+                markdown.CodeFence(fence.Language, fence.Content);
+            }
+            markdown.BlankLine();
+        }
+
+        return hasVisualFences ? markdown.Build() : string.Empty;
+    }
+
     private static bool ShouldIncludeSummary(string summary, bool hasError) {
         if (string.IsNullOrWhiteSpace(summary)) {
             return false;
@@ -294,6 +335,27 @@ internal static class ToolRunMarkdownFormatter {
         } finally {
             outputDoc?.Dispose();
         }
+    }
+
+    private static List<(string Language, string Content)> ExtractFirstPartyVisualFences(
+        IReadOnlyList<(string Language, string Content)> fences) {
+        var selected = new List<(string Language, string Content)>();
+        for (var i = 0; i < fences.Count; i++) {
+            var fence = fences[i];
+            var language = (fence.Language ?? string.Empty).Trim().ToLowerInvariant();
+            if (language.Length == 0) {
+                continue;
+            }
+
+            if (string.Equals(language, "mermaid", StringComparison.Ordinal)
+                || string.Equals(language, ChartFenceLanguage, StringComparison.Ordinal)
+                || string.Equals(language, NetworkFenceLanguage, StringComparison.Ordinal)
+                || string.Equals(language, DataViewPayloadFenceLanguage, StringComparison.Ordinal)) {
+                selected.Add(fence);
+            }
+        }
+
+        return selected;
     }
 
     private static IEnumerable<JsonElement> EnumerateRenderHints(JsonElement renderRoot) {


### PR DESCRIPTION
## Summary
- allow tool transcript bubbles in normal chat mode when tool outputs include render hints, instead of requiring debug mode
- add a non-debug-safe formatter path (`FormatVisualsOnly`) that emits only first-party visual fences (`mermaid`, `ix-chart`, `ix-network`, `ix-dataview`) and excludes failure/hint/summary internals
- route tool transcript markdown selection through a shared helper so debug keeps full diagnostics while non-debug remains visual-only
- add regression tests for visual-only formatting and debug/non-debug tool transcript selection

## Why
This improves chat reliability and UX for first-party visuals by making valid tool-driven charts/diagrams/tables/networks show automatically in standard chat mode, while preserving debug-only internals for troubleshooting.

## Validation
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`