### PR TITLE
Chat: add literal pack alias routing tokens

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -329,6 +329,18 @@ internal sealed partial class ChatServiceSession {
         }
 
         switch (NormalizePackId(packHint)) {
+            case "activedirectory":
+                AddToken("active_directory");
+                break;
+            case "ad":
+                AddToken("active_directory");
+                break;
+            case "adplayground":
+                AddToken("active_directory");
+                break;
+            case "eventlog":
+                AddToken("event_log");
+                break;
             case "domaindetective":
                 AddToken("domain_detective");
                 break;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -216,6 +216,21 @@ public sealed class ChatServicePlannerPromptTests {
     }
 
     [Fact]
+    public void BuildToolRoutingSearchText_IncludesActiveDirectoryLiteralAliasWhenPackCategoryIsAd() {
+        var definition = new ToolDefinition(
+            "directory_scope_probe",
+            "Directory scope probe.",
+            ToolSchema.Object(("domain", ToolSchema.String("Domain DNS name."))).NoAdditionalProperties(),
+            category: "ad");
+
+        var searchText = Assert.IsType<string>(BuildToolRoutingSearchTextMethod.Invoke(null, new object?[] { definition }));
+
+        Assert.Contains("pack ad", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack active_directory", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack:active_directory", searchText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildToolRoutingSearchText_IncludesComputerXAliasForSystemPack() {
         var definition = new ToolDefinition(
             "inventory_collect",
@@ -273,6 +288,22 @@ public sealed class ChatServicePlannerPromptTests {
         Assert.Contains("pack:testimox", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack testimo_x", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack:testimo_x", searchText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildToolRoutingSearchText_IncludesEventLogUnderscoreAliasTokens() {
+        var definition = new ToolDefinition(
+            "event_log_query",
+            "Query event log entries.",
+            ToolSchema.Object(("log_name", ToolSchema.String("Log name."))).NoAdditionalProperties(),
+            category: "event_log");
+
+        var searchText = Assert.IsType<string>(BuildToolRoutingSearchTextMethod.Invoke(null, new object?[] { definition }));
+
+        Assert.Contains("pack eventlog", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack:eventlog", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack event_log", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack:event_log", searchText, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- extend routing pack search token expansion with literal underscore aliases for additional packs
- add explicit literal aliases for `active_directory` (from `ad`/`adplayground`) and `event_log` (from `eventlog`) alongside existing `dns_client_x`, `domain_detective`, and `testimo_x`
- add planner prompt tests that verify the new alias tokens are present in routing search text

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~ChatServicePlannerPromptTests"` *(fails in this workspace due to missing external types from TestimoX/ADPlayground/ComputerX, pre-existing)*
