### PR TITLE
Chat: derive AD fallback domain from request

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -496,6 +496,7 @@ internal sealed partial class ChatServiceSession {
                     sourceToolDefinition: sourceToolDefinition,
                     partialScopeHints: partialScopeHints,
                     partialScopeReason: partialScopeReason,
+                    userRequest: userRequest,
                     hasSourceFailureSignal: hasSourceFailureSignal,
                     mutatingToolHintsByName: mutatingToolHintsByName,
                     out toolCall,
@@ -1756,6 +1757,7 @@ internal sealed partial class ChatServiceSession {
         ToolDefinition? sourceToolDefinition,
         JsonObject partialScopeHints,
         string partialScopeReason,
+        string? userRequest,
         bool hasSourceFailureSignal,
         IReadOnlyDictionary<string, bool>? mutatingToolHintsByName,
         out ToolCall toolCall,
@@ -1774,7 +1776,8 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        var domainName = ResolveDomainDetectiveDomainHint(partialScopeHints);
+        var domainName = ResolveDomainDetectiveDomainHint(partialScopeHints)
+                         ?? TryExtractDomainHintFromUserRequest(userRequest);
         if (string.IsNullOrWhiteSpace(domainName)) {
             reason = "cross_system_ad_discovery_missing_domain_hint";
             return false;
@@ -1862,6 +1865,16 @@ internal sealed partial class ChatServiceSession {
                         ?? ReadNonEmptyHint(hints, "name")
                         ?? ReadNonEmptyHint(hints, "target")
                         ?? ReadNonEmptyHint(hints, "host");
+        if (string.IsNullOrWhiteSpace(preferred)) {
+            return null;
+        }
+
+        var normalized = preferred.Trim().TrimEnd('.');
+        return IsLikelyDomainName(normalized) ? normalized : null;
+    }
+
+    private static string? TryExtractDomainHintFromUserRequest(string? userRequest) {
+        var preferred = TryExtractHostHintFromUserRequest(userRequest);
         if (string.IsNullOrWhiteSpace(preferred)) {
             return null;
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
@@ -812,6 +812,64 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackSystemToAdDiscoveryFallbackUsingRequestDomainHintOnFailure() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_bios_summary"] = "system";
+        packMap["ad_scope_discovery"] = "active_directory";
+
+        var toolDefinitions = new List<ToolDefinition> {
+            new(
+                "system_bios_summary",
+                "Summarize BIOS details for a target computer.",
+                ToolSchema.Object(("computer_name", ToolSchema.String("Computer name.")))
+                    .Required("computer_name")
+                    .NoAdditionalProperties()),
+            new(
+                "ad_scope_discovery",
+                "Discover AD scope.",
+                ToolSchema.Object(
+                        ("domain_name", ToolSchema.String("Domain name.")),
+                        ("discovery_fallback", ToolSchema.String("Fallback mode.")))
+                    .Required("domain_name")
+                    .NoAdditionalProperties())
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-1",
+                Name = "system_bios_summary",
+                Input = """
+                        {"computer_name":"dc01.contoso.local"}
+                        """
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-1",
+                Output = "{}",
+                Ok = false,
+                ErrorCode = "timeout"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_bios_summary"] = false,
+            ["ad_scope_discovery"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "run domain discovery for contoso.local", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("ad_scope_discovery", toolCall.Name);
+        Assert.Contains("pack_contract_cross_system_ad_discovery", reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"domain_name\":\"contoso.local\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDomainDetectiveToTestimoXFallbackOnFailure() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));


### PR DESCRIPTION
## Summary
- extend System -> AD discovery fallback to also resolve domain hints from the user request when tool arguments/output hints do not include a domain
- keep domain extraction shape-based by reusing existing host token extraction plus domain-name validation
- add regression test proving System -> AD fallback can trigger from request-only domain hints

## Testing
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackSystemToAdDiscoveryFallbackUsingRequestDomainHintOnFailure"` *(fails in this workspace before test execution due existing missing-type compile blockers in TestimoX/ComputerX projects)*