### PR TITLE
chat: require cross-pack affinity for fallback candidates

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -1469,30 +1469,37 @@ internal sealed partial class ChatServiceSession {
 
             var score = 0;
             var scope = (routing.Scope ?? string.Empty).Trim();
+            var hasScopeAffinity = false;
             if (string.Equals(scope, preferredScope, StringComparison.OrdinalIgnoreCase)) {
+                hasScopeAffinity = true;
                 score += 500;
             } else if (string.Equals(scope, "general", StringComparison.OrdinalIgnoreCase)) {
                 score += 50;
             }
 
+            var hasOperationAffinity = false;
             if (string.Equals(operation, preferredOperation, StringComparison.OrdinalIgnoreCase)) {
+                hasOperationAffinity = true;
                 score += 300;
             } else if (string.Equals(preferredOperation, "probe", StringComparison.OrdinalIgnoreCase)
                        && string.Equals(operation, "query", StringComparison.OrdinalIgnoreCase)) {
+                hasOperationAffinity = true;
                 score += 120;
             } else if (string.Equals(preferredOperation, "query", StringComparison.OrdinalIgnoreCase)
                        && string.Equals(operation, "probe", StringComparison.OrdinalIgnoreCase)) {
+                hasOperationAffinity = true;
                 score += 120;
             } else if (string.Equals(preferredOperation, "discover", StringComparison.OrdinalIgnoreCase)
                        && (string.Equals(operation, "query", StringComparison.OrdinalIgnoreCase)
                            || string.Equals(operation, "list", StringComparison.OrdinalIgnoreCase)
-                           || string.Equals(operation, "search", StringComparison.OrdinalIgnoreCase)
-                           || string.Equals(operation, ToolRoutingTaxonomy.OperationRead, StringComparison.OrdinalIgnoreCase))) {
+                           || string.Equals(operation, "search", StringComparison.OrdinalIgnoreCase))) {
+                hasOperationAffinity = true;
                 score += 120;
             } else if ((string.Equals(preferredOperation, "query", StringComparison.OrdinalIgnoreCase)
                         || string.Equals(preferredOperation, "list", StringComparison.OrdinalIgnoreCase)
                         || string.Equals(preferredOperation, "search", StringComparison.OrdinalIgnoreCase))
                        && string.Equals(operation, "discover", StringComparison.OrdinalIgnoreCase)) {
+                hasOperationAffinity = true;
                 score += 120;
             }
 
@@ -1520,6 +1527,9 @@ internal sealed partial class ChatServiceSession {
             }
 
             score += 50;
+            if (!hasScopeAffinity && !hasOperationAffinity) {
+                continue;
+            }
 
             rankedCandidates.Add((new CrossPackFallbackCandidate(name, candidateDefinition), score));
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.PackFallback.cs
@@ -1035,6 +1035,59 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossPackSystemToAdDiscoveryFallbackUsingGeneralReadTargetOnlyTool() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_bios_summary"] = "system";
+        packMap["inventory_snapshot"] = "active_directory";
+
+        var toolDefinitions = new List<ToolDefinition> {
+            new(
+                "system_bios_summary",
+                "Summarize BIOS details for a target computer.",
+                ToolSchema.Object(
+                        ("computer_name", ToolSchema.String("Computer name.")))
+                    .Required("computer_name")
+                    .NoAdditionalProperties()),
+            new(
+                "inventory_snapshot",
+                "Return a generic AD inventory snapshot.",
+                ToolSchema.Object(("target", ToolSchema.String("Target identifier."))).NoAdditionalProperties())
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-1",
+                Name = "system_bios_summary",
+                ArgumentsJson = """
+                        {"computer_name":"dc01.contoso.local"}
+                        """
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-1",
+                Output = "{}",
+                Ok = false,
+                ErrorCode = "timeout"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["system_bios_summary"] = false,
+            ["inventory_snapshot"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "run domain discovery for contoso.local", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Null(args[5]);
+        var reason = Assert.IsType<string>(args[6]);
+        Assert.Equal("pack_contract_no_applicable_fallback", reason);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDomainDetectiveToTestimoXFallbackOnFailure() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -920,8 +920,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
         packMap["domaindetective_host_probe_custom"] = "domaindetective";
 
         var sourceSchema = ToolSchema.Object(
-                ("target", ToolSchema.String("target")))
-            .Required("target")
+                ("host", ToolSchema.String("host")))
+            .Required("host")
             .NoAdditionalProperties();
         var targetSchema = ToolSchema.Object(
                 ("host", ToolSchema.String("host")))
@@ -937,7 +937,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             new() {
                 CallId = "call-dns-custom-target",
                 Name = "dnsclientx_reachability_probe",
-                ArgumentsJson = """{"target":"mail.contoso.com"}"""
+                ArgumentsJson = """{"host":"mail.contoso.com"}"""
             }
         };
         var toolOutputs = new List<ToolOutputDto> {


### PR DESCRIPTION
## Summary
- Tightened cross-pack fallback candidate ranking so candidates must have actual routing affinity (scope or operation), not just generic targetable inputs.
- Removed the overly broad `discover -> read` compatibility bonus to avoid selecting weak generic read tools during discovery fallbacks.
- Added regression coverage proving `system -> AD discovery` does not fallback to a generic target-only/read candidate with no routing affinity.
- Updated one custom-candidate replay contract test to use explicit host-scoped source metadata, preserving intent under stricter affinity rules.

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackDomainDetectiveFallbackWithCustomCandidateName|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossPackSystemToAdDiscoveryFallbackUsingGeneralReadTargetOnlyTool"
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall"