### PR TITLE
DomainDetective: harden check catalog immutability

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveCheckNameCatalog.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveCheckNameCatalog.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -10,7 +11,7 @@ using DomainDetective;
 namespace IntelligenceX.Tools.DomainDetective;
 
 internal static class DomainDetectiveCheckNameCatalog {
-    private static readonly string[] DefaultChecksValue = {
+    private static readonly IReadOnlyList<string> DefaultChecksValue = Array.AsReadOnly(new[] {
         "DNSHEALTH",
         "SOA",
         "NS",
@@ -19,28 +20,29 @@ internal static class DomainDetectiveCheckNameCatalog {
         "DMARC",
         "DNSSEC",
         "TTL"
-    };
+    });
 
-    private static readonly IReadOnlyDictionary<string, string> CheckAliasByToken = new Dictionary<string, string>(StringComparer.Ordinal) {
-        ["NAMESERVER"] = "NS",
-        ["NAMESERVERS"] = "NS",
-        ["NAMESERVERRECORD"] = "NS",
-        ["NAMESERVERRECORDS"] = "NS",
-        ["NSRECORD"] = "NS",
-        ["NSRECORDS"] = "NS",
-        ["MXRECORD"] = "MX",
-        ["MXRECORDS"] = "MX",
-        ["MAILSERVER"] = "MX",
-        ["MAILSERVERS"] = "MX",
-        ["SPFRECORD"] = "SPF",
-        ["SPFRECORDS"] = "SPF",
-        ["DMARCRECORD"] = "DMARC",
-        ["DMARCRECORDS"] = "DMARC",
-        ["DKIMRECORD"] = "DKIM",
-        ["DKIMRECORDS"] = "DKIM",
-        ["CAARECORD"] = "CAA",
-        ["CAARECORDS"] = "CAA"
-    };
+    private static readonly IReadOnlyDictionary<string, string> CheckAliasByToken = new ReadOnlyDictionary<string, string>(
+        new Dictionary<string, string>(StringComparer.Ordinal) {
+            ["NAMESERVER"] = "NS",
+            ["NAMESERVERS"] = "NS",
+            ["NAMESERVERRECORD"] = "NS",
+            ["NAMESERVERRECORDS"] = "NS",
+            ["NSRECORD"] = "NS",
+            ["NSRECORDS"] = "NS",
+            ["MXRECORD"] = "MX",
+            ["MXRECORDS"] = "MX",
+            ["MAILSERVER"] = "MX",
+            ["MAILSERVERS"] = "MX",
+            ["SPFRECORD"] = "SPF",
+            ["SPFRECORDS"] = "SPF",
+            ["DMARCRECORD"] = "DMARC",
+            ["DMARCRECORDS"] = "DMARC",
+            ["DKIMRECORD"] = "DKIM",
+            ["DKIMRECORDS"] = "DKIM",
+            ["CAARECORD"] = "CAA",
+            ["CAARECORDS"] = "CAA"
+        });
 
     internal static IReadOnlyList<string> DefaultChecks => DefaultChecksValue;
     internal static IReadOnlyDictionary<string, string> AliasByToken => CheckAliasByToken;

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DomainDetectiveCheckNameCatalogTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DomainDetectiveCheckNameCatalogTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using IntelligenceX.Tools.DomainDetective;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class DomainDetectiveCheckNameCatalogTests {
+    private static readonly Type CatalogType =
+        typeof(DomainDetectiveChecksCatalogTool).Assembly.GetType("IntelligenceX.Tools.DomainDetective.DomainDetectiveCheckNameCatalog", throwOnError: true)
+        ?? throw new InvalidOperationException("DomainDetectiveCheckNameCatalog type was not found.");
+
+    private static readonly PropertyInfo DefaultChecksProperty =
+        CatalogType.GetProperty("DefaultChecks", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("DefaultChecks property was not found.");
+
+    private static readonly PropertyInfo AliasByTokenProperty =
+        CatalogType.GetProperty("AliasByToken", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("AliasByToken property was not found.");
+
+    [Fact]
+    public void DefaultChecks_ShouldExposeReadOnlyList() {
+        var checks = Assert.IsAssignableFrom<IList<string>>(DefaultChecksProperty.GetValue(null));
+        var snapshot = checks.ToArray();
+
+        Assert.Throws<NotSupportedException>(() => checks.Add("NEWCHECK"));
+        Assert.Throws<NotSupportedException>(() => checks[0] = "MUTATED");
+        Assert.Equal(snapshot, checks.ToArray());
+    }
+
+    [Fact]
+    public void AliasByToken_ShouldExposeReadOnlyDictionary() {
+        var aliases = Assert.IsAssignableFrom<IDictionary<string, string>>(AliasByTokenProperty.GetValue(null));
+        var snapshot = aliases.ToArray();
+
+        Assert.Throws<NotSupportedException>(() => aliases["NAMESERVERS"] = "MUTATED");
+        Assert.Throws<NotSupportedException>(() => aliases.Add("NEWALIAS", "NS"));
+        Assert.Equal(snapshot, aliases.ToArray());
+    }
+}


### PR DESCRIPTION
## Summary
- harden `DomainDetectiveCheckNameCatalog` so default checks and alias maps are exposed via read-only wrappers instead of mutable backing collections
- keep existing behavior and contracts intact while preventing accidental in-assembly mutation
- add regression tests that verify these internal collections reject mutation via reflection access

## Validation
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/IntelligenceX.Tools.DomainDetective.csproj -c Release` ✅
- `dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~DomainDetective"` ❌ blocked by pre-existing optional dependency/type resolution failures in sibling packs (`TestimoX`, `ADPlayground`)