### PR TITLE
Chat: clamp overflow-size max_new_visuals overrides

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
@@ -151,12 +151,12 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue)
+        if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue)
             || parsedValue < 0) {
             return false;
         }
 
-        maxNewVisuals = parsedValue;
+        maxNewVisuals = parsedValue > int.MaxValue ? int.MaxValue : (int)parsedValue;
         return true;
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -132,6 +132,20 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("include at most 3 new visual block(s)", text, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_ClampsLargeStructuredMaxNewVisualsToSupportedRange() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            max_new_visuals: 9999999999
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max_new_visuals: 3", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("include at most 3 new visual block(s)", text, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData("-1")]
     [InlineData("abc")]


### PR DESCRIPTION
## Summary
- improve max_new_visuals structured parsing to accept large non-negative integers safely
- parse via long and cap to int.MaxValue before policy-level clamp, so overflow-size values are not silently ignored
- add regression coverage proving very large values still clamp to supported prompt contract max

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter ""FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_ClampsLargeStructuredMaxNewVisualsToSupportedRange"" /p:TestimoXRoot=C:/Support/GitHub/TestimoX *(fails locally due pre-existing missing external TestimoX/ComputerX/ADPlayground types in sibling dependencies)*
