### PR TITLE
Chat: isolate phase heartbeat test hooks from runtime API

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -248,7 +248,30 @@ internal sealed partial class ChatServiceSession {
             """;
     }
 
-    internal async Task RunPhaseProgressLoopAsync(
+    internal Task RunPhaseProgressLoopAsync(
+        StreamWriter writer,
+        string requestId,
+        string threadId,
+        string phaseStatus,
+        string? phaseMessage,
+        string heartbeatLabel,
+        int heartbeatSeconds,
+        CancellationToken cancellationToken,
+        Task phaseTask) {
+        return RunPhaseProgressLoopCoreAsync(
+            writer,
+            requestId,
+            threadId,
+            phaseStatus,
+            phaseMessage,
+            heartbeatLabel,
+            heartbeatSeconds,
+            cancellationToken,
+            phaseTask,
+            heartbeatTaskFactory: null);
+    }
+
+    internal Task RunPhaseProgressLoopForTestingAsync(
         StreamWriter writer,
         string requestId,
         string threadId,
@@ -258,7 +281,35 @@ internal sealed partial class ChatServiceSession {
         int heartbeatSeconds,
         CancellationToken cancellationToken,
         Task phaseTask,
-        Func<CancellationToken, Task>? heartbeatTaskFactory = null) {
+        Func<CancellationToken, Task> heartbeatTaskFactory) {
+        if (heartbeatTaskFactory is null) {
+            throw new ArgumentNullException(nameof(heartbeatTaskFactory));
+        }
+
+        return RunPhaseProgressLoopCoreAsync(
+            writer,
+            requestId,
+            threadId,
+            phaseStatus,
+            phaseMessage,
+            heartbeatLabel,
+            heartbeatSeconds,
+            cancellationToken,
+            phaseTask,
+            heartbeatTaskFactory);
+    }
+
+    private async Task RunPhaseProgressLoopCoreAsync(
+        StreamWriter writer,
+        string requestId,
+        string threadId,
+        string phaseStatus,
+        string? phaseMessage,
+        string heartbeatLabel,
+        int heartbeatSeconds,
+        CancellationToken cancellationToken,
+        Task phaseTask,
+        Func<CancellationToken, Task>? heartbeatTaskFactory) {
         var status = string.IsNullOrWhiteSpace(phaseStatus) ? "thinking" : phaseStatus.Trim();
         if (!string.IsNullOrWhiteSpace(phaseMessage)) {
             await TryWriteStatusAsync(writer, requestId, threadId, status: status, message: phaseMessage).ConfigureAwait(false);
@@ -333,6 +384,8 @@ internal sealed partial class ChatServiceSession {
             return heartbeatCancellationToken.IsCancellationRequested || cancellationToken.IsCancellationRequested;
         }
 
+        // The heartbeat loop should throw OCE with either the linked heartbeat token
+        // or the outer request token. Treat other canceled tokens as unexpected.
         return (failureToken == heartbeatCancellationToken && heartbeatCancellationToken.IsCancellationRequested)
                || (failureToken == cancellationToken && cancellationToken.IsCancellationRequested);
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
@@ -300,7 +300,21 @@ public sealed partial class ChatServiceRoutingTrimTests {
     private static async Task InvokePhaseProgressLoopAsync(ChatServiceSession session, StreamWriter writer, string phaseStatus, string phaseMessage,
         string heartbeatLabel, int heartbeatSeconds, Task phaseTask, CancellationToken cancellationToken = default,
         Func<CancellationToken, Task>? heartbeatTaskFactory = null) {
-        await session.RunPhaseProgressLoopAsync(
+        if (heartbeatTaskFactory is null) {
+            await session.RunPhaseProgressLoopAsync(
+                writer,
+                "req-intelligence-loop",
+                "thread-intelligence-loop",
+                phaseStatus,
+                phaseMessage,
+                heartbeatLabel,
+                heartbeatSeconds,
+                cancellationToken,
+                phaseTask);
+            return;
+        }
+
+        await session.RunPhaseProgressLoopForTestingAsync(
             writer,
             "req-intelligence-loop",
             "thread-intelligence-loop",


### PR DESCRIPTION
## Summary\n- keep RunPhaseProgressLoopAsync production-only (no injected test factory on runtime signature)\n- add explicit internal test hook RunPhaseProgressLoopForTestingAsync for deterministic heartbeat-failure injection\n- document cancellation-token matching invariant in suppression helper\n- keep existing deterministic heartbeat reliability tests routed through the test hook\n\n## Validation\n- dotnet build IntelligenceX.sln -c Release\n- dotnet test IntelligenceX.sln -c Release\n- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll\n- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll\n