### PR TITLE
tools: add prioritized render hints to domain summary output

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveDomainSummaryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.DomainDetective/DomainDetectiveDomainSummaryTool.cs
@@ -166,7 +166,14 @@ public sealed class DomainDetectiveDomainSummaryTool : DomainDetectiveToolBase, 
             .Add("dns_endpoint", result.DnsEndpoint)
             .Add("hints_count", result.Summary.Hints.Count);
 
-        return ToolResponse.OkModel(result, meta: meta, summaryMarkdown: summaryMarkdown);
+        return ToolOutputEnvelope.OkFlatWithRenderValue(
+            root: ToolJson.ToJsonObjectSnakeCase(result),
+            meta: meta,
+            summaryMarkdown: summaryMarkdown,
+            render: BuildRenderHints(
+                analysisOverviewCount: result.AnalysisOverview.Count,
+                checksRequestedCount: result.ChecksRequested.Count,
+                hintCount: result.Summary.Hints.Count));
 #endif
     }
 
@@ -210,6 +217,42 @@ public sealed class DomainDetectiveDomainSummaryTool : DomainDetectiveToolBase, 
 
     private static string NormalizeCheckLookupToken(string value) {
         return DomainDetectiveCheckNameCatalog.NormalizeCheckLookupToken(value);
+    }
+
+    private static JsonValue? BuildRenderHints(
+        int analysisOverviewCount,
+        int checksRequestedCount,
+        int hintCount) {
+        var hints = new JsonArray();
+
+        if (analysisOverviewCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "analysis_overview",
+                    new ToolColumn("check", "Check", "string"),
+                    new ToolColumn("has_result", "Has result", "bool"),
+                    new ToolColumn("result_type", "Result type", "string"))
+                .Add("priority", 400));
+        }
+
+        if (checksRequestedCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "checks_requested",
+                    new ToolColumn("value", "Requested check", "string"))
+                .Add("priority", 300));
+        }
+
+        if (hintCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "summary/hints",
+                    new ToolColumn("value", "Hint", "string"))
+                .Add("priority", 200));
+        }
+
+        if (hints.Count == 0) {
+            return null;
+        }
+
+        return JsonValue.From(hints);
     }
 
 #if DOMAINDETECTIVE_ENABLED

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DomainDetectiveDomainSummaryToolRenderHintsTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/DomainDetectiveDomainSummaryToolRenderHintsTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using IntelligenceX.Json;
+using IntelligenceX.Tools.DomainDetective;
+using Xunit;
+
+namespace IntelligenceX.Tools.Tests;
+
+public sealed class DomainDetectiveDomainSummaryToolRenderHintsTests {
+    private static readonly MethodInfo BuildRenderHintsMethod =
+        typeof(DomainDetectiveDomainSummaryTool).GetMethod(
+            "BuildRenderHints",
+            BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildRenderHints method was not found.");
+
+    [Fact]
+    public void BuildRenderHints_ReturnsNullWhenAllSectionsAreEmpty() {
+        var hints = InvokeBuildRenderHints(
+            analysisOverviewCount: 0,
+            checksRequestedCount: 0,
+            hintCount: 0);
+
+        Assert.Null(hints);
+    }
+
+    [Fact]
+    public void BuildRenderHints_EmitsPriorityOrderedSectionTables() {
+        var hints = InvokeBuildRenderHints(
+            analysisOverviewCount: 2,
+            checksRequestedCount: 8,
+            hintCount: 3);
+        Assert.NotNull(hints);
+
+        using var document = JsonDocument.Parse(JsonLite.Serialize(hints!));
+        var renderHints = document.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(3, renderHints.Length);
+
+        Assert.Equal("analysis_overview", renderHints[0].GetProperty("rows_path").GetString());
+        Assert.Equal(400, renderHints[0].GetProperty("priority").GetInt32());
+
+        Assert.Equal("checks_requested", renderHints[1].GetProperty("rows_path").GetString());
+        Assert.Equal(300, renderHints[1].GetProperty("priority").GetInt32());
+
+        Assert.Equal("summary/hints", renderHints[2].GetProperty("rows_path").GetString());
+        Assert.Equal(200, renderHints[2].GetProperty("priority").GetInt32());
+    }
+
+    private static JsonValue? InvokeBuildRenderHints(
+        int analysisOverviewCount,
+        int checksRequestedCount,
+        int hintCount) {
+        var value = BuildRenderHintsMethod.Invoke(
+            null,
+            new object?[] { analysisOverviewCount, checksRequestedCount, hintCount });
+        return value as JsonValue;
+    }
+}


### PR DESCRIPTION
## Summary
- `domaindetective_domain_summary` now emits structured render-hint arrays for analysis overview, requested checks, and summary hints
- each render hint includes explicit `priority` so chat can select a deterministic best visualization path
- response serialization uses `OkFlatWithRenderValue` to preserve render arrays
- added guardrail tests for domain-summary render-hint generation

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter FullyQualifiedName~DomainDetectiveDomainSummaryToolRenderHintsTests|FullyQualifiedName~DomainDetectiveDomainSummaryToolAliasTests
- dotnet build IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release -nologo