### PR TITLE
Chat routing: prefer structured insight strategy over reason text

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -86,7 +86,8 @@ internal sealed partial class ChatServiceSession {
                 ToolName: toolScore.Definition.Name,
                 Confidence: confidence,
                 Score: Math.Round(toolScore.Score, 3),
-                Reason: string.Join(", ", reasons)));
+                Reason: string.Join(", ", reasons),
+                Strategy: ToolRoutingInsightStrategy.WeightedHeuristic));
         }
 
         insights.Sort(static (a, b) => b.Score.CompareTo(a.Score));

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
@@ -270,6 +270,10 @@ internal sealed partial class ChatServiceSession {
         }
 
         for (var i = 0; i < insights.Count; i++) {
+            if (insights[i].Strategy == ToolRoutingInsightStrategy.SemanticPlanner) {
+                return true;
+            }
+
             var reason = insights[i].Reason ?? string.Empty;
             if (reason.IndexOf("semantic planner", StringComparison.OrdinalIgnoreCase) >= 0) {
                 return true;
@@ -280,6 +284,10 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static string ResolveRoutingInsightStrategy(ToolRoutingInsight insight, string defaultStrategy) {
+        if (TryResolveRoutingInsightStrategyFromStructuredHint(insight, out var structuredStrategy)) {
+            return structuredStrategy;
+        }
+
         var reason = (insight.Reason ?? string.Empty).Trim();
         if (reason.Length == 0) {
             return defaultStrategy;
@@ -294,6 +302,16 @@ internal sealed partial class ChatServiceSession {
         }
 
         return defaultStrategy;
+    }
+
+    private static bool TryResolveRoutingInsightStrategyFromStructuredHint(ToolRoutingInsight insight, out string strategy) {
+        strategy = insight.Strategy switch {
+            ToolRoutingInsightStrategy.WeightedHeuristic => "weighted_heuristic",
+            ToolRoutingInsightStrategy.ContinuationSubset => "continuation_subset",
+            ToolRoutingInsightStrategy.SemanticPlanner => "semantic_planner",
+            _ => string.Empty
+        };
+        return strategy.Length > 0;
     }
 
     private bool TryGetContinuationToolSubset(string threadId, string userRequest, IReadOnlyList<ToolDefinition> allDefinitions,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
@@ -290,7 +290,8 @@ internal sealed partial class ChatServiceSession {
                 ToolName: name,
                 Confidence: confidence,
                 Score: Math.Round(score, 3),
-                Reason: reason));
+                Reason: reason,
+                Strategy: ToolRoutingInsightStrategy.SemanticPlanner));
         }
 
         return list;
@@ -572,11 +573,23 @@ internal sealed partial class ChatServiceSession {
         int TokenHits,
         double Adjustment);
 
+    private enum ToolRoutingInsightStrategy {
+        Unknown = 0,
+        WeightedHeuristic = 1,
+        ContinuationSubset = 2,
+        SemanticPlanner = 3
+    }
+
     private readonly record struct ToolRoutingInsight(
         string ToolName,
         string Confidence,
         double Score,
-        string Reason);
+        string Reason,
+        ToolRoutingInsightStrategy Strategy) {
+        public ToolRoutingInsight(string ToolName, string Confidence, double Score, string Reason)
+            : this(ToolName, Confidence, Score, Reason, ToolRoutingInsightStrategy.Unknown) {
+        }
+    }
 
     private readonly record struct ToolRetryProfile(
         int MaxAttempts,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
@@ -72,7 +72,8 @@ internal sealed partial class ChatServiceSession {
                 ToolName: name.Trim(),
                 Confidence: "high",
                 Score: 1d,
-                Reason: "continuation follow-up reuse"));
+                Reason: "continuation follow-up reuse",
+                Strategy: ToolRoutingInsightStrategy.ContinuationSubset));
         }
 
         return list;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingTransparency.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingTransparency.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Xunit;
@@ -68,6 +69,75 @@ public sealed partial class ChatServiceRoutingTrimTests {
         var strategy = Assert.IsType<string>(result);
 
         Assert.Equal("no_tools", strategy);
+    }
+
+    [Fact]
+    public void ResolveRoutingStrategy_UsesStructuredPlannerInsightWithoutReasonText() {
+        var plannerInsight = CreateToolRoutingInsight(
+            toolName: "ad_replication_summary",
+            confidence: "high",
+            score: 1d,
+            reason: "top ranked by planner",
+            strategyName: "SemanticPlanner");
+        var insights = CreateRoutingInsightsArray(plannerInsight);
+
+        var result = ResolveRoutingStrategyMethod.Invoke(null, new object?[] {
+            true,
+            false,
+            false,
+            insights,
+            4,
+            12
+        });
+
+        Assert.Equal("semantic_planner", Assert.IsType<string>(result));
+    }
+
+    [Fact]
+    public void HasPlannerInsight_FallsBackToReasonTextWhenStructuredStrategyIsUnknown() {
+        var plannerInsight = CreateToolRoutingInsight(
+            toolName: "ad_replication_summary",
+            confidence: "high",
+            score: 1d,
+            reason: "semantic planner selection",
+            strategyName: "Unknown");
+        var insights = CreateRoutingInsightsArray(plannerInsight);
+
+        var result = HasPlannerInsightMethod.Invoke(null, new object?[] { insights });
+
+        Assert.True(Assert.IsType<bool>(result));
+    }
+
+    [Fact]
+    public void ResolveRoutingInsightStrategy_UsesStructuredStrategyWithoutReasonText() {
+        var continuationInsight = CreateToolRoutingInsight(
+            toolName: "ad_replication_summary",
+            confidence: "high",
+            score: 1d,
+            reason: "reused prior subset window",
+            strategyName: "ContinuationSubset");
+
+        var result = ResolveRoutingInsightStrategyMethod.Invoke(
+            null,
+            new object?[] { continuationInsight, "weighted_heuristic" });
+
+        Assert.Equal("continuation_subset", Assert.IsType<string>(result));
+    }
+
+    [Fact]
+    public void ResolveRoutingInsightStrategy_FallsBackToReasonTextWhenStructuredStrategyIsUnknown() {
+        var continuationInsight = CreateToolRoutingInsight(
+            toolName: "ad_replication_summary",
+            confidence: "high",
+            score: 1d,
+            reason: "continuation follow-up reuse",
+            strategyName: "Unknown");
+
+        var result = ResolveRoutingInsightStrategyMethod.Invoke(
+            null,
+            new object?[] { continuationInsight, "weighted_heuristic" });
+
+        Assert.Equal("continuation_subset", Assert.IsType<string>(result));
     }
 
     [Fact]
@@ -219,5 +289,33 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.True(budget.GetProperty("contextAwareBudgetApplied").GetBoolean());
         Assert.Equal(8192L, budget.GetProperty("effectiveModelContextLength").GetInt64());
         Assert.Equal(JsonValueKind.Null, budget.GetProperty("requested").ValueKind);
+    }
+
+    private static object CreateToolRoutingInsight(string toolName, string confidence, double score, string reason, string strategyName) {
+        var insightType = ResolveRoutingStrategyMethod.GetParameters()[3].ParameterType.GetGenericArguments()[0];
+        var strategyProperty = insightType.GetProperty("Strategy", BindingFlags.Public | BindingFlags.Instance)
+                               ?? throw new InvalidOperationException("ToolRoutingInsight.Strategy property not found.");
+        var strategyType = strategyProperty.PropertyType;
+        var strategyValue = Enum.Parse(strategyType, strategyName, ignoreCase: true);
+
+        var value = Activator.CreateInstance(
+            insightType,
+            toolName,
+            confidence,
+            score,
+            reason,
+            strategyValue);
+
+        return value ?? throw new InvalidOperationException("ToolRoutingInsight instance could not be created.");
+    }
+
+    private static Array CreateRoutingInsightsArray(params object[] insights) {
+        var insightType = ResolveRoutingStrategyMethod.GetParameters()[3].ParameterType.GetGenericArguments()[0];
+        var array = Array.CreateInstance(insightType, insights.Length);
+        for (var i = 0; i < insights.Length; i++) {
+            array.SetValue(insights[i], i);
+        }
+
+        return array;
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
@@ -218,6 +218,12 @@ public sealed partial class ChatServiceRoutingTrimTests {
     private static readonly MethodInfo ResolveRoutingStrategyMethod =
         typeof(ChatServiceSession).GetMethod("ResolveRoutingStrategy", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("ResolveRoutingStrategy not found.");
+    private static readonly MethodInfo HasPlannerInsightMethod =
+        typeof(ChatServiceSession).GetMethod("HasPlannerInsight", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("HasPlannerInsight not found.");
+    private static readonly MethodInfo ResolveRoutingInsightStrategyMethod =
+        typeof(ChatServiceSession).GetMethod("ResolveRoutingInsightStrategy", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("ResolveRoutingInsightStrategy not found.");
     private static readonly MethodInfo BuildRoutingSelectionMessageMethod =
         typeof(ChatServiceSession).GetMethod("BuildRoutingSelectionMessage", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("BuildRoutingSelectionMessage not found.");


### PR DESCRIPTION
## Summary
- add structured strategy metadata to `ToolRoutingInsight` and populate it at insight creation points (weighted heuristic, continuation subset, semantic planner)
- update routing strategy/planner detection to prefer structured strategy metadata and use reason-text parsing only as backward-compatible fallback
- add regression coverage proving strategy/planner behavior works without reason wording and that fallback behavior remains intact

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~IntelligenceX.Chat.Tests.ChatServiceRoutingTrimTests"
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
