### PR TITLE
Chat: broaden structured visual JSON aliases

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
@@ -20,12 +20,12 @@ internal sealed partial class ChatServiceSession {
     private const string TableVisualType = "table";
     private const string LegacyNetworkVisualType = "visnetwork";
     private const int MaxSupportedProactiveVisualBlocks = 3;
-    private static readonly string[] NetworkJsonNodeAliases = new[] { "nodes", "vertices" };
-    private static readonly string[] NetworkJsonEdgeAliases = new[] { "edges", "links" };
-    private static readonly string[] ChartJsonLabelAliases = new[] { "labels", "categories" };
-    private static readonly string[] ChartJsonSeriesAliases = new[] { "datasets", "series", "data", "values" };
-    private static readonly string[] TableJsonRowAliases = new[] { "rows", "data", "items" };
-    private static readonly string[] TableJsonColumnAliases = new[] { "columns", "headers", "fields" };
+    private static readonly string[] NetworkJsonNodeAliases = new[] { "nodes", "vertices", "entities" };
+    private static readonly string[] NetworkJsonEdgeAliases = new[] { "edges", "links", "relationships", "connections" };
+    private static readonly string[] ChartJsonLabelAliases = new[] { "labels", "categories", "x", "x_axis" };
+    private static readonly string[] ChartJsonSeriesAliases = new[] { "datasets", "series", "data", "values", "points", "metrics" };
+    private static readonly string[] TableJsonRowAliases = new[] { "rows", "data", "items", "records", "entries" };
+    private static readonly string[] TableJsonColumnAliases = new[] { "columns", "headers", "fields", "keys" };
 
     private static readonly VisualTypeCatalogEntry[] VisualTypeCatalog = {
         new(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -110,6 +110,75 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferPreferredVisualFromToolOutputsUsingRelationshipsAliasesWhenVisualsAreAllowed() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"entities\":[{\"id\":\"AD0\"}],\"relationships\":[{\"source\":\"AD0\",\"target\":\"AD1\"}]}",
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...", outputs);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: tool_outputs", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferChartPreferredVisualFromToolOutputsUsingXAxisAndPointsAliasesWhenVisualsAreAllowed() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"x\":[\"Jan\",\"Feb\"],\"points\":[4,7]}",
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...", outputs);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-chart", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: tool_outputs", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferTablePreferredVisualFromToolOutputsUsingRecordsAliasWhenVisualsAreAllowed() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"keys\":[\"host\",\"status\"],\"records\":[[\"DC01\",\"healthy\"]]}",
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...", outputs);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: tool_outputs", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_DoesNotEnableVisualsFromToolOutputsWithoutVisualContract() {
         var outputs = new List<ToolOutputDto> {
             new() {


### PR DESCRIPTION
## Summary
- broaden structured JSON visual inference aliases so proactive formatting can detect real-world payload shapes more reliably
- add new network aliases (ntities, elationships, connections), chart aliases (x, x_axis, points, metrics), and table aliases (ecords, ntries, keys)
- add regression tests covering network/chart/table inference from these new tool-output aliases

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter BuildProactiveFollowUpReviewPrompt_InferPreferredVisualFromToolOutputsUsingRelationshipsAliasesWhenVisualsAreAllowed *(blocked in this workspace by pre-existing missing external types in ADPlayground/TestimoX projects; CI validates in canonical environment)*