### PR TITLE
Expand visual inference for structured JSON chart/table contracts

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
@@ -222,16 +222,45 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (!LooksLikeNetworkJsonVisualContract(text.AsSpan())) {
-            return false;
+        var value = text.AsSpan();
+        if (LooksLikeNetworkJsonVisualContract(value)) {
+            preferredVisualType = NetworkVisualType;
+            return true;
         }
 
-        preferredVisualType = NetworkVisualType;
-        return true;
+        if (LooksLikeChartJsonVisualContract(value)) {
+            preferredVisualType = ChartVisualType;
+            return true;
+        }
+
+        if (LooksLikeTableJsonVisualContract(value)) {
+            preferredVisualType = TableVisualType;
+            return true;
+        }
+
+        return false;
     }
 
     private static bool LooksLikeNetworkJsonVisualContract(ReadOnlySpan<char> text) {
         return ContainsJsonArrayProperty(text, "nodes") && ContainsJsonArrayProperty(text, "edges");
+    }
+
+    private static bool LooksLikeChartJsonVisualContract(ReadOnlySpan<char> text) {
+        if (!ContainsJsonArrayProperty(text, "labels")) {
+            return false;
+        }
+
+        return ContainsJsonArrayProperty(text, "datasets") || ContainsJsonArrayProperty(text, "series");
+    }
+
+    private static bool LooksLikeTableJsonVisualContract(ReadOnlySpan<char> text) {
+        if (!ContainsJsonArrayProperty(text, "rows")) {
+            return false;
+        }
+
+        return ContainsJsonArrayProperty(text, "columns")
+               || ContainsJsonArrayProperty(text, "headers")
+               || ContainsJsonArrayProperty(text, "fields");
     }
 
     private static bool ContainsJsonArrayProperty(ReadOnlySpan<char> text, string propertyName) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -95,6 +95,44 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferChartPreferredVisualFromAssistantDraftStructuredJsonWhenVisualsAreAllowed() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var draft = """
+            Current findings:
+            {"labels":["Jan","Feb"],"datasets":[{"label":"Auth failures","data":[4,7]}]}
+            """;
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, draft);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-chart", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferTablePreferredVisualFromAssistantDraftStructuredJsonWhenVisualsAreAllowed() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var draft = """
+            Current findings:
+            {"headers":["dc","status"],"rows":[["DC01","healthy"]]}
+            """;
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, draft);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_DoesNotInferPreferredVisualFromDraftWhenVisualsRemainDisabled() {
         var request = """
             [Proactive visualization guidance]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -588,6 +588,32 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJsonChartContractWithoutFence() {
+        var request = """
+            Use this structured visual contract if useful:
+            {"labels":["Jan","Feb"],"series":[12,18]}
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-chart", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJsonTableContractWithoutFence() {
+        var request = """
+            Use this structured visual contract if useful:
+            {"columns":["host","status"],"rows":[["dc01","healthy"]]}
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_DoesNotEnableVisualsForNonArrayJsonNodeEdgeMentions() {
         var request = """
             Keep this as plain metadata:


### PR DESCRIPTION
## Summary
- extend structured JSON visual-shape inference beyond network to chart and table
- infer `preferred_visual: ix-chart` for JSON contracts with `"labels": [...]` plus `"series"` or `"datasets"` arrays
- infer `preferred_visual: table` for JSON contracts with `"rows": [...]` plus `"columns"` / `"headers"` / `"fields"` arrays
- add proactive prompt tests for request-based and draft-based chart/table JSON inference

## Validation
- attempted: `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJsonChartContractWithoutFence|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJsonTableContractWithoutFence|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_InferChartPreferredVisualFromAssistantDraftStructuredJsonWhenVisualsAreAllowed|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_InferTablePreferredVisualFromAssistantDraftStructuredJsonWhenVisualsAreAllowed"`
- local compile remains blocked by existing missing type references in `IntelligenceX.Tools.TestimoX`, `IntelligenceX.Tools.ADPlayground`, and `IntelligenceX.Tools.System`
- CI is the authoritative validation environment
