### PR TITLE
Chat: classify suppressed heartbeat failures for diagnostics

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -370,10 +370,11 @@ internal sealed partial class ChatServiceSession {
             return;
         }
 
-        if (ShouldSuppressPhaseHeartbeatFailure(heartbeatFailure, heartbeatCancellationToken, cancellationToken)) {
+        var suppressionReason = GetPhaseHeartbeatSuppressionReason(heartbeatFailure, heartbeatCancellationToken, cancellationToken);
+        if (suppressionReason is not null) {
             Trace.TraceWarning(
                 $"Phase heartbeat loop suppressed failure after phase completion: phase={phaseStatus}; request={requestId}; thread={threadId}; " +
-                $"error={heartbeatFailure.GetType().Name}: {heartbeatFailure.Message}");
+                $"reason={suppressionReason}; error={heartbeatFailure}");
             return;
         }
 
@@ -382,23 +383,35 @@ internal sealed partial class ChatServiceSession {
 
     internal static bool ShouldSuppressPhaseHeartbeatFailure(Exception heartbeatFailure, CancellationToken heartbeatCancellationToken,
         CancellationToken cancellationToken) {
+        return GetPhaseHeartbeatSuppressionReason(heartbeatFailure, heartbeatCancellationToken, cancellationToken) is not null;
+    }
+
+    internal static string? GetPhaseHeartbeatSuppressionReason(Exception heartbeatFailure, CancellationToken heartbeatCancellationToken,
+        CancellationToken cancellationToken) {
         if (heartbeatFailure is IOException) {
-            return true;
+            return "io";
         }
 
         if (heartbeatFailure is not OperationCanceledException canceledException) {
-            return false;
+            return null;
         }
 
         var failureToken = canceledException.CancellationToken;
         if (!failureToken.CanBeCanceled) {
-            return heartbeatCancellationToken.IsCancellationRequested || cancellationToken.IsCancellationRequested;
+            return heartbeatCancellationToken.IsCancellationRequested || cancellationToken.IsCancellationRequested ? "canceled" : null;
         }
 
         // The heartbeat loop should throw OCE with either the linked heartbeat token
         // or the outer request token. Treat other canceled tokens as unexpected.
-        return (failureToken == heartbeatCancellationToken && heartbeatCancellationToken.IsCancellationRequested)
-               || (failureToken == cancellationToken && cancellationToken.IsCancellationRequested);
+        if (failureToken == heartbeatCancellationToken && heartbeatCancellationToken.IsCancellationRequested) {
+            return "heartbeat-canceled";
+        }
+
+        if (failureToken == cancellationToken && cancellationToken.IsCancellationRequested) {
+            return "request-canceled";
+        }
+
+        return null;
     }
 
     private async Task RunPhaseHeartbeatLoopAsync(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
@@ -317,6 +317,46 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void GetPhaseHeartbeatSuppressionReason_ReportsExpectedReasons() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+        using var unrelatedCts = new CancellationTokenSource();
+
+        heartbeatCts.Cancel();
+        outerCts.Cancel();
+        unrelatedCts.Cancel();
+
+        Assert.Equal("io", ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
+            new IOException("io"),
+            heartbeatCts.Token,
+            outerCts.Token));
+        Assert.Equal("heartbeat-canceled", ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
+            new OperationCanceledException("heartbeat", innerException: null, heartbeatCts.Token),
+            heartbeatCts.Token,
+            outerCts.Token));
+        Assert.Equal("request-canceled", ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
+            new OperationCanceledException("outer", innerException: null, outerCts.Token),
+            heartbeatCts.Token,
+            outerCts.Token));
+        Assert.Null(ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
+            new OperationCanceledException("unrelated", innerException: null, unrelatedCts.Token),
+            heartbeatCts.Token,
+            outerCts.Token));
+    }
+
+    [Fact]
+    public void GetPhaseHeartbeatSuppressionReason_UsesGenericCanceledWhenTokenIsUnspecified() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+        heartbeatCts.Cancel();
+
+        Assert.Equal("canceled", ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
+            new OperationCanceledException("canceled-without-token"),
+            heartbeatCts.Token,
+            outerCts.Token));
+    }
+
+    [Fact]
     public async Task ToolRoundStatusLifecycle_EmitsRoundStatusesInDeterministicOrder() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         using var capture = new SynchronizedCaptureStream();


### PR DESCRIPTION
## Summary
- add GetPhaseHeartbeatSuppressionReason(...) to classify expected heartbeat suppressions
- reuse reason-classifier for suppression decision to keep behavior + diagnostics aligned
- enrich suppression warning with reason and full exception payload for better triage
- add integration tests covering IO, heartbeat-token cancel, request-token cancel, generic canceled-token, and unexpected-token paths

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
