### PR TITLE
Infer ix-network visual intent from JSON contract shape

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
@@ -191,6 +191,10 @@ internal sealed partial class ChatServiceSession {
             return true;
         }
 
+        if (TryResolvePreferredVisualTypeFromStructuredJsonSignal(value, out preferredVisualType)) {
+            return true;
+        }
+
         return false;
     }
 
@@ -208,6 +212,65 @@ internal sealed partial class ChatServiceSession {
 
         preferredVisualType = TableVisualType;
         return true;
+    }
+
+    private static bool TryResolvePreferredVisualTypeFromStructuredJsonSignal(
+        string text,
+        out string preferredVisualType) {
+        preferredVisualType = string.Empty;
+        if (string.IsNullOrWhiteSpace(text)) {
+            return false;
+        }
+
+        if (!LooksLikeNetworkJsonVisualContract(text.AsSpan())) {
+            return false;
+        }
+
+        preferredVisualType = NetworkVisualType;
+        return true;
+    }
+
+    private static bool LooksLikeNetworkJsonVisualContract(ReadOnlySpan<char> text) {
+        return ContainsJsonArrayProperty(text, "nodes") && ContainsJsonArrayProperty(text, "edges");
+    }
+
+    private static bool ContainsJsonArrayProperty(ReadOnlySpan<char> text, string propertyName) {
+        if (text.IsEmpty || string.IsNullOrWhiteSpace(propertyName)) {
+            return false;
+        }
+
+        var token = $"\"{propertyName}\"".AsSpan();
+        var searchStart = 0;
+        while (searchStart < text.Length) {
+            var tokenIndex = text.Slice(searchStart).IndexOf(token, StringComparison.OrdinalIgnoreCase);
+            if (tokenIndex < 0) {
+                return false;
+            }
+
+            var propertyIndex = searchStart + tokenIndex;
+            var valueIndex = propertyIndex + token.Length;
+            while (valueIndex < text.Length && char.IsWhiteSpace(text[valueIndex])) {
+                valueIndex++;
+            }
+
+            if (valueIndex >= text.Length || text[valueIndex] != ':') {
+                searchStart = propertyIndex + token.Length;
+                continue;
+            }
+
+            valueIndex++;
+            while (valueIndex < text.Length && char.IsWhiteSpace(text[valueIndex])) {
+                valueIndex++;
+            }
+
+            if (valueIndex < text.Length && text[valueIndex] == '[') {
+                return true;
+            }
+
+            searchStart = propertyIndex + token.Length;
+        }
+
+        return false;
     }
 
     private static bool ContainsMarkdownTableContractSignal(ReadOnlySpan<char> text) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -76,6 +76,25 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferNetworkPreferredVisualFromAssistantDraftStructuredJsonWhenVisualsAreAllowed() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var draft = """
+            Current findings:
+            {"nodes":[{"id":"AD0"}],"edges":[{"from":"AD0","to":"AD1"}]}
+            """;
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, draft);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_DoesNotInferPreferredVisualFromDraftWhenVisualsRemainDisabled() {
         var request = """
             [Proactive visualization guidance]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -575,6 +575,31 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJsonNetworkContractWithoutFence() {
+        var request = """
+            Use this structured visual contract if useful:
+            {"nodes":[{"id":"DC01"},{"id":"DC02"}],"edges":[{"from":"DC01","to":"DC02"}]}
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_DoesNotEnableVisualsForNonArrayJsonNodeEdgeMentions() {
+        var request = """
+            Keep this as plain metadata:
+            {"nodes":"2","edges":"1"}
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: false", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_DoesNotEnableVisualsForPlainKeywordMentions() {
         var request = "Could you include a mermaid diagram if useful?";
         var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");


### PR DESCRIPTION
## Summary
- add shape-based visual contract detection for structured JSON network payloads
- infer `preferred_visual: ix-network` when a request/draft contains JSON-style `"nodes": [...]` + `"edges": [...]` even without fence/backtick tokens
- keep detection strict to avoid keyword brittleness (requires JSON array property shape)
- add regression tests for positive and negative JSON-shape cases in proactive follow-up review prompts

## Validation
- attempted: `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJsonNetworkContractWithoutFence|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_InferNetworkPreferredVisualFromAssistantDraftStructuredJsonWhenVisualsAreAllowed|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_DoesNotEnableVisualsForNonArrayJsonNodeEdgeMentions"`
- local compile is currently blocked by existing missing type references in `IntelligenceX.Tools.TestimoX`, `IntelligenceX.Tools.ADPlayground`, and `IntelligenceX.Tools.System` (e.g. `TestimoX`, `ADPlayground`, `ComputerX` namespaces)
- CI is the authoritative validation environment
