### PR TITLE
Chat: harden tool visual grouping contracts

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
@@ -403,4 +403,101 @@ public sealed class ToolRunMarkdownFormatterTests {
         Assert.Contains("#### Call", markdown);
         Assert.DoesNotContain("<unknown>", markdown, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// Ensures visual-only formatting preserves first-seen call ordering across grouped headings.
+    /// </summary>
+    [Fact]
+    public void FormatVisualsOnly_PreservesFirstSeenCallOrderAcrossGroups() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c20",
+                    Name = "first_tool"
+                },
+                new ToolCallDto {
+                    CallId = "c21",
+                    Name = "second_tool"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c21",
+                    Output = "{\"chart\":{\"type\":\"bar\",\"data\":{\"labels\":[\"B\"],\"datasets\":[{\"data\":[2]}]}}}",
+                    RenderJson = "{\"kind\":\"code\",\"language\":\"chart\",\"content_path\":\"chart\"}"
+                },
+                new ToolOutputDto {
+                    CallId = "c20",
+                    Output = "{\"chart\":{\"type\":\"line\",\"data\":{\"labels\":[\"A\"],\"datasets\":[{\"data\":[1]}]}}}",
+                    RenderJson = "{\"kind\":\"code\",\"language\":\"chart\",\"content_path\":\"chart\"}"
+                }
+            }
+        };
+
+        var markdown = ToolRunMarkdownFormatter.FormatVisualsOnly(
+            tools,
+            name => string.Equals(name, "second_tool", StringComparison.Ordinal) ? "Second Tool" : "First Tool");
+        var secondIndex = markdown.IndexOf("#### Second Tool", StringComparison.Ordinal);
+        var firstIndex = markdown.IndexOf("#### First Tool", StringComparison.Ordinal);
+
+        Assert.True(secondIndex >= 0);
+        Assert.True(firstIndex > secondIndex);
+    }
+
+    /// <summary>
+    /// Ensures visual-only formatting deduplicates repeated visual fences across outputs within the same call group.
+    /// </summary>
+    [Fact]
+    public void FormatVisualsOnly_DeduplicatesRepeatedFencesAcrossOutputsForSameCall() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c22",
+                    Name = "dup_tool"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c22",
+                    Output = "{\"chart\":{\"type\":\"bar\",\"data\":{\"labels\":[\"A\"],\"datasets\":[{\"data\":[1]}]}}}",
+                    RenderJson = "{\"kind\":\"code\",\"language\":\"chart\",\"content_path\":\"chart\"}"
+                },
+                new ToolOutputDto {
+                    CallId = "c22",
+                    Output = "{\"chart\":{\"type\":\"bar\",\"data\":{\"labels\":[\"A\"],\"datasets\":[{\"data\":[1]}]}}}",
+                    RenderJson = "{\"kind\":\"code\",\"language\":\"chart\",\"content_path\":\"chart\"}"
+                }
+            }
+        };
+
+        var markdown = ToolRunMarkdownFormatter.FormatVisualsOnly(tools, _ => "unused");
+
+        Assert.Equal(1, CountOccurrences(markdown, "```ix-chart"));
+    }
+
+    /// <summary>
+    /// Ensures debug formatting falls back to call-based labels when resolved display names are blank.
+    /// </summary>
+    [Fact]
+    public void Format_FallsBackToCallLabelWhenResolvedDisplayNameIsBlank() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c23",
+                    Name = "blank_name_tool"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c23",
+                    Output = "{}",
+                    SummaryMarkdown = "done"
+                }
+            }
+        };
+
+        var markdown = ToolRunMarkdownFormatter.Format(tools, _ => "   ");
+
+        Assert.Contains("#### Call c23", markdown);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.cs
@@ -101,7 +101,8 @@ internal static class ToolRunMarkdownFormatter {
 
     private static string ResolveToolLabel(IReadOnlyDictionary<string, string> namesByCallId, string? callId) {
         if (callId is not null
-            && namesByCallId.TryGetValue(callId, out var name)) {
+            && namesByCallId.TryGetValue(callId, out var name)
+            && !string.IsNullOrWhiteSpace(name)) {
             return name;
         }
 


### PR DESCRIPTION
## Summary
- harden tool label resolution fallback so blank/whitespace display-name mappings do not suppress transcript headings
- add regression coverage for first-party visual grouping contracts:
  - preserves first-seen call ordering across grouped visual headings
  - deduplicates repeated visual fences across outputs for the same call group
  - falls back to call-based labels when resolved display names are blank

## Why
This continues reliability work for chat + tool transcript rendering by locking in stable grouping/ordering behavior and preventing heading loss when display-name metadata is malformed.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~ToolRunMarkdownFormatterTests|FullyQualifiedName~MainWindowToolTranscriptMarkdownTests"`
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`