### PR TITLE
Chat: bound proactive marker parsing to section

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.cs
@@ -167,6 +167,7 @@ internal sealed partial class ChatServiceSession {
 
     private static bool TryReadStructuredProactiveModeEnabledValue(ReadOnlySpan<char> text, out bool enabled) {
         enabled = false;
+        var markerLineSeen = false;
         while (!text.IsEmpty) {
             var lineBreakIndex = text.IndexOfAny('\r', '\n');
             ReadOnlySpan<char> line;
@@ -183,7 +184,35 @@ internal sealed partial class ChatServiceSession {
                 text = text.Slice(nextIndex);
             }
 
+            if (!markerLineSeen) {
+                if (line.IndexOf(ProactiveModeMarker, StringComparison.OrdinalIgnoreCase) >= 0) {
+                    markerLineSeen = true;
+                }
+                continue;
+            }
+
+            if (LooksLikeStructuredSectionHeader(line)) {
+                // Stay within the proactive-mode block and avoid unrelated `enabled:` lines
+                // in following structured sections.
+                return false;
+            }
+
             if (TryParseStructuredProactiveModeEnabledLine(line, out enabled)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool LooksLikeStructuredSectionHeader(ReadOnlySpan<char> line) {
+        var trimmed = line.Trim();
+        if (trimmed.Length < 3 || trimmed[0] != '[' || trimmed[^1] != ']') {
+            return false;
+        }
+
+        for (var i = 1; i < trimmed.Length - 1; i++) {
+            if (!char.IsWhiteSpace(trimmed[i])) {
                 return true;
             }
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -275,6 +275,33 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.True(enabled);
     }
 
+    [Fact]
+    public void TryReadProactiveModeFromRequestText_DoesNotCrossIntoNextStructuredSection() {
+        var requestText = """
+                          [Proactive execution mode]
+                          ix:proactive-mode:v1
+                          note: keep parsing local
+
+                          [Persistent memory]
+                          enabled: true
+                          """;
+
+        var result = ChatServiceSession.TryReadProactiveModeFromRequestText(requestText, out var enabled);
+
+        Assert.False(result);
+        Assert.False(enabled);
+    }
+
+    [Theory]
+    [InlineData("[Proactive execution mode]\nix:proactive-mode:v1\nenabled: \"true")]
+    [InlineData("[Proactive execution mode]\nix:proactive-mode:v1\nenabled: true\"")]
+    public void TryReadProactiveModeFromRequestText_IgnoresMalformedQuotedValues(string requestText) {
+        var result = ChatServiceSession.TryReadProactiveModeFromRequestText(requestText, out var enabled);
+
+        Assert.False(result);
+        Assert.False(enabled);
+    }
+
     [Theory]
     [InlineData(true, true, false, false, false, "Findings summary without actions.", true)]
     [InlineData(true, true, false, false, false, "Findings summary. Do you want me to continue?", false)]


### PR DESCRIPTION
## Summary
- constrain proactive-mode parsing to the local structured block following `ix:proactive-mode:v1`
- prevent unrelated `enabled:` lines in later structured sections from changing proactive routing state
- add regression tests for cross-section boundary handling and malformed quoted boolean values

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~TryReadProactiveModeFromRequestText"
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~StartupToolHealthPrimingBehaviorTests.AwaitStartupToolHealthPrimingForHelloAsync_StopsWaitingWhenCanceled"
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
