### PR TITLE
Chat: keep short pack aliases in routing tokens

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -190,6 +190,7 @@ internal sealed partial class ChatServiceSession {
 
         var tokens = new List<string>(Math.Min(12, maxTokens));
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var previousToken = string.Empty;
         var inToken = false;
         var tokenStart = 0;
         for (var i = 0; i <= normalized.Length; i++) {
@@ -214,25 +215,28 @@ internal sealed partial class ChatServiceSession {
             }
 
             var lower = token.ToLowerInvariant();
-            if (TryAddRoutingTokenCandidate(tokens, seen, lower, maxTokens)) {
+            var allowShortAsciiCandidate = string.Equals(previousToken, "pack", StringComparison.Ordinal);
+            if (TryAddRoutingTokenCandidate(tokens, seen, lower, maxTokens, allowShortAsciiCandidate)) {
                 break;
             }
 
             var separatorNormalized = NormalizeRoutingSeparatorToken(lower);
-            if (TryAddRoutingTokenCandidate(tokens, seen, separatorNormalized, maxTokens)) {
+            if (TryAddRoutingTokenCandidate(tokens, seen, separatorNormalized, maxTokens, allowShortAsciiCandidate)) {
                 break;
             }
 
             var compact = NormalizeCompactToken(lower.AsSpan());
-            if (TryAddRoutingTokenCandidate(tokens, seen, compact, maxTokens)) {
+            if (TryAddRoutingTokenCandidate(tokens, seen, compact, maxTokens, allowShortAsciiCandidate)) {
                 break;
             }
+
+            previousToken = lower;
         }
 
         return tokens.Count == 0 ? Array.Empty<string>() : tokens.ToArray();
     }
 
-    private static bool TryAddRoutingTokenCandidate(List<string> tokens, HashSet<string> seen, string candidate, int maxTokens) {
+    private static bool TryAddRoutingTokenCandidate(List<string> tokens, HashSet<string> seen, string candidate, int maxTokens, bool allowShortAsciiCandidate) {
         var normalized = (candidate ?? string.Empty).Trim();
         if (normalized.Length == 0) {
             return false;
@@ -246,7 +250,7 @@ internal sealed partial class ChatServiceSession {
             }
         }
 
-        var minLen = hasNonAscii ? 2 : 3;
+        var minLen = hasNonAscii ? 2 : allowShortAsciiCandidate ? 2 : 3;
         if (normalized.Length < minLen || !seen.Add(normalized)) {
             return false;
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -346,6 +346,17 @@ public sealed class ChatServicePlannerPromptTests {
     }
 
     [Fact]
+    public void TokenizeRoutingTokens_PreservesShortPackAliasToken_WhenPrefixedByPackMarker() {
+        var result = TokenizeRoutingTokensMethod.Invoke(
+            null,
+            new object?[] { "Use pack:ad and pack:system for this task.", 16 });
+        var tokens = Assert.IsType<string[]>(result);
+
+        Assert.Contains(tokens, token => string.Equals(token, "ad", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "system", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void SelectWeightedToolSubset_UsesRequestedLimit_WhenPromptHasNoRoutingSignal() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var definitions = new List<ToolDefinition>();


### PR DESCRIPTION
## Summary
- keep short ASCII routing tokens (length 2) when they are explicitly prefixed by a pack marker
- preserve this behavior across raw/separator-normalized/compact token candidates
- add regression coverage for pack:ad to prevent AD alias loss in weighted routing

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter TokenizeRoutingTokens_PreservesShortPackAliasToken_WhenPrefixedByPackMarker *(blocked in this workspace by pre-existing missing external types in TestimoX/ComputerX projects; CI validates in canonical environment)*