### PR TITLE
chat: infer preferred visual from draft under structured visual contracts

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -301,29 +301,40 @@ internal sealed partial class ChatServiceSession {
         var hasStructuredOverrides = TryReadProactiveVisualizationOverridesFromRequestText(userRequest, out var hasAllowNewVisualsOverride,
             out var allowNewVisualsFromOverride, out var hasPreferredVisualOverride, out var preferredVisualType,
             out var hasMaxNewVisualsOverride, out var maxNewVisualsOverride);
-        var inferredPreferredVisualType = string.Empty;
-        var hasInferredPreferredVisualType = !hasPreferredVisualOverride
-                                             && TryResolvePreferredVisualTypeFromVisualContractSignal(userRequest, out inferredPreferredVisualType);
-        var hasPreferredVisualDirective = hasPreferredVisualOverride || hasInferredPreferredVisualType;
+        var inferredPreferredVisualTypeFromRequest = string.Empty;
+        var hasInferredPreferredVisualTypeFromRequest = !hasPreferredVisualOverride
+                                                        && TryResolvePreferredVisualTypeFromVisualContractSignal(userRequest, out inferredPreferredVisualTypeFromRequest);
+        var hasPreferredVisualDirectiveFromRequest = hasPreferredVisualOverride || hasInferredPreferredVisualTypeFromRequest;
         var effectivePreferredVisualType = hasPreferredVisualOverride
             ? preferredVisualType
-            : hasInferredPreferredVisualType
-                ? inferredPreferredVisualType
+            : hasInferredPreferredVisualTypeFromRequest
+                ? inferredPreferredVisualTypeFromRequest
                 : string.Empty;
         var hasExplicitAutoPreferredVisualOverride = hasPreferredVisualOverride
             && string.Equals(preferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
         var requestHasVisualContract = requestHasProactiveVisualizationMarker || requestHasVisualContractSignal || hasStructuredOverrides;
-        var hasSpecificPreferredVisualType = hasPreferredVisualDirective
+        var hasSpecificPreferredVisualTypeFromRequest = hasPreferredVisualDirectiveFromRequest
             && !string.Equals(effectivePreferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
         var baseAllowNewVisuals = hasAllowNewVisualsOverride
             ? allowNewVisualsFromOverride
             : hasExplicitAutoPreferredVisualOverride
                 ? false
-            : hasSpecificPreferredVisualType
+            : hasSpecificPreferredVisualTypeFromRequest
                 ? true
-                : hasMaxNewVisualsOverride
+            : hasMaxNewVisualsOverride
                     ? maxNewVisualsOverride > 0
                     : requestHasVisualContractSignal;
+        var hasInferredPreferredVisualTypeFromDraft = false;
+        if (baseAllowNewVisuals
+            && requestHasVisualContract
+            && !hasPreferredVisualDirectiveFromRequest
+            && TryResolvePreferredVisualTypeFromVisualContractSignal(assistantDraft, out var inferredPreferredVisualTypeFromDraft)
+            && !string.IsNullOrWhiteSpace(inferredPreferredVisualTypeFromDraft)) {
+            effectivePreferredVisualType = inferredPreferredVisualTypeFromDraft;
+            hasInferredPreferredVisualTypeFromDraft = true;
+        }
+
+        var hasPreferredVisualDirective = hasPreferredVisualDirectiveFromRequest || hasInferredPreferredVisualTypeFromDraft;
         var maxNewVisuals = hasMaxNewVisualsOverride
             ? Math.Clamp(maxNewVisualsOverride, 0, MaxSupportedProactiveVisualBlocks)
             : baseAllowNewVisuals

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualContracts.cs
@@ -89,7 +89,8 @@ internal sealed partial class ChatServiceSession {
                 break;
             }
 
-            if (TryParseStructuredAllowNewVisualsLine(line, out allowNewVisuals)) {
+            if (TryParseStructuredAllowNewVisualsLine(line, out var parsedAllowNewVisuals)) {
+                allowNewVisuals = parsedAllowNewVisuals;
                 hasAllowNewVisualsOverride = true;
                 hasAnyOverride = true;
                 continue;
@@ -102,7 +103,8 @@ internal sealed partial class ChatServiceSession {
                 continue;
             }
 
-            if (TryParseStructuredMaxNewVisualsLine(line, out maxNewVisualsOverride)) {
+            if (TryParseStructuredMaxNewVisualsLine(line, out var parsedMaxNewVisuals)) {
+                maxNewVisualsOverride = parsedMaxNewVisuals;
                 hasMaxNewVisualsOverride = true;
                 hasAnyOverride = true;
             }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -34,6 +34,47 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferPreferredVisualFromAssistantDraftWhenVisualsAreAllowed() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var draft = """
+            Current findings:
+            ```ix-network
+            {"nodes":[{"id":"AD0"}],"edges":[]}
+            ```
+            """;
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, draft);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_DoesNotInferPreferredVisualFromDraftWhenVisualsRemainDisabled() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            """;
+        var draft = """
+            Current findings:
+            ```ix-network
+            {"nodes":[{"id":"AD0"}],"edges":[]}
+            ```
+            """;
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, draft);
+
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: auto", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_ParsesStructuredVisualOverrideWithInlineComment() {
         var request = """
             [Proactive visualization guidance]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -571,7 +571,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("include at most one new visual block", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("include at most 1 new visual block(s)", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- infer `preferred_visual` from the assistant draft only when structured visual guidance already allows new visuals and the request did not set an explicit preferred visual
- keep request preference precedence and preserve `preferred_visual: auto` when visuals remain disabled
- fix structured visualization override parsing so non-matching lines do not reset previously parsed `allow_new_visuals` values
- align the proactive visual guidance expectation in `ChatServiceRoutingTrimTests` with the emitted numeric contract (`1`)

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "BuildProactiveFollowUpReviewPrompt_" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRoutingTrimTests" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`