### PR TITLE
Chat: use typed retry profile testing hooks

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolExecution.RuntimeAndRecovery.Testing.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolExecution.RuntimeAndRecovery.Testing.cs
@@ -1,19 +1,38 @@
 using System;
+using System.Linq;
 using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Tools;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
-    internal static object ResolveRetryProfileForTesting(ToolDefinition? definition) {
-        return ResolveRetryProfile(definition);
+    internal readonly record struct RetryProfileSnapshot(
+        int MaxAttempts,
+        int DelayBaseMs,
+        bool RetryOnTimeout,
+        bool RetryOnTransport,
+        string[] RetryableErrorCodes);
+
+    internal static RetryProfileSnapshot ResolveRetryProfileForTesting(ToolDefinition? definition) {
+        var profile = ResolveRetryProfile(definition);
+        var retryableCodes = profile.RetryableErrorCodes is { Count: > 0 }
+            ? profile.RetryableErrorCodes.ToArray()
+            : Array.Empty<string>();
+        return new RetryProfileSnapshot(
+            MaxAttempts: profile.MaxAttempts,
+            DelayBaseMs: profile.DelayBaseMs,
+            RetryOnTimeout: profile.RetryOnTimeout,
+            RetryOnTransport: profile.RetryOnTransport,
+            RetryableErrorCodes: retryableCodes);
     }
 
-    internal static bool ShouldRetryToolCallForTesting(ToolOutputDto output, object retryProfile, int attemptIndex) {
-        if (retryProfile is not ToolRetryProfile profile) {
-            throw new ArgumentException("retryProfile must be a ChatServiceSession.ToolRetryProfile instance.", nameof(retryProfile));
-        }
-
+    internal static bool ShouldRetryToolCallForTesting(ToolOutputDto output, RetryProfileSnapshot retryProfile, int attemptIndex) {
+        var profile = new ToolRetryProfile(
+            MaxAttempts: retryProfile.MaxAttempts,
+            DelayBaseMs: retryProfile.DelayBaseMs,
+            RetryOnTimeout: retryProfile.RetryOnTimeout,
+            RetryOnTransport: retryProfile.RetryOnTransport,
+            RetryableErrorCodes: retryProfile.RetryableErrorCodes ?? Array.Empty<string>());
         return ShouldRetryToolCall(output, profile, attemptIndex);
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRetryPolicyTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRetryPolicyTests.cs
@@ -590,12 +590,12 @@ public sealed class ChatServiceRetryPolicyTests {
         Assert.Equal(5, fallbackCall.Arguments.GetInt64("top"));
     }
 
-    private static object InvokeResolveRetryProfile(string toolName) {
+    private static ChatServiceSession.RetryProfileSnapshot InvokeResolveRetryProfile(string toolName) {
         _ = toolName;
         return ChatServiceSession.ResolveRetryProfileForTesting(definition: null);
     }
 
-    private static object InvokeResolveRetryProfile(string toolName, ToolDefinition definition) {
+    private static ChatServiceSession.RetryProfileSnapshot InvokeResolveRetryProfile(string toolName, ToolDefinition definition) {
         _ = toolName;
         return ChatServiceSession.ResolveRetryProfileForTesting(definition);
     }
@@ -613,7 +613,7 @@ public sealed class ChatServiceRetryPolicyTests {
             });
     }
 
-    private static bool InvokeShouldRetryToolCall(ToolOutputDto output, object profile, int attemptIndex) {
+    private static bool InvokeShouldRetryToolCall(ToolOutputDto output, ChatServiceSession.RetryProfileSnapshot profile, int attemptIndex) {
         return ChatServiceSession.ShouldRetryToolCallForTesting(output, profile, attemptIndex);
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolBatchRecovery.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolBatchRecovery.cs
@@ -87,18 +87,6 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ShouldRetryToolCall_RetriesTransientFailureWhenErrorCodeIsMissing() {
-        var resolveRetryProfileMethod = typeof(ChatServiceSession).GetMethod(
-            "ResolveRetryProfile",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            binder: null,
-            types: new[] { typeof(ToolDefinition) },
-            modifiers: null);
-        Assert.NotNull(resolveRetryProfileMethod);
-        var shouldRetryToolCallMethod = typeof(ChatServiceSession).GetMethod(
-            "ShouldRetryToolCall",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(shouldRetryToolCallMethod);
-
         var definition = new ToolDefinition(
             name: "ad_replication_summary",
             description: "AD replication summary",
@@ -109,7 +97,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
                 MaxRetryAttempts = 1,
                 RetryableErrorCodes = new[] { "timeout", "query_failed", "transport_unavailable" }
             });
-        var profile = resolveRetryProfileMethod!.Invoke(null, new object?[] { definition });
+        var profile = ChatServiceSession.ResolveRetryProfileForTesting(definition);
         var output = new ToolOutputDto {
             CallId = "call_003",
             Output = "{\"ok\":false,\"error\":\"transient transport issue\"}",
@@ -119,24 +107,12 @@ public sealed partial class ChatServiceRoutingTrimTests {
             IsTransient = true
         };
 
-        var result = shouldRetryToolCallMethod!.Invoke(null, new[] { output, profile, (object)0 });
-        Assert.True(Assert.IsType<bool>(result));
+        var result = ChatServiceSession.ShouldRetryToolCallForTesting(output, profile, attemptIndex: 0);
+        Assert.True(result);
     }
 
     [Fact]
     public void ShouldRetryToolCall_DoesNotTreatAmbiguousAuthSubstringCodeAsPermanent() {
-        var resolveRetryProfileMethod = typeof(ChatServiceSession).GetMethod(
-            "ResolveRetryProfile",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            binder: null,
-            types: new[] { typeof(ToolDefinition) },
-            modifiers: null);
-        Assert.NotNull(resolveRetryProfileMethod);
-        var shouldRetryToolCallMethod = typeof(ChatServiceSession).GetMethod(
-            "ShouldRetryToolCall",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(shouldRetryToolCallMethod);
-
         var definition = new ToolDefinition(
             name: "ad_replication_summary",
             description: "AD replication summary",
@@ -147,7 +123,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
                 MaxRetryAttempts = 1,
                 RetryableErrorCodes = new[] { "timeout", "query_failed", "transport_unavailable" }
             });
-        var profile = resolveRetryProfileMethod!.Invoke(null, new object?[] { definition });
+        var profile = ChatServiceSession.ResolveRetryProfileForTesting(definition);
         var output = new ToolOutputDto {
             CallId = "call_004",
             Output = "{\"ok\":false,\"error_code\":\"oauth_refresh_transient\",\"error\":\"token refresh race\"}",
@@ -157,8 +133,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
             IsTransient = true
         };
 
-        var result = shouldRetryToolCallMethod!.Invoke(null, new[] { output, profile, (object)0 });
-        Assert.True(Assert.IsType<bool>(result));
+        var result = ChatServiceSession.ShouldRetryToolCallForTesting(output, profile, attemptIndex: 0);
+        Assert.True(result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- replace object/reflection-based retry test access with typed RetryProfileSnapshot hooks
- keep retry behavior implementation unchanged while improving test contract clarity
- update retry tests to call explicit testing APIs instead of private-method reflection

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "ToolHealthDiagnosticsTests|ChatServiceRetryPolicyTests|ChatServiceRoutingTrimTests.ToolBatchRecovery"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "Wave1ToolContractMigrationTests|Wave2ToolContractMigrationTests|SourceGuardrailTests|ToolDefinitionContractTests"