### PR TITLE
chat: honor explicit render hint priority signals

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.IntelligenceLoop.PhaseProgressAndFallback.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.ExceptionServices;
 using System.Text;
@@ -38,6 +39,8 @@ internal sealed partial class ChatServiceSession {
     private const int RenderHintVisualTypePriorityMermaid = 200;
     private const int RenderHintVisualTypePriorityChart = 300;
     private const int RenderHintVisualTypePriorityNetwork = 400;
+    private const int RenderHintPriorityMin = -100000;
+    private const int RenderHintPriorityMax = 100000;
 
     internal static string ResolveAssistantTextBeforeNoTextFallback(
         string assistantDraft,
@@ -505,7 +508,7 @@ internal sealed partial class ChatServiceSession {
                     continue;
                 }
 
-                var candidatePriority = ResolveRenderHintVisualPriority(candidateVisualType);
+                var candidatePriority = ResolveRenderHintPriority(hint, candidateVisualType);
                 if (candidatePriority <= bestPriority) {
                     continue;
                 }
@@ -534,6 +537,14 @@ internal sealed partial class ChatServiceSession {
             TableVisualType => RenderHintVisualTypePriorityTable,
             _ => RenderHintVisualTypePriorityDefault
         };
+    }
+
+    private static int ResolveRenderHintPriority(JsonElement renderHint, string preferredVisualType) {
+        if (!TryReadJsonInt32PropertyIgnoreCase(renderHint, "priority", out var explicitPriority)) {
+            return ResolveRenderHintVisualPriority(preferredVisualType);
+        }
+
+        return Math.Clamp(explicitPriority, RenderHintPriorityMin, RenderHintPriorityMax);
     }
 
     private static bool TryResolvePreferredVisualTypeFromRenderHint(
@@ -588,6 +599,52 @@ internal sealed partial class ChatServiceSession {
             }
 
             value = candidate;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadJsonInt32PropertyIgnoreCase(
+        JsonElement obj,
+        string propertyName,
+        out int value) {
+        value = 0;
+        if (obj.ValueKind != JsonValueKind.Object || string.IsNullOrWhiteSpace(propertyName)) {
+            return false;
+        }
+
+        foreach (var property in obj.EnumerateObject()) {
+            if (!property.NameEquals(propertyName)
+                && !string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            if (property.Value.ValueKind == JsonValueKind.Number) {
+                if (property.Value.TryGetInt32(out var numericValue)) {
+                    value = numericValue;
+                    return true;
+                }
+
+                if (property.Value.TryGetInt64(out var longValue)) {
+                    value = longValue > int.MaxValue ? int.MaxValue : longValue < int.MinValue ? int.MinValue : (int)longValue;
+                    return true;
+                }
+
+                return false;
+            }
+
+            if (property.Value.ValueKind != JsonValueKind.String) {
+                return false;
+            }
+
+            var numericText = (property.Value.GetString() ?? string.Empty).Trim();
+            if (numericText.Length == 0
+                || !int.TryParse(numericText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue)) {
+                return false;
+            }
+
+            value = parsedValue;
             return true;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.VisualContracts.cs
@@ -140,6 +140,64 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_PrefersExplicitRenderHintPriorityOverVisualTypePriority() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"ok\":true,\"events\":[]}",
+                RenderJson = """
+                    [
+                      {"kind":"network","priority":100},
+                      {"kind":"table","priority":900}
+                    ]
+                    """,
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...", outputs);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: table", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: tool_outputs", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildProactiveFollowUpReviewPrompt_FallsBackToVisualTypePriorityWhenRenderHintPriorityIsInvalid() {
+        var request = """
+            [Proactive visualization guidance]
+            ix:proactive-visualization:v1
+            allow_new_visuals: true
+            """;
+        var outputs = new List<ToolOutputDto> {
+            new() {
+                CallId = "c1",
+                Output = "{\"ok\":true}",
+                RenderJson = """
+                    [
+                      {"kind":"table","priority":"high"},
+                      {"kind":"network"}
+                    ]
+                    """,
+                Ok = true
+            }
+        };
+
+        var text = ChatServiceSession.BuildProactiveFollowUpReviewPrompt(request, "Current findings...", outputs);
+
+        Assert.Contains("allow_new_visuals: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("request_has_visual_contract: true", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual: ix-network", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preferred_visual_source: tool_outputs", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildProactiveFollowUpReviewPrompt_InferPreferredVisualFromCodeRenderHintLanguageFallback() {
         var request = """
             [Proactive visualization guidance]


### PR DESCRIPTION
## Summary
- support explicit `priority` on tool `render` hints in proactive visual-type inference
- keep existing type-based defaults as fallback when `priority` is absent or invalid
- add regression coverage proving explicit priority can override type priority and invalid priority safely falls back

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter FullyQualifiedName~BuildProactiveFollowUpReviewPrompt_
- dotnet build IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release -nologo