### PR TITLE
Chat: test cancellation-path suppression in finalizer

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Finalizer.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Finalizer.cs
@@ -66,4 +66,34 @@ public sealed partial class ChatServiceRoutingTrimTests {
             heartbeatCancellationToken: heartbeatCts.Token,
             cancellationToken: outerCts.Token));
     }
+
+    [Fact]
+    public void FinalizePhaseHeartbeatFailure_SuppressesCanceledFailureForHeartbeatToken() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+        heartbeatCts.Cancel();
+
+        ChatServiceSession.FinalizePhaseHeartbeatFailure(
+            heartbeatFailure: new OperationCanceledException("heartbeat-canceled", innerException: null, heartbeatCts.Token),
+            phaseStatus: "phase_review",
+            requestId: "req-intelligence-loop",
+            threadId: "thread-intelligence-loop",
+            heartbeatCancellationToken: heartbeatCts.Token,
+            cancellationToken: outerCts.Token);
+    }
+
+    [Fact]
+    public void FinalizePhaseHeartbeatFailure_SuppressesCanceledFailureForRequestToken() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+        outerCts.Cancel();
+
+        ChatServiceSession.FinalizePhaseHeartbeatFailure(
+            heartbeatFailure: new OperationCanceledException("request-canceled", innerException: null, outerCts.Token),
+            phaseStatus: "phase_review",
+            requestId: "req-intelligence-loop",
+            threadId: "thread-intelligence-loop",
+            heartbeatCancellationToken: heartbeatCts.Token,
+            cancellationToken: outerCts.Token);
+    }
 }


### PR DESCRIPTION
## Summary
- add positive-path finalizer tests for cancellation suppression
- verify FinalizePhaseHeartbeatFailure suppresses OperationCanceledException when cancellation token matches heartbeat token
- verify FinalizePhaseHeartbeatFailure suppresses OperationCanceledException when cancellation token matches outer request token

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
