### PR TITLE
chat: normalize array and boolean fallback hints

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.HostHints.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.HostHints.cs
@@ -366,16 +366,57 @@ internal sealed partial class ChatServiceSession {
             case JsonValueKind.False:
                 destination.Add(propertyName, node.GetBoolean());
                 break;
+            case JsonValueKind.Array: {
+                    var copied = new JsonArray();
+                    foreach (var item in node.EnumerateArray()) {
+                        if (item.ValueKind != JsonValueKind.String) {
+                            continue;
+                        }
+
+                        var value = (item.GetString() ?? string.Empty).Trim();
+                        if (value.Length > 0) {
+                            copied.Add(value);
+                        }
+                    }
+
+                    if (copied.Count > 0) {
+                        destination[propertyName] = JsonValue.From(copied);
+                    }
+                    break;
+                }
         }
     }
 
     private static string? ReadNonEmptyHint(JsonObject hints, string propertyName) {
-        if (!hints.TryGetValue(propertyName, out var node) || node is null || node.Kind != IntelligenceX.Json.JsonValueKind.String) {
+        if (!hints.TryGetValue(propertyName, out var node) || node is null) {
             return null;
         }
 
-        var value = (node.AsString() ?? string.Empty).Trim();
-        return value.Length == 0 ? null : value;
+        if (node.Kind == IntelligenceX.Json.JsonValueKind.String) {
+            var value = (node.AsString() ?? string.Empty).Trim();
+            return value.Length == 0 ? null : value;
+        }
+
+        if (node.Kind == IntelligenceX.Json.JsonValueKind.Array) {
+            var values = node.AsArray();
+            if (values is null || values.Count == 0) {
+                return null;
+            }
+
+            for (var i = 0; i < values.Count; i++) {
+                var item = values[i];
+                if (item is null || item.Kind != IntelligenceX.Json.JsonValueKind.String) {
+                    continue;
+                }
+
+                var value = (item.AsString() ?? string.Empty).Trim();
+                if (value.Length > 0) {
+                    return value;
+                }
+            }
+        }
+
+        return null;
     }
 
     private static bool? ReadHintBoolean(JsonObject hints, string propertyName) {
@@ -383,10 +424,53 @@ internal sealed partial class ChatServiceSession {
             return null;
         }
 
-        return node.Kind switch {
-            IntelligenceX.Json.JsonValueKind.Boolean => node.AsBoolean(),
-            _ => null
-        };
+        if (node.Kind == IntelligenceX.Json.JsonValueKind.Boolean) {
+            return node.AsBoolean();
+        }
+
+        if (node.Kind == IntelligenceX.Json.JsonValueKind.String
+            && TryParseProtocolBoolean((node.AsString() ?? string.Empty).Trim(), out var parsedString)) {
+            return parsedString;
+        }
+
+        if (node.Kind == IntelligenceX.Json.JsonValueKind.Number) {
+            var numeric = node.AsInt64();
+            if (numeric.HasValue && TryMapIntegerBoolean(numeric.Value, out var parsedNumber)) {
+                return parsedNumber;
+            }
+        }
+
+        if (node.Kind == IntelligenceX.Json.JsonValueKind.Array) {
+            var values = node.AsArray();
+            if (values is null || values.Count == 0) {
+                return null;
+            }
+
+            for (var i = 0; i < values.Count; i++) {
+                var item = values[i];
+                if (item is null) {
+                    continue;
+                }
+
+                if (item.Kind == IntelligenceX.Json.JsonValueKind.Boolean) {
+                    return item.AsBoolean();
+                }
+
+                if (item.Kind == IntelligenceX.Json.JsonValueKind.String
+                    && TryParseProtocolBoolean((item.AsString() ?? string.Empty).Trim(), out var parsedStringItem)) {
+                    return parsedStringItem;
+                }
+
+                if (item.Kind == IntelligenceX.Json.JsonValueKind.Number) {
+                    var numeric = item.AsInt64();
+                    if (numeric.HasValue && TryMapIntegerBoolean(numeric.Value, out var parsedNumberItem)) {
+                        return parsedNumberItem;
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 
     private static bool TryReadPositiveIntProperty(JsonElement source, string propertyName, out int value) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackCapabilityFallback.cs
@@ -1676,7 +1676,12 @@ internal sealed partial class ChatServiceSession {
     private static string? ResolveEventlogHostHint(JsonObject hints, string? userRequest) {
         var preferred = ReadNonEmptyHint(hints, "machine_name")
                         ?? ReadNonEmptyHint(hints, "computer_name")
-                        ?? ReadNonEmptyHint(hints, "host");
+                        ?? ReadNonEmptyHint(hints, "host")
+                        ?? ReadNonEmptyHint(hints, "domain_controller")
+                        ?? ReadNonEmptyHint(hints, "machine_names")
+                        ?? ReadNonEmptyHint(hints, "targets")
+                        ?? ReadNonEmptyHint(hints, "servers")
+                        ?? ReadNonEmptyHint(hints, "domain_controllers");
         if (string.IsNullOrWhiteSpace(preferred)) {
             preferred = TryExtractHostHintFromUserRequest(userRequest);
         }
@@ -2195,10 +2200,10 @@ internal sealed partial class ChatServiceSession {
         TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "host", "host", "machine_name", "computer_name");
         TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "name", "name", "target", "domain_name", "domain", "host", "machine_name", "computer_name");
         TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "target", "target", "host", "name", "machine_name", "computer_name", "domain_name", "domain");
-        TryAddSchemaAwareStringArrayHintArgument(toolDefinition, arguments, partialScopeHints, "targets", "target", "host", "name", "machine_name", "computer_name", "domain_name", "domain");
-        TryAddSchemaAwareStringArrayHintArgument(toolDefinition, arguments, partialScopeHints, "machine_names", "machine_name", "computer_name", "host", "name");
-        TryAddSchemaAwareStringArrayHintArgument(toolDefinition, arguments, partialScopeHints, "servers", "domain_controller", "machine_name", "computer_name", "host", "name");
-        TryAddSchemaAwareStringArrayHintArgument(toolDefinition, arguments, partialScopeHints, "domain_controllers", "domain_controller", "machine_name", "computer_name", "host", "name");
+        TryAddSchemaAwareStringArrayHintArgument(toolDefinition, arguments, partialScopeHints, "targets", "targets", "target", "host", "name", "machine_names", "machine_name", "computer_name", "servers", "domain_controllers", "domain_name", "domain");
+        TryAddSchemaAwareStringArrayHintArgument(toolDefinition, arguments, partialScopeHints, "machine_names", "machine_names", "machine_name", "computer_name", "host", "name", "targets", "servers", "domain_controllers");
+        TryAddSchemaAwareStringArrayHintArgument(toolDefinition, arguments, partialScopeHints, "servers", "servers", "domain_controllers", "domain_controller", "machine_names", "machine_name", "computer_name", "host", "name", "targets");
+        TryAddSchemaAwareStringArrayHintArgument(toolDefinition, arguments, partialScopeHints, "domain_controllers", "domain_controllers", "servers", "domain_controller", "machine_names", "machine_name", "computer_name", "host", "name", "targets");
         TryAddSchemaAwareStringHintArgument(toolDefinition, arguments, partialScopeHints, "log_name", "log_name");
         TryAddSchemaAwareBooleanHintArgument(toolDefinition, arguments, partialScopeHints, "include_trusts", "include_trusts");
         TryAddSchemaAwareBooleanHintArgument(toolDefinition, arguments, partialScopeHints, "include_forest_domains", "include_forest_domains");
@@ -2292,22 +2297,67 @@ internal sealed partial class ChatServiceSession {
             return;
         }
 
+        if (TryReadNonEmptyStringArrayHint(partialScopeHints, argumentName, out var directValues)) {
+            arguments[argumentName] = JsonValue.From(directValues);
+            return;
+        }
+
         for (var i = 0; i < hintKeys.Length; i++) {
             var hintKey = (hintKeys[i] ?? string.Empty).Trim();
             if (hintKey.Length == 0) {
                 continue;
             }
 
-            var value = ReadNonEmptyHint(partialScopeHints, hintKey);
-            if (string.IsNullOrWhiteSpace(value)) {
+            if (!TryReadNonEmptyStringArrayHint(partialScopeHints, hintKey, out var values)) {
                 continue;
             }
 
-            var array = new JsonArray();
-            array.Add(value);
-            arguments[argumentName] = JsonValue.From(array);
+            arguments[argumentName] = JsonValue.From(values);
             return;
         }
+    }
+
+    private static bool TryReadNonEmptyStringArrayHint(
+        JsonObject hints,
+        string propertyName,
+        out JsonArray values) {
+        values = new JsonArray();
+        if (!hints.TryGetValue(propertyName, out var node) || node is null) {
+            return false;
+        }
+
+        if (node.Kind == IntelligenceX.Json.JsonValueKind.String) {
+            var value = (node.AsString() ?? string.Empty).Trim();
+            if (value.Length == 0) {
+                return false;
+            }
+
+            values.Add(value);
+            return true;
+        }
+
+        if (node.Kind != IntelligenceX.Json.JsonValueKind.Array) {
+            return false;
+        }
+
+        var array = node.AsArray();
+        if (array is null || array.Count == 0) {
+            return false;
+        }
+
+        for (var i = 0; i < array.Count; i++) {
+            var item = array[i];
+            if (item is null || item.Kind != IntelligenceX.Json.JsonValueKind.String) {
+                continue;
+            }
+
+            var value = (item.AsString() ?? string.Empty).Trim();
+            if (value.Length > 0) {
+                values.Add(value);
+            }
+        }
+
+        return values.Count > 0;
     }
 
     private static void TryAddSchemaAwareStringDefaultArgument(
@@ -2582,6 +2632,10 @@ internal sealed partial class ChatServiceSession {
         CopyHintIfPresent(sourceArguments, destinationHints, "target");
         CopyHintIfPresent(sourceArguments, destinationHints, "name");
         CopyHintIfPresent(sourceArguments, destinationHints, "domain_controller");
+        CopyHintIfPresent(sourceArguments, destinationHints, "targets");
+        CopyHintIfPresent(sourceArguments, destinationHints, "machine_names");
+        CopyHintIfPresent(sourceArguments, destinationHints, "servers");
+        CopyHintIfPresent(sourceArguments, destinationHints, "domain_controllers");
         CopyHintIfPresent(sourceArguments, destinationHints, "log_name");
         CopyHintIfPresent(sourceArguments, destinationHints, "include_trusts");
 
@@ -2804,6 +2858,11 @@ internal sealed partial class ChatServiceSession {
                 CopyHintIfPresent(discoveryStatus, hints, "forest_dns_name");
                 CopyHintIfPresent(discoveryStatus, hints, "computer_name");
                 CopyHintIfPresent(discoveryStatus, hints, "machine_name");
+                CopyHintIfPresent(discoveryStatus, hints, "domain_controller");
+                CopyHintIfPresent(discoveryStatus, hints, "targets");
+                CopyHintIfPresent(discoveryStatus, hints, "machine_names");
+                CopyHintIfPresent(discoveryStatus, hints, "servers");
+                CopyHintIfPresent(discoveryStatus, hints, "domain_controllers");
                 CopyHintIfPresent(discoveryStatus, hints, "log_name");
                 CopyHintIfPresent(discoveryStatus, hints, "include_trusts");
 
@@ -2909,10 +2968,20 @@ internal sealed partial class ChatServiceSession {
             var root = doc.RootElement;
             CopyHintIfPresent(root, hints, "machine_name");
             CopyHintIfPresent(root, hints, "computer_name");
+            CopyHintIfPresent(root, hints, "domain_controller");
+            CopyHintIfPresent(root, hints, "targets");
+            CopyHintIfPresent(root, hints, "machine_names");
+            CopyHintIfPresent(root, hints, "servers");
+            CopyHintIfPresent(root, hints, "domain_controllers");
             CopyHintIfPresent(root, hints, "log_name");
             if (TryReadDiscoveryStatusObject(root, out var discoveryStatus)) {
                 CopyHintIfPresent(discoveryStatus, hints, "machine_name");
                 CopyHintIfPresent(discoveryStatus, hints, "computer_name");
+                CopyHintIfPresent(discoveryStatus, hints, "domain_controller");
+                CopyHintIfPresent(discoveryStatus, hints, "targets");
+                CopyHintIfPresent(discoveryStatus, hints, "machine_names");
+                CopyHintIfPresent(discoveryStatus, hints, "servers");
+                CopyHintIfPresent(discoveryStatus, hints, "domain_controllers");
                 CopyHintIfPresent(discoveryStatus, hints, "log_name");
             }
         } catch (JsonException) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ReplayContracts.cs
@@ -1394,6 +1394,106 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostEventlogEvidenceFromMachineNamesHintArray() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_inventory_query"] = "computerx";
+        packMap["eventlog_live_query"] = "eventlog";
+
+        var systemSchema = ToolSchema.Object(
+                ("machine_names", ToolSchema.Array(ToolSchema.String(), "machine names")))
+            .NoAdditionalProperties();
+        var eventlogSchema = ToolSchema.Object(
+                ("machine_name", ToolSchema.String("machine name")),
+                ("log_name", ToolSchema.String("log name")))
+            .Required("machine_name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("system_inventory_query", "system inventory query", systemSchema),
+            new("eventlog_live_query", "eventlog live query", eventlogSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-sys-machine-array",
+                Name = "system_inventory_query",
+                ArgumentsJson = """{"machine_names":["AD0","AD1"]}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-sys-machine-array",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_live_query"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("eventlog_live_query", toolCall.Name);
+        Assert.Contains("\"machine_name\":\"AD0\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"log_name\":\"System\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostEventlogEvidencePreservingTargetsHintArray() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_inventory_query"] = "computerx";
+        packMap["eventlog_targets_query"] = "eventlog";
+
+        var systemSchema = ToolSchema.Object(
+                ("targets", ToolSchema.Array(ToolSchema.String(), "targets")))
+            .NoAdditionalProperties();
+        var eventlogSchema = ToolSchema.Object(
+                ("targets", ToolSchema.Array(ToolSchema.String(), "targets")),
+                ("log_name", ToolSchema.String("log name")))
+            .Required("targets")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("system_inventory_query", "system inventory query", systemSchema),
+            new("eventlog_targets_query", "eventlog targets query", eventlogSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-sys-target-array",
+                Name = "system_inventory_query",
+                ArgumentsJson = """{"targets":["AD0","AD1"]}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-sys-target-array",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["eventlog_targets_query"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue host diagnostics", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("eventlog_targets_query", toolCall.Name);
+        Assert.Contains("\"targets\":[\"AD0\",\"AD1\"]", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"log_name\":\"System\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryBuildPackCapabilityFallbackToolCall_DoesNotBuildCrossHostEventlogEvidenceFromSystemPackInfoFailure() {
         var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
         var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
@@ -1477,6 +1577,59 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
         Assert.False(Assert.IsType<bool>(result));
         Assert.Equal("pack_contract_no_applicable_fallback", Assert.IsType<string>(args[6]));
+    }
+
+    [Fact]
+    public void TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackSystemToAdDiscoveryFromStringBooleanHint() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var packMap = Assert.IsType<Dictionary<string, string>>(ToolPackIdsByToolNameField.GetValue(session));
+        packMap["system_bios_summary"] = "system";
+        packMap["ad_scope_discovery"] = "active_directory";
+
+        var systemSchema = ToolSchema.Object(
+                ("domain_name", ToolSchema.String("domain name")),
+                ("include_trusts", ToolSchema.String("include trusts")))
+            .Required("domain_name")
+            .NoAdditionalProperties();
+        var adSchema = ToolSchema.Object(
+                ("domain_name", ToolSchema.String("domain name")),
+                ("discovery_fallback", ToolSchema.String("fallback mode")),
+                ("include_trusts", ToolSchema.Boolean()))
+            .Required("domain_name")
+            .NoAdditionalProperties();
+        var toolDefinitions = new List<ToolDefinition> {
+            new("system_bios_summary", "system bios summary", systemSchema),
+            new("ad_scope_discovery", "ad scope discovery", adSchema)
+        };
+        RebuildPackCapabilityFallbackContractsMethod.Invoke(session, new object?[] { toolDefinitions });
+
+        var toolCalls = new List<ToolCallDto> {
+            new() {
+                CallId = "call-sys-ad-bool",
+                Name = "system_bios_summary",
+                ArgumentsJson = """{"domain_name":"contoso.local","include_trusts":"false"}"""
+            }
+        };
+        var toolOutputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "call-sys-ad-bool",
+                Output = """{"ok":false,"error_code":"query_failed"}""",
+                Ok = false,
+                ErrorCode = "query_failed"
+            }
+        };
+        var mutabilityHints = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase) {
+            ["ad_scope_discovery"] = false
+        };
+
+        var args = new object?[] { toolDefinitions, toolCalls, toolOutputs, "continue discovery", mutabilityHints, null, null };
+        var result = TryBuildPackCapabilityFallbackToolCallMethod.Invoke(session, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        var toolCall = Assert.IsType<ToolCall>(args[5]);
+        Assert.Equal("ad_scope_discovery", toolCall.Name);
+        Assert.Contains("\"domain_name\":\"contoso.local\"", toolCall.Input, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"include_trusts\":false", toolCall.Input, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- make fallback hint readers shape-tolerant by accepting first non-empty string from arrays and boolean values from string/number forms
- preserve array hints (targets/machine_names/servers/domain_controllers) when copying source/output hints into partial scope
- improve schema-aware array argument hydration to consume direct array hints and alias arrays without collapsing to a single value
- expand cross-host eventlog host resolution to consume array-derived host hints

## Tests
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostEventlogEvidenceFromMachineNamesHintArray|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostEventlogEvidencePreservingTargetsHintArray|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossPackSystemToAdDiscoveryFromStringBooleanHint|FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall_BuildsCrossHostEventlogEvidenceWithMachineNamesArrayCandidate"
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "FullyQualifiedName~TryBuildPackCapabilityFallbackToolCall"
