### PR TITLE
Tools: enforce strict routing role metadata in registry

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
@@ -717,6 +717,67 @@ public class ToolDefinitionContractTests {
     }
 
     [Fact]
+    public void Register_ShouldRequireRoutingPackId_WhenRequireExplicitRoutingMetadataEnabled() {
+        var definition = new ToolDefinition(
+            name: "custom_strict_packid_probe",
+            description: "Strict routing metadata pack-id probe",
+            parameters: ToolSchema.Object().NoAdditionalProperties(),
+            routing: new ToolRoutingContract {
+                IsRoutingAware = true,
+                RoutingSource = ToolRoutingTaxonomy.SourceExplicit,
+                PackId = string.Empty,
+                Role = ToolRoutingTaxonomy.RoleOperational
+            });
+
+        var registry = new ToolRegistry {
+            RequireExplicitRoutingMetadata = true
+        };
+        var ex = Assert.Throws<InvalidOperationException>(() => registry.Register(new StubTool(definition)));
+        Assert.Contains("Routing.PackId", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Register_ShouldRequirePackInfoRoleConsistency_WhenRequireExplicitRoutingMetadataEnabled() {
+        var definition = new ToolDefinition(
+            name: "custom_pack_info",
+            description: "Strict routing metadata pack-info role probe",
+            parameters: ToolSchema.Object().NoAdditionalProperties(),
+            tags: new[] { "pack_info" },
+            routing: new ToolRoutingContract {
+                IsRoutingAware = true,
+                RoutingSource = ToolRoutingTaxonomy.SourceExplicit,
+                PackId = "system",
+                Role = ToolRoutingTaxonomy.RoleOperational
+            });
+
+        var registry = new ToolRegistry {
+            RequireExplicitRoutingMetadata = true
+        };
+        var ex = Assert.Throws<InvalidOperationException>(() => registry.Register(new StubTool(definition)));
+        Assert.Contains($"Routing.Role='{ToolRoutingTaxonomy.RolePackInfo}'", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Register_ShouldRequireEnvironmentDiscoverRoleConsistency_WhenRequireExplicitRoutingMetadataEnabled() {
+        var definition = new ToolDefinition(
+            name: "custom_environment_discover",
+            description: "Strict routing metadata environment-discover role probe",
+            parameters: ToolSchema.Object().NoAdditionalProperties(),
+            routing: new ToolRoutingContract {
+                IsRoutingAware = true,
+                RoutingSource = ToolRoutingTaxonomy.SourceExplicit,
+                PackId = "system",
+                Role = ToolRoutingTaxonomy.RoleOperational
+            });
+
+        var registry = new ToolRegistry {
+            RequireExplicitRoutingMetadata = true
+        };
+        var ex = Assert.Throws<InvalidOperationException>(() => registry.Register(new StubTool(definition)));
+        Assert.Contains($"Routing.Role='{ToolRoutingTaxonomy.RoleEnvironmentDiscover}'", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Register_ShouldRejectConflictingDomainIntentActionIdsForSameFamily() {
         var firstDefinition = new ToolDefinition(
             name: "custom_ad_pack_a",

--- a/IntelligenceX/Tools/ToolRegistry.cs
+++ b/IntelligenceX/Tools/ToolRegistry.cs
@@ -277,6 +277,12 @@ public sealed class ToolRegistry {
                     $"Tool '{definition.Name}' must declare Routing.PackId when RequireExplicitRoutingMetadata is enabled.");
             }
 
+            var normalizedRole = (contract.Role ?? string.Empty).Trim();
+            if (normalizedRole.Length == 0) {
+                throw new InvalidOperationException(
+                    $"Tool '{definition.Name}' must declare Routing.Role when RequireExplicitRoutingMetadata is enabled.");
+            }
+
             if (!string.Equals(
                     (contract.RoutingSource ?? string.Empty).Trim(),
                     ToolRoutingTaxonomy.SourceExplicit,
@@ -284,9 +290,42 @@ public sealed class ToolRegistry {
                 throw new InvalidOperationException(
                     $"Tool '{definition.Name}' must declare explicit RoutingSource when RequireExplicitRoutingMetadata is enabled.");
             }
+
+            var isPackInfoShape =
+                definition.Name.EndsWith("_pack_info", StringComparison.OrdinalIgnoreCase)
+                || HasTag(definition.Tags, "pack_info");
+            if (isPackInfoShape
+                && !string.Equals(normalizedRole, ToolRoutingTaxonomy.RolePackInfo, StringComparison.OrdinalIgnoreCase)) {
+                throw new InvalidOperationException(
+                    $"Tool '{definition.Name}' must declare Routing.Role='{ToolRoutingTaxonomy.RolePackInfo}' when RequireExplicitRoutingMetadata is enabled.");
+            }
+
+            var isEnvironmentDiscoverShape =
+                definition.Name.EndsWith("_environment_discover", StringComparison.OrdinalIgnoreCase)
+                || HasTag(definition.Tags, ToolRoutingTaxonomy.RoleEnvironmentDiscover);
+            if (isEnvironmentDiscoverShape
+                && !string.Equals(normalizedRole, ToolRoutingTaxonomy.RoleEnvironmentDiscover, StringComparison.OrdinalIgnoreCase)) {
+                throw new InvalidOperationException(
+                    $"Tool '{definition.Name}' must declare Routing.Role='{ToolRoutingTaxonomy.RoleEnvironmentDiscover}' when RequireExplicitRoutingMetadata is enabled.");
+            }
         }
 
         ValidateDomainIntentActionCatalogConsistency(definition, contract);
+    }
+
+    private static bool HasTag(IReadOnlyList<string>? tags, string expectedTag) {
+        if (tags is null || tags.Count == 0 || string.IsNullOrWhiteSpace(expectedTag)) {
+            return false;
+        }
+
+        var expected = expectedTag.Trim();
+        for (var i = 0; i < tags.Count; i++) {
+            if (string.Equals((tags[i] ?? string.Empty).Trim(), expected, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static void ValidateSetupContract(ToolDefinition definition) {


### PR DESCRIPTION
## Summary
- tighten ToolRegistry strict mode (RequireExplicitRoutingMetadata) to enforce explicit routing role metadata checks
- add strict consistency validation for canonical role shapes:
  - *_pack_info (or pack_info tag) must use Routing.Role=pack_info
  - *_environment_discover (or matching tag) must use Routing.Role=environment_discover
- add regression tests in ToolDefinitionContractTests for strict-mode pack-id and role consistency rejections

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "ToolDefinitionContractTests|Wave1ToolContractMigrationTests|Wave2ToolContractMigrationTests|SourceGuardrailTests"