### PR TITLE
Chat: infer preferred visual type from contract signals

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -301,11 +301,24 @@ internal sealed partial class ChatServiceSession {
         var hasStructuredOverrides = TryReadProactiveVisualizationOverridesFromRequestText(userRequest, out var hasAllowNewVisualsOverride,
             out var allowNewVisualsFromOverride, out var hasPreferredVisualOverride, out var preferredVisualType,
             out var hasMaxNewVisualsOverride, out var maxNewVisualsOverride);
+        var inferredPreferredVisualType = string.Empty;
+        var hasInferredPreferredVisualType = !hasPreferredVisualOverride
+                                             && TryResolvePreferredVisualTypeFromVisualContractSignal(userRequest, out inferredPreferredVisualType);
+        var hasPreferredVisualDirective = hasPreferredVisualOverride || hasInferredPreferredVisualType;
+        var effectivePreferredVisualType = hasPreferredVisualOverride
+            ? preferredVisualType
+            : hasInferredPreferredVisualType
+                ? inferredPreferredVisualType
+                : string.Empty;
+        var hasExplicitAutoPreferredVisualOverride = hasPreferredVisualOverride
+            && string.Equals(preferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
         var requestHasVisualContract = requestHasProactiveVisualizationMarker || requestHasVisualContractSignal || hasStructuredOverrides;
-        var hasSpecificPreferredVisualType = hasPreferredVisualOverride
-            && !string.Equals(preferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
+        var hasSpecificPreferredVisualType = hasPreferredVisualDirective
+            && !string.Equals(effectivePreferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
         var baseAllowNewVisuals = hasAllowNewVisualsOverride
             ? allowNewVisualsFromOverride
+            : hasExplicitAutoPreferredVisualOverride
+                ? false
             : hasSpecificPreferredVisualType
                 ? true
                 : hasMaxNewVisualsOverride
@@ -322,8 +335,8 @@ internal sealed partial class ChatServiceSession {
             AllowNewVisuals: allowNewVisuals,
             DraftHasVisuals: draftHasVisuals,
             RequestHasVisualContract: requestHasVisualContract,
-            HasPreferredVisualOverride: hasPreferredVisualOverride,
-            PreferredVisualType: preferredVisualType,
+            HasPreferredVisualOverride: hasPreferredVisualDirective,
+            PreferredVisualType: effectivePreferredVisualType,
             HasMaxNewVisualsOverride: hasMaxNewVisualsOverride,
             MaxNewVisuals: maxNewVisuals);
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
@@ -149,18 +149,55 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static bool ContainsVisualContractSignal(string? text) {
+        return TryResolvePreferredVisualTypeFromVisualContractSignal(text, out _);
+    }
+
+    private static bool TryResolvePreferredVisualTypeFromVisualContractSignal(
+        string? text,
+        out string preferredVisualType) {
+        preferredVisualType = string.Empty;
         var value = (text ?? string.Empty).Trim();
         if (value.Length == 0) {
             return false;
         }
 
+        var content = value.AsSpan();
+        var lineStart = 0;
+        while (lineStart < content.Length) {
+            var lineEnd = content.Slice(lineStart).IndexOf('\n');
+            if (lineEnd < 0) {
+                lineEnd = content.Length - lineStart;
+            }
+
+            var line = content.Slice(lineStart, lineEnd).TrimStart();
+            if (TryGetFenceLanguage(line, out var fenceLanguage)) {
+                if (TryResolvePreferredVisualTypeToken(fenceLanguage, out preferredVisualType)) {
+                    return true;
+                }
+
+                if (ContainsVisualContractFenceLanguage(fenceLanguage)) {
+                    return true;
+                }
+            }
+
+            lineStart += lineEnd + 1;
+        }
+
+        return TryResolvePreferredVisualTypeFromInlineTokenSignal(value, out preferredVisualType);
+    }
+
+    private static bool ContainsVisualContractFenceLanguage(ReadOnlySpan<char> language) {
+        if (language.IsEmpty) {
+            return false;
+        }
+
         for (var i = 0; i < VisualContractFenceLanguages.Length; i++) {
-            if (ContainsFenceLanguage(value, VisualContractFenceLanguages[i])) {
+            if (language.Equals(VisualContractFenceLanguages[i].AsSpan(), StringComparison.OrdinalIgnoreCase)) {
                 return true;
             }
         }
 
-        return ContainsVisualInlineTokenSignal(value);
+        return false;
     }
 
     private static string GetSupportedProactiveVisualBlockListText() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
@@ -265,6 +265,13 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static bool ContainsVisualInlineTokenSignal(string text) {
+        return TryResolvePreferredVisualTypeFromInlineTokenSignal(text, out _);
+    }
+
+    private static bool TryResolvePreferredVisualTypeFromInlineTokenSignal(
+        string text,
+        out string preferredVisualType) {
+        preferredVisualType = string.Empty;
         if (string.IsNullOrWhiteSpace(text) || VisualContractInlineTokenSignals.Count == 0) {
             return false;
         }
@@ -301,6 +308,12 @@ internal sealed partial class ChatServiceSession {
             var content = value.Slice(contentStart, contentEnd - contentStart).Trim();
             var normalizedToken = NormalizeCompactToken(content);
             if (normalizedToken.Length > 0 && VisualContractInlineTokenSignals.Contains(normalizedToken)) {
+                if (!PreferredVisualTypeByToken.TryGetValue(normalizedToken, out var resolvedPreferredVisualType)
+                    || string.IsNullOrWhiteSpace(resolvedPreferredVisualType)) {
+                    preferredVisualType = string.Empty;
+                } else {
+                    preferredVisualType = resolvedPreferredVisualType;
+                }
                 return true;
             }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -104,6 +104,21 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_KeepsExplicitAutoPreferredVisualOverrideWhenSignalExists() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            preferred_visual: auto
+            Use `visnetwork` only if required.
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: auto", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_UsesStructuredMaxNewVisualsOverride() {
         var request = """
             [Proactive visualization guidance]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -570,6 +570,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("include at most one new visual block", text, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -589,6 +590,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -598,6 +600,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -607,6 +610,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-chart", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -616,6 +620,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: mermaid", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -625,6 +630,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -639,6 +645,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -653,6 +660,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -662,6 +670,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- infer `preferred_visual` from structured visual contract signals (fence language and backticked inline tokens) instead of leaving it on `auto`
- normalize inferred aliases via the visual catalog (`visnetwork` -> `ix-network`, `chart` -> `ix-chart`, `diagram` -> `mermaid`, `markdown-table` -> `table`)
- keep explicit structured overrides authoritative (`preferred_visual: auto` still suppresses new visual insertion)
- extend chat routing tests to verify inferred preferred visual output for network/chart/diagram/table signals and explicit-auto precedence

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_AllowsVisualsFor|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_KeepsExplicitAutoPreferredVisualOverrideWhenSignalExists|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_PreservesExplicitAutoPreferredVisualOverride" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\
