### PR TITLE
Chat: make planner candidate selection static with explicit catalog

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingHelpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingHelpers.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Tooling;
 using IntelligenceX.OpenAI;
 using IntelligenceX.OpenAI.AppServer.Models;
 using IntelligenceX.OpenAI.Chat;
@@ -338,7 +339,7 @@ internal sealed partial class ChatServiceSession {
             return (definitions, new List<ToolRoutingInsight>());
         }
 
-        var plannerCandidates = BuildModelPlannerCandidates(definitions, limit);
+        var plannerCandidates = BuildModelPlannerCandidates(definitions, limit, _toolOrchestrationCatalog);
         var planned = await TrySelectToolsViaModelPlannerAsync(client, threadId, userRequest, plannerCandidates, limit, cancellationToken)
             .ConfigureAwait(false);
         if (planned.Count > 0) {
@@ -353,14 +354,17 @@ internal sealed partial class ChatServiceSession {
         return (fallback, fallbackInsights);
     }
 
-    private IReadOnlyList<ToolDefinition> BuildModelPlannerCandidates(IReadOnlyList<ToolDefinition> definitions, int limit) {
+    private static IReadOnlyList<ToolDefinition> BuildModelPlannerCandidates(
+        IReadOnlyList<ToolDefinition> definitions,
+        int limit,
+        ToolOrchestrationCatalog toolOrchestrationCatalog) {
         if (definitions.Count <= 64) {
             return definitions;
         }
 
         var minCandidateLimit = Math.Max(24, limit);
         var candidateLimit = Math.Clamp(Math.Max(limit * 3, minCandidateLimit), minCandidateLimit, Math.Min(definitions.Count, 96));
-        return SelectDeterministicToolSubset(definitions, candidateLimit);
+        return SelectDeterministicToolSubset(definitions, candidateLimit, toolOrchestrationCatalog);
     }
 
     private IReadOnlyList<ToolDefinition> SelectWeightedToolSubset(IReadOnlyList<ToolDefinition> definitions, string requestText, int? maxCandidateTools,
@@ -457,7 +461,7 @@ internal sealed partial class ChatServiceSession {
         }
 
         if (!hasSignal) {
-            return SelectDeterministicToolSubset(definitions, limit);
+            return SelectDeterministicToolSubset(definitions, limit, _toolOrchestrationCatalog);
         }
 
         scored.Sort(static (a, b) => {
@@ -470,7 +474,7 @@ internal sealed partial class ChatServiceSession {
         });
 
         if (scored[0].Score < 1d) {
-            return SelectDeterministicToolSubset(definitions, limit);
+            return SelectDeterministicToolSubset(definitions, limit, _toolOrchestrationCatalog);
         }
 
         var selected = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -484,7 +488,7 @@ internal sealed partial class ChatServiceSession {
         }
 
         if (selectedDefs.Count == 0) {
-            return SelectDeterministicToolSubset(definitions, limit);
+            return SelectDeterministicToolSubset(definitions, limit, _toolOrchestrationCatalog);
         }
 
         var selectionDiagnostics = ResolveWeightedRoutingSelectionDiagnostics(scored, limit, definitions.Count);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -9,6 +9,7 @@ using IntelligenceX.OpenAI;
 using IntelligenceX.OpenAI.AppServer.Models;
 using IntelligenceX.OpenAI.Chat;
 using IntelligenceX.OpenAI.ToolCalling;
+using IntelligenceX.Chat.Tooling;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
 using IntelligenceX.Json;
@@ -17,6 +18,13 @@ namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private IReadOnlyList<ToolDefinition> SelectDeterministicToolSubset(IReadOnlyList<ToolDefinition> definitions, int limit) {
+        return SelectDeterministicToolSubset(definitions, limit, _toolOrchestrationCatalog);
+    }
+
+    private static IReadOnlyList<ToolDefinition> SelectDeterministicToolSubset(
+        IReadOnlyList<ToolDefinition> definitions,
+        int limit,
+        ToolOrchestrationCatalog toolOrchestrationCatalog) {
         if (definitions.Count == 0 || limit <= 0) {
             return Array.Empty<ToolDefinition>();
         }
@@ -51,7 +59,7 @@ internal sealed partial class ChatServiceSession {
         var toolsByFamily = new Dictionary<string, Queue<ToolDefinition>>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < uniqueDefinitions.Count; i++) {
             var definition = uniqueDefinitions[i];
-            var family = ResolveDeterministicSubsetFamilyKey(definition);
+            var family = ResolveDeterministicSubsetFamilyKey(definition, toolOrchestrationCatalog);
             if (!toolsByFamily.TryGetValue(family, out var queue)) {
                 queue = new Queue<ToolDefinition>();
                 toolsByFamily[family] = queue;
@@ -101,13 +109,15 @@ internal sealed partial class ChatServiceSession {
         return selected.Count == 0 ? Array.Empty<ToolDefinition>() : selected;
     }
 
-    private string ResolveDeterministicSubsetFamilyKey(ToolDefinition definition) {
+    private static string ResolveDeterministicSubsetFamilyKey(
+        ToolDefinition definition,
+        ToolOrchestrationCatalog toolOrchestrationCatalog) {
         var normalized = (definition?.Name ?? string.Empty).Trim();
         if (normalized.Length == 0) {
             return string.Empty;
         }
 
-        if (_toolOrchestrationCatalog.TryGetEntry(normalized, out var catalogEntry)) {
+        if (toolOrchestrationCatalog.TryGetEntry(normalized, out var catalogEntry)) {
             if (catalogEntry.PackId.Length > 0) {
                 return catalogEntry.PackId;
             }


### PR DESCRIPTION
## Summary
- refactor BuildModelPlannerCandidates to static and pass ToolOrchestrationCatalog explicitly
- refactor deterministic subset selection core to static and pass catalog explicitly
- keep a compatibility instance overload for SelectDeterministicToolSubset(definitions, limit) so existing routing tests/contracts remain stable

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "ChatServiceRoutingTrimTests|ChatServicePlannerPromptTests|ChatServiceDomainAffinityTests|ToolPackBootstrapMetadataTests"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "Wave1ToolContractMigrationTests|Wave2ToolContractMigrationTests|SourceGuardrailTests|ToolDefinitionContractTests"