### PR TITLE
DomainDetective: add checks catalog tool for deterministic planning

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveCheckNameCatalog.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveCheckNameCatalog.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+#if DOMAINDETECTIVE_ENABLED
+using DomainDetective;
+#endif
+
+namespace IntelligenceX.Tools.DomainDetective;
+
+internal static class DomainDetectiveCheckNameCatalog {
+    private static readonly string[] DefaultChecksValue = {
+        "DNSHEALTH",
+        "SOA",
+        "NS",
+        "MX",
+        "SPF",
+        "DMARC",
+        "DNSSEC",
+        "TTL"
+    };
+
+    private static readonly IReadOnlyDictionary<string, string> CheckAliasByToken = new Dictionary<string, string>(StringComparer.Ordinal) {
+        ["NAMESERVER"] = "NS",
+        ["NAMESERVERS"] = "NS",
+        ["NAMESERVERRECORD"] = "NS",
+        ["NAMESERVERRECORDS"] = "NS",
+        ["NSRECORD"] = "NS",
+        ["NSRECORDS"] = "NS",
+        ["MXRECORD"] = "MX",
+        ["MXRECORDS"] = "MX",
+        ["MAILSERVER"] = "MX",
+        ["MAILSERVERS"] = "MX",
+        ["SPFRECORD"] = "SPF",
+        ["SPFRECORDS"] = "SPF",
+        ["DMARCRECORD"] = "DMARC",
+        ["DMARCRECORDS"] = "DMARC",
+        ["DKIMRECORD"] = "DKIM",
+        ["DKIMRECORDS"] = "DKIM",
+        ["CAARECORD"] = "CAA",
+        ["CAARECORDS"] = "CAA"
+    };
+
+    internal static IReadOnlyList<string> DefaultChecks => DefaultChecksValue;
+    internal static IReadOnlyDictionary<string, string> AliasByToken => CheckAliasByToken;
+
+    internal static string NormalizeDomainDetectiveCheckName(string check) {
+        var token = NormalizeCheckLookupToken(check);
+        if (token.Length == 0) {
+            return string.Empty;
+        }
+
+        if (CheckAliasByToken.TryGetValue(token, out var alias)) {
+            return alias;
+        }
+
+        return token;
+    }
+
+    internal static string NormalizeCheckLookupToken(string value) {
+        var input = (value ?? string.Empty).Trim();
+        if (input.Length == 0) {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(input.Length);
+        for (var i = 0; i < input.Length; i++) {
+            var ch = input[i];
+            if (!char.IsLetterOrDigit(ch)) {
+                continue;
+            }
+
+            builder.Append(char.ToUpperInvariant(ch));
+        }
+
+        return builder.ToString();
+    }
+
+    internal static IReadOnlyList<string> GetSupportedCheckNames() {
+#if DOMAINDETECTIVE_ENABLED
+        return Enum.GetNames<HealthCheckType>()
+            .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+#else
+        return DefaultChecksValue
+            .Concat(CheckAliasByToken.Values)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+#endif
+    }
+
+#if DOMAINDETECTIVE_ENABLED
+    internal static bool TryResolveHealthCheckType(string check, out HealthCheckType parsed) {
+        parsed = default;
+        if (string.IsNullOrWhiteSpace(check)) {
+            return false;
+        }
+
+        var trimmed = check.Trim();
+        if (Enum.TryParse<HealthCheckType>(trimmed, ignoreCase: true, out parsed)) {
+            return true;
+        }
+
+        var normalized = NormalizeDomainDetectiveCheckName(trimmed);
+        if (normalized.Length == 0) {
+            return false;
+        }
+
+        return Enum.TryParse<HealthCheckType>(normalized, ignoreCase: true, out parsed);
+    }
+#endif
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveChecksCatalogTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveChecksCatalogTool.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+
+namespace IntelligenceX.Tools.DomainDetective;
+
+/// <summary>
+/// Returns supported DomainDetective check names and alias normalization guidance.
+/// </summary>
+public sealed class DomainDetectiveChecksCatalogTool : DomainDetectiveToolBase, ITool {
+    private static readonly ToolDefinition DefinitionValue = new(
+        "domaindetective_checks_catalog",
+        "Return supported DomainDetective check names, baseline defaults, and alias normalization guidance.",
+        ToolSchema.Object(
+                ("include_aliases", ToolSchema.Boolean("Include alias-to-canonical normalization entries (default: true).")),
+                ("include_default_checks", ToolSchema.Boolean("Include baseline default checks used by domaindetective_domain_summary (default: true).")))
+            .NoAdditionalProperties());
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DomainDetectiveChecksCatalogTool"/> class.
+    /// </summary>
+    public DomainDetectiveChecksCatalogTool(DomainDetectiveToolOptions options) : base(options) { }
+
+    /// <inheritdoc />
+    public override ToolDefinition Definition => DefinitionValue;
+
+    /// <inheritdoc />
+    protected override Task<string> InvokeCoreAsync(JsonObject? arguments, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var includeAliases = ToolArgs.GetBoolean(arguments, "include_aliases", defaultValue: true);
+        var includeDefaultChecks = ToolArgs.GetBoolean(arguments, "include_default_checks", defaultValue: true);
+
+        var supportedChecks = DomainDetectiveCheckNameCatalog.GetSupportedCheckNames();
+        var defaultChecks = includeDefaultChecks
+            ? DomainDetectiveCheckNameCatalog.DefaultChecks
+                .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+                .ToArray()
+            : Array.Empty<string>();
+        var aliases = includeAliases
+            ? DomainDetectiveCheckNameCatalog.AliasByToken
+                .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(static pair => new DomainDetectiveCheckAliasModel {
+                    Token = pair.Key,
+                    Canonical = pair.Value
+                })
+                .ToArray()
+            : Array.Empty<DomainDetectiveCheckAliasModel>();
+
+        var result = new DomainDetectiveChecksCatalogResultModel {
+            Source = ResolveCatalogSource(),
+            MaxChecksPerRun = Options.MaxChecks,
+            SupportedChecks = supportedChecks,
+            DefaultChecks = defaultChecks,
+            Aliases = aliases,
+            NormalizationRules = new[] {
+                "Input is case-insensitive and non-alphanumeric separators are ignored.",
+                "Known aliases (for example NAMESERVERS, SPFRECORD, DMARCRECORDS) normalize to canonical check names."
+            }
+        };
+
+        var summary = ToolMarkdown.SummaryFacts(
+            title: "DomainDetective checks catalog",
+            facts: new[] {
+                ("Supported checks", result.SupportedChecks.Count.ToString()),
+                ("Default checks", result.DefaultChecks.Count.ToString()),
+                ("Aliases", result.Aliases.Count.ToString()),
+                ("Max checks per run", result.MaxChecksPerRun.ToString())
+            });
+
+        var meta = ToolOutputHints.Meta(count: result.SupportedChecks.Count, truncated: false)
+            .Add("supported_checks", result.SupportedChecks.Count)
+            .Add("default_checks", result.DefaultChecks.Count)
+            .Add("aliases", result.Aliases.Count)
+            .Add("max_checks_per_run", result.MaxChecksPerRun);
+
+        return Task.FromResult(ToolResponse.OkModel(result, meta: meta, summaryMarkdown: summary));
+    }
+
+    private static string ResolveCatalogSource() {
+#if DOMAINDETECTIVE_ENABLED
+        return "enum";
+#else
+        return "fallback";
+#endif
+    }
+
+    private sealed class DomainDetectiveChecksCatalogResultModel {
+        public string Source { get; init; } = string.Empty;
+        public int MaxChecksPerRun { get; init; }
+        public IReadOnlyList<string> SupportedChecks { get; init; } = Array.Empty<string>();
+        public IReadOnlyList<string> DefaultChecks { get; init; } = Array.Empty<string>();
+        public IReadOnlyList<DomainDetectiveCheckAliasModel> Aliases { get; init; } = Array.Empty<DomainDetectiveCheckAliasModel>();
+        public IReadOnlyList<string> NormalizationRules { get; init; } = Array.Empty<string>();
+    }
+
+    private sealed class DomainDetectiveCheckAliasModel {
+        public string Token { get; init; } = string.Empty;
+        public string Canonical { get; init; } = string.Empty;
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveDomainSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveDomainSummaryTool.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Json;
@@ -20,37 +19,6 @@ namespace IntelligenceX.Tools.DomainDetective;
 /// Runs selected DomainDetective checks and returns a condensed domain posture summary.
 /// </summary>
 public sealed class DomainDetectiveDomainSummaryTool : DomainDetectiveToolBase, ITool {
-    private static readonly string[] DefaultChecks = {
-        "DNSHEALTH",
-        "SOA",
-        "NS",
-        "MX",
-        "SPF",
-        "DMARC",
-        "DNSSEC",
-        "TTL"
-    };
-    private static readonly IReadOnlyDictionary<string, string> CheckAliasByToken = new Dictionary<string, string>(StringComparer.Ordinal) {
-        ["NAMESERVER"] = "NS",
-        ["NAMESERVERS"] = "NS",
-        ["NAMESERVERRECORD"] = "NS",
-        ["NAMESERVERRECORDS"] = "NS",
-        ["NSRECORD"] = "NS",
-        ["NSRECORDS"] = "NS",
-        ["MXRECORD"] = "MX",
-        ["MXRECORDS"] = "MX",
-        ["MAILSERVER"] = "MX",
-        ["MAILSERVERS"] = "MX",
-        ["SPFRECORD"] = "SPF",
-        ["SPFRECORDS"] = "SPF",
-        ["DMARCRECORD"] = "DMARC",
-        ["DMARCRECORDS"] = "DMARC",
-        ["DKIMRECORD"] = "DKIM",
-        ["DKIMRECORDS"] = "DKIM",
-        ["CAARECORD"] = "CAA",
-        ["CAARECORDS"] = "CAA"
-    };
-
     private static readonly ToolDefinition DefinitionValue = new(
         "domaindetective_domain_summary",
         "Run selected DomainDetective checks for a domain and return a condensed DNS/email/security posture summary.",
@@ -85,7 +53,7 @@ public sealed class DomainDetectiveDomainSummaryTool : DomainDetectiveToolBase, 
 
         var requestedChecks = ToolArgs.ReadDistinctStringArray(arguments?.GetArray("checks"));
         if (requestedChecks.Count == 0) {
-            requestedChecks.AddRange(DefaultChecks);
+            requestedChecks.AddRange(DomainDetectiveCheckNameCatalog.DefaultChecks);
         }
 
         var timeoutMs = ToolArgs.GetCappedInt32(arguments, "timeout_ms", Options.DefaultTimeoutMs, 1000, Options.MaxTimeoutMs);
@@ -232,55 +200,16 @@ public sealed class DomainDetectiveDomainSummaryTool : DomainDetectiveToolBase, 
     }
 
     private static bool TryResolveHealthCheckType(string check, out HealthCheckType parsed) {
-        parsed = default;
-        if (string.IsNullOrWhiteSpace(check)) {
-            return false;
-        }
-
-        var trimmed = check.Trim();
-        if (Enum.TryParse<HealthCheckType>(trimmed, ignoreCase: true, out parsed)) {
-            return true;
-        }
-
-        var normalized = NormalizeDomainDetectiveCheckName(trimmed);
-        if (normalized.Length == 0) {
-            return false;
-        }
-
-        return Enum.TryParse<HealthCheckType>(normalized, ignoreCase: true, out parsed);
+        return DomainDetectiveCheckNameCatalog.TryResolveHealthCheckType(check, out parsed);
     }
 #endif
 
     private static string NormalizeDomainDetectiveCheckName(string check) {
-        var token = NormalizeCheckLookupToken(check);
-        if (token.Length == 0) {
-            return string.Empty;
-        }
-
-        if (CheckAliasByToken.TryGetValue(token, out var alias)) {
-            return alias;
-        }
-
-        return token;
+        return DomainDetectiveCheckNameCatalog.NormalizeDomainDetectiveCheckName(check);
     }
 
     private static string NormalizeCheckLookupToken(string value) {
-        var input = (value ?? string.Empty).Trim();
-        if (input.Length == 0) {
-            return string.Empty;
-        }
-
-        var builder = new StringBuilder(input.Length);
-        for (var i = 0; i < input.Length; i++) {
-            var ch = input[i];
-            if (!char.IsLetterOrDigit(ch)) {
-                continue;
-            }
-
-            builder.Append(char.ToUpperInvariant(ch));
-        }
-
-        return builder.ToString();
+        return DomainDetectiveCheckNameCatalog.NormalizeCheckLookupToken(value);
     }
 
 #if DOMAINDETECTIVE_ENABLED

--- a/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectivePackInfoTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectivePackInfoTool.cs
@@ -32,12 +32,17 @@ public sealed class DomainDetectivePackInfoTool : DomainDetectiveToolBase, ITool
             engine: "DomainDetective",
             tools: ToolRegistryDomainDetectiveExtensions.GetRegisteredToolNames(Options),
             recommendedFlow: new[] {
+                "Use domaindetective_checks_catalog first when you need canonical check names or alias normalization guidance.",
                 "Use domaindetective_domain_summary for broad domain posture checks (DNS/email/security).",
                 "Use domaindetective_network_probe for host-level ping/traceroute diagnostics.",
                 "When you need resolver-specific evidence, pair with dnsclientx_query.",
                 "When the request is AD directory-scoped (domains/DCs/LDAP), route to AD pack tools instead of DomainDetective."
             },
             flowSteps: new[] {
+                ToolPackGuidance.FlowStep(
+                    goal: "Discover supported check names and aliases",
+                    suggestedTools: new[] { "domaindetective_checks_catalog" },
+                    notes: "Use catalog output to build valid checks[] sets before running summaries."),
                 ToolPackGuidance.FlowStep(
                     goal: "Run bounded domain posture checks",
                     suggestedTools: new[] { "domaindetective_domain_summary" },
@@ -56,6 +61,10 @@ public sealed class DomainDetectivePackInfoTool : DomainDetectiveToolBase, ITool
                     notes: "Use AD pack for Active Directory topology/context; DomainDetective is internet/domain posture focused.")
             },
             capabilities: new[] {
+                ToolPackGuidance.Capability(
+                    id: "check_catalog_discovery",
+                    summary: "List supported check names, baseline defaults, and alias normalization guidance for deterministic checks[] selection.",
+                    primaryTools: new[] { "domaindetective_checks_catalog" }),
                 ToolPackGuidance.Capability(
                     id: "domain_posture_summary",
                     summary: "Run selected DomainDetective health checks and return condensed DNS/email/security posture summary.",

--- a/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/ToolRegistryDomainDetectiveExtensions.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/ToolRegistryDomainDetectiveExtensions.cs
@@ -31,6 +31,7 @@ public static class ToolRegistryDomainDetectiveExtensions {
 
     private static IEnumerable<ITool> CreateTools(DomainDetectiveToolOptions options) {
         yield return new DomainDetectivePackInfoTool(options);
+        yield return new DomainDetectiveChecksCatalogTool(options);
         yield return new DomainDetectiveDomainSummaryTool(options);
         yield return new DomainDetectiveNetworkProbeTool(options);
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DomainDetectiveChecksCatalogToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DomainDetectiveChecksCatalogToolTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+using IntelligenceX.Tools.DomainDetective;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class DomainDetectiveChecksCatalogToolTests {
+    [Fact]
+    public async Task InvokeAsync_ReturnsSupportedChecksDefaultsAndAliases() {
+        var options = new DomainDetectiveToolOptions();
+        var tool = new DomainDetectiveChecksCatalogTool(options);
+
+        var json = await tool.InvokeAsync(arguments: null, cancellationToken: CancellationToken.None);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(options.MaxChecks, root.GetProperty("max_checks_per_run").GetInt32());
+
+        var supportedChecks = root.GetProperty("supported_checks")
+            .EnumerateArray()
+            .Select(static node => node.GetString())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value!.Trim())
+            .ToArray();
+        Assert.NotEmpty(supportedChecks);
+        Assert.Contains("DNSHEALTH", supportedChecks, StringComparer.OrdinalIgnoreCase);
+
+        var defaultChecks = root.GetProperty("default_checks")
+            .EnumerateArray()
+            .Select(static node => node.GetString())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value!.Trim())
+            .ToArray();
+        Assert.Contains("SPF", defaultChecks, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("DMARC", defaultChecks, StringComparer.OrdinalIgnoreCase);
+
+        var aliases = root.GetProperty("aliases").EnumerateArray().ToArray();
+        Assert.NotEmpty(aliases);
+        Assert.Contains(
+            aliases,
+            static node => string.Equals(node.GetProperty("token").GetString(), "NAMESERVERS", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(node.GetProperty("canonical").GetString(), "NS", StringComparison.OrdinalIgnoreCase));
+
+        var normalizationRules = root.GetProperty("normalization_rules")
+            .EnumerateArray()
+            .Select(static node => node.GetString())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value!.Trim())
+            .ToArray();
+        Assert.NotEmpty(normalizationRules);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_AllowsAliasAndDefaultSuppressionFlags() {
+        var tool = new DomainDetectiveChecksCatalogTool(new DomainDetectiveToolOptions());
+        var arguments = JsonNode.Parse("""
+            {
+              "include_aliases": false,
+              "include_default_checks": false
+            }
+            """) as JsonObject;
+
+        var json = await tool.InvokeAsync(arguments, CancellationToken.None);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(0, root.GetProperty("aliases").GetArrayLength());
+        Assert.Equal(0, root.GetProperty("default_checks").GetArrayLength());
+        Assert.True(root.GetProperty("supported_checks").GetArrayLength() > 0);
+    }
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
@@ -574,6 +574,7 @@ public class ToolDefinitionContractTests {
         Assert.Contains("dnsclientx_query", names);
         Assert.Contains("dnsclientx_ping", names);
         Assert.Contains("domaindetective_pack_info", names);
+        Assert.Contains("domaindetective_checks_catalog", names);
         Assert.Contains("domaindetective_domain_summary", names);
         Assert.Contains("domaindetective_network_probe", names);
     }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPackInfoContractTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolPackInfoContractTests.cs
@@ -231,6 +231,9 @@ public class ToolPackInfoContractTests {
         var root = document.RootElement;
         Assert.Equal("domaindetective", root.GetProperty("pack").GetString());
 
+        var tools = ReadStringArray(root.GetProperty("tools"));
+        Assert.Contains("domaindetective_checks_catalog", tools, StringComparer.OrdinalIgnoreCase);
+
         var entityHandoffs = root.GetProperty("entity_handoffs");
         Assert.Equal(JsonValueKind.Array, entityHandoffs.ValueKind);
         Assert.True(entityHandoffs.GetArrayLength() > 0);


### PR DESCRIPTION
## Summary
- add new domaindetective_checks_catalog tool to expose supported check names, baseline defaults, and alias normalization guidance
- extract shared DomainDetective check-name normalization and alias logic into DomainDetectiveCheckNameCatalog for helper reuse and contract stability
- refactor domaindetective_domain_summary to reuse shared check-name resolver logic (no output-contract drift)
- update DomainDetective pack guidance to include an explicit preflight step for deterministic checks[] planning
- add targeted tests for the new catalog tool and registration/pack-info exposure

## Why
- improves routing reliability by giving the agent a deterministic way to discover valid DomainDetective checks before execution
- reduces invalid-check failures and makes tool planning less brittle across natural-language check-name variants

## Testing
- dotnet build IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/IntelligenceX.Tools.DomainDetective.csproj -c Release ✅
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter ""FullyQualifiedName~DomainDetective"" ❌ *(fails locally due pre-existing missing external TestimoX/ComputerX/ADPlayground types in sibling dependencies)*
