### PR TITLE
Centralize routing insight strategy label mapping

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
@@ -283,6 +283,15 @@ internal sealed partial class ChatServiceSession {
         return false;
     }
 
+    private static string ResolveRoutingInsightStrategyLabel(ToolRoutingInsightStrategy strategy) {
+        return strategy switch {
+            ToolRoutingInsightStrategy.WeightedHeuristic => "weighted_heuristic",
+            ToolRoutingInsightStrategy.ContinuationSubset => "continuation_subset",
+            ToolRoutingInsightStrategy.SemanticPlanner => "semantic_planner",
+            _ => string.Empty
+        };
+    }
+
     private static string ResolveRoutingInsightStrategy(ToolRoutingInsight insight, string defaultStrategy) {
         if (TryResolveRoutingInsightStrategyFromStructuredHint(insight, out var structuredStrategy)) {
             return structuredStrategy;
@@ -294,23 +303,18 @@ internal sealed partial class ChatServiceSession {
         }
 
         if (reason.IndexOf("continuation", StringComparison.OrdinalIgnoreCase) >= 0) {
-            return "continuation_subset";
+            return ResolveRoutingInsightStrategyLabel(ToolRoutingInsightStrategy.ContinuationSubset);
         }
 
         if (reason.IndexOf("semantic planner", StringComparison.OrdinalIgnoreCase) >= 0) {
-            return "semantic_planner";
+            return ResolveRoutingInsightStrategyLabel(ToolRoutingInsightStrategy.SemanticPlanner);
         }
 
         return defaultStrategy;
     }
 
     private static bool TryResolveRoutingInsightStrategyFromStructuredHint(ToolRoutingInsight insight, out string strategy) {
-        strategy = insight.Strategy switch {
-            ToolRoutingInsightStrategy.WeightedHeuristic => "weighted_heuristic",
-            ToolRoutingInsightStrategy.ContinuationSubset => "continuation_subset",
-            ToolRoutingInsightStrategy.SemanticPlanner => "semantic_planner",
-            _ => string.Empty
-        };
+        strategy = ResolveRoutingInsightStrategyLabel(insight.Strategy);
         return strategy.Length > 0;
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
@@ -129,15 +129,15 @@ internal sealed partial class ChatServiceSession {
         }
 
         if (usedContinuationSubset) {
-            return "continuation_subset";
+            return ResolveRoutingInsightStrategyLabel(ToolRoutingInsightStrategy.ContinuationSubset);
         }
 
         if (HasPlannerInsight(insights)) {
-            return "semantic_planner";
+            return ResolveRoutingInsightStrategyLabel(ToolRoutingInsightStrategy.SemanticPlanner);
         }
 
         if (selectedToolCount < totalToolCount) {
-            return "weighted_heuristic";
+            return ResolveRoutingInsightStrategyLabel(ToolRoutingInsightStrategy.WeightedHeuristic);
         }
 
         return "full_toolset";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingTransparency.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingTransparency.cs
@@ -108,6 +108,19 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.True(Assert.IsType<bool>(result));
     }
 
+    [Theory]
+    [InlineData("WeightedHeuristic", "weighted_heuristic")]
+    [InlineData("ContinuationSubset", "continuation_subset")]
+    [InlineData("SemanticPlanner", "semantic_planner")]
+    [InlineData("Unknown", "")]
+    public void ResolveRoutingInsightStrategyLabel_MapsStructuredStrategyValues(string strategyName, string expectedLabel) {
+        var strategyValue = CreateToolRoutingInsightStrategy(strategyName);
+
+        var result = ResolveRoutingInsightStrategyLabelMethod.Invoke(null, new[] { strategyValue });
+
+        Assert.Equal(expectedLabel, Assert.IsType<string>(result));
+    }
+
     [Fact]
     public void ResolveRoutingInsightStrategy_UsesStructuredStrategyWithoutReasonText() {
         var continuationInsight = CreateToolRoutingInsight(
@@ -307,6 +320,14 @@ public sealed partial class ChatServiceRoutingTrimTests {
             strategyValue);
 
         return value ?? throw new InvalidOperationException("ToolRoutingInsight instance could not be created.");
+    }
+
+    private static object CreateToolRoutingInsightStrategy(string strategyName) {
+        var insightType = ResolveRoutingStrategyMethod.GetParameters()[3].ParameterType.GetGenericArguments()[0];
+        var strategyProperty = insightType.GetProperty("Strategy", BindingFlags.Public | BindingFlags.Instance)
+                               ?? throw new InvalidOperationException("ToolRoutingInsight.Strategy property not found.");
+        var strategyType = strategyProperty.PropertyType;
+        return Enum.Parse(strategyType, strategyName, ignoreCase: true);
     }
 
     private static Array CreateRoutingInsightsArray(params object[] insights) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
@@ -224,6 +224,9 @@ public sealed partial class ChatServiceRoutingTrimTests {
     private static readonly MethodInfo ResolveRoutingInsightStrategyMethod =
         typeof(ChatServiceSession).GetMethod("ResolveRoutingInsightStrategy", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("ResolveRoutingInsightStrategy not found.");
+    private static readonly MethodInfo ResolveRoutingInsightStrategyLabelMethod =
+        typeof(ChatServiceSession).GetMethod("ResolveRoutingInsightStrategyLabel", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("ResolveRoutingInsightStrategyLabel not found.");
     private static readonly MethodInfo BuildRoutingSelectionMessageMethod =
         typeof(ChatServiceSession).GetMethod("BuildRoutingSelectionMessage", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("BuildRoutingSelectionMessage not found.");


### PR DESCRIPTION
## Summary
- centralize enum-to-label mapping for `ToolRoutingInsightStrategy` in a single helper to prevent future strategy string drift
- route both insight-strategy resolution and routing-strategy emission through the shared mapping helper
- add regression tests locking the mapping outputs (including `Unknown` => empty label) while preserving existing behavior

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "(FullyQualifiedName~ChatServiceRoutingTrimTests.ResolveRoutingInsightStrategyLabel_MapsStructuredStrategyValues|FullyQualifiedName~ChatServiceRoutingTrimTests.ResolveRoutingInsightStrategy_|FullyQualifiedName~ChatServiceRoutingTrimTests.ResolveRoutingStrategy_)"
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
