### PR TITLE
Chat: add EventLog -> System host baseline cross-fallback

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -381,6 +381,21 @@ internal sealed partial class ChatServiceSession {
                 return true;
             }
 
+            if (TryBuildCrossHostSystemBaselineFallbackToolCall(
+                    toolDefinitions: toolDefinitions,
+                    priorCalledTools: priorCalledTools,
+                    sourcePackId: sourcePackId,
+                    sourceTool: sourceTool,
+                    partialScopeHints: partialScopeHints,
+                    partialScopeReason: partialScopeReason,
+                    userRequest: userRequest,
+                    hasSourceFailureSignal: hasSourceFailureSignal,
+                    mutatingToolHintsByName: mutatingToolHintsByName,
+                    out toolCall,
+                    out reason)) {
+                return true;
+            }
+
             for (var i = 0; i < packContract.FallbackTools.Length; i++) {
                 var candidateTool = packContract.FallbackTools[i];
                 if (string.Equals(candidateTool, sourceTool, StringComparison.OrdinalIgnoreCase)) {
@@ -734,6 +749,124 @@ internal sealed partial class ChatServiceSession {
                  + "->"
                  + candidateTool;
         return true;
+    }
+
+    private bool TryBuildCrossHostSystemBaselineFallbackToolCall(
+        IReadOnlyList<ToolDefinition> toolDefinitions,
+        IReadOnlySet<string> priorCalledTools,
+        string sourcePackId,
+        string sourceTool,
+        JsonObject partialScopeHints,
+        string partialScopeReason,
+        string? userRequest,
+        bool hasSourceFailureSignal,
+        IReadOnlyDictionary<string, bool>? mutatingToolHintsByName,
+        out ToolCall toolCall,
+        out string reason) {
+        toolCall = null!;
+        reason = "cross_host_system_baseline_not_applicable";
+
+        if (!PackIdMatches(sourcePackId, "eventlog")
+            || !hasSourceFailureSignal) {
+            reason = "cross_host_system_baseline_source_not_eligible";
+            return false;
+        }
+
+        if (!IsEventlogSourceToolForSystemBaselineFallback(sourceTool)) {
+            reason = "cross_host_system_baseline_source_tool_not_supported";
+            return false;
+        }
+
+        const string candidateTool = "system_info";
+        if (priorCalledTools.Contains(candidateTool)) {
+            reason = "cross_host_system_baseline_candidate_already_called";
+            return false;
+        }
+
+        if (!TryGetToolDefinitionByName(toolDefinitions, candidateTool, out var toolDefinition)) {
+            reason = "cross_host_system_baseline_candidate_unavailable";
+            return false;
+        }
+
+        if (!_toolPackIdsByToolName.TryGetValue(candidateTool, out var candidatePackIdRaw)
+            || !PackIdMatches(candidatePackIdRaw, "system")) {
+            reason = "cross_host_system_baseline_candidate_not_in_system_pack";
+            return false;
+        }
+
+        var mutability = ResolveStructuredNextActionMutability(
+            declaredMutability: ActionMutability.Unknown,
+            toolName: candidateTool,
+            toolDefinition: toolDefinition,
+            mutatingToolHintsByName: mutatingToolHintsByName);
+        if (mutability != ActionMutability.ReadOnly) {
+            reason = "cross_host_system_baseline_candidate_not_read_only";
+            return false;
+        }
+
+        var computerName = ResolveEventlogHostHint(partialScopeHints, userRequest);
+        if (string.IsNullOrWhiteSpace(computerName)) {
+            reason = "cross_host_system_baseline_missing_host_hint";
+            return false;
+        }
+
+        var fallbackArguments = new JsonObject(StringComparer.Ordinal)
+            .Add("computer_name", computerName);
+        var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
+        if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
+            || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
+            reason = "cross_host_system_baseline_candidate_missing_required_args";
+            return false;
+        }
+
+        var serializedArguments = JsonLite.Serialize(normalizedArguments);
+        var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
+        var raw = new JsonObject()
+            .Add("type", "tool_call")
+            .Add("call_id", fallbackCallId)
+            .Add("name", candidateTool)
+            .Add("arguments", serializedArguments);
+
+        toolCall = new ToolCall(
+            callId: fallbackCallId,
+            name: candidateTool,
+            input: serializedArguments,
+            arguments: normalizedArguments,
+            raw: raw);
+        reason = "pack_contract_cross_host_system_baseline:"
+                 + sourcePackId
+                 + ":"
+                 + partialScopeReason
+                 + "->"
+                 + candidateTool;
+        return true;
+    }
+
+    private static bool IsEventlogSourceToolForSystemBaselineFallback(string sourceTool) {
+        return string.Equals(sourceTool, "eventlog_live_query", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(sourceTool, "eventlog_live_stats", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(sourceTool, "eventlog_top_events", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(sourceTool, "eventlog_timeline_query", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(sourceTool, "eventlog_evtx_find", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(sourceTool, "eventlog_evtx_query", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(sourceTool, "eventlog_evtx_stats", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(sourceTool, "eventlog_evtx_security_summary", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? ResolveEventlogHostHint(JsonObject hints, string? userRequest) {
+        var preferred = ReadNonEmptyHint(hints, "machine_name")
+                        ?? ReadNonEmptyHint(hints, "computer_name")
+                        ?? ReadNonEmptyHint(hints, "host");
+        if (string.IsNullOrWhiteSpace(preferred)) {
+            preferred = TryExtractHostHintFromUserRequest(userRequest);
+        }
+
+        if (string.IsNullOrWhiteSpace(preferred)) {
+            return null;
+        }
+
+        var normalized = preferred.Trim();
+        return normalized.IndexOf(' ', StringComparison.Ordinal) >= 0 ? null : normalized;
     }
 
     private static string? ResolveDnsClientXNameHint(JsonObject hints) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -655,6 +655,100 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostSystemBaselineFromEventlogFailure() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_live_query"] = "eventlog";
+        packMap["system_info"] = "computerx";
+
+        var eventlogSchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")))
+            .NoAdditionalProperties();
+        var systemSchema = ToolSchema.Object(
+                ("computer_name", ToolSchema.String("computer name")))
+            .Required("computer_name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_live_query", "live query", eventlogSchema),
+            new("system_info", "system info", systemSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-ev-host",
+                Name = "eventlog_live_query",
+                ArgumentsJson = """{"machine_name":"AD0"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ev-host",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_info"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("system_info", toolCall.Name);
+        Assert.Contains("\"computer_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cross_host_system_baseline", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossHostSystemBaselineWithoutHostHint() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_live_query"] = "eventlog";
+        packMap["system_info"] = "computerx";
+
+        var eventlogSchema = ToolSchema.Object().NoAdditionalProperties();
+        var systemSchema = ToolSchema.Object(
+                ("computer_name", ToolSchema.String("computer name")))
+            .Required("computer_name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_live_query", "live query", eventlogSchema),
+            new("system_info", "system info", systemSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-ev-nohost",
+                Name = "eventlog_live_query",
+                ArgumentsJson = "{}"
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ev-nohost",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_info"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Equal("pack_contract_no_applicable_fallback", Assert.IsType<string>(args[6]));
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsEventlogLiveQueryFallbackWhenEvtxAccessDeniedWithHostHint() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));


### PR DESCRIPTION
## Summary
- add cross-pack host recovery path from EventLog failures to System baseline collection
- when eligible EventLog host-scoped tools fail and host hint is available, auto-fallback to `system_info` with `computer_name`
- keep fallback read-only and gated by pack ownership (`system` / `computerx` alias)
- add replay-contract tests for:
  - successful EventLog -> System cross-host fallback
  - no-fallback behavior when host hint is missing
- preserve existing EventLog recovery behavior (cross-DC preference and EVTX access-denied path)

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostSystemBaselineFromEventlogFailure|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossHostSystemBaselineWithoutHostHint|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_KeepsHostScopedEventlogFallbackWhenRequestIsHostTargeted|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_PrefersAdDiscoveryBeforeCrossDcEventlogFanOut|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsEventlogLiveQueryFallbackWhenEvtxAccessDeniedWithHostHint" -m:1 -p:UseSharedCompilation=false -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_ -m:1 -p:UseSharedCompilation=false -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`
