### PR TITLE
chat: broaden planner pack inference for alias tool prefixes

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
@@ -382,28 +382,8 @@ internal sealed partial class ChatServiceSession {
         }
 
         var toolName = (definition.Name ?? string.Empty).Trim();
-        if (toolName.StartsWith("ad_", StringComparison.OrdinalIgnoreCase)) {
-            return "active_directory";
-        }
-
-        if (toolName.StartsWith("eventlog_", StringComparison.OrdinalIgnoreCase)) {
-            return "eventlog";
-        }
-
-        if (toolName.StartsWith("system_", StringComparison.OrdinalIgnoreCase)) {
-            return "system";
-        }
-
-        if (toolName.StartsWith("testimox_", StringComparison.OrdinalIgnoreCase)) {
-            return "testimox";
-        }
-
-        if (toolName.StartsWith("domaindetective_", StringComparison.OrdinalIgnoreCase)) {
-            return "domaindetective";
-        }
-
-        if (toolName.StartsWith("dnsclientx_", StringComparison.OrdinalIgnoreCase)) {
-            return "dnsclientx";
+        if (TryResolvePackHintFromToolNamePrefix(toolName, out var packHintFromPrefix)) {
+            return packHintFromPrefix;
         }
 
         if (PackIdMatches(category, "active_directory")) {
@@ -431,6 +411,54 @@ internal sealed partial class ChatServiceSession {
         }
 
         return string.Empty;
+    }
+
+    private static bool TryResolvePackHintFromToolNamePrefix(string toolName, out string packHint) {
+        packHint = string.Empty;
+        var normalizedToolName = (toolName ?? string.Empty).Trim();
+        if (normalizedToolName.Length == 0) {
+            return false;
+        }
+
+        if (normalizedToolName.StartsWith("ad_", StringComparison.OrdinalIgnoreCase)
+            || normalizedToolName.StartsWith("active_directory_", StringComparison.OrdinalIgnoreCase)
+            || normalizedToolName.StartsWith("adplayground_", StringComparison.OrdinalIgnoreCase)) {
+            packHint = "active_directory";
+            return true;
+        }
+
+        if (normalizedToolName.StartsWith("eventlog_", StringComparison.OrdinalIgnoreCase)
+            || normalizedToolName.StartsWith("event_log_", StringComparison.OrdinalIgnoreCase)) {
+            packHint = "eventlog";
+            return true;
+        }
+
+        if (normalizedToolName.StartsWith("system_", StringComparison.OrdinalIgnoreCase)
+            || normalizedToolName.StartsWith("computerx_", StringComparison.OrdinalIgnoreCase)
+            || normalizedToolName.StartsWith("wsl_", StringComparison.OrdinalIgnoreCase)) {
+            packHint = "system";
+            return true;
+        }
+
+        if (normalizedToolName.StartsWith("testimox_", StringComparison.OrdinalIgnoreCase)
+            || normalizedToolName.StartsWith("testimo_x_", StringComparison.OrdinalIgnoreCase)) {
+            packHint = "testimox";
+            return true;
+        }
+
+        if (normalizedToolName.StartsWith("domaindetective_", StringComparison.OrdinalIgnoreCase)
+            || normalizedToolName.StartsWith("domain_detective_", StringComparison.OrdinalIgnoreCase)) {
+            packHint = "domaindetective";
+            return true;
+        }
+
+        if (normalizedToolName.StartsWith("dnsclientx_", StringComparison.OrdinalIgnoreCase)
+            || normalizedToolName.StartsWith("dns_client_x_", StringComparison.OrdinalIgnoreCase)) {
+            packHint = "dnsclientx";
+            return true;
+        }
+
+        return false;
     }
 
     private static string[] ExtractPlannerTags(ToolDefinition definition, int maxCount) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -112,6 +112,42 @@ public sealed class ChatServicePlannerPromptTests {
     }
 
     [Fact]
+    public void BuildModelPlannerPrompt_IncludesPackHintFromComputerXAliasPrefixWhenTagMissing() {
+        var definitions = new List<ToolDefinition> {
+            new(
+                "computerx_inventory_snapshot",
+                "ComputerX inventory snapshot.",
+                ToolSchema.Object().NoAdditionalProperties())
+        };
+
+        var prompt = Assert.IsType<string>(BuildModelPlannerPromptMethod.Invoke(null, new object?[] {
+            "collect host baseline",
+            definitions,
+            4
+        }));
+
+        Assert.Contains("pack: system", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildModelPlannerPrompt_IncludesPackHintFromDomainDetectiveAliasPrefixWhenTagMissing() {
+        var definitions = new List<ToolDefinition> {
+            new(
+                "domain_detective_domain_summary",
+                "Domain posture summary.",
+                ToolSchema.Object(("domain", ToolSchema.String("Domain name."))).NoAdditionalProperties())
+        };
+
+        var prompt = Assert.IsType<string>(BuildModelPlannerPromptMethod.Invoke(null, new object?[] {
+            "summarize contoso.com",
+            definitions,
+            4
+        }));
+
+        Assert.Contains("pack: domaindetective", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildToolRoutingSearchText_IncludesSchemaTokens() {
         var definition = new ToolDefinition(
             "eventlog_top_events",
@@ -155,6 +191,19 @@ public sealed class ChatServicePlannerPromptTests {
 
         Assert.Contains("pack system", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack computerx", searchText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildToolRoutingSearchText_IncludesDnsClientXAliasTokensFromToolNamePrefixFallback() {
+        var definition = new ToolDefinition(
+            "dns_client_x_query",
+            "Query DNS records.",
+            ToolSchema.Object(("name", ToolSchema.String("Name."))).NoAdditionalProperties());
+
+        var searchText = Assert.IsType<string>(BuildToolRoutingSearchTextMethod.Invoke(null, new object?[] { definition }));
+
+        Assert.Contains("pack dnsclientx", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack:dnsclientx", searchText, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- refactor planner pack inference into a shared prefix helper to reduce brittle hardcoded checks and keep pack inference consistent
- expand alias-prefix support so planner/search routing recognizes:
  - `computerx_*` and `wsl_*` -> system pack
  - `domain_detective_*` -> DomainDetective pack
  - `dns_client_x_*` -> DnsClientX pack
  - `testimo_x_*` -> TestimoX pack
  - legacy/canonical prefixes remain supported
- keep tag-based `pack:` inference precedence unchanged

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServicePlannerPromptTests" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRoutingTrimTests" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`