### PR TITLE
Improve pack fallback reliability with safe no-scope pack-info recovery

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -34,7 +34,8 @@ internal sealed partial class ChatServiceSession {
                 "ad_scope_discovery",
                 "ad_forest_discover",
                 "ad_domain_controllers",
-                "ad_directory_discovery_diagnostics"
+                "ad_directory_discovery_diagnostics",
+                "ad_pack_info"
             },
             availableToolNames: availableToolNames);
 
@@ -44,7 +45,8 @@ internal sealed partial class ChatServiceSession {
                 "eventlog_live_query",
                 "eventlog_live_stats",
                 "eventlog_top_events",
-                "eventlog_timeline_query"
+                "eventlog_timeline_query",
+                "eventlog_pack_info"
             },
             availableToolNames: availableToolNames);
 
@@ -54,7 +56,8 @@ internal sealed partial class ChatServiceSession {
                 "system_updates_installed",
                 "system_patch_compliance",
                 "system_security_options",
-                "system_info"
+                "system_info",
+                "system_pack_info"
             },
             availableToolNames: availableToolNames);
 
@@ -71,7 +74,8 @@ internal sealed partial class ChatServiceSession {
             packId: "domaindetective",
             candidateTools: new[] {
                 "domaindetective_domain_summary",
-                "domaindetective_network_probe"
+                "domaindetective_network_probe",
+                "domaindetective_pack_info"
             },
             availableToolNames: availableToolNames);
 
@@ -79,7 +83,8 @@ internal sealed partial class ChatServiceSession {
             packId: "testimox",
             candidateTools: new[] {
                 "testimox_rules_list",
-                "testimox_rules_run"
+                "testimox_rules_run",
+                "testimox_pack_info"
             },
             availableToolNames: availableToolNames);
     }
@@ -207,7 +212,9 @@ internal sealed partial class ChatServiceSession {
                 }
             }
 
-            if (!hasPartialScopeHints && partialScopeHints.Count == 0) {
+            var hasFallbackHints = hasPartialScopeHints || partialScopeHints.Count > 0;
+            var hasSourceFailureSignal = HasToolFailureSignal(output);
+            if (!hasFallbackHints && !hasSourceFailureSignal) {
                 continue;
             }
 
@@ -227,6 +234,10 @@ internal sealed partial class ChatServiceSession {
             for (var i = 0; i < packContract.FallbackTools.Length; i++) {
                 var candidateTool = packContract.FallbackTools[i];
                 if (string.Equals(candidateTool, sourceTool, StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                if (!hasFallbackHints && !IsHintlessSafeFallbackCandidate(candidateTool)) {
                     continue;
                 }
 
@@ -270,10 +281,14 @@ internal sealed partial class ChatServiceSession {
                     input: serializedArguments,
                     arguments: normalizedArguments,
                     raw: raw);
-                reason = "pack_contract_partial_scope_autofallback:"
+                var reasonPrefix = hasFallbackHints
+                    ? "pack_contract_partial_scope_autofallback:"
+                    : "pack_contract_failure_autofallback:";
+                var reasonDetail = hasFallbackHints ? partialScopeReason : "source_tool_failed_without_scope_hints";
+                reason = reasonPrefix
                          + sourcePackId
                          + ":"
-                         + partialScopeReason
+                         + reasonDetail
                          + "->"
                          + candidateTool;
                 return true;
@@ -642,6 +657,17 @@ internal sealed partial class ChatServiceSession {
         }
 
         return !HasTestimoSelectionArguments(arguments);
+    }
+
+    private static bool IsHintlessSafeFallbackCandidate(string candidateTool) {
+        var normalized = (candidateTool ?? string.Empty).Trim();
+        return normalized.EndsWith("_pack_info", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool HasToolFailureSignal(ToolOutputDto output) {
+        return output.Ok == false
+               || !string.IsNullOrWhiteSpace(output.ErrorCode)
+               || !string.IsNullOrWhiteSpace(output.Error);
     }
 
     private static bool HasTestimoSelectionArguments(JsonObject arguments) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -183,6 +183,80 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsComputerXPackInfoFallbackWhenSourceFailsWithoutHints() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_info"] = "computerx";
+        packMap["system_pack_info"] = "computerx";
+
+        var schema = ToolSchema.Object().NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("system_info", "system info", schema),
+            new("system_pack_info", "system pack info", schema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() { CallId = "call-sys", Name = "system_info" }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-sys",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_pack_info"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("system_pack_info", toolCall.Name);
+        Assert.Contains("pack_contract_failure_autofallback", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildHintlessPackInfoFallbackWhenSourceDidNotFail() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_info"] = "computerx";
+        packMap["system_pack_info"] = "computerx";
+
+        var schema = ToolSchema.Object().NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("system_info", "system info", schema),
+            new("system_pack_info", "system pack info", schema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() { CallId = "call-sys", Name = "system_info" }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-sys",
+                Output = """{"ok":true,"host":"srv01"}""",
+                Ok = true
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_pack_info"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Equal("pack_contract_no_applicable_fallback", Assert.IsType<string>(args[6]));
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_PrefersAdDiscoveryBeforeCrossDcEventlogFanOut() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));


### PR DESCRIPTION
## Summary
- expand pack capability fallback contracts to include `*_pack_info` recovery tools for AD, EventLog, System/ComputerX, DomainDetective, and TestimoX
- add a guarded fallback path that can recover from failed tool outputs even when no partial-scope hints are available
- keep no-scope fallback safe by allowing only `*_pack_info` tools and only when the source output indicates failure
- preserve existing scoped fallback behavior for richer follow-up actions when discovery/error hints are present

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release /p:TestimoXRoot=C:\Support\GitHub\TestimoX\ --filter "FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall"`