### PR TITLE
chat: prioritize richer render hints from arrays

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -33,6 +33,11 @@ internal sealed partial class ChatServiceSession {
     private const int PreferredVisualSourceScoreRenderHint = 300;
     private const int PreferredVisualSourceScoreSummaryMarkdown = 200;
     private const int PreferredVisualSourceScoreOutputPayload = 100;
+    private const int RenderHintVisualTypePriorityDefault = 10;
+    private const int RenderHintVisualTypePriorityTable = 100;
+    private const int RenderHintVisualTypePriorityMermaid = 200;
+    private const int RenderHintVisualTypePriorityChart = 300;
+    private const int RenderHintVisualTypePriorityNetwork = 400;
 
     internal static string ResolveAssistantTextBeforeNoTextFallback(
         string assistantDraft,
@@ -488,21 +493,47 @@ internal sealed partial class ChatServiceSession {
                 return false;
             }
 
+            var bestPriority = int.MinValue;
+            var bestVisualType = string.Empty;
             foreach (var hint in document.RootElement.EnumerateArray()) {
                 if (hint.ValueKind != JsonValueKind.Object) {
                     continue;
                 }
 
-                if (TryResolvePreferredVisualTypeFromRenderHint(hint, out preferredVisualType)) {
-                    return true;
+                if (!TryResolvePreferredVisualTypeFromRenderHint(hint, out var candidateVisualType)
+                    || string.IsNullOrWhiteSpace(candidateVisualType)) {
+                    continue;
                 }
+
+                var candidatePriority = ResolveRenderHintVisualPriority(candidateVisualType);
+                if (candidatePriority <= bestPriority) {
+                    continue;
+                }
+
+                bestPriority = candidatePriority;
+                bestVisualType = candidateVisualType;
             }
 
-            return false;
+            if (string.IsNullOrWhiteSpace(bestVisualType)) {
+                return false;
+            }
+
+            preferredVisualType = bestVisualType;
+            return true;
         } catch (JsonException) {
             preferredVisualType = string.Empty;
             return false;
         }
+    }
+
+    private static int ResolveRenderHintVisualPriority(string preferredVisualType) {
+        return preferredVisualType switch {
+            NetworkVisualType => RenderHintVisualTypePriorityNetwork,
+            ChartVisualType => RenderHintVisualTypePriorityChart,
+            MermaidVisualType => RenderHintVisualTypePriorityMermaid,
+            TableVisualType => RenderHintVisualTypePriorityTable,
+            _ => RenderHintVisualTypePriorityDefault
+        };
     }
 
     private static bool TryResolvePreferredVisualTypeFromRenderHint(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -111,6 +111,35 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_PrefersHigherPriorityRenderHintFromArrayWhenVisualsAreAllowed() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"ok\":true,\"events\":[]}",
+                RenderJson = """
+                    [
+                      {"kind":"table","rows_path":"events"},
+                      {"kind":"network","content":{"nodes":[{"id":"AD0"}],"edges":[]}}
+                    ]
+                    """,
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...", outputs);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: tool_outputs", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_InferPreferredVisualFromCodeRenderHintLanguageFallback() {
         var request = """
             [Proactive visualization guidance]


### PR DESCRIPTION
## Summary
- when a tool output includes multiple render hints, select preferred visual type by deterministic visual-priority instead of first-match order
- keep existing source-priority behavior unchanged (render hints still outrank summary/payload signals)
- add regression coverage for mixed render-hint arrays (table + network) so network wins as the richer visual signal

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_
- dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release -nologo