### PR TITLE
Chat: add TestimoX to DomainDetective fallback

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -397,6 +397,19 @@ internal sealed partial class ChatServiceSession {
                 return true;
             }
 
+            if (TryBuildCrossPublicPostureEvidenceFallbackToDomainDetective(
+                    toolDefinitions: toolDefinitions,
+                    priorCalledTools: priorCalledTools,
+                    sourcePackId: sourcePackId,
+                    partialScopeHints: partialScopeHints,
+                    partialScopeReason: partialScopeReason,
+                    hasSourceFailureSignal: hasSourceFailureSignal,
+                    mutatingToolHintsByName: mutatingToolHintsByName,
+                    out toolCall,
+                    out reason)) {
+                return true;
+            }
+
             if (TryBuildCrossPublicDnsEvidenceFallbackToolCall(
                     toolDefinitions: toolDefinitions,
                     priorCalledTools: priorCalledTools,
@@ -833,6 +846,80 @@ internal sealed partial class ChatServiceSession {
         }
 
         reason = "cross_public_posture_testimox_candidate_missing_required_args";
+        return false;
+    }
+
+    private bool TryBuildCrossPublicPostureEvidenceFallbackToDomainDetective(
+        IReadOnlyList<ToolDefinition> toolDefinitions,
+        IReadOnlySet<string> priorCalledTools,
+        string sourcePackId,
+        JsonObject partialScopeHints,
+        string partialScopeReason,
+        bool hasSourceFailureSignal,
+        IReadOnlyDictionary<string, bool>? mutatingToolHintsByName,
+        out ToolCall toolCall,
+        out string reason) {
+        toolCall = null!;
+        reason = "cross_public_posture_domaindetective_not_applicable";
+
+        if (!PackIdMatches(sourcePackId, "testimox")
+            || !hasSourceFailureSignal) {
+            reason = "cross_public_posture_domaindetective_source_not_eligible";
+            return false;
+        }
+
+        if (!TryResolveCrossPackCandidateToolsByRouting(
+                toolDefinitions: toolDefinitions,
+                priorCalledTools: priorCalledTools,
+                targetPackId: "domaindetective",
+                preferredScope: "domain",
+                preferredOperation: "query",
+                mutatingToolHintsByName: mutatingToolHintsByName,
+                out var candidates)) {
+            reason = "cross_public_posture_domaindetective_candidate_unavailable";
+            return false;
+        }
+
+        for (var i = 0; i < candidates.Count; i++) {
+            var candidateTool = candidates[i].ToolName;
+            var toolDefinition = candidates[i].Definition;
+
+            var fallbackArguments = BuildPackFallbackArguments(
+                sourcePackId: NormalizePackId("domaindetective"),
+                candidateTool: candidateTool,
+                partialScopeHints: partialScopeHints);
+            AddSchemaAwareFallbackHintArguments(toolDefinition, fallbackArguments, partialScopeHints);
+            AddSchemaAwareFallbackDefaultArguments("domaindetective", toolDefinition, fallbackArguments, partialScopeHints);
+            var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
+            if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
+                || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
+                continue;
+            }
+
+            var serializedArguments = JsonLite.Serialize(normalizedArguments);
+            var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
+            var raw = new JsonObject()
+                .Add("type", "tool_call")
+                .Add("call_id", fallbackCallId)
+                .Add("name", candidateTool)
+                .Add("arguments", serializedArguments);
+
+            toolCall = new ToolCall(
+                callId: fallbackCallId,
+                name: candidateTool,
+                input: serializedArguments,
+                arguments: normalizedArguments,
+                raw: raw);
+            reason = "pack_contract_cross_public_posture_domaindetective:"
+                     + sourcePackId
+                     + ":"
+                     + partialScopeReason
+                     + "->"
+                     + candidateTool;
+            return true;
+        }
+
+        reason = "cross_public_posture_domaindetective_candidate_missing_required_args";
         return false;
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
@@ -749,4 +749,58 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("\"domain_name\":\"contoso.com\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackTestimoXToDomainDetectiveFallbackOnFailure() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["testimox_rules_list"] = "testimox";
+        packMap["domaindetective_domain_summary"] = "domaindetective";
+
+        var toolDefinitions = new List<ToolDefinition> {
+            new(
+                "testimox_rules_list",
+                "List TestimoX rules.",
+                ToolSchema.Object(("domain_name", ToolSchema.String("Domain name."))).NoAdditionalProperties()),
+            new(
+                "domaindetective_domain_summary",
+                "Summarize public domain posture.",
+                ToolSchema.Object(("domain", ToolSchema.String("Domain name.")))
+                    .Required("domain")
+                    .NoAdditionalProperties())
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-1",
+                Name = "testimox_rules_list",
+                Input = """
+                        {"domain_name":"contoso.com"}
+                        """
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-1",
+                Output = "{}",
+                Ok = false,
+                ErrorCode = "timeout"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["testimox_rules_list"] = false,
+            ["domaindetective_domain_summary"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "run public posture checks", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("domaindetective_domain_summary", toolCall.Name);
+        Assert.Contains("pack_contract_cross_public_posture_domaindetective", reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"domain\":\"contoso.com\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+    }
+
 }


### PR DESCRIPTION
## Summary
- add cross-pack fallback from failed TestimoX public posture calls to read-only DomainDetective domain posture candidates
- keep fallback argument shaping schema-aware with existing required-argument/skip-candidate guards
- add regression test for TestimoX -> DomainDetective fallback tool selection and domain argument mapping

## Testing
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackTestimoXToDomainDetectiveFallbackOnFailure"` *(fails in this workspace before test execution due existing missing-type compile blockers in ComputerX/ADPlayground projects)*