### PR TITLE
Sanitize transcript transport artifacts for display

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowTranscriptLoadNormalizationTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowTranscriptLoadNormalizationTests.cs
@@ -219,4 +219,61 @@ public sealed class MainWindowTranscriptLoadNormalizationTests {
         Assert.Contains("end --> Gateway", prepared, StringComparison.Ordinal);
         Assert.DoesNotContain("\nend\n--> Gateway", prepared, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// Ensures prepared transcript output strips execution-contract working-memory payload artifacts from assistant messages.
+    /// </summary>
+    [Fact]
+    public void BuildPreparedTranscript_StripsExecutionBlockedWorkingMemoryArtifacts() {
+        var markdown = TranscriptMarkdownFormatter.Format(new (string Role, string Text, DateTime Time, string? Model)[] {
+            ("Assistant", """
+                          [Execution blocked] ix: execution-contract: v1 I do not have confirmed tool output for this selected action yet.
+
+                          Selected action request: [Working memory checkpoint] ix: working-memory: v1 domain_scope_family: ad_domain recent_tools: ad_environment_discover
+                          recent_evidence_1: ad_environment_discover: #
+
+                          ## Active Directory: Environment Discovery
+
+                          | Field | Value |
+                          | --- | --- |
+                          | Domain controller |  |
+
+                          Reason code: no_tool_calls_after_watchdog_retry
+                          """, new DateTime(2026, 4, 7, 20, 47, 32, DateTimeKind.Local), "gpt-5.4")
+        }, "HH:mm:ss").Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        Assert.Contains("[Execution blocked]", markdown, StringComparison.Ordinal);
+        Assert.Contains("Reason code: no_tool_calls_after_watchdog_retry", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("Working memory checkpoint", markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ix:working-memory:v1", markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("domain_scope_family", markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("recent_tools", markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Active Directory: Environment Discovery", markdown, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Ensures recovered-findings tables are rehydrated from flattened fallback markdown and inline execution-contract markers are removed.
+    /// </summary>
+    [Fact]
+    public void BuildPreparedTranscript_RehydratesFlattenedRecoveredFindingsAndRemovesInlineExecutionContractMarker() {
+        var markdown = TranscriptMarkdownFormatter.Format(new (string Role, string Text, DateTime Time, string? Model)[] {
+            ("Assistant", """
+                          Recovered findings from executed tools (model returned no text):
+
+                          ### Active Directory: Environment Discovery | Field | Value | | --- | --- | | Domain controller |  | | Search base DN | DC=ad,DC=evotec,DC=xyz | | DNS domain | ad.evotec.xyz | | Forest | ad.evotec.xyz |
+                          """, new DateTime(2026, 4, 7, 20, 39, 34, DateTimeKind.Local), "gpt-5.4"),
+            ("Assistant", """
+                          [Execution blocked] ix: execution-contract: v1 I do not have confirmed tool output for this selected action yet.
+
+                          Reason code: no_tool_calls_after_watchdog_retry
+                          """, new DateTime(2026, 4, 7, 20, 47, 32, DateTimeKind.Local), "gpt-5.4")
+        }, "HH:mm:ss").Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        Assert.Contains("| Field | Value |", markdown, StringComparison.Ordinal);
+        Assert.Contains("| Search base DN | DC=ad,DC=evotec,DC=xyz |", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("Environment Discovery | Field | Value", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("ix: execution-contract: v1", markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ix:execution-contract:v1", markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("I do not have confirmed tool output for this selected action yet.", markdown, StringComparison.Ordinal);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowTranscriptLoadNormalizationTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowTranscriptLoadNormalizationTests.cs
@@ -201,6 +201,34 @@ public sealed class MainWindowTranscriptLoadNormalizationTests {
     }
 
     /// <summary>
+    /// Ensures display-time preparation keeps the older runtime-only sanitization contract
+    /// before applying display-specific transport cleanup.
+    /// </summary>
+    [Fact]
+    public void PrepareMessageBodyForDisplay_ForAssistant_StripsRuntimeMetadataAndRepairsMermaidFence() {
+        const string input = """
+            ```ix_memory{"upserts":[{"fact":"User likes visuals"}]}
+            ```[Answer progression plan]
+            ix: answer-plan: v1user_goal: show the topologyadvance_reason: provide a usable diagramJasne — tu masz diagram.
+
+            ~~~mermaidflowchart LR F["Forest<br/>ad.evotec.xyz"]
+            D1["Domain<br/>ad.evotec.xyz"]
+            F --> D1```
+            Interpretacja: to jest diagram struktury.
+            """;
+
+        var prepared = TranscriptMarkdownPreparation.PrepareMessageBodyForDisplay("Assistant", input)
+            .Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        Assert.DoesNotContain("ix_memory", prepared, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("answer-plan", prepared, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Jasne — tu masz diagram.", prepared, StringComparison.Ordinal);
+        Assert.Contains("```mermaid\nflowchart LR", prepared, StringComparison.Ordinal);
+        Assert.Contains("F --> D1\n```", prepared, StringComparison.Ordinal);
+        Assert.Contains("Interpretacja: to jest diagram struktury.", prepared, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Ensures Mermaid repair does not split valid statements where the identifier itself is named <c>end</c>.
     /// </summary>
     [Fact]
@@ -293,6 +321,25 @@ public sealed class MainWindowTranscriptLoadNormalizationTests {
 
         Assert.Contains("| Col A | Col B | Col C |", markdown, StringComparison.Ordinal);
         Assert.Contains("| Value 1 |  | Value 3 |", markdown, StringComparison.Ordinal);
+        Assert.Contains("| Value 4 | Value 5 | Value 6 |", markdown, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Ensures collapsed recovered-findings tables preserve an intentionally blank first column
+    /// instead of shifting later cells left during rehydration.
+    /// </summary>
+    [Fact]
+    public void BuildPreparedTranscript_RehydratesFlattenedRecoveredFindingsTableWithLeadingEmptyCell() {
+        var markdown = TranscriptMarkdownFormatter.Format(new (string Role, string Text, DateTime Time, string? Model)[] {
+            ("Assistant", """
+                          Recovered findings from executed tools (model returned no text):
+
+                          ### Sample Summary | Col A | Col B | Col C | | --- | --- | --- | |  | Value 2 | Value 3 | | Value 4 | Value 5 | Value 6 |
+                          """, new DateTime(2026, 4, 7, 20, 54, 34, DateTimeKind.Local), "gpt-5.4")
+        }, "HH:mm:ss").Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        Assert.Contains("| Col A | Col B | Col C |", markdown, StringComparison.Ordinal);
+        Assert.Contains("|  | Value 2 | Value 3 |", markdown, StringComparison.Ordinal);
         Assert.Contains("| Value 4 | Value 5 | Value 6 |", markdown, StringComparison.Ordinal);
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowTranscriptLoadNormalizationTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowTranscriptLoadNormalizationTests.cs
@@ -276,4 +276,23 @@ public sealed class MainWindowTranscriptLoadNormalizationTests {
         Assert.DoesNotContain("ix:execution-contract:v1", markdown, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("I do not have confirmed tool output for this selected action yet.", markdown, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// Ensures collapsed recovered-findings tables keep empty middle cells inside rows
+    /// instead of treating them as row separators during rehydration.
+    /// </summary>
+    [Fact]
+    public void BuildPreparedTranscript_RehydratesFlattenedRecoveredFindingsTableWithEmptyMiddleCell() {
+        var markdown = TranscriptMarkdownFormatter.Format(new (string Role, string Text, DateTime Time, string? Model)[] {
+            ("Assistant", """
+                          Recovered findings from executed tools (model returned no text):
+
+                          ### Sample Summary | Col A | Col B | Col C | | --- | --- | --- | | Value 1 |  | Value 3 | | Value 4 | Value 5 | Value 6 |
+                          """, new DateTime(2026, 4, 7, 20, 52, 34, DateTimeKind.Local), "gpt-5.4")
+        }, "HH:mm:ss").Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        Assert.Contains("| Col A | Col B | Col C |", markdown, StringComparison.Ordinal);
+        Assert.Contains("| Value 1 |  | Value 3 |", markdown, StringComparison.Ordinal);
+        Assert.Contains("| Value 4 | Value 5 | Value 6 |", markdown, StringComparison.Ordinal);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
@@ -626,4 +626,36 @@ public sealed partial class TranscriptHtmlFormatterTests {
         Assert.DoesNotContain("recent_tools", html, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("Active Directory: Environment Discovery", html, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// Ensures execution-blocked trailing notes keep multi-line markdown structure
+    /// instead of flattening tables into unrelated paragraphs.
+    /// </summary>
+    [Fact]
+    public void Format_PreservesExecutionBlockedTrailingMarkdownStructure() {
+        var options = OfficeImoMarkdownRuntimeContract.CreateTranscriptRendererOptions();
+        var now = new DateTime(2026, 4, 13, 18, 15, 0, DateTimeKind.Local);
+        var html = TranscriptHtmlFormatter.Format(new[] {
+            ("Assistant", """
+                          [Execution blocked]
+                          ix:execution-contract:v1 Waiting for confirmed tool output.
+
+                          Reason code: no_tool_calls_after_watchdog_retry
+
+                          Diagnostic summary:
+
+                          | Field | Value |
+                          | --- | --- |
+                          | Scope | ad.evotec.xyz |
+                          | Retry | required |
+                          """, now)
+        }, "HH:mm:ss", options);
+
+        Assert.Contains("no_tool_calls_after_watchdog_retry", html, StringComparison.Ordinal);
+        Assert.Contains("Diagnostic summary:", html, StringComparison.Ordinal);
+        Assert.Contains("<table", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ad.evotec.xyz", html, StringComparison.Ordinal);
+        Assert.Contains("required", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<p>| Field | Value |</p>", html, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterTests.cs
@@ -591,39 +591,39 @@ public sealed partial class TranscriptHtmlFormatterTests {
     }
 
     /// <summary>
-    /// Ensures execution-blocked callouts preserve structured markdown blocks after metadata extraction.
+    /// Ensures execution-blocked outcome cards strip leaked working-memory checkpoint payloads from transcript HTML.
     /// </summary>
     [Fact]
-    public void Format_RendersExecutionBlockedStructuredMarkdownBody() {
+    public void Format_StripsWorkingMemoryCheckpointArtifactsFromExecutionBlockedOutcome() {
         var options = OfficeImoMarkdownRuntimeContract.CreateTranscriptRendererOptions();
-        var now = new DateTime(2026, 4, 7, 12, 17, 42, DateTimeKind.Local);
+        var now = new DateTime(2026, 4, 7, 20, 47, 32, DateTimeKind.Local);
         var html = TranscriptHtmlFormatter.Format(new[] {
             ("Assistant", """
-                          [Execution blocked]
-                          ix:execution-contract:v1 I do not have confirmed tool output for this selected action yet.
+                          [Execution blocked] ix: execution-contract: v1 I do not have confirmed tool output for this selected action yet.
 
-                          Reason code: no_tool_calls_after_watchdog_retry
-
-                          [Working memory checkpoint]
+                          Selected action request: [Working memory checkpoint] ix: working-memory: v1 domain_scope_family: ad_domain recent_tools: ad_environment_discover
+                          recent_evidence_1: ad_environment_discover: #
 
                           ## Active Directory: Environment Discovery
 
                           | Field | Value |
                           | --- | --- |
-                          | Domain controller | dc1.ad.evotec.xyz |
-                          | Search base DN | DC=ad,DC=evotec,DC=xyz |
+                          | Domain controller |  |
+
+                          Reason code: no_tool_calls_after_watchdog_retry
 
                           Please retry this action in this context, or use the action command below.
-
                           Tool receipt: no tools were run in this turn.
                           """, now)
         }, "HH:mm:ss", options);
 
-        Assert.Contains("outcome-kind-execution-blocked", html, StringComparison.Ordinal);
-        Assert.Contains("Working memory checkpoint", html, StringComparison.Ordinal);
-        Assert.Contains("Active Directory: Environment Discovery", html, StringComparison.Ordinal);
-        Assert.Contains("<table", html, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Domain controller", html, StringComparison.Ordinal);
+        Assert.Contains("Execution blocked", html, StringComparison.Ordinal);
+        Assert.Contains("no_tool_calls_after_watchdog_retry", html, StringComparison.Ordinal);
         Assert.Contains("Tool receipt: no tools were run in this turn.", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Working memory checkpoint", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ix:working-memory:v1", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("domain_scope_family", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("recent_tools", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Active Directory: Environment Discovery", html, StringComparison.Ordinal);
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/TranscriptMarkdownDocumentBuilder.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/TranscriptMarkdownDocumentBuilder.cs
@@ -11,7 +11,7 @@ internal static class TranscriptMarkdownDocumentBuilder {
     public static string BuildPreparedTranscript(
         IEnumerable<(string Role, string Text, DateTime Time, string? Model)> messages,
         string timestampFormat) {
-        return Build(messages, timestampFormat, static (role, messageText) => TranscriptMarkdownPreparation.PrepareMessageBody(role, messageText));
+        return Build(messages, timestampFormat, static (role, messageText) => TranscriptMarkdownPreparation.PrepareMessageBodyForDisplay(role, messageText));
     }
 
     public static string BuildRawTranscript(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/TranscriptMarkdownPreparation.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/TranscriptMarkdownPreparation.cs
@@ -56,6 +56,39 @@ internal static class TranscriptMarkdownPreparation {
         "advances_current_ask:",
         "advance_reason:"
     ];
+    private static readonly Regex SpacedExecutionContractMarkerRegex = new(
+        @"ix:\s*execution-contract:\s*v1",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex SpacedWorkingMemoryMarkerRegex = new(
+        @"ix:\s*working-memory:\s*v1",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex InlineExecutionBlockedHeaderRegex = new(
+        @"(?im)^(\s*\[Execution blocked\])\s+(?=\S)",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex WorkingMemoryCheckpointBlockRegex = new(
+        @"(?is)(?:\bSelected action request:\s*)?\[Working memory checkpoint\].*?(?=(?:\r?\n\s*(?:Reason code:|Please retry|Tool receipt:|Action:))|$)",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex WorkingMemoryMarkerBlockRegex = new(
+        @"(?is)ix:working-memory:v1.*?(?=(?:\r?\n\s*(?:Reason code:|Please retry|Tool receipt:|Action:))|$)",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex EmptySelectedActionRequestLineRegex = new(
+        @"(?im)^\s*Selected action request:\s*$\r?\n?",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex ExecutionContractMarkerLineRegex = new(
+        @"(?im)^\s*ix:execution-contract:v1\s*$\r?\n?",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex InlineExecutionContractMarkerRegex = new(
+        @"(?i)\bix:execution-contract:v1\b\s*",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex ExcessBlankLinesRegex = new(
+        @"(?:\r?\n){3,}",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex RecoveredFindingsHeadingPipeRegex = new(
+        @"(?m)^(### [^|\r\n]+?)\s+\|",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    private static readonly Regex MarkdownTableSeparatorCellRegex = new(
+        @"^:?-{3,}:?$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     public static string NormalizePersistedTranscriptText(string? role, string text, out bool repaired) {
         ArgumentNullException.ThrowIfNull(text);
@@ -87,6 +120,9 @@ internal static class TranscriptMarkdownPreparation {
 
     public static string PrepareMessageBody(string? text) =>
         TranscriptMarkdownContract.PrepareMessageBody(NormalizeMessageBodyCore(text));
+
+    public static string PrepareMessageBodyForDisplay(string? role, string? text) =>
+        TranscriptMarkdownContract.PrepareMessageBody(NormalizeDisplayMessageBodyCore(role, text));
 
     public static string PrepareOutcomeDetailBody(string? text) =>
         TranscriptMarkdownContract.PrepareTranscriptMarkdownForExport(NormalizeMessageBodyCore(text)).Trim();
@@ -121,11 +157,39 @@ internal static class TranscriptMarkdownPreparation {
         return TranscriptMarkdownNormalizer.NormalizeForRendering(value);
     }
 
+    private static string NormalizeDisplayMessageBodyCore(string? role, string? text) {
+        var value = text ?? string.Empty;
+        if (value.Length == 0) {
+            return string.Empty;
+        }
+
+        if (RequiresAssistantTransportArtifactSanitization(role, value)) {
+            value = SanitizeAssistantTransportArtifacts(value);
+        }
+
+        return TranscriptMarkdownNormalizer.NormalizeForRendering(value);
+    }
+
     private static bool ShouldStripRuntimeOnlyArtifacts(string? role) {
         var normalizedRole = (role ?? string.Empty).Trim();
         return normalizedRole.Equals("Assistant", StringComparison.OrdinalIgnoreCase)
                || normalizedRole.Equals("System", StringComparison.OrdinalIgnoreCase)
                || normalizedRole.Equals("Tools", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool RequiresAssistantTransportArtifactSanitization(string? role, string text) {
+        if (!string.Equals(role, "Assistant", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(role, "System", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        return text.IndexOf("[Execution blocked]", StringComparison.OrdinalIgnoreCase) >= 0
+               || text.IndexOf("Recovered findings from executed tools", StringComparison.OrdinalIgnoreCase) >= 0
+               || text.IndexOf("ix: execution-contract: v1", StringComparison.OrdinalIgnoreCase) >= 0
+               || text.IndexOf("ix:execution-contract:v1", StringComparison.OrdinalIgnoreCase) >= 0
+               || text.IndexOf("ix: working-memory: v1", StringComparison.OrdinalIgnoreCase) >= 0
+               || text.IndexOf("ix:working-memory:v1", StringComparison.OrdinalIgnoreCase) >= 0
+               || text.IndexOf("[Working memory checkpoint]", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private static string SanitizeRuntimeOnlyArtifacts(string text) {
@@ -137,6 +201,212 @@ internal static class TranscriptMarkdownPreparation {
         sanitized = StripAnswerPlanBlocks(sanitized);
         sanitized = RepairMermaidBlocks(sanitized);
         return sanitized.Trim();
+    }
+
+    private static string SanitizeAssistantTransportArtifacts(string text) {
+        var original = text ?? string.Empty;
+        if (original.Length == 0) {
+            return string.Empty;
+        }
+
+        var newline = original.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+        var normalized = original.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        normalized = SpacedExecutionContractMarkerRegex.Replace(normalized, "ix:execution-contract:v1");
+        normalized = SpacedWorkingMemoryMarkerRegex.Replace(normalized, "ix:working-memory:v1");
+        normalized = InlineExecutionBlockedHeaderRegex.Replace(normalized, "$1\n");
+
+        if (normalized.IndexOf("[Execution blocked]", StringComparison.OrdinalIgnoreCase) >= 0) {
+            normalized = InlineExecutionContractMarkerRegex.Replace(normalized, string.Empty);
+            normalized = WorkingMemoryCheckpointBlockRegex.Replace(normalized, string.Empty);
+            normalized = WorkingMemoryMarkerBlockRegex.Replace(normalized, string.Empty);
+            normalized = ExecutionContractMarkerLineRegex.Replace(normalized, string.Empty);
+            normalized = EmptySelectedActionRequestLineRegex.Replace(normalized, string.Empty);
+        }
+
+        if (normalized.IndexOf("Recovered findings from executed tools", StringComparison.OrdinalIgnoreCase) >= 0) {
+            normalized = RecoveredFindingsHeadingPipeRegex.Replace(normalized, "$1\n\n|");
+            normalized = RehydrateCollapsedRecoveredFindingsTables(normalized);
+        }
+
+        normalized = ExcessBlankLinesRegex.Replace(normalized, "\n\n").Trim();
+        return newline == "\r\n"
+            ? normalized.Replace("\n", "\r\n", StringComparison.Ordinal)
+            : normalized;
+    }
+
+    private static string RehydrateCollapsedRecoveredFindingsTables(string text) {
+        var lines = text.Split('\n');
+        for (var i = 0; i < lines.Length; i++) {
+            var line = lines[i] ?? string.Empty;
+            var trimmed = line.TrimStart();
+            var indentLength = line.Length - trimmed.Length;
+            var indent = indentLength > 0 ? line[..indentLength] : string.Empty;
+
+            if (trimmed.StartsWith("### ", StringComparison.Ordinal) && trimmed.IndexOf('|') > 0) {
+                var headingPipeIndex = trimmed.IndexOf('|');
+                var heading = trimmed[..headingPipeIndex].TrimEnd();
+                var tableText = trimmed[headingPipeIndex..].Trim();
+                if (!TryRehydrateCollapsedMarkdownTable(tableText, out var expandedTable)) {
+                    continue;
+                }
+
+                lines[i] = indent + heading + "\n\n" + indent + expandedTable.Replace("\n", "\n" + indent, StringComparison.Ordinal);
+                continue;
+            }
+
+            if (!trimmed.StartsWith("|", StringComparison.Ordinal) || i <= 0) {
+                continue;
+            }
+
+            var previousTrimmed = (lines[i - 1] ?? string.Empty).TrimStart();
+            if (!previousTrimmed.StartsWith("### ", StringComparison.Ordinal)) {
+                continue;
+            }
+
+            if (!TryRehydrateCollapsedMarkdownTable(trimmed, out var expandedTableOnNextLine)) {
+                continue;
+            }
+
+            lines[i] = indent + expandedTableOnNextLine.Replace("\n", "\n" + indent, StringComparison.Ordinal);
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    private static bool TryRehydrateCollapsedMarkdownTable(string text, out string table) {
+        table = string.Empty;
+        var normalized = (text ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return false;
+        }
+
+        normalized = NormalizeCollapsedMarkdownTableRows(normalized);
+        if (normalized.IndexOf('\n') >= 0) {
+            table = normalized;
+            return true;
+        }
+
+        if (!normalized.StartsWith("|", StringComparison.Ordinal)) {
+            normalized = "| " + normalized;
+        }
+
+        var rawCells = normalized.Split('|');
+        var cells = new List<string>(rawCells.Length);
+        for (var i = 0; i < rawCells.Length; i++) {
+            cells.Add((rawCells[i] ?? string.Empty).Trim());
+        }
+
+        while (cells.Count > 0 && cells[0].Length == 0) {
+            cells.RemoveAt(0);
+        }
+
+        while (cells.Count > 0 && cells[^1].Length == 0) {
+            cells.RemoveAt(cells.Count - 1);
+        }
+
+        if (cells.Count < 4) {
+            return false;
+        }
+
+        var separatorStart = -1;
+        for (var i = 1; i < cells.Count; i++) {
+            if (MarkdownTableSeparatorCellRegex.IsMatch(cells[i])) {
+                separatorStart = i;
+                break;
+            }
+        }
+
+        if (separatorStart < 2) {
+            return false;
+        }
+
+        var columnCount = separatorStart;
+        if (cells.Count < columnCount * 2) {
+            return false;
+        }
+
+        for (var i = separatorStart; i < separatorStart + columnCount; i++) {
+            if (i >= cells.Count || !MarkdownTableSeparatorCellRegex.IsMatch(cells[i])) {
+                return false;
+            }
+        }
+
+        var builder = new StringBuilder();
+        AppendMarkdownTableRow(builder, cells, 0, columnCount, useSeparatorCells: false);
+        builder.Append('\n');
+        AppendMarkdownTableRow(builder, cells, separatorStart, columnCount, useSeparatorCells: true);
+
+        for (var i = separatorStart + columnCount; i < cells.Count; i += columnCount) {
+            builder.Append('\n');
+            AppendMarkdownTableRow(builder, cells, i, columnCount, useSeparatorCells: false);
+        }
+
+        table = builder.ToString();
+        return true;
+    }
+
+    private static string NormalizeCollapsedMarkdownTableRows(string text) {
+        var normalized = (text ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(normalized.Length + 16);
+        for (var i = 0; i < normalized.Length; i++) {
+            if (normalized[i] != '|') {
+                builder.Append(normalized[i]);
+                continue;
+            }
+
+            var whitespaceStart = i + 1;
+            var cursor = whitespaceStart;
+            while (cursor < normalized.Length && char.IsWhiteSpace(normalized[cursor]) && normalized[cursor] is not ('\r' or '\n')) {
+                cursor++;
+            }
+
+            if (cursor < normalized.Length && normalized[cursor] == '|') {
+                var nextContent = cursor + 1;
+                while (nextContent < normalized.Length && char.IsWhiteSpace(normalized[nextContent]) && normalized[nextContent] is not ('\r' or '\n')) {
+                    nextContent++;
+                }
+
+                if (nextContent < normalized.Length) {
+                    builder.Append('|')
+                        .Append('\n')
+                        .Append('|');
+                    i = cursor;
+                    continue;
+                }
+            }
+
+            builder.Append('|');
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendMarkdownTableRow(
+        StringBuilder builder,
+        IReadOnlyList<string> cells,
+        int startIndex,
+        int columnCount,
+        bool useSeparatorCells) {
+        builder.Append("| ");
+        for (var i = 0; i < columnCount; i++) {
+            if (i > 0) {
+                builder.Append(" | ");
+            }
+
+            var index = startIndex + i;
+            var cell = index < cells.Count ? cells[index] : string.Empty;
+            if (useSeparatorCells) {
+                cell = MarkdownTableSeparatorCellRegex.IsMatch(cell) ? cell : "---";
+            }
+
+            builder.Append(cell);
+        }
+
+        builder.Append(" |");
     }
 
     private static string StripAnswerPlanBlocks(string text) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/TranscriptMarkdownPreparation.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/TranscriptMarkdownPreparation.cs
@@ -163,6 +163,10 @@ internal static class TranscriptMarkdownPreparation {
             return string.Empty;
         }
 
+        if (ShouldStripRuntimeOnlyArtifacts(role)) {
+            value = SanitizeRuntimeOnlyArtifacts(value);
+        }
+
         if (RequiresAssistantTransportArtifactSanitization(role, value)) {
             value = SanitizeAssistantTransportArtifacts(value);
         }
@@ -280,7 +284,6 @@ internal static class TranscriptMarkdownPreparation {
             return false;
         }
 
-        normalized = NormalizeCollapsedMarkdownTableRows(normalized);
         if (normalized.IndexOf('\n') >= 0) {
             table = normalized;
             return true;
@@ -309,36 +312,98 @@ internal static class TranscriptMarkdownPreparation {
         }
 
         var separatorStart = -1;
+        var columnCount = 0;
         for (var i = 1; i < cells.Count; i++) {
-            if (MarkdownTableSeparatorCellRegex.IsMatch(cells[i])) {
-                separatorStart = i;
-                break;
+            if (!MarkdownTableSeparatorCellRegex.IsMatch(cells[i])) {
+                continue;
             }
+
+            var runLength = 0;
+            while (i + runLength < cells.Count && MarkdownTableSeparatorCellRegex.IsMatch(cells[i + runLength])) {
+                runLength++;
+            }
+
+            var headerEndExclusive = i;
+            if (i > 0 && cells[i - 1].Length == 0) {
+                headerEndExclusive = i - 1;
+            }
+
+            if (runLength <= 0 || headerEndExclusive < runLength) {
+                continue;
+            }
+
+            separatorStart = i;
+            columnCount = runLength;
+            break;
         }
 
-        if (separatorStart < 2) {
+        if (separatorStart < 2 || columnCount <= 0) {
             return false;
         }
 
-        var columnCount = separatorStart;
-        if (cells.Count < columnCount * 2) {
+        var headerStart = separatorStart;
+        if (cells[separatorStart - 1].Length == 0) {
+            headerStart--;
+        }
+        headerStart -= columnCount;
+        if (headerStart < 0) {
             return false;
         }
 
-        for (var i = separatorStart; i < separatorStart + columnCount; i++) {
-            if (i >= cells.Count || !MarkdownTableSeparatorCellRegex.IsMatch(cells[i])) {
+        var headerCells = new List<string>(columnCount);
+        for (var i = 0; i < columnCount; i++) {
+            headerCells.Add(cells[headerStart + i]);
+        }
+
+        var separatorCells = new List<string>(columnCount);
+        for (var i = 0; i < columnCount; i++) {
+            if (separatorStart + i >= cells.Count || !MarkdownTableSeparatorCellRegex.IsMatch(cells[separatorStart + i])) {
                 return false;
             }
+
+            separatorCells.Add(cells[separatorStart + i]);
+        }
+
+        var rows = new List<List<string>>();
+        var currentRow = new List<string>(columnCount);
+        for (var i = separatorStart + columnCount; i < cells.Count; i++) {
+            var cell = cells[i];
+            if (currentRow.Count == 0 && cell.Length == 0) {
+                continue;
+            }
+
+            if (currentRow.Count == columnCount) {
+                if (cell.Length == 0) {
+                    continue;
+                }
+
+                rows.Add(currentRow);
+                currentRow = new List<string>(columnCount);
+            }
+
+            currentRow.Add(cell);
+        }
+
+        if (currentRow.Count > 0) {
+            while (currentRow.Count < columnCount) {
+                currentRow.Add(string.Empty);
+            }
+
+            rows.Add(currentRow);
+        }
+
+        if (rows.Count == 0) {
+            return false;
         }
 
         var builder = new StringBuilder();
-        AppendMarkdownTableRow(builder, cells, 0, columnCount, useSeparatorCells: false);
+        AppendMarkdownTableRow(builder, headerCells, 0, columnCount, useSeparatorCells: false);
         builder.Append('\n');
-        AppendMarkdownTableRow(builder, cells, separatorStart, columnCount, useSeparatorCells: true);
+        AppendMarkdownTableRow(builder, separatorCells, 0, columnCount, useSeparatorCells: true);
 
-        for (var i = separatorStart + columnCount; i < cells.Count; i += columnCount) {
+        for (var i = 0; i < rows.Count; i++) {
             builder.Append('\n');
-            AppendMarkdownTableRow(builder, cells, i, columnCount, useSeparatorCells: false);
+            AppendMarkdownTableRow(builder, rows[i], 0, columnCount, useSeparatorCells: false);
         }
 
         table = builder.ToString();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/TranscriptMarkdownPreparation.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Markdown/TranscriptMarkdownPreparation.cs
@@ -84,7 +84,7 @@ internal static class TranscriptMarkdownPreparation {
         @"(?:\r?\n){3,}",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex RecoveredFindingsHeadingPipeRegex = new(
-        @"(?m)^(### [^|\r\n]+?)\s+\|",
+        @"(?m)^(#{1,6} [^|\r\n]+?)\s+\|",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
     private static readonly Regex MarkdownTableSeparatorCellRegex = new(
         @"^:?-{3,}:?$",
@@ -121,8 +121,18 @@ internal static class TranscriptMarkdownPreparation {
     public static string PrepareMessageBody(string? text) =>
         TranscriptMarkdownContract.PrepareMessageBody(NormalizeMessageBodyCore(text));
 
-    public static string PrepareMessageBodyForDisplay(string? role, string? text) =>
-        TranscriptMarkdownContract.PrepareMessageBody(NormalizeDisplayMessageBodyCore(role, text));
+    public static string PrepareMessageBodyForDisplay(string? role, string? text) {
+        var value = NormalizeMessageBodyCore(role, text);
+        if (value.Length == 0) {
+            return string.Empty;
+        }
+
+        if (RequiresAssistantTransportArtifactSanitization(role, value)) {
+            value = TranscriptMarkdownNormalizer.NormalizeForRendering(SanitizeAssistantTransportArtifacts(value));
+        }
+
+        return TranscriptMarkdownContract.PrepareMessageBody(value);
+    }
 
     public static string PrepareOutcomeDetailBody(string? text) =>
         TranscriptMarkdownContract.PrepareTranscriptMarkdownForExport(NormalizeMessageBodyCore(text)).Trim();
@@ -154,23 +164,6 @@ internal static class TranscriptMarkdownPreparation {
 
     private static string NormalizeMessageBodyCore(string? text) {
         var value = text ?? string.Empty;
-        return TranscriptMarkdownNormalizer.NormalizeForRendering(value);
-    }
-
-    private static string NormalizeDisplayMessageBodyCore(string? role, string? text) {
-        var value = text ?? string.Empty;
-        if (value.Length == 0) {
-            return string.Empty;
-        }
-
-        if (ShouldStripRuntimeOnlyArtifacts(role)) {
-            value = SanitizeRuntimeOnlyArtifacts(value);
-        }
-
-        if (RequiresAssistantTransportArtifactSanitization(role, value)) {
-            value = SanitizeAssistantTransportArtifacts(value);
-        }
-
         return TranscriptMarkdownNormalizer.NormalizeForRendering(value);
     }
 
@@ -246,10 +239,7 @@ internal static class TranscriptMarkdownPreparation {
             var indentLength = line.Length - trimmed.Length;
             var indent = indentLength > 0 ? line[..indentLength] : string.Empty;
 
-            if (trimmed.StartsWith("### ", StringComparison.Ordinal) && trimmed.IndexOf('|') > 0) {
-                var headingPipeIndex = trimmed.IndexOf('|');
-                var heading = trimmed[..headingPipeIndex].TrimEnd();
-                var tableText = trimmed[headingPipeIndex..].Trim();
+            if (TrySplitMarkdownHeadingPipe(trimmed, out var heading, out var tableText)) {
                 if (!TryRehydrateCollapsedMarkdownTable(tableText, out var expandedTable)) {
                     continue;
                 }
@@ -262,8 +252,17 @@ internal static class TranscriptMarkdownPreparation {
                 continue;
             }
 
-            var previousTrimmed = (lines[i - 1] ?? string.Empty).TrimStart();
-            if (!previousTrimmed.StartsWith("### ", StringComparison.Ordinal)) {
+            var previousIndex = i - 1;
+            while (previousIndex >= 0 && string.IsNullOrWhiteSpace(lines[previousIndex])) {
+                previousIndex--;
+            }
+
+            if (previousIndex < 0) {
+                continue;
+            }
+
+            var previousTrimmed = (lines[previousIndex] ?? string.Empty).TrimStart();
+            if (!IsMarkdownHeadingLine(previousTrimmed)) {
                 continue;
             }
 
@@ -275,6 +274,41 @@ internal static class TranscriptMarkdownPreparation {
         }
 
         return string.Join("\n", lines);
+    }
+
+    private static bool TrySplitMarkdownHeadingPipe(string text, out string heading, out string tableText) {
+        heading = string.Empty;
+        tableText = string.Empty;
+
+        var trimmed = (text ?? string.Empty).Trim();
+        if (!IsMarkdownHeadingLine(trimmed)) {
+            return false;
+        }
+
+        var pipeIndex = trimmed.IndexOf('|');
+        if (pipeIndex <= 0) {
+            return false;
+        }
+
+        heading = trimmed[..pipeIndex].TrimEnd();
+        tableText = trimmed[pipeIndex..].Trim();
+        return heading.Length > 0 && tableText.Length > 0;
+    }
+
+    private static bool IsMarkdownHeadingLine(string text) {
+        var trimmed = (text ?? string.Empty).TrimStart();
+        if (trimmed.Length < 3 || trimmed[0] != '#') {
+            return false;
+        }
+
+        var markerLength = 0;
+        while (markerLength < trimmed.Length && trimmed[markerLength] == '#') {
+            markerLength++;
+        }
+
+        return markerLength is >= 1 and <= 6
+               && markerLength < trimmed.Length
+               && trimmed[markerLength] == ' ';
     }
 
     private static bool TryRehydrateCollapsedMarkdownTable(string text, out string table) {
@@ -299,11 +333,11 @@ internal static class TranscriptMarkdownPreparation {
             cells.Add((rawCells[i] ?? string.Empty).Trim());
         }
 
-        while (cells.Count > 0 && cells[0].Length == 0) {
+        if (cells.Count > 0 && cells[0].Length == 0) {
             cells.RemoveAt(0);
         }
 
-        while (cells.Count > 0 && cells[^1].Length == 0) {
+        if (cells.Count > 0 && cells[^1].Length == 0) {
             cells.RemoveAt(cells.Count - 1);
         }
 
@@ -365,31 +399,22 @@ internal static class TranscriptMarkdownPreparation {
         }
 
         var rows = new List<List<string>>();
-        var currentRow = new List<string>(columnCount);
-        for (var i = separatorStart + columnCount; i < cells.Count; i++) {
-            var cell = cells[i];
-            if (currentRow.Count == 0 && cell.Length == 0) {
-                continue;
-            }
-
-            if (currentRow.Count == columnCount) {
-                if (cell.Length == 0) {
-                    continue;
+        var rowCursor = separatorStart + columnCount;
+        while (rowCursor < cells.Count) {
+            if (cells[rowCursor].Length == 0) {
+                rowCursor++;
+                if (rowCursor >= cells.Count) {
+                    break;
                 }
-
-                rows.Add(currentRow);
-                currentRow = new List<string>(columnCount);
             }
 
-            currentRow.Add(cell);
-        }
-
-        if (currentRow.Count > 0) {
-            while (currentRow.Count < columnCount) {
-                currentRow.Add(string.Empty);
+            var row = new List<string>(columnCount);
+            for (var i = 0; i < columnCount; i++) {
+                row.Add(rowCursor < cells.Count ? cells[rowCursor] : string.Empty);
+                rowCursor++;
             }
 
-            rows.Add(currentRow);
+            rows.Add(row);
         }
 
         if (rows.Count == 0) {
@@ -408,46 +433,6 @@ internal static class TranscriptMarkdownPreparation {
 
         table = builder.ToString();
         return true;
-    }
-
-    private static string NormalizeCollapsedMarkdownTableRows(string text) {
-        var normalized = (text ?? string.Empty).Trim();
-        if (normalized.Length == 0) {
-            return string.Empty;
-        }
-
-        var builder = new StringBuilder(normalized.Length + 16);
-        for (var i = 0; i < normalized.Length; i++) {
-            if (normalized[i] != '|') {
-                builder.Append(normalized[i]);
-                continue;
-            }
-
-            var whitespaceStart = i + 1;
-            var cursor = whitespaceStart;
-            while (cursor < normalized.Length && char.IsWhiteSpace(normalized[cursor]) && normalized[cursor] is not ('\r' or '\n')) {
-                cursor++;
-            }
-
-            if (cursor < normalized.Length && normalized[cursor] == '|') {
-                var nextContent = cursor + 1;
-                while (nextContent < normalized.Length && char.IsWhiteSpace(normalized[nextContent]) && normalized[nextContent] is not ('\r' or '\n')) {
-                    nextContent++;
-                }
-
-                if (nextContent < normalized.Length) {
-                    builder.Append('|')
-                        .Append('\n')
-                        .Append('|');
-                    i = cursor;
-                    continue;
-                }
-            }
-
-            builder.Append('|');
-        }
-
-        return builder.ToString();
     }
 
     private static void AppendMarkdownTableRow(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptHtmlFormatter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptHtmlFormatter.cs
@@ -65,7 +65,7 @@ internal static class TranscriptHtmlFormatter {
         MarkdownRendererOptions markdownOptions) {
         ArgumentNullException.ThrowIfNull(markdownOptions);
 
-        var normalizedText = TranscriptMarkdownPreparation.PrepareMessageBody(role, text);
+        var normalizedText = TranscriptMarkdownPreparation.PrepareMessageBodyForDisplay(role, text);
         if (string.IsNullOrWhiteSpace(normalizedText)) {
             return string.Empty;
         }
@@ -114,7 +114,7 @@ internal static class TranscriptHtmlFormatter {
         var messageIndex = 0;
 
         foreach (var message in messages) {
-            var normalizedText = TranscriptMarkdownPreparation.PrepareMessageBody(message.Role, message.Text);
+            var normalizedText = TranscriptMarkdownPreparation.PrepareMessageBodyForDisplay(message.Role, message.Text);
             if (string.IsNullOrWhiteSpace(normalizedText)) {
                 messageIndex++;
                 continue;
@@ -485,27 +485,20 @@ internal static class TranscriptHtmlFormatter {
         string selectedAction = string.Empty;
         string actionCommand = string.Empty;
         string reasonCode = string.Empty;
-        var body = new StringBuilder();
-        var bodyStarted = false;
+        var trailingNotes = new List<string>();
 
         for (var i = 0; i < lines.Length; i++) {
-            var rawLine = lines[i] ?? string.Empty;
-            var line = rawLine.Trim();
+            var line = lines[i].Trim();
+            if (line.Length == 0) {
+                continue;
+            }
 
             if (line.IndexOf(ExecutionContractMarker, StringComparison.OrdinalIgnoreCase) >= 0) {
                 line = line.Replace(ExecutionContractMarker, string.Empty, StringComparison.OrdinalIgnoreCase)
                     .Trim(' ', ':', '-', '\t');
-                rawLine = line;
-                if (line.Length == 0 && !bodyStarted) {
-                    continue;
-                }
             }
 
             if (summary.Length == 0) {
-                if (line.Length == 0) {
-                    continue;
-                }
-
                 summary = line;
                 continue;
             }
@@ -537,15 +530,7 @@ internal static class TranscriptHtmlFormatter {
                 continue;
             }
 
-            if (line.Length == 0 && !bodyStarted) {
-                continue;
-            }
-
-            if (bodyStarted) {
-                body.AppendLine();
-            }
-            body.Append(rawLine);
-            bodyStarted = true;
+            trailingNotes.Add(line);
         }
 
         var detail = new StringBuilder();
@@ -570,13 +555,18 @@ internal static class TranscriptHtmlFormatter {
             }
         }
 
-        var preservedBody = body.ToString().Trim();
-        if (preservedBody.Length > 0) {
+        if (trailingNotes.Count > 0) {
             if (detail.Length > 0) {
-                detail.AppendLine().AppendLine();
+                detail.AppendLine();
             }
 
-            detail.Append(preservedBody);
+            for (var i = 0; i < trailingNotes.Count; i++) {
+                if (i > 0) {
+                    detail.AppendLine().AppendLine();
+                }
+
+                detail.Append(trailingNotes[i]);
+            }
         }
 
         return TranscriptMarkdownPreparation.PrepareOutcomeDetailBody(detail.ToString());

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptHtmlFormatter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Rendering/TranscriptHtmlFormatter.cs
@@ -485,53 +485,54 @@ internal static class TranscriptHtmlFormatter {
         string selectedAction = string.Empty;
         string actionCommand = string.Empty;
         string reasonCode = string.Empty;
-        var trailingNotes = new List<string>();
+        var consumedLines = new bool[lines.Length];
 
         for (var i = 0; i < lines.Length; i++) {
-            var line = lines[i].Trim();
+            var line = SanitizeExecutionBlockedDetailLine(lines[i]).Trim();
             if (line.Length == 0) {
                 continue;
             }
 
-            if (line.IndexOf(ExecutionContractMarker, StringComparison.OrdinalIgnoreCase) >= 0) {
-                line = line.Replace(ExecutionContractMarker, string.Empty, StringComparison.OrdinalIgnoreCase)
-                    .Trim(' ', ':', '-', '\t');
-            }
-
             if (summary.Length == 0) {
                 summary = line;
+                consumedLines[i] = true;
                 continue;
             }
 
             if (line.StartsWith("Selected action request:", StringComparison.OrdinalIgnoreCase)) {
                 selectedAction = line["Selected action request:".Length..].Trim();
+                consumedLines[i] = true;
                 continue;
             }
 
             if (line.StartsWith("Action:", StringComparison.OrdinalIgnoreCase)) {
                 actionCommand = line["Action:".Length..].Trim();
+                consumedLines[i] = true;
                 continue;
             }
 
             if (line.StartsWith("Reason code:", StringComparison.OrdinalIgnoreCase)) {
+                consumedLines[i] = true;
                 reasonCode = line["Reason code:".Length..].Trim();
                 if (reasonCode.Length == 0) {
                     for (var j = i + 1; j < lines.Length; j++) {
-                        var next = lines[j].Trim();
+                        var next = SanitizeExecutionBlockedDetailLine(lines[j]).Trim();
                         if (next.Length == 0) {
+                            consumedLines[j] = true;
                             continue;
                         }
 
                         reasonCode = next;
+                        consumedLines[j] = true;
                         i = j;
                         break;
                     }
                 }
                 continue;
             }
-
-            trailingNotes.Add(line);
         }
+
+        var trailingNotes = BuildExecutionBlockedTrailingNotes(lines, consumedLines);
 
         var detail = new StringBuilder();
         if (summary.Length > 0) {
@@ -555,21 +556,51 @@ internal static class TranscriptHtmlFormatter {
             }
         }
 
-        if (trailingNotes.Count > 0) {
+        if (trailingNotes.Length > 0) {
             if (detail.Length > 0) {
-                detail.AppendLine();
+                detail.AppendLine().AppendLine();
             }
 
-            for (var i = 0; i < trailingNotes.Count; i++) {
-                if (i > 0) {
-                    detail.AppendLine().AppendLine();
-                }
-
-                detail.Append(trailingNotes[i]);
-            }
+            detail.Append(trailingNotes);
         }
 
         return TranscriptMarkdownPreparation.PrepareOutcomeDetailBody(detail.ToString());
+    }
+
+    private static string BuildExecutionBlockedTrailingNotes(IReadOnlyList<string> lines, IReadOnlyList<bool> consumedLines) {
+        var trailingLines = new List<string>(lines.Count);
+        for (var i = 0; i < lines.Count; i++) {
+            if (consumedLines[i]) {
+                continue;
+            }
+
+            trailingLines.Add(SanitizeExecutionBlockedDetailLine(lines[i]));
+        }
+
+        var start = 0;
+        while (start < trailingLines.Count && string.IsNullOrWhiteSpace(trailingLines[start])) {
+            start++;
+        }
+
+        var end = trailingLines.Count - 1;
+        while (end >= start && string.IsNullOrWhiteSpace(trailingLines[end])) {
+            end--;
+        }
+
+        if (end < start) {
+            return string.Empty;
+        }
+
+        return string.Join('\n', trailingLines.GetRange(start, end - start + 1));
+    }
+
+    private static string SanitizeExecutionBlockedDetailLine(string? line) {
+        var value = line ?? string.Empty;
+        if (value.IndexOf(ExecutionContractMarker, StringComparison.OrdinalIgnoreCase) < 0) {
+            return value;
+        }
+
+        return value.Replace(ExecutionContractMarker, string.Empty, StringComparison.OrdinalIgnoreCase);
     }
 
     private static void AppendExecutionBlockedMetadataLine(StringBuilder detail, string label, string value) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/TranscriptForensicsExporter.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/TranscriptForensicsExporter.cs
@@ -116,7 +116,7 @@ internal static class TranscriptForensicsExporter {
         for (var i = 0; i < sourceMessages.Count; i++) {
             var message = sourceMessages[i];
             var rawText = message.RawText ?? string.Empty;
-            var normalizedText = TranscriptMarkdownPreparation.PrepareMessageBody(message.Role, rawText);
+            var normalizedText = TranscriptMarkdownPreparation.PrepareMessageBodyForDisplay(message.Role, rawText);
             if (string.IsNullOrWhiteSpace(normalizedText)) {
                 continue;
             }


### PR DESCRIPTION
## Summary
- sanitize execution-blocked transport artifacts only at display/export time instead of letting working-memory payloads leak into transcripts
- rehydrate flattened recovered-findings markdown tables so fallback summaries stay readable in transcript/export surfaces
- extend app tests to cover the new display sanitization while keeping the older mermaid and markdown cleanup coverage intact

## Testing
- dotnet test IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/IntelligenceX.Chat.App.Tests.csproj -c Release