### PR TITLE
Redesign footer navigation to scale with large menu sets

### DIFF
--- a/Website/static/css/main.css
+++ b/Website/static/css/main.css
@@ -52,17 +52,31 @@ p { margin: 0 0 1rem; color: var(--pf-muted); }
 /* ===== Footer ===== */
 .ix-footer { border-top: 1px solid var(--pf-border); padding: 3.25rem 0 2rem; margin-top: 4rem; }
 .ix-footer-inner { max-width: var(--pf-max-width); margin: 0 auto; padding: 0 1.5rem; }
-.ix-footer-grid { display: grid; grid-template-columns: minmax(260px, 1.25fr) minmax(230px, 1.4fr) minmax(210px, 1.15fr) minmax(170px, 0.95fr); gap: 2rem 2.35rem; margin-bottom: 2rem; align-items: start; }
-.ix-footer-brand { }
+.ix-footer-grid { display: grid; grid-template-columns: minmax(260px, 1.05fr) minmax(0, 2fr); gap: 1.25rem 2rem; margin-bottom: 2rem; align-items: start; }
 .ix-footer-logo { display: flex; align-items: center; gap: 0.5rem; font-weight: 600; margin-bottom: 0.75rem; color: var(--pf-ink-strong, #fff); }
 .ix-footer-tagline { font-size: 0.875rem; color: var(--pf-muted); margin: 0; line-height: 1.5; }
-.ix-footer-heading { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--pf-ink); margin: 0 0 0.75rem; font-weight: 600; }
-.ix-footer-col ul { list-style: none; padding: 0; margin: 0; }
-.ix-footer-links { display: grid; grid-template-columns: 1fr; gap: 0.42rem 1.2rem; }
-.ix-footer-links.is-split { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.ix-footer-col li { margin: 0; min-width: 0; }
-.ix-footer-col a { display: block; font-size: 0.875rem; line-height: 1.45; color: var(--pf-muted); overflow-wrap: anywhere; }
-.ix-footer-col a:hover { color: var(--pf-accent); }
+.ix-footer-catalog { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.9rem; }
+.ix-footer-section {
+  border: 1px solid var(--pf-border);
+  border-radius: var(--pf-radius-sm);
+  background:
+    linear-gradient(160deg, rgba(56, 189, 248, 0.07), rgba(56, 189, 248, 0) 48%),
+    var(--pf-card-bg);
+  padding: 0.9rem 1rem 1rem;
+}
+.ix-footer-heading { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--pf-ink); margin: 0 0 0.7rem; font-weight: 600; }
+.ix-footer-links { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: 1fr; gap: 0.42rem 1.1rem; }
+.ix-footer-links.is-dense { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.ix-footer-links.is-mega { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.ix-footer-links.is-scroll {
+  max-height: 11.5rem;
+  overflow: auto;
+  padding-right: 0.35rem;
+  scrollbar-width: thin;
+}
+.ix-footer-links li { margin: 0; min-width: 0; }
+.ix-footer-links a { display: block; font-size: 0.84rem; line-height: 1.4; color: var(--pf-muted); overflow-wrap: anywhere; }
+.ix-footer-links a:hover { color: var(--pf-accent); }
 .ix-footer-bottom { border-top: 1px solid var(--pf-border); padding-top: 1.5rem; display: flex; justify-content: space-between; font-size: 0.8rem; color: var(--pf-muted); }
 .ix-footer-bottom a { color: var(--pf-muted); }
 .ix-footer-bottom a:hover { color: var(--pf-accent); }
@@ -538,11 +552,11 @@ blockquote p:last-child { margin-bottom: 0; }
 /* ===== Responsive ===== */
 @media (max-width: 1180px) {
   .ix-footer-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: 1fr;
   }
   .ix-footer-brand {
     grid-column: 1 / -1;
-    max-width: 620px;
+    max-width: 640px;
   }
 }
 
@@ -552,8 +566,9 @@ blockquote p:last-child { margin-bottom: 0; }
   body.nav-open .ix-nav { display: flex; flex-direction: column; position: absolute; top: 64px; left: 0; right: 0; background: var(--pf-bg-alt); border-bottom: 1px solid var(--pf-border); padding: 1rem 1.5rem; gap: 1rem; }
   body.nav-open .ix-nav-links { flex-direction: column; gap: 0.75rem; }
   body.nav-open .ix-actions { flex-wrap: wrap; }
-  .ix-footer-grid { grid-template-columns: 1fr; }
-  .ix-footer-links.is-split { grid-template-columns: 1fr; }
+  .ix-footer-catalog { grid-template-columns: 1fr; }
+  .ix-footer-links.is-dense,
+  .ix-footer-links.is-mega { grid-template-columns: 1fr; }
   .ix-footer-bottom { flex-direction: column; gap: 0.5rem; }
   h1 { font-size: 1.75rem; }
   h2 { font-size: 1.375rem; }

--- a/Website/themes/intelligencex/partials/footer.html
+++ b/Website/themes/intelligencex/partials/footer.html
@@ -1,5 +1,19 @@
 <footer class="ix-footer">
   <div class="ix-footer-inner">
+    {{ footer_docs = null }}
+    {{ footer_resources = null }}
+    {{ footer_company = null }}
+    {{ if navigation.menus }}
+      {{ for menu in navigation.menus }}
+        {{ if menu.name == "footer-docs" }}
+          {{ footer_docs = menu }}
+        {{ else if menu.name == "footer-resources" }}
+          {{ footer_resources = menu }}
+        {{ else if menu.name == "footer-company" }}
+          {{ footer_company = menu }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
     <div class="ix-footer-grid">
       <div class="ix-footer-brand">
         <div class="ix-footer-logo">
@@ -11,36 +25,38 @@
         </div>
         <p class="ix-footer-tagline">AI-powered code review using your own ChatGPT or Copilot account. Zero trust, full control.</p>
       </div>
-      {{ if navigation.menus && navigation.menus.size > 1 }}
-      <div class="ix-footer-col ix-footer-col--docs">
+      <div class="ix-footer-catalog">
+      {{ if footer_docs && footer_docs.items && footer_docs.items.size > 0 }}
+      <section class="ix-footer-section ix-footer-section--docs">
         <p class="ix-footer-heading">Documentation</p>
-        <ul class="ix-footer-links{{ if navigation.menus[1].items.size > 8 }} is-split{{ end }}">
-          {{ for link in navigation.menus[1].items }}
-          <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+        <ul class="ix-footer-links{{ if footer_docs.items.size > 8 }} is-dense{{ end }}{{ if footer_docs.items.size > 14 }} is-mega{{ end }}{{ if footer_docs.items.size > 20 }} is-scroll{{ end }}">
+          {{ for link in footer_docs.items }}
+          <li><a href="{{ link.url }}"{{ if link.external }} target="_blank" rel="noopener"{{ end }}>{{ link.title }}</a></li>
           {{ end }}
         </ul>
-      </div>
+      </section>
       {{ end }}
-      {{ if navigation.menus && navigation.menus.size > 2 }}
-      <div class="ix-footer-col ix-footer-col--resources">
+      {{ if footer_resources && footer_resources.items && footer_resources.items.size > 0 }}
+      <section class="ix-footer-section ix-footer-section--resources">
         <p class="ix-footer-heading">Resources</p>
-        <ul class="ix-footer-links{{ if navigation.menus[2].items.size > 8 }} is-split{{ end }}">
-          {{ for link in navigation.menus[2].items }}
-          <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+        <ul class="ix-footer-links{{ if footer_resources.items.size > 8 }} is-dense{{ end }}{{ if footer_resources.items.size > 14 }} is-mega{{ end }}{{ if footer_resources.items.size > 20 }} is-scroll{{ end }}">
+          {{ for link in footer_resources.items }}
+          <li><a href="{{ link.url }}"{{ if link.external }} target="_blank" rel="noopener"{{ end }}>{{ link.title }}</a></li>
           {{ end }}
         </ul>
-      </div>
+      </section>
       {{ end }}
-      {{ if navigation.menus && navigation.menus.size > 3 }}
-      <div class="ix-footer-col ix-footer-col--company">
+      {{ if footer_company && footer_company.items && footer_company.items.size > 0 }}
+      <section class="ix-footer-section ix-footer-section--company">
         <p class="ix-footer-heading">Company</p>
         <ul class="ix-footer-links">
-          {{ for link in navigation.menus[3].items }}
-          <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+          {{ for link in footer_company.items }}
+          <li><a href="{{ link.url }}"{{ if link.external }} target="_blank" rel="noopener"{{ end }}>{{ link.title }}</a></li>
           {{ end }}
         </ul>
-      </div>
+      </section>
       {{ end }}
+      </div>
     </div>
     <div class="ix-footer-bottom">
       <p>MIT License. Built with <a href="https://github.com/EvotecIT/PSPublishModule">PowerForge</a>.</p>


### PR DESCRIPTION
## Summary
- redesign the site footer into a card-based navigation catalog instead of one long raw list block
- make footer rendering robust by resolving ooter-docs, ooter-resources, and ooter-company by menu name (no index assumptions)
- add density tiers for long lists (is-dense, is-mega, is-scroll) so future large menus stay readable
- keep mobile behavior clean by collapsing dense grids to single-column stacks

## Why
The current footer becomes visually heavy as menu groups grow. This update keeps discoverability while preventing the footer from turning into one long text wall.

## Validation
- attempted local website build (./build.ps1 -Dev) but local engine/CLI currently fails before render in this environment due to missing pf.release_button helper
- verified template/CSS diffs and class mappings align across partial + stylesheet
