### PR TITLE
Chat: add TestimoX to AD cross-pack fallback

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -371,6 +371,19 @@ internal sealed partial class ChatServiceSession {
                 return true;
             }
 
+            if (TryBuildCrossAdDiscoveryFallbackFromTestimoXToolCall(
+                    toolDefinitions: toolDefinitions,
+                    priorCalledTools: priorCalledTools,
+                    sourcePackId: sourcePackId,
+                    partialScopeHints: partialScopeHints,
+                    partialScopeReason: partialScopeReason,
+                    hasSourceFailureSignal: hasSourceFailureSignal,
+                    mutatingToolHintsByName: mutatingToolHintsByName,
+                    out toolCall,
+                    out reason)) {
+                return true;
+            }
+
             if (TryBuildCrossPublicDnsEvidenceFallbackToolCall(
                     toolDefinitions: toolDefinitions,
                     priorCalledTools: priorCalledTools,
@@ -659,6 +672,80 @@ internal sealed partial class ChatServiceSession {
         }
 
         reason = "cross_ad_posture_candidate_missing_required_args";
+        return false;
+    }
+
+    private bool TryBuildCrossAdDiscoveryFallbackFromTestimoXToolCall(
+        IReadOnlyList<ToolDefinition> toolDefinitions,
+        IReadOnlySet<string> priorCalledTools,
+        string sourcePackId,
+        JsonObject partialScopeHints,
+        string partialScopeReason,
+        bool hasSourceFailureSignal,
+        IReadOnlyDictionary<string, bool>? mutatingToolHintsByName,
+        out ToolCall toolCall,
+        out string reason) {
+        toolCall = null!;
+        reason = "cross_testimox_ad_discovery_not_applicable";
+
+        if (!PackIdMatches(sourcePackId, "testimox")
+            || !hasSourceFailureSignal) {
+            reason = "cross_testimox_ad_discovery_source_not_eligible";
+            return false;
+        }
+
+        if (!TryResolveCrossPackCandidateToolsByRouting(
+                toolDefinitions: toolDefinitions,
+                priorCalledTools: priorCalledTools,
+                targetPackId: "active_directory",
+                preferredScope: "domain",
+                preferredOperation: "discover",
+                mutatingToolHintsByName: mutatingToolHintsByName,
+                out var candidates)) {
+            reason = "cross_testimox_ad_discovery_candidate_unavailable";
+            return false;
+        }
+
+        for (var i = 0; i < candidates.Count; i++) {
+            var candidateTool = candidates[i].ToolName;
+            var toolDefinition = candidates[i].Definition;
+
+            var fallbackArguments = BuildPackFallbackArguments(
+                sourcePackId: NormalizePackId("active_directory"),
+                candidateTool: candidateTool,
+                partialScopeHints: partialScopeHints);
+            AddSchemaAwareFallbackHintArguments(toolDefinition, fallbackArguments, partialScopeHints);
+            AddSchemaAwareFallbackDefaultArguments("active_directory", toolDefinition, fallbackArguments, partialScopeHints);
+            var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
+            if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
+                || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
+                continue;
+            }
+
+            var serializedArguments = JsonLite.Serialize(normalizedArguments);
+            var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
+            var raw = new JsonObject()
+                .Add("type", "tool_call")
+                .Add("call_id", fallbackCallId)
+                .Add("name", candidateTool)
+                .Add("arguments", serializedArguments);
+
+            toolCall = new ToolCall(
+                callId: fallbackCallId,
+                name: candidateTool,
+                input: serializedArguments,
+                arguments: normalizedArguments,
+                raw: raw);
+            reason = "pack_contract_cross_testimox_ad_discovery:"
+                     + sourcePackId
+                     + ":"
+                     + partialScopeReason
+                     + "->"
+                     + candidateTool;
+            return true;
+        }
+
+        reason = "cross_testimox_ad_discovery_candidate_missing_required_args";
         return false;
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
@@ -638,4 +638,59 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("\"domain_name\":\"contoso.local\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackTestimoXToAdFallbackOnFailure() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["testimox_rules_run"] = "testimox";
+        packMap["ad_scope_discovery"] = "active_directory";
+
+        var toolDefinitions = new List<ToolDefinition> {
+            new(
+                "testimox_rules_run",
+                "Run selected TestimoX rules.",
+                ToolSchema.Object(("search_text", ToolSchema.String("Search text."))).NoAdditionalProperties()),
+            new(
+                "ad_scope_discovery",
+                "Discover AD scope.",
+                ToolSchema.Object(
+                        ("domain_name", ToolSchema.String("Domain name.")),
+                        ("discovery_fallback", ToolSchema.String("Fallback mode.")))
+                    .NoAdditionalProperties())
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-1",
+                Name = "testimox_rules_run",
+                Input = """
+                        {"domain_name":"contoso.local","search_text":"kerberos"}
+                        """
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-1",
+                Output = "{}",
+                Ok = false,
+                ErrorCode = "timeout"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["testimox_rules_run"] = false,
+            ["ad_scope_discovery"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "run posture checks", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("ad_scope_discovery", toolCall.Name);
+        Assert.Contains("pack_contract_cross_testimox_ad_discovery", reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"discovery_fallback\":\"current_forest\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+    }
+
 }


### PR DESCRIPTION
## Summary
- add reverse cross-pack fallback from failed TestimoX posture calls to read-only Active Directory discovery tools
- when TestimoX source calls fail, prefer AD domain-scope discovery candidates before generic same-pack retries
- use AD fallback argument defaults (discovery_fallback, domain hints) in this cross-pack recovery path
- add regression coverage for TestimoX failure pivoting to d_scope_discovery

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackTestimoXToAdFallbackOnFailure *(blocked in this workspace by pre-existing missing external types in ADPlayground/TestimoX projects; CI validates in canonical environment)*