### PR TITLE
Harden Copilot reviewer launcher defaults

### DIFF
--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -9,11 +9,11 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@482dacb576ea43105aab3e2e9026e00b15631cb6
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@2b3adb4ffe114132d85520ca2dc8c7b9b3fad642
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 482dacb576ea43105aab3e2e9026e00b15631cb6
+      powerforge_ref: 2b3adb4ffe114132d85520ca2dc8c7b9b3fad642

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -9,11 +9,11 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@10757f12978162b54ac314b512a3a77e227502fd
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@482dacb576ea43105aab3e2e9026e00b15631cb6
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 10757f12978162b54ac314b512a3a77e227502fd
+      powerforge_ref: 482dacb576ea43105aab3e2e9026e00b15631cb6

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -661,9 +661,10 @@ GitHub Actions input/env aliases:
 Use this to forward selected environment variables into the Copilot CLI process without committing secrets.
 By default the CLI process **does** inherit the runner environment. Set `inheritEnvironment` to `false` and use
 `envAllowlist`/`env` to pass only what the CLI needs when you want a strict environment.
-Set `launcher` to `gh` to run Copilot through `gh copilot --` when that wrapper can already launch the Copilot CLI.
-Set `launcher` to `auto` to use the standalone binary when it is on `PATH` and only fall back to `gh copilot --`
-after a wrapper capability probe succeeds. This avoids assuming GitHub CLI can bootstrap Copilot on every runner.
+Set `launcher` to `gh` to explicitly run Copilot through `gh copilot --`.
+Set `launcher` to `auto` to use the standalone `copilot` binary path. This is the safer default for reviewer server mode:
+the GitHub CLI wrapper can sometimes launch the CLI for simple commands while still hanging in long-running server mode.
+Use `autoInstall` with the standalone path when the runner does not already have `copilot` installed.
 
 ```json
 {
@@ -787,7 +788,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `azureTokenEnv`: env var name that contains the ADO token (default `SYSTEM_ACCESSTOKEN` if set)
 - `azureAuthScheme`: `bearer` (System.AccessToken/JWT) or `basic`/`pat`
 - `copilot.transport`: `cli` or `direct` (aliases: `api`, `http`)
-- `copilot.launcher`: `binary`, `gh`, or `auto`; `gh` executes `gh copilot --` before the reviewer server flags
+- `copilot.launcher`: `binary`, `gh`, or `auto`; `auto` uses the standalone binary path, while `gh` explicitly executes `gh copilot --` before the reviewer server flags
 - `copilot.inheritEnvironment`: inherit full runner environment for Copilot CLI (`true` by default)
 
 **Path filter order of operations**

--- a/IntelligenceX.Reviewer/ReviewDiagnostics.cs
+++ b/IntelligenceX.Reviewer/ReviewDiagnostics.cs
@@ -211,7 +211,7 @@ internal static class ReviewDiagnostics {
         sb.AppendLine("WARNING: Review failed to complete due to a provider request error.");
         sb.AppendLine();
         sb.AppendLine($"- Provider: {settings.Provider.ToString().ToLowerInvariant()}");
-        sb.AppendLine($"- Transport: {settings.OpenAITransport}");
+        sb.AppendLine($"- Transport: {DescribeTransport(settings)}");
         sb.AppendLine($"- Model: {settings.Model}");
         sb.AppendLine($"- Category: {classification.Category} ({(classification.IsTransient ? "transient" : "non-transient")})");
         if (!string.IsNullOrWhiteSpace(classification.Summary)) {
@@ -251,7 +251,7 @@ internal static class ReviewDiagnostics {
         ReviewRetryState? retryState) {
         var classification = Classify(ex);
         Console.Error.WriteLine("Provider request failed.");
-        Console.Error.WriteLine($"Provider: {settings.Provider.ToString().ToLowerInvariant()} | Transport: {settings.OpenAITransport} | Model: {settings.Model}");
+        Console.Error.WriteLine($"Provider: {settings.Provider.ToString().ToLowerInvariant()} | Transport: {DescribeTransport(settings)} | Model: {settings.Model}");
         Console.Error.WriteLine($"Category: {classification.Category} ({(classification.IsTransient ? "transient" : "non-transient")})");
         if (retryState is not null && retryState.LastAttempt > 0) {
             Console.Error.WriteLine($"Retry: {retryState.LastAttempt}/{retryState.MaxAttempts}");
@@ -303,11 +303,17 @@ internal static class ReviewDiagnostics {
             Console.Error.WriteLine($"RPC error: {FormatExceptionSummary(snapshot.LastRpcError, true)}");
         }
         if (snapshot.StandardError.Count > 0) {
-            Console.Error.WriteLine("App-server stderr (most recent first):");
+            Console.Error.WriteLine("Provider stderr (most recent first):");
             for (var i = snapshot.StandardError.Count - 1; i >= 0; i--) {
                 Console.Error.WriteLine($"  {snapshot.StandardError[i]}");
             }
         }
+    }
+
+    private static string DescribeTransport(ReviewSettings settings) {
+        return settings.Provider == ReviewProvider.Copilot
+            ? settings.CopilotTransport.ToString()
+            : settings.OpenAITransport.ToString();
     }
 
     internal static WorkflowFailureInfo ClassifyWorkflowFailureLog(string? logText) {

--- a/IntelligenceX.Reviewer/ReviewRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewRunner.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -346,6 +344,10 @@ internal sealed partial class ReviewRunner {
     }
 
     private CopilotClientOptions BuildCopilotClientOptions() {
+        return BuildCopilotClientOptions(out _);
+    }
+
+    private CopilotClientOptions BuildCopilotClientOptions(out string launcherDiagnostic) {
         var options = new CopilotClientOptions();
         var launcher = ApplyCopilotLauncher(options);
         if (!string.IsNullOrWhiteSpace(_settings.CopilotCliUrl)) {
@@ -363,14 +365,15 @@ internal sealed partial class ReviewRunner {
         }
         options.AutoInstallPrerelease = _settings.CopilotAutoInstallPrerelease;
         ApplyCopilotEnvironment(options);
+        launcherDiagnostic = BuildCopilotLauncherDiagnostic(launcher, options);
         if (_settings.Diagnostics) {
-            Console.Error.WriteLine(BuildCopilotLauncherDiagnostic(launcher, options));
+            Console.Error.WriteLine(launcherDiagnostic);
         }
         return options;
     }
 
     private string ApplyCopilotLauncher(CopilotClientOptions options) {
-        var launcher = ResolveCopilotLauncher(_settings, CommandExists, GhCopilotWrapperCanLaunchCli);
+        var launcher = ResolveCopilotLauncher(_settings);
 
         if (string.Equals(launcher, "gh", StringComparison.OrdinalIgnoreCase)) {
             options.CliPath = "gh";
@@ -385,26 +388,16 @@ internal sealed partial class ReviewRunner {
         return "binary";
     }
 
-    internal static string ResolveCopilotLauncherForTests(ReviewSettings settings, bool copilotExists, bool ghExists,
-        bool ghCopilotWrapperCanLaunchCli) =>
-        ResolveCopilotLauncher(settings,
-            command => string.Equals(command, "copilot", StringComparison.OrdinalIgnoreCase)
-                ? copilotExists
-                : ghExists,
-            () => ghCopilotWrapperCanLaunchCli);
+    internal static string ResolveCopilotLauncherForTests(ReviewSettings settings) =>
+        ResolveCopilotLauncher(settings);
 
-    private static string ResolveCopilotLauncher(ReviewSettings settings, Func<string, bool> commandExists,
-        Func<bool> ghCopilotWrapperCanLaunchCli) {
+    private static string ResolveCopilotLauncher(ReviewSettings settings) {
         var launcher = ReviewSettings.NormalizeCopilotLauncher(settings.CopilotLauncher, "binary");
         if (!string.Equals(launcher, "auto", StringComparison.OrdinalIgnoreCase)) {
             return launcher;
         }
 
-        if (!string.IsNullOrWhiteSpace(settings.CopilotCliPath) || commandExists("copilot") || !commandExists("gh")) {
-            return "binary";
-        }
-
-        return ghCopilotWrapperCanLaunchCli() ? "gh" : "binary";
+        return "binary";
     }
 
     private string BuildCopilotLauncherDiagnostic(string launcher, CopilotClientOptions options) {
@@ -431,9 +424,12 @@ internal sealed partial class ReviewRunner {
         if (_settings.CopilotTransport == CopilotTransportKind.Direct) {
             return await RunCopilotDirectAsync(prompt, cancellationToken).ConfigureAwait(false);
         }
-        var options = BuildCopilotClientOptions();
+        var options = BuildCopilotClientOptions(out var launcherDiagnostic);
 
         await using var client = await CopilotClient.StartAsync(options, cancellationToken).ConfigureAwait(false);
+        var stderrLines = new Queue<string>();
+        var stderrLock = new object();
+        client.StandardErrorReceived += (_, line) => CaptureCopilotStderr(stderrLines, stderrLock, line);
         var session = await client.CreateSessionAsync(new CopilotSessionOptions {
             Model = _settings.Model,
             Streaming = true
@@ -479,7 +475,7 @@ internal sealed partial class ReviewRunner {
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeout.CancelAfter(TimeSpan.FromSeconds(_settings.WaitSeconds));
         using var registration = timeout.Token.Register(() =>
-            tcs.TrySetException(new TimeoutException($"Copilot review timed out after {_settings.WaitSeconds} seconds.")));
+            tcs.TrySetException(new TimeoutException(BuildCopilotTimeoutMessage(launcherDiagnostic, stderrLines, stderrLock))));
 
         var result = await tcs.Task.ConfigureAwait(false);
 
@@ -494,6 +490,42 @@ internal sealed partial class ReviewRunner {
         }
 
         return result ?? string.Empty;
+    }
+
+    private string BuildCopilotTimeoutMessage(string launcherDiagnostic, Queue<string> stderrLines, object stderrLock) {
+        var sb = new StringBuilder();
+        sb.Append("Copilot review timed out after ");
+        sb.Append(_settings.WaitSeconds);
+        sb.Append(" seconds. ");
+        sb.Append(launcherDiagnostic);
+        sb.Append(" If this run uses the GitHub CLI wrapper, try copilot.launcher=binary with copilot.autoInstall=true; ");
+        sb.Append("the wrapper can launch the CLI but still hang in reviewer server mode on some runners.");
+
+        List<string> lines;
+        lock (stderrLock) {
+            lines = new List<string>(stderrLines);
+        }
+        if (lines.Count > 0) {
+            sb.AppendLine();
+            sb.AppendLine("Recent Copilot CLI stderr:");
+            for (var i = Math.Max(0, lines.Count - 6); i < lines.Count; i++) {
+                sb.Append("  ");
+                sb.AppendLine(lines[i]);
+            }
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static void CaptureCopilotStderr(Queue<string> stderrLines, object stderrLock, string? line) {
+        if (string.IsNullOrWhiteSpace(line)) {
+            return;
+        }
+        lock (stderrLock) {
+            stderrLines.Enqueue(line.Trim());
+            while (stderrLines.Count > 8) {
+                stderrLines.Dequeue();
+            }
+        }
     }
 
     private async Task<string> RunCopilotDirectAsync(string prompt, CancellationToken cancellationToken) {
@@ -696,71 +728,4 @@ internal sealed partial class ReviewRunner {
         }
     }
 
-    private static bool CommandExists(string command) {
-        var path = Environment.GetEnvironmentVariable("PATH");
-        if (string.IsNullOrWhiteSpace(path)) {
-            return false;
-        }
-
-        var extensions = new List<string> { string.Empty };
-        if (OperatingSystem.IsWindows()) {
-            var pathExt = Environment.GetEnvironmentVariable("PATHEXT");
-            extensions = string.IsNullOrWhiteSpace(pathExt)
-                ? new List<string> { ".exe", ".cmd", ".bat" }
-                : new List<string>(pathExt.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
-        }
-
-        foreach (var directory in path.Split(Path.PathSeparator)) {
-            if (string.IsNullOrWhiteSpace(directory)) {
-                continue;
-            }
-            foreach (var extension in extensions) {
-                var candidate = Path.Combine(directory.Trim(), command + extension);
-                if (File.Exists(candidate)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private static bool GhCopilotWrapperCanLaunchCli() {
-        try {
-            using var process = new Process();
-            process.StartInfo = new ProcessStartInfo {
-                FileName = "gh",
-                RedirectStandardError = true,
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-            process.StartInfo.ArgumentList.Add("copilot");
-            process.StartInfo.ArgumentList.Add("--");
-            process.StartInfo.ArgumentList.Add("--version");
-            if (!process.Start()) {
-                return false;
-            }
-
-            if (!process.WaitForExit(5000)) {
-                try {
-                    process.Kill(entireProcessTree: true);
-                } catch {
-                    // Best-effort cleanup for a capability probe.
-                }
-                return false;
-            }
-
-            var output = process.StandardOutput.ReadToEnd();
-            var error = process.StandardError.ReadToEnd();
-            var combined = string.Concat(output, "\n", error);
-            if (combined.Contains("not installed", StringComparison.OrdinalIgnoreCase)) {
-                return false;
-            }
-            return process.ExitCode == 0 &&
-                combined.Contains("copilot", StringComparison.OrdinalIgnoreCase);
-        } catch {
-            return false;
-        }
-    }
 }

--- a/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
@@ -157,6 +157,16 @@ internal static partial class Program {
         }
     }
 
+    private static void TestReviewFailureBodyUsesCopilotTransport() {
+        var settings = new ReviewSettings {
+            Provider = ReviewProvider.Copilot,
+            CopilotTransport = CopilotTransportKind.Direct
+        };
+        var body = ReviewDiagnostics.BuildFailureBody(new TimeoutException("timed out"), settings, null, null);
+        AssertContainsText(body, "- Provider: copilot", "copilot failure body provider");
+        AssertContainsText(body, "- Transport: Direct", "copilot failure body transport");
+    }
+
     private static void TestReviewFailureBodyIncludesSafeAuthRefreshDetail() {
         var settings = new ReviewSettings { Diagnostics = true };
         var ex = new InvalidOperationException("OAuth token request failed (401): refresh_token_reused. Your refresh token has already been used to generate a new access token. Please try signing in again.");

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -1043,6 +1043,19 @@ internal static partial class Program {
         AssertEqual("bash", command.FileName, "copilot linux auto install file");
     }
 
+    private static void TestCopilotCliAutoInstallDefaultsHonorLinuxPrerelease() {
+        var command = IntelligenceX.Copilot.CopilotCliInstall.GetDefaultCommandForPlatform(
+            isWindows: false,
+            isMac: false,
+            isLinux: true,
+            prerelease: true);
+
+        AssertEqual(IntelligenceX.Copilot.CopilotCliInstallMethod.Npm, command.Method,
+            "copilot linux prerelease auto install default");
+        AssertContainsText(command.Arguments, "@github/copilot@prerelease",
+            "copilot linux prerelease auto install package");
+    }
+
     private static void TestCopilotCliAutoInstallDefaultsKeepMacHomebrew() {
         var command = IntelligenceX.Copilot.CopilotCliInstall.GetDefaultCommandForPlatform(
             isWindows: false,

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -1001,26 +1001,56 @@ internal static partial class Program {
         AssertSequenceEqual(new[] { "copilot", "--" }, options.CliArgs.ToArray(), "copilot gh launcher args");
     }
 
-    private static void TestCopilotAutoLauncherRequiresUsableGhWrapper() {
+    private static void TestCopilotAutoLauncherUsesBinary() {
         var settings = new ReviewSettings {
             CopilotLauncher = "auto"
         };
 
-        var resolved = ReviewRunner.ResolveCopilotLauncherForTests(settings,
-            copilotExists: false, ghExists: true, ghCopilotWrapperCanLaunchCli: false);
+        var resolved = ReviewRunner.ResolveCopilotLauncherForTests(settings);
 
-        AssertEqual("binary", resolved, "copilot auto launcher does not assume gh can bootstrap copilot");
+        AssertEqual("binary", resolved, "copilot auto launcher uses standalone binary path");
     }
 
-    private static void TestCopilotAutoLauncherUsesGhWhenWrapperCanLaunchCli() {
+    private static void TestCopilotAutoLauncherKeepsGhWrapperExplicit() {
         var settings = new ReviewSettings {
             CopilotLauncher = "auto"
         };
 
-        var resolved = ReviewRunner.ResolveCopilotLauncherForTests(settings,
-            copilotExists: false, ghExists: true, ghCopilotWrapperCanLaunchCli: true);
+        var resolved = ReviewRunner.ResolveCopilotLauncherForTests(settings);
 
-        AssertEqual("gh", resolved, "copilot auto launcher uses gh only after wrapper probe succeeds");
+        AssertEqual("binary", resolved, "copilot auto launcher keeps gh wrapper as explicit opt-in");
+    }
+
+    private static void TestCopilotAutoLauncherUsesBinaryForAutoInstall() {
+        var settings = new ReviewSettings {
+            CopilotLauncher = "auto",
+            CopilotAutoInstall = true
+        };
+
+        var resolved = ReviewRunner.ResolveCopilotLauncherForTests(settings);
+
+        AssertEqual("binary", resolved, "copilot auto launcher lets missing binary be resolved by auto-install");
+    }
+
+    private static void TestCopilotCliAutoInstallDefaultsPreferLinuxScript() {
+        var command = IntelligenceX.Copilot.CopilotCliInstall.GetDefaultCommandForPlatform(
+            isWindows: false,
+            isMac: false,
+            isLinux: true);
+
+        AssertEqual(IntelligenceX.Copilot.CopilotCliInstallMethod.Script, command.Method,
+            "copilot linux auto install default");
+        AssertEqual("bash", command.FileName, "copilot linux auto install file");
+    }
+
+    private static void TestCopilotCliAutoInstallDefaultsKeepMacHomebrew() {
+        var command = IntelligenceX.Copilot.CopilotCliInstall.GetDefaultCommandForPlatform(
+            isWindows: false,
+            isMac: true,
+            isLinux: false);
+
+        AssertEqual(IntelligenceX.Copilot.CopilotCliInstallMethod.Homebrew, command.Method,
+            "copilot mac auto install default");
     }
 
     private static void TestCopilotLauncherDiagnosticsDescribeResolvedCommand() {

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -69,6 +69,7 @@ internal static partial class Program {
         failed += Run("Review retry extra attempt", TestReviewRetryExtraAttempt);
         failed += Run("Review failure marker", TestReviewFailureMarker);
         failed += Run("Review failure body redacts errors", TestReviewFailureBodyRedactsErrors);
+        failed += Run("Review failure body uses Copilot transport", TestReviewFailureBodyUsesCopilotTransport);
         failed += Run("Review failure body includes safe auth refresh detail", TestReviewFailureBodyIncludesSafeAuthRefreshDetail);
         failed += Run("Build auth remediation command quotes repo when needed", TestBuildAuthRemediationCommandQuotesRepoWhenNeeded);
         failed += Run("Build auth remediation command escapes embedded quotes", TestBuildAuthRemediationCommandEscapesEmbeddedQuotes);
@@ -670,10 +671,16 @@ internal static partial class Program {
         failed += Run("Copilot env allowlist config", TestCopilotEnvAllowlistConfig);
         failed += Run("Copilot launcher env", TestCopilotLauncherEnv);
         failed += Run("Copilot gh launcher builds wrapper command", TestCopilotGhLauncherBuildsWrapperCommand);
-        failed += Run("Copilot auto launcher requires usable gh wrapper",
-            TestCopilotAutoLauncherRequiresUsableGhWrapper);
-        failed += Run("Copilot auto launcher uses gh when wrapper can launch CLI",
-            TestCopilotAutoLauncherUsesGhWhenWrapperCanLaunchCli);
+        failed += Run("Copilot auto launcher uses binary",
+            TestCopilotAutoLauncherUsesBinary);
+        failed += Run("Copilot auto launcher keeps gh wrapper explicit",
+            TestCopilotAutoLauncherKeepsGhWrapperExplicit);
+        failed += Run("Copilot auto launcher uses binary for auto-install",
+            TestCopilotAutoLauncherUsesBinaryForAutoInstall);
+        failed += Run("Copilot CLI auto-install defaults prefer Linux script",
+            TestCopilotCliAutoInstallDefaultsPreferLinuxScript);
+        failed += Run("Copilot CLI auto-install defaults keep macOS Homebrew",
+            TestCopilotCliAutoInstallDefaultsKeepMacHomebrew);
         failed += Run("Copilot launcher diagnostics describe resolved command",
             TestCopilotLauncherDiagnosticsDescribeResolvedCommand);
         failed += Run("Copilot binary launcher keeps direct cli path", TestCopilotBinaryLauncherKeepsDirectCliPath);

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -679,6 +679,8 @@ internal static partial class Program {
             TestCopilotAutoLauncherUsesBinaryForAutoInstall);
         failed += Run("Copilot CLI auto-install defaults prefer Linux script",
             TestCopilotCliAutoInstallDefaultsPreferLinuxScript);
+        failed += Run("Copilot CLI auto-install defaults honor Linux prerelease",
+            TestCopilotCliAutoInstallDefaultsHonorLinuxPrerelease);
         failed += Run("Copilot CLI auto-install defaults keep macOS Homebrew",
             TestCopilotCliAutoInstallDefaultsKeepMacHomebrew);
         failed += Run("Copilot launcher diagnostics describe resolved command",

--- a/IntelligenceX/Providers/Copilot/CopilotCliInstall.cs
+++ b/IntelligenceX/Providers/Copilot/CopilotCliInstall.cs
@@ -82,18 +82,22 @@ public static class CopilotCliInstall {
                 prerelease ? "install GitHub.Copilot.Prerelease" : "install GitHub.Copilot",
                 "WinGet"));
             list.Add(Npm(prerelease));
-        } else if (IsMac() || IsLinux()) {
+        } else if (IsMac()) {
             list.Add(new CopilotCliInstallCommand(
                 CopilotCliInstallMethod.Homebrew,
                 "brew",
                 prerelease ? "install copilot-cli@prerelease" : "install copilot-cli",
                 "Homebrew"));
             list.Add(Npm(prerelease));
+            list.Add(Script());
+        } else if (IsLinux()) {
+            list.Add(Script());
+            list.Add(Npm(prerelease));
             list.Add(new CopilotCliInstallCommand(
-                CopilotCliInstallMethod.Script,
-                "bash",
-                "-c \"curl -fsSL https://gh.io/copilot-install | bash\"",
-                "Install script (macOS/Linux)"));
+                CopilotCliInstallMethod.Homebrew,
+                "brew",
+                prerelease ? "install copilot-cli@prerelease" : "install copilot-cli",
+                "Homebrew"));
         } else {
             list.Add(Npm(prerelease));
         }
@@ -105,19 +109,27 @@ public static class CopilotCliInstall {
     /// </summary>
     /// <param name="prerelease">Whether to use prerelease versions.</param>
     public static CopilotCliInstallCommand GetDefaultCommand(bool prerelease = false) {
-        if (IsWindows()) {
+        return GetDefaultCommandForPlatform(IsWindows(), IsMac(), IsLinux(), prerelease);
+    }
+
+    internal static CopilotCliInstallCommand GetDefaultCommandForPlatform(bool isWindows, bool isMac, bool isLinux,
+        bool prerelease = false) {
+        if (isWindows) {
             return new CopilotCliInstallCommand(
                 CopilotCliInstallMethod.Winget,
                 "winget",
                 prerelease ? "install GitHub.Copilot.Prerelease" : "install GitHub.Copilot",
                 "WinGet");
         }
-        if (IsMac() || IsLinux()) {
+        if (isMac) {
             return new CopilotCliInstallCommand(
                 CopilotCliInstallMethod.Homebrew,
                 "brew",
                 prerelease ? "install copilot-cli@prerelease" : "install copilot-cli",
                 "Homebrew");
+        }
+        if (isLinux) {
+            return Script();
         }
         return Npm(prerelease);
     }
@@ -143,11 +155,7 @@ public static class CopilotCliInstall {
                 prerelease ? "install copilot-cli@prerelease" : "install copilot-cli",
                 "Homebrew"),
             CopilotCliInstallMethod.Npm => Npm(prerelease),
-            CopilotCliInstallMethod.Script => new CopilotCliInstallCommand(
-                CopilotCliInstallMethod.Script,
-                "bash",
-                "-c \"curl -fsSL https://gh.io/copilot-install | bash\"",
-                "Install script (macOS/Linux)"),
+            CopilotCliInstallMethod.Script => Script(),
             _ => GetDefaultCommand(prerelease)
         };
     }
@@ -198,6 +206,14 @@ public static class CopilotCliInstall {
             "npm",
             prerelease ? "install -g @github/copilot@prerelease" : "install -g @github/copilot",
             "npm (Node.js 22+)");
+    }
+
+    private static CopilotCliInstallCommand Script() {
+        return new CopilotCliInstallCommand(
+            CopilotCliInstallMethod.Script,
+            "bash",
+            "-c \"curl -fsSL https://gh.io/copilot-install | bash\"",
+            "Install script (macOS/Linux)");
     }
 
     private static bool IsWindows() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);

--- a/IntelligenceX/Providers/Copilot/CopilotCliInstall.cs
+++ b/IntelligenceX/Providers/Copilot/CopilotCliInstall.cs
@@ -91,8 +91,12 @@ public static class CopilotCliInstall {
             list.Add(Npm(prerelease));
             list.Add(Script());
         } else if (IsLinux()) {
-            list.Add(Script());
-            list.Add(Npm(prerelease));
+            if (prerelease) {
+                list.Add(Npm(prerelease));
+            } else {
+                list.Add(Script());
+                list.Add(Npm(prerelease));
+            }
             list.Add(new CopilotCliInstallCommand(
                 CopilotCliInstallMethod.Homebrew,
                 "brew",
@@ -129,7 +133,7 @@ public static class CopilotCliInstall {
                 "Homebrew");
         }
         if (isLinux) {
-            return Script();
+            return prerelease ? Npm(prerelease) : Script();
         }
         return Npm(prerelease);
     }

--- a/InternalDocs/rfcs/ix-review-history-copilot-orchestration.md
+++ b/InternalDocs/rfcs/ix-review-history-copilot-orchestration.md
@@ -213,7 +213,7 @@ Suggested shape:
 Suggested semantics:
 - `binary`: execute `copilot` directly
 - `gh`: execute `gh copilot --`
-- `auto`: use the direct binary when present, otherwise choose `gh copilot --` only after a wrapper capability probe succeeds
+- `auto`: use the standalone binary path and let `autoInstall` provision it when enabled
 
 Validation requirements before enabling `gh` by default:
 - confirm server/protocol compatibility for reviewer transport mode
@@ -279,7 +279,7 @@ Current status:
 - bounded review-history JSON/Markdown artifacts are written under `artifacts/reviewer/history/` when `review.history.artifacts` is enabled
 - bounded JSON/Markdown comparison artifacts plus append-only JSONL metrics are written under `artifacts/reviewer/swarm-shadow/` when `review.swarm.metrics` is enabled
 - managed workflow wrappers/templates pass through history, Copilot model/launcher, and swarm-shadow overrides to the reusable workflow
-- `copilot.launcher=auto` now probes whether `gh copilot -- --version` can actually launch the CLI before selecting the wrapper path
+- `copilot.launcher=auto` keeps the GitHub CLI wrapper as an explicit opt-in because live workflow proof showed `gh copilot --` can launch but still time out in reviewer server mode
 - public output still comes from the single-review path
 - deeper longitudinal history analysis across uploaded workflow artifacts remains pending
 


### PR DESCRIPTION
## Summary
- keep `copilot.launcher=auto` on the standalone binary path instead of selecting the `gh copilot --` wrapper after a simple capability probe
- prefer the Copilot install script as the Linux auto-install default, while keeping Homebrew as the macOS default
- improve Copilot timeout/failure diagnostics by including launcher details, recent CLI stderr when available, and Copilot-specific transport labels
- update docs/RFC notes and reviewer harness coverage for the new launcher behavior

## Validation
- `git diff --check`
- `dotnet build .\IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net8.0 --no-restore /nr:false`
- `dotnet .\IntelligenceX.Tests\bin\Release\net8.0\IntelligenceX.Tests.dll`
- `dotnet build .\IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net10.0 --no-restore /nr:false`
- `dotnet .\IntelligenceX.Tests\bin\Release\net10.0\IntelligenceX.Tests.dll`
- `dotnet build .\IntelligenceX.sln -c Release /nr:false`

## Notes
- `dotnet test .\IntelligenceX.sln -c Release --no-restore /nr:false` currently fails in broader Chat/Tools suites unrelated to this branch: OfficeIMO package pin mismatch, tool-pack reflection/bootstrap assumptions, AD schema snapshot drift, and chat routing/tool-pack failures. The reviewer-specific harnesses and full solution build are clean.