### PR TITLE
Chat: expand structured visual JSON aliases

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
@@ -20,6 +20,12 @@ internal sealed partial class ChatServiceSession {
     private const string TableVisualType = "table";
     private const string LegacyNetworkVisualType = "visnetwork";
     private const int MaxSupportedProactiveVisualBlocks = 3;
+    private static readonly string[] NetworkJsonNodeAliases = new[] { "nodes", "vertices" };
+    private static readonly string[] NetworkJsonEdgeAliases = new[] { "edges", "links" };
+    private static readonly string[] ChartJsonLabelAliases = new[] { "labels", "categories" };
+    private static readonly string[] ChartJsonSeriesAliases = new[] { "datasets", "series", "data", "values" };
+    private static readonly string[] TableJsonRowAliases = new[] { "rows", "data", "items" };
+    private static readonly string[] TableJsonColumnAliases = new[] { "columns", "headers", "fields" };
 
     private static readonly VisualTypeCatalogEntry[] VisualTypeCatalog = {
         new(
@@ -350,47 +356,75 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static bool LooksLikeNetworkJsonVisualContract(ReadOnlySpan<char> text) {
-        return ContainsJsonArrayProperty(text, "nodes") && ContainsJsonArrayProperty(text, "edges");
+        return ContainsAnyJsonArrayProperty(text, NetworkJsonNodeAliases)
+               && ContainsAnyJsonArrayProperty(text, NetworkJsonEdgeAliases);
     }
 
     private static bool LooksLikeNetworkJsonVisualContract(JsonElement element) {
-        return HasJsonArrayProperty(element, "nodes") && HasJsonArrayProperty(element, "edges");
+        return HasAnyJsonArrayProperty(element, NetworkJsonNodeAliases)
+               && HasAnyJsonArrayProperty(element, NetworkJsonEdgeAliases);
     }
 
     private static bool LooksLikeChartJsonVisualContract(ReadOnlySpan<char> text) {
-        if (!ContainsJsonArrayProperty(text, "labels")) {
+        if (!ContainsAnyJsonArrayProperty(text, ChartJsonLabelAliases)) {
             return false;
         }
 
-        return ContainsJsonArrayProperty(text, "datasets") || ContainsJsonArrayProperty(text, "series");
+        return ContainsAnyJsonArrayProperty(text, ChartJsonSeriesAliases);
     }
 
     private static bool LooksLikeChartJsonVisualContract(JsonElement element) {
-        if (!HasJsonArrayProperty(element, "labels")) {
+        if (!HasAnyJsonArrayProperty(element, ChartJsonLabelAliases)) {
             return false;
         }
 
-        return HasJsonArrayProperty(element, "datasets") || HasJsonArrayProperty(element, "series");
+        return HasAnyJsonArrayProperty(element, ChartJsonSeriesAliases);
     }
 
     private static bool LooksLikeTableJsonVisualContract(ReadOnlySpan<char> text) {
-        if (!ContainsJsonArrayProperty(text, "rows")) {
+        if (!ContainsAnyJsonArrayProperty(text, TableJsonRowAliases)) {
             return false;
         }
 
-        return ContainsJsonArrayProperty(text, "columns")
-               || ContainsJsonArrayProperty(text, "headers")
-               || ContainsJsonArrayProperty(text, "fields");
+        return ContainsAnyJsonArrayProperty(text, TableJsonColumnAliases);
     }
 
     private static bool LooksLikeTableJsonVisualContract(JsonElement element) {
-        if (!HasJsonArrayProperty(element, "rows")) {
+        if (!HasAnyJsonArrayProperty(element, TableJsonRowAliases)) {
             return false;
         }
 
-        return HasJsonArrayProperty(element, "columns")
-               || HasJsonArrayProperty(element, "headers")
-               || HasJsonArrayProperty(element, "fields");
+        return HasAnyJsonArrayProperty(element, TableJsonColumnAliases);
+    }
+
+    private static bool ContainsAnyJsonArrayProperty(ReadOnlySpan<char> text, string[] propertyNames) {
+        if (propertyNames is null || propertyNames.Length == 0) {
+            return false;
+        }
+
+        for (var i = 0; i < propertyNames.Length; i++) {
+            var propertyName = propertyNames[i];
+            if (ContainsJsonArrayProperty(text, propertyName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasAnyJsonArrayProperty(JsonElement element, string[] propertyNames) {
+        if (propertyNames is null || propertyNames.Length == 0) {
+            return false;
+        }
+
+        for (var i = 0; i < propertyNames.Length; i++) {
+            var propertyName = propertyNames[i];
+            if (HasJsonArrayProperty(element, propertyName)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool ContainsJsonArrayProperty(ReadOnlySpan<char> text, string propertyName) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -87,6 +87,29 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferPreferredVisualFromToolOutputsUsingLinksAliasWhenVisualsAreAllowed() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"nodes\":[{\"id\":\"AD0\"}],\"links\":[{\"source\":\"AD0\",\"target\":\"AD1\"}]}",
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...", outputs);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: tool_outputs", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_DoesNotEnableVisualsFromToolOutputsWithoutVisualContract() {
         var outputs = new List<ToolOutputDto> {
             new() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.cs
@@ -588,6 +588,19 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJsonNetworkContractUsingLinksAlias() {
+        var request = """
+            Use this structured visual contract if useful:
+            {"nodes":[{"id":"DC01"},{"id":"DC02"}],"links":[{"source":"DC01","target":"DC02"}]}
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJsonChartContractWithoutFence() {
         var request = """
             Use this structured visual contract if useful:
@@ -601,10 +614,36 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJsonChartContractUsingCategoriesAndDataAliases() {
+        var request = """
+            Use this structured visual contract if useful:
+            {"categories":["Jan","Feb"],"data":[12,18]}
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-chart", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJsonTableContractWithoutFence() {
         var request = """
             Use this structured visual contract if useful:
             {"columns":["host","status"],"rows":[["dc01","healthy"]]}
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJsonTableContractUsingDataAlias() {
+        var request = """
+            Use this structured visual contract if useful:
+            {"headers":["host","status"],"data":[["dc01","healthy"]]}
             """;
         var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
 


### PR DESCRIPTION
## Summary
- expand structured JSON visual contract detection with alias catalogs instead of single hardcoded keys
- add support for network (`links`), chart (`categories`, `data`, `values`), and table (`data`, `items`) JSON variants
- add regression tests for alias-based request and tool-output inference

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_AllowsVisualsForStructuredJson"` *(fails in this workspace due to missing external types from TestimoX/ADPlayground/ComputerX, pre-existing)*
