### PR TITLE
Tools: stop implicit routing backfill for explicit contracts

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolDefinitionContractTests.cs
@@ -196,6 +196,47 @@ public class ToolDefinitionContractTests {
     }
 
     [Fact]
+    public void Enrich_ShouldNotBackfillRoutingPackOrFamily_WhenRoutingSourceIsExplicit() {
+        var definition = new ToolDefinition(
+            name: "ad_custom_probe",
+            description: "Probe",
+            parameters: ToolSchema.Object().NoAdditionalProperties(),
+            category: "active_directory",
+            routing: new ToolRoutingContract {
+                IsRoutingAware = true,
+                RoutingSource = ToolRoutingTaxonomy.SourceExplicit,
+                PackId = string.Empty,
+                Role = ToolRoutingTaxonomy.RoleOperational,
+                DomainIntentFamily = string.Empty,
+                DomainIntentActionId = string.Empty
+            });
+
+        var enriched = ToolSelectionMetadata.Enrich(definition, toolType: null);
+        var routing = Assert.IsType<ToolRoutingContract>(enriched.Routing);
+
+        Assert.Equal(ToolRoutingTaxonomy.SourceExplicit, routing.RoutingSource, ignoreCase: true);
+        Assert.Equal(string.Empty, routing.PackId);
+        Assert.Equal(string.Empty, routing.DomainIntentFamily);
+        Assert.Equal(string.Empty, routing.DomainIntentActionId);
+    }
+
+    [Fact]
+    public void Enrich_ShouldInferRoutingPackAndFamily_WhenRoutingSourceIsInferred() {
+        var definition = new ToolDefinition(
+            name: "ad_custom_probe",
+            description: "Probe",
+            parameters: ToolSchema.Object().NoAdditionalProperties(),
+            category: "active_directory");
+
+        var enriched = ToolSelectionMetadata.Enrich(definition, toolType: null);
+        var routing = Assert.IsType<ToolRoutingContract>(enriched.Routing);
+
+        Assert.Equal("active_directory", routing.PackId, ignoreCase: true);
+        Assert.Equal(ToolSelectionMetadata.DomainIntentFamilyAd, routing.DomainIntentFamily);
+        Assert.Equal(ToolSelectionMetadata.DomainIntentActionIdAd, routing.DomainIntentActionId);
+    }
+
+    [Fact]
     public void CreateAliasDefinition_ShouldMergeAndSortEnrichedTagsDeterministically() {
         var canonical = ToolSelectionMetadata.Enrich(
             new ToolDefinition(

--- a/IntelligenceX/Tools/ToolSelectionMetadata.cs
+++ b/IntelligenceX/Tools/ToolSelectionMetadata.cs
@@ -1304,18 +1304,27 @@ public static class ToolSelectionMetadata {
         ToolSelectionRoutingInfo routing,
         IReadOnlyList<string> enrichedTags) {
         var existing = definition.Routing;
+        var normalizedExistingSource = NormalizeToken(existing?.RoutingSource, fallback: string.Empty);
+        var hasExplicitExistingSource = string.Equals(
+            normalizedExistingSource,
+            ToolRoutingTaxonomy.SourceExplicit,
+            StringComparison.OrdinalIgnoreCase);
 
         var packId = NormalizeToken(existing?.PackId, fallback: string.Empty);
         if (packId.Length == 0) {
-            TryResolvePackId(definition.Name, category, enrichedTags, out packId);
+            if (!hasExplicitExistingSource) {
+                TryResolvePackId(definition.Name, category, enrichedTags, out packId);
+            }
         } else {
             TryNormalizePackId(packId, out packId);
         }
 
-        var role = ResolveRoutingRole(
-            toolName: definition.Name,
-            existingRole: existing?.Role,
-            tags: enrichedTags);
+        var role = hasExplicitExistingSource
+            ? NormalizeToken(existing?.Role, fallback: string.Empty)
+            : ResolveRoutingRole(
+                toolName: definition.Name,
+                existingRole: existing?.Role,
+                tags: enrichedTags);
         var source = ResolveRoutingSource(
             existingSource: existing?.RoutingSource,
             tags: enrichedTags,
@@ -1323,7 +1332,9 @@ public static class ToolSelectionMetadata {
 
         var family = NormalizeToken(existing?.DomainIntentFamily, fallback: string.Empty);
         if (!TryNormalizeDomainIntentFamilyToken(family, out family)) {
-            TryResolveDomainIntentFamily(definition.Name, category, enrichedTags, out family);
+            if (!hasExplicitExistingSource) {
+                TryResolveDomainIntentFamily(definition.Name, category, enrichedTags, out family);
+            }
         }
 
         var actionId = (existing?.DomainIntentActionId ?? string.Empty).Trim();


### PR DESCRIPTION
## Summary
- gate ToolSelectionMetadata routing inference when an incoming routing contract already declares RoutingSource=explicit
- prevent silent backfill of PackId/role/domain family from category/name/tag heuristics in that explicit-contract path
- add regression tests proving:
  - explicit source does not backfill pack/family/action
  - inferred source still performs current inference behavior

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "ToolDefinitionContractTests|Wave1ToolContractMigrationTests|Wave2ToolContractMigrationTests|SourceGuardrailTests"