### PR TITLE
Chat: narrow heartbeat suppression and log context

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -257,7 +257,8 @@ internal sealed partial class ChatServiceSession {
         string heartbeatLabel,
         int heartbeatSeconds,
         CancellationToken cancellationToken,
-        Task phaseTask) {
+        Task phaseTask,
+        Func<CancellationToken, Task>? heartbeatTaskFactory = null) {
         var status = string.IsNullOrWhiteSpace(phaseStatus) ? "thinking" : phaseStatus.Trim();
         if (!string.IsNullOrWhiteSpace(phaseMessage)) {
             await TryWriteStatusAsync(writer, requestId, threadId, status: status, message: phaseMessage).ConfigureAwait(false);
@@ -272,15 +273,17 @@ internal sealed partial class ChatServiceSession {
         var sw = Stopwatch.StartNew();
         using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         using var timer = new PeriodicTimer(heartbeatInterval);
-        var heartbeatTask = RunPhaseHeartbeatLoopAsync(
-            writer,
-            requestId,
-            threadId,
-            heartbeatLabel,
-            sw,
-            phaseTask,
-            timer,
-            heartbeatCts.Token);
+        var heartbeatTask = heartbeatTaskFactory is null
+            ? RunPhaseHeartbeatLoopAsync(
+                writer,
+                requestId,
+                threadId,
+                heartbeatLabel,
+                sw,
+                phaseTask,
+                timer,
+                heartbeatCts.Token)
+            : heartbeatTaskFactory(heartbeatCts.Token);
         await Task.WhenAny(phaseTask, heartbeatTask).ConfigureAwait(false);
         heartbeatCts.Cancel();
         Exception? heartbeatFailure = null;
@@ -291,13 +294,23 @@ internal sealed partial class ChatServiceSession {
         }
 
         await phaseTask.ConfigureAwait(false);
+        FinalizePhaseHeartbeatFailure(heartbeatFailure, status, requestId, threadId, heartbeatCts.Token, cancellationToken);
+    }
+
+    internal static void FinalizePhaseHeartbeatFailure(
+        Exception? heartbeatFailure,
+        string phaseStatus,
+        string requestId,
+        string threadId,
+        CancellationToken heartbeatCancellationToken,
+        CancellationToken cancellationToken) {
         if (heartbeatFailure is null) {
             return;
         }
 
-        if (ShouldSuppressPhaseHeartbeatFailure(heartbeatFailure, heartbeatCts, cancellationToken)) {
+        if (ShouldSuppressPhaseHeartbeatFailure(heartbeatFailure, heartbeatCancellationToken, cancellationToken)) {
             Trace.TraceWarning(
-                $"Phase heartbeat loop suppressed failure after phase completion: phase={status}; request={requestId}; thread={threadId}; " +
+                $"Phase heartbeat loop suppressed failure after phase completion: phase={phaseStatus}; request={requestId}; thread={threadId}; " +
                 $"error={heartbeatFailure.GetType().Name}: {heartbeatFailure.Message}");
             return;
         }
@@ -305,14 +318,23 @@ internal sealed partial class ChatServiceSession {
         ExceptionDispatchInfo.Capture(heartbeatFailure).Throw();
     }
 
-    private static bool ShouldSuppressPhaseHeartbeatFailure(Exception heartbeatFailure, CancellationTokenSource heartbeatCts,
+    internal static bool ShouldSuppressPhaseHeartbeatFailure(Exception heartbeatFailure, CancellationToken heartbeatCancellationToken,
         CancellationToken cancellationToken) {
         if (heartbeatFailure is IOException) {
             return true;
         }
 
-        return heartbeatFailure is OperationCanceledException
-               && (heartbeatCts.IsCancellationRequested || cancellationToken.IsCancellationRequested);
+        if (heartbeatFailure is not OperationCanceledException canceledException) {
+            return false;
+        }
+
+        var failureToken = canceledException.CancellationToken;
+        if (!failureToken.CanBeCanceled) {
+            return heartbeatCancellationToken.IsCancellationRequested || cancellationToken.IsCancellationRequested;
+        }
+
+        return (failureToken == heartbeatCancellationToken && heartbeatCancellationToken.IsCancellationRequested)
+               || (failureToken == cancellationToken && cancellationToken.IsCancellationRequested);
     }
 
     private async Task RunPhaseHeartbeatLoopAsync(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
@@ -142,6 +142,82 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public async Task PhaseProgressLoop_UnexpectedHeartbeatFailureIsRethrownWhenPhaseSucceeds() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+
+        async Task FaultingHeartbeatAsync(CancellationToken _) {
+            await Task.Yield();
+            throw new InvalidOperationException("heartbeat-failed");
+        }
+
+        var invokeTask = InvokePhaseProgressLoopAsync(
+            session,
+            writer,
+            "phase_review",
+            "Reviewing...",
+            "Reviewing response",
+            1,
+            Task.CompletedTask,
+            heartbeatTaskFactory: FaultingHeartbeatAsync);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => invokeTask);
+        Assert.Equal("heartbeat-failed", ex.Message);
+    }
+
+    [Fact]
+    public async Task PhaseProgressLoop_SuppressesCanceledHeartbeatFailureWhenOuterTokenIsCanceled() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+        using var outerCts = new CancellationTokenSource();
+        outerCts.Cancel();
+
+        Task CanceledHeartbeatAsync(CancellationToken _) =>
+            Task.FromException(new OperationCanceledException("outer-canceled", innerException: null, outerCts.Token));
+
+        await InvokePhaseProgressLoopAsync(
+            session,
+            writer,
+            "phase_review",
+            "Reviewing...",
+            "Reviewing response",
+            1,
+            Task.CompletedTask,
+            outerCts.Token,
+            CanceledHeartbeatAsync);
+    }
+
+    [Fact]
+    public void ShouldSuppressPhaseHeartbeatFailure_RequiresMatchingCanceledToken() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+        using var unrelatedCts = new CancellationTokenSource();
+
+        heartbeatCts.Cancel();
+        outerCts.Cancel();
+        unrelatedCts.Cancel();
+
+        Assert.True(ChatServiceSession.ShouldSuppressPhaseHeartbeatFailure(
+            new IOException("io"),
+            heartbeatCts.Token,
+            outerCts.Token));
+        Assert.True(ChatServiceSession.ShouldSuppressPhaseHeartbeatFailure(
+            new OperationCanceledException("heartbeat", innerException: null, heartbeatCts.Token),
+            heartbeatCts.Token,
+            outerCts.Token));
+        Assert.True(ChatServiceSession.ShouldSuppressPhaseHeartbeatFailure(
+            new OperationCanceledException("outer", innerException: null, outerCts.Token),
+            heartbeatCts.Token,
+            outerCts.Token));
+        Assert.False(ChatServiceSession.ShouldSuppressPhaseHeartbeatFailure(
+            new OperationCanceledException("unrelated", innerException: null, unrelatedCts.Token),
+            heartbeatCts.Token,
+            outerCts.Token));
+    }
+
+    [Fact]
     public async Task ToolRoundStatusLifecycle_EmitsRoundStatusesInDeterministicOrder() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         using var capture = new SynchronizedCaptureStream();
@@ -222,7 +298,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     private static async Task InvokePhaseProgressLoopAsync(ChatServiceSession session, StreamWriter writer, string phaseStatus, string phaseMessage,
-        string heartbeatLabel, int heartbeatSeconds, Task phaseTask, CancellationToken cancellationToken = default) {
+        string heartbeatLabel, int heartbeatSeconds, Task phaseTask, CancellationToken cancellationToken = default,
+        Func<CancellationToken, Task>? heartbeatTaskFactory = null) {
         await session.RunPhaseProgressLoopAsync(
             writer,
             "req-intelligence-loop",
@@ -232,7 +309,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
             heartbeatLabel,
             heartbeatSeconds,
             cancellationToken,
-            phaseTask);
+            phaseTask,
+            heartbeatTaskFactory);
     }
 
     private static List<string> ParseStatuses(byte[] snapshotBytes) {


### PR DESCRIPTION
## Summary
- narrow post-phase heartbeat suppression to expected failures (`IOException` and cancellation) instead of blanket suppression
- keep phase outcome authoritative, but rethrow unexpected heartbeat exceptions after successful phase completion
- enrich suppressed-heartbeat warning logs with phase/request/thread context for better triage
- keep deterministic integration coverage for the core race where heartbeat write failures must not override phase-task failures

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~PhaseProgressLoop_"
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
