### PR TITLE
Normalize pack prefix matching across routing aliases

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
@@ -420,40 +420,32 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (normalizedToolName.StartsWith("ad_", StringComparison.OrdinalIgnoreCase)
-            || normalizedToolName.StartsWith("active_directory_", StringComparison.OrdinalIgnoreCase)
-            || normalizedToolName.StartsWith("adplayground_", StringComparison.OrdinalIgnoreCase)) {
+        if (IsAdDomainIntentToolName(normalizedToolName)) {
             packHint = "active_directory";
             return true;
         }
 
-        if (normalizedToolName.StartsWith("eventlog_", StringComparison.OrdinalIgnoreCase)
-            || normalizedToolName.StartsWith("event_log_", StringComparison.OrdinalIgnoreCase)) {
+        if (IsEventLogToolName(normalizedToolName)) {
             packHint = "eventlog";
             return true;
         }
 
-        if (normalizedToolName.StartsWith("system_", StringComparison.OrdinalIgnoreCase)
-            || normalizedToolName.StartsWith("computerx_", StringComparison.OrdinalIgnoreCase)
-            || normalizedToolName.StartsWith("wsl_", StringComparison.OrdinalIgnoreCase)) {
+        if (IsSystemToolName(normalizedToolName)) {
             packHint = "system";
             return true;
         }
 
-        if (normalizedToolName.StartsWith("testimox_", StringComparison.OrdinalIgnoreCase)
-            || normalizedToolName.StartsWith("testimo_x_", StringComparison.OrdinalIgnoreCase)) {
+        if (IsTestimoXToolName(normalizedToolName)) {
             packHint = "testimox";
             return true;
         }
 
-        if (normalizedToolName.StartsWith("domaindetective_", StringComparison.OrdinalIgnoreCase)
-            || normalizedToolName.StartsWith("domain_detective_", StringComparison.OrdinalIgnoreCase)) {
+        if (IsDomainDetectiveToolName(normalizedToolName)) {
             packHint = "domaindetective";
             return true;
         }
 
-        if (normalizedToolName.StartsWith("dnsclientx_", StringComparison.OrdinalIgnoreCase)
-            || normalizedToolName.StartsWith("dns_client_x_", StringComparison.OrdinalIgnoreCase)) {
+        if (IsDnsClientXToolName(normalizedToolName)) {
             packHint = "dnsclientx";
             return true;
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.cs
@@ -62,6 +62,25 @@ internal sealed partial class ChatServiceSession {
         "public_domain",
         "act_domain_scope_public"
     };
+    private static readonly string[] ActiveDirectoryToolNamePrefixes = new[] { "ad_", "active_directory_", "adplayground_" };
+    private static readonly string[] ActiveDirectoryToolNameCompactPrefixes = new[] { "activedirectory", "adplayground" };
+    private static readonly string[] PublicDomainToolNamePrefixes = new[] {
+        "dnsclientx_",
+        "dns_client_x_",
+        "domaindetective_",
+        "domain_detective_"
+    };
+    private static readonly string[] PublicDomainToolNameCompactPrefixes = new[] { "dnsclientx", "domaindetective" };
+    private static readonly string[] EventLogToolNamePrefixes = new[] { "eventlog_", "event_log_" };
+    private static readonly string[] EventLogToolNameCompactPrefixes = new[] { "eventlog" };
+    private static readonly string[] SystemToolNamePrefixes = new[] { "system_", "computerx_", "wsl_" };
+    private static readonly string[] SystemToolNameCompactPrefixes = new[] { "computerx", "wsl" };
+    private static readonly string[] TestimoXToolNamePrefixes = new[] { "testimox_", "testimo_x_" };
+    private static readonly string[] TestimoXToolNameCompactPrefixes = new[] { "testimox" };
+    private static readonly string[] DomainDetectiveToolNamePrefixes = new[] { "domaindetective_", "domain_detective_" };
+    private static readonly string[] DomainDetectiveToolNameCompactPrefixes = new[] { "domaindetective" };
+    private static readonly string[] DnsClientXToolNamePrefixes = new[] { "dnsclientx_", "dns_client_x_" };
+    private static readonly string[] DnsClientXToolNameCompactPrefixes = new[] { "dnsclientx" };
 
     private static List<ToolRoutingInsight> BuildContinuationRoutingInsights(IReadOnlyList<ToolDefinition> selectedDefs) {
         var list = new List<ToolRoutingInsight>(selectedDefs.Count);
@@ -393,16 +412,83 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static bool IsAdDomainIntentToolName(string toolName) {
-        return toolName.StartsWith("ad_", StringComparison.OrdinalIgnoreCase)
-               || toolName.StartsWith("active_directory_", StringComparison.OrdinalIgnoreCase)
-               || toolName.StartsWith("adplayground_", StringComparison.OrdinalIgnoreCase);
+        return MatchesToolNameLiteralOrCompactPrefix(toolName, ActiveDirectoryToolNamePrefixes, ActiveDirectoryToolNameCompactPrefixes);
     }
 
     private static bool IsPublicDomainIntentToolName(string toolName) {
-        return toolName.StartsWith("dnsclientx_", StringComparison.OrdinalIgnoreCase)
-               || toolName.StartsWith("dns_client_x_", StringComparison.OrdinalIgnoreCase)
-               || toolName.StartsWith("domaindetective_", StringComparison.OrdinalIgnoreCase)
-               || toolName.StartsWith("domain_detective_", StringComparison.OrdinalIgnoreCase);
+        return MatchesToolNameLiteralOrCompactPrefix(toolName, PublicDomainToolNamePrefixes, PublicDomainToolNameCompactPrefixes);
+    }
+
+    private static bool IsEventLogToolName(string toolName) {
+        return MatchesToolNameLiteralOrCompactPrefix(toolName, EventLogToolNamePrefixes, EventLogToolNameCompactPrefixes);
+    }
+
+    private static bool IsSystemToolName(string toolName) {
+        return MatchesToolNameLiteralOrCompactPrefix(toolName, SystemToolNamePrefixes, SystemToolNameCompactPrefixes);
+    }
+
+    private static bool IsTestimoXToolName(string toolName) {
+        return MatchesToolNameLiteralOrCompactPrefix(toolName, TestimoXToolNamePrefixes, TestimoXToolNameCompactPrefixes);
+    }
+
+    private static bool IsDomainDetectiveToolName(string toolName) {
+        return MatchesToolNameLiteralOrCompactPrefix(toolName, DomainDetectiveToolNamePrefixes, DomainDetectiveToolNameCompactPrefixes);
+    }
+
+    private static bool IsDnsClientXToolName(string toolName) {
+        return MatchesToolNameLiteralOrCompactPrefix(toolName, DnsClientXToolNamePrefixes, DnsClientXToolNameCompactPrefixes);
+    }
+
+    private static bool MatchesToolNameLiteralOrCompactPrefix(string toolName, string[] literalPrefixes, string[] compactPrefixes) {
+        var normalizedToolName = (toolName ?? string.Empty).Trim();
+        if (normalizedToolName.Length == 0) {
+            return false;
+        }
+
+        if (StartsWithAnyPrefix(normalizedToolName, literalPrefixes)) {
+            return true;
+        }
+
+        if (compactPrefixes.Length == 0) {
+            return false;
+        }
+
+        var compactToolName = NormalizeCompactToken(normalizedToolName.AsSpan());
+        if (compactToolName.Length == 0) {
+            return false;
+        }
+
+        for (var i = 0; i < compactPrefixes.Length; i++) {
+            var compactPrefix = compactPrefixes[i];
+            if (compactPrefix.Length == 0) {
+                continue;
+            }
+
+            if (compactToolName.StartsWith(compactPrefix, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool StartsWithAnyPrefix(string value, string[] prefixes) {
+        if (string.IsNullOrWhiteSpace(value) || prefixes is null || prefixes.Length == 0) {
+            return false;
+        }
+
+        for (var i = 0; i < prefixes.Length; i++) {
+            var prefix = prefixes[i];
+            if (string.IsNullOrWhiteSpace(prefix)) {
+                continue;
+            }
+
+            if (value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string ResolveDomainIntentFamily(ToolDefinition definition) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -148,6 +148,42 @@ public sealed class ChatServicePlannerPromptTests {
     }
 
     [Fact]
+    public void BuildModelPlannerPrompt_IncludesPackHintFromHyphenatedAliasPrefixWhenTagMissing() {
+        var definitions = new List<ToolDefinition> {
+            new(
+                "domain-detective-domain-summary",
+                "Domain posture summary.",
+                ToolSchema.Object(("domain", ToolSchema.String("Domain name."))).NoAdditionalProperties())
+        };
+
+        var prompt = Assert.IsType<string>(BuildModelPlannerPromptMethod.Invoke(null, new object?[] {
+            "summarize contoso.com",
+            definitions,
+            4
+        }));
+
+        Assert.Contains("pack: domaindetective", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildModelPlannerPrompt_IncludesPackHintFromHyphenatedComputerXAliasPrefixWhenTagMissing() {
+        var definitions = new List<ToolDefinition> {
+            new(
+                "computerx-inventory-snapshot",
+                "ComputerX inventory snapshot.",
+                ToolSchema.Object().NoAdditionalProperties())
+        };
+
+        var prompt = Assert.IsType<string>(BuildModelPlannerPromptMethod.Invoke(null, new object?[] {
+            "collect host baseline",
+            definitions,
+            4
+        }));
+
+        Assert.Contains("pack: system", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildToolRoutingSearchText_IncludesSchemaTokens() {
         var definition = new ToolDefinition(
             "eventlog_top_events",
@@ -204,6 +240,19 @@ public sealed class ChatServicePlannerPromptTests {
 
         Assert.Contains("pack dnsclientx", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack:dnsclientx", searchText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildToolRoutingSearchText_IncludesDomainDetectivePackTokensFromHyphenatedToolNamePrefixFallback() {
+        var definition = new ToolDefinition(
+            "domain-detective-query",
+            "Query domain evidence.",
+            ToolSchema.Object(("name", ToolSchema.String("Name."))).NoAdditionalProperties());
+
+        var searchText = Assert.IsType<string>(BuildToolRoutingSearchTextMethod.Invoke(null, new object?[] { definition }));
+
+        Assert.Contains("pack domaindetective", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack:domaindetective", searchText, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.DomainIntent.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.DomainIntent.cs
@@ -66,6 +66,30 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ShouldRequestDomainIntentClarification_TrueForMixedHyphenatedAliasPrefixedAdAndPublicDomainSubset() {
+        var selectedTools = new List<ToolDefinition> {
+            new("active-directory-scope-discovery", description: "AD scope"),
+            new("adplayground-domain-controllers", description: "AD DCs"),
+            new("dns-client-x-query", description: "DNS query"),
+            new("domain-detective-domain-summary", description: "Domain summary"),
+            new("eventlog-live-query", description: "Event log")
+        };
+
+        var result = ShouldRequestDomainIntentClarificationMethod.Invoke(
+            null,
+            new object?[] {
+                true,
+                false,
+                false,
+                selectedTools.Count,
+                24,
+                selectedTools
+            });
+
+        Assert.True(Assert.IsType<bool>(result));
+    }
+
+    [Fact]
     public void ShouldRequestDomainIntentClarification_FalseWhenOneFamilyDominates() {
         var selectedTools = new List<ToolDefinition> {
             new("ad_scope_discovery", description: "AD scope"),


### PR DESCRIPTION
## Summary
- replace duplicated per-file prefix checks with shared literal+compact tool-name prefix matching helpers
- apply compact-prefix matching to AD/public-domain family detection and planner pack-hint inference
- improve alias robustness for hyphen/underscore/camel-like forms across ADPlayground, DomainDetective, DnsClientX, TestimoX, ComputerX/system, and EventLog packs
- add regression tests for hyphenated alias tool names in planner prompt/search text and domain-intent clarification selection

## Validation
- attempted: `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildModelPlannerPrompt_IncludesPackHintFromHyphenatedAliasPrefixWhenTagMissing|FullyQualifiedName~BuildModelPlannerPrompt_IncludesPackHintFromHyphenatedComputerXAliasPrefixWhenTagMissing|FullyQualifiedName~BuildToolRoutingSearchText_IncludesDomainDetectivePackTokensFromHyphenatedToolNamePrefixFallback|FullyQualifiedName~ShouldRequestDomainIntentClarification_TrueForMixedHyphenatedAliasPrefixedAdAndPublicDomainSubset"`
- local compile remains blocked by existing missing type references in `IntelligenceX.Tools.TestimoX`, `IntelligenceX.Tools.ADPlayground`, and `IntelligenceX.Tools.System`
- CI is the authoritative validation environment
