### PR TITLE
Chat: tighten proactive visual marker matching

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -335,7 +335,40 @@ internal sealed partial class ChatServiceSession {
 
     private static bool ContainsProactiveVisualizationMarker(string? text) {
         var value = text ?? string.Empty;
-        return value.IndexOf(ProactiveVisualizationMarker, StringComparison.OrdinalIgnoreCase) >= 0;
+        if (value.Length == 0) {
+            return false;
+        }
+
+        var marker = ProactiveVisualizationMarker.AsSpan();
+        var remaining = value.AsSpan();
+        while (!remaining.IsEmpty) {
+            var lineBreakIndex = remaining.IndexOfAny('\r', '\n');
+            ReadOnlySpan<char> line;
+            if (lineBreakIndex < 0) {
+                line = remaining;
+                remaining = ReadOnlySpan<char>.Empty;
+            } else {
+                line = remaining.Slice(0, lineBreakIndex);
+                var nextIndex = lineBreakIndex + 1;
+                if (nextIndex < remaining.Length && remaining[lineBreakIndex] == '\r' && remaining[nextIndex] == '\n') {
+                    nextIndex++;
+                }
+
+                remaining = remaining.Slice(nextIndex);
+            }
+
+            var trimmed = line.Trim();
+            if (!trimmed.StartsWith(marker, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            var suffix = trimmed.Slice(marker.Length).TrimStart();
+            if (suffix.IsEmpty || suffix[0] == '#') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool ContainsVisualContractSignal(string? text) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -199,6 +199,29 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_DoesNotTreatEmbeddedMarkerTextAsVisualContract() {
+        const string request = "Please treat ix:proactive-visualization:v1 as a literal log token.";
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("request_has_visual_contract: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max_new_visuals: 0", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_TreatsMarkerLineWithInlineCommentAsVisualContract() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1 # from orchestrator
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max_new_visuals: 0", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_IgnoresUnknownStructuredPreferredVisual() {
         var request = """
             [Proactive visualization guidance]


### PR DESCRIPTION
## Summary
- tighten proactive-visual marker detection from broad substring matching to line-level marker matching
- allow marker lines with optional trailing inline comments, while preventing embedded marker text in unrelated prose from triggering contract mode
- add regression tests for both negative (embedded token) and positive (line marker + comment) cases

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter ""FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_DoesNotTreatEmbeddedMarkerTextAsVisualContract|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_TreatsMarkerLineWithInlineCommentAsVisualContract"" /p:TestimoXRoot=C:/Support/GitHub/TestimoX *(fails locally due pre-existing missing external TestimoX/ComputerX/ADPlayground types in sibling dependencies)*
