### PR TITLE
Chat: derive EVTX access-denied fallback source eligibility from metadata

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -311,12 +311,14 @@ internal sealed partial class ChatServiceSession {
                 || packContract.FallbackTools.Length == 0) {
                 continue;
             }
+            TryGetToolDefinitionByName(toolDefinitions, sourceTool, out var sourceToolDefinition);
 
             var hasPartialScopeHints = TryReadDiscoveryPartialScopeHints(output.Output, out var partialScopeHints, out var partialScopeReason);
             if (!hasPartialScopeHints) {
                 if (!TryReadPackCapabilityErrorFallbackHints(
                         sourcePackId: sourcePackId,
                         sourceTool: sourceTool,
+                        sourceToolDefinition: sourceToolDefinition,
                         output: output,
                         toolOutputs: toolOutputs,
                         userRequest: userRequest,
@@ -339,7 +341,6 @@ internal sealed partial class ChatServiceSession {
             if (!hasFallbackHints && !hasSourceFailureSignal) {
                 continue;
             }
-            TryGetToolDefinitionByName(toolDefinitions, sourceTool, out var sourceToolDefinition);
 
             if (TryBuildCrossDomainControllerDiscoveryFirstFallbackToolCall(
                     toolDefinitions: toolDefinitions,
@@ -1311,6 +1312,7 @@ internal sealed partial class ChatServiceSession {
     private static bool TryReadPackCapabilityErrorFallbackHints(
         string sourcePackId,
         string sourceTool,
+        ToolDefinition? sourceToolDefinition,
         ToolOutputDto output,
         IReadOnlyList<ToolOutputDto> toolOutputs,
         string? userRequest,
@@ -1324,10 +1326,7 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (!string.Equals(sourceTool, "eventlog_evtx_find", StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(sourceTool, "eventlog_evtx_query", StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(sourceTool, "eventlog_evtx_stats", StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(sourceTool, "eventlog_evtx_security_summary", StringComparison.OrdinalIgnoreCase)) {
+        if (!IsSourceToolEligibleForEvtxAccessDeniedFallback(sourceTool, sourceToolDefinition)) {
             reason = "source_tool_not_evtx";
             return false;
         }
@@ -1361,6 +1360,23 @@ internal sealed partial class ChatServiceSession {
 
         reason = "evtx_access_denied_live_query_fallback";
         return true;
+    }
+
+    private static bool IsSourceToolEligibleForEvtxAccessDeniedFallback(
+        string sourceTool,
+        ToolDefinition? sourceToolDefinition) {
+        if (!TryResolveSourceRoutingInfo(sourceTool, sourceToolDefinition, out var routingInfo)
+            || !IsCrossHostFallbackReadOnlyOperation(routingInfo.Operation)) {
+            return false;
+        }
+
+        var scope = (routingInfo.Scope ?? string.Empty).Trim();
+        if (string.Equals(scope, "file", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        var normalizedSourceTool = (sourceTool ?? string.Empty).Trim();
+        return normalizedSourceTool.IndexOf("_evtx_", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private static void CopyHintIfPresent(JsonObject source, JsonObject destination, string propertyName) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -1331,6 +1331,113 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsEventlogLiveQueryFallbackFromMetadataEligibleEvtxSource() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_custom_evtx_query"] = "eventlog";
+        packMap["eventlog_live_query"] = "eventlog";
+
+        var sourceSchema = ToolSchema.Object(
+                ("path", ToolSchema.String("Path to the .evtx file.")))
+            .Required("path")
+            .NoAdditionalProperties();
+        var liveQuerySchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")),
+                ("log_name", ToolSchema.String("log name")))
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_custom_evtx_query", "custom evtx query", sourceSchema),
+            new("eventlog_live_query", "live query", liveQuerySchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-evtx-meta",
+                Name = "eventlog_custom_evtx_query",
+                ArgumentsJson = """{"path":"C:\\Logs\\System.evtx"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-evtx-meta",
+                Output = """{"ok":false,"error_code":"access_denied"}""",
+                Ok = false,
+                ErrorCode = "access_denied"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_live_query"] = false
+        };
+
+        var args = new object?[] {
+            toolDefinitions,
+            toolCalls,
+            toolOutputs,
+            "Can you check AD0 for reboot evidence?",
+            mutabilityHints,
+            null,
+            null
+        };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("eventlog_live_query", toolCall.Name);
+        Assert.Contains("\"machine_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildEventlogLiveQueryFallbackFromEventlogPackInfoFailure() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_custom_pack_info"] = "eventlog";
+        packMap["eventlog_live_query"] = "eventlog";
+
+        var schema = ToolSchema.Object().NoAdditionalProperties();
+        var liveQuerySchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")))
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_custom_pack_info", "custom pack info", schema),
+            new("eventlog_live_query", "live query", liveQuerySchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-evtx-guide",
+                Name = "eventlog_custom_pack_info"
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-evtx-guide",
+                Output = """{"ok":false,"error_code":"access_denied"}""",
+                Ok = false,
+                ErrorCode = "access_denied"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_live_query"] = false
+        };
+
+        var args = new object?[] {
+            toolDefinitions,
+            toolCalls,
+            toolOutputs,
+            "Can you check AD0 for reboot evidence?",
+            mutabilityHints,
+            null,
+            null
+        };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Equal("pack_contract_no_applicable_fallback", Assert.IsType<string>(args[6]));
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_ResolvesHostHintAgainstPriorDiscoveryOutputs() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));


### PR DESCRIPTION
## Summary
- replace hardcoded EventLog EVTX source-tool allowlist in EVTX access-denied fallback with metadata-driven eligibility
- gate eligibility via source routing metadata (`ToolSelectionMetadata.ResolveRouting`) + read-only operation checks
- keep EVTX-specific behavior by accepting file-scope tools and `_evtx_` tool families, while excluding guide/pack-info sources
- add replay contract tests for custom EVTX source names and explicit pack-info exclusion

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "TryBuildPackCapabilityFallbackToolCall_" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\
