### PR TITLE
Chat: emit proactive visual source telemetry

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -27,6 +27,7 @@ internal sealed partial class ChatServiceSession {
         bool RequestHasVisualContract,
         bool HasPreferredVisualOverride,
         string PreferredVisualType,
+        string PreferredVisualSource,
         bool HasMaxNewVisualsOverride,
         int MaxNewVisuals);
 
@@ -250,6 +251,9 @@ internal sealed partial class ChatServiceSession {
         var preferredVisualTypeText = visualPolicy.HasPreferredVisualOverride
             ? visualPolicy.PreferredVisualType
             : "auto";
+        var preferredVisualSourceText = visualPolicy.HasPreferredVisualOverride
+            ? visualPolicy.PreferredVisualSource
+            : "none";
         var maxNewVisualsText = visualPolicy.HasMaxNewVisualsOverride
             ? visualPolicy.MaxNewVisuals.ToString()
             : visualPolicy.AllowNewVisuals
@@ -275,6 +279,7 @@ internal sealed partial class ChatServiceSession {
             draft_has_visuals: {{draftHasVisualsText}}
             request_has_visual_contract: {{requestHasVisualContractText}}
             preferred_visual: {{preferredVisualTypeText}}
+            preferred_visual_source: {{preferredVisualSourceText}}
             max_new_visuals: {{maxNewVisualsText}}
 
             User request:
@@ -320,6 +325,7 @@ internal sealed partial class ChatServiceSession {
             : hasInferredPreferredVisualTypeFromRequest
                 ? inferredPreferredVisualTypeFromRequest
                 : string.Empty;
+        var preferredVisualSource = hasPreferredVisualDirectiveFromRequest ? "request" : "none";
         var hasExplicitAutoPreferredVisualOverride = hasPreferredVisualOverride
             && string.Equals(preferredVisualType, "auto", StringComparison.OrdinalIgnoreCase);
         var requestHasVisualContract = requestHasProactiveVisualizationMarker || requestHasVisualContractSignal || hasStructuredOverrides;
@@ -341,6 +347,7 @@ internal sealed partial class ChatServiceSession {
             && TryResolvePreferredVisualTypeFromToolOutputs(toolOutputs, out var inferredPreferredVisualTypeFromToolOutputs)
             && !string.IsNullOrWhiteSpace(inferredPreferredVisualTypeFromToolOutputs)) {
             effectivePreferredVisualType = inferredPreferredVisualTypeFromToolOutputs;
+            preferredVisualSource = "tool_outputs";
             hasInferredPreferredVisualTypeFromToolOutputs = true;
         }
 
@@ -352,6 +359,7 @@ internal sealed partial class ChatServiceSession {
             && TryResolvePreferredVisualTypeFromVisualContractSignal(assistantDraft, out var inferredPreferredVisualTypeFromDraft)
             && !string.IsNullOrWhiteSpace(inferredPreferredVisualTypeFromDraft)) {
             effectivePreferredVisualType = inferredPreferredVisualTypeFromDraft;
+            preferredVisualSource = "draft";
             hasInferredPreferredVisualTypeFromDraft = true;
         }
 
@@ -371,6 +379,7 @@ internal sealed partial class ChatServiceSession {
             RequestHasVisualContract: requestHasVisualContract,
             HasPreferredVisualOverride: hasPreferredVisualDirective,
             PreferredVisualType: effectivePreferredVisualType,
+            PreferredVisualSource: preferredVisualSource,
             HasMaxNewVisualsOverride: hasMaxNewVisualsOverride,
             MaxNewVisuals: maxNewVisuals);
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -54,6 +54,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: draft", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -82,6 +83,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: tool_outputs", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -99,6 +101,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("allow_new_visuals: false", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: false", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("preferred_visual: auto", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: none", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -224,6 +227,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: request", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("If preferred_visual is set, prefer that visual format", text, StringComparison.OrdinalIgnoreCase);
     }
 


### PR DESCRIPTION
## Summary
- add `preferred_visual_source` to proactive visualization policy and prompt contract
- mark source as `request`, `tool_outputs`, `draft`, or `none` based on how preferred visual is resolved
- extend visual-contract routing tests to assert the new telemetry field across request/draft/tool/no-contract paths

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServiceRoutingTrimTests"` *(fails in this workspace due to missing external types from TestimoX/ADPlayground/ComputerX, pre-existing)*
