### PR TITLE
Chat: add schema-aware fallback defaults for custom tools

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -452,6 +452,7 @@ internal sealed partial class ChatServiceSession {
                     candidateTool: candidateTool,
                     partialScopeHints: partialScopeHints);
                 AddSchemaAwareFallbackHintArguments(toolDefinition, fallbackArguments, partialScopeHints);
+                AddSchemaAwareFallbackDefaultArguments(sourcePackId, toolDefinition, fallbackArguments, partialScopeHints);
                 var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
                 if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
                     || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
@@ -541,6 +542,7 @@ internal sealed partial class ChatServiceSession {
                 candidateTool: candidateTool,
                 partialScopeHints: partialScopeHints);
             AddSchemaAwareFallbackHintArguments(toolDefinition, fallbackArguments, partialScopeHints);
+            AddSchemaAwareFallbackDefaultArguments("active_directory", toolDefinition, fallbackArguments, partialScopeHints);
             var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
             if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
                 || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
@@ -1488,6 +1490,37 @@ internal sealed partial class ChatServiceSession {
         TryAddSchemaAwareBooleanHintArgument(toolDefinition, arguments, partialScopeHints, "include_forest_domains", "include_forest_domains");
     }
 
+    private static void AddSchemaAwareFallbackDefaultArguments(
+        string sourcePackId,
+        ToolDefinition toolDefinition,
+        JsonObject arguments,
+        JsonObject partialScopeHints) {
+        if (PackIdMatches(sourcePackId, "active_directory")) {
+            var includeTrusts = ReadHintBoolean(partialScopeHints, "include_trusts") ?? true;
+            TryAddSchemaAwareStringDefaultArgument(toolDefinition, arguments, "discovery_fallback", "current_forest");
+            TryAddSchemaAwareBooleanDefaultArgument(toolDefinition, arguments, "include_forest_domains", true);
+            TryAddSchemaAwareBooleanDefaultArgument(toolDefinition, arguments, "include_trusts", includeTrusts);
+            TryAddSchemaAwareIntegerDefaultArgument(toolDefinition, arguments, "max_domain_controllers_total", 5000);
+            TryAddSchemaAwareIntegerDefaultArgument(toolDefinition, arguments, "max_domain_controllers_per_domain", 500);
+            TryAddSchemaAwareIntegerDefaultArgument(toolDefinition, arguments, "max_results", 500);
+            TryAddSchemaAwareIntegerDefaultArgument(toolDefinition, arguments, "max_issues", 2000);
+            TryAddSchemaAwareBooleanDefaultArgument(toolDefinition, arguments, "include_dns_srv_comparison", true);
+            TryAddSchemaAwareBooleanDefaultArgument(toolDefinition, arguments, "include_host_resolution", true);
+            TryAddSchemaAwareBooleanDefaultArgument(toolDefinition, arguments, "include_directory_topology", true);
+            return;
+        }
+
+        if (PackIdMatches(sourcePackId, "eventlog")) {
+            TryAddSchemaAwareIntegerDefaultArgument(toolDefinition, arguments, "max_events", 200);
+            TryAddSchemaAwareIntegerDefaultArgument(toolDefinition, arguments, "max_events_scanned", 1200);
+            return;
+        }
+
+        if (PackIdMatches(sourcePackId, "system")) {
+            TryAddSchemaAwareBooleanDefaultArgument(toolDefinition, arguments, "include_pending_local", false);
+        }
+    }
+
     private static void TryAddSchemaAwareStringHintArgument(
         ToolDefinition toolDefinition,
         JsonObject arguments,
@@ -1532,6 +1565,45 @@ internal sealed partial class ChatServiceSession {
         }
 
         arguments[argumentName] = JsonValue.From(value.Value);
+    }
+
+    private static void TryAddSchemaAwareStringDefaultArgument(
+        ToolDefinition toolDefinition,
+        JsonObject arguments,
+        string argumentName,
+        string defaultValue) {
+        if (arguments.TryGetValue(argumentName, out _)
+            || !ToolDefinitionHasInputProperty(toolDefinition, argumentName)) {
+            return;
+        }
+
+        arguments[argumentName] = JsonValue.From(defaultValue);
+    }
+
+    private static void TryAddSchemaAwareBooleanDefaultArgument(
+        ToolDefinition toolDefinition,
+        JsonObject arguments,
+        string argumentName,
+        bool defaultValue) {
+        if (arguments.TryGetValue(argumentName, out _)
+            || !ToolDefinitionHasInputProperty(toolDefinition, argumentName)) {
+            return;
+        }
+
+        arguments[argumentName] = JsonValue.From(defaultValue);
+    }
+
+    private static void TryAddSchemaAwareIntegerDefaultArgument(
+        ToolDefinition toolDefinition,
+        JsonObject arguments,
+        string argumentName,
+        int defaultValue) {
+        if (arguments.TryGetValue(argumentName, out _)
+            || !ToolDefinitionHasInputProperty(toolDefinition, argumentName)) {
+            return;
+        }
+
+        arguments[argumentName] = JsonValue.From(defaultValue);
     }
 
     private static bool TryReadPackCapabilityErrorFallbackHints(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -128,6 +128,49 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCustomAdFallbackUsingSchemaAwareDefaults() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["ad_environment_discover"] = "active_directory";
+        packMap["ad_domain_inventory_custom"] = "active_directory";
+
+        var sourceSchema = ToolSchema.Object().NoAdditionalProperties();
+        var targetSchema = ToolSchema.Object(
+                ("domain_name", ToolSchema.String("domain name")),
+                ("max_results", ToolSchema.Integer("max results")))
+            .Required("domain_name", "max_results")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("ad_environment_discover", "discover", sourceSchema),
+            new("ad_domain_inventory_custom", "custom ad inventory", targetSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() { CallId = "call-ad-defaults", Name = "ad_environment_discover" }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ad-defaults",
+                Output = """{"ok":true,"discovery_status":{"limited_discovery":true,"domain_name":"contoso.local"}}""",
+                Ok = true
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["ad_domain_inventory_custom"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue AD discovery", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("ad_domain_inventory_custom", toolCall.Name);
+        Assert.Contains("\"domain_name\":\"contoso.local\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"max_results\":500", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsDynamicPackInfoFallbackForNonHardcodedPackId() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
@@ -1506,6 +1549,64 @@ public sealed partial class ChatServiceRoutingTrimTests {
         var reason = Assert.IsType<string>(args[6]);
         Assert.Equal("ad_dc_discovery_custom", toolCall.Name);
         Assert.Contains("\"domain_name\":\"ad.evotec.xyz\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cross_dc_discovery_first", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_PrefersCustomAdDiscoveryRequiringSchemaDefaultBeforeCrossDcEventlogFanOut() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["eventlog_live_stats"] = "eventlog";
+        packMap["eventlog_live_query"] = "eventlog";
+        packMap["ad_dc_discovery_with_default_custom"] = "active_directory";
+
+        var schema = ToolSchema.Object().NoAdditionalProperties();
+        var adSchema = ToolSchema.Object(
+                ("domain_name", ToolSchema.String("domain name")),
+                ("discovery_fallback", ToolSchema.String("fallback mode")))
+            .Required("domain_name", "discovery_fallback")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("eventlog_live_stats", "live stats", schema),
+            new("eventlog_live_query", "live query", schema),
+            new("ad_dc_discovery_with_default_custom", "custom scope", adSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() { CallId = "call-ev-default", Name = "eventlog_live_stats" }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-ev-default",
+                Output = """
+                         {"ok":true,"discovery_status":{"limited_discovery":true,"machine_name":"AD0","domain_name":"ad.evotec.xyz"}}
+                         """,
+                Ok = true
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_live_query"] = false,
+            ["ad_dc_discovery_with_default_custom"] = false
+        };
+
+        var args = new object?[] {
+            toolDefinitions,
+            toolCalls,
+            toolOutputs,
+            "Could you check other domain controllers for the same issue?",
+            mutabilityHints,
+            null,
+            null
+        };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("ad_dc_discovery_with_default_custom", toolCall.Name);
+        Assert.Contains("\"domain_name\":\"ad.evotec.xyz\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"discovery_fallback\":\"current_forest\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("cross_dc_discovery_first", reason, StringComparison.OrdinalIgnoreCase);
     }
 


### PR DESCRIPTION
## Summary
- add schema-aware fallback default hydration so custom tools can receive pack-level defaults without hardcoded tool-name checks
- apply defaults in both generic same-pack fallback path and cross-DC AD discovery-first path
- current default sets include:
  - Active Directory: `discovery_fallback`, forest/discovery booleans, and AD pagination/diagnostic limits when schema supports them
  - EventLog: `max_events`, `max_events_scanned`
  - System: `include_pending_local`
- keep existing hardcoded known-tool defaults intact; new logic only fills missing schema-supported fields
- add regressions proving custom AD tools can now satisfy required `max_results` and `discovery_fallback` via defaults

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "TryBuildPackCapabilityFallbackToolCall_" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\
