### PR TITLE
Chat: guard request-domain fallback from host FQDN

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -1874,13 +1874,83 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static string? TryExtractDomainHintFromUserRequest(string? userRequest) {
-        var preferred = TryExtractHostHintFromUserRequest(userRequest);
-        if (string.IsNullOrWhiteSpace(preferred)) {
+        var text = NormalizeRoutingUserText((userRequest ?? string.Empty).Trim());
+        if (text.Length == 0) {
             return null;
         }
 
-        var normalized = preferred.Trim().TrimEnd('.');
-        return IsLikelyDomainName(normalized) ? normalized : null;
+        var bestCandidate = string.Empty;
+        var bestScore = 0;
+        var tokenStart = -1;
+        for (var i = 0; i <= text.Length; i++) {
+            var ch = i < text.Length ? text[i] : '\0';
+            var tokenChar = i < text.Length
+                            && (char.IsLetterOrDigit(ch) || ch == '.' || ch == '-' || ch == '_');
+            if (tokenChar) {
+                if (tokenStart < 0) {
+                    tokenStart = i;
+                }
+                continue;
+            }
+
+            if (tokenStart < 0) {
+                continue;
+            }
+
+            var candidate = text.Substring(tokenStart, i - tokenStart).Trim().TrimEnd('.');
+            tokenStart = -1;
+            var score = ScoreDomainHintCandidate(candidate);
+            if (score <= bestScore) {
+                continue;
+            }
+
+            bestScore = score;
+            bestCandidate = candidate;
+        }
+
+        return bestScore > 0 ? bestCandidate : null;
+    }
+
+    private static int ScoreDomainHintCandidate(string candidate) {
+        var normalized = (candidate ?? string.Empty).Trim().TrimEnd('.');
+        if (!IsLikelyDomainName(normalized) || LooksLikeHostFqdnCandidate(normalized)) {
+            return 0;
+        }
+
+        var score = 1;
+        var labels = normalized.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (labels.Length >= 2) {
+            score += Math.Min(labels.Length, 3);
+        }
+
+        var rootLabel = labels.Length > 0 ? labels[0] : string.Empty;
+        if (rootLabel.Length >= 4) {
+            score += 1;
+        }
+
+        var tldLabel = labels.Length > 1 ? labels[^1] : string.Empty;
+        if (tldLabel.Length is >= 2 and <= 6) {
+            score += 1;
+        }
+
+        return score;
+    }
+
+    private static bool LooksLikeHostFqdnCandidate(string candidate) {
+        var normalized = (candidate ?? string.Empty).Trim().TrimEnd('.');
+        var dotIndex = normalized.IndexOf('.', StringComparison.Ordinal);
+        if (dotIndex <= 0) {
+            return false;
+        }
+
+        var leftLabel = normalized[..dotIndex];
+        for (var i = 0; i < leftLabel.Length; i++) {
+            if (char.IsDigit(leftLabel[i])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool ShouldPreferAdDiscoveryBeforeEventlogFanOut(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
@@ -870,6 +870,60 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossPackSystemToAdDiscoveryFallbackUsingHostOnlyRequestHint() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_bios_summary"] = "system";
+        packMap["ad_scope_discovery"] = "active_directory";
+
+        var toolDefinitions = new List<ToolDefinition> {
+            new(
+                "system_bios_summary",
+                "Summarize BIOS details for a target computer.",
+                ToolSchema.Object(("computer_name", ToolSchema.String("Computer name.")))
+                    .Required("computer_name")
+                    .NoAdditionalProperties()),
+            new(
+                "ad_scope_discovery",
+                "Discover AD scope.",
+                ToolSchema.Object(
+                        ("domain_name", ToolSchema.String("Domain name.")),
+                        ("discovery_fallback", ToolSchema.String("Fallback mode.")))
+                    .Required("domain_name")
+                    .NoAdditionalProperties())
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-1",
+                Name = "system_bios_summary",
+                Input = """
+                        {"computer_name":"dc01.contoso.local"}
+                        """
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-1",
+                Output = "{}",
+                Ok = false,
+                ErrorCode = "timeout"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_bios_summary"] = false,
+            ["ad_scope_discovery"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "run domain discovery for dc01.contoso.local", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Null(args[5]);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDomainDetectiveToTestimoXFallbackOnFailure() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));


### PR DESCRIPTION
## Summary
- harden request-domain extraction used by System -> AD fallback so host-only FQDN hints (for example `dc01.contoso.local`) do not get treated as AD domain targets
- replace host-token reuse with dedicated domain token scoring that filters likely host FQDN candidates
- add regression coverage that keeps the existing request-domain positive path and blocks host-only request fallback path

## Testing
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackSystemToAdDiscoveryFallbackUsingRequestDomainHintOnFailure|TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossPackSystemToAdDiscoveryFallbackUsingHostOnlyRequestHint"` *(fails in this workspace before test execution due existing missing-type compile blockers in ComputerX/ADPlayground projects)*