### PR TITLE
Chat tests: add max_new_visuals boundary coverage

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -147,6 +147,23 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Theory]
+    [InlineData("2147483647")]
+    [InlineData("2147483648")]
+    [InlineData("9223372036854775807")]
+    public void BuildProactiveFollowUpReviewPrompt_ClampsBoundaryStructuredMaxNewVisualsToSupportedRange(string value) {
+        var request = $$"""
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            max_new_visuals: {{value}}
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max_new_visuals: 3", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("include at most 3 new visual block(s)", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
     [InlineData("-1")]
     [InlineData("abc")]
     public void BuildProactiveFollowUpReviewPrompt_IgnoresInvalidStructuredMaxNewVisualsOverride(string invalidMax) {


### PR DESCRIPTION
## Summary
- add boundary-value coverage for structured max_new_visuals parsing and clamp behavior
- verify int.MaxValue, int.MaxValue + 1, and long.MaxValue all produce the same supported contract cap
- assert both structured output (max_new_visuals: 3) and guidance text to prevent regression drift

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter ""FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_ClampsBoundaryStructuredMaxNewVisualsToSupportedRange"" /p:TestimoXRoot=C:/Support/GitHub/TestimoX *(fails locally due pre-existing missing external TestimoX/ComputerX/ADPlayground types in sibling dependencies)*
