### PR TITLE
Chat: expand preferred visual aliases

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
@@ -31,25 +31,25 @@ internal sealed partial class ChatServiceSession {
         new(
             CanonicalType: MermaidVisualType,
             SupportsProactiveFenceGuidance: true,
-            PreferredAliases: new[] { "diagram" },
+            PreferredAliases: new[] { "diagram", "flowchart" },
             FenceLanguageSignals: new[] { MermaidVisualType },
             InlineTokenSignals: new[] { MermaidVisualType, "diagram" }),
         new(
             CanonicalType: ChartVisualType,
             SupportsProactiveFenceGuidance: true,
-            PreferredAliases: new[] { "chart" },
+            PreferredAliases: new[] { "chart", "plot" },
             FenceLanguageSignals: new[] { ChartVisualType },
             InlineTokenSignals: new[] { ChartVisualType, "chart" }),
         new(
             CanonicalType: NetworkVisualType,
             SupportsProactiveFenceGuidance: true,
-            PreferredAliases: new[] { "network", LegacyNetworkVisualType },
+            PreferredAliases: new[] { "network", "graph", "node-link", LegacyNetworkVisualType },
             FenceLanguageSignals: new[] { NetworkVisualType, LegacyNetworkVisualType },
             InlineTokenSignals: new[] { NetworkVisualType, "network", LegacyNetworkVisualType }),
         new(
             CanonicalType: TableVisualType,
             SupportsProactiveFenceGuidance: false,
-            PreferredAliases: new[] { "markdown-table", "markdown_table" },
+            PreferredAliases: new[] { "markdown-table", "markdown_table", "data-table", "datatable", "grid" },
             FenceLanguageSignals: Array.Empty<string>(),
             InlineTokenSignals: new[] { TableVisualType, "markdown-table", "markdown_table" })
     };

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -324,11 +324,38 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_NormalizesGraphPreferredVisualAlias() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            preferred_visual: graph
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: request", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_ParsesPreferredVisualTypeWithInlineComment() {
         var request = """
             [Proactive visualization guidance]
             ix:proactive-visualization:v1
             preferred_visual_type: chart # keep compact
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-chart", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_NormalizesPlotPreferredVisualAlias() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            preferred_visual_type: plot
             """;
         var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
 
@@ -348,6 +375,20 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("If preferred_visual is set, prefer that visual format", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_NormalizesDatatablePreferredVisualAlias() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            preferred_visual: datatable
+            """;
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...");
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: request", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- expand preferred visual aliases so intent-driven formatting is less brittle
- add lowchart for mermaid, plot for charts, graph/
ode-link for network visuals, and data-table/datatable/grid for table visuals
- add regression tests for graph, plot, and datatable structured preferred visual directives

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter BuildProactiveFollowUpReviewPrompt_NormalizesGraphPreferredVisualAlias *(blocked in this workspace by pre-existing missing external types in System/ADPlayground/TestimoX projects; CI validates in canonical environment)*