### PR TITLE
chat: allow domain-scoped system->ad fallback eligibility

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -1390,7 +1390,8 @@ internal sealed partial class ChatServiceSession {
 
         var scope = (routingInfo.Scope ?? string.Empty).Trim();
         if (!string.Equals(scope, "host", StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(scope, "file", StringComparison.OrdinalIgnoreCase)) {
+            && !string.Equals(scope, "file", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(scope, "domain", StringComparison.OrdinalIgnoreCase)) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- Fixed a pre-existing chat fallback gap where system tools inferred as `domain` scope were rejected from the `system -> active_directory` cross-pack discovery fallback path.
- Updated the eligibility gate to accept `domain` scope (in addition to `host`/`file`) for this specific read-only fallback flow.
- This unblocks the existing regression scenario `TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackSystemToAdDiscoveryFallbackOnFailure` on current `master`.

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackSystemToAdDiscoveryFallbackOnFailure|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackSystemToAdDiscoveryFallbackUsingRequestDomainHintOnFailure|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossPackSystemToAdDiscoveryFallbackUsingHostOnlyRequestHint|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossPackSystemToAdDiscoveryFallbackUsingIpDomainHintOnFailure"
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall"