### PR TITLE
Chat: use metadata-ranked candidates for cross-DC fallback

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -13,6 +13,9 @@ internal sealed partial class ChatServiceSession {
     private readonly record struct PackCapabilityFallbackContract(
         string PackId,
         string[] FallbackTools);
+    private readonly record struct CrossPackFallbackCandidate(
+        string ToolName,
+        ToolDefinition Definition);
 
     private void RebuildPackCapabilityFallbackContracts(IReadOnlyList<ToolDefinition> definitions) {
         _packCapabilityFallbackContractsByPackId.Clear();
@@ -511,29 +514,26 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        for (var i = 0; i < adContract.FallbackTools.Length; i++) {
-            var candidateTool = adContract.FallbackTools[i];
-            if (priorCalledTools.Contains(candidateTool)) {
-                continue;
-            }
+        if (adContract.FallbackTools.Length == 0) {
+            reason = "cross_dc_discovery_pack_unavailable";
+            return false;
+        }
 
-            if (!TryGetToolDefinitionByName(toolDefinitions, candidateTool, out var toolDefinition)) {
-                continue;
-            }
+        if (!TryResolveCrossPackCandidateToolsByRouting(
+                toolDefinitions: toolDefinitions,
+                priorCalledTools: priorCalledTools,
+                targetPackId: "active_directory",
+                preferredScope: "domain",
+                preferredOperation: "discover",
+                mutatingToolHintsByName: mutatingToolHintsByName,
+                out var candidates)) {
+            reason = "cross_dc_discovery_first_no_ad_candidate";
+            return false;
+        }
 
-            if (!_toolPackIdsByToolName.TryGetValue(candidateTool, out var candidatePackIdRaw)
-                || !PackIdMatches(candidatePackIdRaw, "active_directory")) {
-                continue;
-            }
-
-            var mutability = ResolveStructuredNextActionMutability(
-                declaredMutability: ActionMutability.Unknown,
-                toolName: candidateTool,
-                toolDefinition: toolDefinition,
-                mutatingToolHintsByName: mutatingToolHintsByName);
-            if (mutability != ActionMutability.ReadOnly) {
-                continue;
-            }
+        for (var i = 0; i < candidates.Count; i++) {
+            var candidateTool = candidates[i].ToolName;
+            var toolDefinition = candidates[i].Definition;
 
             var fallbackArguments = BuildPackFallbackArguments(
                 sourcePackId: NormalizePackId("active_directory"),
@@ -873,7 +873,34 @@ internal sealed partial class ChatServiceSession {
         candidateTool = string.Empty;
         toolDefinition = null!;
 
-        var bestScore = int.MinValue;
+        if (!TryResolveCrossPackCandidateToolsByRouting(
+                toolDefinitions: toolDefinitions,
+                priorCalledTools: priorCalledTools,
+                targetPackId: targetPackId,
+                preferredScope: preferredScope,
+                preferredOperation: preferredOperation,
+                mutatingToolHintsByName: mutatingToolHintsByName,
+                out var candidates)
+            || candidates.Count == 0) {
+            return false;
+        }
+
+        candidateTool = candidates[0].ToolName;
+        toolDefinition = candidates[0].Definition;
+        return true;
+    }
+
+    private bool TryResolveCrossPackCandidateToolsByRouting(
+        IReadOnlyList<ToolDefinition> toolDefinitions,
+        IReadOnlySet<string> priorCalledTools,
+        string targetPackId,
+        string preferredScope,
+        string preferredOperation,
+        IReadOnlyDictionary<string, bool>? mutatingToolHintsByName,
+        out IReadOnlyList<CrossPackFallbackCandidate> candidates) {
+        candidates = Array.Empty<CrossPackFallbackCandidate>();
+
+        var rankedCandidates = new List<(CrossPackFallbackCandidate Candidate, int Score)>(toolDefinitions.Count);
         for (var i = 0; i < toolDefinitions.Count; i++) {
             var candidateDefinition = toolDefinitions[i];
             var name = (candidateDefinition.Name ?? string.Empty).Trim();
@@ -919,6 +946,17 @@ internal sealed partial class ChatServiceSession {
             } else if (string.Equals(preferredOperation, "query", StringComparison.OrdinalIgnoreCase)
                        && string.Equals(operation, "probe", StringComparison.OrdinalIgnoreCase)) {
                 score += 120;
+            } else if (string.Equals(preferredOperation, "discover", StringComparison.OrdinalIgnoreCase)
+                       && (string.Equals(operation, "query", StringComparison.OrdinalIgnoreCase)
+                           || string.Equals(operation, "list", StringComparison.OrdinalIgnoreCase)
+                           || string.Equals(operation, "search", StringComparison.OrdinalIgnoreCase)
+                           || string.Equals(operation, ToolRoutingTaxonomy.OperationRead, StringComparison.OrdinalIgnoreCase))) {
+                score += 120;
+            } else if ((string.Equals(preferredOperation, "query", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(preferredOperation, "list", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(preferredOperation, "search", StringComparison.OrdinalIgnoreCase))
+                       && string.Equals(operation, "discover", StringComparison.OrdinalIgnoreCase)) {
+                score += 120;
             }
 
             if (TryGetToolRequiredArgumentCount(candidateDefinition, out var requiredArgumentCount)) {
@@ -939,22 +977,37 @@ internal sealed partial class ChatServiceSession {
                 score += 50;
             }
 
-            if (score < bestScore) {
-                continue;
-            }
-
-            if (score == bestScore
-                && candidateTool.Length > 0
-                && StringComparer.OrdinalIgnoreCase.Compare(name, candidateTool) >= 0) {
-                continue;
-            }
-
-            bestScore = score;
-            candidateTool = name;
-            toolDefinition = candidateDefinition;
+            rankedCandidates.Add((new CrossPackFallbackCandidate(name, candidateDefinition), score));
         }
 
-        return candidateTool.Length > 0;
+        if (rankedCandidates.Count == 0) {
+            return false;
+        }
+
+        rankedCandidates.Sort(static (left, right) => {
+            var scoreCompare = right.Score.CompareTo(left.Score);
+            if (scoreCompare != 0) {
+                return scoreCompare;
+            }
+
+            return StringComparer.OrdinalIgnoreCase.Compare(left.Candidate.ToolName, right.Candidate.ToolName);
+        });
+
+        var orderedCandidates = new List<CrossPackFallbackCandidate>(rankedCandidates.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < rankedCandidates.Count; i++) {
+            var candidate = rankedCandidates[i].Candidate;
+            if (seen.Add(candidate.ToolName)) {
+                orderedCandidates.Add(candidate);
+            }
+        }
+
+        if (orderedCandidates.Count == 0) {
+            return false;
+        }
+
+        candidates = orderedCandidates;
+        return true;
     }
 
     private static bool TryResolveCrossPublicRoutingPreference(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -1192,6 +1192,115 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_PrefersCustomAdDiscoveryCandidateBeforeCrossDcEventlogFanOut() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_live_stats"] = "eventlog";
+        packMap["eventlog_live_query"] = "eventlog";
+        packMap["ad_dc_fabric_discover"] = "active_directory";
+
+        var schema = ToolSchema.Object().NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_live_stats", "live stats", schema),
+            new("eventlog_live_query", "live query", schema),
+            new("ad_dc_fabric_discover", "custom scope", schema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() { CallId = "call-ev", Name = "eventlog_live_stats" }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ev",
+                Output = """
+                         {"ok":true,"discovery_status":{"limited_discovery":true,"machine_name":"AD0","domain_name":"ad.evotec.xyz"}}
+                         """,
+                Ok = true
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_live_query"] = false,
+            ["ad_dc_fabric_discover"] = false
+        };
+
+        var args = new object?[] {
+            toolDefinitions,
+            toolCalls,
+            toolOutputs,
+            "Could you check other domain controllers for the same issue?",
+            mutabilityHints,
+            null,
+            null
+        };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("ad_dc_fabric_discover", toolCall.Name);
+        Assert.Contains("cross_dc_discovery_first", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_SkipsAdPackInfoWhenCrossDcDiscoveryCandidatesAreNotViable() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_live_stats"] = "eventlog";
+        packMap["eventlog_live_query"] = "eventlog";
+        packMap["ad_discovery_requires_token"] = "active_directory";
+        packMap["ad_custom_pack_info"] = "active_directory";
+
+        var schema = ToolSchema.Object().NoAdditionalProperties();
+        var adSchema = ToolSchema.Object(
+                ("tenant_token", ToolSchema.String("tenant token")))
+            .Required("tenant_token")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_live_stats", "live stats", schema),
+            new("eventlog_live_query", "live query", schema),
+            new("ad_discovery_requires_token", "custom discovery", adSchema),
+            new("ad_custom_pack_info", "custom pack info", schema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() { CallId = "call-ev", Name = "eventlog_live_stats" }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ev",
+                Output = """
+                         {"ok":true,"discovery_status":{"limited_discovery":true,"machine_name":"AD0","domain_name":"ad.evotec.xyz"}}
+                         """,
+                Ok = true
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_live_query"] = false,
+            ["ad_discovery_requires_token"] = false,
+            ["ad_custom_pack_info"] = false
+        };
+
+        var args = new object?[] {
+            toolDefinitions,
+            toolCalls,
+            toolOutputs,
+            "Could you check other domain controllers for the same issue?",
+            mutabilityHints,
+            null,
+            null
+        };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("eventlog_live_query", toolCall.Name);
+        Assert.DoesNotContain("cross_dc_discovery_first", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_KeepsHostScopedEventlogFallbackWhenRequestIsHostTargeted() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));


### PR DESCRIPTION
## Summary
- refactor cross-domain-controller discovery-first fallback to use metadata-ranked cross-pack candidates instead of contract-order iteration
- reuse a shared candidate enumeration helper and keep `TryResolveCrossPackCandidateToolByRouting` as the first-candidate wrapper
- exclude hintless `*_pack_info` tools from cross-DC discovery-first selection, so we only run actual discovery-style AD candidates
- add replay regression tests for custom AD discovery candidates and for skipping AD pack-info when discovery candidates are not viable

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "TryBuildPackCapabilityFallbackToolCall_" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\
