### PR TITLE
Improve lexical routing with pack-family alias tokens

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -269,6 +269,8 @@ internal sealed partial class ChatServiceSession {
             }
         }
 
+        AppendRoutingPackTokens(sb, definition);
+
         var schemaArguments = ExtractToolSchemaPropertyNames(definition, maxCount: 12, out var hasTableViewProjection);
         for (var i = 0; i < schemaArguments.Length; i++) {
             sb.Append(' ').Append(schemaArguments[i]);
@@ -287,6 +289,30 @@ internal sealed partial class ChatServiceSession {
         }
 
         return sb.ToString();
+    }
+
+    private static void AppendRoutingPackTokens(StringBuilder sb, ToolDefinition definition) {
+        var category = ResolvePlannerCategory(definition);
+        var packHint = ResolvePlannerPackHint(definition, category);
+        if (packHint.Length == 0) {
+            return;
+        }
+
+        var appended = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        void AppendPackToken(string value) {
+            var token = (value ?? string.Empty).Trim();
+            if (token.Length == 0 || !appended.Add(token)) {
+                return;
+            }
+
+            sb.Append(" pack ").Append(token);
+            sb.Append(" pack:").Append(token);
+        }
+
+        AppendPackToken(packHint);
+        foreach (var alias in GetNormalizedPackAliases(packHint)) {
+            AppendPackToken(alias);
+        }
     }
 
     private static string[] ExtractToolSchemaPropertyNames(ToolDefinition definition, int maxCount, out bool hasTableViewProjection) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -1087,6 +1087,10 @@ internal sealed partial class ChatServiceSession {
                 AddAlias("active_directory");
                 AddAlias("adplayground");
                 break;
+            case "adplayground":
+                AddAlias("active_directory");
+                AddAlias("ad");
+                break;
             case "system":
                 AddAlias("computerx");
                 break;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -131,6 +131,33 @@ public sealed class ChatServicePlannerPromptTests {
     }
 
     [Fact]
+    public void BuildToolRoutingSearchText_IncludesPackTokensFromNameFallback() {
+        var definition = new ToolDefinition(
+            "ad_get_users",
+            "Read directory users.",
+            ToolSchema.Object(("domain", ToolSchema.String("Domain DNS name."))).NoAdditionalProperties());
+
+        var searchText = Assert.IsType<string>(BuildToolRoutingSearchTextMethod.Invoke(null, new object?[] { definition }));
+
+        Assert.Contains("pack active_directory", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack adplayground", searchText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildToolRoutingSearchText_IncludesComputerXAliasForSystemPack() {
+        var definition = new ToolDefinition(
+            "inventory_collect",
+            "Collect host inventory.",
+            ToolSchema.Object(("computer_name", ToolSchema.String("Target host."))).NoAdditionalProperties(),
+            category: "computerx");
+
+        var searchText = Assert.IsType<string>(BuildToolRoutingSearchTextMethod.Invoke(null, new object?[] { definition }));
+
+        Assert.Contains("pack system", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack computerx", searchText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void SelectWeightedToolSubset_UsesRequestedLimit_WhenPromptHasNoRoutingSignal() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var definitions = new List<ToolDefinition>();


### PR DESCRIPTION
## Summary
- enrich `BuildToolRoutingSearchText` with explicit `pack` and `pack:` signals derived from taxonomy-aware pack hints
- include normalized pack aliases in routing search text so weighted lexical routing matches AD/ADPlayground and System/ComputerX family terms
- add planner/routing tests asserting new pack token coverage for AD and ComputerX scenarios

## Validation
- attempted: `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServicePlannerPromptTests"`
- local environment is currently blocked by external engine reference/API drift in sibling TestimoX/ADPlayground/ComputerX projects (pre-existing in this workstation layout), so full local test execution could not complete
