### PR TITLE
Add structured preferred visual contract for proactive prompts

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -30,6 +30,7 @@ internal sealed partial class ChatServiceSession {
         bool AllowNewVisuals,
         bool DraftHasVisuals,
         bool RequestHasVisualContract,
+        bool HasPreferredVisualOverride,
         string PreferredVisualType);
 
     internal static string ResolveAssistantTextBeforeNoTextFallback(
@@ -242,11 +243,15 @@ internal sealed partial class ChatServiceSession {
         var allowNewVisualsText = visualPolicy.AllowNewVisuals ? "true" : "false";
         var draftHasVisualsText = visualPolicy.DraftHasVisuals ? "true" : "false";
         var requestHasVisualContractText = visualPolicy.RequestHasVisualContract ? "true" : "false";
-        var preferredVisualTypeText = visualPolicy.PreferredVisualType.Length > 0 ? visualPolicy.PreferredVisualType : "auto";
+        var preferredVisualTypeText = visualPolicy.HasPreferredVisualOverride
+            ? visualPolicy.PreferredVisualType
+            : "auto";
+        var hasSpecificPreferredVisualType = visualPolicy.HasPreferredVisualOverride
+            && !string.Equals(visualPolicy.PreferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
         var visualRequirementLine = visualPolicy.AllowNewVisuals
             ? "- If allow_new_visuals is true, include at most one new visual block and only when it materially compresses complex evidence."
             : "- If allow_new_visuals is false, do not introduce new mermaid/ix-chart/ix-network blocks in this proactive rewrite.";
-        var preferredVisualRequirementLine = visualPolicy.AllowNewVisuals && visualPolicy.PreferredVisualType.Length > 0
+        var preferredVisualRequirementLine = visualPolicy.AllowNewVisuals && hasSpecificPreferredVisualType
             ? "- If preferred_visual is set, prefer that visual format for any newly introduced visual block unless another supported format is clearly better."
             : string.Empty;
         return $$"""
@@ -289,11 +294,13 @@ internal sealed partial class ChatServiceSession {
     private static ProactiveVisualizationPolicy ResolveProactiveVisualizationPolicy(string userRequest, string assistantDraft) {
         var requestHasVisualContractSignal = ContainsVisualContractSignal(userRequest);
         var hasStructuredOverrides = TryReadProactiveVisualizationOverridesFromRequestText(userRequest, out var hasAllowNewVisualsOverride,
-            out var allowNewVisualsFromOverride, out var preferredVisualType);
+            out var allowNewVisualsFromOverride, out var hasPreferredVisualOverride, out var preferredVisualType);
         var requestHasVisualContract = requestHasVisualContractSignal || hasStructuredOverrides;
+        var hasSpecificPreferredVisualType = hasPreferredVisualOverride
+            && !string.Equals(preferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
         var allowNewVisuals = hasAllowNewVisualsOverride
             ? allowNewVisualsFromOverride
-            : preferredVisualType.Length > 0
+            : hasSpecificPreferredVisualType
                 ? true
                 : requestHasVisualContractSignal;
         var draftHasVisuals = ContainsVisualContractSignal(assistantDraft);
@@ -301,6 +308,7 @@ internal sealed partial class ChatServiceSession {
             AllowNewVisuals: allowNewVisuals,
             DraftHasVisuals: draftHasVisuals,
             RequestHasVisualContract: requestHasVisualContract,
+            HasPreferredVisualOverride: hasPreferredVisualOverride,
             PreferredVisualType: preferredVisualType);
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
@@ -9,9 +9,11 @@ internal sealed partial class ChatServiceSession {
         string? requestText,
         out bool hasAllowNewVisualsOverride,
         out bool allowNewVisuals,
+        out bool hasPreferredVisualOverride,
         out string preferredVisualType) {
         hasAllowNewVisualsOverride = false;
         allowNewVisuals = false;
+        hasPreferredVisualOverride = false;
         preferredVisualType = string.Empty;
         var text = requestText ?? string.Empty;
         if (text.Length == 0) {
@@ -33,6 +35,7 @@ internal sealed partial class ChatServiceSession {
             scan,
             out hasAllowNewVisualsOverride,
             out allowNewVisuals,
+            out hasPreferredVisualOverride,
             out preferredVisualType);
     }
 
@@ -40,9 +43,11 @@ internal sealed partial class ChatServiceSession {
         ReadOnlySpan<char> text,
         out bool hasAllowNewVisualsOverride,
         out bool allowNewVisuals,
+        out bool hasPreferredVisualOverride,
         out string preferredVisualType) {
         hasAllowNewVisualsOverride = false;
         allowNewVisuals = false;
+        hasPreferredVisualOverride = false;
         preferredVisualType = string.Empty;
         var markerLineSeen = false;
         var hasAnyOverride = false;
@@ -81,6 +86,7 @@ internal sealed partial class ChatServiceSession {
 
             if (TryParseStructuredPreferredVisualLine(line, out var parsedPreferredVisualType)) {
                 preferredVisualType = parsedPreferredVisualType;
+                hasPreferredVisualOverride = true;
                 hasAnyOverride = true;
             }
         }
@@ -143,6 +149,7 @@ internal sealed partial class ChatServiceSession {
         var normalized = NormalizeCompactToken(value);
         switch (normalized) {
             case "auto":
+                preferredVisualType = "auto";
                 return true;
             case "ixnetwork":
             case "network":

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -75,6 +75,21 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_PreservesExplicitAutoPreferredVisualOverride() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            preferred_visual: auto
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: auto", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("If preferred_visual is set, prefer that visual format", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_IgnoresUnknownStructuredPreferredVisual() {
         var request = """
             [Proactive visualization guidance]


### PR DESCRIPTION
## Summary
- add structured `preferred_visual` / `preferred_visual_type` parsing under `ix:proactive-visualization:v1`
- canonicalize visual aliases (`visnetwork`/`network` -> `ix-network`, `chart` -> `ix-chart`, etc.) and keep `auto` behavior explicit
- make proactive visual policy structured-first: explicit `allow_new_visuals` override wins, preferred visual can opt into visuals when allow flag is omitted
- include `preferred_visual` in proactive prompt guidance so rewrites pick consistent visual flows only when contract says so
- add regression tests for preferred visual aliasing, inline comments, and unknown-value fallback

## Validation
- attempted: `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildProactiveFollowUpReviewPrompt" /p:TestimoXRoot=C:/Support/GitHub/TestimoX`
- local execution remains blocked by pre-existing external engine/API mismatches in sibling TestimoX/ComputerX/ADPlayground references
