### PR TITLE
Chat: support structured max_new_visuals proactive contract

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -25,13 +25,16 @@ internal sealed partial class ChatServiceSession {
     private const string ChartFenceLanguage = "ix-chart";
     private const string NetworkFenceLanguage = "ix-network";
     private const string LegacyNetworkFenceLanguage = "visnetwork";
+    private const int MaxSupportedProactiveVisualBlocks = 3;
 
     private readonly record struct ProactiveVisualizationPolicy(
         bool AllowNewVisuals,
         bool DraftHasVisuals,
         bool RequestHasVisualContract,
         bool HasPreferredVisualOverride,
-        string PreferredVisualType);
+        string PreferredVisualType,
+        bool HasMaxNewVisualsOverride,
+        int MaxNewVisuals);
 
     internal static string ResolveAssistantTextBeforeNoTextFallback(
         string assistantDraft,
@@ -246,10 +249,15 @@ internal sealed partial class ChatServiceSession {
         var preferredVisualTypeText = visualPolicy.HasPreferredVisualOverride
             ? visualPolicy.PreferredVisualType
             : "auto";
+        var maxNewVisualsText = visualPolicy.HasMaxNewVisualsOverride
+            ? visualPolicy.MaxNewVisuals.ToString()
+            : visualPolicy.AllowNewVisuals
+                ? "1"
+                : "0";
         var hasSpecificPreferredVisualType = visualPolicy.HasPreferredVisualOverride
             && !string.Equals(visualPolicy.PreferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
-        var visualRequirementLine = visualPolicy.AllowNewVisuals
-            ? "- If allow_new_visuals is true, include at most one new visual block and only when it materially compresses complex evidence."
+        var visualRequirementLine = visualPolicy.AllowNewVisuals && visualPolicy.MaxNewVisuals > 0
+            ? $"- If allow_new_visuals is true, include at most {visualPolicy.MaxNewVisuals} new visual block(s) and only when it materially compresses complex evidence."
             : "- If allow_new_visuals is false, do not introduce new mermaid/ix-chart/ix-network blocks in this proactive rewrite.";
         var preferredVisualRequirementLine = visualPolicy.AllowNewVisuals && hasSpecificPreferredVisualType
             ? "- If preferred_visual is set, prefer that visual format for any newly introduced visual block unless another supported format is clearly better."
@@ -265,6 +273,7 @@ internal sealed partial class ChatServiceSession {
             draft_has_visuals: {{draftHasVisualsText}}
             request_has_visual_contract: {{requestHasVisualContractText}}
             preferred_visual: {{preferredVisualTypeText}}
+            max_new_visuals: {{maxNewVisualsText}}
 
             User request:
             {{requestText}}
@@ -294,22 +303,33 @@ internal sealed partial class ChatServiceSession {
     private static ProactiveVisualizationPolicy ResolveProactiveVisualizationPolicy(string userRequest, string assistantDraft) {
         var requestHasVisualContractSignal = ContainsVisualContractSignal(userRequest);
         var hasStructuredOverrides = TryReadProactiveVisualizationOverridesFromRequestText(userRequest, out var hasAllowNewVisualsOverride,
-            out var allowNewVisualsFromOverride, out var hasPreferredVisualOverride, out var preferredVisualType);
+            out var allowNewVisualsFromOverride, out var hasPreferredVisualOverride, out var preferredVisualType,
+            out var hasMaxNewVisualsOverride, out var maxNewVisualsOverride);
         var requestHasVisualContract = requestHasVisualContractSignal || hasStructuredOverrides;
         var hasSpecificPreferredVisualType = hasPreferredVisualOverride
             && !string.Equals(preferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
-        var allowNewVisuals = hasAllowNewVisualsOverride
+        var baseAllowNewVisuals = hasAllowNewVisualsOverride
             ? allowNewVisualsFromOverride
             : hasSpecificPreferredVisualType
                 ? true
-                : requestHasVisualContractSignal;
+                : hasMaxNewVisualsOverride
+                    ? maxNewVisualsOverride > 0
+                    : requestHasVisualContractSignal;
+        var maxNewVisuals = hasMaxNewVisualsOverride
+            ? Math.Clamp(maxNewVisualsOverride, 0, MaxSupportedProactiveVisualBlocks)
+            : baseAllowNewVisuals
+                ? 1
+                : 0;
+        var allowNewVisuals = baseAllowNewVisuals && maxNewVisuals > 0;
         var draftHasVisuals = ContainsVisualContractSignal(assistantDraft);
         return new ProactiveVisualizationPolicy(
             AllowNewVisuals: allowNewVisuals,
             DraftHasVisuals: draftHasVisuals,
             RequestHasVisualContract: requestHasVisualContract,
             HasPreferredVisualOverride: hasPreferredVisualOverride,
-            PreferredVisualType: preferredVisualType);
+            PreferredVisualType: preferredVisualType,
+            HasMaxNewVisualsOverride: hasMaxNewVisualsOverride,
+            MaxNewVisuals: maxNewVisuals);
     }
 
     private static bool ContainsVisualContractSignal(string? text) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace IntelligenceX.Chat.Service;
 
@@ -10,11 +11,15 @@ internal sealed partial class ChatServiceSession {
         out bool hasAllowNewVisualsOverride,
         out bool allowNewVisuals,
         out bool hasPreferredVisualOverride,
-        out string preferredVisualType) {
+        out string preferredVisualType,
+        out bool hasMaxNewVisualsOverride,
+        out int maxNewVisualsOverride) {
         hasAllowNewVisualsOverride = false;
         allowNewVisuals = false;
         hasPreferredVisualOverride = false;
         preferredVisualType = string.Empty;
+        hasMaxNewVisualsOverride = false;
+        maxNewVisualsOverride = 0;
         var text = requestText ?? string.Empty;
         if (text.Length == 0) {
             return false;
@@ -36,7 +41,9 @@ internal sealed partial class ChatServiceSession {
             out hasAllowNewVisualsOverride,
             out allowNewVisuals,
             out hasPreferredVisualOverride,
-            out preferredVisualType);
+            out preferredVisualType,
+            out hasMaxNewVisualsOverride,
+            out maxNewVisualsOverride);
     }
 
     private static bool TryReadStructuredProactiveVisualizationOverrides(
@@ -44,11 +51,15 @@ internal sealed partial class ChatServiceSession {
         out bool hasAllowNewVisualsOverride,
         out bool allowNewVisuals,
         out bool hasPreferredVisualOverride,
-        out string preferredVisualType) {
+        out string preferredVisualType,
+        out bool hasMaxNewVisualsOverride,
+        out int maxNewVisualsOverride) {
         hasAllowNewVisualsOverride = false;
         allowNewVisuals = false;
         hasPreferredVisualOverride = false;
         preferredVisualType = string.Empty;
+        hasMaxNewVisualsOverride = false;
+        maxNewVisualsOverride = 0;
         var markerLineSeen = false;
         var hasAnyOverride = false;
         while (!text.IsEmpty) {
@@ -88,6 +99,12 @@ internal sealed partial class ChatServiceSession {
                 preferredVisualType = parsedPreferredVisualType;
                 hasPreferredVisualOverride = true;
                 hasAnyOverride = true;
+                continue;
+            }
+
+            if (TryParseStructuredMaxNewVisualsLine(line, out maxNewVisualsOverride)) {
+                hasMaxNewVisualsOverride = true;
+                hasAnyOverride = true;
             }
         }
 
@@ -126,6 +143,21 @@ internal sealed partial class ChatServiceSession {
         }
 
         return false;
+    }
+
+    private static bool TryParseStructuredMaxNewVisualsLine(ReadOnlySpan<char> line, out int maxNewVisuals) {
+        maxNewVisuals = 0;
+        if (!TryParseStructuredKeyValueLine(line, "max_new_visuals", out var value)) {
+            return false;
+        }
+
+        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue)
+            || parsedValue < 0) {
+            return false;
+        }
+
+        maxNewVisuals = parsedValue;
+        return true;
     }
 
     private static bool TryParseStructuredKeyValueLine(ReadOnlySpan<char> line, string key, out ReadOnlySpan<char> value) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -90,6 +90,49 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_UsesStructuredMaxNewVisualsOverride() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            max_new_visuals: 2
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max_new_visuals: 2", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("include at most 2 new visual block(s)", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_DisablesVisualsWhenMaxNewVisualsIsZero() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            max_new_visuals: 0
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max_new_visuals: 0", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("do not introduce new mermaid/ix-chart/ix-network blocks", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_ClampsStructuredMaxNewVisualsToSupportedRange() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            max_new_visuals: 99
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max_new_visuals: 3", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("include at most 3 new visual block(s)", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_IgnoresUnknownStructuredPreferredVisual() {
         var request = """
             [Proactive visualization guidance]


### PR DESCRIPTION
## Summary
- add structured max_new_visuals override support to proactive visualization contract parsing
- make proactive follow-up prompt generation contract-driven for visual block limits instead of hardcoded single-block behavior
- clamp requested max visuals to supported range and keep explicit llow_new_visuals/preferred_visual precedence rules
- add coverage for max override, zero-disable behavior, and clamp behavior

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter ""FullyQualifiedName~BuildProactiveFollowUpReviewPrompt"" /p:TestimoXRoot=C:/Support/GitHub/TestimoX *(fails locally due pre-existing missing external TestimoX/ComputerX/ADPlayground types in sibling dependencies)*
