### PR TITLE
Chat: reduce render-hint dedupe hash allocation churn

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
 using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.App.Markdown;
 using Xunit;
@@ -9,6 +12,11 @@ namespace IntelligenceX.Chat.App.Tests;
 /// Tests for tool-run markdown formatting.
 /// </summary>
 public sealed class ToolRunMarkdownFormatterTests {
+    private static readonly MethodInfo ComputeUtf8Sha256HexMethod = typeof(ToolRunMarkdownFormatter).GetMethod(
+        "ComputeUtf8Sha256Hex",
+        BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("ComputeUtf8Sha256Hex method was not found.");
+
     private static int CountOccurrences(string text, string token) {
         if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(token)) {
             return 0;
@@ -528,5 +536,17 @@ public sealed class ToolRunMarkdownFormatterTests {
 
         Assert.Equal(1, CountOccurrences(markdown, "```text"));
         Assert.Contains(largeSnippet, markdown, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Ensures chunked UTF-8 hashing remains equivalent to canonical UTF-8 SHA-256 for surrogate-boundary content.
+    /// </summary>
+    [Fact]
+    public void ComputeUtf8Sha256Hex_MatchesCanonicalHashForSurrogateBoundaryContent() {
+        var value = new string('a', 1023) + "😀" + new string('b', 1024);
+        var expected = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+        var actual = (string)ComputeUtf8Sha256HexMethod.Invoke(null, new object[] { value })!;
+
+        Assert.Equal(expected, actual);
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.RenderHints.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.RenderHints.cs
@@ -217,14 +217,18 @@ internal static partial class ToolRunMarkdownFormatter {
 
     private static string ComputeUtf8Sha256Hex(string value) {
         using var incremental = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var encoder = Encoding.UTF8.GetEncoder();
         Span<byte> buffer = stackalloc byte[DedupHashChunkMaxBytes];
         var offset = 0;
         while (offset < value.Length) {
             var chunkChars = Math.Min(DedupHashChunkChars, value.Length - offset);
             var span = value.AsSpan(offset, chunkChars);
-            var bytesWritten = Encoding.UTF8.GetBytes(span, buffer);
-            incremental.AppendData(buffer[..bytesWritten]);
-            offset += chunkChars;
+            var flush = offset + chunkChars >= value.Length;
+            encoder.Convert(span, buffer, flush, out var charsUsed, out var bytesUsed, out _);
+            if (bytesUsed > 0) {
+                incremental.AppendData(buffer[..bytesUsed]);
+            }
+            offset += charsUsed;
         }
 
         return Convert.ToHexString(incremental.GetHashAndReset());


### PR DESCRIPTION
## Summary
- optimize render-hint dedupe key hashing to avoid large transient UTF-8 byte-array allocations
  - switch from `Encoding.UTF8.GetBytes(value)` + one-shot hash to chunked UTF-8 hashing via `IncrementalHash`
  - preserve dedupe key contract (`language:sha256:length`)
- add regression coverage for large render-hint payload dedupe stability

## Why
This improves chat/tool reliability under large tool outputs by reducing per-turn allocation spikes in the render-hint dedupe path, while keeping output behavior unchanged.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~ToolRunMarkdownFormatterTests|FullyQualifiedName~MainWindowToolTranscriptMarkdownTests"`
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`