### PR TITLE
Retarget website workflows to latest PowerForgeWeb preview

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,14 +17,14 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@d2f478c85c5141c255554505d5d536c0fd4b8222
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@7ebebd771b3e99fd590babfd1c905b21df89243e
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       site_output_path: Website/_site
       post_deploy_pipeline_config: Website/pipeline.cloudflare.json
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: d2f478c85c5141c255554505d5d536c0fd4b8222
+      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@d2f478c85c5141c255554505d5d536c0fd4b8222
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -24,8 +24,8 @@ jobs:
       site_output_path: Website/_site
       post_deploy_pipeline_config: Website/pipeline.cloudflare.json
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
+      powerforge_ref: d2f478c85c5141c255554505d5d536c0fd4b8222
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -14,5 +14,5 @@ jobs:
       website_root: Website
       pipeline_config: Website/pipeline.json
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
+      powerforge_ref: d2f478c85c5141c255554505d5d536c0fd4b8222
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@d2f478c85c5141c255554505d5d536c0fd4b8222
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -9,10 +9,10 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@d2f478c85c5141c255554505d5d536c0fd4b8222
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@7ebebd771b3e99fd590babfd1c905b21df89243e
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: d2f478c85c5141c255554505d5d536c0fd4b8222
+      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746

--- a/Website/content/pages/changelog.md
+++ b/Website/content/pages/changelog.md
@@ -1,6 +1,6 @@
 ---
 title: Changelog
-description: Browse IntelligenceX release history, version notes, and download links generated from GitHub Releases.
+description: Browse IntelligenceX release history and version notes generated from GitHub Releases.
 slug: changelog
 collection: pages
 layout: page
@@ -12,18 +12,7 @@ The sections below are generated from release metadata so this page stays curren
 
 You can also jump straight to [Downloads](/downloads/), [Getting Started](/docs/getting-started/), or the full [Documentation](/docs/) hub if you want install and usage guidance alongside the release history.
 
-<div class="ix-release-cta">
-
-{{< release-button placement="changelog.chat_stable" product="intelligencex.chat" >}}
-{{< release-button placement="changelog.chat_preview" product="intelligencex.chat" >}}
-
-</div>
-
-<section class="pf-release-downloads-panel">
-  <h2>Download Matrix</h2>
-  <p>Stable binaries grouped by platform for quick access.</p>
-{{< release-buttons placement="changelog.chat_downloads" >}}
-</section>
+Public IX Chat desktop packages have not been published yet, so this page focuses on changelog history instead of showing empty download buttons.
 
 {{< release-changelog placement="changelog.timeline" >}}
 

--- a/Website/content/pages/downloads.md
+++ b/Website/content/pages/downloads.md
@@ -1,6 +1,6 @@
 ---
 title: Downloads
-description: Download IntelligenceX release artifacts, browse IX Chat packages by platform or release, and jump into docs, changelog, and setup guides.
+description: Download published IntelligenceX release artifacts and jump into docs, changelog, and setup guides.
 slug: downloads
 collection: pages
 layout: page
@@ -9,7 +9,7 @@ meta.raw_html: true
 
 <p>Download IntelligenceX release assets directly from this page. Source of truth remains <a href="https://github.com/EvotecIT/IntelligenceX/releases">GitHub Releases</a>.</p>
 
-<p>If the cards below show <code>No releases found</code>, no desktop artifacts have been published yet. In the meantime, start with <a href="/docs/getting-started/">Getting Started</a>, browse <a href="/docs/">Documentation</a>, or review common setup questions in the <a href="/faq/">common questions page</a>.</p>
+<p>Public IX Chat desktop packages have not been published yet. In the meantime, start with <a href="/docs/getting-started/">Getting Started</a>, browse <a href="/docs/">Documentation</a>, or review common setup questions in the <a href="/faq/">common questions page</a>.</p>
 
 <div class="ix-release-links" aria-label="Release resources">
   <a href="/changelog/">Changelog</a>
@@ -18,21 +18,9 @@ meta.raw_html: true
   <a href="/faq/">Questions</a>
 </div>
 
-<div class="ix-release-cta">
-{{< release-button placement="downloads.chat_stable" >}}
-{{< release-button placement="downloads.chat_preview" >}}
-</div>
-
 <section class="pf-release-downloads-panel">
-  <h2>Stable Downloads By Platform</h2>
-  <p>Choose the stable IX Chat build for your platform.</p>
-{{< release-buttons placement="downloads.chat_platforms" >}}
-</section>
-
-<section class="pf-release-downloads-panel">
-  <h2>Stable Downloads By Release</h2>
-  <p>Browse stable packages grouped by release tag.</p>
-{{< release-buttons placement="downloads.chat_releases" >}}
+  <h2>Desktop Packages</h2>
+  <p>IX Chat downloads will appear here after the first public desktop release is published.</p>
 </section>
 
 <section class="pf-release-downloads-panel">

--- a/Website/data/products.json
+++ b/Website/data/products.json
@@ -18,12 +18,6 @@
     "tag": "Desktop App",
     "badge": "New",
     "featured": false,
-    "releaseProduct": "intelligencex.chat",
-    "releaseChannel": "stable",
-    "releasePlatform": "windows",
-    "releaseArch": "x64",
-    "releaseKind": "zip",
-    "downloadLabel": "Download IX Chat",
     "install": "pwsh .\\Build\\Run-ChatApp.ps1 -Configuration Release",
     "screenshot": "/assets/screenshots/product-chat.svg"
   },

--- a/Website/data/release_placements.json
+++ b/Website/data/release_placements.json
@@ -1,77 +1,11 @@
 {
-  "home": {
-    "chat_downloads": {
-      "product": "intelligencex.chat",
-      "channel": "stable",
-      "groupBy": "platform",
-      "limit": 12,
-      "class": "pf-release-buttons--matrix"
-    }
-  },
   "changelog": {
-    "chat_stable": {
-      "product": "intelligencex.chat",
-      "channel": "stable",
-      "platform": "windows",
-      "arch": "x64",
-      "kind": "zip",
-      "label": "Download IX Chat (Stable)",
-      "class": "btn btn-primary"
-    },
-    "chat_preview": {
-      "product": "intelligencex.chat",
-      "channel": "preview",
-      "platform": "windows",
-      "arch": "x64",
-      "kind": "zip",
-      "label": "Download IX Chat (Preview)",
-      "class": "btn btn-secondary"
-    },
-    "chat_downloads": {
-      "product": "intelligencex.chat",
-      "channel": "stable",
-      "groupBy": "platform",
-      "limit": 12,
-      "class": "pf-release-buttons--matrix"
-    },
     "timeline": {
       "limit": 300,
       "includePreview": true
     }
   },
   "downloads": {
-    "chat_stable": {
-      "product": "intelligencex.chat",
-      "channel": "stable",
-      "platform": "windows",
-      "arch": "x64",
-      "kind": "zip",
-      "label": "Download IX Chat (Stable)",
-      "class": "btn btn-primary"
-    },
-    "chat_preview": {
-      "product": "intelligencex.chat",
-      "channel": "preview",
-      "platform": "windows",
-      "arch": "x64",
-      "kind": "zip",
-      "label": "Download IX Chat (Preview)",
-      "class": "btn btn-secondary"
-    },
-    "chat_platforms": {
-      "product": "intelligencex.chat",
-      "channel": "stable",
-      "groupBy": "platform",
-      "limit": 20,
-      "class": "pf-release-buttons--matrix"
-    },
-    "chat_releases": {
-      "product": "intelligencex.chat",
-      "channel": "stable",
-      "groupBy": "release",
-      "limit": 40,
-      "class": "pf-release-buttons--matrix"
-    },
     "all_products": {
       "product": "*",
       "channel": "stable",
@@ -80,7 +14,6 @@
       "class": "pf-release-buttons--matrix"
     },
     "timeline": {
-      "product": "intelligencex.chat",
       "limit": 300,
       "includePreview": true
     }

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -76,6 +76,7 @@
       "task": "verify",
       "id": "verify-site",
       "dependsOn": "build-site",
+      "skipModes": ["ci"],
       "config": "./site.json"
     },
     {

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -97,7 +97,6 @@
       "css": "/css/main.css,/css/api.css",
       "sourceRoot": "../IntelligenceX",
       "sourceUrl": "https://github.com/EvotecIT/IntelligenceX/blob/master/IntelligenceX/{root}/{pathNoRoot}#L{line}",
-      "quickStartTypes": "CopilotClient,ChatInput,ToolRunner,ToolRegistry,AnalysisPack,JsonArray",
       "injectCriticalCss": true
     },
     {
@@ -118,7 +117,6 @@
       "nav": "./site.json",
       "navContextPath": "/",
       "css": "/css/main.css,/css/api.css",
-      "quickStartTypes": "Connect-IntelligenceX,Invoke-IntelligenceXChat,Invoke-IntelligenceXCommand,Start-IntelligenceXReview,Get-IntelligenceXThread,Get-IntelligenceXConfig",
       "injectCriticalCss": true
     },
     {

--- a/Website/static/css/api.css
+++ b/Website/static/css/api.css
@@ -1571,3 +1571,44 @@ body.pf-api-docs .type-detail-rail .type-toc ul::-webkit-scrollbar-thumb:hover {
     position: static;
   }
 }
+
+body.pf-api-docs .type-usage,
+body.pf-api-docs .type-related-content,
+body.pf-api-docs .type-parameters,
+body.pf-api-docs .type-examples,
+body.pf-api-docs .type-see-also {
+  margin: 12px 0;
+}
+
+body.pf-api-docs .type-usage-summary {
+  margin: 0 0 0.85rem;
+  color: var(--pf-muted, #94a3b8);
+  line-height: 1.6;
+}
+
+body.pf-api-docs .usage-group {
+  margin-top: 10px;
+  padding: 12px 14px;
+  background: var(--pf-card-bg, rgba(30, 41, 59, 0.55));
+  border: 1px solid var(--pf-border, rgba(148, 163, 184, 0.18));
+  border-radius: 12px;
+}
+
+body.pf-api-docs .usage-group h3 {
+  margin: 0 0 0.65rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+}
+
+body.pf-api-docs .usage-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+[data-theme="light"] body.pf-api-docs .usage-group {
+  background: var(--pf-card-bg, #ffffff);
+  border-color: var(--pf-border, rgba(148, 163, 184, 0.45));
+}

--- a/Website/themes/intelligencex/theme.manifest.json
+++ b/Website/themes/intelligencex/theme.manifest.json
@@ -20,7 +20,7 @@
   },
   "featureContracts": {
     "apiDocs": {
-      "requiredPartials": ["api-header", "api-footer"],
+      "requiredPartials": ["api-header", "api-footer", "theme-tokens"],
       "cssHrefs": ["/css/main.css", "/css/api.css"],
       "requiredCssSelectors": [
         ".api-layout",


### PR DESCRIPTION
## Summary
- retarget website workflows to PSPublishModule commit d2f478c85c5141c255554505d5d536c0fd4b8222
- update package-mode sites to PowerForgeWeb-v1.0.0-preview-202604140746
- keep the scope to workflow pins only

## Why
This picks up the merged Magick.NET-Q8-AnyCPU 14.12.0 engine fix from PSPublishModule PR #316 and points the website workflows at the fresh preview release built from that merge.
