### PR TITLE
Infer proactive visuals from structured tool outputs

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -234,9 +234,16 @@ internal sealed partial class ChatServiceSession {
     }
 
     internal static string BuildProactiveFollowUpReviewPrompt(string userRequest, string assistantDraft) {
+        return BuildProactiveFollowUpReviewPrompt(userRequest, assistantDraft, toolOutputs: null);
+    }
+
+    internal static string BuildProactiveFollowUpReviewPrompt(
+        string userRequest,
+        string assistantDraft,
+        IReadOnlyList<ToolOutputDto>? toolOutputs) {
         var requestText = TrimForPrompt(userRequest, 520);
         var draftText = TrimForPrompt(assistantDraft, 1800);
-        var visualPolicy = ResolveProactiveVisualizationPolicy(userRequest, assistantDraft);
+        var visualPolicy = ResolveProactiveVisualizationPolicy(userRequest, assistantDraft, toolOutputs);
         var allowNewVisualsText = visualPolicy.AllowNewVisuals ? "true" : "false";
         var draftHasVisualsText = visualPolicy.DraftHasVisuals ? "true" : "false";
         var requestHasVisualContractText = visualPolicy.RequestHasVisualContract ? "true" : "false";
@@ -295,7 +302,10 @@ internal sealed partial class ChatServiceSession {
             """;
     }
 
-    private static ProactiveVisualizationPolicy ResolveProactiveVisualizationPolicy(string userRequest, string assistantDraft) {
+    private static ProactiveVisualizationPolicy ResolveProactiveVisualizationPolicy(
+        string userRequest,
+        string assistantDraft,
+        IReadOnlyList<ToolOutputDto>? toolOutputs) {
         var requestHasProactiveVisualizationMarker = ContainsProactiveVisualizationMarker(userRequest);
         var requestHasVisualContractSignal = ContainsVisualContractSignal(userRequest);
         var hasStructuredOverrides = TryReadProactiveVisualizationOverridesFromRequestText(userRequest, out var hasAllowNewVisualsOverride,
@@ -324,17 +334,30 @@ internal sealed partial class ChatServiceSession {
             : hasMaxNewVisualsOverride
                     ? maxNewVisualsOverride > 0
                     : requestHasVisualContractSignal;
+        var hasInferredPreferredVisualTypeFromToolOutputs = false;
+        if (baseAllowNewVisuals
+            && requestHasVisualContract
+            && !hasPreferredVisualDirectiveFromRequest
+            && TryResolvePreferredVisualTypeFromToolOutputs(toolOutputs, out var inferredPreferredVisualTypeFromToolOutputs)
+            && !string.IsNullOrWhiteSpace(inferredPreferredVisualTypeFromToolOutputs)) {
+            effectivePreferredVisualType = inferredPreferredVisualTypeFromToolOutputs;
+            hasInferredPreferredVisualTypeFromToolOutputs = true;
+        }
+
         var hasInferredPreferredVisualTypeFromDraft = false;
         if (baseAllowNewVisuals
             && requestHasVisualContract
             && !hasPreferredVisualDirectiveFromRequest
+            && !hasInferredPreferredVisualTypeFromToolOutputs
             && TryResolvePreferredVisualTypeFromVisualContractSignal(assistantDraft, out var inferredPreferredVisualTypeFromDraft)
             && !string.IsNullOrWhiteSpace(inferredPreferredVisualTypeFromDraft)) {
             effectivePreferredVisualType = inferredPreferredVisualTypeFromDraft;
             hasInferredPreferredVisualTypeFromDraft = true;
         }
 
-        var hasPreferredVisualDirective = hasPreferredVisualDirectiveFromRequest || hasInferredPreferredVisualTypeFromDraft;
+        var hasPreferredVisualDirective = hasPreferredVisualDirectiveFromRequest
+                                          || hasInferredPreferredVisualTypeFromToolOutputs
+                                          || hasInferredPreferredVisualTypeFromDraft;
         var maxNewVisuals = hasMaxNewVisualsOverride
             ? Math.Clamp(maxNewVisualsOverride, 0, MaxSupportedProactiveVisualBlocks)
             : baseAllowNewVisuals
@@ -350,6 +373,53 @@ internal sealed partial class ChatServiceSession {
             PreferredVisualType: effectivePreferredVisualType,
             HasMaxNewVisualsOverride: hasMaxNewVisualsOverride,
             MaxNewVisuals: maxNewVisuals);
+    }
+
+    private static bool TryResolvePreferredVisualTypeFromToolOutputs(
+        IReadOnlyList<ToolOutputDto>? toolOutputs,
+        out string preferredVisualType) {
+        preferredVisualType = string.Empty;
+        if (toolOutputs is null || toolOutputs.Count == 0) {
+            return false;
+        }
+
+        for (var i = toolOutputs.Count - 1; i >= 0; i--) {
+            var output = toolOutputs[i];
+            if (output is null) {
+                continue;
+            }
+
+            if (TryResolvePreferredVisualTypeFromVisualContractSignal(output.SummaryMarkdown, out preferredVisualType)
+                && !string.IsNullOrWhiteSpace(preferredVisualType)) {
+                return true;
+            }
+
+            if (TryResolvePreferredVisualTypeFromToolOutputPayload(output.Output, out preferredVisualType)
+                && !string.IsNullOrWhiteSpace(preferredVisualType)) {
+                return true;
+            }
+        }
+
+        preferredVisualType = string.Empty;
+        return false;
+    }
+
+    private static bool TryResolvePreferredVisualTypeFromToolOutputPayload(
+        string? outputPayload,
+        out string preferredVisualType) {
+        preferredVisualType = string.Empty;
+        var payload = (outputPayload ?? string.Empty).Trim();
+        if (payload.Length < 2) {
+            return false;
+        }
+
+        try {
+            using var document = JsonDocument.Parse(payload);
+            return TryResolvePreferredVisualTypeFromJsonElement(document.RootElement, out preferredVisualType);
+        } catch (JsonException) {
+            preferredVisualType = string.Empty;
+            return false;
+        }
     }
 
     private static bool ContainsProactiveVisualizationMarker(string? text) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedFinalize.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedFinalize.cs
@@ -524,7 +524,7 @@ internal sealed partial class ChatServiceSession {
 
                 if (!noResultWatchdogTriggered && proactiveDecision.ShouldAttempt) {
                     proactiveFollowUpUsed = true;
-                    var proactivePrompt = BuildProactiveFollowUpReviewPrompt(routedUserRequest, text);
+                    var proactivePrompt = BuildProactiveFollowUpReviewPrompt(routedUserRequest, text, toolOutputs);
                     turn = await RunReviewOnlyModelPhaseWithProgressAsync(
                             client,
                             writer,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.Service;
 using Xunit;
 
@@ -52,6 +54,51 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferPreferredVisualFromToolOutputsWhenVisualsAreAllowed() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var draft = """
+            Current findings:
+            | host | status |
+            | --- | --- |
+            | AD0 | healthy |
+            """;
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"nodes\":[{\"id\":\"AD0\"}],\"edges\":[]}",
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, draft, outputs);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_DoesNotEnableVisualsFromToolOutputsWithoutVisualContract() {
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"labels\":[\"Jan\",\"Feb\"],\"series\":[1,2]}",
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt("analyze logons", "Current findings...", outputs);
+
+        Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: false", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: auto", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- pass recent tool outputs into proactive follow-up review prompt generation
- infer `preferred_visual` from structured tool output payloads (JSON object/array shape), not just request/draft lexical contracts
- prioritize inferred visual from tool outputs over draft-only inference when request allows visuals
- keep behavior safe: tool outputs alone do not enable visuals if request has no visual contract
- add regression tests for positive and negative tool-output-driven visual inference cases

## Validation
- attempted: `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_InferPreferredVisualFromToolOutputsWhenVisualsAreAllowed|FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_DoesNotEnableVisualsFromToolOutputsWithoutVisualContract"`
- local compile remains blocked by existing missing type references in `IntelligenceX.Tools.TestimoX`, `IntelligenceX.Tools.ADPlayground`, and `IntelligenceX.Tools.System`
- CI is the authoritative validation environment
