### PR TITLE
Chat: complete phase-progress null-guard contract tests

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
@@ -50,6 +50,46 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public async Task PhaseProgressLoop_ThrowsWhenRequestIdIsNull() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => session.RunPhaseProgressLoopAsync(
+            writer,
+            null!,
+            "thread-intelligence-loop",
+            "phase_review",
+            "Reviewing...",
+            "Reviewing response",
+            0,
+            CancellationToken.None,
+            Task.CompletedTask));
+
+        Assert.Equal("requestId", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task PhaseProgressLoop_ThrowsWhenThreadIdIsNull() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => session.RunPhaseProgressLoopAsync(
+            writer,
+            "req-intelligence-loop",
+            null!,
+            "phase_review",
+            "Reviewing...",
+            "Reviewing response",
+            0,
+            CancellationToken.None,
+            Task.CompletedTask));
+
+        Assert.Equal("threadId", ex.ParamName);
+    }
+
+    [Fact]
     public async Task PhaseProgressLoopForTesting_ThrowsWhenHeartbeatTaskFactoryIsNull() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         using var capture = new SynchronizedCaptureStream();


### PR DESCRIPTION
## Summary\n- add integration coverage for RunPhaseProgressLoopAsync null equestId guard\n- add integration coverage for RunPhaseProgressLoopAsync null 	hreadId guard\n- keep contract-level ParamName assertions for deterministic behavior\n\n## Validation\n- dotnet build IntelligenceX.sln -c Release\n- dotnet test IntelligenceX.sln -c Release\n- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll\n- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll\n