### PR TITLE
chat: infer table visual contracts from markdown table shape

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
@@ -183,7 +183,149 @@ internal sealed partial class ChatServiceSession {
             lineStart += lineEnd + 1;
         }
 
-        return TryResolvePreferredVisualTypeFromInlineTokenSignal(value, out preferredVisualType);
+        if (TryResolvePreferredVisualTypeFromInlineTokenSignal(value, out preferredVisualType)) {
+            return true;
+        }
+
+        if (TryResolvePreferredVisualTypeFromMarkdownTableSignal(value, out preferredVisualType)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryResolvePreferredVisualTypeFromMarkdownTableSignal(
+        string text,
+        out string preferredVisualType) {
+        preferredVisualType = string.Empty;
+        if (string.IsNullOrWhiteSpace(text)) {
+            return false;
+        }
+
+        if (!ContainsMarkdownTableContractSignal(text.AsSpan())) {
+            return false;
+        }
+
+        preferredVisualType = TableVisualType;
+        return true;
+    }
+
+    private static bool ContainsMarkdownTableContractSignal(ReadOnlySpan<char> text) {
+        var lineStart = 0;
+        while (lineStart < text.Length) {
+            ReadOnlySpan<char> headerLine;
+            lineStart = ReadNextLine(text, lineStart, out headerLine);
+            if (!LooksLikeMarkdownTableHeaderRow(headerLine)) {
+                continue;
+            }
+
+            if (lineStart >= text.Length) {
+                return false;
+            }
+
+            ReadOnlySpan<char> separatorLine;
+            _ = ReadNextLine(text, lineStart, out separatorLine);
+            if (LooksLikeMarkdownTableSeparatorRow(separatorLine)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static int ReadNextLine(ReadOnlySpan<char> text, int startIndex, out ReadOnlySpan<char> line) {
+        if (startIndex >= text.Length) {
+            line = ReadOnlySpan<char>.Empty;
+            return text.Length;
+        }
+
+        var remaining = text.Slice(startIndex);
+        var lineBreakIndex = remaining.IndexOfAny('\r', '\n');
+        if (lineBreakIndex < 0) {
+            line = remaining;
+            return text.Length;
+        }
+
+        line = remaining.Slice(0, lineBreakIndex);
+        var nextIndex = startIndex + lineBreakIndex + 1;
+        if (nextIndex < text.Length && text[startIndex + lineBreakIndex] == '\r' && text[nextIndex] == '\n') {
+            nextIndex++;
+        }
+
+        return nextIndex;
+    }
+
+    private static bool LooksLikeMarkdownTableHeaderRow(ReadOnlySpan<char> line) {
+        var trimmed = line.Trim();
+        if (trimmed.IsEmpty || trimmed.IndexOf('|') < 0) {
+            return false;
+        }
+
+        var cellCount = 0;
+        var hasTextualCell = false;
+        var parts = trimmed.ToString().Split('|', StringSplitOptions.None);
+        for (var i = 0; i < parts.Length; i++) {
+            var cell = parts[i].Trim();
+            if (cell.Length == 0) {
+                continue;
+            }
+
+            cellCount++;
+            if (ContainsLetterOrDigit(cell.AsSpan())) {
+                hasTextualCell = true;
+            }
+        }
+
+        return cellCount >= 2 && hasTextualCell;
+    }
+
+    private static bool LooksLikeMarkdownTableSeparatorRow(ReadOnlySpan<char> line) {
+        var trimmed = line.Trim();
+        if (trimmed.IsEmpty || trimmed.IndexOf('|') < 0) {
+            return false;
+        }
+
+        var separatorCellCount = 0;
+        var parts = trimmed.ToString().Split('|', StringSplitOptions.None);
+        for (var i = 0; i < parts.Length; i++) {
+            var cell = parts[i].Trim();
+            if (cell.Length == 0) {
+                continue;
+            }
+
+            var dashCount = 0;
+            for (var j = 0; j < cell.Length; j++) {
+                var ch = cell[j];
+                if (ch == '-') {
+                    dashCount++;
+                    continue;
+                }
+
+                if (ch == ':') {
+                    continue;
+                }
+
+                return false;
+            }
+
+            if (dashCount < 3) {
+                return false;
+            }
+
+            separatorCellCount++;
+        }
+
+        return separatorCellCount >= 2;
+    }
+
+    private static bool ContainsLetterOrDigit(ReadOnlySpan<char> value) {
+        for (var i = 0; i < value.Length; i++) {
+            if (char.IsLetterOrDigit(value[i])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool ContainsVisualContractFenceLanguage(ReadOnlySpan<char> language) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -55,6 +55,27 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferTablePreferredVisualFromAssistantDraftMarkdownTableWhenVisualsAreAllowed() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var draft = """
+            Current findings:
+            | dc | status |
+            | --- | --- |
+            | dc01 | healthy |
+            """;
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, draft);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_DoesNotInferPreferredVisualFromDraftWhenVisualsRemainDisabled() {
         var request = """
             [Proactive visualization guidance]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -604,6 +604,34 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForMarkdownTableContract() {
+        var request = """
+            Use this table format if useful:
+            | server | status |
+            | --- | --- |
+            | DC01 | healthy |
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_DoesNotEnableVisualsForPipeSeparatedTextWithoutMarkdownTableSeparator() {
+        var request = """
+            Keep this literal text:
+            server | status
+            DC01 | healthy
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: false", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForBacktickedChartAliasToken() {
         var request = "If needed, include a compact `chart` for trend comparison.";
         var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");


### PR DESCRIPTION
## Summary
- detect markdown-table visual contracts using shape-based parsing (header + separator row), not lexical keyword matching
- infer `preferred_visual: table` when request text includes a markdown table contract
- infer `preferred_visual: table` from the assistant draft when structured visualization allows new visuals and no explicit preferred visual was requested
- keep non-table pipe-separated text out of visual-contract routing to avoid false positives

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "BuildProactiveFollowUpReviewPrompt_" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRoutingTrimTests" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`