### PR TITLE
Chat: continue cross-pack fallbacks across ranked candidates

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -599,15 +599,14 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (!TryResolveCrossPackCandidateToolByRouting(
+        if (!TryResolveCrossPackCandidateToolsByRouting(
                 toolDefinitions: toolDefinitions,
                 priorCalledTools: priorCalledTools,
                 targetPackId: "dnsclientx",
                 preferredScope: preferredScope,
                 preferredOperation: preferredOperation,
                 mutatingToolHintsByName: mutatingToolHintsByName,
-                out var candidateTool,
-                out var toolDefinition)) {
+                out var candidates)) {
             reason = "cross_public_dns_candidate_unavailable";
             return false;
         }
@@ -618,46 +617,54 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        var fallbackArguments = new JsonObject(StringComparer.Ordinal);
         var preferTarget = string.Equals(preferredScope, "host", StringComparison.OrdinalIgnoreCase)
                            || string.Equals(preferredOperation, "probe", StringComparison.OrdinalIgnoreCase);
-        if (preferTarget) {
-            if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, name, "target", "host", "name", "domain")) {
-                fallbackArguments.Add("target", name);
+        for (var i = 0; i < candidates.Count; i++) {
+            var candidateTool = candidates[i].ToolName;
+            var toolDefinition = candidates[i].Definition;
+
+            var fallbackArguments = new JsonObject(StringComparer.Ordinal);
+            if (preferTarget) {
+                if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, name, "target", "host", "name", "domain")) {
+                    fallbackArguments.Add("target", name);
+                }
+            } else {
+                if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, name, "name", "domain", "host", "target")) {
+                    fallbackArguments.Add("name", name);
+                }
             }
-        } else {
-            if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, name, "name", "domain", "host", "target")) {
-                fallbackArguments.Add("name", name);
+
+            var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
+            if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
+                || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
+                continue;
             }
-        }
-        var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
-        if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
-            || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
-            reason = "cross_public_dns_candidate_missing_required_args";
-            return false;
+
+            var serializedArguments = JsonLite.Serialize(normalizedArguments);
+            var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
+            var raw = new JsonObject()
+                .Add("type", "tool_call")
+                .Add("call_id", fallbackCallId)
+                .Add("name", candidateTool)
+                .Add("arguments", serializedArguments);
+
+            toolCall = new ToolCall(
+                callId: fallbackCallId,
+                name: candidateTool,
+                input: serializedArguments,
+                arguments: normalizedArguments,
+                raw: raw);
+            reason = "pack_contract_cross_public_dns_evidence:"
+                     + sourcePackId
+                     + ":"
+                     + partialScopeReason
+                     + "->"
+                     + candidateTool;
+            return true;
         }
 
-        var serializedArguments = JsonLite.Serialize(normalizedArguments);
-        var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
-        var raw = new JsonObject()
-            .Add("type", "tool_call")
-            .Add("call_id", fallbackCallId)
-            .Add("name", candidateTool)
-            .Add("arguments", serializedArguments);
-
-        toolCall = new ToolCall(
-            callId: fallbackCallId,
-            name: candidateTool,
-            input: serializedArguments,
-            arguments: normalizedArguments,
-            raw: raw);
-        reason = "pack_contract_cross_public_dns_evidence:"
-                 + sourcePackId
-                 + ":"
-                 + partialScopeReason
-                 + "->"
-                 + candidateTool;
-        return true;
+        reason = "cross_public_dns_candidate_missing_required_args";
+        return false;
     }
 
     private bool TryBuildCrossPublicDomainPostureFallbackToolCall(
@@ -686,70 +693,79 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (!TryResolveCrossPackCandidateToolByRouting(
+        if (!TryResolveCrossPackCandidateToolsByRouting(
                 toolDefinitions: toolDefinitions,
                 priorCalledTools: priorCalledTools,
                 targetPackId: "domaindetective",
                 preferredScope: preferredScope,
                 preferredOperation: preferredOperation,
                 mutatingToolHintsByName: mutatingToolHintsByName,
-                out var candidateTool,
-                out var toolDefinition)) {
+                out var candidates)) {
             reason = "cross_public_domain_candidate_unavailable";
             return false;
         }
 
-        var fallbackArguments = new JsonObject(StringComparer.Ordinal);
         var preferHostScope = string.Equals(preferredScope, "host", StringComparison.OrdinalIgnoreCase)
                               || string.Equals(preferredOperation, "probe", StringComparison.OrdinalIgnoreCase);
+        string fallbackValue;
+        string[] preferredKeys;
         if (preferHostScope) {
             var host = ResolveDnsClientXNameHint(partialScopeHints);
             if (string.IsNullOrWhiteSpace(host)) {
                 reason = "cross_public_domain_missing_host_hint";
                 return false;
             }
-            if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, host, "host", "target", "name", "domain")) {
-                fallbackArguments.Add("host", host);
-            }
+            fallbackValue = host;
+            preferredKeys = new[] { "host", "target", "name", "domain" };
         } else {
             var domain = ResolveDomainDetectiveDomainHint(partialScopeHints);
             if (string.IsNullOrWhiteSpace(domain)) {
                 reason = "cross_public_domain_missing_domain_hint";
                 return false;
             }
-            if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, domain, "domain", "name", "host", "target")) {
-                fallbackArguments.Add("domain", domain);
+            fallbackValue = domain;
+            preferredKeys = new[] { "domain", "name", "host", "target" };
+        }
+
+        for (var i = 0; i < candidates.Count; i++) {
+            var candidateTool = candidates[i].ToolName;
+            var toolDefinition = candidates[i].Definition;
+            var fallbackArguments = new JsonObject(StringComparer.Ordinal);
+            if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, fallbackValue, preferredKeys)) {
+                fallbackArguments[preferredKeys[0]] = JsonValue.From(fallbackValue);
             }
+
+            var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
+            if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
+                || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
+                continue;
+            }
+
+            var serializedArguments = JsonLite.Serialize(normalizedArguments);
+            var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
+            var raw = new JsonObject()
+                .Add("type", "tool_call")
+                .Add("call_id", fallbackCallId)
+                .Add("name", candidateTool)
+                .Add("arguments", serializedArguments);
+
+            toolCall = new ToolCall(
+                callId: fallbackCallId,
+                name: candidateTool,
+                input: serializedArguments,
+                arguments: normalizedArguments,
+                raw: raw);
+            reason = "pack_contract_cross_public_domain_posture:"
+                     + sourcePackId
+                     + ":"
+                     + partialScopeReason
+                     + "->"
+                     + candidateTool;
+            return true;
         }
 
-        var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
-        if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
-            || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
-            reason = "cross_public_domain_candidate_missing_required_args";
-            return false;
-        }
-
-        var serializedArguments = JsonLite.Serialize(normalizedArguments);
-        var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
-        var raw = new JsonObject()
-            .Add("type", "tool_call")
-            .Add("call_id", fallbackCallId)
-            .Add("name", candidateTool)
-            .Add("arguments", serializedArguments);
-
-        toolCall = new ToolCall(
-            callId: fallbackCallId,
-            name: candidateTool,
-            input: serializedArguments,
-            arguments: normalizedArguments,
-            raw: raw);
-        reason = "pack_contract_cross_public_domain_posture:"
-                 + sourcePackId
-                 + ":"
-                 + partialScopeReason
-                 + "->"
-                 + candidateTool;
-        return true;
+        reason = "cross_public_domain_candidate_missing_required_args";
+        return false;
     }
 
     private bool TryBuildCrossHostSystemBaselineFallbackToolCall(
@@ -779,15 +795,14 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (!TryResolveCrossPackCandidateToolByRouting(
+        if (!TryResolveCrossPackCandidateToolsByRouting(
                 toolDefinitions: toolDefinitions,
                 priorCalledTools: priorCalledTools,
                 targetPackId: "system",
                 preferredScope: "host",
                 preferredOperation: ToolRoutingTaxonomy.OperationRead,
                 mutatingToolHintsByName: mutatingToolHintsByName,
-                out var candidateTool,
-                out var toolDefinition)) {
+                out var candidates)) {
             reason = "cross_host_system_baseline_candidate_unavailable";
             return false;
         }
@@ -798,38 +813,45 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        var fallbackArguments = new JsonObject(StringComparer.Ordinal);
-        if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, computerName, "computer_name", "machine_name", "host", "target", "name")) {
-            fallbackArguments.Add("computer_name", computerName);
-        }
-        var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
-        if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
-            || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
-            reason = "cross_host_system_baseline_candidate_missing_required_args";
-            return false;
+        for (var i = 0; i < candidates.Count; i++) {
+            var candidateTool = candidates[i].ToolName;
+            var toolDefinition = candidates[i].Definition;
+            var fallbackArguments = new JsonObject(StringComparer.Ordinal);
+            if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, computerName, "computer_name", "machine_name", "host", "target", "name")) {
+                fallbackArguments.Add("computer_name", computerName);
+            }
+
+            var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
+            if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
+                || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
+                continue;
+            }
+
+            var serializedArguments = JsonLite.Serialize(normalizedArguments);
+            var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
+            var raw = new JsonObject()
+                .Add("type", "tool_call")
+                .Add("call_id", fallbackCallId)
+                .Add("name", candidateTool)
+                .Add("arguments", serializedArguments);
+
+            toolCall = new ToolCall(
+                callId: fallbackCallId,
+                name: candidateTool,
+                input: serializedArguments,
+                arguments: normalizedArguments,
+                raw: raw);
+            reason = "pack_contract_cross_host_system_baseline:"
+                     + sourcePackId
+                     + ":"
+                     + partialScopeReason
+                     + "->"
+                     + candidateTool;
+            return true;
         }
 
-        var serializedArguments = JsonLite.Serialize(normalizedArguments);
-        var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
-        var raw = new JsonObject()
-            .Add("type", "tool_call")
-            .Add("call_id", fallbackCallId)
-            .Add("name", candidateTool)
-            .Add("arguments", serializedArguments);
-
-        toolCall = new ToolCall(
-            callId: fallbackCallId,
-            name: candidateTool,
-            input: serializedArguments,
-            arguments: normalizedArguments,
-            raw: raw);
-        reason = "pack_contract_cross_host_system_baseline:"
-                 + sourcePackId
-                 + ":"
-                 + partialScopeReason
-                 + "->"
-                 + candidateTool;
-        return true;
+        reason = "cross_host_system_baseline_candidate_missing_required_args";
+        return false;
     }
 
     private static bool IsSourceToolEligibleForCrossHostSystemBaselineFallback(
@@ -1160,15 +1182,14 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (!TryResolveCrossPackCandidateToolByRouting(
+        if (!TryResolveCrossPackCandidateToolsByRouting(
                 toolDefinitions: toolDefinitions,
                 priorCalledTools: priorCalledTools,
                 targetPackId: "eventlog",
                 preferredScope: "host",
                 preferredOperation: "query",
                 mutatingToolHintsByName: mutatingToolHintsByName,
-                out var candidateTool,
-                out var toolDefinition)) {
+                out var candidates)) {
             reason = "cross_host_eventlog_evidence_candidate_unavailable";
             return false;
         }
@@ -1179,44 +1200,51 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        var fallbackArguments = new JsonObject(StringComparer.Ordinal);
-        if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, machineName, "machine_name", "computer_name", "host", "target", "name")) {
-            fallbackArguments.Add("machine_name", machineName);
-        }
-        if (ToolDefinitionHasInputProperty(toolDefinition, "log_name")) {
-            fallbackArguments.Add("log_name", "System");
-        }
-        if (ToolDefinitionHasInputProperty(toolDefinition, "max_events")) {
-            fallbackArguments.Add("max_events", 200);
-        }
-        var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
-        if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
-            || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
-            reason = "cross_host_eventlog_evidence_candidate_missing_required_args";
-            return false;
+        for (var i = 0; i < candidates.Count; i++) {
+            var candidateTool = candidates[i].ToolName;
+            var toolDefinition = candidates[i].Definition;
+            var fallbackArguments = new JsonObject(StringComparer.Ordinal);
+            if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, machineName, "machine_name", "computer_name", "host", "target", "name")) {
+                fallbackArguments.Add("machine_name", machineName);
+            }
+            if (ToolDefinitionHasInputProperty(toolDefinition, "log_name")) {
+                fallbackArguments.Add("log_name", "System");
+            }
+            if (ToolDefinitionHasInputProperty(toolDefinition, "max_events")) {
+                fallbackArguments.Add("max_events", 200);
+            }
+
+            var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
+            if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
+                || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
+                continue;
+            }
+
+            var serializedArguments = JsonLite.Serialize(normalizedArguments);
+            var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
+            var raw = new JsonObject()
+                .Add("type", "tool_call")
+                .Add("call_id", fallbackCallId)
+                .Add("name", candidateTool)
+                .Add("arguments", serializedArguments);
+
+            toolCall = new ToolCall(
+                callId: fallbackCallId,
+                name: candidateTool,
+                input: serializedArguments,
+                arguments: normalizedArguments,
+                raw: raw);
+            reason = "pack_contract_cross_host_eventlog_evidence:"
+                     + sourcePackId
+                     + ":"
+                     + partialScopeReason
+                     + "->"
+                     + candidateTool;
+            return true;
         }
 
-        var serializedArguments = JsonLite.Serialize(normalizedArguments);
-        var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
-        var raw = new JsonObject()
-            .Add("type", "tool_call")
-            .Add("call_id", fallbackCallId)
-            .Add("name", candidateTool)
-            .Add("arguments", serializedArguments);
-
-        toolCall = new ToolCall(
-            callId: fallbackCallId,
-            name: candidateTool,
-            input: serializedArguments,
-            arguments: normalizedArguments,
-            raw: raw);
-        reason = "pack_contract_cross_host_eventlog_evidence:"
-                 + sourcePackId
-                 + ":"
-                 + partialScopeReason
-                 + "->"
-                 + candidateTool;
-        return true;
+        reason = "cross_host_eventlog_evidence_candidate_missing_required_args";
+        return false;
     }
 
     private static string? ResolveDnsClientXNameHint(JsonObject hints) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -274,6 +274,63 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDnsClientXFallbackFromSecondCandidateWhenTopCandidateMissingRequiredArgs() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["domaindetective_domain_summary"] = "domaindetective";
+        packMap["dnsclientx_a_query_requires_ticket"] = "dnsclientx";
+        packMap["dnsclientx_b_query"] = "dnsclientx";
+
+        var sourceSchema = ToolSchema.Object(
+                ("domain", ToolSchema.String("domain")))
+            .Required("domain")
+            .NoAdditionalProperties();
+        var dnsPrimarySchema = ToolSchema.Object(
+                ("name", ToolSchema.String("name")),
+                ("ticket_id", ToolSchema.String("ticket id")))
+            .Required("ticket_id")
+            .NoAdditionalProperties();
+        var dnsSecondarySchema = ToolSchema.Object(
+                ("name", ToolSchema.String("name")))
+            .Required("name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("domaindetective_domain_summary", "domain summary", sourceSchema),
+            new("dnsclientx_a_query_requires_ticket", "dns query primary", dnsPrimarySchema),
+            new("dnsclientx_b_query", "dns query secondary", dnsSecondarySchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-dd-fallback-loop",
+                Name = "domaindetective_domain_summary",
+                ArgumentsJson = """{"domain":"contoso.com"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-dd-fallback-loop",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["dnsclientx_a_query_requires_ticket"] = false,
+            ["dnsclientx_b_query"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("dnsclientx_b_query", toolCall.Name);
+        Assert.Contains("\"name\":\"contoso.com\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDnsClientXQueryFallbackFromMetadataEligibleDomainDetectiveSource() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
@@ -568,6 +625,63 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Equal("domaindetective_domain_summary", toolCall.Name);
         Assert.Contains("\"domain\":\"contoso.com\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("cross_public_domain", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDomainDetectiveFallbackFromSecondCandidateWhenTopCandidateMissingRequiredArgs() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["dnsclientx_query"] = "dnsclientx";
+        packMap["domaindetective_a_domain_summary_requires_ticket"] = "domaindetective";
+        packMap["domaindetective_b_domain_summary"] = "domaindetective";
+
+        var sourceSchema = ToolSchema.Object(
+                ("name", ToolSchema.String("name")))
+            .Required("name")
+            .NoAdditionalProperties();
+        var primarySchema = ToolSchema.Object(
+                ("domain", ToolSchema.String("domain")),
+                ("ticket_id", ToolSchema.String("ticket id")))
+            .Required("ticket_id")
+            .NoAdditionalProperties();
+        var secondarySchema = ToolSchema.Object(
+                ("domain", ToolSchema.String("domain")))
+            .Required("domain")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("dnsclientx_query", "dns query", sourceSchema),
+            new("domaindetective_a_domain_summary_requires_ticket", "domain summary primary", primarySchema),
+            new("domaindetective_b_domain_summary", "domain summary secondary", secondarySchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-dns-fallback-loop",
+                Name = "dnsclientx_query",
+                ArgumentsJson = """{"name":"contoso.com"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-dns-fallback-loop",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["domaindetective_a_domain_summary_requires_ticket"] = false,
+            ["domaindetective_b_domain_summary"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("domaindetective_b_domain_summary", toolCall.Name);
+        Assert.Contains("\"domain\":\"contoso.com\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -992,6 +1106,62 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("\"machine_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("\"log_name\":\"System\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("cross_host_eventlog_evidence", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostEventlogEvidenceFromSecondCandidateWhenTopCandidateMissingRequiredArgs() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_info"] = "computerx";
+        packMap["eventlog_a_live_query_requires_ticket"] = "eventlog";
+        packMap["eventlog_b_live_query"] = "eventlog";
+
+        var systemSchema = ToolSchema.Object(
+                ("computer_name", ToolSchema.String("computer name")))
+            .NoAdditionalProperties();
+        var eventlogPrimarySchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")),
+                ("ticket_id", ToolSchema.String("ticket id")))
+            .Required("ticket_id")
+            .NoAdditionalProperties();
+        var eventlogSecondarySchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")))
+            .Required("machine_name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("system_info", "system info", systemSchema),
+            new("eventlog_a_live_query_requires_ticket", "eventlog query primary", eventlogPrimarySchema),
+            new("eventlog_b_live_query", "eventlog query secondary", eventlogSecondarySchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-sys-eventlog-loop",
+                Name = "system_info",
+                ArgumentsJson = """{"computer_name":"AD0"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-sys-eventlog-loop",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_a_live_query_requires_ticket"] = false,
+            ["eventlog_b_live_query"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("eventlog_b_live_query", toolCall.Name);
+        Assert.Contains("\"machine_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -1494,6 +1664,62 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Equal("system_info", toolCall.Name);
         Assert.Contains("\"computer_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("cross_host_system_baseline", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostSystemBaselineFromSecondCandidateWhenTopCandidateMissingRequiredArgs() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_live_query"] = "eventlog";
+        packMap["system_a_inventory_requires_ticket"] = "computerx";
+        packMap["system_b_info"] = "computerx";
+
+        var eventlogSchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")))
+            .NoAdditionalProperties();
+        var systemPrimarySchema = ToolSchema.Object(
+                ("computer_name", ToolSchema.String("computer name")),
+                ("ticket_id", ToolSchema.String("ticket id")))
+            .Required("ticket_id")
+            .NoAdditionalProperties();
+        var systemSecondarySchema = ToolSchema.Object(
+                ("computer_name", ToolSchema.String("computer name")))
+            .Required("computer_name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_live_query", "live query", eventlogSchema),
+            new("system_a_inventory_requires_ticket", "system inventory primary", systemPrimarySchema),
+            new("system_b_info", "system info secondary", systemSecondarySchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-ev-system-loop",
+                Name = "eventlog_live_query",
+                ArgumentsJson = """{"machine_name":"AD0"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ev-system-loop",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_a_inventory_requires_ticket"] = false,
+            ["system_b_info"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("system_b_info", toolCall.Name);
+        Assert.Contains("\"computer_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- make cross-pack fallback builders iterate ranked candidates (instead of failing after the first candidate)
- apply continuation behavior in these paths:
  - cross public DNS evidence fallback (DomainDetective -> DnsClientX)
  - cross public domain posture fallback (DnsClientX -> DomainDetective)
  - cross host system baseline fallback (EventLog -> System/ComputerX)
  - cross host EventLog evidence fallback (System/ComputerX -> EventLog)
- preserve existing ranking/scoring; only change behavior when top candidate misses required args (continue to next candidate)
- add replay tests proving fallback moves to second candidate when first requires unsupported arguments

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "TryBuildPackCapabilityFallbackToolCall_" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\
