### PR TITLE
Chat: centralize pack fallback telemetry family tokens

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -2557,6 +2557,26 @@ internal sealed partial class ChatServiceSession {
         return aliases.Contains(normalizedActual);
     }
 
+    private static readonly string[] PackFallbackTelemetryPublicDomainReasonTokens = {
+        "cross_public_"
+    };
+
+    private static readonly string[] PackFallbackTelemetryHostReasonTokens = {
+        "cross_host_"
+    };
+
+    private static readonly string[] PackFallbackTelemetryAdDomainReasonTokens = {
+        "cross_system_ad_",
+        "cross_dc_discovery_first",
+        "cross_ad_",
+        "_ad_discovery"
+    };
+
+    private static readonly string[] PackFallbackTelemetryPackContractReasonTokens = {
+        "pack_contract_partial_scope_autofallback",
+        "pack_contract_failure_autofallback"
+    };
+
     private static string AppendPackFallbackTelemetryMarker(string reason, string sourcePackId, string candidateTool) {
         var normalizedReason = (reason ?? string.Empty).Trim();
         if (normalizedReason.Length == 0
@@ -2593,27 +2613,38 @@ internal sealed partial class ChatServiceSession {
             return "general";
         }
 
-        if (normalized.IndexOf("cross_public_", StringComparison.OrdinalIgnoreCase) >= 0) {
+        if (ContainsPackFallbackTelemetryReasonToken(normalized, PackFallbackTelemetryPublicDomainReasonTokens)) {
             return "public_domain";
         }
 
-        if (normalized.IndexOf("cross_host_", StringComparison.OrdinalIgnoreCase) >= 0) {
+        if (ContainsPackFallbackTelemetryReasonToken(normalized, PackFallbackTelemetryHostReasonTokens)) {
             return "host";
         }
 
-        if (normalized.IndexOf("cross_system_ad_", StringComparison.OrdinalIgnoreCase) >= 0
-            || normalized.IndexOf("cross_dc_discovery_first", StringComparison.OrdinalIgnoreCase) >= 0
-            || normalized.IndexOf("cross_ad_", StringComparison.OrdinalIgnoreCase) >= 0
-            || normalized.IndexOf("_ad_discovery", StringComparison.OrdinalIgnoreCase) >= 0) {
+        if (ContainsPackFallbackTelemetryReasonToken(normalized, PackFallbackTelemetryAdDomainReasonTokens)) {
             return "ad_domain";
         }
 
-        if (normalized.IndexOf("pack_contract_partial_scope_autofallback", StringComparison.OrdinalIgnoreCase) >= 0
-            || normalized.IndexOf("pack_contract_failure_autofallback", StringComparison.OrdinalIgnoreCase) >= 0) {
+        if (ContainsPackFallbackTelemetryReasonToken(normalized, PackFallbackTelemetryPackContractReasonTokens)) {
             return "pack_contract";
         }
 
         return "general";
+    }
+
+    private static bool ContainsPackFallbackTelemetryReasonToken(string reason, IReadOnlyList<string> tokens) {
+        for (var i = 0; i < tokens.Count; i++) {
+            var token = tokens[i];
+            if (string.IsNullOrWhiteSpace(token)) {
+                continue;
+            }
+
+            if (reason.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string EncodePackFallbackTelemetryFieldValue(string value) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -229,6 +229,20 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains("family=pack_contract", reason, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData("pack_contract_cross_public_posture_testimox:domaindetective:query_failed->testimox_rules_list", "public_domain")]
+    [InlineData("pack_contract_cross_host_eventlog_evidence:computerx:query_failed->eventlog_live_query", "host")]
+    [InlineData("pack_contract_cross_system_ad_discovery:system:query_failed->ad_scope_discovery", "ad_domain")]
+    [InlineData("pack_contract_failure_autofallback:customx:query_failed->customx_pack_info", "pack_contract")]
+    [InlineData("pack_contract_unclassified_path:customx:query_failed->customx_pack_info", "general")]
+    public void ResolvePackFallbackTelemetryFamily_UsesStableReasonTokens(string reason, string expectedFamily) {
+        var method = typeof(ChatServiceSession).GetMethod("ResolvePackFallbackTelemetryFamily", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var result = method!.Invoke(null, new object?[] { reason });
+        Assert.Equal(expectedFamily, Assert.IsType<string>(result), StringComparer.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsDomainDetectiveFallbackFromSourceArguments() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();


### PR DESCRIPTION
## Summary
- centralize pack-fallback telemetry family classification tokens into dedicated static token sets
- replace repeated inline substring checks with a single helper (`ContainsPackFallbackTelemetryReasonToken`) to reduce drift risk as new fallback reasons are added
- add a focused test for `ResolvePackFallbackTelemetryFamily` to lock expected family mapping behavior for public-domain, host, ad-domain, pack-contract, and fallback-general reasons

## Testing
- `dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~AppendPackFallbackTelemetryMarker_EncodesFieldValuesForMachineParsing|FullyQualifiedName~ResolvePackFallbackTelemetryFamily_UsesStableReasonTokens"` *(fails during build in current workspace with existing CS0246 missing-type errors in System/ADPlayground/TestimoX dependencies; tests do not execute)*