### PR TITLE
Build: fix post-sync compile errors in chat and tools tests

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.DomainIntentAffinity.cs
@@ -259,7 +259,7 @@ internal sealed partial class ChatServiceSession {
             ? weightedAmbiguityClusterSize
             : null;
         var normalizedWeightedAmbiguitySecondRatio = weightedAmbiguityWidened && weightedAmbiguitySecondScoreRatio is > 0d
-            ? Math.Round(weightedAmbiguitySecondScoreRatio.Value, 3)
+            ? (double?)Math.Round(weightedAmbiguitySecondScoreRatio.Value, 3)
             : null;
         return JsonSerializer.Serialize(new {
             strategy = (strategy ?? string.Empty).Trim(),

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
@@ -665,7 +665,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new() {
                 CallId = "call-1",
                 Name = "testimox_rules_run",
-                Input = """
+                ArgumentsJson = """
                         {"domain_name":"contoso.local","search_text":"kerberos"}
                         """
             }
@@ -722,7 +722,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new() {
                 CallId = "call-1",
                 Name = "ad_domain_controllers",
-                Input = """
+                ArgumentsJson = """
                         {"domain_name":"contoso.local","computer_name":"dc01.contoso.local"}
                         """
             }
@@ -782,7 +782,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new() {
                 CallId = "call-1",
                 Name = "system_bios_summary",
-                Input = """
+                ArgumentsJson = """
                         {"computer_name":"dc01.contoso.local","domain_name":"contoso.local"}
                         """
             }
@@ -842,7 +842,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new() {
                 CallId = "call-1",
                 Name = "system_bios_summary",
-                Input = """
+                ArgumentsJson = """
                         {"computer_name":"dc01.contoso.local"}
                         """
             }
@@ -900,7 +900,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new() {
                 CallId = "call-1",
                 Name = "system_bios_summary",
-                Input = """
+                ArgumentsJson = """
                         {"computer_name":"dc01.contoso.local"}
                         """
             }
@@ -956,7 +956,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new() {
                 CallId = "call-1",
                 Name = "system_bios_summary",
-                Input = """
+                ArgumentsJson = """
                         {"computer_name":"dc01.contoso.local","domain_name":"10.0.0.5"}
                         """
             }
@@ -1008,7 +1008,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new() {
                 CallId = "call-1",
                 Name = "domaindetective_domain_summary",
-                Input = """
+                ArgumentsJson = """
                         {"domain":"contoso.com"}
                         """
             }
@@ -1063,7 +1063,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new() {
                 CallId = "call-1",
                 Name = "testimox_rules_list",
-                Input = """
+                ArgumentsJson = """
                         {"domain_name":"contoso.com"}
                         """
             }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DomainDetectiveChecksCatalogToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DomainDetectiveChecksCatalogToolTests.cs
@@ -59,12 +59,9 @@ public sealed class DomainDetectiveChecksCatalogToolTests {
     [Fact]
     public async Task InvokeAsync_AllowsAliasAndDefaultSuppressionFlags() {
         var tool = new DomainDetectiveChecksCatalogTool(new DomainDetectiveToolOptions());
-        var arguments = JsonNode.Parse("""
-            {
-              "include_aliases": false,
-              "include_default_checks": false
-            }
-            """) as JsonObject;
+        var arguments = new JsonObject()
+            .Add("include_aliases", false)
+            .Add("include_default_checks", false);
 
         var json = await tool.InvokeAsync(arguments, CancellationToken.None);
         using var document = JsonDocument.Parse(json);


### PR DESCRIPTION
## Summary
- fix nullable-typing compile error in weighted ambiguity routing metadata (`double` vs `null` ternary)
- update pack-fallback chat tests to use `ToolCallDto.ArgumentsJson` instead of removed `Input` initializer property
- simplify DomainDetective checks-catalog test arguments to use `IntelligenceX.Json.JsonObject` directly (avoids `JsonNode`/`JsonObject` ambiguity)

## Validation
- synced local `C:\Support\GitHub\TestimoX` to `origin/master` (`Already up to date`)
- `dotnet build IntelligenceX.sln -c Release /p:TestimoXRoot=C:\Support\GitHub\TestimoX\` ✅ (`0` warnings, `0` errors)
- `dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Service/IntelligenceX.Chat.Service.csproj -c Release /p:TestimoXRoot=C:\Support\GitHub\TestimoX\` ✅
- `dotnet build IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release /p:TestimoXRoot=C:\Support\GitHub\TestimoX\` ✅