### PR TITLE
Downloads: clarify empty-state when no releases are published

### DIFF
--- a/Website/content/pages/downloads.md
+++ b/Website/content/pages/downloads.md
@@ -9,6 +9,8 @@ meta.raw_html: true
 
 Download IntelligenceX release assets directly from this page. Source of truth remains [GitHub Releases](https://github.com/EvotecIT/IntelligenceX/releases).
 
+If the cards below show `No releases found`, no desktop artifacts have been published yet. In the meantime, start with [Getting Started](/docs/getting-started/) and project docs.
+
 <div class="ix-release-cta">
 {{< release-button placement="downloads.chat_stable" >}}
 {{< release-button placement="downloads.chat_preview" >}}


### PR DESCRIPTION
## Summary\n- add explicit copy on /downloads/ explaining that No releases found is expected before first desktop release\n- point users to /docs/getting-started/ while waiting for published artifacts\n\n## Why\n- reduces confusion on a fresh project where release assets are not yet published