### PR TITLE
Chat: harden tool-output fallback against null entries

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -54,7 +54,11 @@ internal sealed partial class ChatServiceSession {
         var toolNamesByCallId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         if (toolCalls is { Count: > 0 }) {
             for (var i = 0; i < toolCalls.Count; i++) {
-                var call = toolCalls[i];
+                ToolCallDto? call = toolCalls[i];
+                if (call is null) {
+                    continue;
+                }
+
                 var callId = (call.CallId ?? string.Empty).Trim();
                 var toolName = (call.Name ?? string.Empty).Trim();
                 if (callId.Length == 0 || toolName.Length == 0) {
@@ -66,12 +70,18 @@ internal sealed partial class ChatServiceSession {
         }
 
         var bulletLines = new List<string>(capacity: Math.Min(3, toolOutputs.Count));
+        var usableOutputCount = 0;
         for (var i = 0; i < toolOutputs.Count; i++) {
-            if (bulletLines.Count >= 3) {
-                break;
+            ToolOutputDto? output = toolOutputs[i];
+            if (output is null) {
+                continue;
             }
 
-            var output = toolOutputs[i];
+            usableOutputCount++;
+            if (bulletLines.Count >= 3) {
+                continue;
+            }
+
             var summary = BuildToolOutputFallbackSummary(output);
             if (summary.Length == 0) {
                 continue;
@@ -88,7 +98,7 @@ internal sealed partial class ChatServiceSession {
             return normalizedAssistantDraft;
         }
 
-        var remainingCount = Math.Max(0, toolOutputs.Count - bulletLines.Count);
+        var remainingCount = Math.Max(0, usableOutputCount - bulletLines.Count);
         var builder = new StringBuilder();
         builder.AppendLine("Recovered findings from executed tools (model returned no text):");
         for (var i = 0; i < bulletLines.Count; i++) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.Service;
 using IntelligenceX.Json;
@@ -469,6 +470,45 @@ public sealed partial class ChatServiceRoutingTrimTests {
             toolOutputs: Array.Empty<ToolOutputDto>());
 
         Assert.Equal("Already have final response.", text);
+    }
+
+    [Fact]
+    public void ResolveAssistantTextFromToolOutputsFallback_IgnoresNullCallAndOutputEntries() {
+        var text = ChatServiceSession.ResolveAssistantTextFromToolOutputsFallback(
+            assistantDraft: string.Empty,
+            toolCalls: new List<ToolCallDto> {
+                null!,
+                new ToolCallDto {
+                    CallId = "call-2",
+                    Name = "ad_user_find",
+                    ArgumentsJson = "{}"
+                }
+            },
+            toolOutputs: new List<ToolOutputDto> {
+                null!,
+                new ToolOutputDto {
+                    CallId = "call-2",
+                    Output = "{\"ok\":true}",
+                    SummaryMarkdown = "Found 12 matching users in requested scope."
+                }
+            });
+
+        Assert.Contains("Recovered findings from executed tools", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ad_user_find", text, StringComparison.Ordinal);
+        Assert.Contains("Found 12 matching users", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolveAssistantTextFromToolOutputsFallback_ReturnsEmptyWhenOnlyNullOutputsArePresent() {
+        var text = ChatServiceSession.ResolveAssistantTextFromToolOutputsFallback(
+            assistantDraft: string.Empty,
+            toolCalls: Array.Empty<ToolCallDto>(),
+            toolOutputs: new List<ToolOutputDto> {
+                null!,
+                null!
+            });
+
+        Assert.Equal(string.Empty, text);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- harden `ResolveAssistantTextFromToolOutputsFallback` against unexpected null entries in `toolCalls` and `toolOutputs`
- keep fallback behavior stable while skipping malformed entries instead of risking null dereferences
- compute `remainingCount` from usable (non-null) outputs for accurate fallback summary tails
- add regression coverage for null-entry scenarios in fallback text generation

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ResolveAssistantTextFromToolOutputsFallback|FullyQualifiedName~ResolveAssistantTextBeforeNoTextFallback|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt|FullyQualifiedName~TryReadProactiveModeFromRequestText"
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
