### PR TITLE
Chat: add phase-progress guardrails and test-hook hygiene

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.ExceptionServices;
@@ -258,6 +259,7 @@ internal sealed partial class ChatServiceSession {
         int heartbeatSeconds,
         CancellationToken cancellationToken,
         Task phaseTask) {
+        ValidatePhaseProgressLoopArgs(writer, requestId, threadId, phaseTask);
         return RunPhaseProgressLoopCoreAsync(
             writer,
             requestId,
@@ -271,6 +273,7 @@ internal sealed partial class ChatServiceSession {
             heartbeatTaskFactory: null);
     }
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     internal Task RunPhaseProgressLoopForTestingAsync(
         StreamWriter writer,
         string requestId,
@@ -282,6 +285,7 @@ internal sealed partial class ChatServiceSession {
         CancellationToken cancellationToken,
         Task phaseTask,
         Func<CancellationToken, Task> heartbeatTaskFactory) {
+        ValidatePhaseProgressLoopArgs(writer, requestId, threadId, phaseTask);
         if (heartbeatTaskFactory is null) {
             throw new ArgumentNullException(nameof(heartbeatTaskFactory));
         }
@@ -297,6 +301,13 @@ internal sealed partial class ChatServiceSession {
             cancellationToken,
             phaseTask,
             heartbeatTaskFactory);
+    }
+
+    private static void ValidatePhaseProgressLoopArgs(StreamWriter writer, string requestId, string threadId, Task phaseTask) {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(requestId);
+        ArgumentNullException.ThrowIfNull(threadId);
+        ArgumentNullException.ThrowIfNull(phaseTask);
     }
 
     private async Task RunPhaseProgressLoopCoreAsync(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
@@ -12,6 +12,65 @@ namespace IntelligenceX.Chat.Tests;
 
 public sealed partial class ChatServiceRoutingTrimTests {
     [Fact]
+    public async Task PhaseProgressLoop_ThrowsWhenWriterIsNull() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => session.RunPhaseProgressLoopAsync(
+            null!,
+            "req-intelligence-loop",
+            "thread-intelligence-loop",
+            "phase_review",
+            "Reviewing...",
+            "Reviewing response",
+            0,
+            CancellationToken.None,
+            Task.CompletedTask));
+
+        Assert.Equal("writer", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task PhaseProgressLoop_ThrowsWhenPhaseTaskIsNull() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => session.RunPhaseProgressLoopAsync(
+            writer,
+            "req-intelligence-loop",
+            "thread-intelligence-loop",
+            "phase_review",
+            "Reviewing...",
+            "Reviewing response",
+            0,
+            CancellationToken.None,
+            null!));
+
+        Assert.Equal("phaseTask", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task PhaseProgressLoopForTesting_ThrowsWhenHeartbeatTaskFactoryIsNull() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => session.RunPhaseProgressLoopForTestingAsync(
+            writer,
+            "req-intelligence-loop",
+            "thread-intelligence-loop",
+            "phase_review",
+            "Reviewing...",
+            "Reviewing response",
+            1,
+            CancellationToken.None,
+            Task.CompletedTask,
+            null!));
+
+        Assert.Equal("heartbeatTaskFactory", ex.ParamName);
+    }
+
+    [Fact]
     public async Task PhaseProgressLoop_EmitsPlanExecuteReviewInOrder() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         using var capture = new SynchronizedCaptureStream();


### PR DESCRIPTION
## Summary\n- add fail-fast argument guards for phase-progress execution (writer, equestId, 	hreadId, phaseTask)\n- mark RunPhaseProgressLoopForTestingAsync as hidden from normal API discovery (EditorBrowsable(Never))\n- add integration tests that lock null-guard contracts and test-hook null-factory guard\n\n## Validation\n- dotnet build IntelligenceX.sln -c Release\n- dotnet test IntelligenceX.sln -c Release\n- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll\n- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll\n