### PR TITLE
tools: add prioritized render hints to AD discovery outputs

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdEnvironmentDiscoverTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdEnvironmentDiscoverTool.cs
@@ -181,15 +181,87 @@ public sealed class AdEnvironmentDiscoverTool : ActiveDirectoryToolBase, ITool {
             dnsDomainName: effectiveDnsDomainName,
             forestDnsName: effectiveForestDnsName);
 
-        return Task.FromResult(ToolResponse.OkFactsModel(
-            model: model,
-            title: "Active Directory: Environment Discovery",
-            facts: facts,
+        var factRows = new List<IReadOnlyList<string>>(facts.Count);
+        for (var i = 0; i < facts.Count; i++) {
+            var fact = facts[i];
+            factRows.Add(new[] { fact.Key, fact.Value });
+        }
+
+        var summaryMarkdown = ToolMarkdownContract.Create()
+            .AddTable(
+                title: "Active Directory: Environment Discovery",
+                headers: new[] { "Field", "Value" },
+                rows: factRows,
+                totalCount: factRows.Count,
+                truncated: false)
+            .Build();
+
+        return Task.FromResult(ToolOutputEnvelope.OkFlatWithRenderValue(
+            root: ToolJson.ToJsonObjectSnakeCase(model),
             meta: meta,
-            keyHeader: "Field",
-            valueHeader: "Value",
-            truncated: false,
-            render: null));
+            summaryMarkdown: summaryMarkdown,
+            render: BuildRenderHints(
+                domainControllerCount: discoveredDomainControllers.Count,
+                discoveredDomainCount: domainControllerDiscovery.DiscoveredDomains.Count,
+                discoverySourceCount: domainControllerDiscovery.Sources.Count,
+                nextActionCount: nextActions.Count,
+                missingReasonCount: domainControllerDiscovery.MissingReasons.Count)));
+    }
+
+    private static JsonValue? BuildRenderHints(
+        int domainControllerCount,
+        int discoveredDomainCount,
+        int discoverySourceCount,
+        int nextActionCount,
+        int missingReasonCount) {
+        var hints = new JsonArray();
+
+        if (discoverySourceCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "domain_controller_discovery/sources",
+                    new ToolColumn("source", "Source", "string"),
+                    new ToolColumn("ok", "Ok", "bool"),
+                    new ToolColumn("added", "Added", "int"),
+                    new ToolColumn("error_code", "Error code", "string"),
+                    new ToolColumn("error", "Error", "string"))
+                .Add("priority", 450));
+        }
+
+        if (domainControllerCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "domain_controllers",
+                    new ToolColumn("value", "Domain controller", "string"))
+                .Add("priority", 400));
+        }
+
+        if (nextActionCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "next_actions",
+                    new ToolColumn("tool", "Tool", "string"),
+                    new ToolColumn("reason", "Reason", "string"),
+                    new ToolColumn("mutating", "Mutating", "bool"))
+                .Add("priority", 300));
+        }
+
+        if (discoveredDomainCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "domain_controller_discovery/domains",
+                    new ToolColumn("value", "Domain", "string"))
+                .Add("priority", 200));
+        }
+
+        if (missingReasonCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "domain_controller_discovery/missing_reasons",
+                    new ToolColumn("value", "Missing reason", "string"))
+                .Add("priority", 100));
+        }
+
+        if (hints.Count == 0) {
+            return null;
+        }
+
+        return JsonValue.From(hints);
     }
 
     private static bool TryExtractDomainNameFromDistinguishedName(string? distinguishedName, out string domainName) {

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdForestDiscoverTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdForestDiscoverTool.cs
@@ -472,7 +472,84 @@ public sealed partial class AdForestDiscoverTool : ActiveDirectoryToolBase, IToo
             $"Forest: `{effectiveForest ?? string.Empty}`; Domains: `{domains.Count}`; DCs: `{allDcs.Count}`; Trusts: `{trusts.Count}`.",
             "Receipt includes discovery steps and per-domain DC source attempts.");
 
-        return ToolResponse.OkModel(model, summaryMarkdown: summary);
+        return ToolOutputEnvelope.OkFlatWithRenderValue(
+            root: ToolJson.ToJsonObjectSnakeCase(model),
+            summaryMarkdown: summary,
+            render: BuildRenderHints(
+                domainControllersByDomainCount: dcByDomain.Count,
+                domainControllerCount: allDcs.Count,
+                domainCount: domains.Count,
+                trustCount: trusts.Count,
+                receiptStepCount: receipt.Count,
+                nextActionCount: chain.NextActions.Count));
+    }
+
+    private static JsonValue? BuildRenderHints(
+        int domainControllersByDomainCount,
+        int domainControllerCount,
+        int domainCount,
+        int trustCount,
+        int receiptStepCount,
+        int nextActionCount) {
+        var hints = new JsonArray();
+
+        if (domainControllersByDomainCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "domain_controllers_by_domain",
+                    new ToolColumn("domain_name", "Domain", "string"),
+                    new ToolColumn("domain_controller_count", "DC count", "int"))
+                .Add("priority", 500));
+        }
+
+        if (domainControllerCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "domain_controllers",
+                    new ToolColumn("value", "Domain controller", "string"))
+                .Add("priority", 450));
+        }
+
+        if (domainCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "domains",
+                    new ToolColumn("value", "Domain", "string"))
+                .Add("priority", 400));
+        }
+
+        if (trustCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "trusts",
+                    new ToolColumn("scope", "Scope", "string"),
+                    new ToolColumn("source_name", "Source", "string"),
+                    new ToolColumn("target_name", "Target", "string"),
+                    new ToolColumn("trust_type", "Type", "string"),
+                    new ToolColumn("trust_direction", "Direction", "string"))
+                .Add("priority", 300));
+        }
+
+        if (receiptStepCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "receipt/steps",
+                    new ToolColumn("name", "Step", "string"),
+                    new ToolColumn("ok", "Ok", "bool"),
+                    new ToolColumn("duration_ms", "Duration (ms)", "int"),
+                    new ToolColumn("error_type", "Error type", "string"))
+                .Add("priority", 200));
+        }
+
+        if (nextActionCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "next_actions",
+                    new ToolColumn("tool", "Tool", "string"),
+                    new ToolColumn("reason", "Reason", "string"),
+                    new ToolColumn("mutating", "Mutating", "bool"))
+                .Add("priority", 150));
+        }
+
+        if (hints.Count == 0) {
+            return null;
+        }
+
+        return JsonValue.From(hints);
     }
 
     private static ToolChainContractModel BuildChainContract(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdEnvironmentDiscoverToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdEnvironmentDiscoverToolTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using IntelligenceX.Tools.ADPlayground;
 using IntelligenceX.Tools.Common;
 using Xunit;
@@ -14,6 +16,9 @@ public sealed class AdEnvironmentDiscoverToolTests {
     private static readonly MethodInfo TryExtractDomainNameFromDistinguishedNameMethod =
         typeof(AdEnvironmentDiscoverTool).GetMethod("TryExtractDomainNameFromDistinguishedName", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("TryExtractDomainNameFromDistinguishedName not found.");
+    private static readonly MethodInfo BuildRenderHintsMethod =
+        typeof(AdEnvironmentDiscoverTool).GetMethod("BuildRenderHints", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildRenderHints not found.");
 
     [Fact]
     public void BuildReadOnlyEnvironmentNextActions_WhenNotLimited_ReturnsEmpty() {
@@ -66,5 +71,41 @@ public sealed class AdEnvironmentDiscoverToolTests {
 
         Assert.True(result is bool value && !value);
         Assert.Equal(string.Empty, args[1] as string);
+    }
+
+    [Fact]
+    public void BuildRenderHints_WhenSectionsExist_EmitsPrioritizedHints() {
+        var result = BuildRenderHintsMethod.Invoke(
+            null,
+            new object?[] { 4, 2, 3, 2, 1 });
+
+        Assert.NotNull(result);
+        using var doc = JsonDocument.Parse(result!.ToString()!);
+        var renderHints = doc.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(5, renderHints.Length);
+
+        Assert.Equal("domain_controller_discovery/sources", renderHints[0].GetProperty("rows_path").GetString());
+        Assert.Equal(450, renderHints[0].GetProperty("priority").GetInt32());
+
+        Assert.Equal("domain_controllers", renderHints[1].GetProperty("rows_path").GetString());
+        Assert.Equal(400, renderHints[1].GetProperty("priority").GetInt32());
+
+        Assert.Equal("next_actions", renderHints[2].GetProperty("rows_path").GetString());
+        Assert.Equal(300, renderHints[2].GetProperty("priority").GetInt32());
+
+        Assert.Equal("domain_controller_discovery/domains", renderHints[3].GetProperty("rows_path").GetString());
+        Assert.Equal(200, renderHints[3].GetProperty("priority").GetInt32());
+
+        Assert.Equal("domain_controller_discovery/missing_reasons", renderHints[4].GetProperty("rows_path").GetString());
+        Assert.Equal(100, renderHints[4].GetProperty("priority").GetInt32());
+    }
+
+    [Fact]
+    public void BuildRenderHints_WhenNoSectionsExist_ReturnsNull() {
+        var result = BuildRenderHintsMethod.Invoke(
+            null,
+            new object?[] { 0, 0, 0, 0, 0 });
+
+        Assert.Null(result);
     }
 }

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdForestDiscoverToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdForestDiscoverToolTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,6 +11,10 @@ using Xunit;
 namespace IntelligenceX.Tools.Tests;
 
 public sealed class AdForestDiscoverToolTests {
+    private static readonly MethodInfo BuildRenderHintsMethod =
+        typeof(AdForestDiscoverTool).GetMethod("BuildRenderHints", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildRenderHints not found.");
+
     [Fact]
     public async Task InvokeAsync_WhenFallbackCurrentDomain_EmitsChainingContractFields() {
         var tool = new AdForestDiscoverTool(new ActiveDirectoryToolOptions());
@@ -99,5 +105,44 @@ public sealed class AdForestDiscoverToolTests {
         var typedArguments = expansionAction.Value.GetProperty("arguments");
         Assert.True(typedArguments.TryGetProperty("include_trusts", out var includeTrusts));
         Assert.True(includeTrusts.GetBoolean());
+    }
+
+    [Fact]
+    public void BuildRenderHints_WhenSectionsExist_EmitsPrioritizedHints() {
+        var result = BuildRenderHintsMethod.Invoke(
+            null,
+            new object?[] { 2, 5, 3, 1, 4, 2 });
+
+        Assert.NotNull(result);
+        using var doc = JsonDocument.Parse(result!.ToString()!);
+        var renderHints = doc.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(6, renderHints.Length);
+
+        Assert.Equal("domain_controllers_by_domain", renderHints[0].GetProperty("rows_path").GetString());
+        Assert.Equal(500, renderHints[0].GetProperty("priority").GetInt32());
+
+        Assert.Equal("domain_controllers", renderHints[1].GetProperty("rows_path").GetString());
+        Assert.Equal(450, renderHints[1].GetProperty("priority").GetInt32());
+
+        Assert.Equal("domains", renderHints[2].GetProperty("rows_path").GetString());
+        Assert.Equal(400, renderHints[2].GetProperty("priority").GetInt32());
+
+        Assert.Equal("trusts", renderHints[3].GetProperty("rows_path").GetString());
+        Assert.Equal(300, renderHints[3].GetProperty("priority").GetInt32());
+
+        Assert.Equal("receipt/steps", renderHints[4].GetProperty("rows_path").GetString());
+        Assert.Equal(200, renderHints[4].GetProperty("priority").GetInt32());
+
+        Assert.Equal("next_actions", renderHints[5].GetProperty("rows_path").GetString());
+        Assert.Equal(150, renderHints[5].GetProperty("priority").GetInt32());
+    }
+
+    [Fact]
+    public void BuildRenderHints_WhenNoSectionsExist_ReturnsNull() {
+        var result = BuildRenderHintsMethod.Invoke(
+            null,
+            new object?[] { 0, 0, 0, 0, 0, 0 });
+
+        Assert.Null(result);
     }
 }


### PR DESCRIPTION
## Summary
- add prioritized render-hint arrays to `ad_environment_discover` so chat can prefer discovery source, domain-controller, and next-action tables
- add prioritized render-hint arrays to `ad_forest_discover` so chat can prioritize per-domain DC inventory and trust/receipt views
- add deterministic tests for both tools' render-hint ordering and null behavior when no renderable sections exist

## Testing
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~AdEnvironmentDiscoverToolTests|FullyQualifiedName~AdForestDiscoverToolTests"
- dotnet build IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/IntelligenceX.Tools.ADPlayground.csproj -c Release -nologo
