### PR TITLE
chat: harden cross-pack fallback candidate targeting

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -1503,15 +1503,22 @@ internal sealed partial class ChatServiceSession {
                 }
             }
 
-            if (ToolDefinitionHasInputProperty(candidateDefinition, "name")
-                || ToolDefinitionHasInputProperty(candidateDefinition, "target")
-                || ToolDefinitionHasInputProperty(candidateDefinition, "domain")
-                || ToolDefinitionHasInputProperty(candidateDefinition, "host")
-                || ToolDefinitionHasInputProperty(candidateDefinition, "computer_name")
-                || ToolDefinitionHasInputProperty(candidateDefinition, "machine_name")
-                || ToolDefinitionHasInputProperty(candidateDefinition, "log_name")) {
-                score += 50;
+            var hasTargetableInputProperty = ToolDefinitionHasInputProperty(candidateDefinition, "name")
+                                             || ToolDefinitionHasInputProperty(candidateDefinition, "target")
+                                             || ToolDefinitionHasInputProperty(candidateDefinition, "domain")
+                                             || ToolDefinitionHasInputProperty(candidateDefinition, "domain_name")
+                                             || ToolDefinitionHasInputProperty(candidateDefinition, "dns_domain_name")
+                                             || ToolDefinitionHasInputProperty(candidateDefinition, "forest_name")
+                                             || ToolDefinitionHasInputProperty(candidateDefinition, "host")
+                                             || ToolDefinitionHasInputProperty(candidateDefinition, "computer_name")
+                                             || ToolDefinitionHasInputProperty(candidateDefinition, "machine_name")
+                                             || ToolDefinitionHasInputProperty(candidateDefinition, "domain_controller")
+                                             || ToolDefinitionHasInputProperty(candidateDefinition, "log_name");
+            if (!hasTargetableInputProperty) {
+                continue;
             }
+
+            score += 50;
 
             rankedCandidates.Add((new CrossPackFallbackCandidate(name, candidateDefinition), score));
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
@@ -982,6 +982,59 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossPackSystemToAdDiscoveryFallbackUsingGenericUntargetedTool() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_bios_summary"] = "system";
+        packMap["ad_inventory_snapshot"] = "active_directory";
+
+        var toolDefinitions = new List<ToolDefinition> {
+            new(
+                "system_bios_summary",
+                "Summarize BIOS details for a target computer.",
+                ToolSchema.Object(
+                        ("computer_name", ToolSchema.String("Computer name.")))
+                    .Required("computer_name")
+                    .NoAdditionalProperties()),
+            new(
+                "ad_inventory_snapshot",
+                "Return a generic AD inventory snapshot.",
+                ToolSchema.Object().NoAdditionalProperties())
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-1",
+                Name = "system_bios_summary",
+                ArgumentsJson = """
+                        {"computer_name":"dc01.contoso.local"}
+                        """
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-1",
+                Output = "{}",
+                Ok = false,
+                ErrorCode = "timeout"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_bios_summary"] = false,
+            ["ad_inventory_snapshot"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "run domain discovery for contoso.local", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Null(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("pack_contract_no_applicable_fallback", reason);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDomainDetectiveToTestimoXFallbackOnFailure() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -1438,10 +1438,17 @@ public sealed partial class ChatServiceRoutingTrimTests {
         packMap["ad_scope_discovery"] = "active_directory";
 
         var schema = ToolSchema.Object().NoAdditionalProperties();
+        var eventlogSchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")),
+                ("log_name", ToolSchema.String("log name")))
+            .NoAdditionalProperties();
+        var adSchema = ToolSchema.Object(
+                ("domain_name", ToolSchema.String("domain name")))
+            .NoAdditionalProperties();
         var toolDefinitions = new List<ToolDefinition> {
             new("eventlog_live_stats", "live stats", schema),
-            new("eventlog_live_query", "live query", schema),
-            new("ad_scope_discovery", "scope", schema)
+            new("eventlog_live_query", "live query", eventlogSchema),
+            new("ad_scope_discovery", "scope", adSchema)
         };
         RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
 
@@ -1489,10 +1496,17 @@ public sealed partial class ChatServiceRoutingTrimTests {
         packMap["ad_dc_fabric_discover"] = "active_directory";
 
         var schema = ToolSchema.Object().NoAdditionalProperties();
+        var eventlogSchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")),
+                ("log_name", ToolSchema.String("log name")))
+            .NoAdditionalProperties();
+        var adSchema = ToolSchema.Object(
+                ("domain_name", ToolSchema.String("domain name")))
+            .NoAdditionalProperties();
         var toolDefinitions = new List<ToolDefinition> {
             new("eventlog_live_stats", "live stats", schema),
-            new("eventlog_live_query", "live query", schema),
-            new("ad_dc_fabric_discover", "custom scope", schema)
+            new("eventlog_live_query", "live query", eventlogSchema),
+            new("ad_dc_fabric_discover", "custom scope", adSchema)
         };
         RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
 


### PR DESCRIPTION
## Summary
- Hardened cross-pack fallback candidate resolution so automatic fallback only considers target tools that expose targetable scope inputs (domain/host/machine/etc.), reducing selection of generic untargeted tools.
- Added a regression test proving system->AD fallback does not pivot to a generic untargeted AD tool when no scoped candidate is available.
- Updated replay-contract fallback tests to use realistic targetable schemas for AD/eventlog candidates, preserving intended routing preference checks under stricter selection.

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_PrefersAdDiscoveryBeforeCrossDcEventlogFanOut|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_PrefersCustomAdDiscoveryCandidateBeforeCrossDcEventlogFanOut|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossPackSystemToAdDiscoveryFallbackUsingGenericUntargetedTool"
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall&FullyQualifiedName!=IntelligenceX.Chat.Tests.ChatServiceRoutingTrimTests.TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackSystemToAdDiscoveryFallbackOnFailure"

## Notes
- `TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackSystemToAdDiscoveryFallbackOnFailure` is currently failing on clean `master` as well (pre-existing baseline issue).