### PR TITLE
Chat: cover generic-canceled suppression finalizer paths

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Finalizer.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Finalizer.cs
@@ -124,4 +124,38 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.Same(failure, ex);
     }
+
+    [Fact]
+    public void FinalizePhaseHeartbeatFailure_SuppressesGenericCanceledWhenHeartbeatCancellationIsRequested() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+        heartbeatCts.Cancel();
+
+        var ex = Record.Exception(() => ChatServiceSession.FinalizePhaseHeartbeatFailure(
+            heartbeatFailure: new OperationCanceledException("generic-canceled"),
+            phaseStatus: "phase_review",
+            requestId: "req-intelligence-loop",
+            threadId: "thread-intelligence-loop",
+            heartbeatCancellationToken: heartbeatCts.Token,
+            cancellationToken: outerCts.Token));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void FinalizePhaseHeartbeatFailure_SuppressesGenericCanceledWhenRequestCancellationIsRequested() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+        outerCts.Cancel();
+
+        var ex = Record.Exception(() => ChatServiceSession.FinalizePhaseHeartbeatFailure(
+            heartbeatFailure: new OperationCanceledException("generic-canceled"),
+            phaseStatus: "phase_review",
+            requestId: "req-intelligence-loop",
+            threadId: "thread-intelligence-loop",
+            heartbeatCancellationToken: heartbeatCts.Token,
+            cancellationToken: outerCts.Token));
+
+        Assert.Null(ex);
+    }
 }


### PR DESCRIPTION
## Summary
- add finalizer tests for generic OperationCanceledException suppression when heartbeat cancellation is requested
- add finalizer tests for generic OperationCanceledException suppression when request cancellation is requested
- keep runtime behavior unchanged while completing cancellation-branch contract coverage

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
