### PR TITLE
Chat: trim table lookup allocations on small rows

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ToolRunMarkdownFormatterTests.cs
@@ -176,6 +176,33 @@ public sealed class ToolRunMarkdownFormatterTests {
     }
 
     /// <summary>
+    /// Ensures table matrix fallback behavior remains stable for non-object row nodes.
+    /// </summary>
+    [Fact]
+    public void Format_TableRenderHint_PreservesFallbackForNonObjectRows() {
+        var tools = new ToolRunDto {
+            Calls = new[] {
+                new ToolCallDto {
+                    CallId = "c4c",
+                    Name = "testimox_rules_list"
+                }
+            },
+            Outputs = new[] {
+                new ToolOutputDto {
+                    CallId = "c4c",
+                    Output = "{\"rules_view\":[\"scalar\",[\"array-name\",\"array-status\"],{\"name\":\"ObjectName\",\"status\":\"ObjectStatus\"}]}",
+                    RenderJson = "{\"kind\":\"table\",\"rows_path\":\"rules_view\",\"columns\":[{\"key\":\"name\",\"label\":\"Name\"},{\"key\":\"status\",\"label\":\"Status\"}]}"
+                }
+            }
+        };
+
+        var markdown = ToolRunMarkdownFormatter.Format(tools, _ => "TestimoX Rules List");
+
+        Assert.Contains("```ix-dataview", markdown);
+        Assert.Contains("\"rows\":[[\"Name\",\"Status\"],[\"scalar\",\"\"],[\"array-name\",\"array-status\"],[\"ObjectName\",\"ObjectStatus\"]]", markdown);
+    }
+
+    /// <summary>
     /// Ensures render arrays can emit first-party visual fences and map visnetwork to ix-network.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.RenderHints.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/ToolRunMarkdownFormatter.RenderHints.cs
@@ -12,6 +12,7 @@ internal static partial class ToolRunMarkdownFormatter {
     // Keep stack allocation bounded (~4 KB) while reducing encoder/hash call overhead.
     private const int DedupHashChunkChars = 1024;
     private const int DedupHashChunkMaxBytes = DedupHashChunkChars * 4;
+    private const int CaseInsensitiveLookupMapColumnThreshold = 2;
 
     private static List<(string Language, string Content)> BuildRenderHintFences(ToolOutputDto output) {
         var fences = new List<(string Language, string Content)>();
@@ -297,7 +298,9 @@ internal static partial class ToolRunMarkdownFormatter {
             var row = new string[columns.Count];
             switch (rowNode.ValueKind) {
                 case JsonValueKind.Object:
-                    var propertyMap = BuildCaseInsensitivePropertyMap(rowNode);
+                    var propertyMap = columns.Count >= CaseInsensitiveLookupMapColumnThreshold
+                        ? BuildCaseInsensitivePropertyMap(rowNode)
+                        : null;
                     for (var i = 0; i < columns.Count; i++) {
                         row[i] = TryGetPropertyValueCaseInsensitive(rowNode, columns[i].Key, out var valueNode, propertyMap)
                             ? FormatJsonElement(valueNode)
@@ -410,7 +413,7 @@ internal static partial class ToolRunMarkdownFormatter {
         JsonElement obj,
         string propertyName,
         out JsonElement value,
-        IReadOnlyDictionary<string, JsonElement>? propertyMap) {
+        IReadOnlyDictionary<string, JsonElement>? propertyMap = null) {
         value = default;
         if (obj.ValueKind != JsonValueKind.Object || string.IsNullOrWhiteSpace(propertyName)) {
             return false;


### PR DESCRIPTION
## Summary
- avoid building a case-insensitive per-row property map for tiny table shapes by gating map creation with a small column threshold
- keep case-insensitive lookup support intact for multi-column rows where cached lookup has meaningful payoff
- add regression coverage for non-object row fallback behavior (scalar and array rows) to lock existing table matrix semantics

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
