### PR TITLE
Enable agent readiness for IntelligenceX website

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -23,8 +23,9 @@ jobs:
       pipeline_config: Website/pipeline.json
       site_output_path: Website/_site
       post_deploy_pipeline_config: Website/pipeline.cloudflare.json
+      engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
+      powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -25,6 +25,7 @@ jobs:
       post_deploy_pipeline_config: Website/pipeline.cloudflare.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_repository: EvotecIT/PSPublishModule
       powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
     secrets:

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -15,5 +15,6 @@ jobs:
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_repository: EvotecIT/PSPublishModule
       powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -13,6 +13,7 @@ jobs:
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
+      engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
+      powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -224,9 +224,19 @@
       "cacheHeadersOut": "_headers"
     },
     {
+      "task": "agent-ready",
+      "id": "agent-ready",
+      "dependsOn": "optimize-site",
+      "skipModes": ["dev"],
+      "operation": "prepare",
+      "config": "./site.json",
+      "siteRoot": "./_site",
+      "failOnFailures": true
+    },
+    {
       "task": "doctor",
       "id": "doctor-site",
-      "dependsOn": "optimize-site",
+      "dependsOn": "agent-ready",
       "skipModes": ["dev"],
       "config": "./site.json",
       "siteRoot": "./_site",

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -231,6 +231,7 @@
       "operation": "prepare",
       "config": "./site.json",
       "siteRoot": "./_site",
+      "output": "./_reports/agent-ready.json",
       "failOnFailures": true
     },
     {

--- a/Website/site.json
+++ b/Website/site.json
@@ -75,6 +75,9 @@
   "Head": {
     "Links": [
       { "Rel": "icon", "Href": "/favicon.svg", "Type": "image/svg+xml" }
+    ],
+    "Meta": [
+      { "Name": "robots", "Content": "index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1" }
     ]
   },
   "Social": {
@@ -112,6 +115,92 @@
     ],
     "OrganizationEmail": "support@evotec.xyz",
     "OrganizationContactUrl": "https://evotec.xyz/docs/getting-started/"
+  },
+  "AgentReadiness": {
+    "Enabled": true,
+    "HeadersPath": "_headers",
+    "LinkHeaders": true,
+    "Robots": true,
+    "SecurityHeaders": {
+      "Enabled": true,
+      "ContentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+    },
+    "ContentSignals": {
+      "Enabled": true,
+      "Search": true,
+      "AiInput": true,
+      "AiTrain": false
+    },
+    "BotRules": [
+      { "UserAgent": "GPTBot", "Allow": "/" },
+      { "UserAgent": "ChatGPT-User", "Allow": "/" },
+      { "UserAgent": "OAI-SearchBot", "Allow": "/" },
+      { "UserAgent": "ClaudeBot", "Allow": "/" },
+      { "UserAgent": "Claude-SearchBot", "Allow": "/" },
+      { "UserAgent": "Claude-User", "Allow": "/" },
+      { "UserAgent": "PerplexityBot", "Allow": "/" },
+      { "UserAgent": "Perplexity-User", "Allow": "/" },
+      { "UserAgent": "Google-Extended", "Allow": "/" },
+      { "UserAgent": "Applebot-Extended", "Allow": "/" },
+      { "UserAgent": "Meta-ExternalAgent", "Allow": "/" },
+      { "UserAgent": "Amazonbot", "Allow": "/" },
+      { "UserAgent": "CCBot", "Allow": "/" }
+    ],
+    "ApiCatalog": {
+      "Enabled": true,
+      "Entries": [
+        {
+          "Anchor": "/api/",
+          "ServiceDesc": "/api/index.json",
+          "ServiceDoc": "/api/",
+          "Title": "IntelligenceX .NET API Reference"
+        },
+        {
+          "Anchor": "/api/powershell/",
+          "ServiceDesc": "/api/powershell/index.json",
+          "ServiceDoc": "/api/powershell/",
+          "Title": "IntelligenceX PowerShell API Reference"
+        }
+      ]
+    },
+    "AgentSkills": {
+      "Enabled": true,
+      "Skills": [
+        {
+          "Name": "intelligencex-site-assistant",
+          "Type": "skill-md",
+          "Description": "Use IntelligenceX documentation, API reference, sitemap, and llms files.",
+          "Content": "---\nname: intelligencex-site-assistant\ndescription: Use IntelligenceX documentation, API reference, sitemap, and llms resources.\n---\n\n# IntelligenceX Site Assistant\n\nUse this skill when answering questions about IntelligenceX.\n\n- Prefer canonical pages from https://intelligencex.dev.\n- Use `/docs/` for product and workflow guidance.\n- Use `/api/` for .NET API reference and `/api/powershell/` for PowerShell cmdlets.\n- Check `/llms.txt`, `/llms.json`, and `/llms-full.txt` when present for agent-readable summaries.\n- Check `/.well-known/api-catalog` before assuming API documentation paths.\n- Respect `/robots.txt` and Content-Signal preferences.\n"
+        }
+      ]
+    },
+    "AgentsJson": {
+      "Enabled": true,
+      "Description": "Agent-facing discovery metadata for IntelligenceX documentation, API reference, and support resources."
+    },
+    "A2AAgentCard": {
+      "Enabled": true,
+      "Name": "IntelligenceX Documentation Discovery",
+      "Description": "Discover IntelligenceX documentation, API reference, llms summaries, sitemap, and project resources.",
+      "Url": "/",
+      "DocumentationUrl": "/docs/",
+      "Skills": [
+        {
+          "Id": "documentation-discovery",
+          "Name": "Documentation discovery",
+          "Description": "Find IntelligenceX product documentation, API reference, release resources, and support pages.",
+          "Tags": ["documentation", "api-reference", "sitemap", "llms"]
+        }
+      ]
+    },
+    "McpServerCard": {
+      "Enabled": false
+    },
+    "OpenApi": {
+      "Enabled": false
+    },
+    "WebMcp": false,
+    "MarkdownNegotiation": true
   },
   "EditLinks": {
     "Enabled": true,

--- a/Website/site.json
+++ b/Website/site.json
@@ -123,7 +123,7 @@
     "Robots": true,
     "SecurityHeaders": {
       "Enabled": true,
-      "ContentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      "ContentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     },
     "ContentSignals": {
       "Enabled": true,


### PR DESCRIPTION
## Summary
- Enable PowerForge AgentReadiness for intelligencex.dev with scanner-facing robots, Content Signals, AI bot rules, security headers, API catalog, Agent Skills, agents.json, and A2A discovery metadata.
- Add meta robots defaults for discoverability.
- Add an agent-ready CI pipeline step after optimize and before doctor, failing the build on readiness failures.

## Validation
- .\build.ps1 -CI -SkipBuildTool
- .\build.ps1 -CI -SkipBuildTool -Only agent-ready
- powerforge-web agent-ready prepare --site-root .\_site --config .\site.json --fail-on-failures --output json

Latest agent-ready check reported: 35 checks, 0 failed, 2 warnings.