### PR TITLE
Chat: normalize separator-aware routing tokens

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -194,7 +194,7 @@ internal sealed partial class ChatServiceSession {
         var tokenStart = 0;
         for (var i = 0; i <= normalized.Length; i++) {
             var ch = i < normalized.Length ? normalized[i] : '\0';
-            var isTokenChar = i < normalized.Length && char.IsLetterOrDigit(ch);
+            var isTokenChar = i < normalized.Length && (char.IsLetterOrDigit(ch) || ch is '_' or '-');
             if (isTokenChar) {
                 if (!inToken) {
                     inToken = true;
@@ -214,28 +214,72 @@ internal sealed partial class ChatServiceSession {
             }
 
             var lower = token.ToLowerInvariant();
-            var hasNonAscii = false;
-            for (var t = 0; t < lower.Length; t++) {
-                if (lower[t] > 127) {
-                    hasNonAscii = true;
-                    break;
-                }
+            if (TryAddRoutingTokenCandidate(tokens, seen, lower, maxTokens)) {
+                break;
             }
 
-            var minLen = hasNonAscii ? 2 : 3;
-            if (lower.Length < minLen) {
-                continue;
+            var separatorNormalized = NormalizeRoutingSeparatorToken(lower);
+            if (TryAddRoutingTokenCandidate(tokens, seen, separatorNormalized, maxTokens)) {
+                break;
             }
 
-            if (seen.Add(lower)) {
-                tokens.Add(lower);
-                if (tokens.Count >= maxTokens) {
-                    break;
-                }
+            var compact = NormalizeCompactToken(lower.AsSpan());
+            if (TryAddRoutingTokenCandidate(tokens, seen, compact, maxTokens)) {
+                break;
             }
         }
 
         return tokens.Count == 0 ? Array.Empty<string>() : tokens.ToArray();
+    }
+
+    private static bool TryAddRoutingTokenCandidate(List<string> tokens, HashSet<string> seen, string candidate, int maxTokens) {
+        var normalized = (candidate ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return false;
+        }
+
+        var hasNonAscii = false;
+        for (var i = 0; i < normalized.Length; i++) {
+            if (normalized[i] > 127) {
+                hasNonAscii = true;
+                break;
+            }
+        }
+
+        var minLen = hasNonAscii ? 2 : 3;
+        if (normalized.Length < minLen || !seen.Add(normalized)) {
+            return false;
+        }
+
+        tokens.Add(normalized);
+        return tokens.Count >= maxTokens;
+    }
+
+    private static string NormalizeRoutingSeparatorToken(string value) {
+        var normalized = (value ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(normalized.Length);
+        var previousWasSeparator = false;
+        for (var i = 0; i < normalized.Length; i++) {
+            var ch = normalized[i];
+            if (char.IsLetterOrDigit(ch)) {
+                sb.Append(char.ToLowerInvariant(ch));
+                previousWasSeparator = false;
+                continue;
+            }
+
+            if (ch is '_' or '-') {
+                if (!previousWasSeparator && sb.Length > 0) {
+                    sb.Append('_');
+                    previousWasSeparator = true;
+                }
+            }
+        }
+
+        return sb.ToString().Trim('_');
     }
 
     private static string BuildToolRoutingSearchText(ToolDefinition definition) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -23,6 +23,9 @@ public sealed class ChatServicePlannerPromptTests {
     private static readonly MethodInfo BuildToolRoutingSearchTextMethod =
         typeof(ChatServiceSession).GetMethod("BuildToolRoutingSearchText", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("BuildToolRoutingSearchText not found.");
+    private static readonly MethodInfo TokenizeRoutingTokensMethod =
+        typeof(ChatServiceSession).GetMethod("TokenizeRoutingTokens", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("TokenizeRoutingTokens not found.");
 
     private static readonly MethodInfo SelectWeightedToolSubsetMethod =
         typeof(ChatServiceSession).GetMethod("SelectWeightedToolSubset", BindingFlags.NonPublic | BindingFlags.Instance)
@@ -325,6 +328,21 @@ public sealed class ChatServicePlannerPromptTests {
         Assert.Contains("pack:eventlog", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack event_log", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack:event_log", searchText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TokenizeRoutingTokens_PreservesSeparatorAwarePackAliasTokensAndCompactVariants() {
+        var result = TokenizeRoutingTokensMethod.Invoke(
+            null,
+            new object?[] { "Use pack:domain_detective and pack:dns-client-x with pack:testimo_x.", 16 });
+        var tokens = Assert.IsType<string[]>(result);
+
+        Assert.Contains(tokens, token => string.Equals(token, "domain_detective", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "domaindetective", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "dns_client_x", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "dnsclientx", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "testimo_x", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "testimox", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- keep _ and - as token characters in weighted routing tokenization so pack aliases stay coherent
- add separator-normalized token candidates (for example dns-client-x -> dns_client_x)
- add compact token candidates (for example dns_client_x -> dnsclientx) to improve matching robustness
- add regression coverage for domain_detective, dns-client-x, and 	estimo_x token variants

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter TokenizeRoutingTokens_PreservesSeparatorAwarePackAliasTokensAndCompactVariants *(fails in this workspace due to pre-existing ADPlayground missing-type compile blockers; CI validates in canonical environment)*