### PR TITLE
Centralize pending-action question signals for CTA confirmation

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.Cta.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.Cta.cs
@@ -98,7 +98,7 @@ internal sealed partial class ChatServiceSession {
         }
 
         // Guardrails must run on raw input (pre-normalization) to avoid normalization widening matches.
-        if (raw.IndexOfAny(PendingActionConfirmationQuestionPunctuation) >= 0) {
+        if (ContainsQuestionSignal(raw)) {
             return false;
         }
         if (raw.IndexOfAny(PendingActionConfirmationDisqualifierPunctuation) >= 0) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.cs
@@ -16,7 +16,6 @@ internal sealed partial class ChatServiceSession {
     private static readonly Regex LooseActionBlockRegex = new(
         @"(?is)(?:^|\n)\s*id\s*:?\s*(?<id>[^\r\n]+)\s*\r?\n\s*title\s*:?\s*(?<title>[^\r\n]*)\s*\r?\n\s*request\s*:?\s*(?<request>.*?)\r?\n\s*reply\s*:?\s*(?<reply>[^\r\n]+)",
         RegexOptions.CultureInvariant);
-    private static readonly char[] PendingActionConfirmationQuestionPunctuation = new[] { '?', '？', '¿', '؟' };
     private static readonly char[] PendingActionConfirmationDisqualifierPunctuation = new[] { ':', ';', '\uFF1A', '\uFF1B' }; // ： ；
     private static readonly char[] PendingActionConfirmationStructuredDisqualifierChars =
         new[] { '\\', '{', '}', '[', ']', '<', '>', '=' };
@@ -379,7 +378,7 @@ internal sealed partial class ChatServiceSession {
             return true;
         }
 
-        if (trimmed.IndexOfAny(PendingActionConfirmationQuestionPunctuation) >= 0
+        if (ContainsQuestionSignal(trimmed)
             || trimmed.IndexOfAny(PendingActionConfirmationDisqualifierPunctuation) >= 0
             || LooksLikeStructuredPendingActionConfirmationInput(trimmed)) {
             reason = "follow_up_disqualified_shape";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.PendingActionsCtaConfirmation.cs
@@ -180,6 +180,32 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Theory]
+    [InlineData("run now?")]
+    [InlineData("run now\uFF1F")]
+    [InlineData("\u00BFrun now")]
+    [InlineData("run now\u061F")]
+    public void ExpandContinuationUserRequest_DoesNotConfirmWhenFollowUpContainsQuestionSignal(string input) {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var assistantDraft = """
+            If you say "run now", I'll execute it.
+
+            [Action]
+            ix:action:v1
+            id: act_001
+            title: First
+            request: Do first thing.
+            mutating: false
+            reply: /act act_001
+            """;
+
+        RememberPendingActionsMethod.Invoke(session, new object?[] { "thread-001", assistantDraft });
+        var result = ExpandContinuationUserRequestMethod.Invoke(session, new object?[] { "thread-001", input });
+        var expanded = Assert.IsType<string>(result);
+
+        Assert.Equal(input, expanded);
+    }
+
+    [Theory]
     [InlineData("{run now}")]
     [InlineData("{\"run now\"}")]
     [InlineData("[run now]")]


### PR DESCRIPTION
## Summary
- centralize pending-action and CTA confirmation question-signal checks via shared `ContainsQuestionSignal(...)` instead of duplicated punctuation lists
- keep CTA continuation confirmation language-neutral by reusing the shared text-signal helper path
- add theory coverage for Unicode question punctuation (`?`, `？`, `¿`, `؟`) to prevent regression

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~ExpandContinuationUserRequest_DoesNotConfirmWhenFollowUpContainsQuestionSignal"
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~PendingAction"
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
