### PR TITLE
chat: extend transient retries for domain/testimox/computerx tool packs

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolExecution.RuntimeAndRecovery.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolExecution.RuntimeAndRecovery.cs
@@ -547,8 +547,17 @@ internal sealed partial class ChatServiceSession {
             return new ToolRetryProfile(MaxAttempts: 2, DelayBaseMs: 150, RetryOnTimeout: true, RetryOnTransport: true);
         }
         if (normalized.StartsWith("system_", StringComparison.Ordinal)
+            || normalized.StartsWith("computerx_", StringComparison.Ordinal)
             || normalized.StartsWith("wsl_", StringComparison.Ordinal)) {
             return new ToolRetryProfile(MaxAttempts: 2, DelayBaseMs: 120, RetryOnTimeout: true, RetryOnTransport: true);
+        }
+        if (normalized.StartsWith("domaindetective_", StringComparison.Ordinal)
+            || normalized.StartsWith("domain_detective_", StringComparison.Ordinal)
+            || normalized.StartsWith("dnsclientx_", StringComparison.Ordinal)
+            || normalized.StartsWith("dns_client_x_", StringComparison.Ordinal)
+            || normalized.StartsWith("testimox_", StringComparison.Ordinal)
+            || normalized.StartsWith("testimo_x_", StringComparison.Ordinal)) {
+            return new ToolRetryProfile(MaxAttempts: 2, DelayBaseMs: 180, RetryOnTimeout: true, RetryOnTransport: true);
         }
         if (normalized.StartsWith("fs_", StringComparison.Ordinal)) {
             return new ToolRetryProfile(MaxAttempts: 2, DelayBaseMs: 90, RetryOnTimeout: true, RetryOnTransport: false);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRetryPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRetryPolicyTests.cs
@@ -85,6 +85,70 @@ public sealed class ChatServiceRetryPolicyTests {
     }
 
     [Fact]
+    public void ShouldRetryToolCall_RetriesTimeoutForDomainDetectiveProfile() {
+        var profile = InvokeResolveRetryProfile("domaindetective_domain_summary");
+        var output = new ToolOutputDto {
+            CallId = "call-3c",
+            Output = "{\"error\":\"Tool timed out.\"}",
+            Ok = false,
+            ErrorCode = "tool_timeout",
+            Error = "Tool timed out."
+        };
+
+        var shouldRetry = InvokeShouldRetryToolCall(output, profile, attemptIndex: 0);
+
+        Assert.True(shouldRetry);
+    }
+
+    [Fact]
+    public void ShouldRetryToolCall_RetriesTransportForDnsClientXProfile() {
+        var profile = InvokeResolveRetryProfile("dnsclientx_query");
+        var output = new ToolOutputDto {
+            CallId = "call-3d",
+            Output = "{\"error\":\"Service temporarily unavailable.\"}",
+            Ok = false,
+            ErrorCode = "transport_unavailable",
+            Error = "Service temporarily unavailable."
+        };
+
+        var shouldRetry = InvokeShouldRetryToolCall(output, profile, attemptIndex: 0);
+
+        Assert.True(shouldRetry);
+    }
+
+    [Fact]
+    public void ShouldRetryToolCall_RetriesTransportForTestimoXProfile() {
+        var profile = InvokeResolveRetryProfile("testimox_rules_run");
+        var output = new ToolOutputDto {
+            CallId = "call-3e",
+            Output = "{\"error\":\"Upstream connection reset.\"}",
+            Ok = false,
+            ErrorCode = "transport_unavailable",
+            Error = "Upstream connection reset."
+        };
+
+        var shouldRetry = InvokeShouldRetryToolCall(output, profile, attemptIndex: 0);
+
+        Assert.True(shouldRetry);
+    }
+
+    [Fact]
+    public void ShouldRetryToolCall_RetriesTimeoutForComputerXPrefixProfile() {
+        var profile = InvokeResolveRetryProfile("computerx_inventory_snapshot");
+        var output = new ToolOutputDto {
+            CallId = "call-3f",
+            Output = "{\"error\":\"Tool timed out.\"}",
+            Ok = false,
+            ErrorCode = "tool_timeout",
+            Error = "Tool timed out."
+        };
+
+        var shouldRetry = InvokeShouldRetryToolCall(output, profile, attemptIndex: 0);
+
+        Assert.True(shouldRetry);
+    }
+
+    [Fact]
     public void ShouldRetryToolCall_DoesNotRetryDomainScopeGuardrailFailure() {
         var profile = InvokeResolveRetryProfile("ad_replication_summary");
         var output = new ToolOutputDto {


### PR DESCRIPTION
## Summary
- extend transient retry profiles beyond `ad_`/`eventlog_`/`system_` so DomainDetective, DnsClientX, TestimoX, and ComputerX-prefixed tools get the same bounded retry resilience
- map `computerx_` to the system retry profile for parity with system/host diagnostics behavior
- add retry-policy tests proving timeout/transport retries now apply for:
  - `domaindetective_*`
  - `dnsclientx_*`
  - `testimox_*`
  - `computerx_*`

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRetryPolicyTests" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRoutingTrimTests" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`