### PR TITLE
Chat tests: harden invalid max_new_visuals override behavior

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -132,6 +132,23 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("include at most 3 new visual block(s)", text, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("abc")]
+    public void BuildProactiveFollowUpReviewPrompt_IgnoresInvalidStructuredMaxNewVisualsOverride(string invalidMax) {
+        var request = $$"""
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            max_new_visuals: {{invalidMax}}
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max_new_visuals: 1", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("include at most 1 new visual block(s)", text, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void BuildProactiveFollowUpReviewPrompt_IgnoresUnknownStructuredPreferredVisual() {
         var request = """


### PR DESCRIPTION
## Summary
- add coverage for invalid max_new_visuals values in proactive visualization contract parsing
- verify invalid numeric/non-numeric values are ignored while valid llow_new_visuals: true still yields default max_new_visuals: 1
- lock in prompt contract text (llow_new_visuals, max_new_visuals, and visual requirement line) for these invalid-input cases

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter ""FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_IgnoresInvalidStructuredMaxNewVisualsOverride"" /p:TestimoXRoot=C:/Support/GitHub/TestimoX *(fails locally due pre-existing missing external TestimoX/ComputerX/ADPlayground types in sibling dependencies)*
