### PR TITLE
Chat: support more proactive marker comment forms

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -363,7 +363,10 @@ internal sealed partial class ChatServiceSession {
             }
 
             var suffix = trimmed.Slice(marker.Length).TrimStart();
-            if (suffix.IsEmpty || suffix[0] == '#') {
+            if (suffix.IsEmpty
+                || suffix[0] == '#'
+                || suffix[0] == ';'
+                || (suffix[0] == '/' && suffix.Length > 1 && suffix[1] == '/')) {
                 return true;
             }
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -222,6 +222,29 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_TreatsMarkerLineWithSlashSlashCommentAsVisualContract() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1 // from orchestrator
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max_new_visuals: 0", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_TreatsMarkerLineWithSemicolonCommentAndCrLfAsVisualContract() {
+        const string request = "[Proactive visualization guidance]\r\n\r\nix:proactive-visualization:v1 ; from orchestrator\r\n";
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("max_new_visuals: 0", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_IgnoresUnknownStructuredPreferredVisual() {
         var request = """
             [Proactive visualization guidance]


### PR DESCRIPTION
## Summary
- extend proactive visualization marker-line parsing to accept additional inline comment styles (// and ;) in addition to #
- keep line-level matching rules from prior hardening to avoid substring false positives
- add regression tests for slash-slash and semicolon comment variants
- add CRLF + blank-line coverage for marker parsing behavior

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter ""FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_TreatsMarkerLineWithSlashSlashCommentAsVisualContract|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_TreatsMarkerLineWithSemicolonCommentAndCrLfAsVisualContract"" /p:TestimoXRoot=C:/Support/GitHub/TestimoX *(fails locally due pre-existing missing external TestimoX/ComputerX/ADPlayground types in sibling dependencies)*
