### PR TITLE
tools: add prioritized render hints to dns query output

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.DnsClientX/DnsClientXQueryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.DnsClientX/DnsClientXQueryTool.cs
@@ -227,7 +227,15 @@ public sealed class DnsClientXQueryTool : DnsClientXToolBase, ITool {
             meta.Add("error_code", result.ErrorCode);
         }
 
-        return ToolResponse.OkModel(result, meta: meta, summaryMarkdown: summary);
+        return ToolOutputEnvelope.OkFlatWithRenderValue(
+            root: ToolJson.ToJsonObjectSnakeCase(result),
+            meta: meta,
+            summaryMarkdown: summary,
+            render: BuildRenderHints(
+                answerCount: result.Answers.Count,
+                authorityCount: result.Authorities.Count,
+                additionalCount: result.Additional.Count,
+                questionCount: result.Questions.Count));
 #endif
     }
 
@@ -287,6 +295,58 @@ public sealed class DnsClientXQueryTool : DnsClientXToolBase, ITool {
                && answerCount <= 0
                && authorityCount <= 0
                && additionalCount <= 0;
+    }
+
+    private static JsonValue? BuildRenderHints(
+        int answerCount,
+        int authorityCount,
+        int additionalCount,
+        int questionCount) {
+        var hints = new JsonArray();
+
+        if (answerCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "answers",
+                    new ToolColumn("name", "Name", "string"),
+                    new ToolColumn("type", "Type", "string"),
+                    new ToolColumn("ttl", "TTL", "int"),
+                    new ToolColumn("data", "Data", "string"))
+                .Add("priority", 400));
+        }
+
+        if (authorityCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "authorities",
+                    new ToolColumn("name", "Name", "string"),
+                    new ToolColumn("type", "Type", "string"),
+                    new ToolColumn("ttl", "TTL", "int"),
+                    new ToolColumn("data", "Data", "string"))
+                .Add("priority", 300));
+        }
+
+        if (additionalCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "additional",
+                    new ToolColumn("name", "Name", "string"),
+                    new ToolColumn("type", "Type", "string"),
+                    new ToolColumn("ttl", "TTL", "int"),
+                    new ToolColumn("data", "Data", "string"))
+                .Add("priority", 200));
+        }
+
+        if (questionCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "questions",
+                    new ToolColumn("name", "Name", "string"),
+                    new ToolColumn("type", "Type", "string"))
+                .Add("priority", 100));
+        }
+
+        if (hints.Count == 0) {
+            return null;
+        }
+
+        return JsonValue.From(hints);
     }
 
     private sealed class DnsClientXQueryResultModel {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DnsClientXQueryToolGuardrailTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DnsClientXQueryToolGuardrailTests.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Linq;
 using System.Reflection;
+using System.Text.Json;
+using IntelligenceX.Json;
 using IntelligenceX.Tools.DnsClientX;
 using Xunit;
 
@@ -11,6 +14,11 @@ public sealed class DnsClientXQueryToolGuardrailTests {
             "IsSuspiciousEmptyNoErrorResponse",
             BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("IsSuspiciousEmptyNoErrorResponse method was not found.");
+    private static readonly MethodInfo BuildRenderHintsMethod =
+        typeof(DnsClientXQueryTool).GetMethod(
+            "BuildRenderHints",
+            BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildRenderHints method was not found.");
 
     [Fact]
     public void IsSuspiciousEmptyNoErrorResponse_ReturnsTrueWhenAllSectionsAreEmptyAndNotTruncated() {
@@ -46,6 +54,43 @@ public sealed class DnsClientXQueryToolGuardrailTests {
         Assert.False(suspicious);
     }
 
+    [Fact]
+    public void BuildRenderHints_ReturnsNullWhenAllSectionsAreEmpty() {
+        var hints = InvokeBuildRenderHints(
+            answerCount: 0,
+            authorityCount: 0,
+            additionalCount: 0,
+            questionCount: 0);
+
+        Assert.Null(hints);
+    }
+
+    [Fact]
+    public void BuildRenderHints_EmitsPriorityOrderedSectionTables() {
+        var hints = InvokeBuildRenderHints(
+            answerCount: 2,
+            authorityCount: 1,
+            additionalCount: 1,
+            questionCount: 1);
+        Assert.NotNull(hints);
+
+        using var document = JsonDocument.Parse(JsonLite.Serialize(hints!));
+        var renderHints = document.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(4, renderHints.Length);
+
+        Assert.Equal("answers", renderHints[0].GetProperty("rows_path").GetString());
+        Assert.Equal(400, renderHints[0].GetProperty("priority").GetInt32());
+
+        Assert.Equal("authorities", renderHints[1].GetProperty("rows_path").GetString());
+        Assert.Equal(300, renderHints[1].GetProperty("priority").GetInt32());
+
+        Assert.Equal("additional", renderHints[2].GetProperty("rows_path").GetString());
+        Assert.Equal(200, renderHints[2].GetProperty("priority").GetInt32());
+
+        Assert.Equal("questions", renderHints[3].GetProperty("rows_path").GetString());
+        Assert.Equal(100, renderHints[3].GetProperty("priority").GetInt32());
+    }
+
     private static bool InvokeIsSuspiciousEmptyNoErrorResponse(
         int questionCount,
         int answerCount,
@@ -57,5 +102,15 @@ public sealed class DnsClientXQueryToolGuardrailTests {
             new object?[] { questionCount, answerCount, authorityCount, additionalCount, isTruncated });
         return Assert.IsType<bool>(value);
     }
-}
 
+    private static JsonValue? InvokeBuildRenderHints(
+        int answerCount,
+        int authorityCount,
+        int additionalCount,
+        int questionCount) {
+        var value = BuildRenderHintsMethod.Invoke(
+            null,
+            new object?[] { answerCount, authorityCount, additionalCount, questionCount });
+        return value as JsonValue;
+    }
+}


### PR DESCRIPTION
## Summary
- `dnsclientx_query` now emits structured render-hint arrays for `answers`, `authorities`, `additional`, and `questions`
- each render hint includes explicit `priority` so chat can choose the most useful section deterministically
- response serialization now uses `OkFlatWithRenderValue` to preserve array render contracts
- added guardrail tests for the render-hint builder ordering/null behavior

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter FullyQualifiedName~DnsClientXQueryToolGuardrailTests
- dotnet build IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release -nologo