### PR TITLE
Chat: compact-match domain intent technical signals

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentSignals.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentSignals.cs
@@ -224,6 +224,7 @@ internal sealed partial class ChatServiceSession {
     private static bool ContainsDomainSignalToken(string text, string token) {
         var normalizedText = (text ?? string.Empty).Trim();
         var normalizedToken = NormalizeDomainSignalTokenValue(token);
+        var compactToken = NormalizeCompactToken(normalizedToken.AsSpan());
         if (normalizedText.Length == 0 || normalizedToken.Length == 0) {
             return false;
         }
@@ -254,6 +255,11 @@ internal sealed partial class ChatServiceSession {
             }
 
             if (string.Equals(candidate, normalizedToken, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+
+            if (compactToken.Length > 0
+                && string.Equals(NormalizeCompactToken(candidate.AsSpan()), compactToken, StringComparison.OrdinalIgnoreCase)) {
                 return true;
             }
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceDomainAffinityTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceDomainAffinityTests.cs
@@ -383,6 +383,8 @@ public sealed class ChatServiceDomainAffinityTests {
     [InlineData("Por favor revisar DNS publico", "public_domain")]
     [InlineData("Verifier DNS public du domaine", "public_domain")]
     [InlineData("Use adplayground for this domain", "ad_domain")]
+    [InlineData("Use ad_playground for this domain", "ad_domain")]
+    [InlineData("Use ad-playground for this domain", "ad_domain")]
     [InlineData("active_directory diagnostics for this domain", "ad_domain")]
     [InlineData("Run domaindetective checks for this zone", "public_domain")]
     [InlineData("Run domain_detective checks for this zone", "public_domain")]


### PR DESCRIPTION
## Summary
- make domain-intent technical signal matching resilient to separator variants by adding compact-form token comparisons
- this lets signals like d_playground and d-playground resolve against canonical dplayground intent tokens
- add regression coverage for underscore and hyphen ADPlayground signal forms in language-neutral domain-intent parsing tests

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter TryResolvePendingDomainIntentClarificationSelection_ParsesLanguageNeutralTechnicalSignals *(blocked in this workspace by pre-existing missing external types in TestimoX/ComputerX projects; CI validates in canonical environment)*