### PR TITLE
Use Copilot prompt mode for reviewer runs

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -662,8 +662,9 @@ Use this to forward selected environment variables into the Copilot CLI process 
 By default the CLI process **does** inherit the runner environment. Set `inheritEnvironment` to `false` and use
 `envAllowlist`/`env` to pass only what the CLI needs when you want a strict environment.
 Set `launcher` to `gh` to explicitly run Copilot through `gh copilot --`.
-Set `launcher` to `auto` to use the standalone `copilot` binary path. This is the safer default for reviewer server mode:
-the GitHub CLI wrapper can sometimes launch the CLI for simple commands while still hanging in long-running server mode.
+Set `launcher` to `auto` to use the standalone `copilot` binary path. This is the safer default for reviewer CI runs:
+the reviewer validates status/auth through the CLI server protocol, then generates the review through the documented
+non-interactive prompt mode to avoid long-running server-session hangs on hosted runners.
 Use `autoInstall` with the standalone path when the runner does not already have `copilot` installed.
 Set `model` only when you want to force a Copilot CLI model id. When `provider` is `copilot` and only the generic
 `review.model` is the default OpenAI value, the reviewer leaves Copilot model selection to the CLI default.

--- a/IntelligenceX.Reviewer/ReviewDiagnostics.cs
+++ b/IntelligenceX.Reviewer/ReviewDiagnostics.cs
@@ -328,7 +328,7 @@ internal static class ReviewDiagnostics {
             : settings.OpenAITransport.ToString();
     }
 
-    private static string DescribeModel(ReviewSettings settings) {
+    internal static string DescribeModel(ReviewSettings settings) {
         if (settings.Provider == ReviewProvider.Copilot) {
             var model = ReviewRunner.ResolveCopilotModel(settings);
             if (!string.IsNullOrWhiteSpace(model)) {

--- a/IntelligenceX.Reviewer/ReviewFormatter.cs
+++ b/IntelligenceX.Reviewer/ReviewFormatter.cs
@@ -81,7 +81,7 @@ internal static class ReviewFormatter {
             ["AutoResolveNote"] = autoResolveLine,
             ["BudgetNote"] = budgetLine,
             ["ReviewBody"] = body,
-            ["Model"] = settings.Model,
+            ["Model"] = ReviewDiagnostics.DescribeModel(settings),
             ["Length"] = settings.Length.ToString().ToLowerInvariant(),
             ["Mode"] = settings.Mode,
             ["ReasoningLine"] = reasoningLine,
@@ -179,7 +179,7 @@ internal static class ReviewFormatter {
             ["ProgressLine"] = statusLine,
             ["Checklist"] = checklist,
             ["PreliminaryBlock"] = preliminaryBlock,
-            ["Model"] = settings.Model,
+            ["Model"] = ReviewDiagnostics.DescribeModel(settings),
             ["Length"] = settings.Length.ToString().ToLowerInvariant(),
             ["Mode"] = settings.Mode
         };

--- a/IntelligenceX.Reviewer/ReviewRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewRunner.cs
@@ -470,6 +470,9 @@ internal sealed partial class ReviewRunner {
         if (_settings.CopilotTransport == CopilotTransportKind.Direct) {
             return await RunCopilotDirectAsync(prompt, cancellationToken).ConfigureAwait(false);
         }
+        if (ShouldUseCopilotPromptMode(_settings)) {
+            return await RunCopilotPromptAsync(prompt, onPartial, cancellationToken).ConfigureAwait(false);
+        }
         var options = BuildCopilotClientOptions(out var launcherDiagnostic);
 
         await using var client = await CopilotClient.StartAsync(options, cancellationToken).ConfigureAwait(false);
@@ -536,6 +539,43 @@ internal sealed partial class ReviewRunner {
         }
 
         return result ?? string.Empty;
+    }
+
+    private async Task<string> RunCopilotPromptAsync(string prompt, Func<string, Task>? onPartial,
+        CancellationToken cancellationToken) {
+        var options = BuildCopilotClientOptions(out var launcherDiagnostic);
+        var client = new ReviewerCopilotPromptRunner(options);
+        if (_settings.Diagnostics) {
+            Console.Error.WriteLine("Copilot review execution mode: prompt.");
+        }
+        try {
+            var result = await client.RunAsync(
+                prompt,
+                ResolveCopilotModel(_settings),
+                TimeSpan.FromSeconds(Math.Max(1, _settings.WaitSeconds)),
+                cancellationToken).ConfigureAwait(false);
+            if (onPartial is not null) {
+                await onPartial(result.Response).ConfigureAwait(false);
+            }
+            if (_settings.Diagnostics && !string.IsNullOrWhiteSpace(result.UsageSummary)) {
+                Console.Error.WriteLine($"Copilot prompt usage: {result.UsageSummary}");
+            }
+            return result.Response;
+        } catch (TimeoutException ex) {
+            throw new TimeoutException(BuildCopilotPromptTimeoutMessage(launcherDiagnostic, ex.Message), ex);
+        }
+    }
+
+    private static bool ShouldUseCopilotPromptMode(ReviewSettings settings) =>
+        string.IsNullOrWhiteSpace(settings.CopilotCliUrl);
+
+    private string BuildCopilotPromptTimeoutMessage(string launcherDiagnostic, string detail) {
+        var sb = new StringBuilder();
+        sb.Append(detail);
+        sb.Append(' ');
+        sb.Append(launcherDiagnostic);
+        sb.Append(" The reviewer used Copilot CLI prompt mode; if this persists, check runner Copilot availability and prompt size.");
+        return sb.ToString().TrimEnd();
     }
 
     private string BuildCopilotTimeoutMessage(string launcherDiagnostic, Queue<string> stderrLines, object stderrLock) {

--- a/IntelligenceX.Reviewer/ReviewerCopilotPromptRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewerCopilotPromptRunner.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Copilot;
+using IntelligenceX.Json;
+
+namespace IntelligenceX.Reviewer;
+
+internal sealed class ReviewerCopilotPromptRunner {
+    private readonly CopilotClientOptions _options;
+
+    public ReviewerCopilotPromptRunner(CopilotClientOptions options) {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public async Task<ReviewerCopilotPromptResult> RunAsync(string prompt, string? model, TimeSpan timeout,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(prompt)) {
+            throw new ArgumentException("Prompt cannot be empty.", nameof(prompt));
+        }
+        if (timeout <= TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be positive.");
+        }
+
+        _options.Validate();
+        var cliPath = await ResolveCliPathOrInstallAsync(_options, cancellationToken).ConfigureAwait(false);
+        var startInfo = BuildStartInfo(_options, cliPath, prompt, model);
+        using var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        try {
+            if (!process.Start()) {
+                throw new InvalidOperationException("Failed to start Copilot CLI prompt process.");
+            }
+        } catch (Exception ex) {
+            throw new InvalidOperationException("Copilot CLI not found or failed to start in prompt mode.", ex);
+        }
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(timeout);
+
+        try {
+            await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+        } catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested) {
+            TryKill(process);
+            var stderr = await ReadCompletedOrEmptyAsync(stderrTask).ConfigureAwait(false);
+            throw new TimeoutException(BuildTimeoutMessage(timeout, stderr), ex);
+        }
+
+        var stdout = await stdoutTask.ConfigureAwait(false);
+        var stderrText = await stderrTask.ConfigureAwait(false);
+        if (process.ExitCode != 0) {
+            throw new InvalidOperationException(BuildExitMessage(process.ExitCode, stdout, stderrText));
+        }
+
+        var parsed = ParseJsonLines(stdout);
+        var response = parsed.Response;
+        if (string.IsNullOrWhiteSpace(response)) {
+            response = stdout.Trim();
+        }
+        if (string.IsNullOrWhiteSpace(response)) {
+            throw new InvalidOperationException(BuildExitMessage(process.ExitCode, stdout, stderrText,
+                "Copilot CLI produced no review content."));
+        }
+
+        return new ReviewerCopilotPromptResult(response.Trim(), parsed.UsageSummary);
+    }
+
+    private static ProcessStartInfo BuildStartInfo(CopilotClientOptions options, string cliPath, string prompt,
+        string? model) {
+        var args = new List<string>();
+        if (options.CliArgs.Count > 0) {
+            args.AddRange(options.CliArgs);
+        }
+        args.Add("-p");
+        args.Add(prompt);
+        args.Add("--silent");
+        args.Add("--no-ask-user");
+        args.Add("--no-custom-instructions");
+        args.Add("--no-auto-update");
+        args.Add("--stream");
+        args.Add("off");
+        args.Add("--output-format");
+        args.Add("json");
+        if (!string.IsNullOrWhiteSpace(model)) {
+            args.Add("--model");
+            args.Add(model!);
+        }
+
+        var (fileName, processArgs) = ResolveCliCommand(cliPath, args);
+        var startInfo = new ProcessStartInfo {
+            FileName = fileName,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            WorkingDirectory = options.WorkingDirectory ?? Environment.CurrentDirectory,
+            CreateNoWindow = true
+        };
+        foreach (var arg in processArgs) {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        if (!options.InheritEnvironment) {
+            startInfo.Environment.Clear();
+        }
+        foreach (var entry in options.Environment) {
+            startInfo.Environment[entry.Key] = entry.Value;
+        }
+        startInfo.Environment.Remove("NODE_DEBUG");
+        return startInfo;
+    }
+
+    private static async Task<string> ResolveCliPathOrInstallAsync(CopilotClientOptions options,
+        CancellationToken cancellationToken) {
+        try {
+            return ResolveCliPath(options.CliPath ?? "copilot");
+        } catch (InvalidOperationException ex) {
+            if (!options.AutoInstallCli) {
+                throw;
+            }
+            var command = CopilotCliInstall.GetCommand(options.AutoInstallMethod, options.AutoInstallPrerelease);
+            var exitCode = await CopilotCliInstall.InstallAsync(command, cancellationToken).ConfigureAwait(false);
+            if (exitCode != 0) {
+                throw new InvalidOperationException($"Copilot CLI install failed with exit code {exitCode}.", ex);
+            }
+            return ResolveCliPath(options.CliPath ?? "copilot");
+        }
+    }
+
+    private static string ResolveCliPath(string cliPath) {
+        if (string.IsNullOrWhiteSpace(cliPath)) {
+            return "copilot";
+        }
+        if (Path.IsPathRooted(cliPath) || cliPath.Contains(Path.DirectorySeparatorChar) ||
+            cliPath.Contains(Path.AltDirectorySeparatorChar)) {
+            return cliPath;
+        }
+
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(pathEnv)) {
+            throw new InvalidOperationException("Copilot CLI not found on PATH.\n" +
+                                                CopilotCliInstall.GetInstallInstructions());
+        }
+
+        var exts = new List<string> { string.Empty };
+        if (IsWindows()) {
+            var pathExt = Environment.GetEnvironmentVariable("PATHEXT");
+            exts = !string.IsNullOrWhiteSpace(pathExt)
+                ? new List<string>(pathExt.Split(';'))
+                : new List<string> { ".exe", ".cmd", ".bat" };
+        }
+
+        foreach (var dir in pathEnv.Split(Path.PathSeparator)) {
+            if (string.IsNullOrWhiteSpace(dir)) {
+                continue;
+            }
+            foreach (var ext in exts) {
+                var candidate = Path.Combine(dir.Trim(), cliPath + ext);
+                if (File.Exists(candidate)) {
+                    return candidate;
+                }
+            }
+        }
+
+        throw new InvalidOperationException("Copilot CLI not found on PATH.\n" +
+                                            CopilotCliInstall.GetInstallInstructions());
+    }
+
+    private static (string FileName, IEnumerable<string> Args) ResolveCliCommand(string cliPath,
+        IEnumerable<string> args) {
+        if (cliPath.EndsWith(".js", StringComparison.OrdinalIgnoreCase)) {
+            return ("node", Prepend(cliPath, args));
+        }
+        if (IsWindows() && !Path.IsPathRooted(cliPath)) {
+            return ("cmd", Prepend("/c", Prepend(cliPath, args)));
+        }
+        return (cliPath, args);
+    }
+
+    private static IEnumerable<string> Prepend(string value, IEnumerable<string> args) {
+        yield return value;
+        foreach (var arg in args) {
+            yield return arg;
+        }
+    }
+
+    private static bool IsWindows() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    private static (string Response, string? UsageSummary) ParseJsonLines(string stdout) {
+        var response = new StringBuilder();
+        string? finalMessage = null;
+        string? usage = null;
+        using var reader = new StringReader(stdout);
+        string? line;
+        while ((line = reader.ReadLine()) is not null) {
+            if (string.IsNullOrWhiteSpace(line)) {
+                continue;
+            }
+            JsonObject? obj;
+            try {
+                obj = JsonLite.Parse(line).AsObject();
+            } catch {
+                continue;
+            }
+            if (obj is null) {
+                continue;
+            }
+
+            var type = obj.GetString("type");
+            var data = obj.GetObject("data");
+            if (string.Equals(type, "assistant.message", StringComparison.Ordinal) && data is not null) {
+                var content = data.GetString("content");
+                if (!string.IsNullOrWhiteSpace(content)) {
+                    finalMessage = content;
+                }
+                continue;
+            }
+            if (string.Equals(type, "assistant.message_delta", StringComparison.Ordinal) && data is not null) {
+                var delta = data.GetString("deltaContent") ?? data.GetString("content");
+                if (!string.IsNullOrWhiteSpace(delta)) {
+                    response.Append(delta);
+                }
+                continue;
+            }
+            if (string.Equals(type, "result", StringComparison.Ordinal)) {
+                usage = BuildUsageSummary(obj.GetObject("usage"));
+            }
+        }
+
+        return (finalMessage ?? response.ToString(), usage);
+    }
+
+    internal static ReviewerCopilotPromptResult ParseJsonLinesForTests(string stdout) {
+        var parsed = ParseJsonLines(stdout);
+        return new ReviewerCopilotPromptResult(parsed.Response, parsed.UsageSummary);
+    }
+
+    private static string? BuildUsageSummary(JsonObject? usage) {
+        if (usage is null) {
+            return null;
+        }
+        var parts = new List<string>();
+        var premiumRequests = usage.GetInt64("premiumRequests");
+        if (premiumRequests.HasValue) {
+            parts.Add($"premium requests: {premiumRequests.Value}");
+        }
+        var apiDuration = usage.GetInt64("totalApiDurationMs");
+        if (apiDuration.HasValue) {
+            parts.Add($"API: {apiDuration.Value} ms");
+        }
+        var sessionDuration = usage.GetInt64("sessionDurationMs");
+        if (sessionDuration.HasValue) {
+            parts.Add($"session: {sessionDuration.Value} ms");
+        }
+        return parts.Count == 0 ? null : string.Join(", ", parts);
+    }
+
+    private static string BuildTimeoutMessage(TimeSpan timeout, string stderr) {
+        var sb = new StringBuilder();
+        sb.Append("Copilot CLI prompt mode timed out after ");
+        sb.Append(timeout.TotalSeconds.ToString("0"));
+        sb.Append(" seconds.");
+        AppendRecentStderr(sb, stderr);
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string BuildExitMessage(int exitCode, string stdout, string stderr, string? prefix = null) {
+        var sb = new StringBuilder();
+        if (!string.IsNullOrWhiteSpace(prefix)) {
+            sb.Append(prefix);
+            sb.Append(' ');
+        }
+        sb.Append("Copilot CLI prompt mode exited with code ");
+        sb.Append(exitCode);
+        sb.Append('.');
+        AppendRecentStderr(sb, stderr);
+        if (string.IsNullOrWhiteSpace(stderr) && !string.IsNullOrWhiteSpace(stdout)) {
+            sb.AppendLine();
+            sb.AppendLine("Recent Copilot CLI stdout:");
+            AppendRecentLines(sb, stdout, maxLines: 6);
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static void AppendRecentStderr(StringBuilder sb, string stderr) {
+        if (string.IsNullOrWhiteSpace(stderr)) {
+            return;
+        }
+        sb.AppendLine();
+        sb.AppendLine("Recent Copilot CLI stderr:");
+        AppendRecentLines(sb, stderr, maxLines: 6);
+    }
+
+    private static void AppendRecentLines(StringBuilder sb, string text, int maxLines) {
+        var lines = text.Replace("\r\n", "\n").Replace('\r', '\n')
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = Math.Max(0, lines.Length - maxLines); i < lines.Length; i++) {
+            sb.Append("  ");
+            sb.AppendLine(lines[i].Trim());
+        }
+    }
+
+    private static async Task<string> ReadCompletedOrEmptyAsync(Task<string> task) {
+        if (!task.IsCompleted) {
+            return string.Empty;
+        }
+        try {
+            return await task.ConfigureAwait(false);
+        } catch {
+            return string.Empty;
+        }
+    }
+
+    private static void TryKill(Process process) {
+        try {
+            if (!process.HasExited) {
+                process.Kill(entireProcessTree: true);
+            }
+        } catch {
+            // Best-effort cleanup only.
+        }
+    }
+}
+
+internal sealed record ReviewerCopilotPromptResult(string Response, string? UsageSummary);

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -1023,6 +1023,21 @@ internal static partial class Program {
         AssertEqual(null, ReviewRunner.ResolveCopilotModel(settings), "copilot default model");
     }
 
+    private static void TestCopilotPromptRunnerParsesJsonOutput() {
+        var output = string.Join("\n", new[] {
+            """{"type":"assistant.message_delta","data":{"deltaContent":"Hel"}}""",
+            """{"type":"assistant.message_delta","data":{"deltaContent":"lo"}}""",
+            """{"type":"assistant.message","data":{"content":"Final review"}}""",
+            """{"type":"result","usage":{"premiumRequests":1,"totalApiDurationMs":2500,"sessionDurationMs":3000}}"""
+        });
+
+        var result = ReviewerCopilotPromptRunner.ParseJsonLinesForTests(output);
+
+        AssertEqual("Final review", result.Response, "copilot prompt final message");
+        AssertContainsText(result.UsageSummary ?? string.Empty, "premium requests: 1", "copilot prompt usage premium");
+        AssertContainsText(result.UsageSummary ?? string.Empty, "API: 2500 ms", "copilot prompt usage api");
+    }
+
     private static void TestCopilotGhLauncherBuildsWrapperCommand() {
         var settings = new ReviewSettings {
             CopilotLauncher = "gh",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -673,6 +673,7 @@ internal static partial class Program {
         failed += Run("Copilot launcher env", TestCopilotLauncherEnv);
         failed += Run("Copilot model env overrides generic model", TestCopilotModelEnvOverridesGenericModel);
         failed += Run("Copilot default OpenAI model uses CLI default", TestCopilotDefaultOpenAiModelUsesCliDefault);
+        failed += Run("Copilot prompt runner parses JSON output", TestCopilotPromptRunnerParsesJsonOutput);
         failed += Run("Copilot gh launcher builds wrapper command", TestCopilotGhLauncherBuildsWrapperCommand);
         failed += Run("Copilot auto launcher uses binary",
             TestCopilotAutoLauncherUsesBinary);
@@ -801,6 +802,7 @@ internal static partial class Program {
             TestReviewSummaryParserMergeBlockerDetectionAllowNoSectionMatch);
         failed += Run("Review formatter model usage section", TestReviewFormatterModelUsageSection);
         failed += Run("Review formatter model usage unavailable", TestReviewFormatterModelUsageUnavailable);
+        failed += Run("Review formatter copilot model usage provider display", TestReviewFormatterCopilotModelUsageUsesProviderDisplay);
         failed += Run("Review formatter golden snapshot", TestReviewFormatterGoldenSnapshot);
         failed += Run("Review formatter normalizes inline section labels", TestReviewFormatterNormalizesInlineSectionLabels);
         failed += Run("Review formatter normalizes malformed heading inline section labels",

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
@@ -685,6 +685,21 @@ internal static partial class Program {
         AssertContainsText(comment, "- Usage: unavailable", "model usage unavailable line");
     }
 
+    private static void TestReviewFormatterCopilotModelUsageUsesProviderDisplay() {
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Test title", "Test body", false, "head",
+            "base", Array.Empty<string>(), "owner/repo", false, null);
+        var settings = new ReviewSettings {
+            Provider = ReviewProvider.Copilot,
+            Model = OpenAIModelCatalog.DefaultModel
+        };
+
+        var comment = ReviewFormatter.BuildComment(context, "Body", settings, inlineSupported: true, inlineSuppressed: false,
+            autoResolveNote: string.Empty, budgetNote: string.Empty, usageLine: string.Empty, findingsBlock: string.Empty);
+
+        AssertContainsText(comment, "- Model: `Copilot CLI default`", "copilot model usage default label");
+        AssertDoesNotContainText(comment, "- Model: `gpt-5.4`", "copilot model usage hides generic OpenAI default");
+    }
+
     private static void TestReviewFormatterGoldenSnapshot() {
         var context = new PullRequestContext("owner/repo", "owner", "repo", 42, "Formatter Golden Snapshot", "Body", false,
             "deadbeefcafebabe", "base", Array.Empty<string>(), "owner/repo", false, null);


### PR DESCRIPTION
## Summary
- run Copilot reviewer generation through the documented non-interactive prompt mode instead of the long-running server session path
- parse Copilot JSONL output and diagnostics from prompt mode, while keeping existing server status/auth preflight
- show provider-aware model labels in review summaries so Copilot default is not displayed as `gpt-5.4`

## Validation
- dotnet build IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net8.0 /nr:false
- dotnet .\IntelligenceX.Tests\bin\Release\net8.0\IntelligenceX.Tests.dll
- dotnet build IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net10.0 --no-restore /nr:false
- dotnet .\IntelligenceX.Tests\bin\Release\net10.0\IntelligenceX.Tests.dll
- git diff --check
