### PR TITLE
Refresh website workflows to latest PowerForge

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,15 +17,15 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       site_output_path: Website/_site
       post_deploy_pipeline_config: Website/pipeline.cloudflare.json
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview
+      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -9,10 +9,10 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview
+      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925


### PR DESCRIPTION
## Summary
- update website CI, deploy, and maintenance workflows to the current PSPublishModule reusable workflow SHA 263eb3ccc4e6948132a5bdd3df9a084501291f68
- move package-mode website runs to PowerForgeWeb-v1.0.0-preview-202603311925
- keep website automation aligned with the newer PowerForge bits before the Magick bump becomes a blocker

## Notes
- this is scoped to website pipeline targeting only