### PR TITLE
Expand domain-intent technical signal aliases

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
@@ -44,6 +44,7 @@ internal sealed partial class ChatServiceSession {
         "gpo",
         "kerberos",
         "adplayground",
+        "active_directory",
         "ad_domain",
         "act_domain_scope_ad"
     };
@@ -55,7 +56,9 @@ internal sealed partial class ChatServiceSession {
         "dkim",
         "ns",
         "dnsclientx",
+        "dns_client_x",
         "domaindetective",
+        "domain_detective",
         "public_domain",
         "act_domain_scope_public"
     };

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceDomainAffinityTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceDomainAffinityTests.cs
@@ -383,8 +383,11 @@ public sealed class ChatServiceDomainAffinityTests {
     [InlineData("Por favor revisar DNS publico", "public_domain")]
     [InlineData("Verifier DNS public du domaine", "public_domain")]
     [InlineData("Use adplayground for this domain", "ad_domain")]
+    [InlineData("active_directory diagnostics for this domain", "ad_domain")]
     [InlineData("Run domaindetective checks for this zone", "public_domain")]
+    [InlineData("Run domain_detective checks for this zone", "public_domain")]
     [InlineData("dnsclientx resolver baseline", "public_domain")]
+    [InlineData("dns_client_x resolver baseline", "public_domain")]
     [InlineData("act_domain_scope_public", "public_domain")]
     [InlineData("ad_domain", "ad_domain")]
     public void TryResolvePendingDomainIntentClarificationSelection_ParsesLanguageNeutralTechnicalSignals(


### PR DESCRIPTION
## Summary
- extend language-neutral domain-intent technical signals with alias-form pack tokens
- add AD signal token: `active_directory`
- add public-domain signal tokens: `domain_detective`, `dns_client_x`
- expand domain-intent clarification tests to cover the new alias signals

## Validation
- attempted: `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceDomainAffinityTests.TryResolvePendingDomainIntentClarificationSelection_ParsesLanguageNeutralTechnicalSignals"`
- local build currently blocked by existing missing type references in `IntelligenceX.Tools.TestimoX` / `IntelligenceX.Tools.ADPlayground` / `IntelligenceX.Tools.System` (e.g. `TestimoX`, `ADPlayground`, `ComputerX` namespaces)
- CI will validate in the canonical environment
