### PR TITLE
chat: recognize alias prefixes in domain-intent family routing

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
@@ -390,12 +390,16 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static bool IsAdDomainIntentToolName(string toolName) {
-        return toolName.StartsWith("ad_", StringComparison.OrdinalIgnoreCase);
+        return toolName.StartsWith("ad_", StringComparison.OrdinalIgnoreCase)
+               || toolName.StartsWith("active_directory_", StringComparison.OrdinalIgnoreCase)
+               || toolName.StartsWith("adplayground_", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsPublicDomainIntentToolName(string toolName) {
         return toolName.StartsWith("dnsclientx_", StringComparison.OrdinalIgnoreCase)
-               || toolName.StartsWith("domaindetective_", StringComparison.OrdinalIgnoreCase);
+               || toolName.StartsWith("dns_client_x_", StringComparison.OrdinalIgnoreCase)
+               || toolName.StartsWith("domaindetective_", StringComparison.OrdinalIgnoreCase)
+               || toolName.StartsWith("domain_detective_", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string ResolveDomainIntentFamily(ToolDefinition definition) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.DomainIntent.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.DomainIntent.cs
@@ -42,6 +42,30 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ShouldRequestDomainIntentClarification_TrueForMixedAliasPrefixedAdAndPublicDomainSubset() {
+        var selectedTools = new List<ToolDefinition> {
+            new("active_directory_scope_discovery", description: "AD scope"),
+            new("adplayground_domain_controllers", description: "AD DCs"),
+            new("dns_client_x_query", description: "DNS query"),
+            new("domain_detective_domain_summary", description: "Domain summary"),
+            new("eventlog_live_query", description: "Event log")
+        };
+
+        var result = ShouldRequestDomainIntentClarificationMethod.Invoke(
+            null,
+            new object?[] {
+                true,
+                false,
+                false,
+                selectedTools.Count,
+                24,
+                selectedTools
+            });
+
+        Assert.True(Assert.IsType<bool>(result));
+    }
+
+    [Fact]
     public void ShouldRequestDomainIntentClarification_FalseWhenOneFamilyDominates() {
         var selectedTools = new List<ToolDefinition> {
             new("ad_scope_discovery", description: "AD scope"),


### PR DESCRIPTION
## Summary
- expand domain-intent family detection to support alias tool-name prefixes, not only legacy canonical prefixes
- AD family now also recognizes:
  - `active_directory_*`
  - `adplayground_*`
- public-domain family now also recognizes:
  - `dns_client_x_*`
  - `domain_detective_*`
- keeps existing canonical prefix behavior unchanged

## Why this helps
- improves AD vs public-domain routing when tool names come from alias naming schemes
- keeps clarification/affinity logic robust across packs (DomainDetective, ADPlayground, DnsClientX)

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "ShouldRequestDomainIntentClarification_" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRoutingTrimTests" -p:TestimoXRoot=C:\Support\GitHub\TestimoX\`