### PR TITLE
Chat: remove name-based fallback from deterministic routing subset

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.RoutingScoring.cs
@@ -127,12 +127,18 @@ internal sealed partial class ChatServiceSession {
             }
         }
 
-        var separator = normalized.IndexOf('_');
-        if (separator > 0) {
-            return normalized[..separator].ToLowerInvariant();
+        var routingPackId = ToolSelectionMetadata.NormalizePackId(definition?.Routing?.PackId);
+        if (routingPackId.Length > 0) {
+            return routingPackId;
         }
 
-        return normalized.ToLowerInvariant();
+        if (ToolSelectionMetadata.TryNormalizeDomainIntentFamily(definition?.Routing?.DomainIntentFamily, out var family)
+            && family.Length > 0) {
+            return "family|" + family;
+        }
+
+        // Keep non-contract fallback generic so routing does not depend on tool-name prefixes/suffixes.
+        return "unassigned";
     }
 
     private static List<ToolRoutingInsight> BuildRoutingInsights(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServicePlannerPromptTests.cs
@@ -437,21 +437,39 @@ public sealed class ChatServicePlannerPromptTests {
             definitions.Add(new ToolDefinition(
                 $"ad_query_{i:D2}",
                 "AD query.",
-                ToolSchema.Object(("target", ToolSchema.String("Target"))).NoAdditionalProperties()));
+                ToolSchema.Object(("target", ToolSchema.String("Target"))).NoAdditionalProperties(),
+                routing: new ToolRoutingContract {
+                    IsRoutingAware = true,
+                    RoutingSource = ToolRoutingTaxonomy.SourceExplicit,
+                    PackId = "active_directory",
+                    Role = ToolRoutingTaxonomy.RoleOperational
+                }));
         }
 
         for (var i = 0; i < 3; i++) {
             definitions.Add(new ToolDefinition(
                 $"eventlog_query_{i:D2}",
                 "Event query.",
-                ToolSchema.Object(("target", ToolSchema.String("Target"))).NoAdditionalProperties()));
+                ToolSchema.Object(("target", ToolSchema.String("Target"))).NoAdditionalProperties(),
+                routing: new ToolRoutingContract {
+                    IsRoutingAware = true,
+                    RoutingSource = ToolRoutingTaxonomy.SourceExplicit,
+                    PackId = "eventlog",
+                    Role = ToolRoutingTaxonomy.RoleOperational
+                }));
         }
 
         for (var i = 0; i < 3; i++) {
             definitions.Add(new ToolDefinition(
                 $"system_info_{i:D2}",
                 "System query.",
-                ToolSchema.Object(("target", ToolSchema.String("Target"))).NoAdditionalProperties()));
+                ToolSchema.Object(("target", ToolSchema.String("Target"))).NoAdditionalProperties(),
+                routing: new ToolRoutingContract {
+                    IsRoutingAware = true,
+                    RoutingSource = ToolRoutingTaxonomy.SourceExplicit,
+                    PackId = "system",
+                    Role = ToolRoutingTaxonomy.RoleOperational
+                }));
         }
 
         var args = new object?[] {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingScoringContracts.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RoutingScoringContracts.cs
@@ -35,4 +35,28 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Contains(selected, static definition => string.Equals(definition.Name, "gamma_inventory", StringComparison.OrdinalIgnoreCase));
         Assert.DoesNotContain(selected, static definition => string.Equals(definition.Name, "beta_inventory", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public void SelectDeterministicToolSubset_DoesNotGroupUnassignedToolsByNamePrefix() {
+        var session = ChatServiceTestSessionFactory.CreateIsolatedSession();
+        var registry = new ToolRegistry();
+        registry.Register(new PreflightStubTool(
+            "alpha_one",
+            CreateRoutingContract(packId: string.Empty, role: ToolRoutingTaxonomy.RoleOperational)));
+        registry.Register(new PreflightStubTool(
+            "alpha_two",
+            CreateRoutingContract(packId: string.Empty, role: ToolRoutingTaxonomy.RoleOperational)));
+        registry.Register(new PreflightStubTool(
+            "beta_one",
+            CreateRoutingContract(packId: string.Empty, role: ToolRoutingTaxonomy.RoleOperational)));
+        SetSessionRegistry(session, registry);
+
+        var result = SelectDeterministicToolSubsetMethod.Invoke(session, new object?[] { registry.GetDefinitions(), 2 });
+        var selected = Assert.IsAssignableFrom<IReadOnlyList<ToolDefinition>>(result);
+
+        Assert.Equal(2, selected.Count);
+        Assert.Contains(selected, static definition => string.Equals(definition.Name, "alpha_one", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(selected, static definition => string.Equals(definition.Name, "alpha_two", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(selected, static definition => string.Equals(definition.Name, "beta_one", StringComparison.OrdinalIgnoreCase));
+    }
 }


### PR DESCRIPTION
## Summary
- remove deterministic subset fallback that grouped tools by name prefix/suffix shape when catalog metadata is unavailable
- prefer contract/canonical metadata only (catalog pack id, routing pack id, normalized domain family), with generic `unassigned` fallback bucket
- update/add tests to align no-signal fallback behavior with contract-driven grouping (not name prefixes)

## Validation
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj -c Release --filter "ChatServiceRoutingTrimTests.RoutingScoringContracts|ChatServiceRoutingTrimTests.PackPreflightContracts|ChatServicePlannerPromptTests|ChatServiceDomainAffinityTests"
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter "Wave1ToolContractMigrationTests|Wave2ToolContractMigrationTests|SourceGuardrailTests|ToolDefinitionContractTests"