### PR TITLE
Chat: include pack aliases in planner prompt

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Secondary.cs
@@ -336,6 +336,10 @@ internal sealed partial class ChatServiceSession {
             }
             if (packHint.Length > 0) {
                 sb.Append(" | pack: ").Append(packHint);
+                var packAliases = ResolvePlannerPackAliases(packHint);
+                if (packAliases.Length > 0) {
+                    sb.Append(" | pack_aliases: ").Append(string.Join(", ", packAliases));
+                }
             }
             if (domainIntentFamily.Length > 0) {
                 sb.Append(" | family: ").Append(domainIntentFamily);
@@ -411,6 +415,31 @@ internal sealed partial class ChatServiceSession {
         }
 
         return string.Empty;
+    }
+
+    private static string[] ResolvePlannerPackAliases(string packHint) {
+        var normalizedPackHint = (packHint ?? string.Empty).Trim();
+        if (normalizedPackHint.Length == 0) {
+            return Array.Empty<string>();
+        }
+
+        var aliases = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { normalizedPackHint };
+        foreach (var token in BuildRoutingPackSearchTokens(normalizedPackHint)) {
+            var alias = (token ?? string.Empty).Trim();
+            if (alias.Length == 0 || !seen.Add(alias)) {
+                continue;
+            }
+
+            aliases.Add(alias);
+        }
+
+        if (aliases.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        aliases.Sort(StringComparer.OrdinalIgnoreCase);
+        return aliases.ToArray();
     }
 
     private static bool TryResolvePackHintFromToolNamePrefix(string toolName, out string packHint) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -88,6 +88,7 @@ public sealed class ChatServicePlannerPromptTests {
 
         Assert.Contains("category: dns", prompt, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack: domaindetective", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack_aliases: domain_detective", prompt, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("family: public_domain", prompt, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("tags: intent:public_domain", prompt, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack:domaindetective", prompt, StringComparison.OrdinalIgnoreCase);
@@ -109,6 +110,26 @@ public sealed class ChatServicePlannerPromptTests {
         }));
 
         Assert.Contains("pack: system", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildModelPlannerPrompt_IncludesPackAliasesForEventLogCategoryAlias() {
+        var definitions = new List<ToolDefinition> {
+            new(
+                "event_log_query",
+                "Query event log entries.",
+                ToolSchema.Object(("log_name", ToolSchema.String("Log name."))).NoAdditionalProperties(),
+                category: "event_log")
+        };
+
+        var prompt = Assert.IsType<string>(BuildModelPlannerPromptMethod.Invoke(null, new object?[] {
+            "collect system log evidence",
+            definitions,
+            4
+        }));
+
+        Assert.Contains("pack: eventlog", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack_aliases: event_log", prompt, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- extend planner prompt tool lines with deterministic `pack_aliases` metadata when a pack hint exists
- derive aliases from the same routing pack-token source used by lexical scoring, excluding the primary `pack` value
- add planner tests covering alias emission for `domaindetective` (`domain_detective`) and `eventlog` (`event_log`) paths

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~BuildModelPlannerPrompt"` *(fails in this workspace due to missing external types from TestimoX/ADPlayground/ComputerX, pre-existing)*
