### PR TITLE
Chat: simplify phase heartbeat orchestration

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -271,21 +271,33 @@ internal sealed partial class ChatServiceSession {
         var sw = Stopwatch.StartNew();
         using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         using var timer = new PeriodicTimer(heartbeatInterval);
-        var stopHeartbeatTask = phaseTask.ContinueWith(
-            static (_, state) => {
-                try {
-                    ((CancellationTokenSource)state!).Cancel();
-                } catch {
-                    // Best-effort heartbeat stop.
-                }
-            },
-            heartbeatCts,
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
+        var heartbeatTask = RunPhaseHeartbeatLoopAsync(
+            writer,
+            requestId,
+            threadId,
+            heartbeatLabel,
+            sw,
+            phaseTask,
+            timer,
+            heartbeatCts.Token);
+        await Task.WhenAny(phaseTask, heartbeatTask).ConfigureAwait(false);
+        heartbeatCts.Cancel();
+        await heartbeatTask.ConfigureAwait(false);
 
+        await phaseTask.ConfigureAwait(false);
+    }
+
+    private async Task RunPhaseHeartbeatLoopAsync(
+        StreamWriter writer,
+        string requestId,
+        string threadId,
+        string heartbeatLabel,
+        Stopwatch sw,
+        Task phaseTask,
+        PeriodicTimer timer,
+        CancellationToken cancellationToken) {
         try {
-            while (await timer.WaitForNextTickAsync(heartbeatCts.Token).ConfigureAwait(false)) {
+            while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false)) {
                 if (phaseTask.IsCompleted) {
                     break;
                 }
@@ -300,13 +312,9 @@ internal sealed partial class ChatServiceSession {
                         message: $"{heartbeatLabel}... ({elapsedSeconds}s)")
                     .ConfigureAwait(false);
             }
-        } catch (OperationCanceledException) when (heartbeatCts.IsCancellationRequested) {
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
             // Expected when the model phase completes or the turn is canceled.
-        } finally {
-            await stopHeartbeatTask.ConfigureAwait(false);
         }
-
-        await phaseTask.ConfigureAwait(false);
     }
 
     internal async Task<TurnInfo> RunModelPhaseWithProgressAsync(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
@@ -95,6 +95,29 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public async Task PhaseProgressLoop_PropagatesPhaseTaskFailure() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+
+        var phaseTask = Task.FromException(new InvalidOperationException("phase-failed"));
+        var invokeTask = InvokePhaseProgressLoopAsync(
+            session,
+            writer,
+            "phase_review",
+            "Reviewing...",
+            "Reviewing response",
+            1,
+            phaseTask);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => invokeTask);
+        Assert.Equal("phase-failed", ex.Message);
+
+        var statuses = ParseStatuses(capture.Snapshot());
+        Assert.Contains("phase_review", statuses);
+    }
+
+    [Fact]
     public async Task ToolRoundStatusLifecycle_EmitsRoundStatusesInDeterministicOrder() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         using var capture = new SynchronizedCaptureStream();


### PR DESCRIPTION
## Summary
- simplify `RunPhaseProgressLoopAsync` heartbeat shutdown by replacing `ContinueWith` with explicit `Task.WhenAny` orchestration
- keep behavior equivalent while making phase/heartbeat coordination easier to reason about and less error-prone
- add integration coverage that confirms phase-task exceptions are still propagated in heartbeat-enabled runs

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~PhaseProgressLoop_|FullyQualifiedName~RunModelPhaseWithProgressAsync_RecoversMissingThreadAndPersistsAlias"
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
