### PR TITLE
Harden routing test hooks with explicit null contracts

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.StatsAndTesting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.StatsAndTesting.cs
@@ -419,18 +419,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     internal void UpdateToolRoutingStatsForTesting(IReadOnlyList<ToolCall> calls, IReadOnlyList<ToolOutputDto> outputs) {
+        ArgumentNullException.ThrowIfNull(calls);
+        ArgumentNullException.ThrowIfNull(outputs);
         UpdateToolRoutingStats(calls, outputs);
     }
 
     internal string ExpandContinuationUserRequestForTesting(string threadId, string userRequest) {
+        ArgumentNullException.ThrowIfNull(threadId);
+        ArgumentNullException.ThrowIfNull(userRequest);
         return ExpandContinuationUserRequest(threadId, userRequest);
     }
 
     internal void RememberUserIntentForTesting(string threadId, string userRequest) {
+        ArgumentNullException.ThrowIfNull(threadId);
+        ArgumentNullException.ThrowIfNull(userRequest);
         RememberUserIntent(threadId, userRequest);
     }
 
     internal void RememberPendingActionsForTesting(string threadId, string assistantReply) {
+        ArgumentNullException.ThrowIfNull(threadId);
+        ArgumentNullException.ThrowIfNull(assistantReply);
         RememberPendingActions(threadId, assistantReply);
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.Part3.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.Part3.cs
@@ -49,6 +49,30 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ExpandContinuationUserRequestForTesting_ThrowsWhenThreadIdIsNull() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+
+        var ex = Assert.Throws<ArgumentNullException>(() => session.ExpandContinuationUserRequestForTesting(null!, "run now"));
+        Assert.Equal("threadId", ex.ParamName);
+    }
+
+    [Fact]
+    public void RememberUserIntentForTesting_ThrowsWhenUserRequestIsNull() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+
+        var ex = Assert.Throws<ArgumentNullException>(() => session.RememberUserIntentForTesting("thread-001", null!));
+        Assert.Equal("userRequest", ex.ParamName);
+    }
+
+    [Fact]
+    public void RememberPendingActionsForTesting_ThrowsWhenAssistantReplyIsNull() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+
+        var ex = Assert.Throws<ArgumentNullException>(() => session.RememberPendingActionsForTesting("thread-001", null!));
+        Assert.Equal("assistantReply", ex.ParamName);
+    }
+
+    [Fact]
     public void ExpandContinuationUserRequest_ResolvesActCommandToPendingActionRequest() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var assistantDraft = """

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
@@ -324,6 +324,22 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains(names, static name => string.Equals(name, "ad_replication_summary", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void UpdateToolRoutingStatsForTesting_ThrowsWhenCallsIsNull() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+
+        var ex = Assert.Throws<ArgumentNullException>(() => session.UpdateToolRoutingStatsForTesting(null!, new List<ToolOutputDto>()));
+        Assert.Equal("calls", ex.ParamName);
+    }
+
+    [Fact]
+    public void UpdateToolRoutingStatsForTesting_ThrowsWhenOutputsIsNull() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+
+        var ex = Assert.Throws<ArgumentNullException>(() => session.UpdateToolRoutingStatsForTesting(new List<ToolCall>(), null!));
+        Assert.Equal("outputs", ex.ParamName);
+    }
+
     [Theory]
     [InlineData("run now")]
     [InlineData("go for it")]


### PR DESCRIPTION
## Summary
- add explicit `ArgumentNullException` guards to routing test hooks (`UpdateToolRoutingStatsForTesting`, `ExpandContinuationUserRequestForTesting`, `RememberUserIntentForTesting`, `RememberPendingActionsForTesting`)
- add regression tests asserting null-guard `ParamName` contracts for each new guard path
- keep runtime chat behavior unchanged while making test-hook contracts deterministic and self-documenting

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ExpandContinuationUserRequestForTesting_ThrowsWhenThreadIdIsNull|FullyQualifiedName~RememberUserIntentForTesting_ThrowsWhenUserRequestIsNull|FullyQualifiedName~RememberPendingActionsForTesting_ThrowsWhenAssistantReplyIsNull|FullyQualifiedName~UpdateToolRoutingStatsForTesting_ThrowsWhenCallsIsNull|FullyQualifiedName~UpdateToolRoutingStatsForTesting_ThrowsWhenOutputsIsNull|FullyQualifiedName~UpdateToolRoutingStats_TracksOutputsWhenCallIdsDifferOnlyByWhitespace"
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.sln -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
