### PR TITLE
Share follow-up shape thresholds across routing and nudge

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.TextAndReplay.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.TextAndReplay.cs
@@ -112,7 +112,7 @@ internal sealed partial class ChatServiceSession {
         }
     }
 
-    private static bool LooksLikeCompactFollowUp(string userRequest) {
+    private static bool LooksLikeFollowUpShape(string userRequest, int maxQuestionChars) {
         var normalized = (userRequest ?? string.Empty).Trim();
         if (normalized.Length == 0) {
             return false;
@@ -122,20 +122,26 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (normalized.Length > 80) {
+        if (normalized.Length > maxQuestionChars) {
             return false;
         }
 
-        var tokenCount = CountLetterDigitTokens(normalized, maxTokens: 12);
+        var tokenCount = CountLetterDigitTokens(normalized, maxTokens: FollowUpShapeTokenScanLimit);
         if (tokenCount == 0) {
             return false;
         }
 
-        if (tokenCount <= 6 && normalized.Length <= 64) {
+        if (tokenCount <= FollowUpShapeShortTokenLimit && normalized.Length <= FollowUpShapeShortCharLimit) {
             return true;
         }
 
-        return tokenCount <= FollowUpQuestionMaxTokens && normalized.Length <= 80 && ContainsQuestionSignal(normalized);
+        return tokenCount <= FollowUpQuestionMaxTokens
+               && normalized.Length <= maxQuestionChars
+               && ContainsQuestionSignal(normalized);
+    }
+
+    private static bool LooksLikeCompactFollowUp(string userRequest) {
+        return LooksLikeFollowUpShape(userRequest, CompactFollowUpQuestionCharLimit);
     }
 
     private static bool LooksLikeContextualFollowUpForExecutionNudge(string userRequest, string assistantDraft) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
@@ -26,7 +26,12 @@ internal sealed partial class ChatServiceSession {
     private const int MaxStructuredNextActionArgumentsChars = 32_768;
     private const int NoResultPhaseLoopThresholdWithToolActivity = 8;
     private const int NoResultPhaseLoopThresholdWithoutToolActivity = 6;
+    private const int FollowUpShapeTokenScanLimit = 16;
+    private const int FollowUpShapeShortTokenLimit = 6;
+    private const int FollowUpShapeShortCharLimit = 64;
     private const int FollowUpQuestionMaxTokens = 12;
+    private const int CompactFollowUpQuestionCharLimit = 80;
+    private const int ContinuationFollowUpQuestionCharLimit = 96;
     private static readonly char[] CallToActionCommaPunctuation = new[] { ',', '\uFF0C', '\u3001', '\u060C' };
     private static readonly char[] CallToActionColonPunctuation = new[] { ':', '\uFF1A', '\uFE13' };
     private enum ActionMutability {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
@@ -554,27 +554,7 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static bool LooksLikeContinuationFollowUp(string userRequest) {
-        var normalized = (userRequest ?? string.Empty).Trim();
-        if (normalized.Length == 0) {
-            return false;
-        }
-
-        if (normalized.Contains('\n', StringComparison.Ordinal) || normalized.Length > 96) {
-            return false;
-        }
-
-        var tokenCount = CountLetterDigitTokens(normalized, maxTokens: 16);
-        if (tokenCount == 0) {
-            return false;
-        }
-
-        if (tokenCount <= 6 && normalized.Length <= 64) {
-            return true;
-        }
-
-        return tokenCount <= FollowUpQuestionMaxTokens
-               && normalized.Length <= 96
-               && ContainsQuestionSignal(normalized);
+        return LooksLikeFollowUpShape(userRequest, ContinuationFollowUpQuestionCharLimit);
     }
 
     private sealed class ToolRoutingStats {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
@@ -339,6 +339,26 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void LooksLikeCompactAndContinuationFollowUp_RejectQuestionWhenTokenCountExceedsSharedLimit() {
+        var userRequest = "a b c d e f g h i j k l m?";
+        var compact = LooksLikeCompactFollowUpMethod.Invoke(null, new object?[] { userRequest });
+        var continuation = LooksLikeContinuationFollowUpMethod.Invoke(null, new object?[] { userRequest });
+
+        Assert.False(Assert.IsType<bool>(compact));
+        Assert.False(Assert.IsType<bool>(continuation));
+    }
+
+    [Fact]
+    public void LooksLikeContinuationFollowUp_AllowsLongerQuestionWindowThanCompactFollowUp() {
+        var userRequest = new string('a', 81) + "?";
+        var compact = LooksLikeCompactFollowUpMethod.Invoke(null, new object?[] { userRequest });
+        var continuation = LooksLikeContinuationFollowUpMethod.Invoke(null, new object?[] { userRequest });
+
+        Assert.False(Assert.IsType<bool>(compact));
+        Assert.True(Assert.IsType<bool>(continuation));
+    }
+
+    [Fact]
     public void ShouldAttemptToolExecutionNudge_TreatsCompactFollowUpByShapeNotKeyword() {
         var keywordRequest = "do it";
         var keywordDraft = "Proceeding with do it now.";


### PR DESCRIPTION
## Summary
- centralize compact/continuation follow-up shape heuristics behind shared named constants/helpers used by both tool-subset routing and tool-execution nudge
- remove duplicated shape magic numbers and keep intentional compact-vs-continuation char-window differences explicit
- add boundary tests for token/char follow-up shape behavior to guard against routing and nudge drift

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~LooksLikeContinuationFollowUp|FullyQualifiedName~LooksLikeCompactFollowUp|FullyQualifiedName~ShouldSkipWeightedRouting|FullyQualifiedName~ShouldAttemptToolExecutionNudge_TreatsCompactFollowUpByShapeNotKeyword"
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
