### PR TITLE
Chat: stabilize UTF-8 hash tests and empty-input coverage

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using IntelligenceX.Chat.Abstractions.Protocol;
@@ -12,11 +11,6 @@ namespace IntelligenceX.Chat.App.Tests;
 /// Tests for tool-run markdown formatting.
 /// </summary>
 public sealed class ToolRunMarkdownFormatterTests {
-    private static readonly MethodInfo ComputeUtf8Sha256HexMethod = typeof(ToolRunMarkdownFormatter).GetMethod(
-        "ComputeUtf8Sha256Hex",
-        BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("ComputeUtf8Sha256Hex method was not found.");
-
     private static int CountOccurrences(string text, string token) {
         if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(token)) {
             return 0;
@@ -545,7 +539,18 @@ public sealed class ToolRunMarkdownFormatterTests {
     public void ComputeUtf8Sha256Hex_MatchesCanonicalHashForSurrogateBoundaryContent() {
         var value = new string('a', 1023) + "😀" + new string('b', 1024);
         var expected = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
-        var actual = (string)ComputeUtf8Sha256HexMethod.Invoke(null, new object[] { value })!;
+        var actual = ToolRunMarkdownFormatter.ComputeUtf8Sha256Hex(value);
+
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Ensures chunked UTF-8 hashing matches canonical SHA-256 for empty input.
+    /// </summary>
+    [Fact]
+    public void ComputeUtf8Sha256Hex_MatchesCanonicalHashForEmptyInput() {
+        var expected = Convert.ToHexString(SHA256.HashData(Array.Empty<byte>()));
+        var actual = ToolRunMarkdownFormatter.ComputeUtf8Sha256Hex(string.Empty);
 
         Assert.Equal(expected, actual);
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.RenderHints.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.RenderHints.cs
@@ -9,6 +9,7 @@ using IntelligenceX.Chat.Abstractions.Protocol;
 namespace IntelligenceX.Chat.App.Markdown;
 
 internal static partial class ToolRunMarkdownFormatter {
+    // Keep stack allocation bounded (~4 KB) while reducing encoder/hash call overhead.
     private const int DedupHashChunkChars = 1024;
     private const int DedupHashChunkMaxBytes = DedupHashChunkChars * 4;
 
@@ -215,7 +216,7 @@ internal static partial class ToolRunMarkdownFormatter {
         return normalizedLanguage + ":" + hash + ":" + value.Length;
     }
 
-    private static string ComputeUtf8Sha256Hex(string value) {
+    internal static string ComputeUtf8Sha256Hex(string value) {
         using var incremental = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         var encoder = Encoding.UTF8.GetEncoder();
         Span<byte> buffer = stackalloc byte[DedupHashChunkMaxBytes];


### PR DESCRIPTION
## Summary
- replace reflection-based hash verification in formatter tests with direct calls to `ToolRunMarkdownFormatter.ComputeUtf8Sha256Hex` (now `internal`)
- add explicit empty-input hash equivalence regression test
- add small maintainability comment explaining dedupe chunk size intent

## Why
This hardens test reliability by removing brittle private-reflection coupling and closes an edge-case gap for empty input hashing, while preserving runtime behavior.

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~ToolRunMarkdownFormatterTests|FullyQualifiedName~MainWindowToolTranscriptMarkdownTests"`
- `dotnet build IntelligenceX.sln -c Release`
- `dotnet test IntelligenceX.sln -c Release`
- `dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll`
- `dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll`