### PR TITLE
Chat: expose ambiguity widening in routing meta

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingHelpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingHelpers.cs
@@ -16,11 +16,19 @@ using IntelligenceX.Json;
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
+    private const string WeightedRoutingAmbiguityMarker = "ix:routing-ambiguity:v1";
     private const double WeightedRoutingAmbiguousSecondScoreRatioThreshold = 0.92d;
     private const double WeightedRoutingAmbiguousClusterScoreRatioThreshold = 0.82d;
     private const int WeightedRoutingAmbiguousClusterMinCount = 3;
     private const int WeightedRoutingAmbiguousSelectionFloor = 10;
     private const int WeightedRoutingAmbiguousSelectionCap = 12;
+
+    private readonly record struct WeightedRoutingSelectionDiagnostics(
+        bool AmbiguityWidened,
+        int BaselineMinSelection,
+        int EffectiveMinSelection,
+        int AmbiguousClusterSize,
+        double SecondScoreRatio);
 
     private static void TraceNoToolExecutionWatchdogDecision(
         string userRequest,
@@ -479,7 +487,8 @@ internal sealed partial class ChatServiceSession {
             return SelectDeterministicToolSubset(definitions, limit);
         }
 
-        var minSelection = ResolveWeightedRoutingMinSelection(scored, limit, definitions.Count);
+        var selectionDiagnostics = ResolveWeightedRoutingSelectionDiagnostics(scored, limit, definitions.Count);
+        var minSelection = selectionDiagnostics.EffectiveMinSelection;
         if (selectedDefs.Count < minSelection) {
             for (var i = selectedDefs.Count; i < scored.Count && selectedDefs.Count < minSelection; i++) {
                 var definition = scored[i].Definition;
@@ -494,24 +503,42 @@ internal sealed partial class ChatServiceSession {
             return definitions;
         }
 
-        insights = BuildRoutingInsights(scored, selectedDefs);
+        insights = BuildRoutingInsights(scored, selectedDefs, selectionDiagnostics);
         return selectedDefs;
     }
 
-    private static int ResolveWeightedRoutingMinSelection(IReadOnlyList<ToolScore> scored, int limit, int definitionCount) {
+    private static WeightedRoutingSelectionDiagnostics ResolveWeightedRoutingSelectionDiagnostics(
+        IReadOnlyList<ToolScore> scored,
+        int limit,
+        int definitionCount) {
         var baseline = Math.Min(definitionCount, Math.Max(8, Math.Min(limit, 12)));
         if (scored.Count < 2 || definitionCount <= baseline) {
-            return baseline;
+            return new WeightedRoutingSelectionDiagnostics(
+                AmbiguityWidened: false,
+                BaselineMinSelection: baseline,
+                EffectiveMinSelection: baseline,
+                AmbiguousClusterSize: 0,
+                SecondScoreRatio: 0d);
         }
 
         var topScore = scored[0].Score;
         if (topScore <= 0d) {
-            return baseline;
+            return new WeightedRoutingSelectionDiagnostics(
+                AmbiguityWidened: false,
+                BaselineMinSelection: baseline,
+                EffectiveMinSelection: baseline,
+                AmbiguousClusterSize: 0,
+                SecondScoreRatio: 0d);
         }
 
         var secondScoreRatio = scored[1].Score / topScore;
         if (secondScoreRatio < WeightedRoutingAmbiguousSecondScoreRatioThreshold) {
-            return baseline;
+            return new WeightedRoutingSelectionDiagnostics(
+                AmbiguityWidened: false,
+                BaselineMinSelection: baseline,
+                EffectiveMinSelection: baseline,
+                AmbiguousClusterSize: 0,
+                SecondScoreRatio: Math.Round(secondScoreRatio, 3));
         }
 
         var ambiguousClusterSize = 0;
@@ -533,7 +560,12 @@ internal sealed partial class ChatServiceSession {
         }
 
         if (ambiguousClusterSize < WeightedRoutingAmbiguousClusterMinCount) {
-            return baseline;
+            return new WeightedRoutingSelectionDiagnostics(
+                AmbiguityWidened: false,
+                BaselineMinSelection: baseline,
+                EffectiveMinSelection: baseline,
+                AmbiguousClusterSize: ambiguousClusterSize,
+                SecondScoreRatio: Math.Round(secondScoreRatio, 3));
         }
 
         var widened = Math.Max(
@@ -541,7 +573,13 @@ internal sealed partial class ChatServiceSession {
             Math.Min(
                 WeightedRoutingAmbiguousSelectionCap,
                 Math.Max(WeightedRoutingAmbiguousSelectionFloor, ambiguousClusterSize)));
-        return Math.Min(definitionCount, widened);
+        var effective = Math.Min(definitionCount, widened);
+        return new WeightedRoutingSelectionDiagnostics(
+            AmbiguityWidened: effective > baseline,
+            BaselineMinSelection: baseline,
+            EffectiveMinSelection: effective,
+            AmbiguousClusterSize: ambiguousClusterSize,
+            SecondScoreRatio: Math.Round(secondScoreRatio, 3));
     }
 
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -139,7 +139,10 @@ internal sealed partial class ChatServiceSession {
         return normalized.ToLowerInvariant();
     }
 
-    private static List<ToolRoutingInsight> BuildRoutingInsights(IReadOnlyList<ToolScore> scored, IReadOnlyList<ToolDefinition> selectedDefs) {
+    private static List<ToolRoutingInsight> BuildRoutingInsights(
+        IReadOnlyList<ToolScore> scored,
+        IReadOnlyList<ToolDefinition> selectedDefs,
+        WeightedRoutingSelectionDiagnostics selectionDiagnostics) {
         if (selectedDefs.Count == 0 || scored.Count == 0) {
             return new List<ToolRoutingInsight>();
         }
@@ -151,6 +154,8 @@ internal sealed partial class ChatServiceSession {
 
         var maxScore = scored[0].Score <= 0 ? 1d : scored[0].Score;
         var insights = new List<ToolRoutingInsight>();
+        var ambiguityReason = BuildWeightedRoutingAmbiguityReason(selectionDiagnostics);
+        var emittedAmbiguityReason = false;
         for (var i = 0; i < scored.Count; i++) {
             var toolScore = scored[i];
             if (!selectedNames.Contains(toolScore.Definition.Name)) {
@@ -176,6 +181,12 @@ internal sealed partial class ChatServiceSession {
                 reasons.Add("general relevance");
             }
 
+            if (!emittedAmbiguityReason && ambiguityReason.Length > 0) {
+                reasons.Add("ambiguous top-score cluster");
+                reasons.Add(ambiguityReason);
+                emittedAmbiguityReason = true;
+            }
+
             insights.Add(new ToolRoutingInsight(
                 ToolName: toolScore.Definition.Name,
                 Confidence: confidence,
@@ -190,6 +201,14 @@ internal sealed partial class ChatServiceSession {
         }
 
         return insights;
+    }
+
+    private static string BuildWeightedRoutingAmbiguityReason(WeightedRoutingSelectionDiagnostics diagnostics) {
+        if (!diagnostics.AmbiguityWidened) {
+            return string.Empty;
+        }
+
+        return $"{WeightedRoutingAmbiguityMarker} baseline={diagnostics.BaselineMinSelection} effective={diagnostics.EffectiveMinSelection} cluster={diagnostics.AmbiguousClusterSize} second_ratio={diagnostics.SecondScoreRatio:0.###}";
     }
 
     private static string[] TokenizeRoutingTokens(string text, int maxTokens) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -140,6 +140,12 @@ internal sealed partial class ChatServiceSession {
         var requestedModelHeartbeatSeconds = request.Options?.ModelHeartbeatSeconds;
 
         var (routingSelectedToolCount, routingTotalToolCount) = NormalizeRoutingToolCounts(toolDefs.Count, originalToolCount);
+        var weightedAmbiguityWidened = TryResolveWeightedRoutingAmbiguityTelemetry(
+            routingInsights,
+            out var weightedAmbiguityBaselineSelection,
+            out var weightedAmbiguityEffectiveSelection,
+            out var weightedAmbiguityClusterSize,
+            out var weightedAmbiguitySecondScoreRatio);
         if (ShouldEmitRoutingTransparency(routingSelectedToolCount, routingTotalToolCount)) {
             var plannerInsightsDetected = HasPlannerInsight(routingInsights);
             var routingStrategy = ResolveRoutingStrategy(
@@ -172,7 +178,12 @@ internal sealed partial class ChatServiceSession {
                 effectiveContextLength: maxCandidateToolDiagnostics.EffectiveContextLength,
                 contextAwareBudgetApplied: maxCandidateToolDiagnostics.ContextAwareBudgetApplied,
                 domainIntentSource: null,
-                domainIntentFamily: null);
+                domainIntentFamily: null,
+                weightedAmbiguityWidened,
+                weightedAmbiguityBaselineSelection,
+                weightedAmbiguityEffectiveSelection,
+                weightedAmbiguityClusterSize,
+                weightedAmbiguitySecondScoreRatio);
             await TryWriteStatusAsync(
                     writer,
                     request.RequestId,
@@ -238,7 +249,12 @@ internal sealed partial class ChatServiceSession {
                     effectiveContextLength: maxCandidateToolDiagnostics.EffectiveContextLength,
                     contextAwareBudgetApplied: maxCandidateToolDiagnostics.ContextAwareBudgetApplied,
                     domainIntentSource: "signal_hint",
-                    domainIntentFamily: signaledFamily);
+                    domainIntentFamily: signaledFamily,
+                    weightedAmbiguityWidened,
+                    weightedAmbiguityBaselineSelection,
+                    weightedAmbiguityEffectiveSelection,
+                    weightedAmbiguityClusterSize,
+                    weightedAmbiguitySecondScoreRatio);
                 await TryWriteStatusAsync(
                         writer,
                         request.RequestId,
@@ -272,7 +288,12 @@ internal sealed partial class ChatServiceSession {
                     effectiveContextLength: maxCandidateToolDiagnostics.EffectiveContextLength,
                     contextAwareBudgetApplied: maxCandidateToolDiagnostics.ContextAwareBudgetApplied,
                     domainIntentSource: "affinity",
-                    domainIntentFamily: affinityFamily);
+                    domainIntentFamily: affinityFamily,
+                    weightedAmbiguityWidened,
+                    weightedAmbiguityBaselineSelection,
+                    weightedAmbiguityEffectiveSelection,
+                    weightedAmbiguityClusterSize,
+                    weightedAmbiguitySecondScoreRatio);
                 await TryWriteStatusAsync(
                         writer,
                         request.RequestId,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
@@ -237,13 +237,30 @@ internal sealed partial class ChatServiceSession {
         long? effectiveContextLength,
         bool contextAwareBudgetApplied,
         string? domainIntentSource,
-        string? domainIntentFamily) {
+        string? domainIntentFamily,
+        bool weightedAmbiguityWidened,
+        int? weightedAmbiguityBaselineSelection,
+        int? weightedAmbiguityEffectiveSelection,
+        int? weightedAmbiguityClusterSize,
+        double? weightedAmbiguitySecondScoreRatio) {
         var (selected, total) = NormalizeRoutingToolCounts(selectedToolCount, totalToolCount);
         var normalizedContextLength = effectiveContextLength is > 0 ? effectiveContextLength : null;
         var normalizedDomainIntentSource = NormalizeRoutingDomainIntentSource(domainIntentSource);
         var normalizedDomainIntentFamily = TryNormalizeDomainIntentFamily(domainIntentFamily, out var parsedDomainIntentFamily)
             ? parsedDomainIntentFamily
             : string.Empty;
+        var normalizedWeightedAmbiguityBaseline = weightedAmbiguityWidened && weightedAmbiguityBaselineSelection is > 0
+            ? weightedAmbiguityBaselineSelection
+            : null;
+        var normalizedWeightedAmbiguityEffective = weightedAmbiguityWidened && weightedAmbiguityEffectiveSelection is > 0
+            ? weightedAmbiguityEffectiveSelection
+            : null;
+        var normalizedWeightedAmbiguityCluster = weightedAmbiguityWidened && weightedAmbiguityClusterSize is > 0
+            ? weightedAmbiguityClusterSize
+            : null;
+        var normalizedWeightedAmbiguitySecondRatio = weightedAmbiguityWidened && weightedAmbiguitySecondScoreRatio is > 0d
+            ? Math.Round(weightedAmbiguitySecondScoreRatio.Value, 3)
+            : null;
         return JsonSerializer.Serialize(new {
             strategy = (strategy ?? string.Empty).Trim(),
             weightedToolRouting,
@@ -263,8 +280,117 @@ internal sealed partial class ChatServiceSession {
             domainIntent = new {
                 source = normalizedDomainIntentSource.Length > 0 ? normalizedDomainIntentSource : null,
                 family = normalizedDomainIntentFamily.Length > 0 ? normalizedDomainIntentFamily : null
+            },
+            weightedAmbiguity = new {
+                widened = weightedAmbiguityWidened,
+                baselineSelection = normalizedWeightedAmbiguityBaseline,
+                effectiveSelection = normalizedWeightedAmbiguityEffective,
+                clusterSize = normalizedWeightedAmbiguityCluster,
+                secondScoreRatio = normalizedWeightedAmbiguitySecondRatio
             }
         });
+    }
+
+    private static bool TryResolveWeightedRoutingAmbiguityTelemetry(
+        IReadOnlyList<ToolRoutingInsight> insights,
+        out int baselineSelection,
+        out int effectiveSelection,
+        out int clusterSize,
+        out double secondScoreRatio) {
+        baselineSelection = 0;
+        effectiveSelection = 0;
+        clusterSize = 0;
+        secondScoreRatio = 0d;
+        if (insights is null || insights.Count == 0) {
+            return false;
+        }
+
+        for (var i = 0; i < insights.Count; i++) {
+            var reason = (insights[i].Reason ?? string.Empty).Trim();
+            if (reason.Length == 0) {
+                continue;
+            }
+
+            if (!TryParseWeightedRoutingAmbiguityMarker(reason, out baselineSelection, out effectiveSelection, out clusterSize, out secondScoreRatio)) {
+                continue;
+            }
+
+            return baselineSelection > 0
+                   && effectiveSelection > baselineSelection
+                   && clusterSize > 0
+                   && secondScoreRatio > 0d;
+        }
+
+        return false;
+    }
+
+    private static bool TryParseWeightedRoutingAmbiguityMarker(
+        string reason,
+        out int baselineSelection,
+        out int effectiveSelection,
+        out int clusterSize,
+        out double secondScoreRatio) {
+        baselineSelection = 0;
+        effectiveSelection = 0;
+        clusterSize = 0;
+        secondScoreRatio = 0d;
+
+        var markerIndex = reason.IndexOf(WeightedRoutingAmbiguityMarker, StringComparison.OrdinalIgnoreCase);
+        if (markerIndex < 0) {
+            return false;
+        }
+
+        var markerTail = reason[(markerIndex + WeightedRoutingAmbiguityMarker.Length)..].Trim();
+        if (markerTail.Length == 0) {
+            return false;
+        }
+
+        var segments = markerTail.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var i = 0; i < segments.Length; i++) {
+            var segment = segments[i];
+            var separator = segment.IndexOf('=');
+            if (separator <= 0 || separator >= segment.Length - 1) {
+                continue;
+            }
+
+            var key = segment[..separator].Trim();
+            var value = segment[(separator + 1)..].Trim().TrimEnd(',', ';');
+            if (key.Length == 0 || value.Length == 0) {
+                continue;
+            }
+
+            if (string.Equals(key, "baseline", StringComparison.OrdinalIgnoreCase)) {
+                if (int.TryParse(value, out var parsed) && parsed > 0) {
+                    baselineSelection = parsed;
+                }
+                continue;
+            }
+
+            if (string.Equals(key, "effective", StringComparison.OrdinalIgnoreCase)) {
+                if (int.TryParse(value, out var parsed) && parsed > 0) {
+                    effectiveSelection = parsed;
+                }
+                continue;
+            }
+
+            if (string.Equals(key, "cluster", StringComparison.OrdinalIgnoreCase)) {
+                if (int.TryParse(value, out var parsed) && parsed > 0) {
+                    clusterSize = parsed;
+                }
+                continue;
+            }
+
+            if (string.Equals(key, "second_ratio", StringComparison.OrdinalIgnoreCase)) {
+                if (double.TryParse(value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var parsed) && parsed > 0d) {
+                    secondScoreRatio = parsed;
+                }
+            }
+        }
+
+        return baselineSelection > 0
+               && effectiveSelection > 0
+               && clusterSize > 0
+               && secondScoreRatio > 0d;
     }
 
     private static string NormalizeRoutingDomainIntentSource(string? source) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -501,6 +501,23 @@ public sealed class ChatServicePlannerPromptTests {
         Assert.Equal(10, selected.Count);
         Assert.Equal("signal_tool_00", selected[0].Name);
         Assert.Equal("signal_tool_09", selected[9].Name);
+
+        var insights = Assert.IsAssignableFrom<System.Collections.IEnumerable>(args[3]);
+        var hasAmbiguityMarker = false;
+        foreach (var insight in insights) {
+            if (insight is null) {
+                continue;
+            }
+
+            var reasonProperty = insight.GetType().GetProperty("Reason", BindingFlags.Public | BindingFlags.Instance);
+            var reason = reasonProperty?.GetValue(insight)?.ToString() ?? string.Empty;
+            if (reason.IndexOf("ix:routing-ambiguity:v1", StringComparison.OrdinalIgnoreCase) >= 0) {
+                hasAmbiguityMarker = true;
+                break;
+            }
+        }
+
+        Assert.True(hasAmbiguityMarker);
     }
 
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingTransparency.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingTransparency.cs
@@ -190,6 +190,11 @@ public sealed partial class ChatServiceRoutingTrimTests {
             null,
             false,
             null,
+            null,
+            false,
+            null,
+            null,
+            null,
             null
         });
         var payload = Assert.IsType<string>(payloadResult);
@@ -215,6 +220,11 @@ public sealed partial class ChatServiceRoutingTrimTests {
             null,
             null,
             false,
+            null,
+            null,
+            false,
+            null,
+            null,
             null,
             null
         });
@@ -246,6 +256,11 @@ public sealed partial class ChatServiceRoutingTrimTests {
             null,
             false,
             null,
+            null,
+            false,
+            null,
+            null,
+            null,
             null
         });
         var payload = Assert.IsType<string>(result);
@@ -272,6 +287,11 @@ public sealed partial class ChatServiceRoutingTrimTests {
             null,
             null,
             false,
+            null,
+            null,
+            false,
+            null,
+            null,
             null,
             null
         });
@@ -300,6 +320,11 @@ public sealed partial class ChatServiceRoutingTrimTests {
             4,
             8192L,
             true,
+            null,
+            null,
+            false,
+            null,
+            null,
             null,
             null
         });
@@ -330,7 +355,12 @@ public sealed partial class ChatServiceRoutingTrimTests {
             16384L,
             false,
             "signal_hint",
-            "public_domain"
+            "public_domain",
+            false,
+            null,
+            null,
+            null,
+            null
         });
         var payload = Assert.IsType<string>(result);
 
@@ -339,6 +369,67 @@ public sealed partial class ChatServiceRoutingTrimTests {
         var domainIntent = root.GetProperty("domainIntent");
         Assert.Equal("signal_hint", domainIntent.GetProperty("source").GetString());
         Assert.Equal("public_domain", domainIntent.GetProperty("family").GetString());
+    }
+
+    [Fact]
+    public void BuildRoutingMetaPayload_IncludesWeightedAmbiguityContextWhenProvided() {
+        var result = BuildRoutingMetaPayloadMethod.Invoke(null, new object?[] {
+            "weighted_heuristic",
+            true,
+            false,
+            false,
+            10,
+            21,
+            7,
+            false,
+            null,
+            8,
+            8192L,
+            true,
+            null,
+            null,
+            true,
+            8,
+            10,
+            10,
+            0.94d
+        });
+        var payload = Assert.IsType<string>(result);
+
+        using var doc = JsonDocument.Parse(payload);
+        var root = doc.RootElement;
+        var weightedAmbiguity = root.GetProperty("weightedAmbiguity");
+        Assert.True(weightedAmbiguity.GetProperty("widened").GetBoolean());
+        Assert.Equal(8, weightedAmbiguity.GetProperty("baselineSelection").GetInt32());
+        Assert.Equal(10, weightedAmbiguity.GetProperty("effectiveSelection").GetInt32());
+        Assert.Equal(10, weightedAmbiguity.GetProperty("clusterSize").GetInt32());
+        Assert.Equal(0.94d, weightedAmbiguity.GetProperty("secondScoreRatio").GetDouble());
+    }
+
+    [Fact]
+    public void TryResolveWeightedRoutingAmbiguityTelemetry_ParsesStructuredMarkerFromInsightReason() {
+        var insight = CreateToolRoutingInsight(
+            toolName: "signal_tool_00",
+            confidence: "high",
+            score: 9.0d,
+            reason: "token match, ix:routing-ambiguity:v1 baseline=8 effective=10 cluster=10 second_ratio=0.938",
+            strategyName: "WeightedHeuristic");
+        var insights = CreateRoutingInsightsArray(insight);
+
+        var args = new object?[] {
+            insights,
+            null,
+            null,
+            null,
+            null
+        };
+        var result = TryResolveWeightedRoutingAmbiguityTelemetryMethod.Invoke(null, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        Assert.Equal(8, Assert.IsType<int>(args[1]));
+        Assert.Equal(10, Assert.IsType<int>(args[2]));
+        Assert.Equal(10, Assert.IsType<int>(args[3]));
+        Assert.Equal(0.938d, Assert.IsType<double>(args[4]), 3);
     }
 
     private static object CreateToolRoutingInsight(string toolName, string confidence, double score, string reason, string strategyName) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.cs
@@ -236,6 +236,9 @@ public sealed partial class ChatServiceRoutingTrimTests {
     private static readonly MethodInfo BuildRoutingMetaPayloadMethod =
         typeof(ChatServiceSession).GetMethod("BuildRoutingMetaPayload", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("BuildRoutingMetaPayload not found.");
+    private static readonly MethodInfo TryResolveWeightedRoutingAmbiguityTelemetryMethod =
+        typeof(ChatServiceSession).GetMethod("TryResolveWeightedRoutingAmbiguityTelemetry", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("TryResolveWeightedRoutingAmbiguityTelemetry not found.");
     private static readonly MethodInfo NormalizeRoutingToolCountsMethod =
         typeof(ChatServiceSession).GetMethod("NormalizeRoutingToolCounts", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("NormalizeRoutingToolCounts not found.");


### PR DESCRIPTION
## Summary
- add structured weighted-routing ambiguity telemetry to outing_meta (weightedAmbiguity block)
- emit ambiguity marker hints from weighted routing insights when top-score clustering widens minimum selection
- parse ambiguity marker metadata into routing meta fields (widened, baseline/effective selection, cluster size, second score ratio)
- add routing transparency tests for payload shape and marker parsing
- extend weighted routing subset test to assert ambiguity marker emission

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter BuildRoutingMetaPayload_IncludesWeightedAmbiguityContextWhenProvided *(blocked in this workspace by pre-existing missing external types in ADPlayground/TestimoX projects; CI validates in canonical environment)*