### PR TITLE
Update OfficeIMO reader version guard

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -20,7 +20,7 @@ public class OfficeImoReadToolTests {
         var propsPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Directory.Build.props"));
         var props = LoadMsBuildProperties(propsPath);
 
-        Assert.Equal("0.1.14", props["OfficeImoReaderNuGetVersion"]);
+        Assert.Equal("0.1.16", props["OfficeImoReaderNuGetVersion"]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- update the OfficeIMO reader package guard test to match the pinned package version in `Directory.Build.props`
- keep the tool-pack preflight aligned with the current published OfficeIMO reader dependency
- confirm the merged-state release rehearsal can complete end to end with Tray portable, Chat portable, and the main IntelligenceX package

## Validation
- dotnet test IntelligenceX.Tools/IntelligenceX.Tools.Tests/IntelligenceX.Tools.Tests.csproj -c Release --filter OfficeImoReadToolTests
- ./Build/Build-Project.ps1 -Configuration Release -Targets IntelligenceX.Tray,IntelligenceX.Chat.App -ToolOutputs Portable -OutputRoot .\Artifacts\ReleaseOutputs\merged-rehearsal-20260407 -StageRoot .\Artifacts\UploadReady\merged-rehearsal-20260407