### PR TITLE
Chat: derive cross-host source eligibility from routing metadata

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -339,6 +339,7 @@ internal sealed partial class ChatServiceSession {
             if (!hasFallbackHints && !hasSourceFailureSignal) {
                 continue;
             }
+            TryGetToolDefinitionByName(toolDefinitions, sourceTool, out var sourceToolDefinition);
 
             if (TryBuildCrossDomainControllerDiscoveryFirstFallbackToolCall(
                     toolDefinitions: toolDefinitions,
@@ -386,6 +387,7 @@ internal sealed partial class ChatServiceSession {
                     priorCalledTools: priorCalledTools,
                     sourcePackId: sourcePackId,
                     sourceTool: sourceTool,
+                    sourceToolDefinition: sourceToolDefinition,
                     partialScopeHints: partialScopeHints,
                     partialScopeReason: partialScopeReason,
                     userRequest: userRequest,
@@ -401,6 +403,7 @@ internal sealed partial class ChatServiceSession {
                     priorCalledTools: priorCalledTools,
                     sourcePackId: sourcePackId,
                     sourceTool: sourceTool,
+                    sourceToolDefinition: sourceToolDefinition,
                     partialScopeHints: partialScopeHints,
                     partialScopeReason: partialScopeReason,
                     userRequest: userRequest,
@@ -771,6 +774,7 @@ internal sealed partial class ChatServiceSession {
         IReadOnlySet<string> priorCalledTools,
         string sourcePackId,
         string sourceTool,
+        ToolDefinition? sourceToolDefinition,
         JsonObject partialScopeHints,
         string partialScopeReason,
         string? userRequest,
@@ -787,7 +791,7 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (!IsEventlogSourceToolForSystemBaselineFallback(sourceTool)) {
+        if (!IsSourceToolEligibleForCrossHostSystemBaselineFallback(sourceTool, sourceToolDefinition)) {
             reason = "cross_host_system_baseline_source_tool_not_supported";
             return false;
         }
@@ -857,15 +861,71 @@ internal sealed partial class ChatServiceSession {
         return true;
     }
 
-    private static bool IsEventlogSourceToolForSystemBaselineFallback(string sourceTool) {
-        return string.Equals(sourceTool, "eventlog_live_query", StringComparison.OrdinalIgnoreCase)
-               || string.Equals(sourceTool, "eventlog_live_stats", StringComparison.OrdinalIgnoreCase)
-               || string.Equals(sourceTool, "eventlog_top_events", StringComparison.OrdinalIgnoreCase)
-               || string.Equals(sourceTool, "eventlog_timeline_query", StringComparison.OrdinalIgnoreCase)
-               || string.Equals(sourceTool, "eventlog_evtx_find", StringComparison.OrdinalIgnoreCase)
-               || string.Equals(sourceTool, "eventlog_evtx_query", StringComparison.OrdinalIgnoreCase)
-               || string.Equals(sourceTool, "eventlog_evtx_stats", StringComparison.OrdinalIgnoreCase)
-               || string.Equals(sourceTool, "eventlog_evtx_security_summary", StringComparison.OrdinalIgnoreCase);
+    private static bool IsSourceToolEligibleForCrossHostSystemBaselineFallback(
+        string sourceTool,
+        ToolDefinition? sourceToolDefinition) {
+        if (!TryResolveSourceRoutingInfo(sourceTool, sourceToolDefinition, out var routingInfo)) {
+            return false;
+        }
+
+        var scope = (routingInfo.Scope ?? string.Empty).Trim();
+        if (!string.Equals(scope, "host", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(scope, "file", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        return IsCrossHostFallbackReadOnlyOperation(routingInfo.Operation);
+    }
+
+    private static bool IsSourceToolEligibleForCrossHostEventlogEvidenceFallback(
+        string sourceTool,
+        ToolDefinition? sourceToolDefinition) {
+        if (!TryResolveSourceRoutingInfo(sourceTool, sourceToolDefinition, out var routingInfo)) {
+            return false;
+        }
+
+        var scope = (routingInfo.Scope ?? string.Empty).Trim();
+        if (!string.Equals(scope, "host", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        return IsCrossHostFallbackReadOnlyOperation(routingInfo.Operation);
+    }
+
+    private static bool TryResolveSourceRoutingInfo(
+        string sourceTool,
+        ToolDefinition? sourceToolDefinition,
+        out ToolSelectionMetadata.ToolSelectionRoutingInfo routingInfo) {
+        routingInfo = null!;
+
+        if (sourceToolDefinition?.WriteGovernance?.IsWriteCapable == true) {
+            return false;
+        }
+
+        var routingDefinition = sourceToolDefinition;
+        if (routingDefinition is null) {
+            var normalizedSourceTool = (sourceTool ?? string.Empty).Trim();
+            if (normalizedSourceTool.Length == 0) {
+                return false;
+            }
+
+            routingDefinition = new ToolDefinition(normalizedSourceTool);
+        }
+
+        routingInfo = ToolSelectionMetadata.ResolveRouting(routingDefinition, toolType: null);
+        return true;
+    }
+
+    private static bool IsCrossHostFallbackReadOnlyOperation(string? operation) {
+        var normalizedOperation = (operation ?? string.Empty).Trim();
+        return string.Equals(normalizedOperation, ToolRoutingTaxonomy.OperationRead, StringComparison.OrdinalIgnoreCase)
+               || string.Equals(normalizedOperation, "query", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(normalizedOperation, "list", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(normalizedOperation, "search", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(normalizedOperation, "summarize", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(normalizedOperation, "probe", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(normalizedOperation, "discover", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(normalizedOperation, "resolve", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? ResolveEventlogHostHint(JsonObject hints, string? userRequest) {
@@ -889,6 +949,7 @@ internal sealed partial class ChatServiceSession {
         IReadOnlySet<string> priorCalledTools,
         string sourcePackId,
         string sourceTool,
+        ToolDefinition? sourceToolDefinition,
         JsonObject partialScopeHints,
         string partialScopeReason,
         string? userRequest,
@@ -905,7 +966,7 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (!string.Equals(sourceTool, "system_info", StringComparison.OrdinalIgnoreCase)) {
+        if (!IsSourceToolEligibleForCrossHostEventlogEvidenceFallback(sourceTool, sourceToolDefinition)) {
             reason = "cross_host_eventlog_evidence_source_tool_not_supported";
             return false;
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -607,6 +607,100 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostEventlogEvidenceFromMetadataEligibleSystemSource() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_inventory_query"] = "computerx";
+        packMap["eventlog_live_query"] = "eventlog";
+
+        var systemSchema = ToolSchema.Object(
+                ("computer_name", ToolSchema.String("computer name")))
+            .NoAdditionalProperties();
+        var eventlogSchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")),
+                ("log_name", ToolSchema.String("log name")),
+                ("max_events", ToolSchema.Integer("max events")))
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("system_inventory_query", "system inventory query", systemSchema),
+            new("eventlog_live_query", "eventlog live query", eventlogSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-sys-meta",
+                Name = "system_inventory_query",
+                ArgumentsJson = """{"computer_name":"AD0"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-sys-meta",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_live_query"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("eventlog_live_query", toolCall.Name);
+        Assert.Contains("\"machine_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cross_host_eventlog_evidence", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossHostEventlogEvidenceFromSystemPackInfoFailure() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_custom_pack_info"] = "computerx";
+        packMap["eventlog_live_query"] = "eventlog";
+
+        var schema = ToolSchema.Object().NoAdditionalProperties();
+        var eventlogSchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")))
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("system_custom_pack_info", "system custom pack info", schema),
+            new("eventlog_live_query", "eventlog live query", eventlogSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-sys-guide",
+                Name = "system_custom_pack_info",
+                ArgumentsJson = """{"computer_name":"AD0"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-sys-guide",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_live_query"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Equal("pack_contract_no_applicable_fallback", Assert.IsType<string>(args[6]));
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossHostEventlogEvidenceWithoutHostHint() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
@@ -797,6 +891,100 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Equal("system_info", toolCall.Name);
         Assert.Contains("\"computer_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("cross_host_system_baseline", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostSystemBaselineFromMetadataEligibleEventlogSource() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_named_events_query"] = "eventlog";
+        packMap["system_info"] = "computerx";
+
+        var eventlogSchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")))
+            .NoAdditionalProperties();
+        var systemSchema = ToolSchema.Object(
+                ("computer_name", ToolSchema.String("computer name")))
+            .Required("computer_name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_named_events_query", "named events query", eventlogSchema),
+            new("system_info", "system info", systemSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-ev-meta",
+                Name = "eventlog_named_events_query",
+                ArgumentsJson = """{"machine_name":"AD0"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ev-meta",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_info"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("system_info", toolCall.Name);
+        Assert.Contains("\"computer_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cross_host_system_baseline", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossHostSystemBaselineFromEventlogPackInfoFailure() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_custom_pack_info"] = "eventlog";
+        packMap["system_info"] = "computerx";
+
+        var schema = ToolSchema.Object().NoAdditionalProperties();
+        var systemSchema = ToolSchema.Object(
+                ("computer_name", ToolSchema.String("computer name")))
+            .Required("computer_name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_custom_pack_info", "eventlog custom pack info", schema),
+            new("system_info", "system info", systemSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-ev-guide",
+                Name = "eventlog_custom_pack_info",
+                ArgumentsJson = """{"machine_name":"AD0"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ev-guide",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_info"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Equal("pack_contract_no_applicable_fallback", Assert.IsType<string>(args[6]));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- replace hardcoded cross-host source tool name checks with routing metadata eligibility (`ToolSelectionMetadata.ResolveRouting`)
- gate EventLog -> System fallback on read-style operations with host/file scope, and System -> EventLog fallback on read-style host scope
- keep defensive behavior for write-capable sources and preserve existing failure/host-hint requirements
- add replay contract tests for metadata-eligible custom source names and guardrails that reject `*_pack_info` guide tools

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "TryBuildPackCapabilityFallbackToolCall_" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\
