### PR TITLE
Chat: lock generic-canceled suppression branches in finalizer

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Finalizer.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Finalizer.cs
@@ -56,6 +56,25 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void FinalizePhaseHeartbeatFailure_RethrowsUnexpectedFailureWhenCancellationIsAlreadyRequested() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+        outerCts.Cancel();
+        var failure = new InvalidOperationException("heartbeat-failed-with-cancellation");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => ChatServiceSession.FinalizePhaseHeartbeatFailure(
+            heartbeatFailure: failure,
+            phaseStatus: "phase_review",
+            requestId: "req-intelligence-loop",
+            threadId: "thread-intelligence-loop",
+            heartbeatCancellationToken: heartbeatCts.Token,
+            cancellationToken: outerCts.Token));
+
+        Assert.Same(failure, ex);
+        Assert.Equal("heartbeat-failed-with-cancellation", ex.Message);
+    }
+
+    [Fact]
     public void FinalizePhaseHeartbeatFailure_RethrowsCanceledFailureFromUnrelatedToken() {
         using var heartbeatCts = new CancellationTokenSource();
         using var outerCts = new CancellationTokenSource();


### PR DESCRIPTION
## Summary
- add boundary test ensuring non-cancellation failures are still rethrown even when cancellation is already requested
- complete generic OperationCanceledException suppression-path coverage with both heartbeat/request cancellation-active cases
- keep runtime behavior unchanged while strengthening suppression contract tests

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
