### PR TITLE
Chat: split finalizer tests to satisfy file-length gate

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Finalizer.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Finalizer.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using System.Threading;
+using IntelligenceX.Chat.Service;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed partial class ChatServiceRoutingTrimTests {
+    [Fact]
+    public void FinalizePhaseHeartbeatFailure_DoesNothingWhenFailureIsNull() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+
+        ChatServiceSession.FinalizePhaseHeartbeatFailure(
+            heartbeatFailure: null,
+            phaseStatus: "phase_review",
+            requestId: "req-intelligence-loop",
+            threadId: "thread-intelligence-loop",
+            heartbeatCancellationToken: heartbeatCts.Token,
+            cancellationToken: outerCts.Token);
+    }
+
+    [Fact]
+    public void FinalizePhaseHeartbeatFailure_SuppressesExpectedIOException() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+
+        ChatServiceSession.FinalizePhaseHeartbeatFailure(
+            heartbeatFailure: new IOException("simulated-io"),
+            phaseStatus: "phase_review",
+            requestId: "req-intelligence-loop",
+            threadId: "thread-intelligence-loop",
+            heartbeatCancellationToken: heartbeatCts.Token,
+            cancellationToken: outerCts.Token);
+    }
+
+    [Fact]
+    public void FinalizePhaseHeartbeatFailure_RethrowsUnexpectedFailure() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => ChatServiceSession.FinalizePhaseHeartbeatFailure(
+            heartbeatFailure: new InvalidOperationException("heartbeat-failed"),
+            phaseStatus: "phase_review",
+            requestId: "req-intelligence-loop",
+            threadId: "thread-intelligence-loop",
+            heartbeatCancellationToken: heartbeatCts.Token,
+            cancellationToken: outerCts.Token));
+
+        Assert.Equal("heartbeat-failed", ex.Message);
+    }
+
+    [Fact]
+    public void FinalizePhaseHeartbeatFailure_RethrowsCanceledFailureFromUnrelatedToken() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+        using var unrelatedCts = new CancellationTokenSource();
+        unrelatedCts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() => ChatServiceSession.FinalizePhaseHeartbeatFailure(
+            heartbeatFailure: new OperationCanceledException("unrelated", innerException: null, unrelatedCts.Token),
+            phaseStatus: "phase_review",
+            requestId: "req-intelligence-loop",
+            threadId: "thread-intelligence-loop",
+            heartbeatCancellationToken: heartbeatCts.Token,
+            cancellationToken: outerCts.Token));
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs
@@ -357,66 +357,6 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
-    public void FinalizePhaseHeartbeatFailure_DoesNothingWhenFailureIsNull() {
-        using var heartbeatCts = new CancellationTokenSource();
-        using var outerCts = new CancellationTokenSource();
-
-        ChatServiceSession.FinalizePhaseHeartbeatFailure(
-            heartbeatFailure: null,
-            phaseStatus: "phase_review",
-            requestId: "req-intelligence-loop",
-            threadId: "thread-intelligence-loop",
-            heartbeatCancellationToken: heartbeatCts.Token,
-            cancellationToken: outerCts.Token);
-    }
-
-    [Fact]
-    public void FinalizePhaseHeartbeatFailure_SuppressesExpectedIOException() {
-        using var heartbeatCts = new CancellationTokenSource();
-        using var outerCts = new CancellationTokenSource();
-
-        ChatServiceSession.FinalizePhaseHeartbeatFailure(
-            heartbeatFailure: new IOException("simulated-io"),
-            phaseStatus: "phase_review",
-            requestId: "req-intelligence-loop",
-            threadId: "thread-intelligence-loop",
-            heartbeatCancellationToken: heartbeatCts.Token,
-            cancellationToken: outerCts.Token);
-    }
-
-    [Fact]
-    public void FinalizePhaseHeartbeatFailure_RethrowsUnexpectedFailure() {
-        using var heartbeatCts = new CancellationTokenSource();
-        using var outerCts = new CancellationTokenSource();
-
-        var ex = Assert.Throws<InvalidOperationException>(() => ChatServiceSession.FinalizePhaseHeartbeatFailure(
-            heartbeatFailure: new InvalidOperationException("heartbeat-failed"),
-            phaseStatus: "phase_review",
-            requestId: "req-intelligence-loop",
-            threadId: "thread-intelligence-loop",
-            heartbeatCancellationToken: heartbeatCts.Token,
-            cancellationToken: outerCts.Token));
-
-        Assert.Equal("heartbeat-failed", ex.Message);
-    }
-
-    [Fact]
-    public void FinalizePhaseHeartbeatFailure_RethrowsCanceledFailureFromUnrelatedToken() {
-        using var heartbeatCts = new CancellationTokenSource();
-        using var outerCts = new CancellationTokenSource();
-        using var unrelatedCts = new CancellationTokenSource();
-        unrelatedCts.Cancel();
-
-        Assert.Throws<OperationCanceledException>(() => ChatServiceSession.FinalizePhaseHeartbeatFailure(
-            heartbeatFailure: new OperationCanceledException("unrelated", innerException: null, unrelatedCts.Token),
-            phaseStatus: "phase_review",
-            requestId: "req-intelligence-loop",
-            threadId: "thread-intelligence-loop",
-            heartbeatCancellationToken: heartbeatCts.Token,
-            cancellationToken: outerCts.Token));
-    }
-
-    [Fact]
     public async Task ToolRoundStatusLifecycle_EmitsRoundStatusesInDeterministicOrder() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         using var capture = new SynchronizedCaptureStream();


### PR DESCRIPTION
## Summary\n- move FinalizePhaseHeartbeatFailure_* contract tests into a dedicated partial test file\n- keep behavior unchanged while reducing ChatServiceRoutingTrimTests.IntelligenceLoop.Integration.cs below the 700-line policy limit\n- preserve test coverage and naming consistency\n\n## Validation\n- dotnet build IntelligenceX.sln -c Release\n- dotnet test IntelligenceX.sln -c Release\n- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll\n- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll\n