### PR TITLE
Chat: add AD to System host fallback

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -384,6 +384,22 @@ internal sealed partial class ChatServiceSession {
                 return true;
             }
 
+            if (TryBuildCrossAdHostSystemBaselineFallbackToolCall(
+                    toolDefinitions: toolDefinitions,
+                    priorCalledTools: priorCalledTools,
+                    sourcePackId: sourcePackId,
+                    sourceTool: sourceTool,
+                    sourceToolDefinition: sourceToolDefinition,
+                    partialScopeHints: partialScopeHints,
+                    partialScopeReason: partialScopeReason,
+                    userRequest: userRequest,
+                    hasSourceFailureSignal: hasSourceFailureSignal,
+                    mutatingToolHintsByName: mutatingToolHintsByName,
+                    out toolCall,
+                    out reason)) {
+                return true;
+            }
+
             if (TryBuildCrossPublicPostureEvidenceFallbackToTestimoX(
                     toolDefinitions: toolDefinitions,
                     priorCalledTools: priorCalledTools,
@@ -772,6 +788,94 @@ internal sealed partial class ChatServiceSession {
         }
 
         reason = "cross_testimox_ad_discovery_candidate_missing_required_args";
+        return false;
+    }
+
+    private bool TryBuildCrossAdHostSystemBaselineFallbackToolCall(
+        IReadOnlyList<ToolDefinition> toolDefinitions,
+        IReadOnlySet<string> priorCalledTools,
+        string sourcePackId,
+        string sourceTool,
+        ToolDefinition? sourceToolDefinition,
+        JsonObject partialScopeHints,
+        string partialScopeReason,
+        string? userRequest,
+        bool hasSourceFailureSignal,
+        IReadOnlyDictionary<string, bool>? mutatingToolHintsByName,
+        out ToolCall toolCall,
+        out string reason) {
+        toolCall = null!;
+        reason = "cross_ad_host_system_baseline_not_applicable";
+
+        if (!PackIdMatches(sourcePackId, "active_directory")
+            || !hasSourceFailureSignal) {
+            reason = "cross_ad_host_system_baseline_source_not_eligible";
+            return false;
+        }
+
+        if (!IsSourceToolEligibleForCrossAdHostSystemBaselineFallback(sourceTool, sourceToolDefinition)) {
+            reason = "cross_ad_host_system_baseline_source_tool_not_supported";
+            return false;
+        }
+
+        if (!TryResolveCrossPackCandidateToolsByRouting(
+                toolDefinitions: toolDefinitions,
+                priorCalledTools: priorCalledTools,
+                targetPackId: "system",
+                preferredScope: "host",
+                preferredOperation: ToolRoutingTaxonomy.OperationRead,
+                mutatingToolHintsByName: mutatingToolHintsByName,
+                out var candidates)) {
+            reason = "cross_ad_host_system_baseline_candidate_unavailable";
+            return false;
+        }
+
+        var computerName = ResolveEventlogHostHint(partialScopeHints, userRequest);
+        if (string.IsNullOrWhiteSpace(computerName)) {
+            reason = "cross_ad_host_system_baseline_missing_host_hint";
+            return false;
+        }
+
+        for (var i = 0; i < candidates.Count; i++) {
+            var candidateTool = candidates[i].ToolName;
+            var toolDefinition = candidates[i].Definition;
+            var fallbackArguments = new JsonObject(StringComparer.Ordinal);
+            if (!TryAddFallbackHintArgumentForCandidate(toolDefinition, fallbackArguments, computerName, "computer_name", "machine_name", "host", "target", "name")) {
+                fallbackArguments.Add("computer_name", computerName);
+            }
+            AddSchemaAwareFallbackHintArguments(toolDefinition, fallbackArguments, partialScopeHints);
+            AddSchemaAwareFallbackDefaultArguments("system", toolDefinition, fallbackArguments, partialScopeHints);
+
+            var normalizedArguments = CoerceStructuredNextActionArgumentsForTool(fallbackArguments, toolDefinition);
+            if (!HasRequiredToolArguments(toolDefinition, normalizedArguments)
+                || ShouldSkipFallbackCandidate(candidateTool, normalizedArguments)) {
+                continue;
+            }
+
+            var serializedArguments = JsonLite.Serialize(normalizedArguments);
+            var fallbackCallId = "host_pack_fallback_" + Guid.NewGuid().ToString("N");
+            var raw = new JsonObject()
+                .Add("type", "tool_call")
+                .Add("call_id", fallbackCallId)
+                .Add("name", candidateTool)
+                .Add("arguments", serializedArguments);
+
+            toolCall = new ToolCall(
+                callId: fallbackCallId,
+                name: candidateTool,
+                input: serializedArguments,
+                arguments: normalizedArguments,
+                raw: raw);
+            reason = "pack_contract_cross_ad_host_system_baseline:"
+                     + sourcePackId
+                     + ":"
+                     + partialScopeReason
+                     + "->"
+                     + candidateTool;
+            return true;
+        }
+
+        reason = "cross_ad_host_system_baseline_candidate_missing_required_args";
         return false;
     }
 
@@ -1214,6 +1318,22 @@ internal sealed partial class ChatServiceSession {
         var scope = (routingInfo.Scope ?? string.Empty).Trim();
         if (!string.Equals(scope, "host", StringComparison.OrdinalIgnoreCase)
             && !string.Equals(scope, "file", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        return IsCrossHostFallbackReadOnlyOperation(routingInfo.Operation);
+    }
+
+    private static bool IsSourceToolEligibleForCrossAdHostSystemBaselineFallback(
+        string sourceTool,
+        ToolDefinition? sourceToolDefinition) {
+        if (!TryResolveSourceRoutingInfo(sourceTool, sourceToolDefinition, out var routingInfo)) {
+            return false;
+        }
+
+        var scope = (routingInfo.Scope ?? string.Empty).Trim();
+        if (!string.Equals(scope, "domain", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(scope, "host", StringComparison.OrdinalIgnoreCase)) {
             return false;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
@@ -694,6 +694,63 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackAdToSystemHostBaselineFallbackOnFailure() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["ad_domain_controllers"] = "active_directory";
+        packMap["system_bios_summary"] = "system";
+
+        var toolDefinitions = new List<ToolDefinition> {
+            new(
+                "ad_domain_controllers",
+                "List AD domain controllers.",
+                ToolSchema.Object(
+                        ("domain_name", ToolSchema.String("Domain name.")),
+                        ("computer_name", ToolSchema.String("Domain controller host name.")))
+                    .NoAdditionalProperties()),
+            new(
+                "system_bios_summary",
+                "Summarize BIOS details for a target computer.",
+                ToolSchema.Object(("computer_name", ToolSchema.String("Computer name.")))
+                    .Required("computer_name")
+                    .NoAdditionalProperties())
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-1",
+                Name = "ad_domain_controllers",
+                Input = """
+                        {"domain_name":"contoso.local","computer_name":"dc01.contoso.local"}
+                        """
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-1",
+                Output = "{}",
+                Ok = false,
+                ErrorCode = "timeout"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["ad_domain_controllers"] = false,
+            ["system_bios_summary"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "check domain controllers and host baseline for dc01.contoso.local", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("system_bios_summary", toolCall.Name);
+        Assert.Contains("pack_contract_cross_ad_host_system_baseline", reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"computer_name\":\"dc01.contoso.local\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDomainDetectiveToTestimoXFallbackOnFailure() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));


### PR DESCRIPTION
## Summary
- add cross-pack fallback from failed ADPlayground/active-directory domain calls to read-only System host baseline candidates when a host hint is available
- guard fallback to read-only source routing scopes (`domain`/`host`) and reuse schema-aware argument/default shaping
- add regression test validating AD -> System fallback tool selection and `computer_name` propagation

## Testing
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackAdToSystemHostBaselineFallbackOnFailure"` *(fails in this workspace before test execution due existing missing-type compile blockers in ComputerX/ADPlayground projects)*