### PR TITLE
Use test hook for tool routing stats update coverage

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.StatsAndTesting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.StatsAndTesting.cs
@@ -418,6 +418,10 @@ internal sealed partial class ChatServiceSession {
         PersistToolRoutingStatsSnapshot();
     }
 
+    internal void UpdateToolRoutingStatsForTesting(IReadOnlyList<ToolCall> calls, IReadOnlyList<ToolOutputDto> outputs) {
+        UpdateToolRoutingStats(calls, outputs);
+    }
+
     internal string ExpandContinuationUserRequestForTesting(string threadId, string userRequest) {
         return ExpandContinuationUserRequest(threadId, userRequest);
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
@@ -318,10 +318,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             }
         };
 
-        var updateMethod = typeof(ChatServiceSession).GetMethod("UpdateToolRoutingStats", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-        Assert.NotNull(updateMethod);
-
-        updateMethod!.Invoke(session, new object[] { calls, outputs });
+        session.UpdateToolRoutingStatsForTesting(calls, outputs);
 
         var names = session.GetTrackedToolRoutingStatNamesForTesting();
         Assert.Contains(names, static name => string.Equals(name, "ad_replication_summary", StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
## Summary
- add `UpdateToolRoutingStatsForTesting(...)` internal test hook in `ChatServiceSession`
- switch `UpdateToolRoutingStats_TracksOutputsWhenCallIdsDifferOnlyByWhitespace` to use the test hook instead of reflection
- keep behavior unchanged while reducing private-signature reflection coupling in routing trim coverage

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~UpdateToolRoutingStats_TracksOutputsWhenCallIdsDifferOnlyByWhitespace|FullyQualifiedName~TrimToolRoutingStatsForTesting_RemovesNonPositiveTimestampEntriesFirst|FullyQualifiedName~TrimWeightedRoutingContextsForTesting_RemovesMissingAndZeroTickEntriesFirst"
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
