### PR TITLE
Chat: derive visual contract signals from a unified catalog

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
@@ -4,46 +4,149 @@ using System.Collections.Generic;
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
+    private readonly record struct VisualTypeCatalogEntry(
+        string CanonicalType,
+        bool SupportsProactiveFenceGuidance,
+        string[] PreferredAliases,
+        string[] FenceLanguageSignals,
+        string[] InlineTokenSignals);
+
     private const string ProactiveVisualizationMarker = "ix:proactive-visualization:v1";
-    private const string MermaidFenceLanguage = "mermaid";
-    private const string ChartFenceLanguage = "ix-chart";
-    private const string NetworkFenceLanguage = "ix-network";
-    private const string LegacyNetworkFenceLanguage = "visnetwork";
+    private const string AutoVisualType = "auto";
+    private const string MermaidVisualType = "mermaid";
+    private const string ChartVisualType = "ix-chart";
+    private const string NetworkVisualType = "ix-network";
+    private const string TableVisualType = "table";
+    private const string LegacyNetworkVisualType = "visnetwork";
     private const int MaxSupportedProactiveVisualBlocks = 3;
 
-    private static readonly string[] ProactiveVisualPromptFenceLanguages = {
-        MermaidFenceLanguage,
-        ChartFenceLanguage,
-        NetworkFenceLanguage
+    private static readonly VisualTypeCatalogEntry[] VisualTypeCatalog = {
+        new(
+            CanonicalType: MermaidVisualType,
+            SupportsProactiveFenceGuidance: true,
+            PreferredAliases: new[] { "diagram" },
+            FenceLanguageSignals: new[] { MermaidVisualType },
+            InlineTokenSignals: new[] { MermaidVisualType, "diagram" }),
+        new(
+            CanonicalType: ChartVisualType,
+            SupportsProactiveFenceGuidance: true,
+            PreferredAliases: new[] { "chart" },
+            FenceLanguageSignals: new[] { ChartVisualType },
+            InlineTokenSignals: new[] { ChartVisualType, "chart" }),
+        new(
+            CanonicalType: NetworkVisualType,
+            SupportsProactiveFenceGuidance: true,
+            PreferredAliases: new[] { "network", LegacyNetworkVisualType },
+            FenceLanguageSignals: new[] { NetworkVisualType, LegacyNetworkVisualType },
+            InlineTokenSignals: new[] { NetworkVisualType, "network", LegacyNetworkVisualType }),
+        new(
+            CanonicalType: TableVisualType,
+            SupportsProactiveFenceGuidance: false,
+            PreferredAliases: new[] { "markdown-table", "markdown_table" },
+            FenceLanguageSignals: Array.Empty<string>(),
+            InlineTokenSignals: new[] { TableVisualType, "markdown-table", "markdown_table" })
     };
 
-    private static readonly string[] VisualContractFenceLanguages = {
-        MermaidFenceLanguage,
-        ChartFenceLanguage,
-        NetworkFenceLanguage,
-        LegacyNetworkFenceLanguage
-    };
+    private static readonly IReadOnlyDictionary<string, string> PreferredVisualTypeByToken = BuildPreferredVisualTypeByToken();
+    private static readonly string[] ProactiveVisualPromptFenceLanguages = BuildProactiveVisualPromptFenceLanguages();
+    private static readonly string[] VisualContractFenceLanguages = BuildVisualContractFenceLanguages();
+    private static readonly HashSet<string> VisualContractInlineTokenSignals = BuildVisualContractInlineTokenSignals();
 
-    private static readonly string[] VisualContractTokenSignals = {
-        MermaidFenceLanguage,
-        ChartFenceLanguage,
-        NetworkFenceLanguage,
-        LegacyNetworkFenceLanguage,
-        "table"
-    };
+    private static IReadOnlyDictionary<string, string> BuildPreferredVisualTypeByToken() {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal) {
+            [AutoVisualType] = AutoVisualType
+        };
 
-    private static readonly IReadOnlyDictionary<string, string> PreferredVisualTypeByToken = new Dictionary<string, string>(StringComparer.Ordinal) {
-        ["auto"] = "auto",
-        ["ixnetwork"] = "ix-network",
-        ["network"] = "ix-network",
-        ["visnetwork"] = "ix-network",
-        ["ixchart"] = "ix-chart",
-        ["chart"] = "ix-chart",
-        ["mermaid"] = "mermaid",
-        ["diagram"] = "mermaid",
-        ["table"] = "table",
-        ["markdowntable"] = "table"
-    };
+        for (var i = 0; i < VisualTypeCatalog.Length; i++) {
+            var entry = VisualTypeCatalog[i];
+            AddPreferredVisualTypeToken(map, entry.CanonicalType, entry.CanonicalType);
+
+            for (var aliasIndex = 0; aliasIndex < entry.PreferredAliases.Length; aliasIndex++) {
+                AddPreferredVisualTypeToken(map, entry.PreferredAliases[aliasIndex], entry.CanonicalType);
+            }
+        }
+
+        return map;
+    }
+
+    private static string[] BuildProactiveVisualPromptFenceLanguages() {
+        var values = new List<string>(VisualTypeCatalog.Length);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        for (var i = 0; i < VisualTypeCatalog.Length; i++) {
+            var entry = VisualTypeCatalog[i];
+            if (!entry.SupportsProactiveFenceGuidance || !seen.Add(entry.CanonicalType)) {
+                continue;
+            }
+
+            values.Add(entry.CanonicalType);
+        }
+
+        return values.Count == 0 ? Array.Empty<string>() : values.ToArray();
+    }
+
+    private static string[] BuildVisualContractFenceLanguages() {
+        var values = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        for (var i = 0; i < VisualTypeCatalog.Length; i++) {
+            var entry = VisualTypeCatalog[i];
+            for (var signalIndex = 0; signalIndex < entry.FenceLanguageSignals.Length; signalIndex++) {
+                var signal = entry.FenceLanguageSignals[signalIndex];
+                if (string.IsNullOrWhiteSpace(signal) || !seen.Add(signal)) {
+                    continue;
+                }
+
+                values.Add(signal);
+            }
+        }
+
+        return values.Count == 0 ? Array.Empty<string>() : values.ToArray();
+    }
+
+    private static HashSet<string> BuildVisualContractInlineTokenSignals() {
+        var signals = new HashSet<string>(StringComparer.Ordinal);
+
+        for (var i = 0; i < VisualTypeCatalog.Length; i++) {
+            var entry = VisualTypeCatalog[i];
+            AddNormalizedInlineSignalToken(signals, entry.CanonicalType);
+
+            for (var aliasIndex = 0; aliasIndex < entry.PreferredAliases.Length; aliasIndex++) {
+                AddNormalizedInlineSignalToken(signals, entry.PreferredAliases[aliasIndex]);
+            }
+
+            for (var signalIndex = 0; signalIndex < entry.FenceLanguageSignals.Length; signalIndex++) {
+                AddNormalizedInlineSignalToken(signals, entry.FenceLanguageSignals[signalIndex]);
+            }
+
+            for (var signalIndex = 0; signalIndex < entry.InlineTokenSignals.Length; signalIndex++) {
+                AddNormalizedInlineSignalToken(signals, entry.InlineTokenSignals[signalIndex]);
+            }
+        }
+
+        return signals;
+    }
+
+    private static void AddPreferredVisualTypeToken(
+        IDictionary<string, string> map,
+        string token,
+        string canonicalType) {
+        var normalizedToken = NormalizeCompactToken(token.AsSpan());
+        if (normalizedToken.Length == 0 || string.IsNullOrWhiteSpace(canonicalType) || map.ContainsKey(normalizedToken)) {
+            return;
+        }
+
+        map[normalizedToken] = canonicalType;
+    }
+
+    private static void AddNormalizedInlineSignalToken(ISet<string> signals, string token) {
+        var normalizedToken = NormalizeCompactToken(token.AsSpan());
+        if (normalizedToken.Length == 0) {
+            return;
+        }
+
+        signals.Add(normalizedToken);
+    }
 
     private static bool ContainsVisualContractSignal(string? text) {
         var value = (text ?? string.Empty).Trim();
@@ -57,13 +160,7 @@ internal sealed partial class ChatServiceSession {
             }
         }
 
-        for (var i = 0; i < VisualContractTokenSignals.Length; i++) {
-            if (ContainsToken(value, VisualContractTokenSignals[i])) {
-                return true;
-            }
-        }
-
-        return false;
+        return ContainsVisualInlineTokenSignal(value);
     }
 
     private static string GetSupportedProactiveVisualBlockListText() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
@@ -264,9 +264,8 @@ internal sealed partial class ChatServiceSession {
         return false;
     }
 
-    private static bool ContainsToken(string text, string token) {
-        var expectedToken = (token ?? string.Empty).Trim();
-        if (expectedToken.Length == 0 || string.IsNullOrWhiteSpace(text)) {
+    private static bool ContainsVisualInlineTokenSignal(string text) {
+        if (string.IsNullOrWhiteSpace(text) || VisualContractInlineTokenSignals.Count == 0) {
             return false;
         }
 
@@ -300,7 +299,8 @@ internal sealed partial class ChatServiceSession {
             }
 
             var content = value.Slice(contentStart, contentEnd - contentStart).Trim();
-            if (content.Equals(expectedToken.AsSpan(), StringComparison.OrdinalIgnoreCase)) {
+            var normalizedToken = NormalizeCompactToken(content);
+            if (normalizedToken.Length > 0 && VisualContractInlineTokenSignals.Contains(normalizedToken)) {
                 return true;
             }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -601,6 +601,33 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForBacktickedChartAliasToken() {
+        var request = "If needed, include a compact `chart` for trend comparison.";
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForBacktickedDiagramAliasToken() {
+        var request = "If needed, include a relationship `diagram`.";
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForBacktickedMarkdownTableAliasToken() {
+        var request = "If useful, return a compact `markdown-table` summary.";
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForWhitespacePrefixedFenceLanguage() {
         var request = """
             Build a relationship summary with explicit contract:


### PR DESCRIPTION
## Summary
- replace duplicated hardcoded visual signal lists with a unified visual-type catalog (canonical type, aliases, fence signals, inline token signals)
- derive preferred visual alias normalization, proactive supported fence list, and request contract signal sets from that catalog
- switch inline visual contract detection to normalized token matching inside backticked segments, preserving structured-only behavior while supporting aliases like `chart`, `diagram`, and `markdown-table`
- add regression tests for explicit backticked alias tokens (`chart`, `diagram`, `markdown-table`)

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_AllowsVisualsForBacktickedChartAliasToken|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_AllowsVisualsForBacktickedDiagramAliasToken|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_AllowsVisualsForBacktickedMarkdownTableAliasToken|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_DoesNotEnableVisualsForPlainKeywordMentions|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_AllowsVisualsForBacktickedLegacyNetworkToken|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_AllowsVisualsForBacktickedTableToken" -m:1 -p:UseSharedCompilation=false -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_UsesStructuredPreferredVisualAlias|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_ParsesPreferredVisualTypeWithInlineComment|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_NormalizesMarkdownTablePreferredVisualAlias|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_PreservesExplicitAutoPreferredVisualOverride" -m:1 -p:UseSharedCompilation=false -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`

## Notes
- baseline `origin/master` currently has 3 known failures in the broad `BuildProactiveFollowUpReviewPrompt_` slice (verified in an isolated worktree), unrelated to this diff:
  - `BuildProactiveFollowUpReviewPrompt_IgnoresInvalidStructuredMaxNewVisualsOverride` (`-1`, `abc`)
  - `BuildProactiveFollowUpReviewPrompt_AllowsOneVisualWhenStructuredVisualContractIsPresent`
