### PR TITLE
Chat: include domain intent context in routing meta

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -170,7 +170,9 @@ internal sealed partial class ChatServiceSession {
                 requestedMaxCandidateTools: requestedMaxCandidateTools,
                 effectiveMaxCandidateTools: maxCandidateTools,
                 effectiveContextLength: maxCandidateToolDiagnostics.EffectiveContextLength,
-                contextAwareBudgetApplied: maxCandidateToolDiagnostics.ContextAwareBudgetApplied);
+                contextAwareBudgetApplied: maxCandidateToolDiagnostics.ContextAwareBudgetApplied,
+                domainIntentSource: null,
+                domainIntentFamily: null);
             await TryWriteStatusAsync(
                     writer,
                     request.RequestId,
@@ -234,7 +236,9 @@ internal sealed partial class ChatServiceSession {
                     requestedMaxCandidateTools: requestedMaxCandidateTools,
                     effectiveMaxCandidateTools: maxCandidateTools,
                     effectiveContextLength: maxCandidateToolDiagnostics.EffectiveContextLength,
-                    contextAwareBudgetApplied: maxCandidateToolDiagnostics.ContextAwareBudgetApplied);
+                    contextAwareBudgetApplied: maxCandidateToolDiagnostics.ContextAwareBudgetApplied,
+                    domainIntentSource: "signal_hint",
+                    domainIntentFamily: signaledFamily);
                 await TryWriteStatusAsync(
                         writer,
                         request.RequestId,
@@ -266,7 +270,9 @@ internal sealed partial class ChatServiceSession {
                     requestedMaxCandidateTools: requestedMaxCandidateTools,
                     effectiveMaxCandidateTools: maxCandidateTools,
                     effectiveContextLength: maxCandidateToolDiagnostics.EffectiveContextLength,
-                    contextAwareBudgetApplied: maxCandidateToolDiagnostics.ContextAwareBudgetApplied);
+                    contextAwareBudgetApplied: maxCandidateToolDiagnostics.ContextAwareBudgetApplied,
+                    domainIntentSource: "affinity",
+                    domainIntentFamily: affinityFamily);
                 await TryWriteStatusAsync(
                         writer,
                         request.RequestId,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
@@ -235,9 +235,15 @@ internal sealed partial class ChatServiceSession {
         int? requestedMaxCandidateTools,
         int? effectiveMaxCandidateTools,
         long? effectiveContextLength,
-        bool contextAwareBudgetApplied) {
+        bool contextAwareBudgetApplied,
+        string? domainIntentSource,
+        string? domainIntentFamily) {
         var (selected, total) = NormalizeRoutingToolCounts(selectedToolCount, totalToolCount);
         var normalizedContextLength = effectiveContextLength is > 0 ? effectiveContextLength : null;
+        var normalizedDomainIntentSource = NormalizeRoutingDomainIntentSource(domainIntentSource);
+        var normalizedDomainIntentFamily = TryNormalizeDomainIntentFamily(domainIntentFamily, out var parsedDomainIntentFamily)
+            ? parsedDomainIntentFamily
+            : string.Empty;
         return JsonSerializer.Serialize(new {
             strategy = (strategy ?? string.Empty).Trim(),
             weightedToolRouting,
@@ -253,8 +259,23 @@ internal sealed partial class ChatServiceSession {
                 effective = effectiveMaxCandidateTools,
                 contextAwareBudgetApplied,
                 effectiveModelContextLength = normalizedContextLength
+            },
+            domainIntent = new {
+                source = normalizedDomainIntentSource.Length > 0 ? normalizedDomainIntentSource : null,
+                family = normalizedDomainIntentFamily.Length > 0 ? normalizedDomainIntentFamily : null
             }
         });
+    }
+
+    private static string NormalizeRoutingDomainIntentSource(string? source) {
+        var normalized = NormalizeCompactToken((source ?? string.Empty).AsSpan());
+        return normalized switch {
+            "signalhint" => "signal_hint",
+            "domainsignalhint" => "signal_hint",
+            "affinity" => "affinity",
+            "domainfamilyaffinity" => "affinity",
+            _ => string.Empty
+        };
     }
 
     private static (int SelectedToolCount, int TotalToolCount) NormalizeRoutingToolCounts(int selectedToolCount, int totalToolCount) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingTransparency.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingTransparency.cs
@@ -188,7 +188,9 @@ public sealed partial class ChatServiceRoutingTrimTests {
             null,
             null,
             null,
-            false
+            false,
+            null,
+            null
         });
         var payload = Assert.IsType<string>(payloadResult);
         using var doc = JsonDocument.Parse(payload);
@@ -212,7 +214,9 @@ public sealed partial class ChatServiceRoutingTrimTests {
             null,
             null,
             null,
-            false
+            false,
+            null,
+            null
         });
         var payload = Assert.IsType<string>(result);
 
@@ -240,7 +244,9 @@ public sealed partial class ChatServiceRoutingTrimTests {
             null,
             null,
             null,
-            false
+            false,
+            null,
+            null
         });
         var payload = Assert.IsType<string>(result);
 
@@ -265,7 +271,9 @@ public sealed partial class ChatServiceRoutingTrimTests {
             null,
             null,
             null,
-            false
+            false,
+            null,
+            null
         });
         var payload = Assert.IsType<string>(result);
 
@@ -291,7 +299,9 @@ public sealed partial class ChatServiceRoutingTrimTests {
             null,
             4,
             8192L,
-            true
+            true,
+            null,
+            null
         });
         var payload = Assert.IsType<string>(result);
 
@@ -302,6 +312,33 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.True(budget.GetProperty("contextAwareBudgetApplied").GetBoolean());
         Assert.Equal(8192L, budget.GetProperty("effectiveModelContextLength").GetInt64());
         Assert.Equal(JsonValueKind.Null, budget.GetProperty("requested").ValueKind);
+    }
+
+    [Fact]
+    public void BuildRoutingMetaPayload_IncludesDomainIntentContextWhenProvided() {
+        var result = BuildRoutingMetaPayloadMethod.Invoke(null, new object?[] {
+            "domain_signal_hint",
+            true,
+            false,
+            false,
+            3,
+            9,
+            1,
+            false,
+            null,
+            5,
+            16384L,
+            false,
+            "signal_hint",
+            "public_domain"
+        });
+        var payload = Assert.IsType<string>(result);
+
+        using var doc = JsonDocument.Parse(payload);
+        var root = doc.RootElement;
+        var domainIntent = root.GetProperty("domainIntent");
+        Assert.Equal("signal_hint", domainIntent.GetProperty("source").GetString());
+        Assert.Equal("public_domain", domainIntent.GetProperty("family").GetString());
     }
 
     private static object CreateToolRoutingInsight(string toolName, string confidence, double score, string reason, string strategyName) {


### PR DESCRIPTION
## Summary
- enrich `routing_meta` payloads with structured domain-intent context (`domainIntent.source`, `domainIntent.family`)
- thread domain-intent source/family through routing meta emission for signal-hint and affinity paths
- add routing transparency test coverage validating domain-intent fields are emitted when provided

## Validation
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~RoutingTransparency"` *(fails in this workspace due to missing external types from TestimoX/ADPlayground/ComputerX, pre-existing)*
