### PR TITLE
Chat: expand routing pack alias search tokens

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -309,10 +309,38 @@ internal sealed partial class ChatServiceSession {
             sb.Append(" pack:").Append(token);
         }
 
-        AppendPackToken(packHint);
-        foreach (var alias in GetNormalizedPackAliases(packHint)) {
+        foreach (var alias in BuildRoutingPackSearchTokens(packHint)) {
             AppendPackToken(alias);
         }
+    }
+
+    private static IEnumerable<string> BuildRoutingPackSearchTokens(string packHint) {
+        var aliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        void AddToken(string value) {
+            var token = (value ?? string.Empty).Trim();
+            if (token.Length > 0) {
+                aliases.Add(token);
+            }
+        }
+
+        AddToken(packHint);
+        foreach (var alias in GetNormalizedPackAliases(packHint)) {
+            AddToken(alias);
+        }
+
+        switch (NormalizePackId(packHint)) {
+            case "domaindetective":
+                AddToken("domain_detective");
+                break;
+            case "dnsclientx":
+                AddToken("dns_client_x");
+                break;
+            case "testimox":
+                AddToken("testimo_x");
+                break;
+        }
+
+        return aliases;
     }
 
     private static string[] ExtractToolSchemaPropertyNames(ToolDefinition definition, int maxCount, out bool hasTableViewProjection) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -240,6 +240,8 @@ public sealed class ChatServicePlannerPromptTests {
 
         Assert.Contains("pack dnsclientx", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack:dnsclientx", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack dns_client_x", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack:dns_client_x", searchText, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -253,6 +255,24 @@ public sealed class ChatServicePlannerPromptTests {
 
         Assert.Contains("pack domaindetective", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack:domaindetective", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack domain_detective", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack:domain_detective", searchText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildToolRoutingSearchText_IncludesTestimoXUnderscoreAliasTokens() {
+        var definition = new ToolDefinition(
+            "health_rules",
+            "Run TestimoX rules.",
+            ToolSchema.Object(("scope", ToolSchema.String("Scope."))).NoAdditionalProperties(),
+            category: "testimox");
+
+        var searchText = Assert.IsType<string>(BuildToolRoutingSearchTextMethod.Invoke(null, new object?[] { definition }));
+
+        Assert.Contains("pack testimox", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack:testimox", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack testimo_x", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack:testimo_x", searchText, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- expand routing search pack tokens with underscore alias variants for `dns_client_x`, `domain_detective`, and `testimo_x`
- keep existing normalized/canonical aliases while appending these literal alias forms for better user-query/tool matching
- add planner prompt tests that validate new alias token inclusion in search text

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServicePlannerPromptTests"` *(fails in this workspace due to missing external types from TestimoX/ADPlayground/ComputerX, pre-existing)*
