### PR TITLE
Chat: centralize visual contract catalog and table token signal

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -20,12 +20,6 @@ internal sealed partial class ChatServiceSession {
     internal const string PhaseHeartbeatSuppressionReasonCanceled = "canceled";
     internal const string PhaseHeartbeatSuppressionReasonHeartbeatCanceled = "heartbeat-canceled";
     internal const string PhaseHeartbeatSuppressionReasonRequestCanceled = "request-canceled";
-    private const string ProactiveVisualizationMarker = "ix:proactive-visualization:v1";
-    private const string MermaidFenceLanguage = "mermaid";
-    private const string ChartFenceLanguage = "ix-chart";
-    private const string NetworkFenceLanguage = "ix-network";
-    private const string LegacyNetworkFenceLanguage = "visnetwork";
-    private const int MaxSupportedProactiveVisualBlocks = 3;
 
     private readonly record struct ProactiveVisualizationPolicy(
         bool AllowNewVisuals,
@@ -256,9 +250,10 @@ internal sealed partial class ChatServiceSession {
                 : "0";
         var hasSpecificPreferredVisualType = visualPolicy.HasPreferredVisualOverride
             && !string.Equals(visualPolicy.PreferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
+        var supportedVisualBlocks = GetSupportedProactiveVisualBlockListText();
         var visualRequirementLine = visualPolicy.AllowNewVisuals && visualPolicy.MaxNewVisuals > 0
             ? $"- If allow_new_visuals is true, include at most {visualPolicy.MaxNewVisuals} new visual block(s) and only when it materially compresses complex evidence."
-            : "- If allow_new_visuals is false, do not introduce new mermaid/ix-chart/ix-network blocks in this proactive rewrite.";
+            : $"- If allow_new_visuals is false, do not introduce new {supportedVisualBlocks} blocks in this proactive rewrite.";
         var preferredVisualRequirementLine = visualPolicy.AllowNewVisuals && hasSpecificPreferredVisualType
             ? "- If preferred_visual is set, prefer that visual format for any newly introduced visual block unless another supported format is clearly better."
             : string.Empty;
@@ -372,22 +367,6 @@ internal sealed partial class ChatServiceSession {
         }
 
         return false;
-    }
-
-    private static bool ContainsVisualContractSignal(string? text) {
-        var value = (text ?? string.Empty).Trim();
-        if (value.Length == 0) {
-            return false;
-        }
-
-        return ContainsFenceLanguage(value, MermaidFenceLanguage)
-               || ContainsFenceLanguage(value, ChartFenceLanguage)
-               || ContainsFenceLanguage(value, NetworkFenceLanguage)
-               || ContainsFenceLanguage(value, LegacyNetworkFenceLanguage)
-               || ContainsToken(value, MermaidFenceLanguage)
-               || ContainsToken(value, ChartFenceLanguage)
-               || ContainsToken(value, NetworkFenceLanguage)
-               || ContainsToken(value, LegacyNetworkFenceLanguage);
     }
 
     internal Task RunPhaseProgressLoopAsync(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace IntelligenceX.Chat.Service;
+
+internal sealed partial class ChatServiceSession {
+    private const string ProactiveVisualizationMarker = "ix:proactive-visualization:v1";
+    private const string MermaidFenceLanguage = "mermaid";
+    private const string ChartFenceLanguage = "ix-chart";
+    private const string NetworkFenceLanguage = "ix-network";
+    private const string LegacyNetworkFenceLanguage = "visnetwork";
+    private const int MaxSupportedProactiveVisualBlocks = 3;
+
+    private static readonly string[] ProactiveVisualPromptFenceLanguages = {
+        MermaidFenceLanguage,
+        ChartFenceLanguage,
+        NetworkFenceLanguage
+    };
+
+    private static readonly string[] VisualContractFenceLanguages = {
+        MermaidFenceLanguage,
+        ChartFenceLanguage,
+        NetworkFenceLanguage,
+        LegacyNetworkFenceLanguage
+    };
+
+    private static readonly string[] VisualContractTokenSignals = {
+        MermaidFenceLanguage,
+        ChartFenceLanguage,
+        NetworkFenceLanguage,
+        LegacyNetworkFenceLanguage,
+        "table"
+    };
+
+    private static readonly IReadOnlyDictionary<string, string> PreferredVisualTypeByToken = new Dictionary<string, string>(StringComparer.Ordinal) {
+        ["auto"] = "auto",
+        ["ixnetwork"] = "ix-network",
+        ["network"] = "ix-network",
+        ["visnetwork"] = "ix-network",
+        ["ixchart"] = "ix-chart",
+        ["chart"] = "ix-chart",
+        ["mermaid"] = "mermaid",
+        ["diagram"] = "mermaid",
+        ["table"] = "table",
+        ["markdowntable"] = "table"
+    };
+
+    private static bool ContainsVisualContractSignal(string? text) {
+        var value = (text ?? string.Empty).Trim();
+        if (value.Length == 0) {
+            return false;
+        }
+
+        for (var i = 0; i < VisualContractFenceLanguages.Length; i++) {
+            if (ContainsFenceLanguage(value, VisualContractFenceLanguages[i])) {
+                return true;
+            }
+        }
+
+        for (var i = 0; i < VisualContractTokenSignals.Length; i++) {
+            if (ContainsToken(value, VisualContractTokenSignals[i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string GetSupportedProactiveVisualBlockListText() {
+        return string.Join("/", ProactiveVisualPromptFenceLanguages);
+    }
+
+    private static bool TryResolvePreferredVisualTypeToken(ReadOnlySpan<char> value, out string preferredVisualType) {
+        preferredVisualType = string.Empty;
+        var normalized = NormalizeCompactToken(value);
+        if (normalized.Length == 0) {
+            return false;
+        }
+
+        return PreferredVisualTypeByToken.TryGetValue(normalized, out preferredVisualType);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
@@ -177,32 +177,7 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static bool TryNormalizePreferredVisualType(ReadOnlySpan<char> value, out string preferredVisualType) {
-        preferredVisualType = string.Empty;
-        var normalized = NormalizeCompactToken(value);
-        switch (normalized) {
-            case "auto":
-                preferredVisualType = "auto";
-                return true;
-            case "ixnetwork":
-            case "network":
-            case "visnetwork":
-                preferredVisualType = "ix-network";
-                return true;
-            case "ixchart":
-            case "chart":
-                preferredVisualType = "ix-chart";
-                return true;
-            case "mermaid":
-            case "diagram":
-                preferredVisualType = "mermaid";
-                return true;
-            case "table":
-            case "markdowntable":
-                preferredVisualType = "table";
-                return true;
-            default:
-                return false;
-        }
+        return TryResolvePreferredVisualTypeToken(value, out preferredVisualType);
     }
 
     private static ReadOnlySpan<char> StripInlineStructuredComment(ReadOnlySpan<char> value) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -75,6 +75,20 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_NormalizesMarkdownTablePreferredVisualAlias() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            preferred_visual_type: markdown-table
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("If preferred_visual is set, prefer that visual format", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_PreservesExplicitAutoPreferredVisualOverride() {
         var request = """
             [Proactive visualization guidance]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -592,6 +592,15 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForBacktickedTableToken() {
+        var request = "If useful, return a compact `table` for quick comparison.";
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForWhitespacePrefixedFenceLanguage() {
         var request = """
             Build a relationship summary with explicit contract:


### PR DESCRIPTION
## Summary
- centralize proactive-visualization contract constants, supported signal types, and preferred-visual alias normalization into a shared visual catalog helper
- remove duplicate hardcoded visual-type checks from routing path and use catalog-driven signal detection instead
- treat explicit backticked `table` token as a structured visual-contract signal (still not plain keyword matching)
- add regression tests for markdown-table preferred-visual alias normalization and table-token visual contract activation

## Validation
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Service/IntelligenceX.Chat.Service.csproj -c Release` ❌ blocked by pre-existing missing optional sibling dependencies (`ComputerX`, `ADPlayground`, `TestimoX`) in local environment
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildProactiveFollowUpReviewPrompt|FullyQualifiedName~TryReadProactiveVisualizationOverridesFromRequestText"` ❌ same compile blocker before tests execute