### PR TITLE
Chat: widen routing subset for ambiguous top scores

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingHelpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingHelpers.cs
@@ -16,6 +16,12 @@ using IntelligenceX.Json;
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
+    private const double WeightedRoutingAmbiguousSecondScoreRatioThreshold = 0.92d;
+    private const double WeightedRoutingAmbiguousClusterScoreRatioThreshold = 0.82d;
+    private const int WeightedRoutingAmbiguousClusterMinCount = 3;
+    private const int WeightedRoutingAmbiguousSelectionFloor = 10;
+    private const int WeightedRoutingAmbiguousSelectionCap = 12;
+
     private static void TraceNoToolExecutionWatchdogDecision(
         string userRequest,
         bool executionContractApplies,
@@ -473,7 +479,7 @@ internal sealed partial class ChatServiceSession {
             return SelectDeterministicToolSubset(definitions, limit);
         }
 
-        var minSelection = Math.Min(definitions.Count, Math.Max(8, Math.Min(limit, 12)));
+        var minSelection = ResolveWeightedRoutingMinSelection(scored, limit, definitions.Count);
         if (selectedDefs.Count < minSelection) {
             for (var i = selectedDefs.Count; i < scored.Count && selectedDefs.Count < minSelection; i++) {
                 var definition = scored[i].Definition;
@@ -490,6 +496,52 @@ internal sealed partial class ChatServiceSession {
 
         insights = BuildRoutingInsights(scored, selectedDefs);
         return selectedDefs;
+    }
+
+    private static int ResolveWeightedRoutingMinSelection(IReadOnlyList<ToolScore> scored, int limit, int definitionCount) {
+        var baseline = Math.Min(definitionCount, Math.Max(8, Math.Min(limit, 12)));
+        if (scored.Count < 2 || definitionCount <= baseline) {
+            return baseline;
+        }
+
+        var topScore = scored[0].Score;
+        if (topScore <= 0d) {
+            return baseline;
+        }
+
+        var secondScoreRatio = scored[1].Score / topScore;
+        if (secondScoreRatio < WeightedRoutingAmbiguousSecondScoreRatioThreshold) {
+            return baseline;
+        }
+
+        var ambiguousClusterSize = 0;
+        for (var i = 0; i < scored.Count; i++) {
+            var score = scored[i].Score;
+            if (score <= 0.01d) {
+                break;
+            }
+
+            var scoreRatio = score / topScore;
+            if (scoreRatio < WeightedRoutingAmbiguousClusterScoreRatioThreshold) {
+                break;
+            }
+
+            ambiguousClusterSize++;
+            if (ambiguousClusterSize >= WeightedRoutingAmbiguousSelectionCap) {
+                break;
+            }
+        }
+
+        if (ambiguousClusterSize < WeightedRoutingAmbiguousClusterMinCount) {
+            return baseline;
+        }
+
+        var widened = Math.Max(
+            baseline,
+            Math.Min(
+                WeightedRoutingAmbiguousSelectionCap,
+                Math.Max(WeightedRoutingAmbiguousSelectionFloor, ambiguousClusterSize)));
+        return Math.Min(definitionCount, widened);
     }
 
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -449,6 +449,37 @@ public sealed class ChatServicePlannerPromptTests {
     }
 
     [Fact]
+    public void SelectWeightedToolSubset_WidensSelection_WhenTopScoresAreAmbiguous() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var definitions = new List<ToolDefinition>();
+        for (var i = 0; i < 10; i++) {
+            definitions.Add(new ToolDefinition(
+                $"signal_tool_{i:D2}",
+                "Collect telemetryx diagnostics.",
+                ToolSchema.Object(("target", ToolSchema.String("Target host."))).NoAdditionalProperties()));
+        }
+
+        for (var i = 0; i < 10; i++) {
+            definitions.Add(new ToolDefinition(
+                $"other_tool_{i:D2}",
+                "Collect generic inventory details.",
+                ToolSchema.Object(("target", ToolSchema.String("Target host."))).NoAdditionalProperties()));
+        }
+
+        var args = new object?[] {
+            definitions,
+            "Please summarize telemetryx for this environment.",
+            8,
+            null
+        };
+        var selected = Assert.IsAssignableFrom<IReadOnlyList<ToolDefinition>>(SelectWeightedToolSubsetMethod.Invoke(session, args));
+
+        Assert.Equal(10, selected.Count);
+        Assert.Equal("signal_tool_00", selected[0].Name);
+        Assert.Equal("signal_tool_09", selected[9].Name);
+    }
+
+    [Fact]
     public void ResolveMaxCandidateToolsSetting_DefaultsCompatibleHttpToEight() {
         var result = ResolveMaxCandidateToolsSettingMethod.Invoke(null, new object?[] { null, OpenAITransportKind.CompatibleHttp });
         var value = Assert.IsType<int>(result);


### PR DESCRIPTION
## Summary
- add ambiguity-aware weighted routing selection floor when top candidate scores are tightly clustered
- keep selection bounded (max 12) while widening from baseline when score ties indicate uncertain ranking
- replace inline min-selection math with a dedicated helper to avoid duplicated magic numbers
- add regression coverage proving subset widening for ambiguous top-score clusters

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter SelectWeightedToolSubset_WidensSelection_WhenTopScoresAreAmbiguous *(blocked in this workspace by pre-existing missing external types in TestimoX/ComputerX projects; CI validates in canonical environment)*