### PR TITLE
tools: add prioritized render hints to ad scope discovery

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdScopeDiscoveryTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdScopeDiscoveryTool.cs
@@ -473,7 +473,81 @@ public sealed partial class AdScopeDiscoveryTool : ActiveDirectoryToolBase, IToo
             $"Forest: `{effectiveForest ?? string.Empty}`; Domains: `{domains.Count}`; DCs: `{allDcs.Count}`; Gaps: `{gaps.Count}`.",
             "Use `receipt.steps` to review endpoints checked, timeouts, and failed probes.");
 
-        return ToolResponse.OkModel(model, summaryMarkdown: summary);
+        return ToolOutputEnvelope.OkFlatWithRenderValue(
+            root: ToolJson.ToJsonObjectSnakeCase(model),
+            summaryMarkdown: summary,
+            render: BuildRenderHints(
+                stepCount: steps.Count,
+                nextActionCount: chain.NextActions.Count,
+                domainControllerByDomainCount: byDomain.Count,
+                domainControllerCount: allDcs.Count,
+                domainCount: domains.Count,
+                gapCount: gaps.Count));
+    }
+
+    private static JsonValue? BuildRenderHints(
+        int stepCount,
+        int nextActionCount,
+        int domainControllerByDomainCount,
+        int domainControllerCount,
+        int domainCount,
+        int gapCount) {
+        var hints = new JsonArray();
+
+        if (stepCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "receipt/steps",
+                    new ToolColumn("name", "Step", "string"),
+                    new ToolColumn("ok", "Ok", "bool"),
+                    new ToolColumn("duration_ms", "Duration (ms)", "int"),
+                    new ToolColumn("timeout_ms", "Timeout (ms)", "int"),
+                    new ToolColumn("error_type", "Error type", "string"))
+                .Add("priority", 500));
+        }
+
+        if (nextActionCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "next_actions",
+                    new ToolColumn("tool", "Tool", "string"),
+                    new ToolColumn("reason", "Reason", "string"),
+                    new ToolColumn("mutating", "Mutating", "bool"))
+                .Add("priority", 400));
+        }
+
+        if (domainControllerByDomainCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "domain_controllers_by_domain",
+                    new ToolColumn("domain_name", "Domain", "string"))
+                .Add("priority", 350));
+        }
+
+        if (domainControllerCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "domain_controllers",
+                    new ToolColumn("value", "Domain controller", "string"))
+                .Add("priority", 300));
+        }
+
+        if (domainCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "domains",
+                    new ToolColumn("value", "Domain", "string"))
+                .Add("priority", 250));
+        }
+
+        if (gapCount > 0) {
+            hints.Add(ToolOutputHints.RenderTable(
+                    "missing",
+                    new ToolColumn("area", "Area", "string"),
+                    new ToolColumn("reason", "Reason", "string"))
+                .Add("priority", 200));
+        }
+
+        if (hints.Count == 0) {
+            return null;
+        }
+
+        return JsonValue.From(hints);
     }
 
     private static ToolChainContractModel BuildChainContract(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdScopeDiscoveryToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/AdScopeDiscoveryToolTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -145,5 +146,27 @@ public class AdScopeDiscoveryToolTests {
         var typedArguments = expansionAction.Value.GetProperty("arguments");
         Assert.True(typedArguments.TryGetProperty("include_trusts", out var includeTrusts));
         Assert.True(includeTrusts.GetBoolean());
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenFallbackCurrentDomain_EmitsPrioritizedRenderHints() {
+        var tool = new AdScopeDiscoveryTool(new ActiveDirectoryToolOptions());
+
+        var json = await tool.InvokeAsync(
+            arguments: new JsonObject()
+                .Add("discovery_fallback", "current_domain"),
+            cancellationToken: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        var renderHints = root.GetProperty("render").EnumerateArray().ToArray();
+        Assert.True(renderHints.Length >= 2);
+
+        Assert.Equal("receipt/steps", renderHints[0].GetProperty("rows_path").GetString());
+        Assert.Equal(500, renderHints[0].GetProperty("priority").GetInt32());
+
+        Assert.Equal("next_actions", renderHints[1].GetProperty("rows_path").GetString());
+        Assert.Equal(400, renderHints[1].GetProperty("priority").GetInt32());
     }
 }


### PR DESCRIPTION
## Summary
- add prioritized render-hint arrays to `ad_scope_discovery` output so chat can prioritize receipt and next-action tables before lower-priority sections
- keep render hints contract-driven (`ToolOutputEnvelope.OkFlatWithRenderValue`) and tied to actual discovered sections
- add a public-output test asserting render-hint ordering for the current-domain fallback path

## Testing
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "FullyQualifiedName~AdScopeDiscoveryToolTests"
- dotnet build IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/IntelligenceX.Tools.ADPlayground.csproj -c Release -nologo
- dotnet build IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release -nologo
