### PR TITLE
Chat: centralize pack id normalization in tools metadata

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
@@ -78,6 +78,8 @@ public sealed class ToolPackBootstrapMetadataTests {
     [InlineData("reviewer_setup", "reviewer_setup")]
     [InlineData("event-log", "eventlog")]
     [InlineData("file system", "filesystem")]
+    [InlineData("testimoxpack", "testimox")]
+    [InlineData("custom pack", "custompack")]
     public void NormalizePackId_UsesCanonicalShape(string input, string expected) {
         var normalized = ToolPackBootstrap.NormalizePackId(input);
         Assert.Equal(expected, normalized);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolPackBootstrap.RegistryAndReflection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolPackBootstrap.RegistryAndReflection.cs
@@ -158,27 +158,7 @@ public static partial class ToolPackBootstrap {
     /// <param name="descriptorId">Descriptor id.</param>
     /// <returns>Canonical pack id, or empty string when input is empty.</returns>
     public static string NormalizePackId(string? descriptorId) {
-        var normalized = (descriptorId ?? string.Empty).Trim().ToLowerInvariant();
-        if (normalized.Length == 0) {
-            return string.Empty;
-        }
-
-        var compact = normalized.Replace("-", string.Empty, StringComparison.Ordinal)
-            .Replace("_", string.Empty, StringComparison.Ordinal)
-            .Replace(" ", string.Empty, StringComparison.Ordinal)
-            .Replace(".", string.Empty, StringComparison.Ordinal);
-        return compact switch {
-            "ad" => "active_directory",
-            "activedirectory" => "active_directory",
-            "adplayground" => "active_directory",
-            "fs" => "filesystem",
-            "eventlogs" => "eventlog",
-            "reviewersetup" => "reviewer_setup",
-            "computerx" => "system",
-            "wsl" => "system",
-            "testimoxpack" => "testimox",
-            _ => compact
-        };
+        return ToolSelectionMetadata.NormalizePackId(descriptorId);
     }
 
     private static void EnsureNoPackIdNormalizationCollision(

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
@@ -155,6 +155,18 @@ public class ToolDefinitionContractTests {
         Assert.Equal(enriched.Tags.OrderBy(static x => x, StringComparer.OrdinalIgnoreCase), enriched.Tags);
     }
 
+    [Theory]
+    [InlineData("ad", "active_directory")]
+    [InlineData("adplayground", "active_directory")]
+    [InlineData("event-logs", "eventlog")]
+    [InlineData("testimoxpack", "testimox")]
+    [InlineData("reviewer setup", "reviewer_setup")]
+    [InlineData("my-pack", "mypack")]
+    public void NormalizePackId_ShouldCanonicalizeKnownAliases_AndCompactUnknownIds(string input, string expected) {
+        var normalized = ToolSelectionMetadata.NormalizePackId(input);
+        Assert.Equal(expected, normalized);
+    }
+
     [Fact]
     public void Enrich_ShouldIgnoreConflictingInputTaxonomyTags() {
         var definition = new ToolDefinition(

--- a/IntelligenceX/Tools/ToolSelectionMetadata.cs
+++ b/IntelligenceX/Tools/ToolSelectionMetadata.cs
@@ -506,6 +506,20 @@ public static class ToolSelectionMetadata {
     }
 
     /// <summary>
+    /// Normalizes a pack identifier into canonical known ids, or compact fallback shape for unknown ids.
+    /// </summary>
+    public static string NormalizePackId(string? value) {
+        var compact = NormalizeCompactToken(value);
+        if (compact.Length == 0) {
+            return string.Empty;
+        }
+
+        return TryNormalizePackId(compact, out var packId)
+            ? packId
+            : compact;
+    }
+
+    /// <summary>
     /// Tries to resolve an AD/public-domain routing family from tool identity hints.
     /// </summary>
     public static bool TryResolveDomainIntentFamily(


### PR DESCRIPTION
## Summary
- add ToolSelectionMetadata.NormalizePackId(string?) as a single canonical normalization API in Tools
- replace Chat-local alias switch in ToolPackBootstrap.NormalizePackId with delegation to Tools metadata
- expand Chat/Tools tests to lock canonical alias handling and compact fallback behavior

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "ToolPackBootstrapMetadataTests"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "ToolDefinitionContractTests"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "Wave1ToolContractMigrationTests|Wave2ToolContractMigrationTests|SourceGuardrailTests|ToolDefinitionContractTests"