### PR TITLE
Add reviewer history and swarm shadow orchestration

### DIFF
--- a/.agents/skills/intelligencex-reviewer-bootstrap/scripts/bootstrap-dry-run.ps1
+++ b/.agents/skills/intelligencex-reviewer-bootstrap/scripts/bootstrap-dry-run.ps1
@@ -155,7 +155,7 @@ if ($Mode -ne "update-secret") {
     if ($workflowContent -notmatch "(?m)^\s*# INTELLIGENCEX:END\s*$") {
         Fail "ERROR: generated workflow missing INTELLIGENCEX:END marker."
     }
-    if ($workflowContent -notmatch "(?m)^\s*uses:\s+(?:\./\.github/workflows/review-intelligencex-reusable\.yml|.+/\.github/workflows/review-intelligencex-reusable\.yml@.+)\s*$") {
+    if ($workflowContent -notmatch "(?m)^\s*uses:\s+(?:\./\.github/workflows/review-intelligencex-(?:core|reusable)\.yml|.+/\.github/workflows/review-intelligencex-(?:core|reusable)\.yml@.+)\s*$") {
         Fail "ERROR: generated workflow missing reusable review workflow reference."
     }
     if ($workflowContent -notmatch "(?m)^\s*if:\s+\$\{\{.+needs-ai-review.+\}\}\s*$") {

--- a/.agents/skills/intelligencex-reviewer-bootstrap/scripts/bootstrap-dry-run.sh
+++ b/.agents/skills/intelligencex-reviewer-bootstrap/scripts/bootstrap-dry-run.sh
@@ -178,7 +178,7 @@ if [[ "$MODE" != "update-secret" ]]; then
     echo "ERROR: generated workflow missing INTELLIGENCEX:END marker." >&2
     exit 1
   fi
-  if ! rg -q '^\s*uses:\s+(?:\./\.github/workflows/review-intelligencex-reusable\.yml|.+/\.github/workflows/review-intelligencex-reusable\.yml@.+)\s*$' "$WORKFLOW_YAML"; then
+  if ! rg -q '^\s*uses:\s+(?:\./\.github/workflows/review-intelligencex-(?:core|reusable)\.yml|.+/\.github/workflows/review-intelligencex-(?:core|reusable)\.yml@.+)\s*$' "$WORKFLOW_YAML"; then
     echo "ERROR: generated workflow missing reusable review workflow reference." >&2
     exit 1
   fi

--- a/.agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.ps1
+++ b/.agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.ps1
@@ -24,7 +24,7 @@ if ($content -notmatch "(?m)^\s*# INTELLIGENCEX:END\s*$") {
 if ($content -notmatch "(?m)^\s*review:\s*$") {
     Fail "ERROR: missing review job in workflow"
 }
-if ($content -notmatch "(?m)^\s*uses:\s+(?:\./\.github/workflows/review-intelligencex-reusable\.yml|.+/\.github/workflows/review-intelligencex-reusable\.yml@.+)\s*$") {
+if ($content -notmatch "(?m)^\s*uses:\s+(?:\./\.github/workflows/review-intelligencex-(?:core|reusable)\.yml|.+/\.github/workflows/review-intelligencex-(?:core|reusable)\.yml@.+)\s*$") {
     Fail "ERROR: missing reusable review workflow reference"
 }
 if ($content -notmatch "(?m)^\s*if:\s+\$\{\{.+needs-ai-review.+\}\}\s*$") {

--- a/.agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.sh
+++ b/.agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.sh
@@ -20,7 +20,7 @@ if ! rg -q '^\s*review:\s*$' "$WORKFLOW_PATH"; then
   echo "ERROR: missing review job in workflow" >&2
   exit 1
 fi
-if ! rg -q '^\s*uses:\s+(?:\./\.github/workflows/review-intelligencex-reusable\.yml|.+/\.github/workflows/review-intelligencex-reusable\.yml@.+)\s*$' "$WORKFLOW_PATH"; then
+if ! rg -q '^\s*uses:\s+(?:\./\.github/workflows/review-intelligencex-(?:core|reusable)\.yml|.+/\.github/workflows/review-intelligencex-(?:core|reusable)\.yml@.+)\s*$' "$WORKFLOW_PATH"; then
   echo "ERROR: missing reusable review workflow reference" >&2
   exit 1
 fi

--- a/.github/workflows/review-intelligencex-core.yml
+++ b/.github/workflows/review-intelligencex-core.yml
@@ -62,6 +62,11 @@ on:
         required: false
         default: ''
         type: string
+      copilot_launcher:
+        description: 'Copilot launcher: binary, gh, or auto'
+        required: false
+        default: ''
+        type: string
       openai_transport:
         description: 'OpenAI transport: native or appserver'
         required: false
@@ -184,6 +189,46 @@ on:
         type: string
       ci_context_classify_infra_failures:
         description: 'Override infra-failure classification for reviewer CI context (true|false)'
+        required: false
+        default: ''
+        type: string
+      history_enabled:
+        description: 'Override reviewer history awareness (true|false) for this run'
+        required: false
+        default: ''
+        type: string
+      history_include_ix_summary_history:
+        description: 'Override inclusion of prior IntelligenceX summary rounds (true|false)'
+        required: false
+        default: ''
+        type: string
+      history_include_review_threads:
+        description: 'Override inclusion of review thread history (true|false)'
+        required: false
+        default: ''
+        type: string
+      history_include_external_bot_summaries:
+        description: 'Override supporting context from configured external bot summaries (true|false)'
+        required: false
+        default: ''
+        type: string
+      history_external_bot_logins:
+        description: 'Override external bot logins included as supporting history context (CSV)'
+        required: false
+        default: ''
+        type: string
+      history_artifacts:
+        description: 'Override reviewer history artifact capture (true|false)'
+        required: false
+        default: ''
+        type: string
+      history_max_rounds:
+        description: 'Override max prior review rounds included in history context'
+        required: false
+        default: ''
+        type: string
+      history_max_items:
+        description: 'Override max findings/comments included per history section'
         required: false
         default: ''
         type: string
@@ -483,6 +528,7 @@ jobs:
       INPUT_MODEL: ${{ inputs.model }}
       INPUT_OPENAI_MODEL: ${{ inputs.openai_model }}
       INPUT_COPILOT_MODEL: ${{ inputs.copilot_model }}
+      INPUT_COPILOT_LAUNCHER: ${{ inputs.copilot_launcher }}
       INPUT_OPENAI_TRANSPORT: ${{ inputs.openai_transport }}
       INPUT_OPENAI_ACCOUNT_ID: ${{ inputs.openai_account_id }}
       INPUT_OPENAI_ACCOUNT_IDS: ${{ inputs.openai_account_ids }}
@@ -510,6 +556,14 @@ jobs:
       INPUT_CI_CONTEXT_MAX_FAILED_RUNS: ${{ inputs.ci_context_max_failed_runs }}
       INPUT_CI_CONTEXT_MAX_SNIPPET_CHARS_PER_RUN: ${{ inputs.ci_context_max_snippet_chars_per_run }}
       INPUT_CI_CONTEXT_CLASSIFY_INFRA_FAILURES: ${{ inputs.ci_context_classify_infra_failures }}
+      INPUT_HISTORY_ENABLED: ${{ inputs.history_enabled }}
+      INPUT_HISTORY_INCLUDE_IX_SUMMARY_HISTORY: ${{ inputs.history_include_ix_summary_history }}
+      INPUT_HISTORY_INCLUDE_REVIEW_THREADS: ${{ inputs.history_include_review_threads }}
+      INPUT_HISTORY_INCLUDE_EXTERNAL_BOT_SUMMARIES: ${{ inputs.history_include_external_bot_summaries }}
+      INPUT_HISTORY_EXTERNAL_BOT_LOGINS: ${{ inputs.history_external_bot_logins }}
+      INPUT_HISTORY_ARTIFACTS: ${{ inputs.history_artifacts }}
+      INPUT_HISTORY_MAX_ROUNDS: ${{ inputs.history_max_rounds }}
+      INPUT_HISTORY_MAX_ITEMS: ${{ inputs.history_max_items }}
       INPUT_SWARM_ENABLED: ${{ inputs.swarm_enabled }}
       INPUT_SWARM_SHADOW_MODE: ${{ inputs.swarm_shadow_mode }}
       INPUT_SWARM_REVIEWERS: ${{ inputs.swarm_reviewers }}

--- a/.github/workflows/review-intelligencex-core.yml
+++ b/.github/workflows/review-intelligencex-core.yml
@@ -741,6 +741,10 @@ jobs:
             echo "Static analysis pre-run skipped: config '$IX_REVIEW_CONFIG_PATH' not found."
             exit 0
           fi
+          if [ ! -f IntelligenceX.Cli/IntelligenceX.Cli.csproj ]; then
+            echo "Static analysis pre-run skipped: IntelligenceX.Cli source project is not available in this checkout."
+            exit 0
+          fi
           dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj -c Release -f net8.0 -p:EnableWindowsTargeting=true -- analyze run --workspace . --config "$IX_REVIEW_CONFIG_PATH"
       - name: Evaluate IntelligenceX analysis gate (pre-review, enforcing)
         shell: bash
@@ -748,6 +752,10 @@ jobs:
           set -euo pipefail
           if [ ! -f "$IX_REVIEW_CONFIG_PATH" ]; then
             echo "Static analysis gate skipped: config '$IX_REVIEW_CONFIG_PATH' not found."
+            exit 0
+          fi
+          if [ ! -f IntelligenceX.Cli/IntelligenceX.Cli.csproj ]; then
+            echo "Static analysis gate skipped: IntelligenceX.Cli source project is not available in this checkout."
             exit 0
           fi
           if [ -s artifacts/changed-files.txt ]; then
@@ -833,6 +841,10 @@ jobs:
           INTELLIGENCEX_GITHUB_TOKEN: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
+          if [ ! -f IntelligenceX.Cli/IntelligenceX.Cli.csproj ]; then
+            echo "Fail-open reviewer summary skipped: IntelligenceX.Cli source project is not available in this checkout."
+            exit 0
+          fi
           dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj -c Release -f net8.0 -- ci review-fail-open-summary \
             --reviewer-source "${{ inputs.reviewer_source }}" \
             --repo "${{ inputs.repo }}" \

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -65,14 +65,6 @@ on:
         description: 'Override reviewer history awareness (true|false)'
         required: false
         default: ''
-      history_include_ix_summary_history:
-        description: 'Include prior IntelligenceX summary rounds in history context (true|false)'
-        required: false
-        default: ''
-      history_include_review_threads:
-        description: 'Include review threads in history context (true|false)'
-        required: false
-        default: ''
       history_include_external_bot_summaries:
         description: 'Include configured external bot summaries as supporting context (true|false)'
         required: false
@@ -83,14 +75,6 @@ on:
         default: ''
       history_artifacts:
         description: 'Write reviewer history artifacts (true|false)'
-        required: false
-        default: ''
-      history_max_rounds:
-        description: 'Max prior review rounds included in history context'
-        required: false
-        default: ''
-      history_max_items:
-        description: 'Max findings/comments included per history section'
         required: false
         default: ''
       swarm_enabled:
@@ -107,10 +91,6 @@ on:
         default: ''
       swarm_max_parallel:
         description: 'Override reviewer swarm max parallel reviewers'
-        required: false
-        default: ''
-      swarm_publish_subreviews:
-        description: 'Override sub-review publishing (true|false); recommended false'
         required: false
         default: ''
       swarm_aggregator_model:

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -25,6 +25,14 @@ on:
         description: 'Optional OpenAI model override for manual runs'
         required: false
         default: ''
+      copilot_model:
+        description: 'Optional Copilot model override for manual runs'
+        required: false
+        default: ''
+      copilot_launcher:
+        description: 'Copilot launcher override for manual runs (binary, gh, auto)'
+        required: false
+        default: ''
       openai_account_id:
         description: 'Override OpenAI account id for this run'
         required: false
@@ -53,6 +61,70 @@ on:
         description: 'Override weekly-limit budget allowance (true|false) for this run'
         required: false
         default: ''
+      history_enabled:
+        description: 'Override reviewer history awareness (true|false)'
+        required: false
+        default: ''
+      history_include_ix_summary_history:
+        description: 'Include prior IntelligenceX summary rounds in history context (true|false)'
+        required: false
+        default: ''
+      history_include_review_threads:
+        description: 'Include review threads in history context (true|false)'
+        required: false
+        default: ''
+      history_include_external_bot_summaries:
+        description: 'Include configured external bot summaries as supporting context (true|false)'
+        required: false
+        default: ''
+      history_external_bot_logins:
+        description: 'External bot logins included as supporting history context (CSV)'
+        required: false
+        default: ''
+      history_artifacts:
+        description: 'Write reviewer history artifacts (true|false)'
+        required: false
+        default: ''
+      history_max_rounds:
+        description: 'Max prior review rounds included in history context'
+        required: false
+        default: ''
+      history_max_items:
+        description: 'Max findings/comments included per history section'
+        required: false
+        default: ''
+      swarm_enabled:
+        description: 'Override reviewer swarm mode (true|false)'
+        required: false
+        default: ''
+      swarm_shadow_mode:
+        description: 'Override reviewer swarm shadow mode (true|false)'
+        required: false
+        default: ''
+      swarm_reviewers:
+        description: 'Override reviewer swarm roles (CSV or JSON)'
+        required: false
+        default: ''
+      swarm_max_parallel:
+        description: 'Override reviewer swarm max parallel reviewers'
+        required: false
+        default: ''
+      swarm_publish_subreviews:
+        description: 'Override sub-review publishing (true|false); recommended false'
+        required: false
+        default: ''
+      swarm_aggregator_model:
+        description: 'Override reviewer swarm aggregator model'
+        required: false
+        default: ''
+      swarm_fail_open_on_partial:
+        description: 'Override swarm partial-failure fail-open behavior (true|false)'
+        required: false
+        default: ''
+      swarm_metrics:
+        description: 'Override swarm metrics/artifact capture (true|false)'
+        required: false
+        default: ''
 
 jobs:
   # INTELLIGENCEX:BEGIN
@@ -77,6 +149,8 @@ jobs:
       provider: ${{ inputs.provider || vars.IX_REVIEW_PROVIDER || 'openai' }}
       model: ${{ inputs.model || vars.IX_REVIEW_MODEL || 'gpt-5.4' }}
       openai_model: ${{ inputs.openai_model }}
+      copilot_model: ${{ inputs.copilot_model }}
+      copilot_launcher: ${{ inputs.copilot_launcher }}
       openai_transport: native
       openai_account_id: ${{ inputs.openai_account_id }}
       openai_account_ids: ${{ inputs.openai_account_ids }}
@@ -85,6 +159,22 @@ jobs:
       usage_budget_guard: ${{ inputs.usage_budget_guard }}
       usage_budget_allow_credits: ${{ inputs.usage_budget_allow_credits }}
       usage_budget_allow_weekly_limit: ${{ inputs.usage_budget_allow_weekly_limit }}
+      history_enabled: ${{ inputs.history_enabled }}
+      history_include_ix_summary_history: ${{ inputs.history_include_ix_summary_history }}
+      history_include_review_threads: ${{ inputs.history_include_review_threads }}
+      history_include_external_bot_summaries: ${{ inputs.history_include_external_bot_summaries }}
+      history_external_bot_logins: ${{ inputs.history_external_bot_logins }}
+      history_artifacts: ${{ inputs.history_artifacts }}
+      history_max_rounds: ${{ inputs.history_max_rounds }}
+      history_max_items: ${{ inputs.history_max_items }}
+      swarm_enabled: ${{ inputs.swarm_enabled }}
+      swarm_shadow_mode: ${{ inputs.swarm_shadow_mode }}
+      swarm_reviewers: ${{ inputs.swarm_reviewers }}
+      swarm_max_parallel: ${{ inputs.swarm_max_parallel }}
+      swarm_publish_subreviews: ${{ inputs.swarm_publish_subreviews }}
+      swarm_aggregator_model: ${{ inputs.swarm_aggregator_model }}
+      swarm_fail_open_on_partial: ${{ inputs.swarm_fail_open_on_partial }}
+      swarm_metrics: ${{ inputs.swarm_metrics }}
       review_config_path: .intelligencex/reviewer.json
       mode: hybrid
       length: medium

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -239,6 +239,9 @@ GitHub Actions input/env aliases:
 ## Swarm review shadow mode (optional)
 
 Use this to opt into multi-reviewer orchestration without changing the public reviewer comment yet.
+In shadow mode, the normal single-review path still produces the public PR comment; selected swarm reviewers and a
+diagnostic aggregator run after the primary review succeeds, and diagnostics can log the shadow results for rollout
+comparison.
 
 All swarm settings are optional and default to off unless you explicitly enable them.
 
@@ -248,10 +251,18 @@ All swarm settings are optional and default to off unless you explicitly enable 
     "swarm": {
       "enabled": true,
       "shadowMode": true,
-      "reviewers": ["correctness", "security", "reliability", "tests"],
+      "reviewers": [
+        "correctness",
+        { "id": "tests", "provider": "copilot", "model": "gpt-5.2" }
+      ],
       "maxParallel": 4,
       "publishSubreviews": false,
       "aggregatorModel": "gpt-5.4",
+      "aggregator": {
+        "provider": "openai",
+        "model": "gpt-5.4",
+        "reasoningEffort": "high"
+      },
       "failOpenOnPartial": true,
       "metrics": true
     }
@@ -262,6 +273,9 @@ All swarm settings are optional and default to off unless you explicitly enable 
 Recommended rollout:
 - enable `shadowMode` first
 - keep `publishSubreviews: false`
+- keep `diagnostics: true` during rollout if you want the resolved plan and shadow result summary in logs
+- keep `metrics: true` if you want diagnostic JSON/Markdown artifacts plus append-only metrics JSONL under `artifacts/reviewer/swarm-shadow/`
+- tune `maxParallel` to control how many independent reviewer lanes execute at once
 - compare cost, latency, and finding quality before enabling public swarm output
 
 GitHub Actions input/env aliases:
@@ -517,6 +531,42 @@ Setup review-policy option constraints:
 }
 ```
 
+## Review history snapshot (repeat-review context)
+
+Use this to feed a compact normalized history block into the review prompt instead of relying only on raw prior-summary prose.
+
+```json
+{
+  "review": {
+    "history": {
+      "enabled": true,
+      "includeIxSummaryHistory": true,
+      "includeReviewThreads": true,
+      "includeExternalBotSummaries": false,
+      "externalBotLogins": ["claude", "copilot-pull-request-reviewer"],
+      "artifacts": true,
+      "maxRounds": 6,
+      "maxItems": 8
+    }
+  }
+}
+```
+
+Recommended first use:
+- enable this when you want repeat reviewer runs to understand prior IX sticky-summary blockers and current thread state
+- leave `includeExternalBotSummaries` off unless you explicitly want bounded Claude/Copilot bot summary excerpts as supporting context
+- keep `summaryStability: true` enabled as well if you want same-SHA wording to stay stable across reruns
+
+GitHub Actions input/env aliases:
+- `history_enabled` / `REVIEW_HISTORY_ENABLED`
+- `history_include_ix_summary_history` / `REVIEW_HISTORY_INCLUDE_IX_SUMMARY_HISTORY`
+- `history_include_review_threads` / `REVIEW_HISTORY_INCLUDE_REVIEW_THREADS`
+- `history_include_external_bot_summaries` / `REVIEW_HISTORY_INCLUDE_EXTERNAL_BOT_SUMMARIES`
+- `history_external_bot_logins` / `REVIEW_HISTORY_EXTERNAL_BOT_LOGINS`
+- `history_artifacts` / `REVIEW_HISTORY_ARTIFACTS`
+- `history_max_rounds` / `REVIEW_HISTORY_MAX_ROUNDS`
+- `history_max_items` / `REVIEW_HISTORY_MAX_ITEMS`
+
 ## Redaction (secrets)
 
 When `redactPii` is enabled, the reviewer applies default redaction patterns for common secrets
@@ -611,6 +661,9 @@ GitHub Actions input/env aliases:
 Use this to forward selected environment variables into the Copilot CLI process without committing secrets.
 By default the CLI process **does** inherit the runner environment. Set `inheritEnvironment` to `false` and use
 `envAllowlist`/`env` to pass only what the CLI needs when you want a strict environment.
+Set `launcher` to `gh` to run Copilot through `gh copilot --`, which can use the GitHub CLI wrapper/downloader path
+when the standalone `copilot` binary is not already present. Set `launcher` to `auto` to use the standalone binary
+when it is on `PATH`, otherwise fall back to `gh copilot --`.
 
 ```json
 {
@@ -618,6 +671,7 @@ By default the CLI process **does** inherit the runner environment. Set `inherit
     "provider": "copilot"
   },
   "copilot": {
+    "launcher": "gh",
     "inheritEnvironment": false,
     "envAllowlist": ["GH_TOKEN", "GITHUB_TOKEN"]
   }
@@ -694,13 +748,22 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `failOpenTransientOnly`: when true, fail-open only on transient errors
   The bundled GitHub workflow exports `REVIEW_FAIL_OPEN=true` and `REVIEW_FAIL_OPEN_TRANSIENT_ONLY=false` so provider auth/runtime failures leave a summary comment instead of blocking CI.
 - `summaryStability`: reuse the previous summary (same commit) as prompt context to avoid noisy rewrites
+- `history.enabled`: include a compact repeat-review history snapshot in the prompt
+- `history.includeIxSummaryHistory`: include the prior IX sticky summary as normalized state
+- `history.includeReviewThreads`: include review thread state/counts in the history snapshot
+- `history.includeExternalBotSummaries`: include bounded external bot summary excerpts as supporting context only
+- `history.externalBotLogins`: external bot authors allowed when `includeExternalBotSummaries` is enabled
+- `history.artifacts`: emit bounded JSON/Markdown history artifacts under `artifacts/reviewer/history/`
+- `history.maxRounds`: cap how many prior owned IX summary rounds are folded into history
+- `history.maxItems`: cap normalized history items and thread excerpts
 - `structuredFindings`: emit a structured findings JSON block for automation
 - `swarm.enabled`: opt into swarm review orchestration (default off)
 - `swarm.shadowMode`: run swarm internally without replacing the public review output
-- `swarm.reviewers`: selected swarm reviewer roles
+- `swarm.reviewers`: selected swarm reviewer roles, either as ids or reviewer objects with provider/model overrides
 - `swarm.maxParallel`: swarm concurrency cap
 - `swarm.publishSubreviews`: whether sub-review outputs can be published directly (recommended false)
-- `swarm.aggregatorModel`: optional model override for the swarm aggregator pass
+- `swarm.aggregatorModel`: optional compatibility alias for the swarm aggregator model
+- `swarm.aggregator`: optional structured aggregator definition with provider/model/reasoningEffort
 - `swarm.failOpenOnPartial`: allow swarm aggregation to proceed when one sub-reviewer fails
 - `swarm.metrics`: emit swarm metrics/artifacts for comparison and rollout evaluation
 - `skipPaths`: if **all** changed files in a PR match these globs, skip reviewing the entire PR
@@ -724,6 +787,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `azureTokenEnv`: env var name that contains the ADO token (default `SYSTEM_ACCESSTOKEN` if set)
 - `azureAuthScheme`: `bearer` (System.AccessToken/JWT) or `basic`/`pat`
 - `copilot.transport`: `cli` or `direct` (aliases: `api`, `http`)
+- `copilot.launcher`: `binary`, `gh`, or `auto`; `gh` executes `gh copilot --` before the reviewer server flags
 - `copilot.inheritEnvironment`: inherit full runner environment for Copilot CLI (`true` by default)
 
 **Path filter order of operations**

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -661,9 +661,9 @@ GitHub Actions input/env aliases:
 Use this to forward selected environment variables into the Copilot CLI process without committing secrets.
 By default the CLI process **does** inherit the runner environment. Set `inheritEnvironment` to `false` and use
 `envAllowlist`/`env` to pass only what the CLI needs when you want a strict environment.
-Set `launcher` to `gh` to run Copilot through `gh copilot --`, which can use the GitHub CLI wrapper/downloader path
-when the standalone `copilot` binary is not already present. Set `launcher` to `auto` to use the standalone binary
-when it is on `PATH`, otherwise fall back to `gh copilot --`.
+Set `launcher` to `gh` to run Copilot through `gh copilot --` when that wrapper can already launch the Copilot CLI.
+Set `launcher` to `auto` to use the standalone binary when it is on `PATH` and only fall back to `gh copilot --`
+after a wrapper capability probe succeeds. This avoids assuming GitHub CLI can bootstrap Copilot on every runner.
 
 ```json
 {

--- a/IntelligenceX.Cli/Templates/review-intelligencex.managed.explicit.yml
+++ b/IntelligenceX.Cli/Templates/review-intelligencex.managed.explicit.yml
@@ -22,6 +22,8 @@ review:
     provider: {{Provider}}
     model: {{Model}}
     openai_model: ${{ inputs.openai_model }}
+    copilot_model: ${{ inputs.copilot_model }}
+    copilot_launcher: ${{ inputs.copilot_launcher }}
     openai_transport: {{OpenAITransport}}
     openai_account_id: ${{ inputs.openai_account_id }}
     openai_account_ids: ${{ inputs.openai_account_ids }}
@@ -30,6 +32,22 @@ review:
     usage_budget_guard: ${{ inputs.usage_budget_guard }}
     usage_budget_allow_credits: ${{ inputs.usage_budget_allow_credits }}
     usage_budget_allow_weekly_limit: ${{ inputs.usage_budget_allow_weekly_limit }}
+    history_enabled: ${{ inputs.history_enabled }}
+    history_include_ix_summary_history: ${{ inputs.history_include_ix_summary_history }}
+    history_include_review_threads: ${{ inputs.history_include_review_threads }}
+    history_include_external_bot_summaries: ${{ inputs.history_include_external_bot_summaries }}
+    history_external_bot_logins: ${{ inputs.history_external_bot_logins }}
+    history_artifacts: ${{ inputs.history_artifacts }}
+    history_max_rounds: ${{ inputs.history_max_rounds }}
+    history_max_items: ${{ inputs.history_max_items }}
+    swarm_enabled: ${{ inputs.swarm_enabled }}
+    swarm_shadow_mode: ${{ inputs.swarm_shadow_mode }}
+    swarm_reviewers: ${{ inputs.swarm_reviewers }}
+    swarm_max_parallel: ${{ inputs.swarm_max_parallel }}
+    swarm_publish_subreviews: ${{ inputs.swarm_publish_subreviews }}
+    swarm_aggregator_model: ${{ inputs.swarm_aggregator_model }}
+    swarm_fail_open_on_partial: ${{ inputs.swarm_fail_open_on_partial }}
+    swarm_metrics: ${{ inputs.swarm_metrics }}
     include_issue_comments: {{IncludeIssueComments}}
     include_review_comments: {{IncludeReviewComments}}
     include_related_prs: {{IncludeRelatedPullRequests}}

--- a/IntelligenceX.Cli/Templates/review-intelligencex.managed.yml
+++ b/IntelligenceX.Cli/Templates/review-intelligencex.managed.yml
@@ -22,6 +22,8 @@ review:
     provider: {{Provider}}
     model: {{Model}}
     openai_model: ${{ inputs.openai_model }}
+    copilot_model: ${{ inputs.copilot_model }}
+    copilot_launcher: ${{ inputs.copilot_launcher }}
     openai_transport: {{OpenAITransport}}
     openai_account_id: ${{ inputs.openai_account_id }}
     openai_account_ids: ${{ inputs.openai_account_ids }}
@@ -30,6 +32,22 @@ review:
     usage_budget_guard: ${{ inputs.usage_budget_guard }}
     usage_budget_allow_credits: ${{ inputs.usage_budget_allow_credits }}
     usage_budget_allow_weekly_limit: ${{ inputs.usage_budget_allow_weekly_limit }}
+    history_enabled: ${{ inputs.history_enabled }}
+    history_include_ix_summary_history: ${{ inputs.history_include_ix_summary_history }}
+    history_include_review_threads: ${{ inputs.history_include_review_threads }}
+    history_include_external_bot_summaries: ${{ inputs.history_include_external_bot_summaries }}
+    history_external_bot_logins: ${{ inputs.history_external_bot_logins }}
+    history_artifacts: ${{ inputs.history_artifacts }}
+    history_max_rounds: ${{ inputs.history_max_rounds }}
+    history_max_items: ${{ inputs.history_max_items }}
+    swarm_enabled: ${{ inputs.swarm_enabled }}
+    swarm_shadow_mode: ${{ inputs.swarm_shadow_mode }}
+    swarm_reviewers: ${{ inputs.swarm_reviewers }}
+    swarm_max_parallel: ${{ inputs.swarm_max_parallel }}
+    swarm_publish_subreviews: ${{ inputs.swarm_publish_subreviews }}
+    swarm_aggregator_model: ${{ inputs.swarm_aggregator_model }}
+    swarm_fail_open_on_partial: ${{ inputs.swarm_fail_open_on_partial }}
+    swarm_metrics: ${{ inputs.swarm_metrics }}
     include_issue_comments: {{IncludeIssueComments}}
     include_review_comments: {{IncludeReviewComments}}
     include_related_prs: {{IncludeRelatedPullRequests}}

--- a/IntelligenceX.Cli/Templates/review-intelligencex.yml
+++ b/IntelligenceX.Cli/Templates/review-intelligencex.yml
@@ -65,14 +65,6 @@ on:
         description: 'Override reviewer history awareness (true|false)'
         required: false
         default: ''
-      history_include_ix_summary_history:
-        description: 'Include prior IntelligenceX summary rounds in history context (true|false)'
-        required: false
-        default: ''
-      history_include_review_threads:
-        description: 'Include review threads in history context (true|false)'
-        required: false
-        default: ''
       history_include_external_bot_summaries:
         description: 'Include configured external bot summaries as supporting context (true|false)'
         required: false
@@ -83,14 +75,6 @@ on:
         default: ''
       history_artifacts:
         description: 'Write reviewer history artifacts (true|false)'
-        required: false
-        default: ''
-      history_max_rounds:
-        description: 'Max prior review rounds included in history context'
-        required: false
-        default: ''
-      history_max_items:
-        description: 'Max findings/comments included per history section'
         required: false
         default: ''
       swarm_enabled:
@@ -107,10 +91,6 @@ on:
         default: ''
       swarm_max_parallel:
         description: 'Override reviewer swarm max parallel reviewers'
-        required: false
-        default: ''
-      swarm_publish_subreviews:
-        description: 'Override sub-review publishing (true|false); recommended false'
         required: false
         default: ''
       swarm_aggregator_model:

--- a/IntelligenceX.Cli/Templates/review-intelligencex.yml
+++ b/IntelligenceX.Cli/Templates/review-intelligencex.yml
@@ -25,6 +25,14 @@ on:
         description: 'Optional OpenAI model override for manual runs'
         required: false
         default: ''
+      copilot_model:
+        description: 'Optional Copilot model override for manual runs'
+        required: false
+        default: ''
+      copilot_launcher:
+        description: 'Copilot launcher override for manual runs (binary, gh, auto)'
+        required: false
+        default: ''
       openai_account_id:
         description: 'Override OpenAI account id for this run'
         required: false
@@ -51,6 +59,70 @@ on:
         default: ''
       usage_budget_allow_weekly_limit:
         description: 'Override weekly-limit budget allowance (true|false) for this run'
+        required: false
+        default: ''
+      history_enabled:
+        description: 'Override reviewer history awareness (true|false)'
+        required: false
+        default: ''
+      history_include_ix_summary_history:
+        description: 'Include prior IntelligenceX summary rounds in history context (true|false)'
+        required: false
+        default: ''
+      history_include_review_threads:
+        description: 'Include review threads in history context (true|false)'
+        required: false
+        default: ''
+      history_include_external_bot_summaries:
+        description: 'Include configured external bot summaries as supporting context (true|false)'
+        required: false
+        default: ''
+      history_external_bot_logins:
+        description: 'External bot logins included as supporting history context (CSV)'
+        required: false
+        default: ''
+      history_artifacts:
+        description: 'Write reviewer history artifacts (true|false)'
+        required: false
+        default: ''
+      history_max_rounds:
+        description: 'Max prior review rounds included in history context'
+        required: false
+        default: ''
+      history_max_items:
+        description: 'Max findings/comments included per history section'
+        required: false
+        default: ''
+      swarm_enabled:
+        description: 'Override reviewer swarm mode (true|false)'
+        required: false
+        default: ''
+      swarm_shadow_mode:
+        description: 'Override reviewer swarm shadow mode (true|false)'
+        required: false
+        default: ''
+      swarm_reviewers:
+        description: 'Override reviewer swarm roles (CSV or JSON)'
+        required: false
+        default: ''
+      swarm_max_parallel:
+        description: 'Override reviewer swarm max parallel reviewers'
+        required: false
+        default: ''
+      swarm_publish_subreviews:
+        description: 'Override sub-review publishing (true|false); recommended false'
+        required: false
+        default: ''
+      swarm_aggregator_model:
+        description: 'Override reviewer swarm aggregator model'
+        required: false
+        default: ''
+      swarm_fail_open_on_partial:
+        description: 'Override swarm partial-failure fail-open behavior (true|false)'
+        required: false
+        default: ''
+      swarm_metrics:
+        description: 'Override swarm metrics/artifact capture (true|false)'
         required: false
         default: ''
 

--- a/IntelligenceX.Reviewer/PromptBuilder.cs
+++ b/IntelligenceX.Reviewer/PromptBuilder.cs
@@ -52,6 +52,7 @@ internal static class PromptBuilder {
             ["Title"] = context.Title ?? string.Empty,
             ["Body"] = string.IsNullOrWhiteSpace(context.Body) ? "<no description>" : context.Body,
             ["Files"] = BuildFilesBlock(files),
+            ["ReviewHistorySection"] = extras?.ReviewHistorySection ?? string.Empty,
             ["CiContextSection"] = extras?.CiContextSection ?? string.Empty,
             ["IssueCommentsSection"] = extras?.IssueCommentsSection ?? string.Empty,
             ["ReviewCommentsSection"] = extras?.ReviewCommentsSection ?? string.Empty,

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -65,6 +65,7 @@ internal static class ReviewConfigLoader {
         ApplyCommentMode(reviewObj, settings);
         ApplyLength(reviewObj, settings);
         ApplyContext(reviewObj, settings);
+        ApplyHistory(reviewObj, settings);
         ApplyCiContext(reviewObj, settings);
         ApplySwarm(reviewObj, settings);
         ApplyCodex(root, settings);
@@ -365,6 +366,28 @@ internal static class ReviewConfigLoader {
             ReadBool(ciContext, "classifyInfraFailures", settings.CiContext.ClassifyInfraFailures);
     }
 
+    private static void ApplyHistory(JsonObject reviewObj, ReviewSettings settings) {
+        var history = reviewObj.GetObject("history");
+        if (history is null) {
+            return;
+        }
+
+        settings.History.Enabled = ReadBool(history, "enabled", settings.History.Enabled);
+        settings.History.IncludeIxSummaryHistory =
+            ReadBool(history, "includeIxSummaryHistory", settings.History.IncludeIxSummaryHistory);
+        settings.History.IncludeReviewThreads =
+            ReadBool(history, "includeReviewThreads", settings.History.IncludeReviewThreads);
+        settings.History.IncludeExternalBotSummaries =
+            ReadBool(history, "includeExternalBotSummaries", settings.History.IncludeExternalBotSummaries);
+        var externalBotLogins = ReadStringList(history, "externalBotLogins");
+        if (externalBotLogins is not null) {
+            settings.History.ExternalBotLogins = externalBotLogins;
+        }
+        settings.History.Artifacts = ReadBool(history, "artifacts", settings.History.Artifacts);
+        settings.History.MaxRounds = Math.Max(0, ReadNonNegativeInt(history, "maxRounds", settings.History.MaxRounds));
+        settings.History.MaxItems = Math.Max(0, ReadNonNegativeInt(history, "maxItems", settings.History.MaxItems));
+    }
+
     private static void ApplySwarm(JsonObject reviewObj, ReviewSettings settings) {
         var swarm = reviewObj.GetObject("swarm");
         if (swarm is null) {
@@ -373,17 +396,104 @@ internal static class ReviewConfigLoader {
 
         settings.Swarm.Enabled = ReadBool(swarm, "enabled", settings.Swarm.Enabled);
         settings.Swarm.ShadowMode = ReadBool(swarm, "shadowMode", settings.Swarm.ShadowMode);
-        var reviewers = ReadStringList(swarm, "reviewers");
-        if (reviewers is not null) {
-            settings.Swarm.Reviewers = ReviewSettings.NormalizeSwarmReviewers(reviewers, settings.Swarm.Reviewers);
-        }
+        ApplySwarmReviewers(swarm, settings);
         settings.Swarm.MaxParallel = Math.Max(1, ReadInt(swarm, "maxParallel", settings.Swarm.MaxParallel));
         settings.Swarm.PublishSubreviews =
             ReadBool(swarm, "publishSubreviews", settings.Swarm.PublishSubreviews);
         settings.Swarm.AggregatorModel = swarm.GetString("aggregatorModel") ?? settings.Swarm.AggregatorModel;
+        if (!string.IsNullOrWhiteSpace(settings.Swarm.AggregatorModel)) {
+            settings.Swarm.Aggregator.Model = settings.Swarm.AggregatorModel;
+        }
+        ApplySwarmAggregator(swarm, settings);
         settings.Swarm.FailOpenOnPartial =
             ReadBool(swarm, "failOpenOnPartial", settings.Swarm.FailOpenOnPartial);
         settings.Swarm.Metrics = ReadBool(swarm, "metrics", settings.Swarm.Metrics);
+    }
+
+    private static void ApplySwarmReviewers(JsonObject swarm, ReviewSettings settings) {
+        if (!swarm.TryGetValue("reviewers", out var reviewersValue) || reviewersValue is null) {
+            return;
+        }
+
+        var reviewersArray = reviewersValue.AsArray();
+        if (reviewersArray is null) {
+            return;
+        }
+
+        var reviewerIds = new List<string>();
+        var reviewerSettings = new List<ReviewSwarmReviewerSettings>();
+        foreach (var item in reviewersArray) {
+            var stringValue = item.AsString();
+            if (!string.IsNullOrWhiteSpace(stringValue)) {
+                reviewerIds.Add(stringValue!);
+                reviewerSettings.Add(new ReviewSwarmReviewerSettings {
+                    Id = stringValue!.Trim()
+                });
+                continue;
+            }
+
+            var obj = item.AsObject();
+            if (obj is null) {
+                continue;
+            }
+
+            var reviewer = ParseSwarmReviewerObject(obj);
+            if (reviewer is null) {
+                continue;
+            }
+
+            reviewerIds.Add(reviewer.Id);
+            reviewerSettings.Add(reviewer);
+        }
+
+        settings.Swarm.Reviewers = ReviewSettings.NormalizeSwarmReviewers(reviewerIds, settings.Swarm.Reviewers);
+        settings.Swarm.ReviewerSettings =
+            ReviewSettings.NormalizeSwarmReviewerSettings(reviewerSettings, settings.Swarm.ReviewerSettings);
+    }
+
+    private static ReviewSwarmReviewerSettings? ParseSwarmReviewerObject(JsonObject obj) {
+        var id = obj.GetString("id");
+        if (string.IsNullOrWhiteSpace(id)) {
+            return null;
+        }
+
+        return new ReviewSwarmReviewerSettings {
+            Id = id!,
+            Provider = ParseOptionalSwarmProvider(obj.GetString("provider")),
+            Model = obj.GetString("model"),
+            ReasoningEffort = ParseOptionalReasoningEffort(obj.GetString("reasoningEffort"))
+        };
+    }
+
+    private static void ApplySwarmAggregator(JsonObject swarm, ReviewSettings settings) {
+        var aggregator = swarm.GetObject("aggregator");
+        if (aggregator is null) {
+            return;
+        }
+
+        settings.Swarm.Aggregator.Provider =
+            ParseOptionalSwarmProvider(aggregator.GetString("provider")) ?? settings.Swarm.Aggregator.Provider;
+        settings.Swarm.Aggregator.Model = aggregator.GetString("model") ?? settings.Swarm.Aggregator.Model;
+        settings.Swarm.Aggregator.ReasoningEffort =
+            ParseOptionalReasoningEffort(aggregator.GetString("reasoningEffort")) ?? settings.Swarm.Aggregator.ReasoningEffort;
+        if (!string.IsNullOrWhiteSpace(settings.Swarm.Aggregator.Model)) {
+            settings.Swarm.AggregatorModel = settings.Swarm.Aggregator.Model;
+        }
+    }
+
+    private static ReviewProvider? ParseOptionalSwarmProvider(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+        return ReviewProviderContracts.ParseProviderOrThrow(value, "review.swarm.provider");
+    }
+
+    private static IntelligenceX.OpenAI.Chat.ReasoningEffort? ParseOptionalReasoningEffort(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        return IntelligenceX.OpenAI.Chat.ChatEnumParser.ParseReasoningEffort(value);
     }
 
     private static void ApplyCodex(JsonObject root, ReviewSettings settings) {
@@ -432,6 +542,8 @@ internal static class ReviewConfigLoader {
         settings.CopilotCliPath = copilot.GetString("cliPath") ?? settings.CopilotCliPath;
         settings.CopilotCliUrl = copilot.GetString("cliUrl") ?? settings.CopilotCliUrl;
         settings.CopilotWorkingDirectory = copilot.GetString("workingDirectory") ?? settings.CopilotWorkingDirectory;
+        settings.CopilotLauncher = ReviewSettings.NormalizeCopilotLauncher(copilot.GetString("launcher"),
+            settings.CopilotLauncher);
         settings.CopilotAutoInstall = ReadBool(copilot, "autoInstall", settings.CopilotAutoInstall);
         settings.CopilotAutoInstallMethod = copilot.GetString("autoInstallMethod") ?? settings.CopilotAutoInstallMethod;
         settings.CopilotAutoInstallPrerelease = ReadBool(copilot, "autoInstallPrerelease", settings.CopilotAutoInstallPrerelease);

--- a/IntelligenceX.Reviewer/ReviewContextExtras.cs
+++ b/IntelligenceX.Reviewer/ReviewContextExtras.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 namespace IntelligenceX.Reviewer;
 
 internal sealed class ReviewContextExtras {
+    public IReadOnlyList<IssueComment> IssueComments { get; set; } = new List<IssueComment>();
+    public ReviewHistorySnapshot ReviewHistory { get; set; } = new();
+    public string ReviewHistorySection { get; set; } = string.Empty;
     public string CiContextSection { get; set; } = string.Empty;
     public string IssueCommentsSection { get; set; } = string.Empty;
     public string ReviewCommentsSection { get; set; } = string.Empty;

--- a/IntelligenceX.Reviewer/ReviewFormatter.cs
+++ b/IntelligenceX.Reviewer/ReviewFormatter.cs
@@ -14,6 +14,7 @@ internal static class ReviewFormatter {
     private static readonly string[] SectionLabels = {
         "Summary 📝",
         "Review Summary 📝",
+        "History Progress 🔁",
         "Todo List ✅",
         "Critical Issues ⚠️ (if any)",
         "Critical Issues ⚠️",
@@ -32,7 +33,8 @@ internal static class ReviewFormatter {
     };
 
     public static string BuildComment(PullRequestContext context, string reviewBody, ReviewSettings settings, bool inlineSupported,
-        bool inlineSuppressed, string? autoResolveNote, string? budgetNote, string? usageLine, string? findingsBlock) {
+        bool inlineSuppressed, string? autoResolveNote, string? budgetNote, string? usageLine, string? findingsBlock,
+        string? historyBlock = null) {
         var inlineNote = string.Empty;
         if (!inlineSupported && settings.Mode != "summary") {
             inlineNote = "> Inline comments are not enabled yet; posting summary only.\n";
@@ -49,6 +51,9 @@ internal static class ReviewFormatter {
         var body = string.IsNullOrWhiteSpace(reviewBody)
             ? "_No review content was produced._"
             : NormalizeSectionLayout(reviewBody.TrimEnd());
+        if (!string.IsNullOrWhiteSpace(historyBlock)) {
+            body = NormalizeSectionLayout($"{historyBlock.Trim()}\n\n{body}");
+        }
 
         var template = ResolveSummaryTemplate(settings);
         var reasoningParts = new List<string>();

--- a/IntelligenceX.Reviewer/ReviewHistoryArtifacts.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryArtifacts.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IntelligenceX.Reviewer;
+
+internal static class ReviewHistoryArtifacts {
+    private const int MaxTextChars = 2000;
+    private const string ArtifactDirectory = "artifacts/reviewer/history";
+    private const string JsonFileName = "ix-review-history.json";
+    private const string MarkdownFileName = "ix-review-history.md";
+
+    public static async Task WriteAsync(PullRequestContext context, ReviewSettings settings,
+        ReviewHistorySnapshot snapshot, string renderedPromptSection, CancellationToken cancellationToken) {
+        if (!settings.History.Enabled || !settings.History.Artifacts || !snapshot.HasContent) {
+            return;
+        }
+
+        Directory.CreateDirectory(ArtifactDirectory);
+        var jsonPath = Path.Combine(ArtifactDirectory, JsonFileName);
+        var markdownPath = Path.Combine(ArtifactDirectory, MarkdownFileName);
+        await File.WriteAllTextAsync(jsonPath, BuildJson(context, snapshot, renderedPromptSection), cancellationToken)
+            .ConfigureAwait(false);
+        await File.WriteAllTextAsync(markdownPath, BuildMarkdown(context, snapshot, renderedPromptSection),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    internal static string BuildJson(PullRequestContext context, ReviewHistorySnapshot snapshot,
+        string renderedPromptSection) {
+        var payload = new {
+            schema = "intelligencex.review.history.v1",
+            generatedAtUtc = DateTimeOffset.UtcNow,
+            repository = context.RepoFullName,
+            pullRequest = context.Number,
+            headSha = context.HeadSha,
+            currentHeadSha = snapshot.CurrentHeadSha,
+            summary = new {
+                rounds = snapshot.Rounds.Count,
+                openFindings = snapshot.OpenFindings.Count,
+                resolvedSinceLastRound = snapshot.ResolvedSinceLastRound.Count,
+                externalSummaries = snapshot.ExternalSummaries.Count,
+                activeThreads = snapshot.ThreadSnapshot?.ActiveCount ?? 0,
+                staleThreads = snapshot.ThreadSnapshot?.StaleCount ?? 0,
+                resolvedThreads = snapshot.ThreadSnapshot?.ResolvedCount ?? 0
+            },
+            rounds = BuildRoundItems(snapshot.Rounds),
+            openFindings = BuildFindingItems(snapshot.OpenFindings),
+            resolvedSinceLastRound = BuildFindingItems(snapshot.ResolvedSinceLastRound),
+            externalSummaries = BuildExternalSummaryItems(snapshot.ExternalSummaries),
+            threadSnapshot = BuildThreadSnapshotItem(snapshot.ThreadSnapshot),
+            renderedPromptSection = TrimText(renderedPromptSection)
+        };
+
+        return JsonSerializer.Serialize(payload, new JsonSerializerOptions {
+            WriteIndented = true
+        });
+    }
+
+    internal static string BuildMarkdown(PullRequestContext context, ReviewHistorySnapshot snapshot,
+        string renderedPromptSection) {
+        var sb = new StringBuilder();
+        sb.AppendLine("# IntelligenceX Review History Artifact");
+        sb.AppendLine();
+        sb.AppendLine($"- Repository: `{context.RepoFullName}`");
+        sb.AppendLine($"- Pull request: `#{context.Number}`");
+        if (!string.IsNullOrWhiteSpace(context.HeadSha)) {
+            sb.AppendLine($"- Head SHA: `{context.HeadSha}`");
+        }
+        sb.AppendLine($"- History rounds: `{snapshot.Rounds.Count}`");
+        sb.AppendLine($"- Open findings: `{snapshot.OpenFindings.Count}`");
+        sb.AppendLine($"- Resolved since last round: `{snapshot.ResolvedSinceLastRound.Count}`");
+        sb.AppendLine($"- External bot summaries: `{snapshot.ExternalSummaries.Count}`");
+        if (snapshot.ThreadSnapshot is not null) {
+            sb.AppendLine($"- Threads: active `{snapshot.ThreadSnapshot.ActiveCount}`, stale `{snapshot.ThreadSnapshot.StaleCount}`, resolved `{snapshot.ThreadSnapshot.ResolvedCount}`");
+        }
+
+        AppendFindings(sb, "Open Findings", snapshot.OpenFindings);
+        AppendFindings(sb, "Resolved Since Last Round", snapshot.ResolvedSinceLastRound);
+        AppendExternalSummaries(sb, snapshot.ExternalSummaries);
+        AppendRounds(sb, snapshot.Rounds);
+        AppendThreads(sb, snapshot.ThreadSnapshot);
+
+        if (!string.IsNullOrWhiteSpace(renderedPromptSection)) {
+            sb.AppendLine();
+            sb.AppendLine("## Prompt Section");
+            sb.AppendLine();
+            sb.AppendLine("```text");
+            sb.AppendLine(TrimText(renderedPromptSection));
+            sb.AppendLine("```");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static IReadOnlyList<object> BuildRoundItems(IReadOnlyList<ReviewHistoryRound> rounds) {
+        var items = new List<object>(rounds.Count);
+        foreach (var round in rounds) {
+            items.Add(new {
+                sequence = round.Sequence,
+                source = round.Source,
+                summaryCommentId = round.SummaryCommentId,
+                reviewedSha = round.ReviewedSha,
+                sameHeadAsCurrent = round.SameHeadAsCurrent,
+                hasMergeBlockers = round.HasMergeBlockers,
+                mergeBlockerStatus = round.MergeBlockerStatus,
+                findings = BuildFindingItems(round.Findings)
+            });
+        }
+        return items;
+    }
+
+    private static IReadOnlyList<object> BuildFindingItems(IReadOnlyList<ReviewHistoryFinding> findings) {
+        var items = new List<object>(findings.Count);
+        foreach (var finding in findings) {
+            items.Add(new {
+                fingerprint = finding.Fingerprint,
+                section = finding.Section,
+                text = TrimText(finding.Text),
+                status = finding.Status
+            });
+        }
+        return items;
+    }
+
+    private static object? BuildThreadSnapshotItem(ReviewHistoryThreadSnapshot? snapshot) {
+        if (snapshot is null) {
+            return null;
+        }
+
+        var excerpts = new List<object>(snapshot.Excerpts.Count);
+        foreach (var excerpt in snapshot.Excerpts) {
+            excerpts.Add(new {
+                threadId = excerpt.ThreadId,
+                status = excerpt.Status,
+                author = excerpt.Author,
+                body = TrimText(excerpt.Body),
+                path = excerpt.Path,
+                line = excerpt.Line
+            });
+        }
+
+        return new {
+            activeCount = snapshot.ActiveCount,
+            resolvedCount = snapshot.ResolvedCount,
+            staleCount = snapshot.StaleCount,
+            excerpts
+        };
+    }
+
+    private static IReadOnlyList<object> BuildExternalSummaryItems(
+        IReadOnlyList<ReviewHistoryExternalSummary> summaries) {
+        var items = new List<object>(summaries.Count);
+        foreach (var summary in summaries) {
+            items.Add(new {
+                commentId = summary.CommentId,
+                author = summary.Author,
+                source = summary.Source,
+                excerpt = TrimText(summary.Excerpt)
+            });
+        }
+        return items;
+    }
+
+    private static void AppendFindings(StringBuilder sb, string title, IReadOnlyList<ReviewHistoryFinding> findings) {
+        sb.AppendLine();
+        sb.Append("## ");
+        sb.AppendLine(title);
+        sb.AppendLine();
+        if (findings.Count == 0) {
+            sb.AppendLine("None.");
+            return;
+        }
+
+        foreach (var finding in findings) {
+            sb.Append("- `");
+            sb.Append(EscapeInline(finding.Status));
+            sb.Append("` [");
+            sb.Append(EscapeInline(finding.Section));
+            sb.Append("] ");
+            sb.AppendLine(TrimText(finding.Text).Replace("\n", " ", StringComparison.Ordinal));
+        }
+    }
+
+    private static void AppendRounds(StringBuilder sb, IReadOnlyList<ReviewHistoryRound> rounds) {
+        sb.AppendLine();
+        sb.AppendLine("## Rounds");
+        sb.AppendLine();
+        if (rounds.Count == 0) {
+            sb.AppendLine("None.");
+            return;
+        }
+
+        foreach (var round in rounds) {
+            sb.Append("- Round ");
+            sb.Append(round.Sequence);
+            sb.Append(": `");
+            sb.Append(EscapeInline(round.ReviewedSha));
+            sb.Append("`, source `");
+            sb.Append(EscapeInline(round.Source));
+            sb.Append("`, blockers `");
+            sb.Append(EscapeInline(round.HasMergeBlockers ? "yes" : "no"));
+            sb.AppendLine("`");
+        }
+    }
+
+    private static void AppendExternalSummaries(StringBuilder sb,
+        IReadOnlyList<ReviewHistoryExternalSummary> summaries) {
+        sb.AppendLine();
+        sb.AppendLine("## External Bot Summaries");
+        sb.AppendLine();
+        if (summaries.Count == 0) {
+            sb.AppendLine("None.");
+            return;
+        }
+
+        sb.AppendLine("Supporting context only; these summaries are not treated as IX-owned blocker state.");
+        foreach (var summary in summaries) {
+            sb.Append("- `");
+            sb.Append(EscapeInline(summary.Author));
+            sb.Append("`: ");
+            sb.AppendLine(TrimText(summary.Excerpt).Replace("\n", " ", StringComparison.Ordinal));
+        }
+    }
+
+    private static void AppendThreads(StringBuilder sb, ReviewHistoryThreadSnapshot? snapshot) {
+        sb.AppendLine();
+        sb.AppendLine("## Thread Snapshot");
+        sb.AppendLine();
+        if (snapshot is null) {
+            sb.AppendLine("None.");
+            return;
+        }
+
+        sb.AppendLine($"Active `{snapshot.ActiveCount}`, stale `{snapshot.StaleCount}`, resolved `{snapshot.ResolvedCount}`.");
+        foreach (var excerpt in snapshot.Excerpts) {
+            var location = string.IsNullOrWhiteSpace(excerpt.Path)
+                ? string.Empty
+                : excerpt.Line.HasValue
+                    ? $" ({excerpt.Path}:{excerpt.Line.Value})"
+                    : $" ({excerpt.Path})";
+            sb.Append("- `");
+            sb.Append(EscapeInline(excerpt.Status));
+            sb.Append("` ");
+            sb.Append(EscapeInline(excerpt.Author));
+            sb.Append(location);
+            sb.Append(": ");
+            sb.AppendLine(TrimText(excerpt.Body).Replace("\n", " ", StringComparison.Ordinal));
+        }
+    }
+
+    private static string TrimText(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return string.Empty;
+        }
+        var normalized = value.Replace("\r", " ").Trim();
+        if (normalized.Length <= MaxTextChars) {
+            return normalized;
+        }
+        const string suffix = "\n\n[truncated for review history artifact]";
+        return normalized.Substring(0, Math.Max(0, MaxTextChars - suffix.Length)) + suffix;
+    }
+
+    private static string EscapeInline(string value) =>
+        value.Replace("`", "\\`", StringComparison.Ordinal);
+}

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -133,6 +133,10 @@ internal static class ReviewHistoryBuilder {
                 continue;
             }
 
+            if (IsProgressSummaryComment(comment.Body)) {
+                continue;
+            }
+
             ownedSummaries.Add(comment);
             if (ownedSummaries.Count >= settings.History.MaxRounds) {
                 break;
@@ -164,6 +168,11 @@ internal static class ReviewHistoryBuilder {
         }
 
         AppendResolvedSinceLastRound(resolvedSinceLastRound, rounds);
+    }
+
+    private static bool IsProgressSummaryComment(string body) {
+        return body.Contains("## IntelligenceX Review (in progress)", StringComparison.OrdinalIgnoreCase) ||
+               body.Contains("### Review Checklist", StringComparison.OrdinalIgnoreCase);
     }
 
     private static void AppendExternalSummaries(List<ReviewHistoryExternalSummary> externalSummaries,

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -123,6 +123,10 @@ internal static class ReviewHistoryBuilder {
     private static void AppendSummaryRounds(List<ReviewHistoryRound> rounds, List<ReviewHistoryFinding> openFindings,
         List<ReviewHistoryFinding> resolvedSinceLastRound, IReadOnlyList<IssueComment> issueComments, string currentHeadSha,
         ReviewSettings settings) {
+        if (settings.History.MaxRounds <= 0) {
+            return;
+        }
+
         var ownedSummaries = new List<IssueComment>();
         foreach (var comment in issueComments) {
             if (!ReviewerApp.IsOwnedSummaryComment(comment) || string.IsNullOrWhiteSpace(comment.Body)) {
@@ -130,7 +134,7 @@ internal static class ReviewHistoryBuilder {
             }
 
             ownedSummaries.Add(comment);
-            if (settings.History.MaxRounds > 0 && ownedSummaries.Count >= settings.History.MaxRounds) {
+            if (ownedSummaries.Count >= settings.History.MaxRounds) {
                 break;
             }
         }

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -1,0 +1,443 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace IntelligenceX.Reviewer;
+
+internal static class ReviewHistoryBuilder {
+    public static ReviewHistorySnapshot BuildSnapshot(IReadOnlyList<IssueComment>? issueComments, string? currentHeadSha,
+        IReadOnlyList<PullRequestReviewThread>? reviewThreads, ReviewSettings settings) {
+        var rounds = new List<ReviewHistoryRound>();
+        var openFindings = new List<ReviewHistoryFinding>();
+        var resolvedSinceLastRound = new List<ReviewHistoryFinding>();
+        var externalSummaries = new List<ReviewHistoryExternalSummary>();
+        var snapshot = new ReviewHistorySnapshot {
+            CurrentHeadSha = currentHeadSha?.Trim() ?? string.Empty
+        };
+        if (!settings.History.Enabled) {
+            return snapshot;
+        }
+
+        if (settings.History.IncludeIxSummaryHistory && issueComments is not null && issueComments.Count > 0) {
+            AppendSummaryRounds(rounds, openFindings, resolvedSinceLastRound, issueComments, snapshot.CurrentHeadSha, settings);
+        }
+
+        if (settings.History.IncludeExternalBotSummaries && issueComments is not null && issueComments.Count > 0) {
+            AppendExternalSummaries(externalSummaries, issueComments, settings);
+        }
+
+        var threadSnapshot = settings.History.IncludeReviewThreads && reviewThreads is not null && reviewThreads.Count > 0
+            ? BuildThreadSnapshot(reviewThreads, settings)
+            : null;
+
+        return new ReviewHistorySnapshot {
+            CurrentHeadSha = snapshot.CurrentHeadSha,
+            Rounds = rounds,
+            OpenFindings = openFindings,
+            ResolvedSinceLastRound = resolvedSinceLastRound,
+            ExternalSummaries = externalSummaries,
+            ThreadSnapshot = threadSnapshot
+        };
+    }
+
+    public static ReviewHistorySnapshot BuildSnapshot(IssueComment? existingSummary, string? currentHeadSha,
+        IReadOnlyList<PullRequestReviewThread>? reviewThreads, ReviewSettings settings) {
+        return existingSummary is null
+            ? BuildSnapshot(Array.Empty<IssueComment>(), currentHeadSha, reviewThreads, settings)
+            : BuildSnapshot(new[] { existingSummary }, currentHeadSha, reviewThreads, settings);
+    }
+
+    public static string Build(IssueComment? existingSummary, string? currentHeadSha,
+        IReadOnlyList<PullRequestReviewThread>? reviewThreads, ReviewSettings settings) {
+        return Render(BuildSnapshot(existingSummary, currentHeadSha, reviewThreads, settings));
+    }
+
+    public static string Render(ReviewHistorySnapshot snapshot) {
+        if (!snapshot.HasContent) {
+            return string.Empty;
+        }
+
+        var lines = new List<string>();
+        AppendDerivedStateLines(lines, snapshot);
+        foreach (var round in snapshot.Rounds) {
+            AppendStickySummaryLines(lines, round, snapshot.CurrentHeadSha);
+        }
+        if (snapshot.ExternalSummaries.Count > 0) {
+            AppendExternalSummaryLines(lines, snapshot.ExternalSummaries);
+        }
+        if (snapshot.ThreadSnapshot is not null) {
+            AppendThreadLines(lines, snapshot.ThreadSnapshot);
+        }
+
+        if (lines.Count == 0) {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine();
+        sb.AppendLine("Review history snapshot:");
+        foreach (var line in lines) {
+            sb.AppendLine(line);
+        }
+        sb.AppendLine("- Use review history as supporting state only. Re-open prior findings only when the current diff or thread state supports it.");
+        sb.AppendLine();
+        return sb.ToString();
+    }
+
+    public static string BuildCommentBlock(ReviewHistorySnapshot snapshot) {
+        if (snapshot.Rounds.Count == 0) {
+            return string.Empty;
+        }
+
+        var lines = new List<string>();
+        if (snapshot.OpenFindings.Count > 0) {
+            lines.Add("Open now:");
+            foreach (var finding in snapshot.OpenFindings) {
+                lines.Add($"- [{NormalizeSectionLabel(finding.Section)}] {finding.Text}");
+            }
+        } else {
+            lines.Add("Open now: none.");
+        }
+
+        if (snapshot.ResolvedSinceLastRound.Count > 0) {
+            lines.Add("Resolved since last round:");
+            foreach (var finding in snapshot.ResolvedSinceLastRound) {
+                lines.Add($"- [{NormalizeSectionLabel(finding.Section)}] {finding.Text}");
+            }
+        }
+
+        if (lines.Count == 1 &&
+            string.Equals(lines[0], "Open now: none.", StringComparison.Ordinal)) {
+            lines.Add("Resolved since last round: none newly resolved.");
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("## History Progress 🔁");
+        sb.AppendLine();
+        foreach (var line in lines) {
+            sb.AppendLine(line);
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static void AppendSummaryRounds(List<ReviewHistoryRound> rounds, List<ReviewHistoryFinding> openFindings,
+        List<ReviewHistoryFinding> resolvedSinceLastRound, IReadOnlyList<IssueComment> issueComments, string currentHeadSha,
+        ReviewSettings settings) {
+        var ownedSummaries = new List<IssueComment>();
+        foreach (var comment in issueComments) {
+            if (!ReviewerApp.IsOwnedSummaryComment(comment) || string.IsNullOrWhiteSpace(comment.Body)) {
+                continue;
+            }
+
+            ownedSummaries.Add(comment);
+            if (settings.History.MaxRounds > 0 && ownedSummaries.Count >= settings.History.MaxRounds) {
+                break;
+            }
+        }
+
+        if (ownedSummaries.Count == 0) {
+            return;
+        }
+
+        ownedSummaries.Reverse();
+        var roundFindingsByFingerprint = new Dictionary<string, ReviewHistoryFinding>(StringComparer.Ordinal);
+        for (var index = 0; index < ownedSummaries.Count; index++) {
+            var round = BuildStickySummaryRound(ownedSummaries[index], currentHeadSha, settings, index + 1);
+            if (round is null) {
+                continue;
+            }
+
+            rounds.Add(round);
+            foreach (var finding in round.Findings) {
+                roundFindingsByFingerprint[finding.Fingerprint] = finding;
+            }
+        }
+
+        foreach (var state in roundFindingsByFingerprint.Values) {
+            if (string.Equals(state.Status, "open", StringComparison.OrdinalIgnoreCase)) {
+                openFindings.Add(state);
+            }
+        }
+
+        AppendResolvedSinceLastRound(resolvedSinceLastRound, rounds);
+    }
+
+    private static void AppendExternalSummaries(List<ReviewHistoryExternalSummary> externalSummaries,
+        IReadOnlyList<IssueComment> issueComments, ReviewSettings settings) {
+        foreach (var comment in issueComments) {
+            if (externalSummaries.Count >= settings.History.MaxItems) {
+                break;
+            }
+            if (ReviewerApp.IsOwnedSummaryComment(comment) || string.IsNullOrWhiteSpace(comment.Body)) {
+                continue;
+            }
+            var author = comment.Author ?? string.Empty;
+            if (!IsExternalBotAuthor(author, settings)) {
+                continue;
+            }
+
+            externalSummaries.Add(new ReviewHistoryExternalSummary {
+                CommentId = comment.Id,
+                Author = string.IsNullOrWhiteSpace(author) ? "unknown" : author.Trim(),
+                Source = "external-bot",
+                Excerpt = TrimText(comment.Body, settings.MaxCommentChars)
+            });
+        }
+    }
+
+    private static void AppendDerivedStateLines(List<string> lines, ReviewHistorySnapshot snapshot) {
+        if (snapshot.OpenFindings.Count > 0) {
+            lines.Add("- Open findings carried into the current state:");
+            foreach (var finding in snapshot.OpenFindings) {
+                lines.Add($"  - [{NormalizeSectionLabel(finding.Section)}] {finding.Text}");
+            }
+        } else if (snapshot.Rounds.Count > 0) {
+            lines.Add("- Open findings carried into the current state: none.");
+        }
+
+        if (snapshot.ResolvedSinceLastRound.Count == 0) {
+            return;
+        }
+
+        lines.Add("- Resolved since the latest prior round:");
+        foreach (var finding in snapshot.ResolvedSinceLastRound) {
+            lines.Add($"  - [{NormalizeSectionLabel(finding.Section)}] {finding.Text}");
+        }
+    }
+
+    private static void AppendResolvedSinceLastRound(List<ReviewHistoryFinding> resolvedSinceLastRound,
+        IReadOnlyList<ReviewHistoryRound> rounds) {
+        if (rounds.Count < 2) {
+            return;
+        }
+
+        var latestRound = rounds[rounds.Count - 1];
+        var previousRound = rounds[rounds.Count - 2];
+        var latestFindings = ToFindingMap(latestRound.Findings);
+        foreach (var finding in previousRound.Findings) {
+            if (!string.Equals(finding.Status, "open", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            if (!latestFindings.TryGetValue(finding.Fingerprint, out var latestFinding)) {
+                continue;
+            }
+
+            if (!string.Equals(latestFinding.Status, "resolved", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            resolvedSinceLastRound.Add(latestFinding);
+        }
+    }
+
+    private static Dictionary<string, ReviewHistoryFinding> ToFindingMap(IReadOnlyList<ReviewHistoryFinding> findings) {
+        var map = new Dictionary<string, ReviewHistoryFinding>(StringComparer.Ordinal);
+        foreach (var finding in findings) {
+            map[finding.Fingerprint] = finding;
+        }
+        return map;
+    }
+
+    private static ReviewHistoryRound? BuildStickySummaryRound(IssueComment existingSummary, string? currentHeadSha,
+        ReviewSettings settings, int sequence = 1) {
+        ReviewSummaryParser.TryGetReviewedCommit(existingSummary.Body, out var reviewedCommit);
+        var findings = ReviewSummaryParser.ExtractMergeBlockerFindings(existingSummary.Body, settings, settings.History.MaxItems);
+        var hasMergeBlockers = ReviewSummaryParser.HasMergeBlockers(existingSummary.Body, settings);
+        var mergeBlockerStatus = findings.Count == 0
+            ? hasMergeBlockers
+                ? "present, but markdown items could not be normalized."
+                : "none."
+            : $"{findings.Count} normalized item(s).";
+        return new ReviewHistoryRound {
+            Sequence = sequence,
+            Source = "intelligencex",
+            SummaryCommentId = existingSummary.Id,
+            ReviewedSha = reviewedCommit?.Trim() ?? string.Empty,
+            SameHeadAsCurrent = !string.IsNullOrWhiteSpace(reviewedCommit) &&
+                                !string.IsNullOrWhiteSpace(currentHeadSha) &&
+                                currentHeadSha.StartsWith(reviewedCommit!, StringComparison.OrdinalIgnoreCase),
+            HasMergeBlockers = hasMergeBlockers,
+            MergeBlockerStatus = mergeBlockerStatus,
+            Findings = ConvertFindings(findings)
+        };
+    }
+
+    private static IReadOnlyList<ReviewHistoryFinding> ConvertFindings(IReadOnlyList<ReviewSummaryFinding> findings) {
+        if (findings.Count == 0) {
+            return Array.Empty<ReviewHistoryFinding>();
+        }
+
+        var converted = new List<ReviewHistoryFinding>(findings.Count);
+        foreach (var finding in findings) {
+            converted.Add(new ReviewHistoryFinding {
+                Fingerprint = finding.Fingerprint,
+                Section = finding.Section,
+                Text = finding.Text,
+                Status = finding.Status
+            });
+        }
+        return converted;
+    }
+
+    private static void AppendStickySummaryLines(List<string> lines, ReviewHistoryRound round, string currentHeadSha) {
+        var hasReviewedCommit = !string.IsNullOrWhiteSpace(round.ReviewedSha);
+        var reviewedCommitLabel = hasReviewedCommit ? $"`{ShortSha(round.ReviewedSha)}`" : "an unknown commit";
+        var currentHeadLabel = string.IsNullOrWhiteSpace(currentHeadSha) ? "unknown head" : $"`{ShortSha(currentHeadSha)}`";
+        var roundLabel = round.SameHeadAsCurrent
+            ? $"same SHA as current head ({currentHeadLabel})"
+            : hasReviewedCommit
+                ? $"prior round on {reviewedCommitLabel} before current head {currentHeadLabel}"
+                : $"prior round before current head {currentHeadLabel}";
+        lines.Add($"- Round {round.Sequence}: IX sticky summary reviewed {reviewedCommitLabel} ({roundLabel}).");
+
+        if (round.Findings.Count == 0) {
+            lines.Add($"- IX merge blockers in sticky summary: {round.MergeBlockerStatus}");
+            return;
+        }
+
+        lines.Add("- IX merge blockers from sticky summary:");
+        foreach (var item in round.Findings) {
+            lines.Add($"  - [{NormalizeSectionLabel(item.Section)}] {item.Text}");
+        }
+    }
+
+    private static ReviewHistoryThreadSnapshot? BuildThreadSnapshot(IReadOnlyList<PullRequestReviewThread> reviewThreads,
+        ReviewSettings settings) {
+        var active = 0;
+        var resolved = 0;
+        var stale = 0;
+        var excerpts = new List<ReviewHistoryThreadExcerpt>();
+        foreach (var thread in reviewThreads) {
+            if (thread.IsResolved) {
+                resolved++;
+            } else if (thread.IsOutdated) {
+                stale++;
+            } else {
+                active++;
+            }
+
+            if (excerpts.Count >= settings.History.MaxItems) {
+                continue;
+            }
+            if (thread.IsResolved) {
+                continue;
+            }
+
+            foreach (var comment in thread.Comments) {
+                if (excerpts.Count >= settings.History.MaxItems) {
+                    break;
+                }
+                if (!ShouldIncludeThreadComment(comment, settings)) {
+                    continue;
+                }
+
+                excerpts.Add(new ReviewHistoryThreadExcerpt {
+                    ThreadId = thread.Id,
+                    Status = thread.IsOutdated ? "stale" : "active",
+                    Author = string.IsNullOrWhiteSpace(comment.Author) ? "unknown" : comment.Author!,
+                    Body = TrimText(comment.Body, settings.MaxCommentChars),
+                    Path = comment.Path,
+                    Line = comment.Line
+                });
+            }
+        }
+
+        if (active == 0 && resolved == 0 && stale == 0) {
+            return null;
+        }
+
+        return new ReviewHistoryThreadSnapshot {
+            ActiveCount = active,
+            ResolvedCount = resolved,
+            StaleCount = stale,
+            Excerpts = excerpts
+        };
+    }
+
+    private static void AppendThreadLines(List<string> lines, ReviewHistoryThreadSnapshot snapshot) {
+        lines.Add($"- Review threads snapshot: active {snapshot.ActiveCount}, resolved {snapshot.ResolvedCount}, stale {snapshot.StaleCount}.");
+        if (snapshot.Excerpts.Count == 0) {
+            return;
+        }
+
+        lines.Add("- Unresolved thread excerpts:");
+        foreach (var excerpt in snapshot.Excerpts) {
+            var location = string.IsNullOrWhiteSpace(excerpt.Path)
+                ? string.Empty
+                : excerpt.Line.HasValue
+                    ? $" ({excerpt.Path}:{excerpt.Line.Value})"
+                    : $" ({excerpt.Path})";
+            lines.Add($"  - [{excerpt.Status}] {excerpt.Author}{location}: {excerpt.Body}");
+        }
+    }
+
+    private static void AppendExternalSummaryLines(List<string> lines,
+        IReadOnlyList<ReviewHistoryExternalSummary> summaries) {
+        lines.Add("- External bot summaries included as supporting context only:");
+        foreach (var summary in summaries) {
+            lines.Add($"  - [{summary.Author}] {summary.Excerpt}");
+        }
+    }
+
+    private static bool ShouldIncludeThreadComment(PullRequestReviewThreadComment comment, ReviewSettings settings) {
+        if (string.IsNullOrWhiteSpace(comment.Body)) {
+            return false;
+        }
+
+        var author = comment.Author ?? string.Empty;
+        if (settings.ReviewThreadsIncludeBots) {
+            return true;
+        }
+
+        if (author.EndsWith("[bot]", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        foreach (var botLogin in settings.ReviewThreadsAutoResolveBotLogins) {
+            if (string.Equals(author, botLogin, StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsExternalBotAuthor(string author, ReviewSettings settings) {
+        if (string.IsNullOrWhiteSpace(author)) {
+            return false;
+        }
+
+        foreach (var login in settings.History.ExternalBotLogins) {
+            if (string.Equals(author.Trim(), login, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static string NormalizeSectionLabel(string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return "unknown";
+        }
+
+        return value.Trim().ToLowerInvariant() switch {
+            "todo list" => "todo",
+            "critical issues" => "critical",
+            _ => value.Trim()
+        };
+    }
+
+    private static string ShortSha(string value) {
+        var trimmed = value.Trim();
+        return trimmed.Length <= 7 ? trimmed : trimmed.Substring(0, 7);
+    }
+
+    private static string TrimText(string value, int maxChars) {
+        var normalized = value.Replace("\r", " ").Replace("\n", " ").Trim();
+        if (maxChars <= 0 || normalized.Length <= maxChars) {
+            return normalized;
+        }
+        return normalized.Substring(0, maxChars) + "...";
+    }
+}

--- a/IntelligenceX.Reviewer/ReviewHistorySnapshot.cs
+++ b/IntelligenceX.Reviewer/ReviewHistorySnapshot.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+namespace IntelligenceX.Reviewer;
+
+internal sealed class ReviewHistorySnapshot {
+    public string CurrentHeadSha { get; init; } = string.Empty;
+    public IReadOnlyList<ReviewHistoryRound> Rounds { get; init; } = Array.Empty<ReviewHistoryRound>();
+    public IReadOnlyList<ReviewHistoryFinding> OpenFindings { get; init; } = Array.Empty<ReviewHistoryFinding>();
+    public IReadOnlyList<ReviewHistoryFinding> ResolvedSinceLastRound { get; init; } = Array.Empty<ReviewHistoryFinding>();
+    public IReadOnlyList<ReviewHistoryExternalSummary> ExternalSummaries { get; init; } =
+        Array.Empty<ReviewHistoryExternalSummary>();
+    public ReviewHistoryThreadSnapshot? ThreadSnapshot { get; init; }
+    public bool HasContent => Rounds.Count > 0 || ExternalSummaries.Count > 0 || ThreadSnapshot is not null;
+}
+
+internal sealed class ReviewHistoryRound {
+    public int Sequence { get; init; }
+    public string Source { get; init; } = "intelligencex";
+    public long? SummaryCommentId { get; init; }
+    public string ReviewedSha { get; init; } = string.Empty;
+    public bool SameHeadAsCurrent { get; init; }
+    public bool HasMergeBlockers { get; init; }
+    public string MergeBlockerStatus { get; init; } = string.Empty;
+    public IReadOnlyList<ReviewHistoryFinding> Findings { get; init; } = Array.Empty<ReviewHistoryFinding>();
+}
+
+internal sealed class ReviewHistoryFinding {
+    public string Fingerprint { get; init; } = string.Empty;
+    public string Section { get; init; } = string.Empty;
+    public string Text { get; init; } = string.Empty;
+    public string Status { get; init; } = "open";
+}
+
+internal sealed class ReviewHistoryExternalSummary {
+    public long? CommentId { get; init; }
+    public string Author { get; init; } = string.Empty;
+    public string Source { get; init; } = "external";
+    public string Excerpt { get; init; } = string.Empty;
+}
+
+internal sealed class ReviewHistoryThreadSnapshot {
+    public int ActiveCount { get; init; }
+    public int ResolvedCount { get; init; }
+    public int StaleCount { get; init; }
+    public IReadOnlyList<ReviewHistoryThreadExcerpt> Excerpts { get; init; } = Array.Empty<ReviewHistoryThreadExcerpt>();
+}
+
+internal sealed class ReviewHistoryThreadExcerpt {
+    public string ThreadId { get; init; } = string.Empty;
+    public string Status { get; init; } = string.Empty;
+    public string Author { get; init; } = string.Empty;
+    public string Body { get; init; } = string.Empty;
+    public string? Path { get; init; }
+    public int? Line { get; init; }
+}

--- a/IntelligenceX.Reviewer/ReviewRunner.TestSeams.cs
+++ b/IntelligenceX.Reviewer/ReviewRunner.TestSeams.cs
@@ -1,4 +1,5 @@
 using IntelligenceX.OpenAI.Native;
+using IntelligenceX.Copilot;
 
 namespace IntelligenceX.Reviewer;
 
@@ -14,4 +15,72 @@ internal sealed partial class ReviewRunner {
     internal static Exception? MapPreflightConnectivityExceptionForTests(HttpRequestException ex, string host,
         TimeSpan timeout, bool cancellationRequested) =>
         MapPreflightConnectivityException(ex, host, timeout, cancellationRequested);
+
+    /// <summary>Test-only forwarder for swarm shadow plan resolution.</summary>
+    internal static ReviewSwarmShadowPlan BuildSwarmShadowPlanForTests(ReviewSettings settings) =>
+        ReviewSwarmShadowPlanner.Build(settings);
+
+    /// <summary>Test-only forwarder for Copilot CLI option resolution.</summary>
+    internal CopilotClientOptions BuildCopilotClientOptionsForTests() =>
+        BuildCopilotClientOptions();
+
+    /// <summary>Test-only forwarder for swarm shadow plan rendering.</summary>
+    internal static string RenderSwarmShadowPlanForTests(ReviewSwarmShadowPlan plan) =>
+        ReviewSwarmShadowPlanner.Render(plan);
+
+    /// <summary>Test-only forwarder for swarm reviewer prompt shaping.</summary>
+    internal static string BuildSwarmShadowReviewerPromptForTests(string basePrompt,
+        ReviewSwarmShadowReviewerPlan reviewer) =>
+        ReviewSwarmShadowRunner.BuildReviewerPrompt(basePrompt, reviewer);
+
+    /// <summary>Test-only forwarder for swarm shadow execution with a fake model executor.</summary>
+    internal static Task<ReviewSwarmShadowRunResult> RunSwarmShadowForTestsAsync(ReviewSettings settings,
+        ReviewSwarmShadowPlan plan, string basePrompt,
+        Func<ReviewSwarmShadowReviewerPlan, string, CancellationToken, Task<string>> executeReviewerAsync,
+        CancellationToken cancellationToken = default) =>
+        ReviewSwarmShadowRunner.RunAsync(settings, plan, basePrompt, executeReviewerAsync,
+            (_, _, _) => Task.FromResult("## Summary 📝\nAggregated shadow result."), cancellationToken);
+
+    /// <summary>Test-only forwarder for swarm shadow execution with fake reviewer and aggregator executors.</summary>
+    internal static Task<ReviewSwarmShadowRunResult> RunSwarmShadowForTestsAsync(ReviewSettings settings,
+        ReviewSwarmShadowPlan plan, string basePrompt,
+        Func<ReviewSwarmShadowReviewerPlan, string, CancellationToken, Task<string>> executeReviewerAsync,
+        Func<ReviewSwarmShadowAggregatorPlan, string, CancellationToken, Task<string>> executeAggregatorAsync,
+        CancellationToken cancellationToken = default) =>
+        ReviewSwarmShadowRunner.RunAsync(settings, plan, basePrompt, executeReviewerAsync, executeAggregatorAsync,
+            cancellationToken);
+
+    /// <summary>Test-only forwarder for swarm aggregator prompt shaping.</summary>
+    internal static string BuildSwarmShadowAggregatorPromptForTests(string basePrompt, ReviewSwarmShadowPlan plan,
+        IReadOnlyList<ReviewSwarmShadowReviewerResult> results) =>
+        ReviewSwarmShadowRunner.BuildAggregatorPrompt(basePrompt, plan, results);
+
+    /// <summary>Test-only forwarder for swarm shadow JSON artifact rendering.</summary>
+    internal static string BuildSwarmShadowArtifactJsonForTests(PullRequestContext context, ReviewSwarmShadowPlan plan,
+        ReviewSwarmShadowRunResult result) =>
+        ReviewSwarmShadowArtifacts.BuildJson(context, plan, result);
+
+    /// <summary>Test-only forwarder for swarm shadow Markdown artifact rendering.</summary>
+    internal static string BuildSwarmShadowArtifactMarkdownForTests(PullRequestContext context, ReviewSwarmShadowPlan plan,
+        ReviewSwarmShadowRunResult result) =>
+        ReviewSwarmShadowArtifacts.BuildMarkdown(context, plan, result);
+
+    /// <summary>Test-only forwarder for swarm shadow metrics rendering.</summary>
+    internal static string BuildSwarmShadowMetricsJsonLineForTests(PullRequestContext context,
+        ReviewSwarmShadowRunResult result) =>
+        ReviewSwarmShadowArtifacts.BuildMetricsJsonLine(context, result);
+
+    /// <summary>Test-only forwarder for review history JSON artifact rendering.</summary>
+    internal static string BuildReviewHistoryArtifactJsonForTests(PullRequestContext context,
+        ReviewHistorySnapshot snapshot, string renderedPromptSection) =>
+        ReviewHistoryArtifacts.BuildJson(context, snapshot, renderedPromptSection);
+
+    /// <summary>Test-only forwarder for review history Markdown artifact rendering.</summary>
+    internal static string BuildReviewHistoryArtifactMarkdownForTests(PullRequestContext context,
+        ReviewHistorySnapshot snapshot, string renderedPromptSection) =>
+        ReviewHistoryArtifacts.BuildMarkdown(context, snapshot, renderedPromptSection);
+
+    /// <summary>Test-only forwarder for swarm shadow result diagnostics.</summary>
+    internal static string RenderSwarmShadowResultsForTests(ReviewSwarmShadowRunResult result) =>
+        ReviewSwarmShadowRunner.RenderResultSummary(result);
 }

--- a/IntelligenceX.Reviewer/ReviewRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewRunner.cs
@@ -346,9 +346,7 @@ internal sealed partial class ReviewRunner {
 
     private CopilotClientOptions BuildCopilotClientOptions() {
         var options = new CopilotClientOptions();
-        if (!string.IsNullOrWhiteSpace(_settings.CopilotCliPath)) {
-            options.CliPath = _settings.CopilotCliPath;
-        }
+        var launcher = ApplyCopilotLauncher(options);
         if (!string.IsNullOrWhiteSpace(_settings.CopilotCliUrl)) {
             options.CliUrl = _settings.CopilotCliUrl;
         }
@@ -364,7 +362,47 @@ internal sealed partial class ReviewRunner {
         }
         options.AutoInstallPrerelease = _settings.CopilotAutoInstallPrerelease;
         ApplyCopilotEnvironment(options);
+        if (_settings.Diagnostics) {
+            Console.Error.WriteLine(BuildCopilotLauncherDiagnostic(launcher, options));
+        }
         return options;
+    }
+
+    private string ApplyCopilotLauncher(CopilotClientOptions options) {
+        var launcher = ReviewSettings.NormalizeCopilotLauncher(_settings.CopilotLauncher, "binary");
+        if (string.Equals(launcher, "auto", StringComparison.OrdinalIgnoreCase)) {
+            launcher = ShouldUseGhCopilotLauncher(_settings) ? "gh" : "binary";
+        }
+
+        if (string.Equals(launcher, "gh", StringComparison.OrdinalIgnoreCase)) {
+            options.CliPath = string.IsNullOrWhiteSpace(_settings.CopilotCliPath) ? "gh" : _settings.CopilotCliPath;
+            options.CliArgs.Add("copilot");
+            options.CliArgs.Add("--");
+            return "gh";
+        }
+
+        if (!string.IsNullOrWhiteSpace(_settings.CopilotCliPath)) {
+            options.CliPath = _settings.CopilotCliPath;
+        }
+        return "binary";
+    }
+
+    private string BuildCopilotLauncherDiagnostic(string launcher, CopilotClientOptions options) {
+        var cliPath = string.IsNullOrWhiteSpace(options.CliPath) ? "copilot" : options.CliPath;
+        var prefixArgs = options.CliArgs.Count == 0 ? "(none)" : string.Join(" ", options.CliArgs);
+        var cliUrl = string.IsNullOrWhiteSpace(options.CliUrl) ? "not configured" : "configured";
+        return string.Concat(
+            "Copilot launcher resolved: ",
+            launcher,
+            "; transport=",
+            _settings.CopilotTransport.ToString().ToLowerInvariant(),
+            "; cliPath=",
+            cliPath,
+            "; prefixArgs=",
+            prefixArgs,
+            "; cliUrl=",
+            cliUrl,
+            ".");
     }
 
 
@@ -636,5 +674,41 @@ internal sealed partial class ReviewRunner {
             options.Environment[entry.Key] = entry.Value;
             SecretsAudit.Record($"Copilot CLI env set: {entry.Key}");
         }
+    }
+
+    private static bool ShouldUseGhCopilotLauncher(ReviewSettings settings) {
+        if (!string.IsNullOrWhiteSpace(settings.CopilotCliPath)) {
+            return false;
+        }
+        return !CommandExists("copilot") && CommandExists("gh");
+    }
+
+    private static bool CommandExists(string command) {
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path)) {
+            return false;
+        }
+
+        var extensions = new List<string> { string.Empty };
+        if (OperatingSystem.IsWindows()) {
+            var pathExt = Environment.GetEnvironmentVariable("PATHEXT");
+            extensions = string.IsNullOrWhiteSpace(pathExt)
+                ? new List<string> { ".exe", ".cmd", ".bat" }
+                : new List<string>(pathExt.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        }
+
+        foreach (var directory in path.Split(Path.PathSeparator)) {
+            if (string.IsNullOrWhiteSpace(directory)) {
+                continue;
+            }
+            foreach (var extension in extensions) {
+                var candidate = Path.Combine(directory.Trim(), command + extension);
+                if (File.Exists(candidate)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/IntelligenceX.Reviewer/ReviewRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewRunner.cs
@@ -373,7 +373,7 @@ internal sealed partial class ReviewRunner {
         var launcher = ResolveCopilotLauncher(_settings, CommandExists, GhCopilotWrapperCanLaunchCli);
 
         if (string.Equals(launcher, "gh", StringComparison.OrdinalIgnoreCase)) {
-            options.CliPath = string.IsNullOrWhiteSpace(_settings.CopilotCliPath) ? "gh" : _settings.CopilotCliPath;
+            options.CliPath = "gh";
             options.CliArgs.Add("copilot");
             options.CliArgs.Add("--");
             return "gh";

--- a/IntelligenceX.Reviewer/ReviewRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -369,10 +370,7 @@ internal sealed partial class ReviewRunner {
     }
 
     private string ApplyCopilotLauncher(CopilotClientOptions options) {
-        var launcher = ReviewSettings.NormalizeCopilotLauncher(_settings.CopilotLauncher, "binary");
-        if (string.Equals(launcher, "auto", StringComparison.OrdinalIgnoreCase)) {
-            launcher = ShouldUseGhCopilotLauncher(_settings) ? "gh" : "binary";
-        }
+        var launcher = ResolveCopilotLauncher(_settings, CommandExists, GhCopilotWrapperCanLaunchCli);
 
         if (string.Equals(launcher, "gh", StringComparison.OrdinalIgnoreCase)) {
             options.CliPath = string.IsNullOrWhiteSpace(_settings.CopilotCliPath) ? "gh" : _settings.CopilotCliPath;
@@ -385,6 +383,28 @@ internal sealed partial class ReviewRunner {
             options.CliPath = _settings.CopilotCliPath;
         }
         return "binary";
+    }
+
+    internal static string ResolveCopilotLauncherForTests(ReviewSettings settings, bool copilotExists, bool ghExists,
+        bool ghCopilotWrapperCanLaunchCli) =>
+        ResolveCopilotLauncher(settings,
+            command => string.Equals(command, "copilot", StringComparison.OrdinalIgnoreCase)
+                ? copilotExists
+                : ghExists,
+            () => ghCopilotWrapperCanLaunchCli);
+
+    private static string ResolveCopilotLauncher(ReviewSettings settings, Func<string, bool> commandExists,
+        Func<bool> ghCopilotWrapperCanLaunchCli) {
+        var launcher = ReviewSettings.NormalizeCopilotLauncher(settings.CopilotLauncher, "binary");
+        if (!string.Equals(launcher, "auto", StringComparison.OrdinalIgnoreCase)) {
+            return launcher;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.CopilotCliPath) || commandExists("copilot") || !commandExists("gh")) {
+            return "binary";
+        }
+
+        return ghCopilotWrapperCanLaunchCli() ? "gh" : "binary";
     }
 
     private string BuildCopilotLauncherDiagnostic(string launcher, CopilotClientOptions options) {
@@ -676,13 +696,6 @@ internal sealed partial class ReviewRunner {
         }
     }
 
-    private static bool ShouldUseGhCopilotLauncher(ReviewSettings settings) {
-        if (!string.IsNullOrWhiteSpace(settings.CopilotCliPath)) {
-            return false;
-        }
-        return !CommandExists("copilot") && CommandExists("gh");
-    }
-
     private static bool CommandExists(string command) {
         var path = Environment.GetEnvironmentVariable("PATH");
         if (string.IsNullOrWhiteSpace(path)) {
@@ -710,5 +723,44 @@ internal sealed partial class ReviewRunner {
         }
 
         return false;
+    }
+
+    private static bool GhCopilotWrapperCanLaunchCli() {
+        try {
+            using var process = new Process();
+            process.StartInfo = new ProcessStartInfo {
+                FileName = "gh",
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            process.StartInfo.ArgumentList.Add("copilot");
+            process.StartInfo.ArgumentList.Add("--");
+            process.StartInfo.ArgumentList.Add("--version");
+            if (!process.Start()) {
+                return false;
+            }
+
+            if (!process.WaitForExit(5000)) {
+                try {
+                    process.Kill(entireProcessTree: true);
+                } catch {
+                    // Best-effort cleanup for a capability probe.
+                }
+                return false;
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            var combined = string.Concat(output, "\n", error);
+            if (combined.Contains("not installed", StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+            return process.ExitCode == 0 &&
+                combined.Contains("copilot", StringComparison.OrdinalIgnoreCase);
+        } catch {
+            return false;
+        }
     }
 }

--- a/IntelligenceX.Reviewer/ReviewSettings.Clone.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.Clone.cs
@@ -1,0 +1,14 @@
+using IntelligenceX.OpenAI.Chat;
+
+namespace IntelligenceX.Reviewer;
+
+internal sealed partial class ReviewSettings {
+    internal ReviewSettings CloneWithProviderOverride(ReviewProvider provider, string model,
+        ReasoningEffort? reasoningEffort) {
+        var clone = (ReviewSettings)MemberwiseClone();
+        clone.Provider = provider;
+        clone.Model = model;
+        clone.ReasoningEffort = reasoningEffort;
+        return clone;
+    }
+}

--- a/IntelligenceX.Reviewer/ReviewSettings.Environment.CommentAndCleanup.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.Environment.CommentAndCleanup.cs
@@ -20,6 +20,11 @@ internal sealed partial class ReviewSettings {
             settings.CopilotWorkingDirectory = copilotWorkingDirectory;
         }
 
+        var copilotLauncher = GetInput("copilot_launcher", "COPILOT_LAUNCHER");
+        if (!string.IsNullOrWhiteSpace(copilotLauncher)) {
+            settings.CopilotLauncher = NormalizeCopilotLauncher(copilotLauncher, settings.CopilotLauncher);
+        }
+
         var copilotAutoInstall = Environment.GetEnvironmentVariable("COPILOT_AUTO_INSTALL");
         if (!string.IsNullOrWhiteSpace(copilotAutoInstall)) {
             settings.CopilotAutoInstall = ParseBoolean(copilotAutoInstall, settings.CopilotAutoInstall);

--- a/IntelligenceX.Reviewer/ReviewSettings.Environment.Support.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.Environment.Support.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using IntelligenceX.Analysis;
 using IntelligenceX.Copilot;
 using IntelligenceX.OpenAI;
@@ -440,9 +441,11 @@ internal sealed partial class ReviewSettings {
 
         var reviewers = GetInput("swarm_reviewers", "REVIEW_SWARM_REVIEWERS");
         if (!string.IsNullOrWhiteSpace(reviewers)) {
-            settings.Swarm.Reviewers = NormalizeSwarmReviewers(ParseList(reviewers), settings.Swarm.Reviewers);
             settings.Swarm.ReviewerSettings =
-                BuildSwarmReviewerSettings(settings.Swarm.Reviewers, settings.Swarm.ReviewerSettings);
+                ParseSwarmReviewerSettingsInput(reviewers, settings.Swarm.ReviewerSettings);
+            settings.Swarm.Reviewers = NormalizeSwarmReviewers(
+                settings.Swarm.ReviewerSettings.Select(static reviewer => reviewer.Id),
+                settings.Swarm.Reviewers);
         }
 
         var maxParallel = GetInput("swarm_max_parallel", "REVIEW_SWARM_MAX_PARALLEL");

--- a/IntelligenceX.Reviewer/ReviewSettings.Environment.Support.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.Environment.Support.cs
@@ -376,6 +376,57 @@ internal sealed partial class ReviewSettings {
         }
     }
 
+    private static void ApplyEnvironmentHistorySettings(ReviewSettings settings) {
+        var enabled = GetInput("history_enabled", "REVIEW_HISTORY_ENABLED");
+        if (!string.IsNullOrWhiteSpace(enabled)) {
+            settings.History.Enabled = ParseBoolean(enabled, settings.History.Enabled);
+        }
+
+        var includeIxSummaryHistory = GetInput(
+            "history_include_ix_summary_history",
+            "REVIEW_HISTORY_INCLUDE_IX_SUMMARY_HISTORY");
+        if (!string.IsNullOrWhiteSpace(includeIxSummaryHistory)) {
+            settings.History.IncludeIxSummaryHistory =
+                ParseBoolean(includeIxSummaryHistory, settings.History.IncludeIxSummaryHistory);
+        }
+
+        var includeReviewThreads = GetInput(
+            "history_include_review_threads",
+            "REVIEW_HISTORY_INCLUDE_REVIEW_THREADS");
+        if (!string.IsNullOrWhiteSpace(includeReviewThreads)) {
+            settings.History.IncludeReviewThreads =
+                ParseBoolean(includeReviewThreads, settings.History.IncludeReviewThreads);
+        }
+
+        var includeExternalBotSummaries = GetInput(
+            "history_include_external_bot_summaries",
+            "REVIEW_HISTORY_INCLUDE_EXTERNAL_BOT_SUMMARIES");
+        if (!string.IsNullOrWhiteSpace(includeExternalBotSummaries)) {
+            settings.History.IncludeExternalBotSummaries =
+                ParseBoolean(includeExternalBotSummaries, settings.History.IncludeExternalBotSummaries);
+        }
+
+        var externalBotLogins = GetInput("history_external_bot_logins", "REVIEW_HISTORY_EXTERNAL_BOT_LOGINS");
+        if (!string.IsNullOrWhiteSpace(externalBotLogins)) {
+            settings.History.ExternalBotLogins = ParseList(externalBotLogins, settings.History.ExternalBotLogins);
+        }
+
+        var artifacts = GetInput("history_artifacts", "REVIEW_HISTORY_ARTIFACTS");
+        if (!string.IsNullOrWhiteSpace(artifacts)) {
+            settings.History.Artifacts = ParseBoolean(artifacts, settings.History.Artifacts);
+        }
+
+        var maxRounds = GetInput("history_max_rounds", "REVIEW_HISTORY_MAX_ROUNDS");
+        if (!string.IsNullOrWhiteSpace(maxRounds)) {
+            settings.History.MaxRounds = ParseNonNegativeInt(maxRounds, settings.History.MaxRounds);
+        }
+
+        var maxItems = GetInput("history_max_items", "REVIEW_HISTORY_MAX_ITEMS");
+        if (!string.IsNullOrWhiteSpace(maxItems)) {
+            settings.History.MaxItems = ParseNonNegativeInt(maxItems, settings.History.MaxItems);
+        }
+    }
+
     private static void ApplyEnvironmentSwarmSettings(ReviewSettings settings) {
         var enabled = GetInput("swarm_enabled", "REVIEW_SWARM_ENABLED");
         if (!string.IsNullOrWhiteSpace(enabled)) {
@@ -390,6 +441,8 @@ internal sealed partial class ReviewSettings {
         var reviewers = GetInput("swarm_reviewers", "REVIEW_SWARM_REVIEWERS");
         if (!string.IsNullOrWhiteSpace(reviewers)) {
             settings.Swarm.Reviewers = NormalizeSwarmReviewers(ParseList(reviewers), settings.Swarm.Reviewers);
+            settings.Swarm.ReviewerSettings =
+                BuildSwarmReviewerSettings(settings.Swarm.Reviewers, settings.Swarm.ReviewerSettings);
         }
 
         var maxParallel = GetInput("swarm_max_parallel", "REVIEW_SWARM_MAX_PARALLEL");
@@ -406,6 +459,7 @@ internal sealed partial class ReviewSettings {
         var aggregatorModel = GetInput("swarm_aggregator_model", "REVIEW_SWARM_AGGREGATOR_MODEL");
         if (!string.IsNullOrWhiteSpace(aggregatorModel)) {
             settings.Swarm.AggregatorModel = aggregatorModel;
+            settings.Swarm.Aggregator.Model = aggregatorModel.Trim();
         }
 
         var failOpenOnPartial = GetInput("swarm_fail_open_on_partial", "REVIEW_SWARM_FAIL_OPEN_ON_PARTIAL");

--- a/IntelligenceX.Reviewer/ReviewSettings.Environment.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.Environment.cs
@@ -5,6 +5,7 @@ internal sealed partial class ReviewSettings {
         ApplyEnvironmentCoreReviewSettings(settings);
         ApplyEnvironmentUsageAndSummarySettings(settings);
         ApplyEnvironmentScopeAndPromptSettings(settings);
+        ApplyEnvironmentHistorySettings(settings);
         ApplyEnvironmentCiContextSettings(settings);
         ApplyEnvironmentSwarmSettings(settings);
         ApplyEnvironmentRetryAndDiagnosticsSettings(settings);

--- a/IntelligenceX.Reviewer/ReviewSettings.Parsing.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.Parsing.cs
@@ -225,6 +225,54 @@ internal sealed partial class ReviewSettings {
         return list.Count == 0 ? fallback ?? Array.Empty<string>() : list;
     }
 
+    internal static IReadOnlyList<ReviewSwarmReviewerSettings> NormalizeSwarmReviewerSettings(
+        IEnumerable<ReviewSwarmReviewerSettings>? values, IReadOnlyList<ReviewSwarmReviewerSettings>? fallback = null) {
+        if (values is null) {
+            return fallback ?? Array.Empty<ReviewSwarmReviewerSettings>();
+        }
+
+        var list = new List<ReviewSwarmReviewerSettings>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in values) {
+            var normalizedId = value.Id?.Trim().ToLowerInvariant();
+            if (string.IsNullOrWhiteSpace(normalizedId)) {
+                continue;
+            }
+            if (!seen.Add(normalizedId)) {
+                continue;
+            }
+
+            list.Add(new ReviewSwarmReviewerSettings {
+                Id = normalizedId,
+                Provider = value.Provider,
+                Model = string.IsNullOrWhiteSpace(value.Model) ? null : value.Model.Trim(),
+                ReasoningEffort = value.ReasoningEffort
+            });
+        }
+
+        return list.Count == 0 ? fallback ?? Array.Empty<ReviewSwarmReviewerSettings>() : list;
+    }
+
+    internal static IReadOnlyList<ReviewSwarmReviewerSettings> BuildSwarmReviewerSettings(
+        IEnumerable<string>? values, IReadOnlyList<ReviewSwarmReviewerSettings>? fallback = null) {
+        if (values is null) {
+            return fallback ?? Array.Empty<ReviewSwarmReviewerSettings>();
+        }
+
+        var normalizedIds = NormalizeSwarmReviewers(values);
+        if (normalizedIds.Count == 0) {
+            return fallback ?? Array.Empty<ReviewSwarmReviewerSettings>();
+        }
+
+        var list = new List<ReviewSwarmReviewerSettings>(normalizedIds.Count);
+        foreach (var id in normalizedIds) {
+            list.Add(new ReviewSwarmReviewerSettings {
+                Id = id
+            });
+        }
+        return list;
+    }
+
     private static CopilotTransportKind ParseCopilotTransport(string? value, CopilotTransportKind fallback) {
         if (string.IsNullOrWhiteSpace(value)) {
             return fallback;
@@ -233,6 +281,19 @@ internal sealed partial class ReviewSettings {
         return normalized switch {
             "direct" or "api" or "http" => CopilotTransportKind.Direct,
             "cli" => CopilotTransportKind.Cli,
+            _ => fallback
+        };
+    }
+
+    internal static string NormalizeCopilotLauncher(string? value, string fallback) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return fallback;
+        }
+        var normalized = value.Trim().ToLowerInvariant();
+        return normalized switch {
+            "binary" or "cli" or "copilot" => "binary",
+            "gh" or "github" or "github-cli" or "github_cli" => "gh",
+            "auto" => "auto",
             _ => fallback
         };
     }

--- a/IntelligenceX.Reviewer/ReviewSettings.Parsing.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.Parsing.cs
@@ -1,10 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text.Json;
 using IntelligenceX.Analysis;
 using IntelligenceX.Copilot;
 using IntelligenceX.OpenAI;
 using IntelligenceX.OpenAI.Chat;
+using JsonArrayNode = System.Text.Json.Nodes.JsonArray;
+using JsonNodeBase = System.Text.Json.Nodes.JsonNode;
+using JsonNodeObject = System.Text.Json.Nodes.JsonObject;
+using JsonValueNode = System.Text.Json.Nodes.JsonValue;
 
 
 namespace IntelligenceX.Reviewer;
@@ -271,6 +276,91 @@ internal sealed partial class ReviewSettings {
             });
         }
         return list;
+    }
+
+    internal static IReadOnlyList<ReviewSwarmReviewerSettings> ParseSwarmReviewerSettingsInput(
+        string? value, IReadOnlyList<ReviewSwarmReviewerSettings>? fallback = null) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return fallback ?? Array.Empty<ReviewSwarmReviewerSettings>();
+        }
+
+        var trimmed = value.Trim();
+        if (trimmed.StartsWith("[", StringComparison.Ordinal) ||
+            trimmed.StartsWith("{", StringComparison.Ordinal)) {
+            try {
+                var node = JsonNodeBase.Parse(trimmed);
+                var parsed = ParseSwarmReviewerSettingsNode(node);
+                return NormalizeSwarmReviewerSettings(parsed, fallback);
+            } catch (JsonException ex) {
+                throw new InvalidOperationException(
+                    "Invalid swarm_reviewers JSON. Use a CSV list or a JSON reviewer object/array.", ex);
+            }
+        }
+
+        var reviewerIds = NormalizeSwarmReviewers(ParseList(trimmed));
+        return BuildSwarmReviewerSettings(reviewerIds, fallback);
+    }
+
+    private static IReadOnlyList<ReviewSwarmReviewerSettings> ParseSwarmReviewerSettingsNode(JsonNodeBase? node) {
+        var list = new List<ReviewSwarmReviewerSettings>();
+        if (node is JsonArrayNode array) {
+            foreach (var item in array) {
+                var reviewer = ParseSwarmReviewerSettingNode(item);
+                if (reviewer is not null) {
+                    list.Add(reviewer);
+                }
+            }
+            return list;
+        }
+
+        var single = ParseSwarmReviewerSettingNode(node);
+        if (single is not null) {
+            list.Add(single);
+        }
+        return list;
+    }
+
+    private static ReviewSwarmReviewerSettings? ParseSwarmReviewerSettingNode(JsonNodeBase? node) {
+        if (node is JsonValueNode valueNode && valueNode.TryGetValue<string>(out var idFromValue)) {
+            return string.IsNullOrWhiteSpace(idFromValue)
+                ? null
+                : new ReviewSwarmReviewerSettings { Id = idFromValue };
+        }
+
+        if (node is not JsonNodeObject obj) {
+            return null;
+        }
+
+        var id = GetJsonString(obj, "id");
+        if (string.IsNullOrWhiteSpace(id)) {
+            return null;
+        }
+
+        return new ReviewSwarmReviewerSettings {
+            Id = id!,
+            Provider = ParseOptionalSwarmProviderInput(GetJsonString(obj, "provider")),
+            Model = GetJsonString(obj, "model"),
+            ReasoningEffort = ParseOptionalReasoningEffortInput(GetJsonString(obj, "reasoningEffort"))
+        };
+    }
+
+    private static string? GetJsonString(JsonNodeObject obj, string propertyName) {
+        var node = obj[propertyName];
+        return node is null ? null : node.GetValue<string>();
+    }
+
+    private static ReviewProvider? ParseOptionalSwarmProviderInput(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+        return ReviewProviderContracts.ParseProviderOrThrow(value, "swarm_reviewers.provider");
+    }
+
+    private static ReasoningEffort? ParseOptionalReasoningEffortInput(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+        return ChatEnumParser.ParseReasoningEffort(value);
     }
 
     private static CopilotTransportKind ParseCopilotTransport(string? value, CopilotTransportKind fallback) {

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -51,12 +51,49 @@ internal sealed class ReviewCiContextSettings {
     public bool ClassifyInfraFailures { get; set; } = true;
 }
 
+internal sealed class ReviewHistorySettings {
+    private static readonly IReadOnlyList<string> DefaultExternalBotLogins = new[] {
+        "claude",
+        "claude[bot]",
+        "copilot-pull-request-reviewer"
+    };
+
+    public bool Enabled { get; set; }
+    public bool IncludeIxSummaryHistory { get; set; } = true;
+    public bool IncludeReviewThreads { get; set; } = true;
+    public bool IncludeExternalBotSummaries { get; set; }
+    public IReadOnlyList<string> ExternalBotLogins { get; set; } = DefaultExternalBotLogins;
+    public bool Artifacts { get; set; }
+    public int MaxRounds { get; set; } = 6;
+    public int MaxItems { get; set; } = 8;
+}
+
+internal sealed class ReviewSwarmReviewerSettings {
+    public string Id { get; set; } = string.Empty;
+    public ReviewProvider? Provider { get; set; }
+    public string? Model { get; set; }
+    public ReasoningEffort? ReasoningEffort { get; set; }
+}
+
+internal sealed class ReviewSwarmAggregatorSettings {
+    public ReviewProvider? Provider { get; set; }
+    public string? Model { get; set; }
+    public ReasoningEffort? ReasoningEffort { get; set; }
+}
+
 internal sealed class ReviewSwarmSettings {
     public bool Enabled { get; set; }
     public bool ShadowMode { get; set; }
     public IReadOnlyList<string> Reviewers { get; set; } = new[] { "correctness", "security", "reliability", "tests" };
+    public IReadOnlyList<ReviewSwarmReviewerSettings> ReviewerSettings { get; set; } = new[] {
+        new ReviewSwarmReviewerSettings { Id = "correctness" },
+        new ReviewSwarmReviewerSettings { Id = "security" },
+        new ReviewSwarmReviewerSettings { Id = "reliability" },
+        new ReviewSwarmReviewerSettings { Id = "tests" }
+    };
     public int MaxParallel { get; set; } = 4;
     public bool PublishSubreviews { get; set; }
+    public ReviewSwarmAggregatorSettings Aggregator { get; } = new();
     public string? AggregatorModel { get; set; }
     public bool FailOpenOnPartial { get; set; } = true;
     public bool Metrics { get; set; } = true;
@@ -393,6 +430,7 @@ internal sealed partial class ReviewSettings {
     public bool IncludeRelatedPrs { get; set; }
     public string? RelatedPrsQuery { get; set; }
     public int MaxRelatedPrs { get; set; } = 5;
+    public ReviewHistorySettings History { get; } = new();
     public ReviewCiContextSettings CiContext { get; } = new();
     public ReviewSwarmSettings Swarm { get; } = new();
     public AnalysisSettings Analysis { get; } = new AnalysisSettings();
@@ -404,6 +442,7 @@ internal sealed partial class ReviewSettings {
     public string? CopilotCliPath { get; set; }
     public string? CopilotCliUrl { get; set; }
     public string? CopilotWorkingDirectory { get; set; }
+    public string CopilotLauncher { get; set; } = "binary";
     public bool CopilotAutoInstall { get; set; }
     public string? CopilotAutoInstallMethod { get; set; }
     public bool CopilotAutoInstallPrerelease { get; set; }

--- a/IntelligenceX.Reviewer/ReviewSummaryParser.cs
+++ b/IntelligenceX.Reviewer/ReviewSummaryParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace IntelligenceX.Reviewer;
 
@@ -182,13 +183,34 @@ internal static class ReviewSummaryParser {
     }
 
     private static string NormalizeHeader(string header) {
-        return header.Trim().ToLowerInvariant();
+        var trimmed = header.Trim();
+        while (trimmed.StartsWith("#", StringComparison.Ordinal)) {
+            trimmed = trimmed.Substring(1).TrimStart();
+        }
+
+        var sb = new StringBuilder(trimmed.Length);
+        var pendingSpace = false;
+        foreach (var ch in trimmed.ToLowerInvariant()) {
+            if (char.IsLetterOrDigit(ch)) {
+                if (pendingSpace && sb.Length > 0) {
+                    sb.Append(' ');
+                }
+                sb.Append(ch);
+                pendingSpace = false;
+            } else {
+                pendingSpace = true;
+            }
+        }
+
+        return sb.ToString().Trim();
     }
 
     private static string MatchConfiguredSection(string header, IReadOnlyList<string> configuredSections) {
         var normalizedHeader = NormalizeHeader(header);
         foreach (var section in configuredSections) {
-            if (normalizedHeader.Contains(section, StringComparison.OrdinalIgnoreCase)) {
+            var normalizedSection = NormalizeHeader(section);
+            if (normalizedHeader.Equals(normalizedSection, StringComparison.OrdinalIgnoreCase) ||
+                normalizedHeader.StartsWith(normalizedSection + " ", StringComparison.OrdinalIgnoreCase)) {
                 return section;
             }
         }

--- a/IntelligenceX.Reviewer/ReviewSummaryParser.cs
+++ b/IntelligenceX.Reviewer/ReviewSummaryParser.cs
@@ -4,6 +4,9 @@ using System.IO;
 
 namespace IntelligenceX.Reviewer;
 
+internal readonly record struct ReviewSummaryItem(string Section, string Text);
+internal readonly record struct ReviewSummaryFinding(string Fingerprint, string Section, string Text, string Status);
+
 internal static class ReviewSummaryParser {
     public static bool TryGetReviewedCommit(string? body, out string? commit) {
         commit = null;
@@ -94,6 +97,90 @@ internal static class ReviewSummaryParser {
         return false;
     }
 
+    internal static IReadOnlyList<ReviewSummaryItem> ExtractMergeBlockerItems(string? body, ReviewSettings? settings = null,
+        int maxItems = 10) {
+        var items = new List<ReviewSummaryItem>();
+        if (string.IsNullOrWhiteSpace(body) || maxItems <= 0) {
+            return items;
+        }
+
+        body = ReviewFormatter.NormalizeSectionLayout(body);
+        var configuredSections = settings?.ResolveMergeBlockerSections()
+                                 ?? new[] { "todo list", "critical issues" };
+        var mergeBlockerSections = ReviewSettings.NormalizeMergeBlockerSections(configuredSections);
+        if (mergeBlockerSections.Count == 0) {
+            mergeBlockerSections = new[] { "todo list", "critical issues" };
+        }
+
+        var currentSection = string.Empty;
+        using var reader = new StringReader(body);
+        string? line;
+        while ((line = reader.ReadLine()) is not null) {
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith("## ", StringComparison.Ordinal)) {
+                currentSection = MatchConfiguredSection(trimmed, mergeBlockerSections);
+                continue;
+            }
+
+            if (currentSection.Length == 0) {
+                continue;
+            }
+
+            if (!TryNormalizeItem(trimmed, out var normalizedItem)) {
+                continue;
+            }
+
+            items.Add(new ReviewSummaryItem(currentSection, normalizedItem));
+            if (items.Count >= maxItems) {
+                break;
+            }
+        }
+
+        return items;
+    }
+
+    internal static IReadOnlyList<ReviewSummaryFinding> ExtractMergeBlockerFindings(string? body, ReviewSettings? settings = null,
+        int maxItems = 10) {
+        var findings = new List<ReviewSummaryFinding>();
+        if (string.IsNullOrWhiteSpace(body) || maxItems <= 0) {
+            return findings;
+        }
+
+        body = ReviewFormatter.NormalizeSectionLayout(body);
+        var configuredSections = settings?.ResolveMergeBlockerSections()
+                                 ?? new[] { "todo list", "critical issues" };
+        var mergeBlockerSections = ReviewSettings.NormalizeMergeBlockerSections(configuredSections);
+        if (mergeBlockerSections.Count == 0) {
+            mergeBlockerSections = new[] { "todo list", "critical issues" };
+        }
+
+        var currentSection = string.Empty;
+        using var reader = new StringReader(body);
+        string? line;
+        while ((line = reader.ReadLine()) is not null) {
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith("## ", StringComparison.Ordinal)) {
+                currentSection = MatchConfiguredSection(trimmed, mergeBlockerSections);
+                continue;
+            }
+
+            if (currentSection.Length == 0) {
+                continue;
+            }
+
+            if (!TryNormalizeFinding(trimmed, currentSection, out var finding)) {
+                continue;
+            }
+
+            findings.Add(finding);
+            if (findings.Count >= maxItems) {
+                break;
+            }
+        }
+
+        return findings;
+    }
+
     private static string NormalizeHeader(string header) {
         return header.Trim().ToLowerInvariant();
     }
@@ -147,6 +234,119 @@ internal static class ReviewSummaryParser {
         }
 
         return false;
+    }
+
+    private static bool TryNormalizeItem(string line, out string normalizedItem) {
+        normalizedItem = string.Empty;
+        if (string.IsNullOrWhiteSpace(line)) {
+            return false;
+        }
+
+        return TryNormalizeFinding(line, "finding", out _, out normalizedItem, out _);
+    }
+
+    private static bool TryNormalizeFinding(string line, string section, out ReviewSummaryFinding finding) {
+        if (TryNormalizeFinding(line, section, out finding, out _, out _)) {
+            return true;
+        }
+
+        finding = default;
+        return false;
+    }
+
+    private static bool TryNormalizeFinding(string line, string section, out ReviewSummaryFinding finding,
+        out string normalizedItem, out string status) {
+        finding = default;
+        normalizedItem = string.Empty;
+        status = string.Empty;
+        if (string.IsNullOrWhiteSpace(line)) {
+            return false;
+        }
+
+        var trimmed = line.Trim();
+        if (trimmed.StartsWith("<!--", StringComparison.Ordinal)) {
+            return false;
+        }
+        if (IsNoneLine(trimmed) || IsPlaceholderLine(trimmed)) {
+            return false;
+        }
+        if (trimmed.StartsWith("*Rationale:", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("*Why", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        if (trimmed.StartsWith("- [ ]", StringComparison.Ordinal)) {
+            normalizedItem = trimmed.Substring(5).Trim();
+            status = "open";
+        } else if (trimmed.StartsWith("- [x]", StringComparison.OrdinalIgnoreCase)) {
+            normalizedItem = trimmed.Substring(5).Trim();
+            status = "resolved";
+        } else if (trimmed.StartsWith("-", StringComparison.Ordinal)) {
+            normalizedItem = trimmed.Substring(1).Trim();
+            status = "open";
+        } else {
+            return false;
+        }
+
+        if (normalizedItem.Length == 0 || IsNoneLine(normalizedItem) || IsPlaceholderLine(normalizedItem)) {
+            return false;
+        }
+
+        finding = new ReviewSummaryFinding(CreateFindingFingerprint(section, normalizedItem), section, normalizedItem, status);
+        return true;
+    }
+
+    private static string CreateFindingFingerprint(string section, string text) {
+        var sectionSlug = Slugify(section, 18);
+        var textSlug = Slugify(text, 36);
+        var hash = ComputeFnv1a32($"{NormalizeHeader(section)}\n{text.Trim()}");
+        return $"{sectionSlug}-{textSlug}-{hash:x8}";
+    }
+
+    private static string Slugify(string value, int maxChars) {
+        if (string.IsNullOrWhiteSpace(value) || maxChars <= 0) {
+            return "item";
+        }
+
+        var chars = new char[maxChars];
+        var length = 0;
+        var lastWasDash = false;
+        foreach (var ch in value.Trim().ToLowerInvariant()) {
+            if (char.IsLetterOrDigit(ch)) {
+                if (length >= maxChars) {
+                    break;
+                }
+                chars[length++] = ch;
+                lastWasDash = false;
+                continue;
+            }
+
+            if (length == 0 || lastWasDash) {
+                continue;
+            }
+            if (length >= maxChars) {
+                break;
+            }
+            chars[length++] = '-';
+            lastWasDash = true;
+        }
+
+        while (length > 0 && chars[length - 1] == '-') {
+            length--;
+        }
+
+        return length == 0 ? "item" : new string(chars, 0, length);
+    }
+
+    private static uint ComputeFnv1a32(string value) {
+        const uint offset = 2166136261;
+        const uint prime = 16777619;
+        var hash = offset;
+        foreach (var ch in value) {
+            hash ^= ch;
+            hash *= prime;
+        }
+        return hash;
     }
 
     private static bool IsNoneLine(string line) {

--- a/IntelligenceX.Reviewer/ReviewSwarmShadowArtifacts.cs
+++ b/IntelligenceX.Reviewer/ReviewSwarmShadowArtifacts.cs
@@ -172,7 +172,7 @@ internal static class ReviewSwarmShadowArtifacts {
             hasFailures = result.HasFailures,
             reviewerDurationMs,
             aggregatorDurationMs,
-            totalDurationMs = reviewerDurationMs + aggregatorDurationMs,
+            totalDurationMs = CalculateTotalDurationMs(result),
             reviewerOutputChars,
             aggregatorOutputChars
         };
@@ -224,6 +224,10 @@ internal static class ReviewSwarmShadowArtifacts {
     }
 
     private static long CalculateTotalDurationMs(ReviewSwarmShadowRunResult result) {
+        if (result.TotalDurationMs > 0) {
+            return result.TotalDurationMs;
+        }
+
         var total = 0L;
         foreach (var item in result.Results) {
             total += Math.Max(0, item.DurationMs);

--- a/IntelligenceX.Reviewer/ReviewSwarmShadowArtifacts.cs
+++ b/IntelligenceX.Reviewer/ReviewSwarmShadowArtifacts.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IntelligenceX.Reviewer;
+
+internal static class ReviewSwarmShadowArtifacts {
+    private const int MaxOutputChars = 12000;
+    private const string ArtifactDirectory = "artifacts/reviewer/swarm-shadow";
+    private const string JsonFileName = "ix-review-swarm-shadow.json";
+    private const string MarkdownFileName = "ix-review-swarm-shadow.md";
+    private const string MetricsFileName = "ix-review-swarm-shadow-metrics.jsonl";
+
+    public static async Task WriteAsync(PullRequestContext context, ReviewSettings settings,
+        ReviewSwarmShadowPlan plan, ReviewSwarmShadowRunResult result, CancellationToken cancellationToken) {
+        if (!settings.Swarm.Metrics || result.Results.Count == 0) {
+            return;
+        }
+
+        Directory.CreateDirectory(ArtifactDirectory);
+        var jsonPath = Path.Combine(ArtifactDirectory, JsonFileName);
+        var markdownPath = Path.Combine(ArtifactDirectory, MarkdownFileName);
+        var metricsPath = Path.Combine(ArtifactDirectory, MetricsFileName);
+        await File.WriteAllTextAsync(jsonPath, BuildJson(context, plan, result), cancellationToken)
+            .ConfigureAwait(false);
+        await File.WriteAllTextAsync(markdownPath, BuildMarkdown(context, plan, result), cancellationToken)
+            .ConfigureAwait(false);
+        await File.AppendAllTextAsync(metricsPath, BuildMetricsJsonLine(context, result) + Environment.NewLine,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    internal static string BuildJson(PullRequestContext context, ReviewSwarmShadowPlan plan,
+        ReviewSwarmShadowRunResult result) {
+        var payload = new {
+            schema = "intelligencex.review.swarmShadow.v1",
+            generatedAtUtc = DateTimeOffset.UtcNow,
+            repository = context.RepoFullName,
+            pullRequest = context.Number,
+            headSha = context.HeadSha,
+            plan = new {
+                enabled = plan.Enabled,
+                shadowMode = plan.ShadowMode,
+                maxParallel = plan.MaxParallel,
+                reviewers = BuildReviewerPlanItems(plan),
+                aggregator = new {
+                    provider = FormatProvider(plan.Aggregator.Provider),
+                    model = plan.Aggregator.Model,
+                    reasoningEffort = plan.Aggregator.ReasoningEffort?.ToString().ToLowerInvariant()
+                }
+            },
+            result = new {
+                hasFailures = result.HasFailures,
+                reviewers = BuildReviewerResultItems(result),
+                aggregator = BuildAggregatorResultItem(result.Aggregator)
+            }
+        };
+
+        return JsonSerializer.Serialize(payload, new JsonSerializerOptions {
+            WriteIndented = true
+        });
+    }
+
+    internal static string BuildMarkdown(PullRequestContext context, ReviewSwarmShadowPlan plan,
+        ReviewSwarmShadowRunResult result) {
+        var sb = new StringBuilder();
+        sb.AppendLine("# IntelligenceX Swarm Shadow Artifact");
+        sb.AppendLine();
+        sb.AppendLine($"- Repository: `{context.RepoFullName}`");
+        sb.AppendLine($"- Pull request: `#{context.Number}`");
+        if (!string.IsNullOrWhiteSpace(context.HeadSha)) {
+            sb.AppendLine($"- Head SHA: `{context.HeadSha}`");
+        }
+        sb.AppendLine($"- Reviewers: `{result.Results.Count}`");
+        sb.AppendLine($"- Failures: `{(result.HasFailures ? "yes" : "no")}`");
+        sb.AppendLine($"- Total shadow duration: `{CalculateTotalDurationMs(result)} ms`");
+        sb.AppendLine();
+        sb.AppendLine("## Plan");
+        sb.AppendLine();
+        sb.AppendLine($"- Parallel cap: `{plan.MaxParallel}`");
+        foreach (var reviewer in plan.Reviewers) {
+            sb.Append("- `");
+            sb.Append(reviewer.Id);
+            sb.Append("`: ");
+            sb.Append(FormatProvider(reviewer.Provider));
+            sb.Append(" / `");
+            sb.Append(reviewer.Model);
+            sb.Append('`');
+            if (reviewer.ReasoningEffort.HasValue) {
+                sb.Append(" / reasoning `");
+                sb.Append(reviewer.ReasoningEffort.Value.ToString().ToLowerInvariant());
+                sb.Append('`');
+            }
+            sb.AppendLine();
+        }
+        sb.Append("- aggregator: ");
+        sb.Append(FormatProvider(plan.Aggregator.Provider));
+        sb.Append(" / `");
+        sb.Append(plan.Aggregator.Model);
+        sb.AppendLine("`");
+        sb.AppendLine();
+        sb.AppendLine("## Results");
+        sb.AppendLine();
+        foreach (var item in result.Results) {
+            sb.Append("### ");
+            sb.AppendLine(item.Reviewer.Id);
+            sb.AppendLine();
+            sb.AppendLine($"- Status: `{(item.Succeeded ? "succeeded" : "failed")}`");
+            sb.AppendLine($"- Duration: `{Math.Max(0, item.DurationMs)} ms`");
+            if (!string.IsNullOrWhiteSpace(item.Error)) {
+                sb.AppendLine($"- Error: `{EscapeInline(item.Error)}`");
+            }
+            if (!string.IsNullOrWhiteSpace(item.Output)) {
+                sb.AppendLine();
+                sb.AppendLine("```markdown");
+                sb.AppendLine(TrimOutput(item.Output));
+                sb.AppendLine("```");
+            }
+            sb.AppendLine();
+        }
+
+        if (result.Aggregator is not null) {
+            sb.AppendLine("### Aggregator");
+            sb.AppendLine();
+            sb.AppendLine($"- Status: `{(result.Aggregator.Succeeded ? "succeeded" : "failed")}`");
+            sb.AppendLine($"- Duration: `{Math.Max(0, result.Aggregator.DurationMs)} ms`");
+            if (!string.IsNullOrWhiteSpace(result.Aggregator.Error)) {
+                sb.AppendLine($"- Error: `{EscapeInline(result.Aggregator.Error)}`");
+            }
+            if (!string.IsNullOrWhiteSpace(result.Aggregator.Output)) {
+                sb.AppendLine();
+                sb.AppendLine("```markdown");
+                sb.AppendLine(TrimOutput(result.Aggregator.Output));
+                sb.AppendLine("```");
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    internal static string BuildMetricsJsonLine(PullRequestContext context, ReviewSwarmShadowRunResult result) {
+        var reviewerSucceeded = 0;
+        var reviewerFailed = 0;
+        var reviewerDurationMs = 0L;
+        var reviewerOutputChars = 0;
+        foreach (var reviewer in result.Results) {
+            if (reviewer.Succeeded) {
+                reviewerSucceeded++;
+            } else {
+                reviewerFailed++;
+            }
+            reviewerDurationMs += Math.Max(0, reviewer.DurationMs);
+            reviewerOutputChars += reviewer.Output?.Length ?? 0;
+        }
+
+        var aggregatorDurationMs = Math.Max(0, result.Aggregator?.DurationMs ?? 0);
+        var aggregatorOutputChars = result.Aggregator?.Output?.Length ?? 0;
+        var payload = new {
+            schema = "intelligencex.review.swarmShadowMetrics.v1",
+            generatedAtUtc = DateTimeOffset.UtcNow,
+            repository = context.RepoFullName,
+            pullRequest = context.Number,
+            headSha = context.HeadSha,
+            reviewerCount = result.Results.Count,
+            reviewerSucceeded,
+            reviewerFailed,
+            aggregatorSucceeded = result.Aggregator?.Succeeded,
+            hasFailures = result.HasFailures,
+            reviewerDurationMs,
+            aggregatorDurationMs,
+            totalDurationMs = reviewerDurationMs + aggregatorDurationMs,
+            reviewerOutputChars,
+            aggregatorOutputChars
+        };
+
+        return JsonSerializer.Serialize(payload);
+    }
+
+    private static IReadOnlyList<object> BuildReviewerPlanItems(ReviewSwarmShadowPlan plan) {
+        var items = new List<object>(plan.Reviewers.Count);
+        foreach (var reviewer in plan.Reviewers) {
+            items.Add(new {
+                id = reviewer.Id,
+                provider = FormatProvider(reviewer.Provider),
+                model = reviewer.Model,
+                reasoningEffort = reviewer.ReasoningEffort?.ToString().ToLowerInvariant()
+            });
+        }
+        return items;
+    }
+
+    private static IReadOnlyList<object> BuildReviewerResultItems(ReviewSwarmShadowRunResult result) {
+        var items = new List<object>(result.Results.Count);
+        foreach (var reviewerResult in result.Results) {
+            items.Add(new {
+                id = reviewerResult.Reviewer.Id,
+                provider = FormatProvider(reviewerResult.Reviewer.Provider),
+                model = reviewerResult.Reviewer.Model,
+                succeeded = reviewerResult.Succeeded,
+                error = reviewerResult.Error,
+                durationMs = Math.Max(0, reviewerResult.DurationMs),
+                outputChars = reviewerResult.Output?.Length ?? 0,
+                output = TrimOutput(reviewerResult.Output ?? string.Empty)
+            });
+        }
+        return items;
+    }
+
+    private static object? BuildAggregatorResultItem(ReviewSwarmShadowAggregatorResult? aggregator) {
+        if (aggregator is null) {
+            return null;
+        }
+        return new {
+            succeeded = aggregator.Succeeded,
+            error = aggregator.Error,
+            durationMs = Math.Max(0, aggregator.DurationMs),
+            outputChars = aggregator.Output?.Length ?? 0,
+            output = TrimOutput(aggregator.Output ?? string.Empty)
+        };
+    }
+
+    private static long CalculateTotalDurationMs(ReviewSwarmShadowRunResult result) {
+        var total = 0L;
+        foreach (var item in result.Results) {
+            total += Math.Max(0, item.DurationMs);
+        }
+        return total + Math.Max(0, result.Aggregator?.DurationMs ?? 0);
+    }
+
+    private static string TrimOutput(string text) {
+        if (text.Length <= MaxOutputChars) {
+            return text;
+        }
+        const string suffix = "\n\n[truncated for swarm shadow artifact]";
+        return text.Substring(0, Math.Max(0, MaxOutputChars - suffix.Length)) + suffix;
+    }
+
+    private static string FormatProvider(ReviewProvider provider) =>
+        provider.ToString().ToLowerInvariant();
+
+    private static string EscapeInline(string value) =>
+        value.Replace("`", "\\`", StringComparison.Ordinal);
+}

--- a/IntelligenceX.Reviewer/ReviewSwarmShadowPlan.cs
+++ b/IntelligenceX.Reviewer/ReviewSwarmShadowPlan.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using IntelligenceX.OpenAI.Chat;
+
+namespace IntelligenceX.Reviewer;
+
+internal sealed class ReviewSwarmShadowReviewerPlan {
+    public string Id { get; init; } = string.Empty;
+    public ReviewProvider Provider { get; init; }
+    public string Model { get; init; } = string.Empty;
+    public ReasoningEffort? ReasoningEffort { get; init; }
+}
+
+internal sealed class ReviewSwarmShadowAggregatorPlan {
+    public ReviewProvider Provider { get; init; }
+    public string Model { get; init; } = string.Empty;
+    public ReasoningEffort? ReasoningEffort { get; init; }
+}
+
+internal sealed class ReviewSwarmShadowPlan {
+    public bool Enabled { get; init; }
+    public bool ShadowMode { get; init; }
+    public int MaxParallel { get; init; }
+    public IReadOnlyList<ReviewSwarmShadowReviewerPlan> Reviewers { get; init; } = Array.Empty<ReviewSwarmShadowReviewerPlan>();
+    public ReviewSwarmShadowAggregatorPlan Aggregator { get; init; } = new();
+}
+
+internal static class ReviewSwarmShadowPlanner {
+    public static ReviewSwarmShadowPlan Build(ReviewSettings settings) {
+        var reviewerSettings = settings.Swarm.ReviewerSettings.Count > 0
+            ? settings.Swarm.ReviewerSettings
+            : ReviewSettings.BuildSwarmReviewerSettings(settings.Swarm.Reviewers);
+
+        var reviewers = new List<ReviewSwarmShadowReviewerPlan>(reviewerSettings.Count);
+        foreach (var reviewer in reviewerSettings) {
+            if (string.IsNullOrWhiteSpace(reviewer.Id)) {
+                continue;
+            }
+
+            reviewers.Add(new ReviewSwarmShadowReviewerPlan {
+                Id = reviewer.Id.Trim().ToLowerInvariant(),
+                Provider = reviewer.Provider ?? settings.Provider,
+                Model = string.IsNullOrWhiteSpace(reviewer.Model) ? settings.Model : reviewer.Model.Trim(),
+                ReasoningEffort = reviewer.ReasoningEffort ?? settings.ReasoningEffort
+            });
+        }
+
+        var aggregatorModel = !string.IsNullOrWhiteSpace(settings.Swarm.Aggregator.Model)
+            ? settings.Swarm.Aggregator.Model!.Trim()
+            : !string.IsNullOrWhiteSpace(settings.Swarm.AggregatorModel)
+                ? settings.Swarm.AggregatorModel!.Trim()
+                : settings.Model;
+
+        return new ReviewSwarmShadowPlan {
+            Enabled = settings.Swarm.Enabled,
+            ShadowMode = settings.Swarm.ShadowMode,
+            MaxParallel = Math.Max(1, settings.Swarm.MaxParallel),
+            Reviewers = reviewers,
+            Aggregator = new ReviewSwarmShadowAggregatorPlan {
+                Provider = settings.Swarm.Aggregator.Provider ?? settings.Provider,
+                Model = aggregatorModel,
+                ReasoningEffort = settings.Swarm.Aggregator.ReasoningEffort ?? settings.ReasoningEffort
+            }
+        };
+    }
+
+    public static string Render(ReviewSwarmShadowPlan plan) {
+        if (!plan.Enabled || !plan.ShadowMode) {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("Swarm shadow plan (public comment remains single-review path):");
+        sb.AppendLine($"- reviewers: {plan.Reviewers.Count} | parallel cap: {plan.MaxParallel}");
+        foreach (var reviewer in plan.Reviewers) {
+            sb.Append("- ");
+            sb.Append(reviewer.Id);
+            sb.Append(" -> ");
+            sb.Append(reviewer.Provider.ToString().ToLowerInvariant());
+            sb.Append(" / ");
+            sb.Append(reviewer.Model);
+            if (reviewer.ReasoningEffort.HasValue) {
+                sb.Append(" / reasoning ");
+                sb.Append(reviewer.ReasoningEffort.Value.ToString().ToLowerInvariant());
+            }
+            sb.AppendLine();
+        }
+
+        sb.Append("- aggregator -> ");
+        sb.Append(plan.Aggregator.Provider.ToString().ToLowerInvariant());
+        sb.Append(" / ");
+        sb.Append(plan.Aggregator.Model);
+        if (plan.Aggregator.ReasoningEffort.HasValue) {
+            sb.Append(" / reasoning ");
+            sb.Append(plan.Aggregator.ReasoningEffort.Value.ToString().ToLowerInvariant());
+        }
+        sb.AppendLine();
+
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/IntelligenceX.Reviewer/ReviewSwarmShadowRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewSwarmShadowRunner.cs
@@ -133,10 +133,25 @@ internal static class ReviewSwarmShadowRunner {
 
     internal static string BuildAggregatorPrompt(string basePrompt, ReviewSwarmShadowPlan plan,
         IReadOnlyList<ReviewSwarmShadowReviewerResult> results) {
+        var aggregatorContext = TrimForAggregator(BuildAggregatorContext(plan, results));
+        var normalizedBasePrompt = basePrompt.TrimEnd();
+        if (normalizedBasePrompt.Length == 0) {
+            return aggregatorContext;
+        }
+
+        const string separator = "\n\n";
+        var basePromptBudget = MaxAggregatorContextChars - aggregatorContext.Length - separator.Length;
+        if (basePromptBudget <= 0) {
+            return aggregatorContext;
+        }
+
+        return string.Concat(TrimForAggregator(normalizedBasePrompt, basePromptBudget).TrimEnd(),
+            separator, aggregatorContext);
+    }
+
+    private static string BuildAggregatorContext(ReviewSwarmShadowPlan plan,
+        IReadOnlyList<ReviewSwarmShadowReviewerResult> results) {
         var sb = new StringBuilder();
-        sb.Append(basePrompt.TrimEnd());
-        sb.AppendLine();
-        sb.AppendLine();
         sb.AppendLine("## Swarm Shadow Aggregator");
         sb.AppendLine("You are aggregating diagnostic-only sub-review outputs. This result will not be posted publicly yet.");
         sb.AppendLine("- Merge overlapping findings into one item.");
@@ -332,17 +347,27 @@ internal static class ReviewSwarmShadowRunner {
         return "correctness, reliability, merge blockers, and user-visible regressions.";
     }
 
-    private static string TrimForAggregator(string text) {
-        if (text.Length <= MaxAggregatorContextChars) {
+    private static string TrimForAggregator(string text) => TrimForAggregator(text, MaxAggregatorContextChars);
+
+    private static string TrimForAggregator(string text, int maxChars) {
+        if (maxChars <= 0) {
+            return string.Empty;
+        }
+        if (text.Length <= maxChars) {
             return text;
         }
         const string suffix = "\n\n[truncated for swarm shadow aggregation]";
-        var trimmed = text.Substring(0, Math.Max(0, MaxAggregatorContextChars - suffix.Length - 8));
+        if (maxChars <= suffix.Length + 8) {
+            return text.Substring(0, maxChars);
+        }
+
+        var trimmed = text.Substring(0, Math.Max(0, maxChars - suffix.Length - 8));
         var closingFence = ResolveOpenMarkdownFence(trimmed);
         if (!string.IsNullOrEmpty(closingFence)) {
             trimmed = string.Concat(trimmed.TrimEnd(), "\n", closingFence);
         }
-        return trimmed + suffix;
+        var result = trimmed + suffix;
+        return result.Length <= maxChars ? result : result.Substring(0, maxChars);
     }
 
     private static string ResolveOpenMarkdownFence(string markdown) {

--- a/IntelligenceX.Reviewer/ReviewSwarmShadowRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewSwarmShadowRunner.cs
@@ -19,6 +19,7 @@ internal sealed class ReviewSwarmShadowRunResult {
     public IReadOnlyList<ReviewSwarmShadowReviewerResult> Results { get; init; } =
         Array.Empty<ReviewSwarmShadowReviewerResult>();
     public ReviewSwarmShadowAggregatorResult? Aggregator { get; init; }
+    public long TotalDurationMs { get; init; }
 
     public bool HasFailures {
         get {
@@ -58,6 +59,7 @@ internal static class ReviewSwarmShadowRunner {
             return new ReviewSwarmShadowRunResult();
         }
 
+        var stopwatch = Stopwatch.StartNew();
         var results = await RunReviewerLanesAsync(settings, plan, basePrompt, executeReviewerAsync,
                 cancellationToken)
             .ConfigureAwait(false);
@@ -65,9 +67,11 @@ internal static class ReviewSwarmShadowRunner {
         var aggregatorResult = await RunAggregatorAsync(settings, plan, basePrompt, results, executeAggregatorAsync,
                 cancellationToken)
             .ConfigureAwait(false);
+        stopwatch.Stop();
         return new ReviewSwarmShadowRunResult {
             Results = results,
-            Aggregator = aggregatorResult
+            Aggregator = aggregatorResult,
+            TotalDurationMs = stopwatch.ElapsedMilliseconds
         };
     }
 

--- a/IntelligenceX.Reviewer/ReviewSwarmShadowRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewSwarmShadowRunner.cs
@@ -173,9 +173,12 @@ internal static class ReviewSwarmShadowRunner {
                 sb.AppendLine(result.Error);
             }
             if (!string.IsNullOrWhiteSpace(result.Output)) {
-                sb.AppendLine("```markdown");
-                sb.AppendLine(TrimForAggregator(result.Output));
-                sb.AppendLine("```");
+                var output = TrimForAggregator(result.Output);
+                var fence = BuildMarkdownFence(output, '~', 4);
+                sb.Append(fence);
+                sb.AppendLine("markdown");
+                sb.AppendLine(output);
+                sb.AppendLine(fence);
             }
             sb.AppendLine();
         }
@@ -348,6 +351,22 @@ internal static class ReviewSwarmShadowRunner {
     }
 
     private static string TrimForAggregator(string text) => TrimForAggregator(text, MaxAggregatorContextChars);
+
+    private static string BuildMarkdownFence(string markdown, char fenceChar, int minimumLength) {
+        var longestRun = 0;
+        var currentRun = 0;
+        foreach (var ch in markdown) {
+            if (ch == fenceChar) {
+                currentRun++;
+                if (currentRun > longestRun) {
+                    longestRun = currentRun;
+                }
+            } else {
+                currentRun = 0;
+            }
+        }
+        return new string(fenceChar, Math.Max(minimumLength, longestRun + 1));
+    }
 
     private static string TrimForAggregator(string text, int maxChars) {
         if (maxChars <= 0) {

--- a/IntelligenceX.Reviewer/ReviewSwarmShadowRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewSwarmShadowRunner.cs
@@ -337,6 +337,46 @@ internal static class ReviewSwarmShadowRunner {
             return text;
         }
         const string suffix = "\n\n[truncated for swarm shadow aggregation]";
-        return text.Substring(0, Math.Max(0, MaxAggregatorContextChars - suffix.Length)) + suffix;
+        var trimmed = text.Substring(0, Math.Max(0, MaxAggregatorContextChars - suffix.Length - 8));
+        var closingFence = ResolveOpenMarkdownFence(trimmed);
+        if (!string.IsNullOrEmpty(closingFence)) {
+            trimmed = string.Concat(trimmed.TrimEnd(), "\n", closingFence);
+        }
+        return trimmed + suffix;
+    }
+
+    private static string ResolveOpenMarkdownFence(string markdown) {
+        var openFenceChar = '\0';
+        var openFenceLength = 0;
+        var lines = markdown.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+        foreach (var line in lines) {
+            var trimmed = line.TrimStart();
+            if (line.Length - trimmed.Length > 3 || trimmed.Length < 3) {
+                continue;
+            }
+            var fenceChar = trimmed[0];
+            if (fenceChar != '`' && fenceChar != '~') {
+                continue;
+            }
+            var fenceLength = 0;
+            while (fenceLength < trimmed.Length && trimmed[fenceLength] == fenceChar) {
+                fenceLength++;
+            }
+            if (fenceLength < 3) {
+                continue;
+            }
+
+            if (openFenceChar == '\0') {
+                openFenceChar = fenceChar;
+                openFenceLength = fenceLength;
+                continue;
+            }
+            if (fenceChar == openFenceChar && fenceLength >= openFenceLength) {
+                openFenceChar = '\0';
+                openFenceLength = 0;
+            }
+        }
+
+        return openFenceChar == '\0' ? string.Empty : new string(openFenceChar, openFenceLength);
     }
 }

--- a/IntelligenceX.Reviewer/ReviewSwarmShadowRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewSwarmShadowRunner.cs
@@ -1,0 +1,342 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IntelligenceX.Reviewer;
+
+internal sealed class ReviewSwarmShadowReviewerResult {
+    public ReviewSwarmShadowReviewerPlan Reviewer { get; init; } = new();
+    public bool Succeeded { get; init; }
+    public string Output { get; init; } = string.Empty;
+    public string? Error { get; init; }
+    public long DurationMs { get; init; }
+}
+
+internal sealed class ReviewSwarmShadowRunResult {
+    public IReadOnlyList<ReviewSwarmShadowReviewerResult> Results { get; init; } =
+        Array.Empty<ReviewSwarmShadowReviewerResult>();
+    public ReviewSwarmShadowAggregatorResult? Aggregator { get; init; }
+
+    public bool HasFailures {
+        get {
+            foreach (var result in Results) {
+                if (!result.Succeeded) {
+                    return true;
+                }
+            }
+            return Aggregator is not null && !Aggregator.Succeeded;
+        }
+    }
+}
+
+internal sealed class ReviewSwarmShadowAggregatorResult {
+    public bool Succeeded { get; init; }
+    public string Output { get; init; } = string.Empty;
+    public string? Error { get; init; }
+    public long DurationMs { get; init; }
+}
+
+internal static class ReviewSwarmShadowRunner {
+    private const int MaxAggregatorContextChars = 24000;
+
+    public static Task<ReviewSwarmShadowRunResult> RunAsync(ReviewSettings settings, ReviewSwarmShadowPlan plan,
+        string basePrompt, CancellationToken cancellationToken) =>
+        RunAsync(settings, plan, basePrompt,
+            (reviewer, prompt, token) => ExecuteReviewerAsync(settings, reviewer, prompt, token),
+            (aggregator, prompt, token) => ExecuteAggregatorAsync(settings, aggregator, prompt, token),
+            cancellationToken);
+
+    internal static async Task<ReviewSwarmShadowRunResult> RunAsync(ReviewSettings settings,
+        ReviewSwarmShadowPlan plan, string basePrompt,
+        Func<ReviewSwarmShadowReviewerPlan, string, CancellationToken, Task<string>> executeReviewerAsync,
+        Func<ReviewSwarmShadowAggregatorPlan, string, CancellationToken, Task<string>> executeAggregatorAsync,
+        CancellationToken cancellationToken) {
+        if (!plan.Enabled || !plan.ShadowMode || plan.Reviewers.Count == 0) {
+            return new ReviewSwarmShadowRunResult();
+        }
+
+        var results = await RunReviewerLanesAsync(settings, plan, basePrompt, executeReviewerAsync,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var aggregatorResult = await RunAggregatorAsync(settings, plan, basePrompt, results, executeAggregatorAsync,
+                cancellationToken)
+            .ConfigureAwait(false);
+        return new ReviewSwarmShadowRunResult {
+            Results = results,
+            Aggregator = aggregatorResult
+        };
+    }
+
+    public static string RenderResultSummary(ReviewSwarmShadowRunResult result) {
+        if (result.Results.Count == 0) {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("Swarm shadow results (not posted publicly):");
+        foreach (var resultItem in result.Results) {
+            sb.Append("- ");
+            sb.Append(resultItem.Reviewer.Id);
+            sb.Append(": ");
+            if (resultItem.Succeeded) {
+                sb.Append("completed");
+                sb.Append(" (");
+                sb.Append(Math.Max(0, resultItem.Output?.Length ?? 0));
+                sb.Append(" chars");
+                AppendDuration(sb, resultItem.DurationMs);
+                sb.Append(')');
+            } else {
+                sb.Append("failed");
+                if (!string.IsNullOrWhiteSpace(resultItem.Error)) {
+                    sb.Append(" - ");
+                    sb.Append(resultItem.Error);
+                }
+                AppendDuration(sb, resultItem.DurationMs);
+            }
+            sb.AppendLine();
+        }
+        if (result.Aggregator is not null) {
+            sb.Append("- aggregator: ");
+            if (result.Aggregator.Succeeded) {
+                sb.Append("completed (");
+                sb.Append(Math.Max(0, result.Aggregator.Output?.Length ?? 0));
+                sb.Append(" chars");
+                AppendDuration(sb, result.Aggregator.DurationMs);
+                sb.Append(')');
+            } else {
+                sb.Append("failed");
+                if (!string.IsNullOrWhiteSpace(result.Aggregator.Error)) {
+                    sb.Append(" - ");
+                    sb.Append(result.Aggregator.Error);
+                }
+                AppendDuration(sb, result.Aggregator.DurationMs);
+            }
+            sb.AppendLine();
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    internal static string BuildReviewerPrompt(string basePrompt, ReviewSwarmShadowReviewerPlan reviewer) {
+        var focus = ResolveReviewerFocus(reviewer.Id);
+        return string.Concat(basePrompt.TrimEnd(), "\n\n",
+            "## Swarm Shadow Reviewer\n",
+            "You are running as an independent shadow reviewer. Your output is diagnostic-only and will not be posted directly.\n",
+            "- Reviewer id: `", reviewer.Id, "`\n",
+            "- Primary focus: ", focus, "\n",
+            "- Do not assume other reviewers will see your reasoning.\n",
+            "- Return concise findings using the existing review markdown contract.\n");
+    }
+
+    internal static string BuildAggregatorPrompt(string basePrompt, ReviewSwarmShadowPlan plan,
+        IReadOnlyList<ReviewSwarmShadowReviewerResult> results) {
+        var sb = new StringBuilder();
+        sb.Append(basePrompt.TrimEnd());
+        sb.AppendLine();
+        sb.AppendLine();
+        sb.AppendLine("## Swarm Shadow Aggregator");
+        sb.AppendLine("You are aggregating diagnostic-only sub-review outputs. This result will not be posted publicly yet.");
+        sb.AppendLine("- Merge overlapping findings into one item.");
+        sb.AppendLine("- Prefer actionable correctness, security, reliability, and test coverage blockers.");
+        sb.AppendLine("- Preserve the existing review markdown contract.");
+        sb.AppendLine("- Note reviewer disagreement only when it materially changes confidence.");
+        sb.Append("- Aggregator model target: `");
+        sb.Append(plan.Aggregator.Model);
+        sb.AppendLine("`.");
+        sb.AppendLine();
+        sb.AppendLine("### Sub-review outputs");
+        foreach (var result in results) {
+            sb.Append("#### ");
+            sb.Append(result.Reviewer.Id);
+            sb.Append(result.Succeeded ? " (succeeded)" : " (failed)");
+            sb.AppendLine();
+            if (!string.IsNullOrWhiteSpace(result.Error)) {
+                sb.Append("Error: ");
+                sb.AppendLine(result.Error);
+            }
+            if (!string.IsNullOrWhiteSpace(result.Output)) {
+                sb.AppendLine("```markdown");
+                sb.AppendLine(TrimForAggregator(result.Output));
+                sb.AppendLine("```");
+            }
+            sb.AppendLine();
+        }
+
+        return TrimForAggregator(sb.ToString());
+    }
+
+    private static async Task<IReadOnlyList<ReviewSwarmShadowReviewerResult>> RunReviewerLanesAsync(
+        ReviewSettings settings, ReviewSwarmShadowPlan plan, string basePrompt,
+        Func<ReviewSwarmShadowReviewerPlan, string, CancellationToken, Task<string>> executeReviewerAsync,
+        CancellationToken cancellationToken) {
+        var results = new ReviewSwarmShadowReviewerResult[plan.Reviewers.Count];
+        var maxParallel = Math.Max(1, Math.Min(plan.MaxParallel, plan.Reviewers.Count));
+        using var semaphore = new SemaphoreSlim(maxParallel, maxParallel);
+        var tasks = new List<Task>(plan.Reviewers.Count);
+        for (var index = 0; index < plan.Reviewers.Count; index++) {
+            var reviewerIndex = index;
+            tasks.Add(Task.Run(async () => {
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try {
+                    results[reviewerIndex] = await RunReviewerLaneAsync(settings, plan.Reviewers[reviewerIndex],
+                            basePrompt, executeReviewerAsync, cancellationToken)
+                        .ConfigureAwait(false);
+                } finally {
+                    semaphore.Release();
+                }
+            }, CancellationToken.None));
+        }
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+        return results;
+    }
+
+    private static async Task<ReviewSwarmShadowReviewerResult> RunReviewerLaneAsync(ReviewSettings settings,
+        ReviewSwarmShadowReviewerPlan reviewer, string basePrompt,
+        Func<ReviewSwarmShadowReviewerPlan, string, CancellationToken, Task<string>> executeReviewerAsync,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        var prompt = BuildReviewerPrompt(basePrompt, reviewer);
+        var stopwatch = Stopwatch.StartNew();
+        try {
+            var output = await executeReviewerAsync(reviewer, prompt, cancellationToken).ConfigureAwait(false);
+            stopwatch.Stop();
+            if (ReviewDiagnostics.IsFailureBody(output)) {
+                var failure = new ReviewSwarmShadowReviewerResult {
+                    Reviewer = reviewer,
+                    Succeeded = false,
+                    Output = output,
+                    Error = "Provider returned a fail-open review body.",
+                    DurationMs = stopwatch.ElapsedMilliseconds
+                };
+                if (!settings.Swarm.FailOpenOnPartial) {
+                    throw new InvalidOperationException(
+                        $"Swarm shadow reviewer '{reviewer.Id}' returned a fail-open review body.");
+                }
+                return failure;
+            }
+
+            return new ReviewSwarmShadowReviewerResult {
+                Reviewer = reviewer,
+                Succeeded = true,
+                Output = output ?? string.Empty,
+                DurationMs = stopwatch.ElapsedMilliseconds
+            };
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception ex) {
+            stopwatch.Stop();
+            var failure = new ReviewSwarmShadowReviewerResult {
+                Reviewer = reviewer,
+                Succeeded = false,
+                Error = $"{ex.GetType().Name}: {ex.Message}",
+                DurationMs = stopwatch.ElapsedMilliseconds
+            };
+            if (!settings.Swarm.FailOpenOnPartial) {
+                throw;
+            }
+            return failure;
+        }
+    }
+
+    private static async Task<string> ExecuteReviewerAsync(ReviewSettings settings,
+        ReviewSwarmShadowReviewerPlan reviewer, string prompt, CancellationToken cancellationToken) {
+        var reviewerSettings = settings.CloneWithProviderOverride(reviewer.Provider, reviewer.Model,
+            reviewer.ReasoningEffort);
+        var runner = new ReviewRunner(reviewerSettings);
+        return await runner.RunAsync(prompt, null, null, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<string> ExecuteAggregatorAsync(ReviewSettings settings,
+        ReviewSwarmShadowAggregatorPlan aggregator, string prompt, CancellationToken cancellationToken) {
+        var aggregatorSettings = settings.CloneWithProviderOverride(aggregator.Provider, aggregator.Model,
+            aggregator.ReasoningEffort);
+        var runner = new ReviewRunner(aggregatorSettings);
+        return await runner.RunAsync(prompt, null, null, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<ReviewSwarmShadowAggregatorResult?> RunAggregatorAsync(ReviewSettings settings,
+        ReviewSwarmShadowPlan plan, string basePrompt, IReadOnlyList<ReviewSwarmShadowReviewerResult> results,
+        Func<ReviewSwarmShadowAggregatorPlan, string, CancellationToken, Task<string>> executeAggregatorAsync,
+        CancellationToken cancellationToken) {
+        if (results.Count == 0) {
+            return null;
+        }
+
+        var prompt = BuildAggregatorPrompt(basePrompt, plan, results);
+        var stopwatch = Stopwatch.StartNew();
+        try {
+            var output = await executeAggregatorAsync(plan.Aggregator, prompt, cancellationToken).ConfigureAwait(false);
+            stopwatch.Stop();
+            if (ReviewDiagnostics.IsFailureBody(output)) {
+                if (!settings.Swarm.FailOpenOnPartial) {
+                    throw new InvalidOperationException("Swarm shadow aggregator returned a fail-open review body.");
+                }
+                return new ReviewSwarmShadowAggregatorResult {
+                    Succeeded = false,
+                    Output = output,
+                    Error = "Provider returned a fail-open review body.",
+                    DurationMs = stopwatch.ElapsedMilliseconds
+                };
+            }
+
+            return new ReviewSwarmShadowAggregatorResult {
+                Succeeded = true,
+                Output = output ?? string.Empty,
+                DurationMs = stopwatch.ElapsedMilliseconds
+            };
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception ex) {
+            stopwatch.Stop();
+            if (!settings.Swarm.FailOpenOnPartial) {
+                throw;
+            }
+            return new ReviewSwarmShadowAggregatorResult {
+                Succeeded = false,
+                Error = $"{ex.GetType().Name}: {ex.Message}",
+                DurationMs = stopwatch.ElapsedMilliseconds
+            };
+        }
+    }
+
+    private static void AppendDuration(StringBuilder sb, long durationMs) {
+        if (durationMs <= 0) {
+            return;
+        }
+        sb.Append(", ");
+        sb.Append(durationMs);
+        sb.Append(" ms");
+    }
+
+    private static string ResolveReviewerFocus(string reviewerId) {
+        var normalized = reviewerId.Trim().ToLowerInvariant();
+        if (normalized.Contains("security", StringComparison.Ordinal)) {
+            return "security, auth boundaries, secret handling, injection risk, and unsafe side effects.";
+        }
+        if (normalized.Contains("test", StringComparison.Ordinal) || normalized.Contains("coverage", StringComparison.Ordinal)) {
+            return "missing regression coverage, brittle tests, and verification gaps.";
+        }
+        if (normalized.Contains("perf", StringComparison.Ordinal) || normalized.Contains("performance", StringComparison.Ordinal)) {
+            return "performance, allocation pressure, network cost, and avoidable repeated work.";
+        }
+        if (normalized.Contains("docs", StringComparison.Ordinal) || normalized.Contains("documentation", StringComparison.Ordinal)) {
+            return "public/internal documentation drift, setup clarity, and migration guidance.";
+        }
+        if (normalized.Contains("compat", StringComparison.Ordinal) || normalized.Contains("interop", StringComparison.Ordinal)) {
+            return "provider interoperability, configuration compatibility, and fallback behavior.";
+        }
+        return "correctness, reliability, merge blockers, and user-visible regressions.";
+    }
+
+    private static string TrimForAggregator(string text) {
+        if (text.Length <= MaxAggregatorContextChars) {
+            return text;
+        }
+        const string suffix = "\n\n[truncated for swarm shadow aggregation]";
+        return text.Substring(0, Math.Max(0, MaxAggregatorContextChars - suffix.Length)) + suffix;
+    }
+}

--- a/IntelligenceX.Reviewer/ReviewerApp.Core.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.Core.cs
@@ -291,10 +291,13 @@ public static partial class ReviewerApp {
 
             IssueComment? existingSummary = null;
             string? previousSummary = null;
-            if (settings.SummaryStability && !string.IsNullOrWhiteSpace(context.HeadSha)) {
+            if (settings.SummaryStability || settings.History.Enabled) {
                 existingSummary = await FindExistingSummaryAsync(codeHostReader, context, settings, cancellationToken)
                     .ConfigureAwait(false);
-                if (existingSummary is not null && !IsSummaryOutdated(existingSummary, context.HeadSha)) {
+                if (settings.SummaryStability &&
+                    existingSummary is not null &&
+                    !string.IsNullOrWhiteSpace(context.HeadSha) &&
+                    !IsSummaryOutdated(existingSummary, context.HeadSha)) {
                     previousSummary = ExtractSummaryBody(existingSummary.Body, settings.MaxCommentChars);
                 }
             }
@@ -328,6 +331,27 @@ public static partial class ReviewerApp {
             var extras = await BuildExtrasAsync(codeHostReader, github, fallbackGithub, context, settings, cancellationToken,
                     settings.TriageOnly)
                 .ConfigureAwait(false);
+            extras.ReviewHistory = extras.IssueComments.Count > 0
+                ? ReviewHistoryBuilder.BuildSnapshot(extras.IssueComments, context.HeadSha, extras.ReviewThreads, settings)
+                : ReviewHistoryBuilder.BuildSnapshot(existingSummary, context.HeadSha, extras.ReviewThreads, settings);
+            extras.ReviewHistorySection = ReviewHistoryBuilder.Render(extras.ReviewHistory);
+            if (settings.History.Artifacts) {
+                try {
+                    await ReviewHistoryArtifacts.WriteAsync(context, settings, extras.ReviewHistory,
+                            extras.ReviewHistorySection, cancellationToken)
+                        .ConfigureAwait(false);
+                    if (settings.Diagnostics && extras.ReviewHistory.HasContent) {
+                        Console.Error.WriteLine("Review history artifacts written under artifacts/reviewer/history.");
+                    }
+                } catch (OperationCanceledException) {
+                    throw;
+                } catch (Exception ex) {
+                    if (settings.Diagnostics) {
+                        Console.Error.WriteLine(
+                            $"Review history artifact write failed open: {ex.GetType().Name}: {ex.Message}");
+                    }
+                }
+            }
             if (settings.TriageOnly) {
                 if (!allowWrites) {
                     Console.WriteLine("Skipping thread triage for untrusted pull request.");
@@ -361,6 +385,16 @@ public static partial class ReviewerApp {
             if (settings.RedactPii) {
                 prompt = Redaction.Apply(prompt, settings.RedactionPatterns, settings.RedactionReplacement);
             }
+            ReviewSwarmShadowPlan? swarmShadowPlan = null;
+            if (settings.Swarm.Enabled && settings.Swarm.ShadowMode) {
+                swarmShadowPlan = ReviewSwarmShadowPlanner.Build(settings);
+                if (settings.Diagnostics) {
+                    var renderedSwarmShadowPlan = ReviewSwarmShadowPlanner.Render(swarmShadowPlan);
+                    if (!string.IsNullOrWhiteSpace(renderedSwarmShadowPlan)) {
+                        Console.Error.WriteLine(renderedSwarmShadowPlan);
+                    }
+                }
+            }
 
             if (allowWrites && settings.ProgressUpdates) {
                 var progressBody = ReviewFormatter.BuildProgressComment(context, settings, progress, null, inlineSupported);
@@ -393,6 +427,45 @@ public static partial class ReviewerApp {
             }
 
             var reviewFailed = ReviewDiagnostics.IsFailureBody(reviewBody);
+            if (swarmShadowPlan is not null && !reviewFailed) {
+                try {
+                    var swarmShadowResult = await ReviewSwarmShadowRunner.RunAsync(settings, swarmShadowPlan, prompt,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    if (settings.Diagnostics) {
+                        var renderedSwarmShadowResults = ReviewSwarmShadowRunner.RenderResultSummary(swarmShadowResult);
+                        if (!string.IsNullOrWhiteSpace(renderedSwarmShadowResults)) {
+                            Console.Error.WriteLine(renderedSwarmShadowResults);
+                        }
+                    }
+                    if (settings.Swarm.Metrics) {
+                        try {
+                            await ReviewSwarmShadowArtifacts.WriteAsync(context, settings, swarmShadowPlan, swarmShadowResult,
+                                    cancellationToken)
+                                .ConfigureAwait(false);
+                            if (settings.Diagnostics) {
+                                Console.Error.WriteLine("Swarm shadow artifacts written under artifacts/reviewer/swarm-shadow.");
+                            }
+                        } catch (OperationCanceledException) {
+                            throw;
+                        } catch (Exception ex) {
+                            if (settings.Diagnostics) {
+                                Console.Error.WriteLine(
+                                    $"Swarm shadow artifact write failed open: {ex.GetType().Name}: {ex.Message}");
+                            }
+                        }
+                    }
+                } catch (OperationCanceledException) {
+                    throw;
+                } catch (Exception ex) when (settings.Swarm.FailOpenOnPartial) {
+                    if (settings.Diagnostics) {
+                        Console.Error.WriteLine($"Swarm shadow execution failed open: {ex.GetType().Name}: {ex.Message}");
+                    }
+                }
+            } else if (swarmShadowPlan is not null && settings.Diagnostics) {
+                Console.Error.WriteLine("Swarm shadow execution skipped because the primary review returned a failure body.");
+            }
+
             var inlineAllowed = inlineSupported && !reviewFailed && allowWrites;
             var inlineComments = Array.Empty<InlineReviewComment>();
             var summaryBody = reviewBody;
@@ -485,8 +558,9 @@ public static partial class ReviewerApp {
             }
             var usageLine = await TryBuildUsageLineAsync(settings, effectiveProvider).ConfigureAwait(false);
             var findingsBlock = settings.StructuredFindings ? ReviewFindingsBuilder.Build(inlineComments) : string.Empty;
+            var historyBlock = ReviewHistoryBuilder.BuildCommentBlock(extras.ReviewHistory);
             var commentBody = ReviewFormatter.BuildComment(context, summaryBody, settings, inlineSupported, inlineSuppressed,
-                autoResolveSummary, budgetNote, usageLine, findingsBlock);
+                autoResolveSummary, budgetNote, usageLine, findingsBlock, historyBlock);
             progress.Review = ReviewProgressState.Complete;
             progress.Finalize = ReviewProgressState.InProgress;
             progress.StatusLine = "Finalizing summary.";

--- a/IntelligenceX.Reviewer/ReviewerApp.Core.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.Core.cs
@@ -291,7 +291,8 @@ public static partial class ReviewerApp {
 
             IssueComment? existingSummary = null;
             string? previousSummary = null;
-            if (settings.SummaryStability || settings.History.Enabled) {
+            if (settings.SummaryStability ||
+                (settings.History.Enabled && settings.History.IncludeIxSummaryHistory)) {
                 existingSummary = await FindExistingSummaryAsync(codeHostReader, context, settings, cancellationToken)
                     .ConfigureAwait(false);
                 if (settings.SummaryStability &&

--- a/IntelligenceX.Reviewer/ReviewerApp.FileContext.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.FileContext.cs
@@ -133,11 +133,13 @@ public static partial class ReviewerApp {
                 Console.Error.WriteLine($"Failed to load CI/check context: {ex.Message}");
             }
         }
-        var loadIssueComments = settings.IncludeIssueComments ||
-                                (settings.History.Enabled && settings.History.IncludeIxSummaryHistory);
+        var historyNeedsIssueComments = settings.History.Enabled &&
+                                        (settings.History.IncludeIxSummaryHistory ||
+                                         settings.History.IncludeExternalBotSummaries);
+        var loadIssueComments = settings.IncludeIssueComments || historyNeedsIssueComments;
         if (loadIssueComments) {
             try {
-                var commentLimit = settings.IncludeIssueComments && !(settings.History.Enabled && settings.History.IncludeIxSummaryHistory)
+                var commentLimit = settings.IncludeIssueComments && !historyNeedsIssueComments
                     ? settings.MaxComments
                     : Math.Max(settings.MaxComments, settings.CommentSearchLimit);
                 var comments = await codeHostReader.ListIssueCommentsAsync(context, commentLimit, cancellationToken)

--- a/IntelligenceX.Reviewer/ReviewerApp.FileContext.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.FileContext.cs
@@ -133,17 +133,28 @@ public static partial class ReviewerApp {
                 Console.Error.WriteLine($"Failed to load CI/check context: {ex.Message}");
             }
         }
-        if (settings.IncludeIssueComments) {
+        var loadIssueComments = settings.IncludeIssueComments ||
+                                (settings.History.Enabled && settings.History.IncludeIxSummaryHistory);
+        if (loadIssueComments) {
             try {
-                var comments = await codeHostReader.ListIssueCommentsAsync(context, settings.MaxComments, cancellationToken)
+                var commentLimit = settings.IncludeIssueComments && !(settings.History.Enabled && settings.History.IncludeIxSummaryHistory)
+                    ? settings.MaxComments
+                    : Math.Max(settings.MaxComments, settings.CommentSearchLimit);
+                var comments = await codeHostReader.ListIssueCommentsAsync(context, commentLimit, cancellationToken)
                     .ConfigureAwait(false);
-                extras.IssueCommentsSection = BuildIssueCommentsSection(comments, settings);
+                extras.IssueComments = comments;
+                if (settings.IncludeIssueComments) {
+                    extras.IssueCommentsSection = BuildIssueCommentsSection(comments, settings);
+                }
             } catch (Exception ex) {
                 // Issue comments are supplemental context; avoid failing the whole review on GitHub rate limits.
                 Console.Error.WriteLine($"Failed to load issue comments: {ex.Message}");
             }
         }
-        var loadThreads = forceReviewThreads || settings.IncludeReviewThreads || settings.ReviewThreadsAutoResolveAI;
+        var loadThreads = forceReviewThreads ||
+                          settings.IncludeReviewThreads ||
+                          settings.ReviewThreadsAutoResolveAI ||
+                          (settings.History.Enabled && settings.History.IncludeReviewThreads);
         if (loadThreads) {
             try {
                 var threadCommentFetchLimit = ResolveThreadCommentFetchLimit(settings);

--- a/IntelligenceX.Reviewer/ReviewerApp.FileContext.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.FileContext.cs
@@ -146,9 +146,7 @@ public static partial class ReviewerApp {
                     .ConfigureAwait(false);
                 extras.IssueComments = comments;
                 if (settings.IncludeIssueComments) {
-                    extras.IssueCommentsSection = BuildIssueCommentsSection(
-                        comments.Take(Math.Max(0, settings.MaxComments)).ToArray(),
-                        settings);
+                    extras.IssueCommentsSection = BuildIssueCommentsSection(comments, settings);
                 }
             } catch (Exception ex) {
                 // Issue comments are supplemental context; avoid failing the whole review on GitHub rate limits.
@@ -346,6 +344,11 @@ public static partial class ReviewerApp {
     }
 
     private static string BuildIssueCommentsSection(IReadOnlyList<IssueComment> comments, ReviewSettings settings) {
+        var maxComments = Math.Max(0, settings.MaxComments);
+        if (maxComments <= 0) {
+            return string.Empty;
+        }
+
         var filtered = new List<IssueComment>();
         foreach (var comment in comments) {
             if (string.IsNullOrWhiteSpace(comment.Body)) {
@@ -359,6 +362,9 @@ public static partial class ReviewerApp {
                 continue;
             }
             filtered.Add(comment);
+            if (filtered.Count >= maxComments) {
+                break;
+            }
         }
         if (filtered.Count == 0) {
             return string.Empty;

--- a/IntelligenceX.Reviewer/ReviewerApp.FileContext.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.FileContext.cs
@@ -146,7 +146,9 @@ public static partial class ReviewerApp {
                     .ConfigureAwait(false);
                 extras.IssueComments = comments;
                 if (settings.IncludeIssueComments) {
-                    extras.IssueCommentsSection = BuildIssueCommentsSection(comments, settings);
+                    extras.IssueCommentsSection = BuildIssueCommentsSection(
+                        comments.Take(Math.Max(0, settings.MaxComments)).ToArray(),
+                        settings);
                 }
             } catch (Exception ex) {
                 // Issue comments are supplemental context; avoid failing the whole review on GitHub rate limits.

--- a/IntelligenceX.Reviewer/ReviewerApp.InlineSummary.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.InlineSummary.cs
@@ -743,6 +743,7 @@ public static partial class ReviewerApp {
         }
 
         var block = string.Join("\n", lines, startIndex, endIndex - startIndex).Trim();
+        block = RemoveSection(block, "History Progress 🔁").Trim();
         if (string.IsNullOrWhiteSpace(block)) {
             return null;
         }
@@ -750,6 +751,44 @@ public static partial class ReviewerApp {
             return block.Substring(0, maxChars) + "...";
         }
         return block;
+    }
+
+    private static string RemoveSection(string body, string headingLabel) {
+        if (string.IsNullOrWhiteSpace(body) || string.IsNullOrWhiteSpace(headingLabel)) {
+            return body;
+        }
+
+        var lines = body.Replace("\r", "").Split('\n');
+        var start = -1;
+        for (var i = 0; i < lines.Length; i++) {
+            var trimmed = lines[i].Trim();
+            if (trimmed.StartsWith("## ", StringComparison.Ordinal) &&
+                trimmed.Substring(3).Trim().StartsWith(headingLabel, StringComparison.OrdinalIgnoreCase)) {
+                start = i;
+                break;
+            }
+        }
+        if (start < 0) {
+            return body;
+        }
+
+        var end = lines.Length;
+        for (var i = start + 1; i < lines.Length; i++) {
+            var trimmed = lines[i].Trim();
+            if (trimmed.StartsWith("## ", StringComparison.Ordinal)) {
+                end = i;
+                break;
+            }
+        }
+
+        var kept = new List<string>(lines.Length - (end - start));
+        for (var i = 0; i < lines.Length; i++) {
+            if (i >= start && i < end) {
+                continue;
+            }
+            kept.Add(lines[i]);
+        }
+        return string.Join("\n", kept);
     }
 
     private static async Task<long?> CreateOrUpdateProgressCommentAsync(IReviewCodeHostReader codeHostReader, GitHubClient github,

--- a/IntelligenceX.Reviewer/ReviewerApp.InlineSummary.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.InlineSummary.cs
@@ -206,7 +206,7 @@ public static partial class ReviewerApp {
                string.Equals(normalizedAuthor, "app/intelligencex-review", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool IsOwnedSummaryComment(IssueComment comment) {
+    internal static bool IsOwnedSummaryComment(IssueComment comment) {
         return comment.Body.Contains(ReviewFormatter.SummaryMarker, StringComparison.OrdinalIgnoreCase) &&
                IsTrustedSummaryAuthor(comment.Author);
     }

--- a/IntelligenceX.Reviewer/ReviewerApp.TestSeams.cs
+++ b/IntelligenceX.Reviewer/ReviewerApp.TestSeams.cs
@@ -76,6 +76,9 @@ public static partial class ReviewerApp {
     /// <summary>Test-only forwarder for summary ownership detection.</summary>
     internal static bool IsOwnedSummaryCommentForTests(IssueComment comment) => IsOwnedSummaryComment(comment);
 
+    /// <summary>Test-only forwarder for summary-stability carryover body extraction.</summary>
+    internal static string? ExtractSummaryBodyForTests(string? body, int maxChars) => ExtractSummaryBody(body, maxChars);
+
     /// <summary>Test-only forwarder for stale-thread auto-resolution.</summary>
     internal static Task AutoResolveStaleThreadsForTestsAsync(GitHubClient github, IReadOnlyList<PullRequestReviewThread> threads,
         ReviewSettings settings, CancellationToken cancellationToken = default) =>

--- a/IntelligenceX.Reviewer/Templates/ReviewPrompt.Compact.md
+++ b/IntelligenceX.Reviewer/Templates/ReviewPrompt.Compact.md
@@ -53,4 +53,4 @@ Description:
 
 Changed files:
 {{Files}}
-{{CiContextSection}}{{ReviewThreadsSection}}
+{{ReviewHistorySection}}{{CiContextSection}}{{ReviewThreadsSection}}

--- a/IntelligenceX.Reviewer/Templates/ReviewPrompt.Long.md
+++ b/IntelligenceX.Reviewer/Templates/ReviewPrompt.Long.md
@@ -53,4 +53,4 @@ Description:
 
 Changed files:
 {{Files}}
-{{CiContextSection}}{{IssueCommentsSection}}{{ReviewCommentsSection}}{{ReviewThreadsSection}}{{RelatedPrsSection}}
+{{ReviewHistorySection}}{{CiContextSection}}{{IssueCommentsSection}}{{ReviewCommentsSection}}{{ReviewThreadsSection}}{{RelatedPrsSection}}

--- a/IntelligenceX.Reviewer/Templates/ReviewPrompt.Medium.md
+++ b/IntelligenceX.Reviewer/Templates/ReviewPrompt.Medium.md
@@ -55,4 +55,4 @@ Description:
 
 Changed files:
 {{Files}}
-{{CiContextSection}}{{IssueCommentsSection}}{{ReviewCommentsSection}}{{ReviewThreadsSection}}{{RelatedPrsSection}}
+{{ReviewHistorySection}}{{CiContextSection}}{{IssueCommentsSection}}{{ReviewCommentsSection}}{{ReviewThreadsSection}}{{RelatedPrsSection}}

--- a/IntelligenceX.Reviewer/Templates/ReviewPrompt.Short.md
+++ b/IntelligenceX.Reviewer/Templates/ReviewPrompt.Short.md
@@ -54,4 +54,4 @@ Description:
 
 Changed files:
 {{Files}}
-{{CiContextSection}}{{IssueCommentsSection}}{{ReviewCommentsSection}}{{ReviewThreadsSection}}{{RelatedPrsSection}}
+{{ReviewHistorySection}}{{CiContextSection}}{{IssueCommentsSection}}{{ReviewCommentsSection}}{{ReviewThreadsSection}}{{RelatedPrsSection}}

--- a/IntelligenceX.Tests/Program.Infrastructure.cs
+++ b/IntelligenceX.Tests/Program.Infrastructure.cs
@@ -261,6 +261,12 @@ internal static partial class Program {
         }
     }
 
+    private static void AssertDoesNotContainText(string value, string unexpected, string name) {
+        if (!string.IsNullOrEmpty(value) && value.IndexOf(unexpected, StringComparison.Ordinal) >= 0) {
+            throw new InvalidOperationException($"Expected {name} not to contain '{unexpected}'.");
+        }
+    }
+
     private static void AssertNotNull(object? value, string name) {
         if (value is null) {
             throw new InvalidOperationException($"Expected {name} to be non-null.");

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -853,6 +853,7 @@ internal static partial class Program {
         try {
             File.WriteAllText(path,
                 "{ \"copilot\": { \"envAllowlist\": [\"GH_TOKEN\"], \"inheritEnvironment\": false, " +
+                "\"launcher\": \"gh\", " +
                 "\"env\": { \"COPILOT_DEBUG\": \"1\" }, " +
                 "\"transport\": \"direct\", \"directUrl\": \"https://example.local/api\", " +
                 "\"directTokenEnv\": \"COPILOT_DIRECT_TOKEN\", \"directTimeoutSeconds\": 12, " +
@@ -863,6 +864,7 @@ internal static partial class Program {
 
             AssertSequenceEqual(new[] { "GH_TOKEN" }, settings.CopilotEnvAllowlist, "copilot env allowlist");
             AssertEqual(false, settings.CopilotInheritEnvironment, "copilot inherit environment");
+            AssertEqual("gh", settings.CopilotLauncher, "copilot launcher");
             AssertEqual("1", settings.CopilotEnv["COPILOT_DEBUG"], "copilot env map");
             AssertEqual(CopilotTransportKind.Direct, settings.CopilotTransport, "copilot transport");
             AssertEqual("https://example.local/api", settings.CopilotDirectUrl, "copilot direct url");
@@ -875,6 +877,62 @@ internal static partial class Program {
                 File.Delete(path);
             }
         }
+    }
+
+    private static void TestCopilotLauncherEnv() {
+        var previousInput = Environment.GetEnvironmentVariable("INPUT_COPILOT_LAUNCHER");
+        var previousEnv = Environment.GetEnvironmentVariable("COPILOT_LAUNCHER");
+        try {
+            Environment.SetEnvironmentVariable("INPUT_COPILOT_LAUNCHER", null);
+            Environment.SetEnvironmentVariable("COPILOT_LAUNCHER", "github-cli");
+            var settings = ReviewSettings.FromEnvironment();
+            AssertEqual("gh", settings.CopilotLauncher, "copilot launcher env");
+        } finally {
+            Environment.SetEnvironmentVariable("INPUT_COPILOT_LAUNCHER", previousInput);
+            Environment.SetEnvironmentVariable("COPILOT_LAUNCHER", previousEnv);
+        }
+    }
+
+    private static void TestCopilotGhLauncherBuildsWrapperCommand() {
+        var settings = new ReviewSettings {
+            CopilotLauncher = "gh"
+        };
+        var options = new ReviewRunner(settings).BuildCopilotClientOptionsForTests();
+
+        AssertEqual("gh", options.CliPath ?? string.Empty, "copilot gh launcher path");
+        AssertSequenceEqual(new[] { "copilot", "--" }, options.CliArgs.ToArray(), "copilot gh launcher args");
+    }
+
+    private static void TestCopilotLauncherDiagnosticsDescribeResolvedCommand() {
+        var originalError = Console.Error;
+        using var errorWriter = new StringWriter();
+        try {
+            Console.SetError(errorWriter);
+            var settings = new ReviewSettings {
+                CopilotLauncher = "gh",
+                Diagnostics = true
+            };
+
+            _ = new ReviewRunner(settings).BuildCopilotClientOptionsForTests();
+        } finally {
+            Console.SetError(originalError);
+        }
+
+        var output = errorWriter.ToString();
+        AssertContainsText(output, "Copilot launcher resolved: gh", "copilot launcher diagnostic mode");
+        AssertContainsText(output, "cliPath=gh", "copilot launcher diagnostic path");
+        AssertContainsText(output, "prefixArgs=copilot --", "copilot launcher diagnostic wrapper args");
+    }
+
+    private static void TestCopilotBinaryLauncherKeepsDirectCliPath() {
+        var settings = new ReviewSettings {
+            CopilotLauncher = "binary",
+            CopilotCliPath = "custom-copilot"
+        };
+        var options = new ReviewRunner(settings).BuildCopilotClientOptionsForTests();
+
+        AssertEqual("custom-copilot", options.CliPath ?? string.Empty, "copilot binary launcher path");
+        AssertEqual(0, options.CliArgs.Count, "copilot binary launcher args");
     }
 
     private static void TestCopilotInheritEnvironmentDefault() {

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -653,6 +653,53 @@ internal static partial class Program {
         AssertEqual(1, extras.IssueComments.Count, "external history issue comments available");
     }
 
+    private static void TestBuildExtrasKeepsIssueCommentPromptCapWithHistory() {
+        using var server = new LocalHttpServer(request => {
+            if (request.Path == "/repos/owner/repo/issues/1/comments?per_page=100&page=1&sort=created&direction=desc") {
+                return new HttpResponse("""
+[
+  {
+    "id": 10,
+    "body": "First prompt comment.",
+    "user": { "login": "alice" },
+    "html_url": "https://example.local/comment/10"
+  },
+  {
+    "id": 11,
+    "body": "Second history-only comment.",
+    "user": { "login": "bob" },
+    "html_url": "https://example.local/comment/11"
+  }
+]
+""");
+            }
+            return null;
+        });
+
+        using var github = new GitHubClient("token", server.BaseUri.ToString().TrimEnd('/'));
+        var settings = new ReviewSettings {
+            IncludeIssueComments = true,
+            IncludeReviewComments = false,
+            IncludeReviewThreads = false,
+            MaxComments = 1,
+            CommentSearchLimit = 2,
+            ReviewThreadsAutoResolveAI = false,
+            ReviewThreadsAutoResolveStale = false
+        };
+        settings.History.Enabled = true;
+        settings.History.IncludeIxSummaryHistory = true;
+
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Title", null, false, "head", "base",
+            Array.Empty<string>(), "owner/repo", false, null);
+
+        var extras = CallBuildExtrasAsync(github, context, settings, false);
+
+        AssertEqual(2, extras.IssueComments.Count, "history can retain deeper issue comments");
+        AssertContainsText(extras.IssueCommentsSection, "First prompt comment.", "issue comments prompt keeps first capped item");
+        AssertEqual(false, extras.IssueCommentsSection.Contains("Second history-only comment.", StringComparison.Ordinal),
+            "issue comments prompt keeps maxComments cap");
+    }
+
     private static void TestBuildExtrasCiFailureEvidenceFailureIsSupplemental() {
         using var server = new LocalHttpServer(request => {
             if (request.Path == "/repos/owner/repo/commits/head/check-runs?per_page=100&page=1") {

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -659,6 +659,12 @@ internal static partial class Program {
                 return new HttpResponse("""
 [
   {
+    "id": 9,
+    "body": "<!-- intelligencex:summary -->\n## IntelligenceX Review\nPrevious sticky summary.",
+    "user": { "login": "intelligencex-review" },
+    "html_url": "https://example.local/comment/9"
+  },
+  {
     "id": 10,
     "body": "First prompt comment.",
     "user": { "login": "alice" },
@@ -695,7 +701,10 @@ internal static partial class Program {
         var extras = CallBuildExtrasAsync(github, context, settings, false);
 
         AssertEqual(2, extras.IssueComments.Count, "history can retain deeper issue comments");
-        AssertContainsText(extras.IssueCommentsSection, "First prompt comment.", "issue comments prompt keeps first capped item");
+        AssertContainsText(extras.IssueCommentsSection, "First prompt comment.",
+            "issue comments prompt caps after filtering sticky summary comments");
+        AssertEqual(false, extras.IssueCommentsSection.Contains("Previous sticky summary.", StringComparison.Ordinal),
+            "issue comments prompt excludes sticky summary before cap");
         AssertEqual(false, extras.IssueCommentsSection.Contains("Second history-only comment.", StringComparison.Ordinal),
             "issue comments prompt keeps maxComments cap");
     }

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -903,6 +903,28 @@ internal static partial class Program {
         AssertSequenceEqual(new[] { "copilot", "--" }, options.CliArgs.ToArray(), "copilot gh launcher args");
     }
 
+    private static void TestCopilotAutoLauncherRequiresUsableGhWrapper() {
+        var settings = new ReviewSettings {
+            CopilotLauncher = "auto"
+        };
+
+        var resolved = ReviewRunner.ResolveCopilotLauncherForTests(settings,
+            copilotExists: false, ghExists: true, ghCopilotWrapperCanLaunchCli: false);
+
+        AssertEqual("binary", resolved, "copilot auto launcher does not assume gh can bootstrap copilot");
+    }
+
+    private static void TestCopilotAutoLauncherUsesGhWhenWrapperCanLaunchCli() {
+        var settings = new ReviewSettings {
+            CopilotLauncher = "auto"
+        };
+
+        var resolved = ReviewRunner.ResolveCopilotLauncherForTests(settings,
+            copilotExists: false, ghExists: true, ghCopilotWrapperCanLaunchCli: true);
+
+        AssertEqual("gh", resolved, "copilot auto launcher uses gh only after wrapper probe succeeds");
+    }
+
     private static void TestCopilotLauncherDiagnosticsDescribeResolvedCommand() {
         var originalError = Console.Error;
         using var errorWriter = new StringWriter();

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -612,6 +612,47 @@ internal static partial class Program {
         AssertEqual(string.Empty, extras.CiContextSection, "build extras ci context failure remains supplemental");
     }
 
+    private static void TestBuildExtrasLoadsIssueCommentsForExternalHistory() {
+        var issueCommentHits = 0;
+        using var server = new LocalHttpServer(request => {
+            if (request.Path == "/repos/owner/repo/issues/1/comments?per_page=100&page=1&sort=created&direction=desc") {
+                issueCommentHits++;
+                return new HttpResponse("""
+[
+  {
+    "id": 10,
+    "body": "Claude summary: prior finding appears resolved.",
+    "user": { "login": "claude" },
+    "html_url": "https://example.local/comment/10"
+  }
+]
+""");
+            }
+            return null;
+        });
+
+        using var github = new GitHubClient("token", server.BaseUri.ToString().TrimEnd('/'));
+        var settings = new ReviewSettings {
+            IncludeIssueComments = false,
+            IncludeReviewComments = false,
+            IncludeReviewThreads = false,
+            ReviewThreadsAutoResolveAI = false,
+            ReviewThreadsAutoResolveStale = false
+        };
+        settings.History.Enabled = true;
+        settings.History.IncludeIxSummaryHistory = false;
+        settings.History.IncludeExternalBotSummaries = true;
+        settings.History.ExternalBotLogins = new[] { "claude" };
+
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Title", null, false, "head", "base",
+            Array.Empty<string>(), "owner/repo", false, null);
+
+        var extras = CallBuildExtrasAsync(github, context, settings, false);
+
+        AssertEqual(1, issueCommentHits, "external history forces issue comment load");
+        AssertEqual(1, extras.IssueComments.Count, "external history issue comments available");
+    }
+
     private static void TestBuildExtrasCiFailureEvidenceFailureIsSupplemental() {
         using var server = new LocalHttpServer(request => {
             if (request.Path == "/repos/owner/repo/commits/head/check-runs?per_page=100&page=1") {
@@ -895,7 +936,8 @@ internal static partial class Program {
 
     private static void TestCopilotGhLauncherBuildsWrapperCommand() {
         var settings = new ReviewSettings {
-            CopilotLauncher = "gh"
+            CopilotLauncher = "gh",
+            CopilotCliPath = "custom-copilot"
         };
         var options = new ReviewRunner(settings).BuildCopilotClientOptionsForTests();
 

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -722,6 +722,8 @@ internal static partial class Program {
         failed += Run("Review history builder includes sticky summary and thread snapshot",
             TestReviewHistoryBuilderIncludesStickySummaryAndThreadSnapshot);
         failed += Run("Review history builder builds comment block", TestReviewHistoryBuilderBuildsCommentBlock);
+        failed += Run("Review summary stability drops history progress block",
+            TestReviewSummaryStabilityDropsHistoryProgressBlock);
         failed += Run("Review history artifacts render json and markdown",
             TestReviewHistoryArtifactsRenderJsonAndMarkdown);
         failed += Run("Redaction defaults", TestRedactionDefaults);
@@ -773,6 +775,8 @@ internal static partial class Program {
             TestReviewSwarmShadowRunnerHonorsMaxParallel);
         failed += Run("Review swarm shadow aggregator prompt includes subreviews",
             TestReviewSwarmShadowAggregatorPromptIncludesSubreviews);
+        failed += Run("Review swarm shadow aggregator prompt uses safe subreview fence",
+            TestReviewSwarmShadowAggregatorPromptUsesSafeSubreviewFence);
         failed += Run("Review swarm shadow aggregator prompt closes truncated fence",
             TestReviewSwarmShadowAggregatorPromptClosesTruncatedFence);
         failed += Run("Review swarm shadow aggregator prompt keeps context with large base",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -775,6 +775,8 @@ internal static partial class Program {
             TestReviewSwarmShadowAggregatorPromptIncludesSubreviews);
         failed += Run("Review swarm shadow aggregator prompt closes truncated fence",
             TestReviewSwarmShadowAggregatorPromptClosesTruncatedFence);
+        failed += Run("Review swarm shadow aggregator prompt keeps context with large base",
+            TestReviewSwarmShadowAggregatorPromptKeepsContextWithLargeBase);
         failed += Run("Review swarm shadow artifacts render json and markdown",
             TestReviewSwarmShadowArtifactsRenderJsonAndMarkdown);
         failed += Run("Review swarm shadow artifacts render metrics json line",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -621,6 +621,8 @@ internal static partial class Program {
         failed += Run("Build extras ci context auto skips operational-only snippets",
             TestBuildExtrasCiContextAutoSkipsOperationalOnlySnippets);
         failed += Run("Build extras ci context failure is supplemental", TestBuildExtrasCiContextFailureIsSupplemental);
+        failed += Run("Build extras loads issue comments for external history",
+            TestBuildExtrasLoadsIssueCommentsForExternalHistory);
         failed += Run("Build extras ci failure evidence failure is supplemental",
             TestBuildExtrasCiFailureEvidenceFailureIsSupplemental);
         failed += Run("Triage thread hydration uses fallback client when provided",
@@ -653,6 +655,7 @@ internal static partial class Program {
         failed += Run("Review settings load config then env precedence for ciContext and swarm",
             TestReviewSettingsLoadConfigThenEnvPrecedenceForCiContextAndSwarm);
         failed += Run("Review settings load swarm reviewer objects", TestReviewSettingsLoadSwarmReviewerObjects);
+        failed += Run("Review settings env swarm reviewers JSON", TestReviewSettingsEnvSwarmReviewersJson);
         failed += Run("Review settings load config allows zero for non-negative limits",
             TestReviewSettingsLoadConfigAllowsZeroForNonNegativeLimits);
         failed += Run("Review settings env allows zero for non-negative limits",
@@ -768,6 +771,8 @@ internal static partial class Program {
             TestReviewSwarmShadowRunnerHonorsMaxParallel);
         failed += Run("Review swarm shadow aggregator prompt includes subreviews",
             TestReviewSwarmShadowAggregatorPromptIncludesSubreviews);
+        failed += Run("Review swarm shadow aggregator prompt closes truncated fence",
+            TestReviewSwarmShadowAggregatorPromptClosesTruncatedFence);
         failed += Run("Review swarm shadow artifacts render json and markdown",
             TestReviewSwarmShadowArtifactsRenderJsonAndMarkdown);
         failed += Run("Review swarm shadow artifacts render metrics json line",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -652,6 +652,7 @@ internal static partial class Program {
         failed += Run("Review settings load config then env precedence", TestReviewSettingsLoadConfigThenEnvPrecedence);
         failed += Run("Review settings load config then env precedence for ciContext and swarm",
             TestReviewSettingsLoadConfigThenEnvPrecedenceForCiContextAndSwarm);
+        failed += Run("Review settings load swarm reviewer objects", TestReviewSettingsLoadSwarmReviewerObjects);
         failed += Run("Review settings load config allows zero for non-negative limits",
             TestReviewSettingsLoadConfigAllowsZeroForNonNegativeLimits);
         failed += Run("Review settings env allows zero for non-negative limits",
@@ -662,6 +663,11 @@ internal static partial class Program {
         failed += Run("Azure code host reader smoke", TestAzureDevOpsCodeHostReaderSmoke);
         failed += Run("Review threads diff range normalize", TestReviewThreadsDiffRangeNormalize);
         failed += Run("Copilot env allowlist config", TestCopilotEnvAllowlistConfig);
+        failed += Run("Copilot launcher env", TestCopilotLauncherEnv);
+        failed += Run("Copilot gh launcher builds wrapper command", TestCopilotGhLauncherBuildsWrapperCommand);
+        failed += Run("Copilot launcher diagnostics describe resolved command",
+            TestCopilotLauncherDiagnosticsDescribeResolvedCommand);
+        failed += Run("Copilot binary launcher keeps direct cli path", TestCopilotBinaryLauncherKeepsDirectCliPath);
         failed += Run("Copilot inherit env default", TestCopilotInheritEnvironmentDefault);
         failed += Run("Copilot direct timeout validation", TestCopilotDirectTimeoutValidation);
         failed += Run("Copilot chat timeout validation", TestCopilotChatTimeoutValidation);
@@ -702,11 +708,18 @@ internal static partial class Program {
         failed += Run("Prompt narrative mode freedom", TestPromptBuilderNarrativeModeFreedom);
         failed += Run("Prompt merge blocker sections default", TestPromptBuilderMergeBlockerSectionsDefault);
         failed += Run("Prompt merge blocker sections compact default", TestPromptBuilderMergeBlockerSectionsCompactDefault);
+        failed += Run("Prompt includes review history section", TestPromptBuilderIncludesReviewHistorySection);
         failed += Run("Prompt includes ci context section", TestPromptBuilderIncludesCiContextSection);
+        failed += Run("Review history builder includes sticky summary and thread snapshot",
+            TestReviewHistoryBuilderIncludesStickySummaryAndThreadSnapshot);
+        failed += Run("Review history builder builds comment block", TestReviewHistoryBuilderBuildsCommentBlock);
+        failed += Run("Review history artifacts render json and markdown",
+            TestReviewHistoryArtifactsRenderJsonAndMarkdown);
         failed += Run("Redaction defaults", TestRedactionDefaults);
         failed += Run("Review budget note", TestReviewBudgetNote);
         failed += Run("Review budget note empty", TestReviewBudgetNoteEmpty);
         failed += Run("Review budget note comment", TestReviewBudgetNoteComment);
+        failed += Run("Review comment includes history block", TestReviewCommentIncludesHistoryBlock);
         failed += Run("Combine notes", TestCombineNotes);
         failed += Run("Review retry backoff multiplier config", TestReviewRetryBackoffMultiplierConfig);
         failed += Run("Review retry backoff multiplier env", TestReviewRetryBackoffMultiplierEnv);
@@ -722,6 +735,7 @@ internal static partial class Program {
         failed += Run("Context deny invalid regex", TestContextDenyInvalidRegex);
         failed += Run("Context deny timeout", TestContextDenyTimeout);
         failed += Run("Review summary parser", TestReviewSummaryParser);
+        failed += Run("Review summary parser finding extraction", TestReviewSummaryParserFindingExtraction);
         failed += Run("Review summary parser merge blocker detection", TestReviewSummaryParserMergeBlockerDetection);
         failed += Run("Review summary parser merge blocker detection inline section labels",
             TestReviewSummaryParserMergeBlockerDetectionInlineSectionLabels);
@@ -739,6 +753,21 @@ internal static partial class Program {
             TestReviewSummaryParserMergeBlockerDetectionCompactAliases);
         failed += Run("Review summary parser merge blocker detection custom sections",
             TestReviewSummaryParserMergeBlockerDetectionCustomSections);
+        failed += Run("Review swarm shadow plan uses reviewer overrides", TestReviewSwarmShadowPlanUsesReviewerOverrides);
+        failed += Run("Review swarm shadow plan falls back to primary provider and model",
+            TestReviewSwarmShadowPlanFallsBackToPrimaryProviderAndModel);
+        failed += Run("Review swarm shadow reviewer prompt shapes focus", TestReviewSwarmShadowReviewerPromptShapesFocus);
+        failed += Run("Review swarm shadow runner captures failures", TestReviewSwarmShadowRunnerCapturesFailures);
+        failed += Run("Review swarm shadow runner fails closed when configured",
+            TestReviewSwarmShadowRunnerFailsClosedWhenConfigured);
+        failed += Run("Review swarm shadow runner honors max parallel",
+            TestReviewSwarmShadowRunnerHonorsMaxParallel);
+        failed += Run("Review swarm shadow aggregator prompt includes subreviews",
+            TestReviewSwarmShadowAggregatorPromptIncludesSubreviews);
+        failed += Run("Review swarm shadow artifacts render json and markdown",
+            TestReviewSwarmShadowArtifactsRenderJsonAndMarkdown);
+        failed += Run("Review swarm shadow artifacts render metrics json line",
+            TestReviewSwarmShadowArtifactsRenderMetricsJsonLine);
         failed += Run("Review summary parser merge blocker detection allow missing section match",
             TestReviewSummaryParserMergeBlockerDetectionAllowNoSectionMatch);
         failed += Run("Review formatter model usage section", TestReviewFormatterModelUsageSection);

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -623,6 +623,8 @@ internal static partial class Program {
         failed += Run("Build extras ci context failure is supplemental", TestBuildExtrasCiContextFailureIsSupplemental);
         failed += Run("Build extras loads issue comments for external history",
             TestBuildExtrasLoadsIssueCommentsForExternalHistory);
+        failed += Run("Build extras keeps issue comment prompt cap with history",
+            TestBuildExtrasKeepsIssueCommentPromptCapWithHistory);
         failed += Run("Build extras ci failure evidence failure is supplemental",
             TestBuildExtrasCiFailureEvidenceFailureIsSupplemental);
         failed += Run("Triage thread hydration uses fallback client when provided",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -665,6 +665,10 @@ internal static partial class Program {
         failed += Run("Copilot env allowlist config", TestCopilotEnvAllowlistConfig);
         failed += Run("Copilot launcher env", TestCopilotLauncherEnv);
         failed += Run("Copilot gh launcher builds wrapper command", TestCopilotGhLauncherBuildsWrapperCommand);
+        failed += Run("Copilot auto launcher requires usable gh wrapper",
+            TestCopilotAutoLauncherRequiresUsableGhWrapper);
+        failed += Run("Copilot auto launcher uses gh when wrapper can launch CLI",
+            TestCopilotAutoLauncherUsesGhWhenWrapperCanLaunchCli);
         failed += Run("Copilot launcher diagnostics describe resolved command",
             TestCopilotLauncherDiagnosticsDescribeResolvedCommand);
         failed += Run("Copilot binary launcher keeps direct cli path", TestCopilotBinaryLauncherKeepsDirectCliPath);

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
@@ -339,6 +339,41 @@ internal static partial class Program {
             "swarm shadow aggregator prompt closes markdown fence before truncation marker");
     }
 
+    private static void TestReviewSwarmShadowAggregatorPromptKeepsContextWithLargeBase() {
+        var plan = new ReviewSwarmShadowPlan {
+            Enabled = true,
+            ShadowMode = true,
+            Aggregator = new ReviewSwarmShadowAggregatorPlan {
+                Provider = ReviewProvider.OpenAI,
+                Model = "gpt-5.4"
+            },
+            Reviewers = new[] {
+                new ReviewSwarmShadowReviewerPlan {
+                    Id = "correctness",
+                    Provider = ReviewProvider.OpenAI,
+                    Model = "gpt-5.4"
+                }
+            }
+        };
+        var results = new[] {
+            new ReviewSwarmShadowReviewerResult {
+                Reviewer = plan.Reviewers[0],
+                Succeeded = true,
+                Output = "Reviewer evidence that must survive base prompt truncation."
+            }
+        };
+
+        var prompt = ReviewRunner.BuildSwarmShadowAggregatorPromptForTests(
+            "Base prompt\n" + new string('b', 30000), plan, results);
+
+        AssertEqual(true, prompt.Length <= 24000, "swarm shadow aggregator prompt stays bounded");
+        AssertContainsText(prompt, "Swarm Shadow Aggregator", "swarm shadow aggregator instructions survive large base");
+        AssertContainsText(prompt, "Reviewer evidence that must survive base prompt truncation.",
+            "swarm shadow aggregator subreview survives large base");
+        AssertContainsText(prompt, "[truncated for swarm shadow aggregation]",
+            "swarm shadow aggregator marks truncated base prompt");
+    }
+
     private static void TestReviewSwarmShadowArtifactsRenderJsonAndMarkdown() {
         var context = new PullRequestContext("owner/repo", "owner", "repo", 12, "Test title", "Body", false,
             "abc1234", "base", Array.Empty<string>(), "owner/repo", false, null);

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
@@ -307,6 +307,37 @@ internal static partial class Program {
         AssertContainsText(prompt, "Merge overlapping findings", "swarm shadow aggregator prompt contract");
     }
 
+    private static void TestReviewSwarmShadowAggregatorPromptUsesSafeSubreviewFence() {
+        var plan = new ReviewSwarmShadowPlan {
+            Enabled = true,
+            ShadowMode = true,
+            Aggregator = new ReviewSwarmShadowAggregatorPlan {
+                Provider = ReviewProvider.OpenAI,
+                Model = "gpt-5.4"
+            },
+            Reviewers = new[] {
+                new ReviewSwarmShadowReviewerPlan {
+                    Id = "correctness",
+                    Provider = ReviewProvider.OpenAI,
+                    Model = "gpt-5.4"
+                }
+            }
+        };
+        var results = new[] {
+            new ReviewSwarmShadowReviewerResult {
+                Reviewer = plan.Reviewers[0],
+                Succeeded = true,
+                Output = "Before\n```suggestion\nreturn true;\n```\nAfter"
+            }
+        };
+
+        var prompt = ReviewRunner.BuildSwarmShadowAggregatorPromptForTests("Base prompt", plan, results);
+
+        AssertContainsText(prompt, "~~~~markdown", "swarm shadow aggregator uses tilde fence wrapper");
+        AssertContainsText(prompt, "```suggestion", "swarm shadow aggregator preserves nested suggestion fence");
+        AssertContainsText(prompt, "After", "swarm shadow aggregator keeps content after nested fence");
+    }
+
     private static void TestReviewSwarmShadowAggregatorPromptClosesTruncatedFence() {
         var plan = new ReviewSwarmShadowPlan {
             Enabled = true,
@@ -335,7 +366,7 @@ internal static partial class Program {
 
         AssertContainsText(prompt, "[truncated for swarm shadow aggregation]",
             "swarm shadow aggregator prompt truncation marker");
-        AssertContainsText(prompt, "\n```\n\n[truncated for swarm shadow aggregation]",
+        AssertContainsText(prompt, "\n~~~~\n\n[truncated for swarm shadow aggregation]",
             "swarm shadow aggregator prompt closes markdown fence before truncation marker");
     }
 
@@ -519,6 +550,22 @@ internal static partial class Program {
             "None."
         });
         AssertEqual(false, ReviewSummaryParser.HasMergeBlockers(checkedOnly), "merge blockers checked checklist is non-blocking");
+
+        var nonCritical = string.Join("\n", new[] {
+            "## Summary 📝",
+            "Looks good.",
+            "",
+            "## Todo List ✅",
+            "None.",
+            "",
+            "## Non-Critical Issues",
+            "- [ ] This should not be treated as a critical merge blocker.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        AssertEqual(false, ReviewSummaryParser.HasMergeBlockers(nonCritical),
+            "merge blockers do not match non-critical heading as critical section");
     }
 
     private static void TestReviewSummaryParserMergeBlockerDetectionCompactDefaults() {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
@@ -307,6 +307,38 @@ internal static partial class Program {
         AssertContainsText(prompt, "Merge overlapping findings", "swarm shadow aggregator prompt contract");
     }
 
+    private static void TestReviewSwarmShadowAggregatorPromptClosesTruncatedFence() {
+        var plan = new ReviewSwarmShadowPlan {
+            Enabled = true,
+            ShadowMode = true,
+            Aggregator = new ReviewSwarmShadowAggregatorPlan {
+                Provider = ReviewProvider.OpenAI,
+                Model = "gpt-5.4"
+            },
+            Reviewers = new[] {
+                new ReviewSwarmShadowReviewerPlan {
+                    Id = "correctness",
+                    Provider = ReviewProvider.OpenAI,
+                    Model = "gpt-5.4"
+                }
+            }
+        };
+        var results = new[] {
+            new ReviewSwarmShadowReviewerResult {
+                Reviewer = plan.Reviewers[0],
+                Succeeded = true,
+                Output = new string('x', 30000)
+            }
+        };
+
+        var prompt = ReviewRunner.BuildSwarmShadowAggregatorPromptForTests("Base prompt", plan, results);
+
+        AssertContainsText(prompt, "[truncated for swarm shadow aggregation]",
+            "swarm shadow aggregator prompt truncation marker");
+        AssertContainsText(prompt, "\n```\n\n[truncated for swarm shadow aggregation]",
+            "swarm shadow aggregator prompt closes markdown fence before truncation marker");
+    }
+
     private static void TestReviewSwarmShadowArtifactsRenderJsonAndMarkdown() {
         var context = new PullRequestContext("owner/repo", "owner", "repo", 12, "Test title", "Body", false,
             "abc1234", "base", Array.Empty<string>(), "owner/repo", false, null);

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
@@ -42,6 +42,356 @@ internal static partial class Program {
         ok = ReviewSummaryParser.TryGetReviewedCommit(malformedThenValid, out commit);
         AssertEqual(true, ok, "malformed then valid");
         AssertEqual("deadbeef", commit, "malformed then valid commit");
+
+    }
+
+    private static void TestReviewSummaryParserFindingExtraction() {
+        var findingsBody = string.Join("\n", new[] {
+            "## Todo List ✅",
+            "- [ ] Fix cancellation race.",
+            "## Critical Issues ⚠️",
+            "- [x] Restore regression coverage."
+        });
+        var findings = ReviewSummaryParser.ExtractMergeBlockerFindings(findingsBody);
+        AssertEqual(2, findings.Count, "findings count");
+        AssertEqual("open", findings[0].Status, "first finding status");
+        AssertEqual("resolved", findings[1].Status, "second finding status");
+        AssertEqual(true, findings[0].Fingerprint.Length > 0, "first finding fingerprint");
+        AssertEqual(false, string.Equals(findings[0].Fingerprint, findings[1].Fingerprint, StringComparison.Ordinal),
+            "finding fingerprints unique");
+    }
+
+    private static void TestReviewSwarmShadowPlanUsesReviewerOverrides() {
+        var settings = new ReviewSettings {
+            Provider = ReviewProvider.OpenAI,
+            Model = "gpt-5.4",
+            ReasoningEffort = ReasoningEffort.Medium
+        };
+        settings.Swarm.Enabled = true;
+        settings.Swarm.ShadowMode = true;
+        settings.Swarm.MaxParallel = 3;
+        settings.Swarm.ReviewerSettings = new[] {
+            new ReviewSwarmReviewerSettings {
+                Id = "correctness",
+                Provider = ReviewProvider.OpenAI,
+                Model = "gpt-5.4",
+                ReasoningEffort = ReasoningEffort.High
+            },
+            new ReviewSwarmReviewerSettings {
+                Id = "tests",
+                Provider = ReviewProvider.Copilot,
+                Model = "gpt-5.2"
+            }
+        };
+        settings.Swarm.Aggregator.Provider = ReviewProvider.Claude;
+        settings.Swarm.Aggregator.Model = "claude-opus-4-1";
+        settings.Swarm.Aggregator.ReasoningEffort = ReasoningEffort.High;
+
+        var plan = ReviewRunner.BuildSwarmShadowPlanForTests(settings);
+
+        AssertEqual(true, plan.Enabled, "swarm shadow plan enabled");
+        AssertEqual(true, plan.ShadowMode, "swarm shadow plan shadow mode");
+        AssertEqual(2, plan.Reviewers.Count, "swarm shadow plan reviewer count");
+        AssertEqual(ReviewProvider.Copilot, plan.Reviewers[1].Provider, "swarm shadow plan reviewer provider override");
+        AssertEqual("gpt-5.2", plan.Reviewers[1].Model, "swarm shadow plan reviewer model override");
+        AssertEqual(ReviewProvider.Claude, plan.Aggregator.Provider, "swarm shadow plan aggregator provider");
+        AssertEqual("claude-opus-4-1", plan.Aggregator.Model, "swarm shadow plan aggregator model");
+    }
+
+    private static void TestReviewSwarmShadowPlanFallsBackToPrimaryProviderAndModel() {
+        var settings = new ReviewSettings {
+            Provider = ReviewProvider.OpenAICompatible,
+            Model = "local-model",
+            ReasoningEffort = ReasoningEffort.Low
+        };
+        settings.Swarm.Enabled = true;
+        settings.Swarm.ShadowMode = true;
+        settings.Swarm.Reviewers = new[] { "correctness", "tests" };
+        settings.Swarm.ReviewerSettings = ReviewSettings.BuildSwarmReviewerSettings(settings.Swarm.Reviewers);
+        settings.Swarm.AggregatorModel = "judge-model";
+
+        var plan = ReviewRunner.BuildSwarmShadowPlanForTests(settings);
+        var rendered = ReviewRunner.RenderSwarmShadowPlanForTests(plan);
+
+        AssertEqual(2, plan.Reviewers.Count, "swarm shadow plan fallback reviewer count");
+        AssertEqual(ReviewProvider.OpenAICompatible, plan.Reviewers[0].Provider, "swarm shadow plan fallback reviewer provider");
+        AssertEqual("local-model", plan.Reviewers[0].Model, "swarm shadow plan fallback reviewer model");
+        AssertEqual("judge-model", plan.Aggregator.Model, "swarm shadow plan fallback aggregator model");
+        AssertContainsText(rendered, "Swarm shadow plan (public comment remains single-review path):",
+            "swarm shadow plan render header");
+        AssertContainsText(rendered, "correctness -> openaicompatible / local-model / reasoning low",
+            "swarm shadow plan render reviewer");
+        AssertContainsText(rendered, "aggregator -> openaicompatible / judge-model / reasoning low",
+            "swarm shadow plan render aggregator");
+    }
+
+    private static void TestReviewSwarmShadowReviewerPromptShapesFocus() {
+        var reviewer = new ReviewSwarmShadowReviewerPlan {
+            Id = "security",
+            Provider = ReviewProvider.OpenAI,
+            Model = "gpt-5.4",
+            ReasoningEffort = ReasoningEffort.High
+        };
+
+        var prompt = ReviewRunner.BuildSwarmShadowReviewerPromptForTests("Base prompt", reviewer);
+
+        AssertContainsText(prompt, "Base prompt", "swarm shadow prompt includes base prompt");
+        AssertContainsText(prompt, "Reviewer id: `security`", "swarm shadow prompt includes reviewer id");
+        AssertContainsText(prompt, "security, auth boundaries", "swarm shadow prompt includes security focus");
+        AssertContainsText(prompt, "existing review markdown contract", "swarm shadow prompt keeps output contract");
+    }
+
+    private static void TestReviewSwarmShadowRunnerCapturesFailures() {
+        var settings = new ReviewSettings();
+        settings.Swarm.Enabled = true;
+        settings.Swarm.ShadowMode = true;
+        settings.Swarm.FailOpenOnPartial = true;
+        var plan = new ReviewSwarmShadowPlan {
+            Enabled = true,
+            ShadowMode = true,
+            Reviewers = new[] {
+                new ReviewSwarmShadowReviewerPlan {
+                    Id = "correctness",
+                    Provider = ReviewProvider.OpenAI,
+                    Model = "gpt-5.4"
+                },
+                new ReviewSwarmShadowReviewerPlan {
+                    Id = "tests",
+                    Provider = ReviewProvider.Copilot,
+                    Model = "gpt-5.2"
+                }
+            }
+        };
+        var seenPrompts = new Dictionary<string, string>(StringComparer.Ordinal);
+        var seenPromptsLock = new object();
+
+        var result = ReviewRunner.RunSwarmShadowForTestsAsync(settings, plan, "Base prompt",
+                (reviewer, prompt, _) => {
+                    lock (seenPromptsLock) {
+                        seenPrompts[reviewer.Id] = prompt;
+                    }
+                    if (reviewer.Id == "tests") {
+                        throw new InvalidOperationException("boom");
+                    }
+                    return Task.FromResult("## Summary 📝\nLooks good.\n## Todo List ✅\nNone.\n## Critical Issues ⚠️\nNone.");
+                })
+            .GetAwaiter()
+            .GetResult();
+        var rendered = ReviewRunner.RenderSwarmShadowResultsForTests(result);
+
+        AssertEqual(2, result.Results.Count, "swarm shadow result count");
+        AssertEqual(false, result.Results[0].Succeeded == result.Results[1].Succeeded,
+            "swarm shadow mixed success and failure");
+        AssertEqual(true, result.HasFailures, "swarm shadow has failures");
+        AssertNotNull(result.Aggregator, "swarm shadow aggregator result");
+        AssertEqual(true, result.Aggregator!.Succeeded, "swarm shadow aggregator succeeds with fake executor");
+        AssertEqual(2, seenPrompts.Count, "swarm shadow executor prompt count");
+        AssertEqual(true, seenPrompts.TryGetValue("tests", out var testsPrompt),
+            "swarm shadow tests prompt captured");
+        AssertContainsText(testsPrompt ?? string.Empty, "missing regression coverage", "swarm shadow tests focus prompt");
+        AssertContainsText(rendered, "correctness: completed", "swarm shadow render completed");
+        AssertContainsText(rendered, "tests: failed - InvalidOperationException: boom", "swarm shadow render failed");
+        AssertContainsText(rendered, "aggregator: completed", "swarm shadow render aggregator");
+    }
+
+    private static void TestReviewSwarmShadowRunnerFailsClosedWhenConfigured() {
+        var settings = new ReviewSettings();
+        settings.Swarm.Enabled = true;
+        settings.Swarm.ShadowMode = true;
+        settings.Swarm.FailOpenOnPartial = false;
+        var plan = new ReviewSwarmShadowPlan {
+            Enabled = true,
+            ShadowMode = true,
+            Reviewers = new[] {
+                new ReviewSwarmShadowReviewerPlan {
+                    Id = "correctness",
+                    Provider = ReviewProvider.OpenAI,
+                    Model = "gpt-5.4"
+                }
+            }
+        };
+
+        AssertThrows<InvalidOperationException>(() =>
+            ReviewRunner.RunSwarmShadowForTestsAsync(settings, plan, "Base prompt",
+                    (_, _, _) => throw new InvalidOperationException("boom"))
+                .GetAwaiter()
+                .GetResult(), "swarm shadow fail closed");
+    }
+
+    private static void TestReviewSwarmShadowRunnerHonorsMaxParallel() {
+        var settings = new ReviewSettings();
+        settings.Swarm.Enabled = true;
+        settings.Swarm.ShadowMode = true;
+        settings.Swarm.FailOpenOnPartial = true;
+        var plan = new ReviewSwarmShadowPlan {
+            Enabled = true,
+            ShadowMode = true,
+            MaxParallel = 2,
+            Reviewers = new[] {
+                new ReviewSwarmShadowReviewerPlan {
+                    Id = "correctness",
+                    Provider = ReviewProvider.OpenAI,
+                    Model = "gpt-5.4"
+                },
+                new ReviewSwarmShadowReviewerPlan {
+                    Id = "tests",
+                    Provider = ReviewProvider.OpenAI,
+                    Model = "gpt-5.4"
+                },
+                new ReviewSwarmShadowReviewerPlan {
+                    Id = "security",
+                    Provider = ReviewProvider.OpenAI,
+                    Model = "gpt-5.4"
+                }
+            }
+        };
+        var active = 0;
+        var maxActive = 0;
+
+        var result = ReviewRunner.RunSwarmShadowForTestsAsync(settings, plan, "Base prompt",
+                async (reviewer, _, _) => {
+                    var current = Interlocked.Increment(ref active);
+                    int snapshot;
+                    do {
+                        snapshot = maxActive;
+                        if (current <= snapshot) {
+                            break;
+                        }
+                    } while (Interlocked.CompareExchange(ref maxActive, current, snapshot) != snapshot);
+
+                    await Task.Delay(50).ConfigureAwait(false);
+                    Interlocked.Decrement(ref active);
+                    return $"## Summary 📝\n{reviewer.Id}\n## Todo List ✅\nNone.\n## Critical Issues ⚠️\nNone.";
+                })
+            .GetAwaiter()
+            .GetResult();
+
+        AssertEqual(3, result.Results.Count, "swarm shadow parallel result count");
+        AssertEqual(2, maxActive, "swarm shadow max parallel honored");
+        AssertEqual("correctness", result.Results[0].Reviewer.Id, "swarm shadow preserves result order first");
+        AssertEqual("tests", result.Results[1].Reviewer.Id, "swarm shadow preserves result order second");
+        AssertEqual("security", result.Results[2].Reviewer.Id, "swarm shadow preserves result order third");
+    }
+
+    private static void TestReviewSwarmShadowAggregatorPromptIncludesSubreviews() {
+        var plan = new ReviewSwarmShadowPlan {
+            Enabled = true,
+            ShadowMode = true,
+            Aggregator = new ReviewSwarmShadowAggregatorPlan {
+                Provider = ReviewProvider.OpenAI,
+                Model = "gpt-5.4",
+                ReasoningEffort = ReasoningEffort.High
+            },
+            Reviewers = new[] {
+                new ReviewSwarmShadowReviewerPlan {
+                    Id = "correctness",
+                    Provider = ReviewProvider.OpenAI,
+                    Model = "gpt-5.4"
+                }
+            }
+        };
+        var results = new[] {
+            new ReviewSwarmShadowReviewerResult {
+                Reviewer = plan.Reviewers[0],
+                Succeeded = true,
+                Output = "## Todo List ✅\n- [ ] Fix the parser null guard."
+            }
+        };
+
+        var prompt = ReviewRunner.BuildSwarmShadowAggregatorPromptForTests("Base prompt", plan, results);
+
+        AssertContainsText(prompt, "Swarm Shadow Aggregator", "swarm shadow aggregator prompt header");
+        AssertContainsText(prompt, "Base prompt", "swarm shadow aggregator prompt base");
+        AssertContainsText(prompt, "correctness (succeeded)", "swarm shadow aggregator prompt reviewer");
+        AssertContainsText(prompt, "Fix the parser null guard", "swarm shadow aggregator prompt output");
+        AssertContainsText(prompt, "Merge overlapping findings", "swarm shadow aggregator prompt contract");
+    }
+
+    private static void TestReviewSwarmShadowArtifactsRenderJsonAndMarkdown() {
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 12, "Test title", "Body", false,
+            "abc1234", "base", Array.Empty<string>(), "owner/repo", false, null);
+        var plan = new ReviewSwarmShadowPlan {
+            Enabled = true,
+            ShadowMode = true,
+            MaxParallel = 2,
+            Reviewers = new[] {
+                new ReviewSwarmShadowReviewerPlan {
+                    Id = "correctness",
+                    Provider = ReviewProvider.OpenAI,
+                    Model = "gpt-5.4"
+                }
+            },
+            Aggregator = new ReviewSwarmShadowAggregatorPlan {
+                Provider = ReviewProvider.Claude,
+                Model = "claude-opus-4-1",
+                ReasoningEffort = ReasoningEffort.High
+            }
+        };
+        var result = new ReviewSwarmShadowRunResult {
+            Results = new[] {
+                new ReviewSwarmShadowReviewerResult {
+                    Reviewer = plan.Reviewers[0],
+                    Succeeded = true,
+                    Output = "## Todo List ✅\nNone.",
+                    DurationMs = 123
+                }
+            },
+            Aggregator = new ReviewSwarmShadowAggregatorResult {
+                Succeeded = true,
+                Output = "## Summary 📝\nAggregated.",
+                DurationMs = 45
+            }
+        };
+
+        var json = ReviewRunner.BuildSwarmShadowArtifactJsonForTests(context, plan, result);
+        var markdown = ReviewRunner.BuildSwarmShadowArtifactMarkdownForTests(context, plan, result);
+
+        AssertContainsText(json, "\"schema\": \"intelligencex.review.swarmShadow.v1\"",
+            "swarm shadow artifact json schema");
+        AssertContainsText(json, "\"repository\": \"owner/repo\"", "swarm shadow artifact json repository");
+        AssertContainsText(json, "\"id\": \"correctness\"", "swarm shadow artifact json reviewer");
+        AssertContainsText(json, "\"provider\": \"claude\"", "swarm shadow artifact json aggregator provider");
+        AssertContainsText(json, "\"durationMs\": 123", "swarm shadow artifact json reviewer duration");
+        AssertContainsText(markdown, "# IntelligenceX Swarm Shadow Artifact", "swarm shadow artifact markdown title");
+        AssertContainsText(markdown, "- Repository: `owner/repo`", "swarm shadow artifact markdown repository");
+        AssertContainsText(markdown, "- Total shadow duration: `168 ms`",
+            "swarm shadow artifact markdown total duration");
+        AssertContainsText(markdown, "### Aggregator", "swarm shadow artifact markdown aggregator");
+    }
+
+    private static void TestReviewSwarmShadowArtifactsRenderMetricsJsonLine() {
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 12, "Test title", "Body", false,
+            "abc1234", "base", Array.Empty<string>(), "owner/repo", false, null);
+        var reviewer = new ReviewSwarmShadowReviewerPlan {
+            Id = "tests",
+            Provider = ReviewProvider.Copilot,
+            Model = "gpt-5.2"
+        };
+        var result = new ReviewSwarmShadowRunResult {
+            Results = new[] {
+                new ReviewSwarmShadowReviewerResult {
+                    Reviewer = reviewer,
+                    Succeeded = false,
+                    Error = "Provider timeout",
+                    DurationMs = 250
+                }
+            },
+            Aggregator = new ReviewSwarmShadowAggregatorResult {
+                Succeeded = true,
+                Output = "Aggregated.",
+                DurationMs = 75
+            }
+        };
+
+        var metrics = ReviewRunner.BuildSwarmShadowMetricsJsonLineForTests(context, result);
+
+        AssertContainsText(metrics, "\"schema\":\"intelligencex.review.swarmShadowMetrics.v1\"",
+            "swarm shadow metrics schema");
+        AssertContainsText(metrics, "\"repository\":\"owner/repo\"", "swarm shadow metrics repository");
+        AssertContainsText(metrics, "\"reviewerCount\":1", "swarm shadow metrics reviewer count");
+        AssertContainsText(metrics, "\"reviewerFailed\":1", "swarm shadow metrics reviewer failed count");
+        AssertContainsText(metrics, "\"aggregatorSucceeded\":true", "swarm shadow metrics aggregator succeeded");
+        AssertContainsText(metrics, "\"totalDurationMs\":325", "swarm shadow metrics total duration");
     }
 
     private static void TestReviewSummaryParserMergeBlockerDetection() {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
@@ -465,6 +465,11 @@ internal static partial class Program {
             Provider = ReviewProvider.Copilot,
             Model = "gpt-5.2"
         };
+        var securityReviewer = new ReviewSwarmShadowReviewerPlan {
+            Id = "security",
+            Provider = ReviewProvider.OpenAI,
+            Model = "gpt-5.4"
+        };
         var result = new ReviewSwarmShadowRunResult {
             Results = new[] {
                 new ReviewSwarmShadowReviewerResult {
@@ -472,13 +477,20 @@ internal static partial class Program {
                     Succeeded = false,
                     Error = "Provider timeout",
                     DurationMs = 250
+                },
+                new ReviewSwarmShadowReviewerResult {
+                    Reviewer = securityReviewer,
+                    Succeeded = true,
+                    Output = "No security blockers.",
+                    DurationMs = 400
                 }
             },
             Aggregator = new ReviewSwarmShadowAggregatorResult {
                 Succeeded = true,
                 Output = "Aggregated.",
                 DurationMs = 75
-            }
+            },
+            TotalDurationMs = 475
         };
 
         var metrics = ReviewRunner.BuildSwarmShadowMetricsJsonLineForTests(context, result);
@@ -486,10 +498,11 @@ internal static partial class Program {
         AssertContainsText(metrics, "\"schema\":\"intelligencex.review.swarmShadowMetrics.v1\"",
             "swarm shadow metrics schema");
         AssertContainsText(metrics, "\"repository\":\"owner/repo\"", "swarm shadow metrics repository");
-        AssertContainsText(metrics, "\"reviewerCount\":1", "swarm shadow metrics reviewer count");
+        AssertContainsText(metrics, "\"reviewerCount\":2", "swarm shadow metrics reviewer count");
         AssertContainsText(metrics, "\"reviewerFailed\":1", "swarm shadow metrics reviewer failed count");
         AssertContainsText(metrics, "\"aggregatorSucceeded\":true", "swarm shadow metrics aggregator succeeded");
-        AssertContainsText(metrics, "\"totalDurationMs\":325", "swarm shadow metrics total duration");
+        AssertContainsText(metrics, "\"reviewerDurationMs\":650", "swarm shadow metrics keeps reviewer duration sum");
+        AssertContainsText(metrics, "\"totalDurationMs\":475", "swarm shadow metrics total duration uses wall time");
     }
 
     private static void TestReviewSummaryParserMergeBlockerDetection() {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -567,6 +567,12 @@ internal static partial class Program {
         AssertContainsText(section, "Review threads snapshot: active 1, resolved 1, stale 0.", "review history thread counts");
         AssertContainsText(section, "reviewer-user (src/app.cs:42): Please add regression coverage.", "review history active thread excerpt");
 
+        settings.History.MaxRounds = 0;
+        snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "def5678", threads, settings);
+        AssertEqual(0, snapshot.Rounds.Count, "review history max rounds zero disables sticky summary rounds");
+        AssertEqual(0, snapshot.OpenFindings.Count, "review history max rounds zero disables open sticky findings");
+        settings.History.MaxRounds = 4;
+
         settings.History.IncludeExternalBotSummaries = true;
         snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "def5678", threads, settings);
         section = ReviewHistoryBuilder.Render(snapshot);
@@ -611,6 +617,38 @@ internal static partial class Program {
         AssertContainsText(block, "[todo] Add null guard in parser.", "review history comment block open item");
         AssertContainsText(block, "Resolved since last round:", "review history comment block resolved label");
         AssertContainsText(block, "[critical] Cover the stale thread path.", "review history comment block resolved item");
+    }
+
+    private static void TestReviewSummaryStabilityDropsHistoryProgressBlock() {
+        var context = BuildContext();
+        var settings = new ReviewSettings {
+            Model = "gpt-5-test",
+            Length = ReviewLength.Medium,
+            Mode = "summary"
+        };
+        var reviewBody = string.Join("\n", new[] {
+            "## Summary 📝",
+            "Looks good overall.",
+            "",
+            "## Todo List ✅",
+            "None."
+        });
+        var historyBlock = string.Join("\n", new[] {
+            "## History Progress 🔁",
+            "",
+            "Open now:",
+            "- [todo] Previous issue."
+        });
+
+        var comment = ReviewFormatter.BuildComment(context, reviewBody, settings, inlineSupported: true,
+            inlineSuppressed: false, autoResolveNote: string.Empty, budgetNote: string.Empty, usageLine: string.Empty,
+            findingsBlock: string.Empty, historyBlock: historyBlock);
+        var extracted = ReviewerApp.ExtractSummaryBodyForTests(comment, 10000) ?? string.Empty;
+
+        AssertDoesNotContainText(extracted, "History Progress 🔁", "summary stability strips history progress heading");
+        AssertDoesNotContainText(extracted, "Previous issue", "summary stability strips history progress body");
+        AssertContainsText(extracted, "## Summary 📝", "summary stability keeps review summary heading");
+        AssertContainsText(extracted, "Looks good overall.", "summary stability keeps review summary body");
     }
 
     private static void TestReviewHistoryArtifactsRenderJsonAndMarkdown() {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -516,10 +516,22 @@ internal static partial class Program {
             "## Critical Issues ⚠️",
             "- [ ] Cover the stale thread path."
         });
+        var progressSummaryBody = string.Join("\n", new[] {
+            "<!-- intelligencex:summary -->",
+            "## IntelligenceX Review (in progress)",
+            "Reviewing PR #42: **Parser update**",
+            "",
+            "- [x] Gather context",
+            "- [ ] Post findings",
+            "",
+            "### Review Checklist",
+            "- [ ] Review changes"
+        });
         var issueComments = new[] {
             new IssueComment(1, summaryBody, "intelligencex-review"),
             new IssueComment(2, "human follow-up note", "reviewer-user"),
             new IssueComment(4, "Claude summary: prior low-priority notes now look resolved.", "claude"),
+            new IssueComment(5, progressSummaryBody, "intelligencex-review"),
             new IssueComment(3, olderSummaryBody, "github-actions")
         };
         var threads = new[] {
@@ -564,6 +576,8 @@ internal static partial class Program {
         AssertContainsText(section, "Round 2: IX sticky summary reviewed `abc1234`", "review history newer round");
         AssertContainsText(section, "[todo] Add null guard in parser.", "review history normalized todo item");
         AssertContainsText(section, "[critical] Cover the stale thread path.", "review history normalized resolved item");
+        AssertDoesNotContainText(section, "in progress", "review history ignores progress summaries");
+        AssertDoesNotContainText(section, "Review Checklist", "review history ignores progress checklist summaries");
         AssertContainsText(section, "Review threads snapshot: active 1, resolved 1, stale 0.", "review history thread counts");
         AssertContainsText(section, "reviewer-user (src/app.cs:42): Please add regression coverage.", "review history active thread excerpt");
 

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -448,19 +448,251 @@ internal static partial class Program {
         var files = BuildFiles("src/app.cs");
         var settings = new ReviewSettings();
         var extras = new ReviewContextExtras {
-            CiContextSection = """
-
-CI / checks context:
-- Head SHA abc1234 check-runs: passed 3, failed 1, pending 0.
-- Failing check-runs: unit-tests (failure).
-
-"""
+            CiContextSection = string.Join("\n", new[] {
+                "",
+                "CI / checks context:",
+                "- Head SHA abc1234 check-runs: passed 3, failed 1, pending 0.",
+                "- Failing check-runs: unit-tests (failure).",
+                ""
+            })
         };
 
         var prompt = PromptBuilder.Build(context, files, settings, null, extras, inlineSupported: false);
 
         AssertContainsText(prompt, "CI / checks context:", "prompt ci context header");
         AssertContainsText(prompt, "unit-tests (failure)", "prompt ci context failing check");
+    }
+
+    private static void TestPromptBuilderIncludesReviewHistorySection() {
+        var context = BuildContext();
+        var files = BuildFiles("src/app.cs");
+        var settings = new ReviewSettings();
+        var extras = new ReviewContextExtras {
+            ReviewHistorySection = string.Join("\n", new[] {
+                "",
+                "Review history snapshot:",
+                "- IX sticky summary reviewed `abc1234` (same SHA as current head (`abc1234`)).",
+                ""
+            })
+        };
+
+        var prompt = PromptBuilder.Build(context, files, settings, null, extras, inlineSupported: false);
+
+        AssertContainsText(prompt, "Review history snapshot:", "prompt review history header");
+        AssertContainsText(prompt, "IX sticky summary reviewed `abc1234`", "prompt review history body");
+    }
+
+    private static void TestReviewHistoryBuilderIncludesStickySummaryAndThreadSnapshot() {
+        var settings = new ReviewSettings {
+            MaxCommentChars = 120
+        };
+        settings.History.Enabled = true;
+        settings.History.MaxRounds = 4;
+        var summaryBody = string.Join("\n", new[] {
+            "<!-- intelligencex:summary -->",
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Summary 📝",
+            "Looks good overall.",
+            "",
+            "## Todo List ✅",
+            "- [ ] Add null guard in parser.",
+            "",
+            "## Critical Issues ⚠️",
+            "- [x] Cover the stale thread path.",
+            "",
+            "## Other Issues 🧯",
+            "None."
+        });
+        var olderSummaryBody = string.Join("\n", new[] {
+            "<!-- intelligencex:summary -->",
+            "## IntelligenceX Review",
+            "Reviewed commit: `9999999`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Add null guard in parser.",
+            "",
+            "## Critical Issues ⚠️",
+            "- [ ] Cover the stale thread path."
+        });
+        var issueComments = new[] {
+            new IssueComment(1, summaryBody, "intelligencex-review"),
+            new IssueComment(2, "human follow-up note", "reviewer-user"),
+            new IssueComment(4, "Claude summary: prior low-priority notes now look resolved.", "claude"),
+            new IssueComment(3, olderSummaryBody, "github-actions")
+        };
+        var threads = new[] {
+            new PullRequestReviewThread(
+                "thread-1",
+                isResolved: false,
+                isOutdated: false,
+                totalComments: 1,
+                comments: new[] {
+                    new PullRequestReviewThreadComment(11, DateTimeOffset.UtcNow, "Please add regression coverage.", "reviewer-user", "src/app.cs", 42)
+                }),
+            new PullRequestReviewThread(
+                "thread-2",
+                isResolved: true,
+                isOutdated: false,
+                totalComments: 1,
+                comments: new[] {
+                    new PullRequestReviewThreadComment(12, DateTimeOffset.UtcNow, "Resolved already.", "reviewer-user", "src/app.cs", 10)
+                })
+        };
+
+        var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "def5678", threads, settings);
+        var section = ReviewHistoryBuilder.Render(snapshot);
+
+        AssertEqual(2, snapshot.Rounds.Count, "review history snapshot rounds");
+        AssertEqual(1, snapshot.OpenFindings.Count, "review history snapshot open findings");
+        AssertEqual(1, snapshot.ResolvedSinceLastRound.Count, "review history snapshot resolved since last round");
+        AssertEqual("9999999", snapshot.Rounds[0].ReviewedSha, "review history snapshot oldest round first");
+        AssertEqual("abc1234", snapshot.Rounds[1].ReviewedSha, "review history snapshot newest round second");
+        AssertEqual(2, snapshot.Rounds[1].Findings.Count, "review history snapshot findings");
+        AssertEqual("open", snapshot.Rounds[1].Findings[0].Status, "review history snapshot first finding status");
+        AssertEqual("resolved", snapshot.Rounds[1].Findings[1].Status, "review history snapshot second finding status");
+        AssertEqual(true, snapshot.Rounds[1].Findings[0].Fingerprint.Length > 0, "review history snapshot fingerprint");
+        AssertEqual("Cover the stale thread path.", snapshot.ResolvedSinceLastRound[0].Text,
+            "review history snapshot resolved finding text");
+        AssertNotNull(snapshot.ThreadSnapshot, "review history snapshot threads");
+        AssertEqual(1, snapshot.ThreadSnapshot!.ActiveCount, "review history snapshot active thread count");
+        AssertContainsText(section, "Review history snapshot:", "review history header");
+        AssertContainsText(section, "Open findings carried into the current state:", "review history open findings summary");
+        AssertContainsText(section, "Resolved since the latest prior round:", "review history resolved summary");
+        AssertContainsText(section, "Round 1: IX sticky summary reviewed `9999999`", "review history older round");
+        AssertContainsText(section, "Round 2: IX sticky summary reviewed `abc1234`", "review history newer round");
+        AssertContainsText(section, "[todo] Add null guard in parser.", "review history normalized todo item");
+        AssertContainsText(section, "[critical] Cover the stale thread path.", "review history normalized resolved item");
+        AssertContainsText(section, "Review threads snapshot: active 1, resolved 1, stale 0.", "review history thread counts");
+        AssertContainsText(section, "reviewer-user (src/app.cs:42): Please add regression coverage.", "review history active thread excerpt");
+
+        settings.History.IncludeExternalBotSummaries = true;
+        snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "def5678", threads, settings);
+        section = ReviewHistoryBuilder.Render(snapshot);
+        AssertEqual(1, snapshot.ExternalSummaries.Count, "review history external summary count");
+        AssertEqual("claude", snapshot.ExternalSummaries[0].Author, "review history external summary author");
+        AssertContainsText(section, "External bot summaries included as supporting context only:",
+            "review history external summary safety label");
+        AssertContainsText(section, "[claude] Claude summary: prior low-priority notes now look resolved.",
+            "review history external summary excerpt");
+    }
+
+    private static void TestReviewHistoryBuilderBuildsCommentBlock() {
+        var snapshot = new ReviewHistorySnapshot {
+            Rounds = new[] {
+                new ReviewHistoryRound {
+                    Sequence = 1,
+                    ReviewedSha = "abc1234"
+                }
+            },
+            OpenFindings = new[] {
+                new ReviewHistoryFinding {
+                    Fingerprint = "open-1",
+                    Section = "todo list",
+                    Text = "Add null guard in parser.",
+                    Status = "open"
+                }
+            },
+            ResolvedSinceLastRound = new[] {
+                new ReviewHistoryFinding {
+                    Fingerprint = "resolved-1",
+                    Section = "critical issues",
+                    Text = "Cover the stale thread path.",
+                    Status = "resolved"
+                }
+            }
+        };
+
+        var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+
+        AssertContainsText(block, "## History Progress 🔁", "review history comment block heading");
+        AssertContainsText(block, "Open now:", "review history comment block open label");
+        AssertContainsText(block, "[todo] Add null guard in parser.", "review history comment block open item");
+        AssertContainsText(block, "Resolved since last round:", "review history comment block resolved label");
+        AssertContainsText(block, "[critical] Cover the stale thread path.", "review history comment block resolved item");
+    }
+
+    private static void TestReviewHistoryArtifactsRenderJsonAndMarkdown() {
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 12, "Test title", "Body", false,
+            "abc1234", "base", Array.Empty<string>(), "owner/repo", false, null);
+        var snapshot = new ReviewHistorySnapshot {
+            CurrentHeadSha = "abc1234",
+            Rounds = new[] {
+                new ReviewHistoryRound {
+                    Sequence = 1,
+                    Source = "intelligencex",
+                    SummaryCommentId = 123,
+                    ReviewedSha = "9999999",
+                    HasMergeBlockers = true,
+                    MergeBlockerStatus = "1 normalized item(s).",
+                    Findings = new[] {
+                        new ReviewHistoryFinding {
+                            Fingerprint = "todo-add-null-guard",
+                            Section = "Todo List",
+                            Text = "Add null guard in parser.",
+                            Status = "open"
+                        }
+                    }
+                }
+            },
+            OpenFindings = new[] {
+                new ReviewHistoryFinding {
+                    Fingerprint = "todo-add-null-guard",
+                    Section = "Todo List",
+                    Text = "Add null guard in parser.",
+                    Status = "open"
+                }
+            },
+            ExternalSummaries = new[] {
+                new ReviewHistoryExternalSummary {
+                    CommentId = 456,
+                    Author = "claude",
+                    Source = "external-bot",
+                    Excerpt = "Claude summary: no additional blockers."
+                }
+            },
+            ThreadSnapshot = new ReviewHistoryThreadSnapshot {
+                ActiveCount = 1,
+                ResolvedCount = 2,
+                StaleCount = 1,
+                Excerpts = new[] {
+                    new ReviewHistoryThreadExcerpt {
+                        ThreadId = "thread-1",
+                        Status = "active",
+                        Author = "reviewer",
+                        Body = "Please add regression coverage.",
+                        Path = "src/app.cs",
+                        Line = 42
+                    }
+                }
+            }
+        };
+
+        var json = ReviewRunner.BuildReviewHistoryArtifactJsonForTests(context, snapshot,
+            "Review history snapshot:\n- Open findings carried into the current state.");
+        var markdown = ReviewRunner.BuildReviewHistoryArtifactMarkdownForTests(context, snapshot,
+            "Review history snapshot:\n- Open findings carried into the current state.");
+
+        AssertContainsText(json, "\"schema\": \"intelligencex.review.history.v1\"",
+            "review history artifact json schema");
+        AssertContainsText(json, "\"repository\": \"owner/repo\"", "review history artifact json repository");
+        AssertContainsText(json, "\"openFindings\": 1", "review history artifact json open count");
+        AssertContainsText(json, "\"fingerprint\": \"todo-add-null-guard\"",
+            "review history artifact json finding fingerprint");
+        AssertContainsText(json, "\"externalSummaries\": 1",
+            "review history artifact json external summary count");
+        AssertContainsText(json, "\"author\": \"claude\"", "review history artifact json external author");
+        AssertContainsText(markdown, "# IntelligenceX Review History Artifact",
+            "review history artifact markdown title");
+        AssertContainsText(markdown, "- Open findings: `1`", "review history artifact markdown open count");
+        AssertContainsText(markdown, "- External bot summaries: `1`",
+            "review history artifact markdown external count");
+        AssertContainsText(markdown, "Supporting context only; these summaries are not treated as IX-owned blocker state.",
+            "review history artifact markdown external safety label");
+        AssertContainsText(markdown, "reviewer (src/app.cs:42): Please add regression coverage.",
+            "review history artifact markdown thread excerpt");
+        AssertContainsText(markdown, "## Prompt Section", "review history artifact markdown prompt section");
     }
 
     private static void TestRedactionDefaults() {
@@ -491,6 +723,24 @@ CI / checks context:
             autoResolveNote: string.Empty, budgetNote: "Review context truncated: showing first 1 of 2 files.",
             usageLine: string.Empty, findingsBlock: string.Empty);
         AssertContainsText(comment, "Review context truncated", "budget note comment");
+    }
+
+    private static void TestReviewCommentIncludesHistoryBlock() {
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Test title", "Test body", false, "abc1234",
+            "base", Array.Empty<string>(), "owner/repo", false, null);
+        var settings = new ReviewSettings();
+        var comment = ReviewFormatter.BuildComment(context, "## Summary 📝\nLooks good overall.", settings,
+            inlineSupported: true, inlineSuppressed: false, autoResolveNote: string.Empty, budgetNote: string.Empty,
+            usageLine: string.Empty, findingsBlock: string.Empty, historyBlock: string.Join("\n", new[] {
+                "## History Progress 🔁",
+                "",
+                "Open now:",
+                "- [todo] Add null guard in parser."
+            }));
+
+        AssertContainsText(comment, "## History Progress 🔁", "review comment history heading");
+        AssertContainsText(comment, "Open now:", "review comment history body");
+        AssertContainsText(comment, "## Summary 📝", "review comment still includes summary");
     }
 
     private static void TestCombineNotes() {

--- a/IntelligenceX.Tests/Program.Reviewer.SettingsAndPrecedence.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.SettingsAndPrecedence.cs
@@ -187,6 +187,12 @@ internal static partial class Program {
         var previousConfigPath = Environment.GetEnvironmentVariable("REVIEW_CONFIG_PATH");
         var previousCiContextEnabled = Environment.GetEnvironmentVariable("REVIEW_CI_CONTEXT_ENABLED");
         var previousCiContextMaxFailedRuns = Environment.GetEnvironmentVariable("REVIEW_CI_CONTEXT_MAX_FAILED_RUNS");
+        var previousHistoryEnabled = Environment.GetEnvironmentVariable("REVIEW_HISTORY_ENABLED");
+        var previousHistoryArtifacts = Environment.GetEnvironmentVariable("REVIEW_HISTORY_ARTIFACTS");
+        var previousHistoryIncludeExternal = Environment.GetEnvironmentVariable("REVIEW_HISTORY_INCLUDE_EXTERNAL_BOT_SUMMARIES");
+        var previousHistoryExternalLogins = Environment.GetEnvironmentVariable("REVIEW_HISTORY_EXTERNAL_BOT_LOGINS");
+        var previousHistoryMaxRounds = Environment.GetEnvironmentVariable("REVIEW_HISTORY_MAX_ROUNDS");
+        var previousHistoryMaxItems = Environment.GetEnvironmentVariable("REVIEW_HISTORY_MAX_ITEMS");
         var previousSwarmEnabled = Environment.GetEnvironmentVariable("REVIEW_SWARM_ENABLED");
         var previousSwarmMaxParallel = Environment.GetEnvironmentVariable("REVIEW_SWARM_MAX_PARALLEL");
         var configPath = Path.Combine(Path.GetTempPath(), $"intelligencex-review-ci-swarm-{Guid.NewGuid():N}.json");
@@ -198,16 +204,26 @@ internal static partial class Program {
       "enabled": true,
       "includeCheckSummary": false,
       "includeFailedRuns": false,
-      "includeFailureSnippets": "always",
-      "maxFailedRuns": 7,
-      "maxSnippetCharsPerRun": 900,
-      "classifyInfraFailures": false
-    },
-    "swarm": {
-      "enabled": true,
-      "shadowMode": true,
-      "reviewers": ["security", "tests", "security"],
-      "maxParallel": 0,
+        "includeFailureSnippets": "always",
+        "maxFailedRuns": 7,
+        "maxSnippetCharsPerRun": 900,
+        "classifyInfraFailures": false
+      },
+      "history": {
+        "enabled": true,
+        "includeIxSummaryHistory": false,
+        "includeReviewThreads": false,
+        "includeExternalBotSummaries": false,
+        "externalBotLogins": ["claude"],
+        "artifacts": false,
+        "maxRounds": 9,
+        "maxItems": 9
+      },
+      "swarm": {
+        "enabled": true,
+        "shadowMode": true,
+        "reviewers": ["security", "tests", "security"],
+        "maxParallel": 0,
       "publishSubreviews": true,
       "aggregatorModel": "gpt-test",
       "failOpenOnPartial": false,
@@ -220,6 +236,12 @@ internal static partial class Program {
             Environment.SetEnvironmentVariable("REVIEW_CONFIG_PATH", configPath);
             Environment.SetEnvironmentVariable("REVIEW_CI_CONTEXT_ENABLED", "false");
             Environment.SetEnvironmentVariable("REVIEW_CI_CONTEXT_MAX_FAILED_RUNS", "2");
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_ENABLED", "false");
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_ARTIFACTS", "true");
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_INCLUDE_EXTERNAL_BOT_SUMMARIES", "true");
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_EXTERNAL_BOT_LOGINS", "claude,copilot-pull-request-reviewer");
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_MAX_ROUNDS", "4");
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_MAX_ITEMS", "4");
             Environment.SetEnvironmentVariable("REVIEW_SWARM_ENABLED", "false");
             Environment.SetEnvironmentVariable("REVIEW_SWARM_MAX_PARALLEL", "3");
 
@@ -235,22 +257,110 @@ internal static partial class Program {
             AssertEqual(false, settings.CiContext.ClassifyInfraFailures,
                 "review settings ciContext config classifyInfraFailures");
 
+            AssertEqual(false, settings.History.Enabled, "review settings env history enabled precedence");
+            AssertEqual(false, settings.History.IncludeIxSummaryHistory,
+                "review settings history config includeIxSummaryHistory");
+            AssertEqual(false, settings.History.IncludeReviewThreads,
+                "review settings history config includeReviewThreads");
+            AssertEqual(true, settings.History.IncludeExternalBotSummaries,
+                "review settings env history include external summaries precedence");
+            AssertSequenceEqual(new[] { "claude", "copilot-pull-request-reviewer" },
+                settings.History.ExternalBotLogins.ToArray(), "review settings env history external bot logins");
+            AssertEqual(true, settings.History.Artifacts, "review settings env history artifacts precedence");
+            AssertEqual(4, settings.History.MaxRounds, "review settings env history maxRounds precedence");
+            AssertEqual(4, settings.History.MaxItems, "review settings env history maxItems precedence");
+
             AssertEqual(false, settings.Swarm.Enabled, "review settings env swarm enabled precedence");
             AssertEqual(true, settings.Swarm.ShadowMode, "review settings swarm config shadowMode");
             AssertSequenceEqual(new[] { "security", "tests" }, settings.Swarm.Reviewers.ToArray(),
                 "review settings swarm reviewers normalization");
+            AssertEqual(2, settings.Swarm.ReviewerSettings.Count, "review settings swarm reviewer settings count");
+            AssertEqual("security", settings.Swarm.ReviewerSettings[0].Id, "review settings swarm reviewer settings first id");
             AssertEqual(3, settings.Swarm.MaxParallel, "review settings env swarm maxParallel precedence");
             AssertEqual(true, settings.Swarm.PublishSubreviews, "review settings swarm config publishSubreviews");
             AssertEqual("gpt-test", settings.Swarm.AggregatorModel ?? string.Empty,
                 "review settings swarm config aggregatorModel");
+            AssertEqual("gpt-test", settings.Swarm.Aggregator.Model ?? string.Empty,
+                "review settings swarm aggregator model sync");
             AssertEqual(false, settings.Swarm.FailOpenOnPartial, "review settings swarm config failOpenOnPartial");
             AssertEqual(false, settings.Swarm.Metrics, "review settings swarm config metrics");
         } finally {
             Environment.SetEnvironmentVariable("REVIEW_CONFIG_PATH", previousConfigPath);
             Environment.SetEnvironmentVariable("REVIEW_CI_CONTEXT_ENABLED", previousCiContextEnabled);
             Environment.SetEnvironmentVariable("REVIEW_CI_CONTEXT_MAX_FAILED_RUNS", previousCiContextMaxFailedRuns);
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_ENABLED", previousHistoryEnabled);
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_ARTIFACTS", previousHistoryArtifacts);
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_INCLUDE_EXTERNAL_BOT_SUMMARIES", previousHistoryIncludeExternal);
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_EXTERNAL_BOT_LOGINS", previousHistoryExternalLogins);
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_MAX_ROUNDS", previousHistoryMaxRounds);
+            Environment.SetEnvironmentVariable("REVIEW_HISTORY_MAX_ITEMS", previousHistoryMaxItems);
             Environment.SetEnvironmentVariable("REVIEW_SWARM_ENABLED", previousSwarmEnabled);
             Environment.SetEnvironmentVariable("REVIEW_SWARM_MAX_PARALLEL", previousSwarmMaxParallel);
+            if (File.Exists(configPath)) {
+                File.Delete(configPath);
+            }
+        }
+    }
+
+    private static void TestReviewSettingsLoadSwarmReviewerObjects() {
+        var previousConfigPath = Environment.GetEnvironmentVariable("REVIEW_CONFIG_PATH");
+        var configPath = Path.Combine(Path.GetTempPath(), $"intelligencex-review-swarm-objects-{Guid.NewGuid():N}.json");
+        try {
+            File.WriteAllText(configPath, """
+{
+  "review": {
+    "swarm": {
+      "enabled": true,
+      "reviewers": [
+        {
+          "id": "correctness",
+          "provider": "openai",
+          "model": "gpt-5.4",
+          "reasoningEffort": "high"
+        },
+        {
+          "id": "tests",
+          "provider": "copilot",
+          "model": "gpt-5.2"
+        }
+      ],
+      "aggregator": {
+        "provider": "openai",
+        "model": "gpt-5.4",
+        "reasoningEffort": "medium"
+      }
+    }
+  }
+}
+""");
+
+            Environment.SetEnvironmentVariable("REVIEW_CONFIG_PATH", configPath);
+
+            var settings = ReviewSettings.Load();
+
+            AssertSequenceEqual(new[] { "correctness", "tests" }, settings.Swarm.Reviewers.ToArray(),
+                "review settings swarm object reviewers ids");
+            AssertEqual(2, settings.Swarm.ReviewerSettings.Count, "review settings swarm object reviewer settings count");
+            AssertEqual(ReviewProvider.OpenAI, settings.Swarm.ReviewerSettings[0].Provider ?? ReviewProvider.Copilot,
+                "review settings swarm object first provider");
+            AssertEqual("gpt-5.4", settings.Swarm.ReviewerSettings[0].Model ?? string.Empty,
+                "review settings swarm object first model");
+            AssertEqual(ReasoningEffort.High, settings.Swarm.ReviewerSettings[0].ReasoningEffort ?? ReasoningEffort.Low,
+                "review settings swarm object first reasoning effort");
+            AssertEqual(ReviewProvider.Copilot, settings.Swarm.ReviewerSettings[1].Provider ?? ReviewProvider.OpenAI,
+                "review settings swarm object second provider");
+            AssertEqual("gpt-5.2", settings.Swarm.ReviewerSettings[1].Model ?? string.Empty,
+                "review settings swarm object second model");
+            AssertEqual(ReviewProvider.OpenAI, settings.Swarm.Aggregator.Provider ?? ReviewProvider.Copilot,
+                "review settings swarm object aggregator provider");
+            AssertEqual("gpt-5.4", settings.Swarm.Aggregator.Model ?? string.Empty,
+                "review settings swarm object aggregator model");
+            AssertEqual("gpt-5.4", settings.Swarm.AggregatorModel ?? string.Empty,
+                "review settings swarm object aggregatorModel sync");
+            AssertEqual(ReasoningEffort.Medium, settings.Swarm.Aggregator.ReasoningEffort ?? ReasoningEffort.Low,
+                "review settings swarm object aggregator reasoning effort");
+        } finally {
+            Environment.SetEnvironmentVariable("REVIEW_CONFIG_PATH", previousConfigPath);
             if (File.Exists(configPath)) {
                 File.Delete(configPath);
             }

--- a/IntelligenceX.Tests/Program.Reviewer.SettingsAndPrecedence.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.SettingsAndPrecedence.cs
@@ -367,6 +367,48 @@ internal static partial class Program {
         }
     }
 
+    private static void TestReviewSettingsEnvSwarmReviewersJson() {
+        var previousReviewers = Environment.GetEnvironmentVariable("REVIEW_SWARM_REVIEWERS");
+        var previousInputReviewers = Environment.GetEnvironmentVariable("INPUT_SWARM_REVIEWERS");
+        try {
+            Environment.SetEnvironmentVariable("REVIEW_SWARM_REVIEWERS", """
+[
+  {
+    "id": "correctness",
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "reasoningEffort": "high"
+  },
+  {
+    "id": "tests",
+    "provider": "copilot",
+    "model": "gpt-5.2"
+  }
+]
+""");
+            Environment.SetEnvironmentVariable("INPUT_SWARM_REVIEWERS", null);
+
+            var settings = ReviewSettings.FromEnvironment();
+
+            AssertSequenceEqual(new[] { "correctness", "tests" }, settings.Swarm.Reviewers.ToArray(),
+                "review settings env swarm json reviewers ids");
+            AssertEqual(2, settings.Swarm.ReviewerSettings.Count, "review settings env swarm json reviewer count");
+            AssertEqual(ReviewProvider.OpenAI, settings.Swarm.ReviewerSettings[0].Provider ?? ReviewProvider.Copilot,
+                "review settings env swarm json first provider");
+            AssertEqual("gpt-5.4", settings.Swarm.ReviewerSettings[0].Model ?? string.Empty,
+                "review settings env swarm json first model");
+            AssertEqual(ReasoningEffort.High, settings.Swarm.ReviewerSettings[0].ReasoningEffort ?? ReasoningEffort.Low,
+                "review settings env swarm json first reasoning effort");
+            AssertEqual(ReviewProvider.Copilot, settings.Swarm.ReviewerSettings[1].Provider ?? ReviewProvider.OpenAI,
+                "review settings env swarm json second provider");
+            AssertEqual("gpt-5.2", settings.Swarm.ReviewerSettings[1].Model ?? string.Empty,
+                "review settings env swarm json second model");
+        } finally {
+            Environment.SetEnvironmentVariable("REVIEW_SWARM_REVIEWERS", previousReviewers);
+            Environment.SetEnvironmentVariable("INPUT_SWARM_REVIEWERS", previousInputReviewers);
+        }
+    }
+
     private static void TestSetupGeneratedReviewerConfigValidatesAndLoadsWithCanonicalRelatedPrs() {
         var previousConfigPath = Environment.GetEnvironmentVariable("REVIEW_CONFIG_PATH");
         var configPath = Path.Combine(Path.GetTempPath(), $"intelligencex-setup-reviewer-config-{Guid.NewGuid():N}.json");

--- a/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
+++ b/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
@@ -139,6 +139,14 @@ jobs:
         AssertContainsText(content, "usage_budget_allow_credits:", "workflow template usage budget credits input");
         AssertContainsText(content, "usage_budget_allow_weekly_limit:",
             "workflow template usage budget weekly input");
+        AssertContainsText(content, "copilot_model:", "workflow template copilot model input");
+        AssertContainsText(content, "copilot_launcher:", "workflow template copilot launcher input");
+        AssertContainsText(content, "history_enabled:", "workflow template history enabled input");
+        AssertContainsText(content, "history_include_external_bot_summaries:",
+            "workflow template external bot history input");
+        AssertContainsText(content, "history_external_bot_logins:", "workflow template external bot login input");
+        AssertContainsText(content, "swarm_enabled:", "workflow template swarm enabled input");
+        AssertContainsText(content, "swarm_max_parallel:", "workflow template swarm max parallel input");
         AssertContainsText(content, "openai_account_id: ${{ inputs.openai_account_id }}",
             "workflow template openai account id pass-through");
         AssertContainsText(content, "openai_account_ids: ${{ inputs.openai_account_ids }}",
@@ -153,6 +161,21 @@ jobs:
             "workflow template usage budget credits pass-through");
         AssertContainsText(content, "usage_budget_allow_weekly_limit: ${{ inputs.usage_budget_allow_weekly_limit }}",
             "workflow template usage budget weekly pass-through");
+        AssertContainsText(content, "copilot_model: ${{ inputs.copilot_model }}",
+            "workflow template copilot model pass-through");
+        AssertContainsText(content, "copilot_launcher: ${{ inputs.copilot_launcher }}",
+            "workflow template copilot launcher pass-through");
+        AssertContainsText(content, "history_enabled: ${{ inputs.history_enabled }}",
+            "workflow template history enabled pass-through");
+        AssertContainsText(content,
+            "history_include_external_bot_summaries: ${{ inputs.history_include_external_bot_summaries }}",
+            "workflow template external bot history pass-through");
+        AssertContainsText(content, "history_external_bot_logins: ${{ inputs.history_external_bot_logins }}",
+            "workflow template external bot login pass-through");
+        AssertContainsText(content, "swarm_enabled: ${{ inputs.swarm_enabled }}",
+            "workflow template swarm enabled pass-through");
+        AssertContainsText(content, "swarm_max_parallel: ${{ inputs.swarm_max_parallel }}",
+            "workflow template swarm max parallel pass-through");
     }
 
     private static void TestSetupWorkflowTemplateIncludesOpenAiModelPassThrough() {
@@ -189,6 +212,17 @@ jobs:
         AssertContainsText(wrapperContent, "workflow_dispatch:", "wrapper workflow defines workflow_dispatch");
         AssertContainsText(wrapperContent, "reviewer_source: source",
             "wrapper workflow keeps PR reviews on repo source to avoid release drift");
+        AssertContainsText(wrapperContent, "copilot_launcher: ${{ inputs.copilot_launcher }}",
+            "wrapper workflow passes copilot launcher through to reusable workflow");
+        AssertContainsText(wrapperContent, "history_enabled: ${{ inputs.history_enabled }}",
+            "wrapper workflow passes history awareness through to reusable workflow");
+        AssertContainsText(wrapperContent,
+            "history_include_external_bot_summaries: ${{ inputs.history_include_external_bot_summaries }}",
+            "wrapper workflow passes external bot history through to reusable workflow");
+        AssertContainsText(wrapperContent, "swarm_enabled: ${{ inputs.swarm_enabled }}",
+            "wrapper workflow passes swarm mode through to reusable workflow");
+        AssertContainsText(wrapperContent, "swarm_max_parallel: ${{ inputs.swarm_max_parallel }}",
+            "wrapper workflow passes swarm max parallel through to reusable workflow");
         AssertEqual(false, content.Contains("workflow_dispatch:", StringComparison.Ordinal),
             "reusable workflow should keep manual dispatch on the wrapper workflow");
         var jobEnvIndex = content.IndexOf("    env:\n", StringComparison.Ordinal);
@@ -202,6 +236,14 @@ jobs:
         AssertContainsText(content, "workflow_call:", "reusable workflow defines workflow_call");
         AssertEqual(1, CountOccurrences(content, "openai_model:"),
             "reusable workflow defines openai_model once for workflow_call");
+        AssertEqual(1, CountOccurrences(content, "copilot_launcher:"),
+            "reusable workflow defines copilot_launcher once for workflow_call");
+        AssertEqual(1, CountOccurrences(content, "history_enabled:"),
+            "reusable workflow defines history_enabled once for workflow_call");
+        AssertEqual(1, CountOccurrences(content, "history_include_external_bot_summaries:"),
+            "reusable workflow defines external bot history once for workflow_call");
+        AssertEqual(1, CountOccurrences(content, "swarm_max_parallel:"),
+            "reusable workflow defines swarm max parallel once for workflow_call");
         AssertContainsText(content, "dotnet-version: '8.0.x'",
             "reusable workflow provisions the .NET 8 SDK for source reviewer runs");
         AssertContainsText(content, "dotnet build IntelligenceX.Reviewer/IntelligenceX.Reviewer.csproj -c Release -f net8.0",
@@ -230,6 +272,13 @@ jobs:
             "release windows reviewer step receives provider api key");
         AssertEqual(1, CountOccurrences(content, "INPUT_PROVIDER: ${{ inputs.provider }}"),
             "reusable workflow defines shared reviewer env once instead of repeating it per step");
+        AssertEqual(1, CountOccurrences(content, "INPUT_COPILOT_LAUNCHER: ${{ inputs.copilot_launcher }}"),
+            "reusable workflow exports copilot launcher env once");
+        AssertEqual(1, CountOccurrences(content, "INPUT_HISTORY_ENABLED: ${{ inputs.history_enabled }}"),
+            "reusable workflow exports history enabled env once");
+        AssertEqual(1, CountOccurrences(content,
+                "INPUT_HISTORY_INCLUDE_EXTERNAL_BOT_SUMMARIES: ${{ inputs.history_include_external_bot_summaries }}"),
+            "reusable workflow exports external bot history env once");
         AssertContainsText(content, "inputs.reviewer_source == 'source' && steps.reviewer_build.outcome == 'success'",
             "reusable workflow gates source reviewer execution on a successful source build");
         AssertContainsText(content, "git diff --name-only HEAD^1 HEAD^2 > artifacts/changed-files.txt",

--- a/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
+++ b/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
@@ -210,6 +210,8 @@ jobs:
         var wrapperContent = NormalizeWorkflowText(File.ReadAllText(wrapperWorkflowPath));
 
         AssertContainsText(wrapperContent, "workflow_dispatch:", "wrapper workflow defines workflow_dispatch");
+        AssertEqual(true, CountWorkflowDispatchInputs(wrapperContent) <= 25,
+            "wrapper workflow stays within GitHub workflow_dispatch input limit");
         AssertContainsText(wrapperContent, "reviewer_source: source",
             "wrapper workflow keeps PR reviews on repo source to avoid release drift");
         AssertContainsText(wrapperContent, "copilot_launcher: ${{ inputs.copilot_launcher }}",
@@ -328,6 +330,28 @@ jobs:
 
     private static string NormalizeWorkflowText(string content) {
         return content.Replace("\r\n", "\n");
+    }
+
+    private static int CountWorkflowDispatchInputs(string content) {
+        var normalized = NormalizeWorkflowText(content);
+        const string marker = "  workflow_dispatch:\n    inputs:\n";
+        var start = normalized.IndexOf(marker, StringComparison.Ordinal);
+        AssertEqual(true, start >= 0, "workflow_dispatch inputs block exists");
+        start += marker.Length;
+        var end = normalized.IndexOf("\njobs:", start, StringComparison.Ordinal);
+        if (end < 0) {
+            end = normalized.Length;
+        }
+
+        var count = 0;
+        foreach (var line in normalized[start..end].Split('\n')) {
+            if (line.StartsWith("      ", StringComparison.Ordinal) &&
+                !line.StartsWith("        ", StringComparison.Ordinal) &&
+                line.TrimEnd().EndsWith(":", StringComparison.Ordinal)) {
+                count++;
+            }
+        }
+        return count;
     }
 
     private static string ExtractWorkflowStepBlock(string content, string stepName) {

--- a/InternalDocs/rfcs/ix-review-history-copilot-orchestration.md
+++ b/InternalDocs/rfcs/ix-review-history-copilot-orchestration.md
@@ -1,0 +1,305 @@
+# RFC Follow-Up: Review History Snapshot and Copilot Model Orchestration
+
+## Status
+
+Draft follow-up to `ix-review-swarm.md`.
+
+This document narrows the next implementation slices so IntelligenceX Reviewer can:
+- understand repeat review rounds in a structured way,
+- support multi-provider and multi-model review fan-out,
+- and validate modern GitHub Copilot CLI launch/auth behavior before depending on it in reviewer workflows.
+
+## Why a follow-up RFC is needed
+
+The existing swarm RFC correctly identifies the missing orchestration layer, but there are now three concrete realities in the codebase:
+- reviewer config already exposes `review.swarm.*`,
+- reviewer runtime now consumes those settings for diagnostic-only shadow sub-reviewer execution,
+- and rerun awareness now has a bounded finding-first `ReviewHistorySnapshot` path for IX-owned summaries and review threads.
+
+There is also a transport risk:
+- the current Copilot integration launches the CLI as an embedded server process,
+- while the current Copilot CLI help surface emphasizes `--acp` and the current GitHub CLI (`gh copilot`) is now a wrapper/downloader entrypoint.
+
+That means the next work should not jump straight to "publish swarm comments." The next work should establish stable building blocks first.
+
+## Current baseline
+
+Today the reviewer can already:
+- reuse the previous sticky summary for the same head SHA,
+- build a normalized review-history snapshot from IX-owned summary rounds and review-thread state,
+- write bounded JSON/Markdown review-history artifacts when `review.history.artifacts` is enabled,
+- include bounded external Claude/Copilot bot summary excerpts as supporting context when explicitly enabled,
+- include issue comments, review comments, and review threads in prompt context,
+- include CI/check summary and bounded failed-run evidence,
+- run one provider with optional sequential fallback,
+- run opt-in shadow sub-reviewers diagnostically without changing the public PR comment,
+- execute shadow sub-reviewer lanes with bounded concurrency from `review.swarm.maxParallel`,
+- expose history, Copilot launcher, and swarm-shadow settings through the managed workflow wrappers/templates for manual rollout experiments,
+- run Copilot via the current embedded CLI transport.
+
+Today the reviewer cannot yet:
+- consume external bot summaries as trusted structured history sources,
+- aggregate multiple provider/model reviewer outputs into one final swarm result,
+- publish an aggregated swarm result as the single IX review comment,
+- rely on `gh copilot` as a validated reviewer launcher path.
+
+## Problem 1: Prior review context is prose-first, not state-first
+
+`summaryStability` helps reduce noisy rewrites, but it does not answer higher-value questions such as:
+- Which blocker first appeared in round 2?
+- Which blocker was resolved by the latest commit?
+- Which prior blocker is still open but now stale/outdated?
+- Which repeated finding is actually the same underlying issue with new wording?
+
+This is why a Claude-style "round history" summary can feel smarter on repeat passes. It is not merely rereading comments; it is presenting a compact state transition model.
+
+## Proposal 1: ReviewHistorySnapshot
+
+Introduce a shared normalized history object built before prompt generation.
+
+Suggested shape:
+
+```json
+{
+  "history": {
+    "currentHeadSha": "abc1234",
+    "rounds": [
+      {
+        "round": 1,
+        "reviewedSha": "def5678",
+        "source": "intelligencex",
+        "summaryId": 123456789,
+        "findings": [
+          {
+            "fingerprint": "basicelement-tr-heuristic-docs",
+            "severity": "low",
+            "section": "Todo List",
+            "title": "BasicElement heuristic undocumented",
+            "status": "resolved",
+            "resolvedBySha": "abc1234",
+            "evidence": "XML docs added at BasicElement.cs:82-83"
+          }
+        ]
+      }
+    ],
+    "openFindings": [],
+    "resolvedSinceLastRound": []
+  }
+}
+```
+
+Normative rules:
+- findings are keyed by stable fingerprints, not raw prose
+- status is computed from current summary markers, thread state, and optional diff evidence
+- "outdated" is not treated as "resolved" unless explicit evidence or resolution exists
+- external bot summaries are opt-in sources, never default sources
+- prompt context should prefer compact normalized lines over raw historical markdown
+
+## Suggested config for review history
+
+```json
+{
+  "review": {
+    "history": {
+      "enabled": true,
+      "includeIxSummaryHistory": true,
+      "includeReviewThreads": true,
+      "includeExternalBotSummaries": false,
+      "externalBotLogins": ["copilot-pull-request-reviewer", "claude"],
+      "maxRounds": 6,
+      "maxFindingsPerRound": 20,
+      "emitResolvedMatrix": true
+    }
+  }
+}
+```
+
+Recommended V1 behavior:
+- default off for external bot summaries
+- default on for IX-owned sticky summary history when `summaryStability` is enabled
+- keep history loading bounded by rounds and findings
+- emit history as prompt input and optional internal artifacts before changing public comment shape
+
+## Problem 2: Swarm settings are scalar-first, not reviewer-first
+
+Current `review.swarm.reviewers` is a list of role ids. That is enough for role selection, but not enough for mixed-model orchestration.
+
+It cannot express:
+- correctness on `gpt-5.4`
+- tests on Copilot `gpt-5.2`
+- security on Claude
+- aggregation on a separate model/provider
+
+## Proposal 2: Reviewer object config
+
+Keep the current string list as a compatibility alias, but add an object form for explicit reviewer definitions.
+
+Suggested shape:
+
+```json
+{
+  "review": {
+    "swarm": {
+      "enabled": true,
+      "shadowMode": true,
+      "maxParallel": 4,
+      "reviewers": [
+        {
+          "id": "correctness",
+          "provider": "openai",
+          "model": "gpt-5.4",
+          "reasoningEffort": "high"
+        },
+        {
+          "id": "tests",
+          "provider": "copilot",
+          "model": "gpt-5.2"
+        },
+        {
+          "id": "security",
+          "provider": "claude",
+          "model": "claude-opus-4-1"
+        }
+      ],
+      "aggregator": {
+        "provider": "openai",
+        "model": "gpt-5.4",
+        "reasoningEffort": "high"
+      }
+    }
+  }
+}
+```
+
+Compatibility rules:
+- `reviewers: ["correctness", "tests"]` expands using repo defaults
+- object form overrides defaults per reviewer
+- aggregator defaults to main review provider/model when omitted
+- sub-reviewers remain read-only and never post directly to GitHub
+
+## Problem 3: Copilot launch path needs explicit validation
+
+The current reviewer transport launches Copilot as a local CLI process. That remains useful, but the surrounding ecosystem changed:
+- `gh copilot` can now launch or download Copilot CLI,
+- Copilot CLI model selection is explicit in the public CLI surface,
+- and the CLI help surface now centers `--acp`.
+
+We should not assume that:
+- `copilot` on PATH,
+- `gh copilot`,
+- and the reviewer's embedded transport
+
+all represent the same supported server protocol.
+
+## Proposal 3: Copilot launcher modes
+
+Add an explicit launcher mode before changing default behavior.
+
+Suggested shape:
+
+```json
+{
+  "review": {
+    "provider": "copilot"
+  },
+  "copilot": {
+    "transport": "cli",
+    "launcher": "auto",
+    "cliPath": "copilot"
+  }
+}
+```
+
+Suggested semantics:
+- `binary`: execute `copilot` directly
+- `gh`: execute `gh copilot --`
+- `auto`: prefer validated `gh copilot` when available, otherwise fall back to direct binary
+
+Validation requirements before enabling `gh` by default:
+- confirm server/protocol compatibility for reviewer transport mode
+- confirm model selection works in reviewer mode
+- confirm auth works without API keys using Copilot subscription on supported runners
+- confirm failure modes are diagnosable and fail-open behavior remains clear
+
+## Recommended rollout order
+
+### Phase 0: Reality-check and guardrails
+
+- add internal validation notes for current Copilot CLI protocol expectations
+- add a reviewer startup diagnostic when Copilot CLI/server capabilities look incompatible
+- avoid changing public docs to imply swarm runtime is already active
+
+### Phase 1: ReviewHistorySnapshot shadow mode
+
+- build normalized IX summary/thread history
+- emit internal artifact only
+- feed compact history block into prompt
+- keep public comment format unchanged except optional "resolved since last round" experiment behind a flag
+
+### Phase 2: Swarm shadow execution
+
+- shared context builder
+- role-specific sub-reviewers (initial diagnostic execution now present)
+- structured result contract
+- aggregator pass (initial diagnostic execution now present)
+- metrics/artifacts only
+
+### Phase 3: Per-reviewer provider/model selection
+
+- object-form reviewer config
+- aggregator config object
+- provider/model/reasoning overrides per role
+- fallback semantics per role and for aggregator
+
+### Phase 4: Public swarm output
+
+- publish one aggregated IX review comment
+- keep current merge-blocker sections
+- keep thread auto-resolve post-aggregation
+- compare against single-review baseline before flipping defaults anywhere
+
+## Acceptance criteria
+
+Review history slice is ready when:
+- repeated reviewer runs can distinguish open vs resolved prior findings
+- identical findings across rounds collapse to one fingerprint
+- resolved matrix output can be generated without rereading raw prior markdown in the prompt
+
+Swarm shadow slice is ready when:
+- multiple reviewer roles run from one shared context
+- aggregator emits one deterministic structured result
+- latency/cost metrics are recorded
+- no additional public PR noise is introduced
+
+Current status:
+- external bot summaries can be included as bounded supporting excerpts only when `review.history.includeExternalBotSummaries` is enabled
+- sub-reviewer diagnostic execution is present behind `review.swarm.enabled` + `review.swarm.shadowMode`
+- sub-reviewer lanes honor `review.swarm.maxParallel` while preserving deterministic result ordering for aggregation
+- aggregator diagnostic execution is present and remains non-public
+- bounded review-history JSON/Markdown artifacts are written under `artifacts/reviewer/history/` when `review.history.artifacts` is enabled
+- bounded JSON/Markdown comparison artifacts plus append-only JSONL metrics are written under `artifacts/reviewer/swarm-shadow/` when `review.swarm.metrics` is enabled
+- managed workflow wrappers/templates pass through history, Copilot model/launcher, and swarm-shadow overrides to the reusable workflow
+- public output still comes from the single-review path
+- deeper longitudinal history analysis across uploaded workflow artifacts remains pending
+
+Copilot launcher slice is ready when:
+- reviewer can intentionally select `binary` or `gh`
+- `auto` behavior is deterministic and logged
+- subscription auth works without API keys on supported environments
+- unsupported or drifting protocol modes fail with actionable diagnostics
+
+## Suggested first implementation tasks
+
+1. Add `ReviewHistorySettings` + schema/env/config plumbing.
+2. Build `ReviewHistorySnapshot` from IX sticky summary + review threads.
+3. Replace `previousSummary` string-only prompt injection with a history section builder.
+4. Add internal artifact output for history normalization.
+5. Add Copilot launcher capability probe and diagnostics.
+6. Continue swarm executor shadow work by adding longitudinal rollout metrics.
+
+## Non-goals for the first slice
+
+- no public multi-comment swarm output
+- no automatic use of external bot summaries by default
+- no direct assumption that `gh copilot` is a drop-in reviewer transport until validated
+- no autonomous fix engine behavior

--- a/InternalDocs/rfcs/ix-review-history-copilot-orchestration.md
+++ b/InternalDocs/rfcs/ix-review-history-copilot-orchestration.md
@@ -18,7 +18,7 @@ The existing swarm RFC correctly identifies the missing orchestration layer, but
 
 There is also a transport risk:
 - the current Copilot integration launches the CLI as an embedded server process,
-- while the current Copilot CLI help surface emphasizes `--acp` and the current GitHub CLI (`gh copilot`) is now a wrapper/downloader entrypoint.
+- while the current Copilot CLI help surface emphasizes `--acp` and the current GitHub CLI (`gh copilot`) is a wrapper entrypoint whose installer/bootstrap behavior is not guaranteed on every runner.
 
 That means the next work should not jump straight to "publish swarm comments." The next work should establish stable building blocks first.
 
@@ -180,7 +180,7 @@ Compatibility rules:
 ## Problem 3: Copilot launch path needs explicit validation
 
 The current reviewer transport launches Copilot as a local CLI process. That remains useful, but the surrounding ecosystem changed:
-- `gh copilot` can now launch or download Copilot CLI,
+- `gh copilot` can launch Copilot CLI when the wrapper can already find or provision it,
 - Copilot CLI model selection is explicit in the public CLI surface,
 - and the CLI help surface now centers `--acp`.
 
@@ -213,7 +213,7 @@ Suggested shape:
 Suggested semantics:
 - `binary`: execute `copilot` directly
 - `gh`: execute `gh copilot --`
-- `auto`: prefer validated `gh copilot` when available, otherwise fall back to direct binary
+- `auto`: use the direct binary when present, otherwise choose `gh copilot --` only after a wrapper capability probe succeeds
 
 Validation requirements before enabling `gh` by default:
 - confirm server/protocol compatibility for reviewer transport mode
@@ -279,6 +279,7 @@ Current status:
 - bounded review-history JSON/Markdown artifacts are written under `artifacts/reviewer/history/` when `review.history.artifacts` is enabled
 - bounded JSON/Markdown comparison artifacts plus append-only JSONL metrics are written under `artifacts/reviewer/swarm-shadow/` when `review.swarm.metrics` is enabled
 - managed workflow wrappers/templates pass through history, Copilot model/launcher, and swarm-shadow overrides to the reusable workflow
+- `copilot.launcher=auto` now probes whether `gh copilot -- --version` can actually launch the CLI before selecting the wrapper path
 - public output still comes from the single-review path
 - deeper longitudinal history analysis across uploaded workflow artifacts remains pending
 

--- a/InternalDocs/rfcs/ix-review-swarm.md
+++ b/InternalDocs/rfcs/ix-review-swarm.md
@@ -6,6 +6,15 @@ Draft.
 
 Proposed as an opt-in extension to IntelligenceX Reviewer, not a default behavior change.
 
+Current implementation reality as of 2026-04-17:
+- `review.swarm.*` config/schema/workflow plumbing exists, including managed wrapper/template pass-through for manual rollout overrides.
+- reviewer runtime still uses the single primary provider path for the public comment, but opt-in shadow mode can now execute selected read-only sub-reviewer lanes with bounded `maxParallel` concurrency and a diagnostic aggregator after the primary review succeeds.
+- shadow rollout artifacts now include bounded JSON/Markdown comparison output and append-only JSONL metrics under `artifacts/reviewer/swarm-shadow/` when `review.swarm.metrics` is enabled.
+- CI/check-aware reviewer context has landed in the current reviewer runtime and should be treated as baseline capability, not a future-only swarm dependency.
+- structured review history now builds a bounded cross-round ledger from IX-owned sticky summaries and review-thread state, with optional bounded artifacts under `artifacts/reviewer/history/`; external bot summaries can be included as opt-in supporting excerpts but are not treated as trusted IX blocker state.
+
+Follow-up detail for phased implementation lives in `InternalDocs/rfcs/ix-review-history-copilot-orchestration.md`.
+
 ## Problem
 
 The current IntelligenceX reviewer is a strong single-pipeline reviewer:
@@ -86,7 +95,7 @@ IntelligenceX already has pieces that make this a natural extension rather than 
 The missing piece is not "more review infrastructure." The missing piece is a multi-reviewer orchestration layer plus a deterministic aggregator contract.
 
 There is also a second missing piece:
-- CI/check awareness inside the reviewer itself, so the reviewer can understand when tests or required checks are already failing and use that as evidence instead of reviewing the diff in isolation.
+- structured cross-round review history inside the reviewer itself, so the reviewer can reason over previously reported blockers and verified resolutions instead of only reusing prior prose.
 
 ## Current Reviewer Baseline
 
@@ -122,6 +131,8 @@ Why:
 
 ### 1.1) CI / Test Awareness as Shared Context
 
+This capability is now largely present in the single-review path and should be preserved as shared infrastructure for future swarm execution, not reimplemented separately.
+
 Reviewer context should optionally include bounded GitHub Actions and PR-check information.
 
 Recommended levels:
@@ -151,7 +162,7 @@ It should be implemented once and shared.
 
 ### 1.2) Reuse Existing IX Check/Run Plumbing
 
-This should reuse the logic already present in PR-watch flows rather than building a second drifting GitHub checks implementation.
+This should continue reusing the logic already present in PR-watch flows rather than building a second drifting GitHub checks implementation.
 
 Existing IX CLI logic already collects:
 - PR check summaries via `gh pr checks`

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -83,16 +83,61 @@
             "classifyInfraFailures": { "type": "boolean" }
           }
         },
+        "history": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "includeIxSummaryHistory": { "type": "boolean" },
+            "includeReviewThreads": { "type": "boolean" },
+            "includeExternalBotSummaries": { "type": "boolean" },
+            "externalBotLogins": {
+              "oneOf": [
+                { "type": "array", "items": { "type": "string" } },
+                { "type": "string" }
+              ]
+            },
+            "artifacts": { "type": "boolean" },
+            "maxRounds": { "type": "integer", "minimum": 0 },
+            "maxItems": { "type": "integer", "minimum": 0 }
+          }
+        },
         "swarm": {
           "type": "object",
           "additionalProperties": true,
           "properties": {
             "enabled": { "type": "boolean" },
             "shadowMode": { "type": "boolean" },
-            "reviewers": { "type": "array", "items": { "type": "string" } },
+            "reviewers": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  { "type": "string" },
+                  {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                      "id": { "type": "string" },
+                      "provider": { "type": "string" },
+                      "model": { "type": "string" },
+                      "reasoningEffort": { "type": "string" }
+                    }
+                  }
+                ]
+              }
+            },
             "maxParallel": { "type": "integer", "minimum": 1 },
             "publishSubreviews": { "type": "boolean" },
             "aggregatorModel": { "type": "string" },
+            "aggregator": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "provider": { "type": "string" },
+                "model": { "type": "string" },
+                "reasoningEffort": { "type": "string" }
+              }
+            },
             "failOpenOnPartial": { "type": "boolean" },
             "metrics": { "type": "boolean" }
           }
@@ -346,6 +391,7 @@
         "cliPath": { "type": "string" },
         "cliUrl": { "type": "string" },
         "workingDirectory": { "type": "string" },
+        "launcher": { "type": "string", "enum": ["binary", "cli", "copilot", "gh", "github", "github-cli", "github_cli", "auto"] },
         "autoInstall": { "type": "boolean" },
         "autoInstallMethod": { "type": "string" },
         "autoInstallPrerelease": { "type": "boolean" },

--- a/Website/.powerforge/audit-baseline.json
+++ b/Website/.powerforge/audit-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generatedAtUtc": "2026-02-15T13:07:55.5132343+00:00",
-  "issueCount": 199,
+  "generatedAtUtc": "2026-04-19T09:02:00.0000000+00:00",
+  "issueCount": 202,
   "keyFormat": "sha256-12-b64url",
   "issueKeyHashes": [
     "-3-wzkNWKGL7NsvC",
@@ -48,6 +48,7 @@
     "AILYh8XSKNMYW5-R",
     "AX5zEoOU0GwLjt7b",
     "aXxpRAKkPn6iY07w",
+    "a6z9Mco480ONKCTz",
     "balhu82WkN8N7UrY",
     "be5KMDuTyNrmbQ3W",
     "bfDpGsNtHxLnsi4D",
@@ -106,6 +107,7 @@
     "jy1gdY688JqTcN6p",
     "KCJ2xRqPJxlmR7ne",
     "khhXiNBxbSPjzBH_",
+    "kAo_4CX7YwbaGsE3",
     "kjvzJRejJKDcxz7C",
     "Kl-YxhPZ7h4t9HLA",
     "ku5ufr_60o8z-it9",
@@ -197,6 +199,7 @@
     "ZB7icTdXyM0JXwqg",
     "ZJipg5LVIVFM3-Me",
     "ZliUO9HAUv55SN6i",
+    "zs3B0zfJv9ZAogSD",
     "zvXOYa0trYhL8Er0",
     "z_WwaqsBGO6Gsxz0",
     "_5givzyUZynqf5wB",


### PR DESCRIPTION
## Summary

Adds structured rerun awareness and diagnostic multi-reviewer groundwork for IntelligenceX Reviewer.

- Builds a bounded `ReviewHistorySnapshot` from IX-owned summaries, review threads, and optional external bot summary excerpts.
- Feeds compact history context into review prompts and can emit JSON/Markdown history artifacts.
- Adds shadow swarm reviewer planning/execution with per-reviewer provider/model overrides, bounded parallelism, diagnostic aggregation, and metrics/artifacts.
- Adds Copilot launcher selection (`binary`, `gh`, `auto`) plus diagnostics for the resolved CLI command.
- Makes `copilot.launcher=auto` conservative: it only selects `gh copilot --` after probing that the wrapper can actually launch the Copilot CLI.
- Exposes history, Copilot launcher/model, and swarm shadow controls through reusable workflow inputs and setup templates.
- Refreshes reviewer bootstrap verifier scripts for the current `review-intelligencex-core.yml` workflow name.

## Validation

- `pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-reviewer-bootstrap/scripts/verify-managed-workflow.ps1 .github/workflows/review-intelligencex.yml`
- `dotnet build .\IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release --no-restore`
- `dotnet .\IntelligenceX.Tests\bin\Release\net8.0\IntelligenceX.Tests.dll`
- `dotnet .\IntelligenceX.Tests\bin\Release\net10.0\IntelligenceX.Tests.dll`
- `git diff --check`

## Copilot launcher smoke

Local smoke confirmed that `gh copilot -- --version` works while the standalone `copilot.exe` is visible, but reports `Copilot CLI not installed` when `copilot.exe` is hidden from `PATH`. The auto launcher therefore now probes the wrapper before choosing `gh`.

## Notes

Public PR review output remains the single primary reviewer path. Swarm execution is diagnostic shadow mode only until rollout metrics and live Copilot launcher validation are proven safe.
