### PR TITLE
Chat: make proactive visual marker a contract signal

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -301,11 +301,12 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static ProactiveVisualizationPolicy ResolveProactiveVisualizationPolicy(string userRequest, string assistantDraft) {
+        var requestHasProactiveVisualizationMarker = ContainsProactiveVisualizationMarker(userRequest);
         var requestHasVisualContractSignal = ContainsVisualContractSignal(userRequest);
         var hasStructuredOverrides = TryReadProactiveVisualizationOverridesFromRequestText(userRequest, out var hasAllowNewVisualsOverride,
             out var allowNewVisualsFromOverride, out var hasPreferredVisualOverride, out var preferredVisualType,
             out var hasMaxNewVisualsOverride, out var maxNewVisualsOverride);
-        var requestHasVisualContract = requestHasVisualContractSignal || hasStructuredOverrides;
+        var requestHasVisualContract = requestHasProactiveVisualizationMarker || requestHasVisualContractSignal || hasStructuredOverrides;
         var hasSpecificPreferredVisualType = hasPreferredVisualOverride
             && !string.Equals(preferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
         var baseAllowNewVisuals = hasAllowNewVisualsOverride
@@ -330,6 +331,11 @@ internal sealed partial class ChatServiceSession {
             PreferredVisualType: preferredVisualType,
             HasMaxNewVisualsOverride: hasMaxNewVisualsOverride,
             MaxNewVisuals: maxNewVisuals);
+    }
+
+    private static bool ContainsProactiveVisualizationMarker(string? text) {
+        var value = text ?? string.Empty;
+        return value.IndexOf(ProactiveVisualizationMarker, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private static bool ContainsVisualContractSignal(string? text) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -157,10 +157,14 @@ public sealed partial class ChatServiceRoutingTrimTests {
             max_new_visuals: {{value}}
             """;
         var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+        var userRequestHeaderIndex = text.IndexOf("User request:", StringComparison.Ordinal);
+        Assert.True(userRequestHeaderIndex >= 0, "Prompt should include a User request section.");
+        var contractHeader = text.Substring(0, userRequestHeaderIndex);
 
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("max_new_visuals: 3", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("include at most 3 new visual block(s)", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain($"max_new_visuals: {value}", contractHeader, StringComparison.OrdinalIgnoreCase);
     }
 
     [Theory]
@@ -178,6 +182,20 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("max_new_visuals: 1", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("include at most 1 new visual block(s)", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_TreatsMarkerAsVisualContractWhenOverridesAreInvalid() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            max_new_visuals:
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max_new_visuals: 0", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- treat ix:proactive-visualization:v1 marker presence itself as visual-contract context in proactive follow-up policy
- keep existing safety semantics: marker-only/invalid overrides do not auto-enable visuals
- add regression coverage that invalid marker payloads still set equest_has_visual_contract: true
- harden boundary tests so the contract header never echoes raw oversized max_new_visuals values

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter ""FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_TreatsMarkerAsVisualContractWhenOverridesAreInvalid|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_ClampsBoundaryStructuredMaxNewVisualsToSupportedRange"" /p:TestimoXRoot=C:/Support/GitHub/TestimoX *(fails locally due pre-existing missing external TestimoX/ComputerX/ADPlayground types in sibling dependencies)*
