### PR TITLE
Chat: centralize heartbeat suppression reason constants

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -16,6 +16,11 @@ using IntelligenceX.OpenAI.Chat;
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
+    internal const string PhaseHeartbeatSuppressionReasonIo = "io";
+    internal const string PhaseHeartbeatSuppressionReasonCanceled = "canceled";
+    internal const string PhaseHeartbeatSuppressionReasonHeartbeatCanceled = "heartbeat-canceled";
+    internal const string PhaseHeartbeatSuppressionReasonRequestCanceled = "request-canceled";
+
     internal static string ResolveAssistantTextBeforeNoTextFallback(
         string assistantDraft,
         string lastNonEmptyAssistantDraft,
@@ -389,7 +394,7 @@ internal sealed partial class ChatServiceSession {
     internal static string? GetPhaseHeartbeatSuppressionReason(Exception heartbeatFailure, CancellationToken heartbeatCancellationToken,
         CancellationToken cancellationToken) {
         if (heartbeatFailure is IOException) {
-            return "io";
+            return PhaseHeartbeatSuppressionReasonIo;
         }
 
         if (heartbeatFailure is not OperationCanceledException canceledException) {
@@ -398,17 +403,19 @@ internal sealed partial class ChatServiceSession {
 
         var failureToken = canceledException.CancellationToken;
         if (!failureToken.CanBeCanceled) {
-            return heartbeatCancellationToken.IsCancellationRequested || cancellationToken.IsCancellationRequested ? "canceled" : null;
+            return heartbeatCancellationToken.IsCancellationRequested || cancellationToken.IsCancellationRequested
+                ? PhaseHeartbeatSuppressionReasonCanceled
+                : null;
         }
 
         // The heartbeat loop should throw OCE with either the linked heartbeat token
         // or the outer request token. Treat other canceled tokens as unexpected.
         if (failureToken == heartbeatCancellationToken && heartbeatCancellationToken.IsCancellationRequested) {
-            return "heartbeat-canceled";
+            return PhaseHeartbeatSuppressionReasonHeartbeatCanceled;
         }
 
         if (failureToken == cancellationToken && cancellationToken.IsCancellationRequested) {
-            return "request-canceled";
+            return PhaseHeartbeatSuppressionReasonRequestCanceled;
         }
 
         return null;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
@@ -326,15 +326,15 @@ public sealed partial class ChatServiceRoutingTrimTests {
         outerCts.Cancel();
         unrelatedCts.Cancel();
 
-        Assert.Equal("io", ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
+        Assert.Equal(ChatServiceSession.PhaseHeartbeatSuppressionReasonIo, ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
             new IOException("io"),
             heartbeatCts.Token,
             outerCts.Token));
-        Assert.Equal("heartbeat-canceled", ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
+        Assert.Equal(ChatServiceSession.PhaseHeartbeatSuppressionReasonHeartbeatCanceled, ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
             new OperationCanceledException("heartbeat", innerException: null, heartbeatCts.Token),
             heartbeatCts.Token,
             outerCts.Token));
-        Assert.Equal("request-canceled", ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
+        Assert.Equal(ChatServiceSession.PhaseHeartbeatSuppressionReasonRequestCanceled, ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
             new OperationCanceledException("outer", innerException: null, outerCts.Token),
             heartbeatCts.Token,
             outerCts.Token));
@@ -350,7 +350,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
         using var outerCts = new CancellationTokenSource();
         heartbeatCts.Cancel();
 
-        Assert.Equal("canceled", ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
+        Assert.Equal(ChatServiceSession.PhaseHeartbeatSuppressionReasonCanceled, ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
             new OperationCanceledException("canceled-without-token"),
             heartbeatCts.Token,
             outerCts.Token));


### PR DESCRIPTION
## Summary\n- centralize heartbeat suppression reason strings into shared internal constants\n- use constants in suppression classifier to avoid reason drift\n- update tests to assert against shared constants instead of duplicate literals\n\n## Validation\n- dotnet build IntelligenceX.sln -c Release\n- dotnet test IntelligenceX.sln -c Release\n- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll\n- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll\n