### PR TITLE
Chat: add underscore aliases for pack routing hints

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -379,12 +379,21 @@ internal sealed partial class ChatServiceSession {
         switch (NormalizePackId(packHint)) {
             case "activedirectory":
                 AddToken("active_directory");
+                AddToken("ad_playground");
                 break;
             case "ad":
                 AddToken("active_directory");
+                AddToken("ad_playground");
                 break;
             case "adplayground":
                 AddToken("active_directory");
+                AddToken("ad_playground");
+                break;
+            case "system":
+                AddToken("computer_x");
+                break;
+            case "computerx":
+                AddToken("computer_x");
                 break;
             case "eventlog":
                 AddToken("event_log");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -237,6 +237,7 @@ public sealed class ChatServicePlannerPromptTests {
 
         Assert.Contains("pack active_directory", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack adplayground", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack ad_playground", searchText, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -252,6 +253,8 @@ public sealed class ChatServicePlannerPromptTests {
         Assert.Contains("pack ad", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack active_directory", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack:active_directory", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack ad_playground", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack:ad_playground", searchText, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -266,6 +269,8 @@ public sealed class ChatServicePlannerPromptTests {
 
         Assert.Contains("pack system", searchText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("pack computerx", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack computer_x", searchText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pack:computer_x", searchText, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- extend routing pack token expansion with underscore literals for ADPlayground (d_playground) and ComputerX/System (computer_x)
- ensure these aliases are emitted into pack/pack: search text for weighted routing and planner hints
- expand planner prompt tests to lock in these alias tokens

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release *(blocked in this workspace by pre-existing missing external types in TestimoX/ADPlayground projects; CI validates in canonical environment)*