### PR TITLE
Chat: hydrate fallback hints from schema-supported keys

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -451,6 +451,7 @@ internal sealed partial class ChatServiceSession {
                     sourcePackId: sourcePackId,
                     candidateTool: candidateTool,
                     partialScopeHints: partialScopeHints);
+                AddSchemaAwareFallbackHintArguments(toolDefinition, fallbackArguments, partialScopeHints);
                 var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
                 if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
                     || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
@@ -539,6 +540,7 @@ internal sealed partial class ChatServiceSession {
                 sourcePackId: NormalizePackId("active_directory"),
                 candidateTool: candidateTool,
                 partialScopeHints: partialScopeHints);
+            AddSchemaAwareFallbackHintArguments(toolDefinition, fallbackArguments, partialScopeHints);
             var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
             if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
                 || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
@@ -1437,6 +1439,71 @@ internal sealed partial class ChatServiceSession {
         }
 
         return args;
+    }
+
+    private static void AddSchemaAwareFallbackHintArguments(
+        ToolDefinition toolDefinition,
+        JsonObject arguments,
+        JsonObject partialScopeHints) {
+        TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "domain_name", "domain_name", "dns_domain_name", "domain");
+        TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "domain", "domain", "domain_name", "dns_domain_name");
+        TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "dns_domain_name", "dns_domain_name", "domain_name", "domain");
+        TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "forest_name", "forest_name", "forest_dns_name");
+        TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "forest_dns_name", "forest_dns_name", "forest_name");
+        TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "machine_name", "machine_name", "computer_name", "host");
+        TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "computer_name", "computer_name", "machine_name", "host");
+        TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "host", "host", "machine_name", "computer_name");
+        TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "name", "name", "target", "domain_name", "domain", "host", "machine_name", "computer_name");
+        TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "target", "target", "host", "name", "machine_name", "computer_name", "domain_name", "domain");
+        TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "log_name", "log_name");
+        TryAddSchemaAwareBooleanHintArgument(toolDefinition, arguments, partialScopeHints, "include_trusts", "include_trusts");
+        TryAddSchemaAwareBooleanHintArgument(toolDefinition, arguments, partialScopeHints, "include_forest_domains", "include_forest_domains");
+    }
+
+    private static void TryAddSchemaAwareStringHintArgument(
+        ToolDefinition toolDefinition,
+        JsonObject arguments,
+        JsonObject partialScopeHints,
+        string argumentName,
+        params string[] hintKeys) {
+        if (arguments.TryGetValue(argumentName, out _)
+            || !ToolDefinitionHasInputProperty(toolDefinition, argumentName)) {
+            return;
+        }
+
+        for (var i = 0; i < hintKeys.Length; i++) {
+            var hintKey = (hintKeys[i] ?? string.Empty).Trim();
+            if (hintKey.Length == 0) {
+                continue;
+            }
+
+            var value = ReadNonEmptyHint(partialScopeHints, hintKey);
+            if (string.IsNullOrWhiteSpace(value)) {
+                continue;
+            }
+
+            arguments[argumentName] = JsonValue.From(value);
+            return;
+        }
+    }
+
+    private static void TryAddSchemaAwareBooleanHintArgument(
+        ToolDefinition toolDefinition,
+        JsonObject arguments,
+        JsonObject partialScopeHints,
+        string argumentName,
+        string hintKey) {
+        if (arguments.TryGetValue(argumentName, out _)
+            || !ToolDefinitionHasInputProperty(toolDefinition, argumentName)) {
+            return;
+        }
+
+        var value = ReadHintBoolean(partialScopeHints, hintKey);
+        if (!value.HasValue) {
+            return;
+        }
+
+        arguments[argumentName] = JsonValue.From(value.Value);
     }
 
     private static bool TryReadPackCapabilityErrorFallbackHints(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -87,6 +87,47 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCustomAdFallbackUsingSchemaAwareDomainHint() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["ad_environment_discover"] = "active_directory";
+        packMap["ad_domain_inventory_custom"] = "active_directory";
+
+        var sourceSchema = ToolSchema.Object().NoAdditionalProperties();
+        var targetSchema = ToolSchema.Object(
+                ("domain_name", ToolSchema.String("domain name")))
+            .Required("domain_name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("ad_environment_discover", "discover", sourceSchema),
+            new("ad_domain_inventory_custom", "custom ad inventory", targetSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() { CallId = "call-ad", Name = "ad_environment_discover" }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ad",
+                Output = """{"ok":true,"discovery_status":{"limited_discovery":true,"domain_name":"contoso.local"}}""",
+                Ok = true
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["ad_domain_inventory_custom"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue AD discovery", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("ad_domain_inventory_custom", toolCall.Name);
+        Assert.Contains("\"domain_name\":\"contoso.local\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsDynamicPackInfoFallbackForNonHardcodedPackId() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
@@ -1239,6 +1280,62 @@ public sealed partial class ChatServiceRoutingTrimTests {
         var toolCall = Assert.IsType<ToolCall>(args[5]);
         var reason = Assert.IsType<string>(args[6]);
         Assert.Equal("ad_dc_fabric_discover", toolCall.Name);
+        Assert.Contains("cross_dc_discovery_first", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_PrefersCustomAdDiscoveryRequiringDomainHintBeforeCrossDcEventlogFanOut() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_live_stats"] = "eventlog";
+        packMap["eventlog_live_query"] = "eventlog";
+        packMap["ad_dc_discovery_custom"] = "active_directory";
+
+        var schema = ToolSchema.Object().NoAdditionalProperties();
+        var adSchema = ToolSchema.Object(
+                ("domain_name", ToolSchema.String("domain name")))
+            .Required("domain_name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_live_stats", "live stats", schema),
+            new("eventlog_live_query", "live query", schema),
+            new("ad_dc_discovery_custom", "custom scope", adSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() { CallId = "call-ev", Name = "eventlog_live_stats" }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ev",
+                Output = """
+                         {"ok":true,"discovery_status":{"limited_discovery":true,"machine_name":"AD0","domain_name":"ad.evotec.xyz"}}
+                         """,
+                Ok = true
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_live_query"] = false,
+            ["ad_dc_discovery_custom"] = false
+        };
+
+        var args = new object?[] {
+            toolDefinitions,
+            toolCalls,
+            toolOutputs,
+            "Could you check other domain controllers for the same issue?",
+            mutabilityHints,
+            null,
+            null
+        };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("ad_dc_discovery_custom", toolCall.Name);
+        Assert.Contains("\"domain_name\":\"ad.evotec.xyz\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("cross_dc_discovery_first", reason, StringComparison.OrdinalIgnoreCase);
     }
 


### PR DESCRIPTION
## Summary
- add schema-aware fallback hint hydration so fallback arguments can be populated for custom tools based on their declared input properties (instead of only hardcoded tool-name branches)
- apply schema-aware hydration in both the generic pack fallback path and the cross-DC AD discovery-first path
- keep existing pack-specific defaults intact while filling missing values for keys like domain_name/domain/host/machine_name/target/name/log_name and selected booleans
- add replay regressions for custom AD fallback tools that require domain_name (same-pack AD fallback and cross-DC fallback)

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "TryBuildPackCapabilityFallbackToolCall_" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\
