### PR TITLE
Improve Copilot reviewer preflight diagnostics

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -665,6 +665,8 @@ Set `launcher` to `gh` to explicitly run Copilot through `gh copilot --`.
 Set `launcher` to `auto` to use the standalone `copilot` binary path. This is the safer default for reviewer server mode:
 the GitHub CLI wrapper can sometimes launch the CLI for simple commands while still hanging in long-running server mode.
 Use `autoInstall` with the standalone path when the runner does not already have `copilot` installed.
+Set `model` only when you want to force a Copilot CLI model id. When `provider` is `copilot` and only the generic
+`review.model` is the default OpenAI value, the reviewer leaves Copilot model selection to the CLI default.
 
 ```json
 {
@@ -673,6 +675,7 @@ Use `autoInstall` with the standalone path when the runner does not already have
   },
   "copilot": {
     "launcher": "gh",
+    "model": "claude-sonnet-4.6",
     "inheritEnvironment": false,
     "envAllowlist": ["GH_TOKEN", "GITHUB_TOKEN"]
   }
@@ -788,6 +791,7 @@ Prefer `directTokenEnv` over `directToken` to avoid committing secrets to source
 - `azureTokenEnv`: env var name that contains the ADO token (default `SYSTEM_ACCESSTOKEN` if set)
 - `azureAuthScheme`: `bearer` (System.AccessToken/JWT) or `basic`/`pat`
 - `copilot.transport`: `cli` or `direct` (aliases: `api`, `http`)
+- `copilot.model`: optional Copilot-specific model override; when omitted, the CLI default is used unless `review.model` was set to a non-default value
 - `copilot.launcher`: `binary`, `gh`, or `auto`; `auto` uses the standalone binary path, while `gh` explicitly executes `gh copilot --` before the reviewer server flags
 - `copilot.inheritEnvironment`: inherit full runner environment for Copilot CLI (`true` by default)
 

--- a/IntelligenceX.Reviewer/ReviewConfigLoader.cs
+++ b/IntelligenceX.Reviewer/ReviewConfigLoader.cs
@@ -542,6 +542,7 @@ internal static class ReviewConfigLoader {
         settings.CopilotCliPath = copilot.GetString("cliPath") ?? settings.CopilotCliPath;
         settings.CopilotCliUrl = copilot.GetString("cliUrl") ?? settings.CopilotCliUrl;
         settings.CopilotWorkingDirectory = copilot.GetString("workingDirectory") ?? settings.CopilotWorkingDirectory;
+        settings.CopilotModel = copilot.GetString("model") ?? settings.CopilotModel;
         settings.CopilotLauncher = ReviewSettings.NormalizeCopilotLauncher(copilot.GetString("launcher"),
             settings.CopilotLauncher);
         settings.CopilotAutoInstall = ReadBool(copilot, "autoInstall", settings.CopilotAutoInstall);

--- a/IntelligenceX.Reviewer/ReviewDiagnostics.cs
+++ b/IntelligenceX.Reviewer/ReviewDiagnostics.cs
@@ -190,6 +190,11 @@ internal static class ReviewDiagnostics {
             message.Contains("token refresh", StringComparison.OrdinalIgnoreCase)) {
             return new ReviewErrorInfo(ReviewErrorCategory.Auth, false, AuthRefreshFailedSummary);
         }
+        if (message.Contains("not authenticated", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("Copilot", StringComparison.OrdinalIgnoreCase) &&
+            message.Contains("sign in", StringComparison.OrdinalIgnoreCase)) {
+            return new ReviewErrorInfo(ReviewErrorCategory.Auth, false, "Copilot authentication failed");
+        }
         if (message.Contains("configuration", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("invalid", StringComparison.OrdinalIgnoreCase)) {
             return new ReviewErrorInfo(ReviewErrorCategory.Config, false, InvalidConfigurationSummary);
@@ -212,7 +217,7 @@ internal static class ReviewDiagnostics {
         sb.AppendLine();
         sb.AppendLine($"- Provider: {settings.Provider.ToString().ToLowerInvariant()}");
         sb.AppendLine($"- Transport: {DescribeTransport(settings)}");
-        sb.AppendLine($"- Model: {settings.Model}");
+        sb.AppendLine($"- Model: {DescribeModel(settings)}");
         sb.AppendLine($"- Category: {classification.Category} ({(classification.IsTransient ? "transient" : "non-transient")})");
         if (!string.IsNullOrWhiteSpace(classification.Summary)) {
             sb.AppendLine($"- Detail: {classification.Summary}");
@@ -241,6 +246,11 @@ internal static class ReviewDiagnostics {
             sb.AppendLine($"> {authLabel} is missing, expired, or stale for this reviewer run.");
             sb.AppendLine("> Reauthenticate locally and refresh `INTELLIGENCEX_AUTH_B64` with:");
             sb.AppendLine($"> `{remediationCommand}`");
+        } else if (classification.Category == ReviewErrorCategory.Auth &&
+                   settings.Provider == ReviewProvider.Copilot) {
+            sb.AppendLine();
+            sb.AppendLine("> Copilot CLI authentication is missing or not usable in this non-interactive runner.");
+            sb.AppendLine("> Sign in on the runner, use a self-hosted runner with a persisted Copilot CLI session, or configure Copilot direct transport.");
         }
         sb.AppendLine();
         sb.AppendLine("_Re-run the workflow once connectivity is restored. Set `REVIEW_FAIL_OPEN=false` to keep failures blocking._");
@@ -251,7 +261,7 @@ internal static class ReviewDiagnostics {
         ReviewRetryState? retryState) {
         var classification = Classify(ex);
         Console.Error.WriteLine("Provider request failed.");
-        Console.Error.WriteLine($"Provider: {settings.Provider.ToString().ToLowerInvariant()} | Transport: {DescribeTransport(settings)} | Model: {settings.Model}");
+        Console.Error.WriteLine($"Provider: {settings.Provider.ToString().ToLowerInvariant()} | Transport: {DescribeTransport(settings)} | Model: {DescribeModel(settings)}");
         Console.Error.WriteLine($"Category: {classification.Category} ({(classification.IsTransient ? "transient" : "non-transient")})");
         if (retryState is not null && retryState.LastAttempt > 0) {
             Console.Error.WriteLine($"Retry: {retryState.LastAttempt}/{retryState.MaxAttempts}");
@@ -314,6 +324,13 @@ internal static class ReviewDiagnostics {
         return settings.Provider == ReviewProvider.Copilot
             ? settings.CopilotTransport.ToString()
             : settings.OpenAITransport.ToString();
+    }
+
+    private static string DescribeModel(ReviewSettings settings) {
+        if (settings.Provider == ReviewProvider.Copilot) {
+            return ReviewRunner.ResolveCopilotModel(settings) ?? "Copilot CLI default";
+        }
+        return settings.Model;
     }
 
     internal static WorkflowFailureInfo ClassifyWorkflowFailureLog(string? logText) {

--- a/IntelligenceX.Reviewer/ReviewDiagnostics.cs
+++ b/IntelligenceX.Reviewer/ReviewDiagnostics.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Text;
+using IntelligenceX.Copilot;
 using IntelligenceX.OpenAI;
 using IntelligenceX.OpenAI.Auth;
 using IntelligenceX.Telemetry;
@@ -162,7 +163,11 @@ internal static class ReviewDiagnostics {
         if (IsResponseEnded(root)) {
             return new ReviewErrorInfo(ReviewErrorCategory.ResponseEnded, true, "Response ended prematurely");
         }
+        var message = root.Message ?? string.Empty;
         if (root is UnauthorizedAccessException) {
+            if (IsCopilotAuthMessage(message)) {
+                return new ReviewErrorInfo(ReviewErrorCategory.Auth, false, "Copilot authentication failed");
+            }
             return new ReviewErrorInfo(ReviewErrorCategory.Auth, false, "Unauthorized");
         }
         if (root is HttpRequestException httpRequest) {
@@ -175,7 +180,6 @@ internal static class ReviewDiagnostics {
         if (root is IOException) {
             return new ReviewErrorInfo(ReviewErrorCategory.Network, true, "I/O error");
         }
-        var message = root.Message ?? string.Empty;
         if (message.Contains("auth bundle", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("INTELLIGENCEX_AUTH", StringComparison.OrdinalIgnoreCase)) {
             return new ReviewErrorInfo(ReviewErrorCategory.Auth, false, AuthBundleSummary);
@@ -190,9 +194,7 @@ internal static class ReviewDiagnostics {
             message.Contains("token refresh", StringComparison.OrdinalIgnoreCase)) {
             return new ReviewErrorInfo(ReviewErrorCategory.Auth, false, AuthRefreshFailedSummary);
         }
-        if (message.Contains("not authenticated", StringComparison.OrdinalIgnoreCase) ||
-            message.Contains("Copilot", StringComparison.OrdinalIgnoreCase) &&
-            message.Contains("sign in", StringComparison.OrdinalIgnoreCase)) {
+        if (IsCopilotAuthMessage(message)) {
             return new ReviewErrorInfo(ReviewErrorCategory.Auth, false, "Copilot authentication failed");
         }
         if (message.Contains("configuration", StringComparison.OrdinalIgnoreCase) ||
@@ -328,9 +330,21 @@ internal static class ReviewDiagnostics {
 
     private static string DescribeModel(ReviewSettings settings) {
         if (settings.Provider == ReviewProvider.Copilot) {
-            return ReviewRunner.ResolveCopilotModel(settings) ?? "Copilot CLI default";
+            var model = ReviewRunner.ResolveCopilotModel(settings);
+            if (!string.IsNullOrWhiteSpace(model)) {
+                return model!;
+            }
+            return settings.CopilotTransport == CopilotTransportKind.Direct
+                ? "Copilot direct model required"
+                : "Copilot CLI default";
         }
         return settings.Model;
+    }
+
+    private static bool IsCopilotAuthMessage(string message) {
+        return message.Contains("Copilot", StringComparison.OrdinalIgnoreCase) &&
+               (message.Contains("not authenticated", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("sign in", StringComparison.OrdinalIgnoreCase));
     }
 
     internal static WorkflowFailureInfo ClassifyWorkflowFailureLog(string? logText) {

--- a/IntelligenceX.Reviewer/ReviewRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewRunner.cs
@@ -547,7 +547,7 @@ internal sealed partial class ReviewRunner {
         sb.Append(" If this run uses the GitHub CLI wrapper, try copilot.launcher=binary with copilot.autoInstall=true; ");
         sb.Append("the wrapper can launch the CLI but still hang in reviewer server mode on some runners.");
 
-        AppendCopilotStderr(sb, stderrLines, stderrLock);
+        AppendCopilotStderr(sb, stderrLines, stderrLock, include: _settings.Diagnostics);
         return sb.ToString().TrimEnd();
     }
 
@@ -558,7 +558,7 @@ internal sealed partial class ReviewRunner {
         sb.Append(" seconds while starting the CLI and checking auth/status. ");
         sb.Append(launcherDiagnostic);
         sb.Append(" This usually means the CLI server mode is waiting on interactive auth or is not responding in GitHub Actions.");
-        AppendCopilotStderr(sb, stderrLines, stderrLock);
+        AppendCopilotStderr(sb, stderrLines, stderrLock, include: _settings.Diagnostics);
         return sb.ToString().TrimEnd();
     }
 
@@ -572,7 +572,7 @@ internal sealed partial class ReviewRunner {
             sb.Append('.');
         }
         sb.Append(" Sign in on the runner before using provider=copilot, use a self-hosted runner with a persisted Copilot CLI session, or configure copilot.transport=direct with an explicit token-backed endpoint.");
-        AppendCopilotStderr(sb, stderrLines, stderrLock);
+        AppendCopilotStderr(sb, stderrLines, stderrLock, include: _settings.Diagnostics);
         return sb.ToString().TrimEnd();
     }
 
@@ -608,7 +608,10 @@ internal sealed partial class ReviewRunner {
                 : $"Copilot model '{model}' is not available to this account. Available models: {available}.");
     }
 
-    private static void AppendCopilotStderr(StringBuilder sb, Queue<string> stderrLines, object stderrLock) {
+    private static void AppendCopilotStderr(StringBuilder sb, Queue<string> stderrLines, object stderrLock, bool include) {
+        if (!include) {
+            return;
+        }
         List<string> lines;
         lock (stderrLock) {
             lines = new List<string>(stderrLines);

--- a/IntelligenceX.Reviewer/ReviewRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewRunner.cs
@@ -323,11 +323,11 @@ internal sealed partial class ReviewRunner {
                 throw new InvalidOperationException($"Copilot directUrl is invalid: '{_settings.CopilotDirectUrl}'.");
             }
 
-            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            timeoutCts.CancelAfter(timeout);
+            using var directTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            directTimeoutCts.CancelAfter(timeout);
             using var request = new HttpRequestMessage(HttpMethod.Get, uri);
             try {
-                using var _ = await PreflightHttp.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeoutCts.Token)
+                using var _ = await PreflightHttp.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, directTimeoutCts.Token)
                     .ConfigureAwait(false);
                 return;
             } catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested) {
@@ -339,8 +339,43 @@ internal sealed partial class ReviewRunner {
             }
         }
 
-        var options = BuildCopilotClientOptions();
+        var options = BuildCopilotClientOptions(out var launcherDiagnostic);
         options.Validate();
+        var effectiveTimeout = options.AutoInstallCli && timeout < TimeSpan.FromSeconds(30)
+            ? TimeSpan.FromSeconds(30)
+            : timeout;
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(effectiveTimeout);
+
+        var stderrLines = new Queue<string>();
+        var stderrLock = new object();
+        try {
+            await using var client = await CopilotClient.StartAsync(options, timeoutCts.Token).ConfigureAwait(false);
+            client.StandardErrorReceived += (_, line) => CaptureCopilotStderr(stderrLines, stderrLock, line);
+
+            var status = await client.GetStatusAsync(timeoutCts.Token).ConfigureAwait(false);
+            if (_settings.Diagnostics) {
+                var version = string.IsNullOrWhiteSpace(status.Version) ? "unknown" : status.Version;
+                Console.Error.WriteLine($"Copilot preflight status OK: version={version}; protocol={status.ProtocolVersion}.");
+            }
+
+            var auth = await client.GetAuthStatusAsync(timeoutCts.Token).ConfigureAwait(false);
+            if (!auth.IsAuthenticated) {
+                throw new UnauthorizedAccessException(BuildCopilotAuthFailureMessage(auth, launcherDiagnostic, stderrLines, stderrLock));
+            }
+            if (_settings.Diagnostics) {
+                var login = string.IsNullOrWhiteSpace(auth.Login) ? "unknown" : auth.Login;
+                var authType = string.IsNullOrWhiteSpace(auth.AuthType) ? "unknown" : auth.AuthType;
+                Console.Error.WriteLine($"Copilot preflight auth OK: login={login}; authType={authType}.");
+            }
+
+            var model = ResolveCopilotModel(_settings);
+            if (!string.IsNullOrWhiteSpace(model)) {
+                await ValidateCopilotModelAsync(client, model!, timeoutCts.Token).ConfigureAwait(false);
+            }
+        } catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested) {
+            throw new TimeoutException(BuildCopilotHealthTimeoutMessage(effectiveTimeout, launcherDiagnostic, stderrLines, stderrLock), ex);
+        }
     }
 
     private CopilotClientOptions BuildCopilotClientOptions() {
@@ -400,6 +435,17 @@ internal sealed partial class ReviewRunner {
         return "binary";
     }
 
+    internal static string? ResolveCopilotModel(ReviewSettings settings) {
+        if (!string.IsNullOrWhiteSpace(settings.CopilotModel)) {
+            return settings.CopilotModel!.Trim();
+        }
+        if (string.IsNullOrWhiteSpace(settings.Model) ||
+            string.Equals(settings.Model, OpenAIModelCatalog.DefaultModel, StringComparison.OrdinalIgnoreCase)) {
+            return null;
+        }
+        return settings.Model.Trim();
+    }
+
     private string BuildCopilotLauncherDiagnostic(string launcher, CopilotClientOptions options) {
         var cliPath = string.IsNullOrWhiteSpace(options.CliPath) ? "copilot" : options.CliPath;
         var prefixArgs = options.CliArgs.Count == 0 ? "(none)" : string.Join(" ", options.CliArgs);
@@ -431,7 +477,7 @@ internal sealed partial class ReviewRunner {
         var stderrLock = new object();
         client.StandardErrorReceived += (_, line) => CaptureCopilotStderr(stderrLines, stderrLock, line);
         var session = await client.CreateSessionAsync(new CopilotSessionOptions {
-            Model = _settings.Model,
+            Model = ResolveCopilotModel(_settings),
             Streaming = true
         }, cancellationToken).ConfigureAwait(false);
 
@@ -501,19 +547,82 @@ internal sealed partial class ReviewRunner {
         sb.Append(" If this run uses the GitHub CLI wrapper, try copilot.launcher=binary with copilot.autoInstall=true; ");
         sb.Append("the wrapper can launch the CLI but still hang in reviewer server mode on some runners.");
 
+        AppendCopilotStderr(sb, stderrLines, stderrLock);
+        return sb.ToString().TrimEnd();
+    }
+
+    private string BuildCopilotHealthTimeoutMessage(TimeSpan timeout, string launcherDiagnostic, Queue<string> stderrLines, object stderrLock) {
+        var sb = new StringBuilder();
+        sb.Append("Copilot health check timed out after ");
+        sb.Append(timeout.TotalSeconds.ToString("0"));
+        sb.Append(" seconds while starting the CLI and checking auth/status. ");
+        sb.Append(launcherDiagnostic);
+        sb.Append(" This usually means the CLI server mode is waiting on interactive auth or is not responding in GitHub Actions.");
+        AppendCopilotStderr(sb, stderrLines, stderrLock);
+        return sb.ToString().TrimEnd();
+    }
+
+    private string BuildCopilotAuthFailureMessage(CopilotAuthStatus auth, string launcherDiagnostic, Queue<string> stderrLines, object stderrLock) {
+        var sb = new StringBuilder();
+        sb.Append("Copilot CLI is not authenticated for this non-interactive reviewer run. ");
+        sb.Append(launcherDiagnostic);
+        if (!string.IsNullOrWhiteSpace(auth.StatusMessage)) {
+            sb.Append(" Status: ");
+            sb.Append(auth.StatusMessage);
+            sb.Append('.');
+        }
+        sb.Append(" Sign in on the runner before using provider=copilot, use a self-hosted runner with a persisted Copilot CLI session, or configure copilot.transport=direct with an explicit token-backed endpoint.");
+        AppendCopilotStderr(sb, stderrLines, stderrLock);
+        return sb.ToString().TrimEnd();
+    }
+
+    private async Task ValidateCopilotModelAsync(CopilotClient client, string model, CancellationToken cancellationToken) {
+        var models = await client.ListModelsAsync(cancellationToken).ConfigureAwait(false);
+        if (models.Count == 0) {
+            if (_settings.Diagnostics) {
+                Console.Error.WriteLine("Copilot preflight model list returned no entries; skipping model availability validation.");
+            }
+            return;
+        }
+
+        foreach (var candidate in models) {
+            if (string.Equals(candidate.Id, model, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(candidate.Name, model, StringComparison.OrdinalIgnoreCase)) {
+                if (_settings.Diagnostics) {
+                    Console.Error.WriteLine($"Copilot preflight model OK: {model}.");
+                }
+                return;
+            }
+        }
+
+        var available = string.Join(", ", models
+            .Select(candidate => string.IsNullOrWhiteSpace(candidate.Name) ||
+                                 string.Equals(candidate.Id, candidate.Name, StringComparison.OrdinalIgnoreCase)
+                ? candidate.Id
+                : $"{candidate.Id} ({candidate.Name})")
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Take(12));
+        throw new InvalidOperationException(
+            string.IsNullOrWhiteSpace(available)
+                ? $"Copilot model '{model}' is not available to this account."
+                : $"Copilot model '{model}' is not available to this account. Available models: {available}.");
+    }
+
+    private static void AppendCopilotStderr(StringBuilder sb, Queue<string> stderrLines, object stderrLock) {
         List<string> lines;
         lock (stderrLock) {
             lines = new List<string>(stderrLines);
         }
-        if (lines.Count > 0) {
-            sb.AppendLine();
-            sb.AppendLine("Recent Copilot CLI stderr:");
-            for (var i = Math.Max(0, lines.Count - 6); i < lines.Count; i++) {
-                sb.Append("  ");
-                sb.AppendLine(lines[i]);
-            }
+        if (lines.Count == 0) {
+            return;
         }
-        return sb.ToString().TrimEnd();
+
+        sb.AppendLine();
+        sb.AppendLine("Recent Copilot CLI stderr:");
+        for (var i = Math.Max(0, lines.Count - 6); i < lines.Count; i++) {
+            sb.Append("  ");
+            sb.AppendLine(lines[i]);
+        }
     }
 
     private static void CaptureCopilotStderr(Queue<string> stderrLines, object stderrLock, string? line) {
@@ -532,8 +641,9 @@ internal sealed partial class ReviewRunner {
         if (string.IsNullOrWhiteSpace(_settings.CopilotDirectUrl)) {
             throw new InvalidOperationException("Copilot direct transport requires copilot.directUrl.");
         }
-        if (string.IsNullOrWhiteSpace(_settings.Model)) {
-            throw new InvalidOperationException("Copilot direct transport requires review.model to be set.");
+        var model = ResolveCopilotModel(_settings);
+        if (string.IsNullOrWhiteSpace(model)) {
+            throw new InvalidOperationException("Copilot direct transport requires copilot.model or review.model to be set.");
         }
         var token = ResolveCopilotDirectToken();
         if (string.IsNullOrWhiteSpace(token) && !HasAuthorizationHeader(_settings.CopilotDirectHeaders)) {
@@ -556,7 +666,7 @@ internal sealed partial class ReviewRunner {
         options.Validate();
 
         using var client = new IntelligenceX.Copilot.Direct.CopilotDirectClient(options);
-        return await client.ChatAsync(prompt, _settings.Model, cancellationToken).ConfigureAwait(false);
+        return await client.ChatAsync(prompt, model!, cancellationToken).ConfigureAwait(false);
     }
 
     private string? ResolveCopilotDirectToken() {

--- a/IntelligenceX.Reviewer/ReviewSettings.Environment.CommentAndCleanup.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.Environment.CommentAndCleanup.cs
@@ -20,6 +20,11 @@ internal sealed partial class ReviewSettings {
             settings.CopilotWorkingDirectory = copilotWorkingDirectory;
         }
 
+        var copilotModel = GetInput("copilot_model", "COPILOT_MODEL");
+        if (!string.IsNullOrWhiteSpace(copilotModel)) {
+            settings.CopilotModel = copilotModel;
+        }
+
         var copilotLauncher = GetInput("copilot_launcher", "COPILOT_LAUNCHER");
         if (!string.IsNullOrWhiteSpace(copilotLauncher)) {
             settings.CopilotLauncher = NormalizeCopilotLauncher(copilotLauncher, settings.CopilotLauncher);

--- a/IntelligenceX.Reviewer/ReviewSettings.cs
+++ b/IntelligenceX.Reviewer/ReviewSettings.cs
@@ -442,6 +442,10 @@ internal sealed partial class ReviewSettings {
     public string? CopilotCliPath { get; set; }
     public string? CopilotCliUrl { get; set; }
     public string? CopilotWorkingDirectory { get; set; }
+    /// <summary>
+    /// Optional Copilot-specific model override. When unset, the CLI default model is used.
+    /// </summary>
+    public string? CopilotModel { get; set; }
     public string CopilotLauncher { get; set; } = "binary";
     public bool CopilotAutoInstall { get; set; }
     public string? CopilotAutoInstallMethod { get; set; }

--- a/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Baseline.Part2.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.AnalysisGate.Baseline.Part2.cs
@@ -265,6 +265,14 @@ internal static partial class Program {
         AssertNotNull(anthropicProps.GetObject("apiKeyEnv"), "reviewer schema anthropic apiKeyEnv property");
         AssertNotNull(anthropicProps.GetObject("timeoutSeconds"), "reviewer schema anthropic timeoutSeconds property");
         AssertNotNull(anthropicProps.GetObject("maxTokens"), "reviewer schema anthropic maxTokens property");
+
+        var copilot = root.GetObject("properties")?.GetObject("copilot");
+        AssertNotNull(copilot, "reviewer schema copilot node");
+        var copilotProps = copilot!.GetObject("properties");
+        AssertNotNull(copilotProps, "reviewer schema copilot.properties");
+        var copilotModel = copilotProps!.GetObject("model");
+        AssertNotNull(copilotModel, "reviewer schema copilot.model property");
+        AssertEqual("string", copilotModel!.GetString("type") ?? string.Empty, "reviewer schema copilot.model type");
     }
 }
 #endif

--- a/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
@@ -165,7 +165,22 @@ internal static partial class Program {
         var body = ReviewDiagnostics.BuildFailureBody(new TimeoutException("timed out"), settings, null, null);
         AssertContainsText(body, "- Provider: copilot", "copilot failure body provider");
         AssertContainsText(body, "- Transport: Direct", "copilot failure body transport");
-        AssertContainsText(body, "- Model: Copilot CLI default", "copilot failure body model");
+        AssertContainsText(body, "- Model: Copilot direct model required", "copilot failure body model");
+    }
+
+    private static void TestReviewFailureBodyClassifiesCopilotUnauthorized() {
+        var settings = new ReviewSettings {
+            Provider = ReviewProvider.Copilot,
+            CopilotTransport = CopilotTransportKind.Cli
+        };
+        var ex = new UnauthorizedAccessException("Copilot CLI is not authenticated for this non-interactive reviewer run. Sign in on the runner.");
+        var classification = ReviewDiagnostics.Classify(ex);
+        AssertEqual(ReviewDiagnostics.ReviewErrorCategory.Auth, classification.Category, "copilot unauthorized category");
+        AssertEqual("Copilot authentication failed", classification.Summary, "copilot unauthorized summary");
+
+        var body = ReviewDiagnostics.BuildFailureBody(ex, settings, null, null);
+        AssertContainsText(body, "- Detail: Copilot authentication failed", "copilot auth failure detail");
+        AssertContainsText(body, "Copilot CLI authentication is missing", "copilot auth failure guidance");
     }
 
     private static void TestReviewFailureBodyIncludesSafeAuthRefreshDetail() {

--- a/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
@@ -165,6 +165,7 @@ internal static partial class Program {
         var body = ReviewDiagnostics.BuildFailureBody(new TimeoutException("timed out"), settings, null, null);
         AssertContainsText(body, "- Provider: copilot", "copilot failure body provider");
         AssertContainsText(body, "- Transport: Direct", "copilot failure body transport");
+        AssertContainsText(body, "- Model: Copilot CLI default", "copilot failure body model");
     }
 
     private static void TestReviewFailureBodyIncludesSafeAuthRefreshDetail() {

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -951,6 +951,7 @@ internal static partial class Program {
             File.WriteAllText(path,
                 "{ \"copilot\": { \"envAllowlist\": [\"GH_TOKEN\"], \"inheritEnvironment\": false, " +
                 "\"launcher\": \"gh\", " +
+                "\"model\": \"claude-sonnet-4.6\", " +
                 "\"env\": { \"COPILOT_DEBUG\": \"1\" }, " +
                 "\"transport\": \"direct\", \"directUrl\": \"https://example.local/api\", " +
                 "\"directTokenEnv\": \"COPILOT_DIRECT_TOKEN\", \"directTimeoutSeconds\": 12, " +
@@ -962,6 +963,7 @@ internal static partial class Program {
             AssertSequenceEqual(new[] { "GH_TOKEN" }, settings.CopilotEnvAllowlist, "copilot env allowlist");
             AssertEqual(false, settings.CopilotInheritEnvironment, "copilot inherit environment");
             AssertEqual("gh", settings.CopilotLauncher, "copilot launcher");
+            AssertEqual("claude-sonnet-4.6", settings.CopilotModel ?? string.Empty, "copilot model");
             AssertEqual("1", settings.CopilotEnv["COPILOT_DEBUG"], "copilot env map");
             AssertEqual(CopilotTransportKind.Direct, settings.CopilotTransport, "copilot transport");
             AssertEqual("https://example.local/api", settings.CopilotDirectUrl, "copilot direct url");
@@ -988,6 +990,37 @@ internal static partial class Program {
             Environment.SetEnvironmentVariable("INPUT_COPILOT_LAUNCHER", previousInput);
             Environment.SetEnvironmentVariable("COPILOT_LAUNCHER", previousEnv);
         }
+    }
+
+    private static void TestCopilotModelEnvOverridesGenericModel() {
+        var previousProvider = Environment.GetEnvironmentVariable("INPUT_PROVIDER");
+        var previousModel = Environment.GetEnvironmentVariable("INPUT_MODEL");
+        var previousCopilotModel = Environment.GetEnvironmentVariable("INPUT_COPILOT_MODEL");
+        try {
+            Environment.SetEnvironmentVariable("INPUT_PROVIDER", "copilot");
+            Environment.SetEnvironmentVariable("INPUT_MODEL", "gpt-5.4");
+            Environment.SetEnvironmentVariable("INPUT_COPILOT_MODEL", "claude-sonnet-4.6");
+            var settings = ReviewSettings.FromEnvironment();
+
+            AssertEqual(ReviewProvider.Copilot, settings.Provider, "copilot provider env");
+            AssertEqual("gpt-5.4", settings.Model, "generic model env remains recorded");
+            AssertEqual("claude-sonnet-4.6", settings.CopilotModel ?? string.Empty, "copilot model env");
+            AssertEqual("claude-sonnet-4.6", ReviewRunner.ResolveCopilotModel(settings) ?? string.Empty,
+                "copilot resolved model prefers copilot_model");
+        } finally {
+            Environment.SetEnvironmentVariable("INPUT_PROVIDER", previousProvider);
+            Environment.SetEnvironmentVariable("INPUT_MODEL", previousModel);
+            Environment.SetEnvironmentVariable("INPUT_COPILOT_MODEL", previousCopilotModel);
+        }
+    }
+
+    private static void TestCopilotDefaultOpenAiModelUsesCliDefault() {
+        var settings = new ReviewSettings {
+            Provider = ReviewProvider.Copilot,
+            Model = OpenAIModelCatalog.DefaultModel
+        };
+
+        AssertEqual(null, ReviewRunner.ResolveCopilotModel(settings), "copilot default model");
     }
 
     private static void TestCopilotGhLauncherBuildsWrapperCommand() {

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -70,6 +70,7 @@ internal static partial class Program {
         failed += Run("Review failure marker", TestReviewFailureMarker);
         failed += Run("Review failure body redacts errors", TestReviewFailureBodyRedactsErrors);
         failed += Run("Review failure body uses Copilot transport", TestReviewFailureBodyUsesCopilotTransport);
+        failed += Run("Review failure body classifies Copilot unauthorized", TestReviewFailureBodyClassifiesCopilotUnauthorized);
         failed += Run("Review failure body includes safe auth refresh detail", TestReviewFailureBodyIncludesSafeAuthRefreshDetail);
         failed += Run("Build auth remediation command quotes repo when needed", TestBuildAuthRemediationCommandQuotesRepoWhenNeeded);
         failed += Run("Build auth remediation command escapes embedded quotes", TestBuildAuthRemediationCommandEscapesEmbeddedQuotes);

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -670,6 +670,8 @@ internal static partial class Program {
         failed += Run("Review threads diff range normalize", TestReviewThreadsDiffRangeNormalize);
         failed += Run("Copilot env allowlist config", TestCopilotEnvAllowlistConfig);
         failed += Run("Copilot launcher env", TestCopilotLauncherEnv);
+        failed += Run("Copilot model env overrides generic model", TestCopilotModelEnvOverridesGenericModel);
+        failed += Run("Copilot default OpenAI model uses CLI default", TestCopilotDefaultOpenAiModelUsesCliDefault);
         failed += Run("Copilot gh launcher builds wrapper command", TestCopilotGhLauncherBuildsWrapperCommand);
         failed += Run("Copilot auto launcher uses binary",
             TestCopilotAutoLauncherUsesBinary);

--- a/Schemas/reviewer.schema.json
+++ b/Schemas/reviewer.schema.json
@@ -391,6 +391,7 @@
         "cliPath": { "type": "string" },
         "cliUrl": { "type": "string" },
         "workingDirectory": { "type": "string" },
+        "model": { "type": "string" },
         "launcher": { "type": "string", "enum": ["binary", "cli", "copilot", "gh", "github", "github-cli", "github_cli", "auto"] },
         "autoInstall": { "type": "boolean" },
         "autoInstallMethod": { "type": "string" },


### PR DESCRIPTION
## Summary
- add Copilot-specific model resolution so the OpenAI default model does not get forced onto Copilot CLI runs
- run Copilot CLI preflight through startup, status, auth, and optional model validation with clearer timeout/auth diagnostics
- document and schema-cover `copilot.model`, plus add regression tests for env/config precedence and failure summaries

## Testing
- `dotnet build IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net8.0 --no-restore /nr:false`
- `dotnet .\IntelligenceX.Tests\bin\Release\net8.0\IntelligenceX.Tests.dll`
- `dotnet build IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net10.0 --no-restore /nr:false`
- `dotnet .\IntelligenceX.Tests\bin\Release\net10.0\IntelligenceX.Tests.dll`
