### PR TITLE
Chat: expand DomainDetective <-> DnsClientX cross-pack recovery

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -550,26 +550,34 @@ internal sealed partial class ChatServiceSession {
         reason = "cross_public_dns_not_applicable";
 
         if (!PackIdMatches(sourcePackId, "domaindetective")
-            || !string.Equals(sourceTool, "domaindetective_domain_summary", StringComparison.OrdinalIgnoreCase)
             || !hasSourceFailureSignal) {
             reason = "cross_public_dns_source_not_eligible";
             return false;
         }
 
-        const string candidateTool = "dnsclientx_query";
+        var candidateTool = string.Equals(sourceTool, "domaindetective_network_probe", StringComparison.OrdinalIgnoreCase)
+            ? "dnsclientx_ping"
+            : string.Equals(sourceTool, "domaindetective_domain_summary", StringComparison.OrdinalIgnoreCase)
+                ? "dnsclientx_query"
+                : string.Empty;
+        if (candidateTool.Length == 0) {
+            reason = "cross_public_dns_source_tool_not_supported";
+            return false;
+        }
+
         if (priorCalledTools.Contains(candidateTool)) {
-            reason = "cross_public_dns_query_already_called";
+            reason = "cross_public_dns_candidate_already_called";
             return false;
         }
 
         if (!TryGetToolDefinitionByName(toolDefinitions, candidateTool, out var toolDefinition)) {
-            reason = "cross_public_dns_query_unavailable";
+            reason = "cross_public_dns_candidate_unavailable";
             return false;
         }
 
         if (!_toolPackIdsByToolName.TryGetValue(candidateTool, out var candidatePackIdRaw)
             || !PackIdMatches(candidatePackIdRaw, "dnsclientx")) {
-            reason = "cross_public_dns_query_not_in_dnsclientx_pack";
+            reason = "cross_public_dns_candidate_not_in_dnsclientx_pack";
             return false;
         }
 
@@ -579,7 +587,7 @@ internal sealed partial class ChatServiceSession {
             toolDefinition: toolDefinition,
             mutatingToolHintsByName: mutatingToolHintsByName);
         if (mutability != ActionMutability.ReadOnly) {
-            reason = "cross_public_dns_query_not_read_only";
+            reason = "cross_public_dns_candidate_not_read_only";
             return false;
         }
 
@@ -589,12 +597,16 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        var fallbackArguments = new JsonObject(StringComparer.Ordinal)
-            .Add("name", name);
+        var fallbackArguments = new JsonObject(StringComparer.Ordinal);
+        if (string.Equals(candidateTool, "dnsclientx_ping", StringComparison.OrdinalIgnoreCase)) {
+            fallbackArguments.Add("target", name);
+        } else {
+            fallbackArguments.Add("name", name);
+        }
         var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
         if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
             || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
-            reason = "cross_public_dns_query_missing_required_args";
+            reason = "cross_public_dns_candidate_missing_required_args";
             return false;
         }
 
@@ -636,26 +648,34 @@ internal sealed partial class ChatServiceSession {
         reason = "cross_public_domain_not_applicable";
 
         if (!PackIdMatches(sourcePackId, "dnsclientx")
-            || !string.Equals(sourceTool, "dnsclientx_query", StringComparison.OrdinalIgnoreCase)
             || !hasSourceFailureSignal) {
             reason = "cross_public_domain_source_not_eligible";
             return false;
         }
 
-        const string candidateTool = "domaindetective_domain_summary";
+        var candidateTool = string.Equals(sourceTool, "dnsclientx_ping", StringComparison.OrdinalIgnoreCase)
+            ? "domaindetective_network_probe"
+            : string.Equals(sourceTool, "dnsclientx_query", StringComparison.OrdinalIgnoreCase)
+                ? "domaindetective_domain_summary"
+                : string.Empty;
+        if (candidateTool.Length == 0) {
+            reason = "cross_public_domain_source_tool_not_supported";
+            return false;
+        }
+
         if (priorCalledTools.Contains(candidateTool)) {
-            reason = "cross_public_domain_summary_already_called";
+            reason = "cross_public_domain_candidate_already_called";
             return false;
         }
 
         if (!TryGetToolDefinitionByName(toolDefinitions, candidateTool, out var toolDefinition)) {
-            reason = "cross_public_domain_summary_unavailable";
+            reason = "cross_public_domain_candidate_unavailable";
             return false;
         }
 
         if (!_toolPackIdsByToolName.TryGetValue(candidateTool, out var candidatePackIdRaw)
             || !PackIdMatches(candidatePackIdRaw, "domaindetective")) {
-            reason = "cross_public_domain_summary_not_in_domaindetective_pack";
+            reason = "cross_public_domain_candidate_not_in_domaindetective_pack";
             return false;
         }
 
@@ -665,22 +685,31 @@ internal sealed partial class ChatServiceSession {
             toolDefinition: toolDefinition,
             mutatingToolHintsByName: mutatingToolHintsByName);
         if (mutability != ActionMutability.ReadOnly) {
-            reason = "cross_public_domain_summary_not_read_only";
+            reason = "cross_public_domain_candidate_not_read_only";
             return false;
         }
 
-        var domain = ResolveDomainDetectiveDomainHint(partialScopeHints);
-        if (string.IsNullOrWhiteSpace(domain)) {
-            reason = "cross_public_domain_missing_domain_hint";
-            return false;
+        var fallbackArguments = new JsonObject(StringComparer.Ordinal);
+        if (string.Equals(candidateTool, "domaindetective_network_probe", StringComparison.OrdinalIgnoreCase)) {
+            var host = ResolveDnsClientXNameHint(partialScopeHints);
+            if (string.IsNullOrWhiteSpace(host)) {
+                reason = "cross_public_domain_missing_host_hint";
+                return false;
+            }
+            fallbackArguments.Add("host", host);
+        } else {
+            var domain = ResolveDomainDetectiveDomainHint(partialScopeHints);
+            if (string.IsNullOrWhiteSpace(domain)) {
+                reason = "cross_public_domain_missing_domain_hint";
+                return false;
+            }
+            fallbackArguments.Add("domain", domain);
         }
 
-        var fallbackArguments = new JsonObject(StringComparer.Ordinal)
-            .Add("domain", domain);
         var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
         if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
             || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
-            reason = "cross_public_domain_summary_missing_required_args";
+            reason = "cross_public_domain_candidate_missing_required_args";
             return false;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -332,6 +332,108 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDnsClientXPingFallbackFromDomainDetectiveProbeFailure() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["domaindetective_network_probe"] = "domaindetective";
+        packMap["dnsclientx_ping"] = "dnsclientx";
+
+        var networkProbeSchema = ToolSchema.Object(
+                ("host", ToolSchema.String("host")))
+            .Required("host")
+            .NoAdditionalProperties();
+        var dnsPingSchema = ToolSchema.Object(
+                ("target", ToolSchema.String("target")))
+            .Required("target")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("domaindetective_network_probe", "network probe", networkProbeSchema),
+            new("dnsclientx_ping", "dns ping", dnsPingSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-dd-probe",
+                Name = "domaindetective_network_probe",
+                ArgumentsJson = """{"host":"mail.contoso.com"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-dd-probe",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["dnsclientx_ping"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue probe investigation", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("dnsclientx_ping", toolCall.Name);
+        Assert.Contains("\"target\":\"mail.contoso.com\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cross_public_dns", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDomainDetectiveProbeFallbackFromDnsClientXPingFailure() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["dnsclientx_ping"] = "dnsclientx";
+        packMap["domaindetective_network_probe"] = "domaindetective";
+
+        var dnsPingSchema = ToolSchema.Object(
+                ("target", ToolSchema.String("target")))
+            .Required("target")
+            .NoAdditionalProperties();
+        var networkProbeSchema = ToolSchema.Object(
+                ("host", ToolSchema.String("host")))
+            .Required("host")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("dnsclientx_ping", "dns ping", dnsPingSchema),
+            new("domaindetective_network_probe", "network probe", networkProbeSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-dns-ping",
+                Name = "dnsclientx_ping",
+                ArgumentsJson = """{"target":"mail.contoso.com"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-dns-ping",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["domaindetective_network_probe"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue dns investigation", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("domaindetective_network_probe", toolCall.Name);
+        Assert.Contains("\"host\":\"mail.contoso.com\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cross_public_domain", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsTestimoXRunFallbackUsingSelectorHints() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));


### PR DESCRIPTION
## Summary
- expand cross-pack recovery logic so DomainDetective and DnsClientX can fallback in both summary and probe directions
- when `domaindetective_network_probe` fails, allow automatic cross-pack fallback to `dnsclientx_ping` (using `target` hint)
- when `dnsclientx_ping` fails, allow automatic cross-pack fallback to `domaindetective_network_probe` (using `host` hint)
- keep existing `domaindetective_domain_summary` <-> `dnsclientx_query` cross-fallback path intact
- generalize candidate-specific reason codes to avoid query-only naming in the broader path

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDnsClientXFallbackFromDomainDetectiveFailure|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsDnsClientXQueryFallbackFromPingSourceArguments|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDomainDetectiveFallbackFromDnsClientXFailure|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDnsClientXPingFallbackFromDomainDetectiveProbeFailure|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDomainDetectiveProbeFallbackFromDnsClientXPingFailure|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsDomainDetectiveFallbackFromSourceArguments" -m:1 -p:UseSharedCompilation=false -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`
