### PR TITLE
Chat: harden visual JSON property matching

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.VisualCatalog.cs
@@ -471,11 +471,15 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (!element.TryGetProperty(propertyName, out var value)) {
-            return false;
+        foreach (var property in element.EnumerateObject()) {
+            if (!property.NameEquals(propertyName) && !string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            return property.Value.ValueKind == JsonValueKind.Array;
         }
 
-        return value.ValueKind == JsonValueKind.Array;
+        return false;
     }
 
     private static bool ContainsLikelyJsonEnvelope(ReadOnlySpan<char> text) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -133,6 +133,29 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferNetworkPreferredVisualFromToolOutputsUsingCaseInsensitivePropertyNames() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"Nodes\":[{\"id\":\"AD0\"}],\"RELATIONSHIPS\":[{\"source\":\"AD0\",\"target\":\"AD1\"}]}",
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...", outputs);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: tool_outputs", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_InferChartPreferredVisualFromToolOutputsUsingXAxisAndPointsAliasesWhenVisualsAreAllowed() {
         var request = """
             [Proactive visualization guidance]
@@ -156,6 +179,29 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferChartPreferredVisualFromToolOutputsUsingCaseInsensitivePropertyNames() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"LABELS\":[\"Jan\",\"Feb\"],\"Series\":[4,7]}",
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...", outputs);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-chart", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: tool_outputs", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_InferTablePreferredVisualFromToolOutputsUsingRecordsAliasWhenVisualsAreAllowed() {
         var request = """
             [Proactive visualization guidance]
@@ -166,6 +212,29 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new() {
                 CallId = "c1",
                 Output = "{\"keys\":[\"host\",\"status\"],\"records\":[[\"DC01\",\"healthy\"]]}",
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...", outputs);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: tool_outputs", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_InferTablePreferredVisualFromToolOutputsUsingCaseInsensitivePropertyNames() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"HEADERS\":[\"host\",\"status\"],\"Rows\":[[\"DC01\",\"healthy\"]]}",
                 Ok = true
             }
         };


### PR DESCRIPTION
## Summary
- make structured JSON visual-shape detection case-insensitive for parsed tool outputs
- allow network/chart/table inference when payloads use mixed casing (for example `Nodes`, `RELATIONSHIPS`, `LABELS`, `Rows`)
- add regression tests covering case-insensitive tool-output inference for ix-network, ix-chart, and table visuals

## Testing
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "CaseInsensitivePropertyNames"` *(fails in this workspace before test execution due existing missing-type compile blockers in ComputerX/ADPlayground/TestimoX projects)*