### PR TITLE
Chat: recognize spaced compound pack phrases

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -16,6 +16,16 @@ using IntelligenceX.Json;
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
+    private static readonly HashSet<string> CompoundPackRoutingTokenCompacts = new(StringComparer.OrdinalIgnoreCase) {
+        "activedirectory",
+        "adplayground",
+        "computerx",
+        "domaindetective",
+        "dnsclientx",
+        "eventlog",
+        "testimox"
+    };
+
 
     private static IReadOnlyList<ToolDefinition> SelectDeterministicToolSubset(IReadOnlyList<ToolDefinition> definitions, int limit) {
         if (definitions.Count == 0 || limit <= 0) {
@@ -190,6 +200,7 @@ internal sealed partial class ChatServiceSession {
 
         var tokens = new List<string>(Math.Min(12, maxTokens));
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var tokenBeforePrevious = string.Empty;
         var previousToken = string.Empty;
         var inToken = false;
         var tokenStart = 0;
@@ -230,10 +241,82 @@ internal sealed partial class ChatServiceSession {
                 break;
             }
 
+            if (TryAddCompoundPackRoutingTokenCandidates(tokens, seen, tokenBeforePrevious, previousToken, lower, maxTokens)) {
+                break;
+            }
+
+            tokenBeforePrevious = previousToken;
             previousToken = lower;
         }
 
         return tokens.Count == 0 ? Array.Empty<string>() : tokens.ToArray();
+    }
+
+    private static bool TryAddCompoundPackRoutingTokenCandidates(
+        List<string> tokens,
+        HashSet<string> seen,
+        string tokenBeforePrevious,
+        string previousToken,
+        string currentToken,
+        int maxTokens) {
+        if (TryAddKnownCompoundPackRoutingTokenCandidate(tokens, seen, previousToken, currentToken, maxTokens)) {
+            return true;
+        }
+
+        if (TryAddKnownCompoundPackRoutingTokenCandidate(tokens, seen, tokenBeforePrevious, previousToken, currentToken, maxTokens)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryAddKnownCompoundPackRoutingTokenCandidate(
+        List<string> tokens,
+        HashSet<string> seen,
+        string firstToken,
+        string secondToken,
+        int maxTokens) {
+        if (string.IsNullOrWhiteSpace(firstToken) || string.IsNullOrWhiteSpace(secondToken)) {
+            return false;
+        }
+
+        var combined = $"{firstToken}_{secondToken}";
+        return TryAddKnownCompoundPackRoutingTokenCandidate(tokens, seen, combined, maxTokens);
+    }
+
+    private static bool TryAddKnownCompoundPackRoutingTokenCandidate(
+        List<string> tokens,
+        HashSet<string> seen,
+        string firstToken,
+        string secondToken,
+        string thirdToken,
+        int maxTokens) {
+        if (string.IsNullOrWhiteSpace(firstToken)
+            || string.IsNullOrWhiteSpace(secondToken)
+            || string.IsNullOrWhiteSpace(thirdToken)) {
+            return false;
+        }
+
+        var combined = $"{firstToken}_{secondToken}_{thirdToken}";
+        return TryAddKnownCompoundPackRoutingTokenCandidate(tokens, seen, combined, maxTokens);
+    }
+
+    private static bool TryAddKnownCompoundPackRoutingTokenCandidate(
+        List<string> tokens,
+        HashSet<string> seen,
+        string combined,
+        int maxTokens) {
+        var compact = NormalizeCompactToken(combined.AsSpan());
+        if (compact.Length == 0 || !CompoundPackRoutingTokenCompacts.Contains(compact)) {
+            return false;
+        }
+
+        var separatorNormalized = NormalizeRoutingSeparatorToken(combined);
+        if (TryAddRoutingTokenCandidate(tokens, seen, separatorNormalized, maxTokens, allowShortAsciiCandidate: false)) {
+            return true;
+        }
+
+        return TryAddRoutingTokenCandidate(tokens, seen, compact, maxTokens, allowShortAsciiCandidate: false);
     }
 
     private static bool TryAddRoutingTokenCandidate(List<string> tokens, HashSet<string> seen, string candidate, int maxTokens, bool allowShortAsciiCandidate) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -362,6 +362,30 @@ public sealed class ChatServicePlannerPromptTests {
     }
 
     [Fact]
+    public void TokenizeRoutingTokens_EmitsCompoundPackTokensForSpacedPackPhrases() {
+        var result = TokenizeRoutingTokensMethod.Invoke(
+            null,
+            new object?[] {
+                "Run domain detective and dns client x checks, then active directory, ad playground, computer x, and testimo x posture.",
+                48
+            });
+        var tokens = Assert.IsType<string[]>(result);
+
+        Assert.Contains(tokens, token => string.Equals(token, "domain_detective", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "domaindetective", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "dns_client_x", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "dnsclientx", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "active_directory", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "activedirectory", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "ad_playground", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "adplayground", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "computer_x", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "computerx", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "testimo_x", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tokens, token => string.Equals(token, "testimox", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void SelectWeightedToolSubset_UsesRequestedLimit_WhenPromptHasNoRoutingSignal() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var definitions = new List<ToolDefinition>();


### PR DESCRIPTION
## Summary
- extend routing tokenization to emit known compound pack tokens from spaced user phrases
- support two-token compounds (domain detective, ctive directory, d playground, computer x, 	estimo x, vent log) and three-token compound (dns client x)
- keep expansion bounded to known pack compounds to avoid noisy generic token combinations
- add regression coverage for spaced pack phrase token emission

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter TokenizeRoutingTokens_EmitsCompoundPackTokensForSpacedPackPhrases *(blocked in this workspace by pre-existing missing external types in TestimoX/ADPlayground projects; CI validates in canonical environment)*