### PR TITLE
Improve chat routing reliability with pack preflight injection

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -18,31 +18,115 @@ namespace IntelligenceX.Chat.Service;
 internal sealed partial class ChatServiceSession {
 
     private static IReadOnlyList<ToolDefinition> SelectDeterministicToolSubset(IReadOnlyList<ToolDefinition> definitions, int limit) {
-        if (definitions.Count == 0) {
+        if (definitions.Count == 0 || limit <= 0) {
             return Array.Empty<ToolDefinition>();
         }
 
-        if (limit >= definitions.Count) {
-            return definitions;
-        }
-
-        var selected = new List<ToolDefinition>(Math.Max(1, limit));
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        for (var i = 0; i < definitions.Count && selected.Count < limit; i++) {
+        var uniqueDefinitions = new List<ToolDefinition>(definitions.Count);
+        var seenToolNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < definitions.Count; i++) {
             var definition = definitions[i];
             if (definition is null) {
                 continue;
             }
 
             var name = (definition.Name ?? string.Empty).Trim();
-            if (name.Length == 0 || !seen.Add(name)) {
+            if (name.Length == 0 || !seenToolNames.Add(name)) {
                 continue;
             }
 
-            selected.Add(definition);
+            uniqueDefinitions.Add(definition);
+        }
+
+        if (uniqueDefinitions.Count == 0) {
+            return Array.Empty<ToolDefinition>();
+        }
+
+        if (limit >= uniqueDefinitions.Count) {
+            return uniqueDefinitions;
+        }
+
+        // Deterministic but less registration-order-biased fallback:
+        // round-robin one tool per family (prefix) before filling remaining slots.
+        var familyOrder = new List<string>(uniqueDefinitions.Count);
+        var toolsByFamily = new Dictionary<string, Queue<ToolDefinition>>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < uniqueDefinitions.Count; i++) {
+            var definition = uniqueDefinitions[i];
+            var family = ResolveDeterministicSubsetFamilyKey(definition.Name);
+            if (!toolsByFamily.TryGetValue(family, out var queue)) {
+                queue = new Queue<ToolDefinition>();
+                toolsByFamily[family] = queue;
+                familyOrder.Add(family);
+            }
+
+            queue.Enqueue(definition);
+        }
+
+        var selected = new List<ToolDefinition>(limit);
+        var selectedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        while (selected.Count < limit) {
+            var addedInPass = false;
+            for (var familyIndex = 0; familyIndex < familyOrder.Count && selected.Count < limit; familyIndex++) {
+                var family = familyOrder[familyIndex];
+                if (!toolsByFamily.TryGetValue(family, out var queue) || queue.Count == 0) {
+                    continue;
+                }
+
+                var candidate = queue.Dequeue();
+                var candidateName = (candidate.Name ?? string.Empty).Trim();
+                if (candidateName.Length == 0 || !selectedNames.Add(candidateName)) {
+                    continue;
+                }
+
+                selected.Add(candidate);
+                addedInPass = true;
+            }
+
+            if (!addedInPass) {
+                break;
+            }
+        }
+
+        if (selected.Count < limit) {
+            for (var i = 0; i < uniqueDefinitions.Count && selected.Count < limit; i++) {
+                var definition = uniqueDefinitions[i];
+                var name = (definition.Name ?? string.Empty).Trim();
+                if (name.Length == 0 || !selectedNames.Add(name)) {
+                    continue;
+                }
+
+                selected.Add(definition);
+            }
         }
 
         return selected.Count == 0 ? Array.Empty<ToolDefinition>() : selected;
+    }
+
+    private static string ResolveDeterministicSubsetFamilyKey(string? toolName) {
+        const string packInfoSuffix = "_pack_info";
+        const string environmentDiscoverSuffix = "_environment_discover";
+
+        var normalized = (toolName ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return string.Empty;
+        }
+
+        if (normalized.EndsWith(packInfoSuffix, StringComparison.OrdinalIgnoreCase)
+            && normalized.Length > packInfoSuffix.Length) {
+            return normalized[..^packInfoSuffix.Length].ToLowerInvariant();
+        }
+
+        if (normalized.EndsWith(environmentDiscoverSuffix, StringComparison.OrdinalIgnoreCase)
+            && normalized.Length > environmentDiscoverSuffix.Length) {
+            return normalized[..^environmentDiscoverSuffix.Length].ToLowerInvariant();
+        }
+
+        var separator = normalized.IndexOf('_');
+        if (separator > 0) {
+            return normalized[..separator].ToLowerInvariant();
+        }
+
+        return normalized.ToLowerInvariant();
     }
 
     private static List<ToolRoutingInsight> BuildRoutingInsights(IReadOnlyList<ToolScore> scored, IReadOnlyList<ToolDefinition> selectedDefs) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -545,12 +545,23 @@ internal sealed partial class ChatServiceSession {
                 continue;
             }
 
+            var hostPackPreflightCalls = BuildHostPackPreflightCalls(threadId, fullToolDefs, extracted);
+            IReadOnlyList<ToolCall> roundCalls;
+            if (hostPackPreflightCalls.Count == 0) {
+                roundCalls = extracted;
+            } else {
+                var mergedRoundCalls = new List<ToolCall>(hostPackPreflightCalls.Count + extracted.Count);
+                mergedRoundCalls.AddRange(hostPackPreflightCalls);
+                mergedRoundCalls.AddRange(extracted);
+                roundCalls = mergedRoundCalls;
+            }
+
             var priorOutputsByCallId = BuildLatestToolOutputsByCallId(toolOutputs);
             var priorToolCallsByCallId = BuildLatestToolCallContractsByCallId(toolCalls);
-            var callsToExecute = new List<ToolCall>(extracted.Count);
-            var replayRecoveredOutputs = new List<ToolOutputDto>(extracted.Count);
-            for (var callIndex = 0; callIndex < extracted.Count; callIndex++) {
-                var call = extracted[callIndex];
+            var callsToExecute = new List<ToolCall>(roundCalls.Count);
+            var replayRecoveredOutputs = new List<ToolOutputDto>(roundCalls.Count);
+            for (var callIndex = 0; callIndex < roundCalls.Count; callIndex++) {
+                var call = roundCalls[callIndex];
                 if (TryGetReplayRecoveredOutputForCall(call, priorOutputsByCallId, priorToolCallsByCallId, out var replayRecoveredOutput)) {
                     replayRecoveredOutputs.Add(replayRecoveredOutput);
                     continue;
@@ -633,8 +644,9 @@ internal sealed partial class ChatServiceSession {
             }
 
             UpdateToolRoutingStats(callsToExecute, executed);
+            RememberSuccessfulPackPreflightCalls(threadId, callsToExecute, executed);
             var executedCallsById = new Dictionary<string, ToolCall>(StringComparer.OrdinalIgnoreCase);
-            foreach (var call in extracted) {
+            foreach (var call in roundCalls) {
                 var normalizedCallId = (call.CallId ?? string.Empty).Trim();
                 if (normalizedCallId.Length == 0) {
                     continue;
@@ -650,7 +662,7 @@ internal sealed partial class ChatServiceSession {
                 }
 
                 var normalizedOutputCallId = ResolveToolOutputCallId(
-                    extracted,
+                    roundCalls,
                     executedCallsById,
                     output.CallId,
                     outputIndex);
@@ -671,7 +683,7 @@ internal sealed partial class ChatServiceSession {
 
             var replayInputOutputs = MergeToolRoundReplayOutputs(executed, replayRecoveredOutputs);
             var next = BuildToolRoundReplayInputWithBudget(
-                extracted,
+                roundCalls,
                 executedCallsById,
                 replayInputOutputs,
                 replayOutputCompactionBudget,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackPreflight.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackPreflight.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Json;
+using IntelligenceX.OpenAI.ToolCalling;
+using IntelligenceX.Tools;
+
+namespace IntelligenceX.Chat.Service;
+
+internal sealed partial class ChatServiceSession {
+    private const string PackInfoToolSuffix = "_pack_info";
+    private const string EnvironmentDiscoverToolSuffix = "_environment_discover";
+    private const string HostPackPreflightCallIdPrefix = "host_pack_preflight_";
+
+    private readonly record struct PackPreflightCatalog(
+        Dictionary<string, ToolDefinition> PackInfoByPrefix,
+        Dictionary<string, ToolDefinition> EnvironmentDiscoverByPrefix,
+        string[] PrefixesByLengthDescending);
+
+    private IReadOnlyList<ToolCall> BuildHostPackPreflightCalls(
+        string threadId,
+        IReadOnlyList<ToolDefinition> allToolDefinitions,
+        IReadOnlyList<ToolCall> extractedCalls) {
+        var normalizedThreadId = (threadId ?? string.Empty).Trim();
+        if (normalizedThreadId.Length == 0 || allToolDefinitions.Count == 0 || extractedCalls.Count == 0) {
+            return Array.Empty<ToolCall>();
+        }
+
+        var catalog = BuildPackPreflightCatalog(allToolDefinitions);
+        if (catalog.PackInfoByPrefix.Count == 0) {
+            return Array.Empty<ToolCall>();
+        }
+
+        var operationalPrefixes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var explicitRoundPreflightNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < extractedCalls.Count; i++) {
+            var callName = (extractedCalls[i].Name ?? string.Empty).Trim();
+            if (callName.Length == 0) {
+                continue;
+            }
+
+            if (TryExtractPackPrefixFromPackInfoTool(callName, out _)
+                || TryExtractPackPrefixFromEnvironmentDiscoverTool(callName, out _)) {
+                explicitRoundPreflightNames.Add(callName);
+                continue;
+            }
+
+            if (TryResolvePackPrefixForOperationalTool(callName, catalog.PrefixesByLengthDescending, out var prefix)) {
+                operationalPrefixes.Add(prefix);
+            }
+        }
+
+        if (operationalPrefixes.Count == 0) {
+            return Array.Empty<ToolCall>();
+        }
+
+        var rememberedPreflightTools = SnapshotRememberedPackPreflightTools(normalizedThreadId);
+        var preflightCalls = new List<ToolCall>();
+        var orderedPrefixes = operationalPrefixes
+            .OrderBy(static prefix => prefix, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        for (var i = 0; i < orderedPrefixes.Length; i++) {
+            var prefix = orderedPrefixes[i];
+            if (catalog.PackInfoByPrefix.TryGetValue(prefix, out var packInfoDefinition)) {
+                var packInfoName = (packInfoDefinition.Name ?? string.Empty).Trim();
+                if (packInfoName.Length > 0
+                    && !explicitRoundPreflightNames.Contains(packInfoName)
+                    && !rememberedPreflightTools.Contains(packInfoName)) {
+                    preflightCalls.Add(BuildHostPackPreflightCall(packInfoName, "pack_info"));
+                }
+            }
+
+            if (!catalog.EnvironmentDiscoverByPrefix.TryGetValue(prefix, out var discoverDefinition)
+                || ToolDefinitionHasRequiredArguments(discoverDefinition)) {
+                continue;
+            }
+
+            var discoverName = (discoverDefinition.Name ?? string.Empty).Trim();
+            if (discoverName.Length == 0
+                || explicitRoundPreflightNames.Contains(discoverName)
+                || rememberedPreflightTools.Contains(discoverName)) {
+                continue;
+            }
+
+            preflightCalls.Add(BuildHostPackPreflightCall(discoverName, "environment_discover"));
+        }
+
+        return preflightCalls.Count == 0 ? Array.Empty<ToolCall>() : preflightCalls;
+    }
+
+    private void RememberSuccessfulPackPreflightCalls(
+        string threadId,
+        IReadOnlyList<ToolCall> executedCalls,
+        IReadOnlyList<ToolOutputDto> outputs) {
+        var normalizedThreadId = (threadId ?? string.Empty).Trim();
+        if (normalizedThreadId.Length == 0 || executedCalls.Count == 0 || outputs.Count == 0) {
+            return;
+        }
+
+        var successfulCallIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < outputs.Count; i++) {
+            var output = outputs[i];
+            if (!IsSuccessfulToolOutput(output)) {
+                continue;
+            }
+
+            var outputCallId = (output.CallId ?? string.Empty).Trim();
+            if (outputCallId.Length > 0) {
+                successfulCallIds.Add(outputCallId);
+            }
+        }
+
+        if (successfulCallIds.Count == 0) {
+            return;
+        }
+
+        var successfulPreflightToolNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < executedCalls.Count; i++) {
+            var call = executedCalls[i];
+            var callId = (call.CallId ?? string.Empty).Trim();
+            var callName = (call.Name ?? string.Empty).Trim();
+            if (callId.Length == 0
+                || callName.Length == 0
+                || !successfulCallIds.Contains(callId)
+                || !IsHostPackPreflightToolName(callName)) {
+                continue;
+            }
+
+            successfulPreflightToolNames.Add(callName);
+        }
+
+        if (successfulPreflightToolNames.Count == 0) {
+            return;
+        }
+
+        lock (_toolRoutingContextLock) {
+            var updated = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (_packPreflightToolNamesByThreadId.TryGetValue(normalizedThreadId, out var existingNames)
+                && existingNames is { Length: > 0 }) {
+                for (var i = 0; i < existingNames.Length; i++) {
+                    var existingName = (existingNames[i] ?? string.Empty).Trim();
+                    if (existingName.Length > 0) {
+                        updated.Add(existingName);
+                    }
+                }
+            }
+
+            var changed = false;
+            foreach (var successfulName in successfulPreflightToolNames) {
+                if (updated.Add(successfulName)) {
+                    changed = true;
+                }
+            }
+
+            if (!changed) {
+                if (!_packPreflightSeenUtcTicks.ContainsKey(normalizedThreadId)) {
+                    _packPreflightSeenUtcTicks[normalizedThreadId] = DateTime.UtcNow.Ticks;
+                    TrimWeightedRoutingContextsNoLock();
+                }
+
+                return;
+            }
+
+            _packPreflightToolNamesByThreadId[normalizedThreadId] = updated
+                .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            _packPreflightSeenUtcTicks[normalizedThreadId] = DateTime.UtcNow.Ticks;
+            TrimWeightedRoutingContextsNoLock();
+        }
+    }
+
+    private static PackPreflightCatalog BuildPackPreflightCatalog(IReadOnlyList<ToolDefinition> definitions) {
+        var packInfoByPrefix = new Dictionary<string, ToolDefinition>(StringComparer.OrdinalIgnoreCase);
+        var discoverByPrefix = new Dictionary<string, ToolDefinition>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < definitions.Count; i++) {
+            var definition = definitions[i];
+            if (definition is null) {
+                continue;
+            }
+
+            var name = (definition.Name ?? string.Empty).Trim();
+            if (name.Length == 0) {
+                continue;
+            }
+
+            if (TryExtractPackPrefixFromPackInfoTool(name, out var packInfoPrefix)) {
+                if (!packInfoByPrefix.ContainsKey(packInfoPrefix)) {
+                    packInfoByPrefix[packInfoPrefix] = definition;
+                }
+
+                continue;
+            }
+
+            if (TryExtractPackPrefixFromEnvironmentDiscoverTool(name, out var discoverPrefix)
+                && !discoverByPrefix.ContainsKey(discoverPrefix)) {
+                discoverByPrefix[discoverPrefix] = definition;
+            }
+        }
+
+        if (packInfoByPrefix.Count == 0 && discoverByPrefix.Count == 0) {
+            return new PackPreflightCatalog(
+                PackInfoByPrefix: packInfoByPrefix,
+                EnvironmentDiscoverByPrefix: discoverByPrefix,
+                PrefixesByLengthDescending: Array.Empty<string>());
+        }
+
+        var prefixes = packInfoByPrefix.Keys
+            .Concat(discoverByPrefix.Keys)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(static prefix => prefix.Length)
+            .ThenBy(static prefix => prefix, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return new PackPreflightCatalog(packInfoByPrefix, discoverByPrefix, prefixes);
+    }
+
+    private HashSet<string> SnapshotRememberedPackPreflightTools(string normalizedThreadId) {
+        lock (_toolRoutingContextLock) {
+            if (!_packPreflightToolNamesByThreadId.TryGetValue(normalizedThreadId, out var names) || names is not { Length: > 0 }) {
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            _packPreflightSeenUtcTicks[normalizedThreadId] = DateTime.UtcNow.Ticks;
+            TrimWeightedRoutingContextsNoLock();
+            return new HashSet<string>(names, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private static bool TryResolvePackPrefixForOperationalTool(
+        string toolName,
+        IReadOnlyList<string> knownPrefixes,
+        out string prefix) {
+        prefix = string.Empty;
+        var normalizedName = (toolName ?? string.Empty).Trim();
+        if (normalizedName.Length == 0 || knownPrefixes.Count == 0) {
+            return false;
+        }
+
+        for (var i = 0; i < knownPrefixes.Count; i++) {
+            var candidate = knownPrefixes[i];
+            if (candidate.Length == 0 || normalizedName.Length <= candidate.Length) {
+                continue;
+            }
+
+            if (!normalizedName.StartsWith(candidate, StringComparison.OrdinalIgnoreCase)
+                || normalizedName[candidate.Length] != '_') {
+                continue;
+            }
+
+            prefix = candidate;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool ToolDefinitionHasRequiredArguments(ToolDefinition definition) {
+        if (definition?.Parameters is null) {
+            return false;
+        }
+
+        var required = definition.Parameters.GetArray("required");
+        return required is { Count: > 0 };
+    }
+
+    private static bool TryExtractPackPrefixFromPackInfoTool(string toolName, out string prefix) {
+        return TryExtractPackPrefixFromPreflightTool(toolName, PackInfoToolSuffix, out prefix);
+    }
+
+    private static bool TryExtractPackPrefixFromEnvironmentDiscoverTool(string toolName, out string prefix) {
+        return TryExtractPackPrefixFromPreflightTool(toolName, EnvironmentDiscoverToolSuffix, out prefix);
+    }
+
+    private static bool TryExtractPackPrefixFromPreflightTool(string toolName, string suffix, out string prefix) {
+        prefix = string.Empty;
+        var normalized = (toolName ?? string.Empty).Trim();
+        if (normalized.Length <= suffix.Length || !normalized.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        prefix = normalized[..^suffix.Length].Trim();
+        return prefix.Length > 0;
+    }
+
+    private static bool IsHostPackPreflightToolName(string toolName) {
+        var normalized = (toolName ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return false;
+        }
+
+        return normalized.EndsWith(PackInfoToolSuffix, StringComparison.OrdinalIgnoreCase)
+               || normalized.EndsWith(EnvironmentDiscoverToolSuffix, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ToolCall BuildHostPackPreflightCall(string toolName, string role) {
+        var callId = HostPackPreflightCallIdPrefix + role + "_" + Guid.NewGuid().ToString("N");
+        var arguments = new JsonObject(StringComparer.Ordinal);
+        var serializedArguments = JsonLite.Serialize(arguments);
+        var raw = new JsonObject(StringComparer.Ordinal)
+            .Add("type", "tool_call")
+            .Add("call_id", callId)
+            .Add("name", toolName)
+            .Add("arguments", serializedArguments);
+
+        return new ToolCall(
+            callId: callId,
+            name: toolName,
+            input: serializedArguments,
+            arguments: arguments,
+            raw: raw);
+    }
+
+    private static bool IsSuccessfulToolOutput(ToolOutputDto output) {
+        return output.Ok != false
+               && string.IsNullOrWhiteSpace(output.ErrorCode)
+               && string.IsNullOrWhiteSpace(output.Error);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
@@ -609,6 +609,8 @@ internal sealed partial class ChatServiceSession {
             _domainIntentFamilyByThreadId.Clear();
             _domainIntentFamilySeenUtcTicks.Clear();
             _pendingDomainIntentClarificationSeenUtcTicks.Clear();
+            _packPreflightToolNamesByThreadId.Clear();
+            _packPreflightSeenUtcTicks.Clear();
         }
         _lastUserIntentByThreadId.Clear();
         _lastUserIntentSeenUtcTicks.Clear();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.StatsAndTesting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.StatsAndTesting.cs
@@ -182,7 +182,8 @@ internal sealed partial class ChatServiceSession {
     private void TrimWeightedRoutingContextsNoLock() {
         Debug.Assert(Monitor.IsEntered(_toolRoutingContextLock));
 
-        // Weighted-tool-subset, user-intent, pending-action, structured-next-action, planner-thread, and domain-intent contexts share the same
+        // Weighted-tool-subset, user-intent, pending-action, structured-next-action, planner-thread, domain-intent, and pack-preflight
+        // contexts share the same
         // key space (active thread id), so trim all when any grows beyond its cap.
         var weightedRemoveCount = _lastWeightedToolNamesByThreadId.Count - MaxTrackedWeightedRoutingContexts;
         var intentRemoveCount = _lastUserIntentByThreadId.Count - MaxTrackedUserIntentContexts;
@@ -192,10 +193,11 @@ internal sealed partial class ChatServiceSession {
         var domainIntentRemoveCount = _domainIntentFamilyByThreadId.Count - MaxTrackedDomainIntentFamilyContexts;
         var domainClarificationRemoveCount =
             _pendingDomainIntentClarificationSeenUtcTicks.Count - MaxTrackedDomainIntentClarificationContexts;
+        var packPreflightRemoveCount = _packPreflightToolNamesByThreadId.Count - MaxTrackedPackPreflightContexts;
         var removeCount = Math.Max(
             Math.Max(
                 Math.Max(Math.Max(weightedRemoveCount, intentRemoveCount), Math.Max(pendingRemoveCount, structuredNextActionRemoveCount)),
-                Math.Max(plannerRemoveCount, Math.Max(domainIntentRemoveCount, domainClarificationRemoveCount))),
+                Math.Max(plannerRemoveCount, Math.Max(domainIntentRemoveCount, Math.Max(domainClarificationRemoveCount, packPreflightRemoveCount)))),
             0);
         if (removeCount <= 0) {
             return;
@@ -281,6 +283,20 @@ internal sealed partial class ChatServiceSession {
                 removedInvalid = true;
             }
         }
+        foreach (var threadId in _packPreflightToolNamesByThreadId.Keys.ToArray()) {
+            if (!_packPreflightSeenUtcTicks.TryGetValue(threadId, out var ticks) || !TryGetUtcDateTimeFromTicks(ticks, out var seenUtc)) {
+                _packPreflightToolNamesByThreadId.Remove(threadId);
+                _packPreflightSeenUtcTicks.Remove(threadId);
+                removedInvalid = true;
+                continue;
+            }
+
+            if (DateTime.UtcNow - seenUtc > PackPreflightContextMaxAge) {
+                _packPreflightToolNamesByThreadId.Remove(threadId);
+                _packPreflightSeenUtcTicks.Remove(threadId);
+                removedInvalid = true;
+            }
+        }
         if (removedInvalid) {
             weightedRemoveCount = _lastWeightedToolNamesByThreadId.Count - MaxTrackedWeightedRoutingContexts;
             intentRemoveCount = _lastUserIntentByThreadId.Count - MaxTrackedUserIntentContexts;
@@ -290,10 +306,11 @@ internal sealed partial class ChatServiceSession {
             domainIntentRemoveCount = _domainIntentFamilyByThreadId.Count - MaxTrackedDomainIntentFamilyContexts;
             domainClarificationRemoveCount =
                 _pendingDomainIntentClarificationSeenUtcTicks.Count - MaxTrackedDomainIntentClarificationContexts;
+            packPreflightRemoveCount = _packPreflightToolNamesByThreadId.Count - MaxTrackedPackPreflightContexts;
             removeCount = Math.Max(
                 Math.Max(
                     Math.Max(Math.Max(weightedRemoveCount, intentRemoveCount), Math.Max(pendingRemoveCount, structuredNextActionRemoveCount)),
-                    Math.Max(plannerRemoveCount, Math.Max(domainIntentRemoveCount, domainClarificationRemoveCount))),
+                    Math.Max(plannerRemoveCount, Math.Max(domainIntentRemoveCount, Math.Max(domainClarificationRemoveCount, packPreflightRemoveCount)))),
                 0);
             if (removeCount <= 0) {
                 return;
@@ -317,6 +334,9 @@ internal sealed partial class ChatServiceSession {
             seenThreadIds.Add(threadId);
         }
         foreach (var threadId in _pendingDomainIntentClarificationSeenUtcTicks.Keys) {
+            seenThreadIds.Add(threadId);
+        }
+        foreach (var threadId in _packPreflightToolNamesByThreadId.Keys) {
             seenThreadIds.Add(threadId);
         }
 
@@ -345,6 +365,9 @@ internal sealed partial class ChatServiceSession {
                 if (_pendingDomainIntentClarificationSeenUtcTicks.TryGetValue(threadId, out var clarificationTicks) && clarificationTicks > ticks) {
                     ticks = clarificationTicks;
                 }
+                if (_packPreflightSeenUtcTicks.TryGetValue(threadId, out var preflightTicks) && preflightTicks > ticks) {
+                    ticks = preflightTicks;
+                }
                 return (ThreadId: threadId, Ticks: ticks);
             })
             .OrderBy(item => item.Ticks)
@@ -367,6 +390,8 @@ internal sealed partial class ChatServiceSession {
             _domainIntentFamilyByThreadId.Remove(threadId);
             _domainIntentFamilySeenUtcTicks.Remove(threadId);
             _pendingDomainIntentClarificationSeenUtcTicks.Remove(threadId);
+            _packPreflightToolNamesByThreadId.Remove(threadId);
+            _packPreflightSeenUtcTicks.Remove(threadId);
         }
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
@@ -32,6 +32,7 @@ internal sealed partial class ChatServiceSession {
     private const int MaxTrackedPlannerThreadContexts = 128;
     private const int MaxTrackedDomainIntentFamilyContexts = 256;
     private const int MaxTrackedDomainIntentClarificationContexts = 256;
+    private const int MaxTrackedPackPreflightContexts = 256;
     private const int MaxTrackedThreadRecoveryAliases = 256;
     private const int MaxTrackedThreadToolEvidenceContexts = 128;
     private const int MaxToolEvidenceEntriesPerThread = 48;
@@ -41,6 +42,7 @@ internal sealed partial class ChatServiceSession {
     private static readonly TimeSpan PlannerThreadContextMaxAge = TimeSpan.FromHours(6);
     private static readonly TimeSpan DomainIntentFamilyContextMaxAge = TimeSpan.FromHours(8);
     private static readonly TimeSpan DomainIntentClarificationContextMaxAge = TimeSpan.FromHours(2);
+    private static readonly TimeSpan PackPreflightContextMaxAge = TimeSpan.FromHours(8);
     private static readonly TimeSpan ThreadRecoveryAliasContextMaxAge = TimeSpan.FromHours(12);
     private static readonly TimeSpan ThreadToolEvidenceContextMaxAge = TimeSpan.FromHours(8);
     private static readonly TimeSpan StartupToolHealthPrimeBudget = TimeSpan.FromSeconds(6);
@@ -75,6 +77,8 @@ internal sealed partial class ChatServiceSession {
     private readonly Dictionary<string, string> _domainIntentFamilyByThreadId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, long> _domainIntentFamilySeenUtcTicks = new(StringComparer.Ordinal);
     private readonly Dictionary<string, long> _pendingDomainIntentClarificationSeenUtcTicks = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string[]> _packPreflightToolNamesByThreadId = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, long> _packPreflightSeenUtcTicks = new(StringComparer.Ordinal);
     private readonly object _threadRecoveryAliasLock = new();
     private readonly Dictionary<string, string> _recoveredThreadAliasesByThreadId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, long> _recoveredThreadAliasSeenUtcTicksByThreadId = new(StringComparer.Ordinal);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -113,6 +113,45 @@ public sealed class ChatServicePlannerPromptTests {
     }
 
     [Fact]
+    public void SelectWeightedToolSubset_NoSignalFallback_DiversifiesAcrossToolFamilies() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var definitions = new List<ToolDefinition>();
+        for (var i = 0; i < 10; i++) {
+            definitions.Add(new ToolDefinition(
+                $"ad_query_{i:D2}",
+                "AD query.",
+                ToolSchema.Object(("target", ToolSchema.String("Target"))).NoAdditionalProperties()));
+        }
+
+        for (var i = 0; i < 3; i++) {
+            definitions.Add(new ToolDefinition(
+                $"eventlog_query_{i:D2}",
+                "Event query.",
+                ToolSchema.Object(("target", ToolSchema.String("Target"))).NoAdditionalProperties()));
+        }
+
+        for (var i = 0; i < 3; i++) {
+            definitions.Add(new ToolDefinition(
+                $"system_info_{i:D2}",
+                "System query.",
+                ToolSchema.Object(("target", ToolSchema.String("Target"))).NoAdditionalProperties()));
+        }
+
+        var args = new object?[] {
+            definitions,
+            "Please summarize release readiness trends for this quarter.",
+            4,
+            null
+        };
+        var selected = Assert.IsAssignableFrom<IReadOnlyList<ToolDefinition>>(SelectWeightedToolSubsetMethod.Invoke(session, args));
+
+        Assert.Equal(4, selected.Count);
+        Assert.Contains(selected, tool => string.Equals(tool.Name, "ad_query_00", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(selected, tool => string.Equals(tool.Name, "eventlog_query_00", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(selected, tool => string.Equals(tool.Name, "system_info_00", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void SelectWeightedToolSubset_UsesFullToolSet_WhenWeightedRoutingIsSkippedForShortPrompt() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var definitions = new List<ToolDefinition>();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
@@ -658,5 +658,314 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("\"ix_action_selection\"", expandedText, StringComparison.Ordinal);
         Assert.Contains("\"id\":\"act_scope_read\"", expandedText, StringComparison.Ordinal);
     }
-}
 
+    [Fact]
+    public async Task RunChatOnCurrentThreadAsync_InsertsPackPreflightBeforeOperationalToolCalls_WhenMissingInRound() {
+        using var server = new DeterministicCompatibleHttpServer(responseIndex => responseIndex switch {
+            1 => JsonSerializer.Serialize(new {
+                id = "chatcmpl-preflight-insert-1",
+                @object = "chat.completion",
+                choices = new[] {
+                    new {
+                        index = 0,
+                        message = new {
+                            role = "assistant",
+                            tool_calls = new[] {
+                                new {
+                                    id = "call_ad_search_1",
+                                    type = "function",
+                                    function = new {
+                                        name = "ad_search",
+                                        arguments = JsonSerializer.Serialize(new { query = "dc inventory" })
+                                    }
+                                }
+                            }
+                        },
+                        finish_reason = "tool_calls"
+                    }
+                }
+            }),
+            2 => JsonSerializer.Serialize(new {
+                id = "chatcmpl-preflight-insert-final",
+                @object = "chat.completion",
+                choices = new[] {
+                    new {
+                        index = 0,
+                        message = new {
+                            role = "assistant",
+                            content = "AD scope complete."
+                        },
+                        finish_reason = "stop"
+                    }
+                }
+            }),
+            _ => JsonSerializer.Serialize(new {
+                id = "chatcmpl-preflight-insert-extra",
+                @object = "chat.completion",
+                choices = new[] {
+                    new {
+                        index = 0,
+                        message = new {
+                            role = "assistant",
+                            content = "Unexpected extra chat request."
+                        },
+                        finish_reason = "stop"
+                    }
+                }
+            })
+        });
+
+        var serviceOptions = new ServiceOptions {
+            OpenAITransport = OpenAITransportKind.CompatibleHttp,
+            OpenAIBaseUrl = server.BaseUrl,
+            OpenAIAllowInsecureHttp = true,
+            OpenAIStreaming = false,
+            Model = "mock-local-model",
+            MaxToolRounds = 4,
+            EnableTestimoXPack = false,
+            EnableOfficeImoPack = false
+        };
+        var session = new ChatServiceSession(serviceOptions, Stream.Null);
+        var registry = new ToolRegistry();
+        registry.Register(new RoundTripStubTool("ad_pack_info", static (_, _) => Task.FromResult("{\"ok\":true,\"summary_markdown\":\"ad pack ready\"}")));
+        registry.Register(new RoundTripStubTool("ad_environment_discover", static (_, _) => Task.FromResult("{\"ok\":true,\"summary_markdown\":\"scope discovered\"}")));
+        registry.Register(new RoundTripStubTool("ad_search", static (_, _) => Task.FromResult("{\"ok\":true,\"summary_markdown\":\"search complete\"}")));
+        RegistryField.SetValue(session, registry);
+
+        var clientOptions = new IntelligenceXClientOptions {
+            TransportKind = OpenAITransportKind.CompatibleHttp,
+            AutoInitialize = false,
+            DefaultModel = "mock-local-model"
+        };
+        clientOptions.CompatibleHttpOptions.BaseUrl = server.BaseUrl;
+        clientOptions.CompatibleHttpOptions.AuthMode = OpenAICompatibleHttpAuthMode.None;
+        clientOptions.CompatibleHttpOptions.Streaming = false;
+        clientOptions.CompatibleHttpOptions.AllowInsecureHttp = true;
+
+        using var client = await IntelligenceXClient.ConnectAsync(clientOptions);
+        var thread = await client.StartNewThreadAsync("mock-local-model");
+
+        var request = new ChatRequest {
+            RequestId = "req-pack-preflight-insert",
+            ThreadId = thread.Id,
+            Text = "Run AD search and summarize scope.",
+            Options = new ChatRequestOptions {
+                WeightedToolRouting = false,
+                MaxToolRounds = 4,
+                ParallelTools = false,
+                PlanExecuteReviewLoop = false,
+                ModelHeartbeatSeconds = 0
+            }
+        };
+
+        using var capture = new SynchronizedCaptureStream();
+        using var writer = new StreamWriter(capture, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+        var runResult = await InvokeRunChatOnCurrentThreadAsync(
+            session,
+            client,
+            writer,
+            request,
+            thread.Id,
+            CancellationToken.None);
+
+        Assert.Equal(2, server.ChatCompletionRequestCount);
+        var resultMessage = GetPropertyValue<ChatResultMessage>(runResult, "Result");
+        Assert.NotNull(resultMessage.Tools);
+        Assert.Equal(3, resultMessage.Tools!.Calls.Count);
+        Assert.Equal("ad_pack_info", resultMessage.Tools.Calls[0].Name);
+        Assert.Equal("ad_environment_discover", resultMessage.Tools.Calls[1].Name);
+        Assert.Equal("ad_search", resultMessage.Tools.Calls[2].Name);
+        Assert.StartsWith("host_pack_preflight_", resultMessage.Tools.Calls[0].CallId, StringComparison.Ordinal);
+        Assert.StartsWith("host_pack_preflight_", resultMessage.Tools.Calls[1].CallId, StringComparison.Ordinal);
+        Assert.Equal("call_ad_search_1", resultMessage.Tools.Calls[2].CallId);
+
+        var reviewRequestBody = server.GetChatRequestBody(1);
+        Assert.True(ContainsToolMessageForCallId(reviewRequestBody, resultMessage.Tools.Calls[0].CallId));
+        Assert.True(ContainsToolMessageForCallId(reviewRequestBody, resultMessage.Tools.Calls[1].CallId));
+        Assert.True(ContainsToolMessageForCallId(reviewRequestBody, "call_ad_search_1"));
+    }
+
+    [Fact]
+    public async Task RunChatOnCurrentThreadAsync_DoesNotRepeatPackPreflightOnSameThreadAfterSuccessfulExecution() {
+        using var server = new DeterministicCompatibleHttpServer(responseIndex => responseIndex switch {
+            1 => JsonSerializer.Serialize(new {
+                id = "chatcmpl-preflight-turn1-call",
+                @object = "chat.completion",
+                choices = new[] {
+                    new {
+                        index = 0,
+                        message = new {
+                            role = "assistant",
+                            tool_calls = new[] {
+                                new {
+                                    id = "call_ad_search_turn1",
+                                    type = "function",
+                                    function = new {
+                                        name = "ad_search",
+                                        arguments = JsonSerializer.Serialize(new { query = "turn1" })
+                                    }
+                                }
+                            }
+                        },
+                        finish_reason = "tool_calls"
+                    }
+                }
+            }),
+            2 => JsonSerializer.Serialize(new {
+                id = "chatcmpl-preflight-turn1-final",
+                @object = "chat.completion",
+                choices = new[] {
+                    new {
+                        index = 0,
+                        message = new {
+                            role = "assistant",
+                            content = "Turn 1 complete."
+                        },
+                        finish_reason = "stop"
+                    }
+                }
+            }),
+            3 => JsonSerializer.Serialize(new {
+                id = "chatcmpl-preflight-turn2-call",
+                @object = "chat.completion",
+                choices = new[] {
+                    new {
+                        index = 0,
+                        message = new {
+                            role = "assistant",
+                            tool_calls = new[] {
+                                new {
+                                    id = "call_ad_search_turn2",
+                                    type = "function",
+                                    function = new {
+                                        name = "ad_search",
+                                        arguments = JsonSerializer.Serialize(new { query = "turn2" })
+                                    }
+                                }
+                            }
+                        },
+                        finish_reason = "tool_calls"
+                    }
+                }
+            }),
+            4 => JsonSerializer.Serialize(new {
+                id = "chatcmpl-preflight-turn2-final",
+                @object = "chat.completion",
+                choices = new[] {
+                    new {
+                        index = 0,
+                        message = new {
+                            role = "assistant",
+                            content = "Turn 2 complete."
+                        },
+                        finish_reason = "stop"
+                    }
+                }
+            }),
+            _ => JsonSerializer.Serialize(new {
+                id = "chatcmpl-preflight-repeat-extra",
+                @object = "chat.completion",
+                choices = new[] {
+                    new {
+                        index = 0,
+                        message = new {
+                            role = "assistant",
+                            content = "Unexpected extra chat request."
+                        },
+                        finish_reason = "stop"
+                    }
+                }
+            })
+        });
+
+        var serviceOptions = new ServiceOptions {
+            OpenAITransport = OpenAITransportKind.CompatibleHttp,
+            OpenAIBaseUrl = server.BaseUrl,
+            OpenAIAllowInsecureHttp = true,
+            OpenAIStreaming = false,
+            Model = "mock-local-model",
+            MaxToolRounds = 4,
+            EnableTestimoXPack = false,
+            EnableOfficeImoPack = false
+        };
+        var session = new ChatServiceSession(serviceOptions, Stream.Null);
+        var registry = new ToolRegistry();
+        registry.Register(new RoundTripStubTool("ad_pack_info", static (_, _) => Task.FromResult("{\"ok\":true,\"summary_markdown\":\"ad pack ready\"}")));
+        registry.Register(new RoundTripStubTool("ad_environment_discover", static (_, _) => Task.FromResult("{\"ok\":true,\"summary_markdown\":\"scope discovered\"}")));
+        registry.Register(new RoundTripStubTool("ad_search", static (_, _) => Task.FromResult("{\"ok\":true,\"summary_markdown\":\"search complete\"}")));
+        RegistryField.SetValue(session, registry);
+
+        var clientOptions = new IntelligenceXClientOptions {
+            TransportKind = OpenAITransportKind.CompatibleHttp,
+            AutoInitialize = false,
+            DefaultModel = "mock-local-model"
+        };
+        clientOptions.CompatibleHttpOptions.BaseUrl = server.BaseUrl;
+        clientOptions.CompatibleHttpOptions.AuthMode = OpenAICompatibleHttpAuthMode.None;
+        clientOptions.CompatibleHttpOptions.Streaming = false;
+        clientOptions.CompatibleHttpOptions.AllowInsecureHttp = true;
+
+        using var client = await IntelligenceXClient.ConnectAsync(clientOptions);
+        var thread = await client.StartNewThreadAsync("mock-local-model");
+
+        var request1 = new ChatRequest {
+            RequestId = "req-pack-preflight-turn1",
+            ThreadId = thread.Id,
+            Text = "Run AD search, turn 1.",
+            Options = new ChatRequestOptions {
+                WeightedToolRouting = false,
+                MaxToolRounds = 4,
+                ParallelTools = false,
+                PlanExecuteReviewLoop = false,
+                ModelHeartbeatSeconds = 0
+            }
+        };
+
+        var request2 = new ChatRequest {
+            RequestId = "req-pack-preflight-turn2",
+            ThreadId = thread.Id,
+            Text = "Run AD search, turn 2.",
+            Options = new ChatRequestOptions {
+                WeightedToolRouting = false,
+                MaxToolRounds = 4,
+                ParallelTools = false,
+                PlanExecuteReviewLoop = false,
+                ModelHeartbeatSeconds = 0
+            }
+        };
+
+        using var capture1 = new SynchronizedCaptureStream();
+        using var writer1 = new StreamWriter(capture1, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+        var runResult1 = await InvokeRunChatOnCurrentThreadAsync(
+            session,
+            client,
+            writer1,
+            request1,
+            thread.Id,
+            CancellationToken.None);
+
+        using var capture2 = new SynchronizedCaptureStream();
+        using var writer2 = new StreamWriter(capture2, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
+        var runResult2 = await InvokeRunChatOnCurrentThreadAsync(
+            session,
+            client,
+            writer2,
+            request2,
+            thread.Id,
+            CancellationToken.None);
+
+        Assert.Equal(4, server.ChatCompletionRequestCount);
+
+        var resultMessage1 = GetPropertyValue<ChatResultMessage>(runResult1, "Result");
+        Assert.NotNull(resultMessage1.Tools);
+        Assert.Equal(3, resultMessage1.Tools!.Calls.Count);
+        Assert.Contains(resultMessage1.Tools.Calls, call => call.CallId.StartsWith("host_pack_preflight_", StringComparison.Ordinal));
+
+        var resultMessage2 = GetPropertyValue<ChatResultMessage>(runResult2, "Result");
+        Assert.NotNull(resultMessage2.Tools);
+        Assert.Single(resultMessage2.Tools!.Calls);
+        Assert.Equal("ad_search", resultMessage2.Tools.Calls[0].Name);
+        Assert.Equal("call_ad_search_turn2", resultMessage2.Tools.Calls[0].CallId);
+        Assert.DoesNotContain(resultMessage2.Tools.Calls, call => call.CallId.StartsWith("host_pack_preflight_", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary
- reduce low-signal routing bias by making deterministic tool subset selection family-diverse (round-robin by tool family/prefix)
- add host-side pack preflight injection before operational tool execution:
  - auto-insert `*_pack_info`
  - auto-insert `*_environment_discover` when it has no required args
- track successful preflight tools per thread and avoid repeating preflight calls on later turns in the same thread
- include injected preflight calls in tool call/output tracking and replay input pairing
- clear and trim preflight thread context together with existing routing caches

## Tests
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release /p:TestimoXRoot=C:\Support\GitHub\TestimoX\ --filter "FullyQualifiedName~ChatServicePlannerPromptTests|FullyQualifiedName~RunChatOnCurrentThreadAsync_InsertsPackPreflightBeforeOperationalToolCalls_WhenMissingInRound|FullyQualifiedName~RunChatOnCurrentThreadAsync_DoesNotRepeatPackPreflightOnSameThreadAfterSuccessfulExecution"`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release /p:TestimoXRoot=C:\Support\GitHub\TestimoX\ --filter "FullyQualifiedName~ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd|FullyQualifiedName~ChatServicePlannerPromptTests"`
