### PR TITLE
Harden heartbeat suppression guards and stabilize priming cancellation test

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -388,11 +388,13 @@ internal sealed partial class ChatServiceSession {
 
     internal static bool ShouldSuppressPhaseHeartbeatFailure(Exception heartbeatFailure, CancellationToken heartbeatCancellationToken,
         CancellationToken cancellationToken) {
+        ArgumentNullException.ThrowIfNull(heartbeatFailure);
         return GetPhaseHeartbeatSuppressionReason(heartbeatFailure, heartbeatCancellationToken, cancellationToken) is not null;
     }
 
     internal static string? GetPhaseHeartbeatSuppressionReason(Exception heartbeatFailure, CancellationToken heartbeatCancellationToken,
         CancellationToken cancellationToken) {
+        ArgumentNullException.ThrowIfNull(heartbeatFailure);
         if (heartbeatFailure is IOException) {
             return PhaseHeartbeatSuppressionReasonIo;
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Finalizer.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.Finalizer.cs
@@ -130,6 +130,32 @@ public sealed partial class ChatServiceRoutingTrimTests {
             cancellationToken: outerCts.Token);
     }
 
+    [Fact]
+    public void ShouldSuppressPhaseHeartbeatFailure_ThrowsWhenFailureIsNull() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+
+        var ex = Assert.Throws<ArgumentNullException>(() => ChatServiceSession.ShouldSuppressPhaseHeartbeatFailure(
+            heartbeatFailure: null!,
+            heartbeatCancellationToken: heartbeatCts.Token,
+            cancellationToken: outerCts.Token));
+
+        Assert.Equal("heartbeatFailure", ex.ParamName);
+    }
+
+    [Fact]
+    public void GetPhaseHeartbeatSuppressionReason_ThrowsWhenFailureIsNull() {
+        using var heartbeatCts = new CancellationTokenSource();
+        using var outerCts = new CancellationTokenSource();
+
+        var ex = Assert.Throws<ArgumentNullException>(() => ChatServiceSession.GetPhaseHeartbeatSuppressionReason(
+            heartbeatFailure: null!,
+            heartbeatCancellationToken: heartbeatCts.Token,
+            cancellationToken: outerCts.Token));
+
+        Assert.Equal("heartbeatFailure", ex.ParamName);
+    }
+
     private static void AssertSuppressed(Exception failure, CancellationToken heartbeatCancellationToken, CancellationToken cancellationToken) {
         var ex = Record.Exception(() => InvokeFinalize(failure, heartbeatCancellationToken, cancellationToken));
         Assert.Null(ex);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthPrimingBehaviorTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthPrimingBehaviorTests.cs
@@ -57,16 +57,17 @@ public sealed class StartupToolHealthPrimingBehaviorTests {
     [Fact]
     public async Task AwaitStartupToolHealthPrimingForHelloAsync_StopsWaitingWhenCanceled() {
         var priming = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var cts = new CancellationTokenSource(millisecondsDelay: 30);
-        var stopwatch = Stopwatch.StartNew();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
 
-        await ChatServiceSession.AwaitStartupToolHealthPrimingForHelloAsync(
+        var waitTask = ChatServiceSession.AwaitStartupToolHealthPrimingForHelloAsync(
             priming.Task,
             TimeSpan.FromSeconds(5),
             cts.Token);
 
-        stopwatch.Stop();
+        var completed = await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(2)));
+        Assert.Same(waitTask, completed);
+        await waitTask;
         Assert.False(priming.Task.IsCompleted);
-        Assert.InRange(stopwatch.ElapsedMilliseconds, 0, 1500);
     }
 }


### PR DESCRIPTION
## Summary
- add explicit null guards for phase-heartbeat suppression helper inputs
- add regression tests that assert `ArgumentNullException` parameter names for null heartbeat failures
- replace stopwatch-based cancellation timing assertion with deterministic completion-vs-timeout signaling in startup priming behavior tests

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~StartupToolHealthPrimingBehaviorTests|FullyQualifiedName~FinalizePhaseHeartbeatFailure_|FullyQualifiedName~GetPhaseHeartbeatSuppressionReason_|FullyQualifiedName~ShouldSuppressPhaseHeartbeatFailure_"
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
