### PR TITLE
Hide non-debug tool visuals in chat and fix copy button clipping

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowToolTranscriptMarkdownTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowToolTranscriptMarkdownTests.cs
@@ -69,4 +69,19 @@ public sealed class MainWindowToolTranscriptMarkdownTests {
 
         Assert.Equal(string.Empty, markdown);
     }
+
+    /// <summary>
+    /// Ensures non-debug transcript formatting does not require a display-name resolver.
+    /// </summary>
+    [Fact]
+    public void BuildToolRunTranscriptMarkdown_NonDebug_DoesNotRequireResolver() {
+        var tools = new ToolRunDto {
+            Calls = Array.Empty<ToolCallDto>(),
+            Outputs = Array.Empty<ToolOutputDto>()
+        };
+
+        var markdown = MainWindow.BuildToolRunTranscriptMarkdown(tools, debugMode: false, null!);
+
+        Assert.Equal(string.Empty, markdown);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.ToolPresentation.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.ToolPresentation.cs
@@ -18,10 +18,12 @@ public sealed partial class MainWindow : Window {
         bool debugMode,
         Func<string?, string> resolveToolDisplayName) {
         ArgumentNullException.ThrowIfNull(tools);
+        if (!debugMode) {
+            return string.Empty;
+        }
+
         ArgumentNullException.ThrowIfNull(resolveToolDisplayName);
-        return debugMode
-            ? ToolRunMarkdownFormatter.Format(tools, resolveToolDisplayName)
-            : string.Empty;
+        return ToolRunMarkdownFormatter.Format(tools, resolveToolDisplayName);
     }
 
     private string BuildToolRunTranscriptMarkdown(ToolRunDto tools) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.chat.css
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.chat.css
@@ -99,6 +99,7 @@
 .msg-row.assistant .bubble {
   background: var(--ix-bubble-assistant-bg);
   border: 1px solid var(--ix-bubble-assistant-border);
+  padding-right: 44px;
 }
 
 .msg-row.assistant.assistant-draft .avatar {
@@ -124,6 +125,7 @@
 .msg-row.user .bubble {
   background: var(--ix-bubble-user-bg);
   border: 1px solid var(--ix-bubble-user-border);
+  padding-left: 44px;
 }
 
 .msg-row.system .bubble {


### PR DESCRIPTION
## Summary
- stop rendering tool transcript bubbles in standard (non-debug) chat turns
- keep full tool transcript rendering available in debug mode
- fix copy button positioning so it stays inside chat bubble bounds and is not clipped

## Why
- standard conversation should not show internal Tool visuals blocks by default
- users reported confusing tool noise and copy button being cut off near edges

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release --filter "FullyQualifiedName~MainWindowToolTranscriptMarkdownTests"
- passed (2/2)

## Notes
- there is an unrelated existing failure in ToolRunMarkdownFormatterTests.Format_TableRenderHint_PreservesFallbackForNonObjectRows when running that test directly; not touched by this change
