### PR TITLE
Chat: remove hardcoded proactive visual wording

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -292,7 +292,7 @@ internal sealed partial class ChatServiceSession {
             - Keep all existing factual findings that are already supported by tool output.
             - Keep the response natural and conversational, not scripted.
             - Add proactive follow-ups only when they provide real value (typically 1-3 key items).
-            - Prefer concise prose/bullets by default; keep tables/diagrams/charts/networks optional.
+            - Prefer concise prose/bullets by default; keep visual blocks optional.
             - Use visuals only when they materially improve clarity over plain markdown.
             {{visualRequirementLine}}
             {{preferredVisualRequirementLine}}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -308,6 +308,14 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_UsesGenericVisualOptionalityGuidanceText() {
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt("Analyze current findings.", "Current findings...");
+
+        Assert.Contains("keep visual blocks optional", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("tables/diagrams/charts/networks", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_UsesStructuredPreferredVisualAlias() {
         var request = """
             [Proactive visualization guidance]


### PR DESCRIPTION
## Summary
- remove hardcoded 	ables/diagrams/charts/networks wording from proactive review guidance
- replace with generic isual blocks guidance to keep the prompt resilient as supported formats evolve
- add regression coverage to ensure prompt text stays generic and does not reintroduce the hardcoded list

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter BuildProactiveFollowUpReviewPrompt_UsesGenericVisualOptionalityGuidanceText *(blocked in this workspace by pre-existing missing external types in ADPlayground/TestimoX projects; CI validates in canonical environment)*