### PR TITLE
tools: support render hint arrays for richer visual guidance

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveChecksCatalogTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveChecksCatalogTool.cs
@@ -51,12 +51,20 @@ public sealed class DomainDetectiveChecksCatalogTool : DomainDetectiveToolBase, 
                 })
                 .ToArray()
             : Array.Empty<DomainDetectiveCheckAliasModel>();
+        var defaultCheckLookup = new HashSet<string>(defaultChecks, StringComparer.OrdinalIgnoreCase);
+        var checkRows = supportedChecks
+            .Select(check => new DomainDetectiveCheckRowModel {
+                Check = check,
+                IsDefault = defaultCheckLookup.Contains(check)
+            })
+            .ToArray();
 
         var result = new DomainDetectiveChecksCatalogResultModel {
             Source = ResolveCatalogSource(),
             MaxChecksPerRun = Options.MaxChecks,
             SupportedChecks = supportedChecks,
             DefaultChecks = defaultChecks,
+            CheckRows = checkRows,
             Aliases = aliases,
             NormalizationRules = new[] {
                 "Input is case-insensitive and non-alphanumeric separators are ignored.",
@@ -78,8 +86,23 @@ public sealed class DomainDetectiveChecksCatalogTool : DomainDetectiveToolBase, 
             .Add("default_checks", result.DefaultChecks.Count)
             .Add("aliases", result.Aliases.Count)
             .Add("max_checks_per_run", result.MaxChecksPerRun);
+        var renderHints = new JsonArray()
+            .Add(ToolOutputHints.RenderTable(
+                "check_rows",
+                new ToolColumn("check", "Check", "string"),
+                new ToolColumn("is_default", "Default", "bool")));
+        if (result.Aliases.Count > 0) {
+            renderHints.Add(ToolOutputHints.RenderTable(
+                "aliases",
+                new ToolColumn("token", "Alias", "string"),
+                new ToolColumn("canonical", "Canonical", "string")));
+        }
 
-        return Task.FromResult(ToolResponse.OkModel(result, meta: meta, summaryMarkdown: summary));
+        return Task.FromResult(ToolOutputEnvelope.OkFlatWithRenderValue(
+            root: ToolJson.ToJsonObjectSnakeCase(result),
+            meta: meta,
+            summaryMarkdown: summary,
+            render: JsonValue.From(renderHints)));
     }
 
     private static string ResolveCatalogSource() {
@@ -95,8 +118,14 @@ public sealed class DomainDetectiveChecksCatalogTool : DomainDetectiveToolBase, 
         public int MaxChecksPerRun { get; init; }
         public IReadOnlyList<string> SupportedChecks { get; init; } = Array.Empty<string>();
         public IReadOnlyList<string> DefaultChecks { get; init; } = Array.Empty<string>();
+        public IReadOnlyList<DomainDetectiveCheckRowModel> CheckRows { get; init; } = Array.Empty<DomainDetectiveCheckRowModel>();
         public IReadOnlyList<DomainDetectiveCheckAliasModel> Aliases { get; init; } = Array.Empty<DomainDetectiveCheckAliasModel>();
         public IReadOnlyList<string> NormalizationRules { get; init; } = Array.Empty<string>();
+    }
+
+    private sealed class DomainDetectiveCheckRowModel {
+        public string Check { get; init; } = string.Empty;
+        public bool IsDefault { get; init; }
     }
 
     private sealed class DomainDetectiveCheckAliasModel {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DomainDetectiveChecksCatalogToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DomainDetectiveChecksCatalogToolTests.cs
@@ -46,6 +46,41 @@ public sealed class DomainDetectiveChecksCatalogToolTests {
             aliases,
             static node => string.Equals(node.GetProperty("token").GetString(), "NAMESERVERS", StringComparison.OrdinalIgnoreCase)
                 && string.Equals(node.GetProperty("canonical").GetString(), "NS", StringComparison.OrdinalIgnoreCase));
+        var checkRows = root.GetProperty("check_rows").EnumerateArray().ToArray();
+        Assert.Equal(supportedChecks.Length, checkRows.Length);
+        Assert.Contains(checkRows, static node => node.GetProperty("is_default").GetBoolean());
+
+        var renderHints = root.GetProperty("render").EnumerateArray().ToArray();
+        Assert.NotEmpty(renderHints);
+
+        var primaryTable = renderHints[0];
+        Assert.Equal("table", primaryTable.GetProperty("kind").GetString());
+        Assert.Equal("check_rows", primaryTable.GetProperty("rows_path").GetString());
+        var primaryColumns = primaryTable.GetProperty("columns")
+            .EnumerateArray()
+            .Select(static node => node.GetProperty("key").GetString())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value!.Trim())
+            .ToArray();
+        Assert.NotEmpty(primaryColumns);
+
+        foreach (var key in primaryColumns) {
+            Assert.True(checkRows[0].TryGetProperty(key, out _), $"Missing check_rows property for column key '{key}'.");
+        }
+
+        var aliasTable = renderHints.Single(static hint =>
+            string.Equals(hint.GetProperty("rows_path").GetString(), "aliases", StringComparison.OrdinalIgnoreCase));
+        var aliasColumns = aliasTable.GetProperty("columns")
+            .EnumerateArray()
+            .Select(static node => node.GetProperty("key").GetString())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value!.Trim())
+            .ToArray();
+        Assert.NotEmpty(aliasColumns);
+
+        foreach (var key in aliasColumns) {
+            Assert.True(aliases[0].TryGetProperty(key, out _), $"Missing aliases property for column key '{key}'.");
+        }
 
         var normalizationRules = root.GetProperty("normalization_rules")
             .EnumerateArray()
@@ -71,5 +106,14 @@ public sealed class DomainDetectiveChecksCatalogToolTests {
         Assert.Equal(0, root.GetProperty("aliases").GetArrayLength());
         Assert.Equal(0, root.GetProperty("default_checks").GetArrayLength());
         Assert.True(root.GetProperty("supported_checks").GetArrayLength() > 0);
+
+        var checkRows = root.GetProperty("check_rows").EnumerateArray().ToArray();
+        Assert.NotEmpty(checkRows);
+        Assert.DoesNotContain(checkRows, static node => node.GetProperty("is_default").GetBoolean());
+
+        var renderHints = root.GetProperty("render").EnumerateArray().ToArray();
+        Assert.Single(renderHints);
+        Assert.Equal("table", renderHints[0].GetProperty("kind").GetString());
+        Assert.Equal("check_rows", renderHints[0].GetProperty("rows_path").GetString());
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolOutputEnvelopeRenderValueTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolOutputEnvelopeRenderValueTests.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using IntelligenceX.Json;
+using IntelligenceX.Tools;
+using IntelligenceX.Tools.Common;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class ToolOutputEnvelopeRenderValueTests {
+    [Fact]
+    public void OkFlatWithRenderValue_AllowsRenderHintArrays() {
+        var root = new JsonObject().Add("name", "demo");
+        var meta = ToolOutputHints.Meta(count: 1, truncated: false);
+        var render = new JsonArray()
+            .Add(ToolOutputHints.RenderTable(
+                "rows",
+                new ToolColumn("id", "Id", "string")))
+            .Add(ToolOutputHints.RenderCode(language: "ix-network", contentPath: "graph"));
+
+        var json = ToolOutputEnvelope.OkFlatWithRenderValue(
+            root: root,
+            meta: meta,
+            summaryMarkdown: "demo",
+            render: JsonValue.From(render));
+
+        using var document = JsonDocument.Parse(json);
+        var envelope = document.RootElement;
+        Assert.True(envelope.GetProperty("ok").GetBoolean());
+        Assert.Equal("demo", envelope.GetProperty("summary_markdown").GetString());
+        Assert.Equal(global::System.Text.Json.JsonValueKind.Array, envelope.GetProperty("render").ValueKind);
+        Assert.Equal(2, envelope.GetProperty("render").GetArrayLength());
+    }
+}

--- a/IntelligenceX/Tools/ToolOutputEnvelope.cs
+++ b/IntelligenceX/Tools/ToolOutputEnvelope.cs
@@ -24,6 +24,22 @@ public static class ToolOutputEnvelope {
     /// <param name="summaryMarkdown">Optional human-readable markdown summary for UI display.</param>
     /// <param name="render">Optional UI render hints (tables, columns, types, etc.).</param>
     public static JsonObject OkFlatObject(JsonObject? root = null, JsonObject? meta = null, string? summaryMarkdown = null, JsonObject? render = null) {
+        return OkFlatObjectWithRenderValue(
+            root: root,
+            meta: meta,
+            summaryMarkdown: summaryMarkdown,
+            render: render is null ? null : JsonValue.From(render));
+    }
+
+    /// <summary>
+    /// Creates a success envelope (<c>ok=true</c>) where tool-specific fields are placed at the root level
+    /// and <c>render</c> can be either an object or an array.
+    /// </summary>
+    public static JsonObject OkFlatObjectWithRenderValue(
+        JsonObject? root = null,
+        JsonObject? meta = null,
+        string? summaryMarkdown = null,
+        JsonValue? render = null) {
         var obj = new JsonObject().Add("ok", true);
 
         if (root is not null) {
@@ -38,9 +54,7 @@ public static class ToolOutputEnvelope {
         if (!string.IsNullOrWhiteSpace(summaryMarkdown)) {
             obj.Add("summary_markdown", summaryMarkdown);
         }
-        if (render is not null) {
-            obj.Add("render", render);
-        }
+        TryAddRenderValue(obj, render);
 
         return obj;
     }
@@ -52,6 +66,16 @@ public static class ToolOutputEnvelope {
         => JsonLite.Serialize(OkFlatObject(root, meta, summaryMarkdown, render));
 
     /// <summary>
+    /// Serializes a flat success envelope (<c>ok=true</c>) as JSON where <c>render</c> can be either an object or an array.
+    /// </summary>
+    public static string OkFlatWithRenderValue(
+        JsonObject? root = null,
+        JsonObject? meta = null,
+        string? summaryMarkdown = null,
+        JsonValue? render = null)
+        => JsonLite.Serialize(OkFlatObjectWithRenderValue(root, meta, summaryMarkdown, render));
+
+    /// <summary>
     /// Creates a success envelope (<c>ok=true</c>).
     /// </summary>
     /// <param name="data">Optional data payload.</param>
@@ -59,6 +83,21 @@ public static class ToolOutputEnvelope {
     /// <param name="summaryMarkdown">Optional human-readable markdown summary for UI display.</param>
     /// <param name="render">Optional UI render hints (tables, columns, types, etc.).</param>
     public static JsonObject OkObject(JsonObject? data = null, JsonObject? meta = null, string? summaryMarkdown = null, JsonObject? render = null) {
+        return OkObjectWithRenderValue(
+            data: data,
+            meta: meta,
+            summaryMarkdown: summaryMarkdown,
+            render: render is null ? null : JsonValue.From(render));
+    }
+
+    /// <summary>
+    /// Creates a success envelope (<c>ok=true</c>) where <c>render</c> can be either an object or an array.
+    /// </summary>
+    public static JsonObject OkObjectWithRenderValue(
+        JsonObject? data = null,
+        JsonObject? meta = null,
+        string? summaryMarkdown = null,
+        JsonValue? render = null) {
         var obj = new JsonObject().Add("ok", true);
         if (data is not null) {
             obj.Add("data", data);
@@ -69,9 +108,7 @@ public static class ToolOutputEnvelope {
         if (!string.IsNullOrWhiteSpace(summaryMarkdown)) {
             obj.Add("summary_markdown", summaryMarkdown);
         }
-        if (render is not null) {
-            obj.Add("render", render);
-        }
+        TryAddRenderValue(obj, render);
         return obj;
     }
 
@@ -80,6 +117,16 @@ public static class ToolOutputEnvelope {
     /// </summary>
     public static string Ok(JsonObject? data = null, JsonObject? meta = null, string? summaryMarkdown = null, JsonObject? render = null)
         => JsonLite.Serialize(OkObject(data, meta, summaryMarkdown, render));
+
+    /// <summary>
+    /// Serializes a success envelope (<c>ok=true</c>) as JSON where <c>render</c> can be either an object or an array.
+    /// </summary>
+    public static string OkWithRenderValue(
+        JsonObject? data = null,
+        JsonObject? meta = null,
+        string? summaryMarkdown = null,
+        JsonValue? render = null)
+        => JsonLite.Serialize(OkObjectWithRenderValue(data, meta, summaryMarkdown, render));
 
     /// <summary>
     /// Creates an error envelope (<c>ok=false</c>).
@@ -149,4 +196,12 @@ public static class ToolOutputEnvelope {
         bool isTransient = false,
         JsonObject? meta = null)
         => JsonLite.Serialize(ErrorObject(errorCode, error, hints, isTransient, meta));
+
+    private static void TryAddRenderValue(JsonObject destination, JsonValue? render) {
+        if (render is null || render.Kind == JsonValueKind.Null) {
+            return;
+        }
+
+        destination.Add("render", render);
+    }
 }


### PR DESCRIPTION
## Summary
- add new ToolOutputEnvelope helpers that accept render as a JsonValue so tools can emit either a single render object or a render-hints array
- update domaindetective_checks_catalog to emit structured check_rows and render-hint tables (primary checks table plus aliases table)
- add regression coverage for render-array envelopes and DomainDetective catalog render hints

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter FullyQualifiedName~DomainDetectiveChecksCatalogToolTests|FullyQualifiedName~ToolOutputEnvelopeRenderValueTests
- dotnet build IntelligenceX.sln -c Release -nologo