### PR TITLE
Chat: derive cross-host candidate selection from routing metadata

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -777,30 +777,16 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        const string candidateTool = "system_info";
-        if (priorCalledTools.Contains(candidateTool)) {
-            reason = "cross_host_system_baseline_candidate_already_called";
-            return false;
-        }
-
-        if (!TryGetToolDefinitionByName(toolDefinitions, candidateTool, out var toolDefinition)) {
+        if (!TryResolveCrossPackCandidateToolByRouting(
+                toolDefinitions: toolDefinitions,
+                priorCalledTools: priorCalledTools,
+                targetPackId: "system",
+                preferredScope: "host",
+                preferredOperation: ToolRoutingTaxonomy.OperationRead,
+                mutatingToolHintsByName: mutatingToolHintsByName,
+                out var candidateTool,
+                out var toolDefinition)) {
             reason = "cross_host_system_baseline_candidate_unavailable";
-            return false;
-        }
-
-        if (!_toolPackIdsByToolName.TryGetValue(candidateTool, out var candidatePackIdRaw)
-            || !PackIdMatches(candidatePackIdRaw, "system")) {
-            reason = "cross_host_system_baseline_candidate_not_in_system_pack";
-            return false;
-        }
-
-        var mutability = ResolveStructuredNextActionMutability(
-            declaredMutability: ActionMutability.Unknown,
-            toolName: candidateTool,
-            toolDefinition: toolDefinition,
-            mutatingToolHintsByName: mutatingToolHintsByName);
-        if (mutability != ActionMutability.ReadOnly) {
-            reason = "cross_host_system_baseline_candidate_not_read_only";
             return false;
         }
 
@@ -810,8 +796,10 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        var fallbackArguments = new JsonObject(StringComparer.Ordinal)
-            .Add("computer_name", computerName);
+        var fallbackArguments = new JsonObject(StringComparer.Ordinal);
+        if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, computerName, "computer_name", "machine_name", "host", "target", "name")) {
+            fallbackArguments.Add("computer_name", computerName);
+        }
         var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
         if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
             || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
@@ -944,7 +932,10 @@ internal sealed partial class ChatServiceSession {
             if (ToolDefinitionHasInputProperty(candidateDefinition, "name")
                 || ToolDefinitionHasInputProperty(candidateDefinition, "target")
                 || ToolDefinitionHasInputProperty(candidateDefinition, "domain")
-                || ToolDefinitionHasInputProperty(candidateDefinition, "host")) {
+                || ToolDefinitionHasInputProperty(candidateDefinition, "host")
+                || ToolDefinitionHasInputProperty(candidateDefinition, "computer_name")
+                || ToolDefinitionHasInputProperty(candidateDefinition, "machine_name")
+                || ToolDefinitionHasInputProperty(candidateDefinition, "log_name")) {
                 score += 50;
             }
 
@@ -1114,30 +1105,16 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        const string candidateTool = "eventlog_live_query";
-        if (priorCalledTools.Contains(candidateTool)) {
-            reason = "cross_host_eventlog_evidence_candidate_already_called";
-            return false;
-        }
-
-        if (!TryGetToolDefinitionByName(toolDefinitions, candidateTool, out var toolDefinition)) {
+        if (!TryResolveCrossPackCandidateToolByRouting(
+                toolDefinitions: toolDefinitions,
+                priorCalledTools: priorCalledTools,
+                targetPackId: "eventlog",
+                preferredScope: "host",
+                preferredOperation: "query",
+                mutatingToolHintsByName: mutatingToolHintsByName,
+                out var candidateTool,
+                out var toolDefinition)) {
             reason = "cross_host_eventlog_evidence_candidate_unavailable";
-            return false;
-        }
-
-        if (!_toolPackIdsByToolName.TryGetValue(candidateTool, out var candidatePackIdRaw)
-            || !PackIdMatches(candidatePackIdRaw, "eventlog")) {
-            reason = "cross_host_eventlog_evidence_candidate_not_in_eventlog_pack";
-            return false;
-        }
-
-        var mutability = ResolveStructuredNextActionMutability(
-            declaredMutability: ActionMutability.Unknown,
-            toolName: candidateTool,
-            toolDefinition: toolDefinition,
-            mutatingToolHintsByName: mutatingToolHintsByName);
-        if (mutability != ActionMutability.ReadOnly) {
-            reason = "cross_host_eventlog_evidence_candidate_not_read_only";
             return false;
         }
 
@@ -1147,10 +1124,16 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        var fallbackArguments = new JsonObject(StringComparer.Ordinal)
-            .Add("machine_name", machineName)
-            .Add("log_name", "System")
-            .Add("max_events", 200);
+        var fallbackArguments = new JsonObject(StringComparer.Ordinal);
+        if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, machineName, "machine_name", "computer_name", "host", "target", "name")) {
+            fallbackArguments.Add("machine_name", machineName);
+        }
+        if (ToolDefinitionHasInputProperty(toolDefinition, "log_name")) {
+            fallbackArguments.Add("log_name", "System");
+        }
+        if (ToolDefinitionHasInputProperty(toolDefinition, "max_events")) {
+            fallbackArguments.Add("max_events", 200);
+        }
         var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
         if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
             || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -1005,6 +1005,56 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostEventlogEvidenceWithCustomCandidateName() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_inventory_query"] = "computerx";
+        packMap["eventlog_host_query_custom"] = "eventlog";
+
+        var systemSchema = ToolSchema.Object(
+                ("computer_name", ToolSchema.String("computer name")))
+            .NoAdditionalProperties();
+        var eventlogSchema = ToolSchema.Object(
+                ("host", ToolSchema.String("host")),
+                ("log_name", ToolSchema.String("log name")))
+            .Required("host")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("system_inventory_query", "system inventory query", systemSchema),
+            new("eventlog_host_query_custom", "eventlog host query custom", eventlogSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-sys-custom",
+                Name = "system_inventory_query",
+                ArgumentsJson = """{"computer_name":"AD0"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-sys-custom",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_host_query_custom"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("eventlog_host_query_custom", toolCall.Name);
+        Assert.Contains("\"host\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"log_name\":\"System\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossHostEventlogEvidenceFromSystemPackInfoFailure() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
@@ -1288,6 +1338,54 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Equal("system_info", toolCall.Name);
         Assert.Contains("\"computer_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("cross_host_system_baseline", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostSystemBaselineWithCustomCandidateName() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_named_events_query"] = "eventlog";
+        packMap["system_host_inventory_custom"] = "computerx";
+
+        var eventlogSchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")))
+            .NoAdditionalProperties();
+        var systemSchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")))
+            .Required("machine_name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_named_events_query", "named events query", eventlogSchema),
+            new("system_host_inventory_custom", "system host inventory custom", systemSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-ev-custom",
+                Name = "eventlog_named_events_query",
+                ArgumentsJson = """{"machine_name":"AD0"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ev-custom",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_host_inventory_custom"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("system_host_inventory_custom", toolCall.Name);
+        Assert.Contains("\"machine_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- replace hardcoded cross-host candidate tool names (`system_info`, `eventlog_live_query`) with metadata-driven target-pack selection
- reuse routing-based candidate ranking (scope/operation/read-only/schema-fit) so new System/EventLog tools can be selected without code changes
- keep host hint handling resilient by writing to supported candidate schema keys (`computer_name`/`machine_name`/`host`/`target`/`name`)
- keep EventLog defaults opportunistic (`log_name=System`, `max_events=200`) only when candidate schema supports them
- add replay tests proving custom cross-host candidate names are selected in both directions

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "TryBuildPackCapabilityFallbackToolCall_" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\
