### PR TITLE
Disable Copilot built-in MCPs in reviewer prompt mode

### DIFF
--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -664,7 +664,8 @@ By default the CLI process **does** inherit the runner environment. Set `inherit
 Set `launcher` to `gh` to explicitly run Copilot through `gh copilot --`.
 Set `launcher` to `auto` to use the standalone `copilot` binary path. This is the safer default for reviewer CI runs:
 the reviewer validates status/auth through the CLI server protocol, then generates the review through the documented
-non-interactive prompt mode to avoid long-running server-session hangs on hosted runners.
+non-interactive prompt mode with built-in MCP servers disabled to avoid long-running server-session hangs and tool
+startup failures on hosted runners.
 Use `autoInstall` with the standalone path when the runner does not already have `copilot` installed.
 Set `model` only when you want to force a Copilot CLI model id. When `provider` is `copilot` and only the generic
 `review.model` is the default OpenAI value, the reviewer leaves Copilot model selection to the CLI default.

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -664,8 +664,8 @@ By default the CLI process **does** inherit the runner environment. Set `inherit
 Set `launcher` to `gh` to explicitly run Copilot through `gh copilot --`.
 Set `launcher` to `auto` to use the standalone `copilot` binary path. This is the safer default for reviewer CI runs:
 the reviewer validates status/auth through the CLI server protocol, then generates the review through the documented
-non-interactive prompt mode with built-in MCP servers disabled to avoid long-running server-session hangs and tool
-startup failures on hosted runners.
+non-interactive prompt mode with built-in Model Context Protocol (MCP) servers disabled via
+`--disable-builtin-mcps` to avoid long-running server-session hangs and tool startup failures on hosted runners.
 Use `autoInstall` with the standalone path when the runner does not already have `copilot` installed.
 Set `model` only when you want to force a Copilot CLI model id. When `provider` is `copilot` and only the generic
 `review.model` is the default OpenAI value, the reviewer leaves Copilot model selection to the CLI default.

--- a/IntelligenceX.Reviewer/ReviewerCopilotPromptRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewerCopilotPromptRunner.cs
@@ -29,7 +29,32 @@ internal sealed class ReviewerCopilotPromptRunner {
 
         _options.Validate();
         var cliPath = await ResolveCliPathOrInstallAsync(_options, cancellationToken).ConfigureAwait(false);
-        var startInfo = BuildStartInfo(_options, cliPath, prompt, model);
+        var startInfo = BuildStartInfo(_options, cliPath, prompt, model, disableBuiltinMcps: true);
+        var result = await RunProcessAsync(startInfo, timeout, cancellationToken).ConfigureAwait(false);
+        if (result.ExitCode != 0 && IsUnsupportedDisableBuiltinMcpsFlag(result.Stdout, result.Stderr)) {
+            startInfo = BuildStartInfo(_options, cliPath, prompt, model, disableBuiltinMcps: false);
+            result = await RunProcessAsync(startInfo, timeout, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (result.ExitCode != 0) {
+            throw new InvalidOperationException(BuildExitMessage(result.ExitCode, result.Stdout, result.Stderr));
+        }
+
+        var parsed = ParseJsonLines(result.Stdout);
+        var response = parsed.Response;
+        if (string.IsNullOrWhiteSpace(response)) {
+            response = result.Stdout.Trim();
+        }
+        if (string.IsNullOrWhiteSpace(response)) {
+            throw new InvalidOperationException(BuildExitMessage(result.ExitCode, result.Stdout, result.Stderr,
+                "Copilot CLI produced no review content."));
+        }
+
+        return new ReviewerCopilotPromptResult(response.Trim(), parsed.UsageSummary);
+    }
+
+    private static async Task<CopilotPromptProcessResult> RunProcessAsync(ProcessStartInfo startInfo,
+        TimeSpan timeout, CancellationToken cancellationToken) {
         using var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
         try {
             if (!process.Start()) {
@@ -54,25 +79,11 @@ internal sealed class ReviewerCopilotPromptRunner {
 
         var stdout = await stdoutTask.ConfigureAwait(false);
         var stderrText = await stderrTask.ConfigureAwait(false);
-        if (process.ExitCode != 0) {
-            throw new InvalidOperationException(BuildExitMessage(process.ExitCode, stdout, stderrText));
-        }
-
-        var parsed = ParseJsonLines(stdout);
-        var response = parsed.Response;
-        if (string.IsNullOrWhiteSpace(response)) {
-            response = stdout.Trim();
-        }
-        if (string.IsNullOrWhiteSpace(response)) {
-            throw new InvalidOperationException(BuildExitMessage(process.ExitCode, stdout, stderrText,
-                "Copilot CLI produced no review content."));
-        }
-
-        return new ReviewerCopilotPromptResult(response.Trim(), parsed.UsageSummary);
+        return new CopilotPromptProcessResult(process.ExitCode, stdout, stderrText);
     }
 
     private static ProcessStartInfo BuildStartInfo(CopilotClientOptions options, string cliPath, string prompt,
-        string? model) {
+        string? model, bool disableBuiltinMcps) {
         var args = new List<string>();
         if (options.CliArgs.Count > 0) {
             args.AddRange(options.CliArgs);
@@ -83,7 +94,9 @@ internal sealed class ReviewerCopilotPromptRunner {
         args.Add("--no-ask-user");
         args.Add("--no-custom-instructions");
         args.Add("--no-auto-update");
-        args.Add("--disable-builtin-mcps");
+        if (disableBuiltinMcps) {
+            args.Add("--disable-builtin-mcps");
+        }
         args.Add("--stream");
         args.Add("off");
         args.Add("--output-format");
@@ -241,6 +254,26 @@ internal sealed class ReviewerCopilotPromptRunner {
         return new ReviewerCopilotPromptResult(parsed.Response, parsed.UsageSummary);
     }
 
+    internal static string[] BuildArgumentsForTests(CopilotClientOptions options, string cliPath, string prompt,
+        string? model = null, bool disableBuiltinMcps = true) {
+        var startInfo = BuildStartInfo(options, cliPath, prompt, model, disableBuiltinMcps);
+        var args = new string[startInfo.ArgumentList.Count];
+        startInfo.ArgumentList.CopyTo(args, 0);
+        return args;
+    }
+
+    internal static bool IsUnsupportedDisableBuiltinMcpsFlagForTests(string stdout, string stderr) =>
+        IsUnsupportedDisableBuiltinMcpsFlag(stdout, stderr);
+
+    private static bool IsUnsupportedDisableBuiltinMcpsFlag(string stdout, string stderr) {
+        var combined = string.Concat(stdout, "\n", stderr);
+        return combined.Contains("--disable-builtin-mcps", StringComparison.OrdinalIgnoreCase) &&
+               (combined.Contains("unknown", StringComparison.OrdinalIgnoreCase) ||
+                combined.Contains("unrecognized", StringComparison.OrdinalIgnoreCase) ||
+                combined.Contains("invalid option", StringComparison.OrdinalIgnoreCase) ||
+                combined.Contains("unexpected argument", StringComparison.OrdinalIgnoreCase));
+    }
+
     private static string? BuildUsageSummary(JsonObject? usage) {
         if (usage is null) {
             return null;
@@ -329,3 +362,5 @@ internal sealed class ReviewerCopilotPromptRunner {
 }
 
 internal sealed record ReviewerCopilotPromptResult(string Response, string? UsageSummary);
+
+internal sealed record CopilotPromptProcessResult(int ExitCode, string Stdout, string Stderr);

--- a/IntelligenceX.Reviewer/ReviewerCopilotPromptRunner.cs
+++ b/IntelligenceX.Reviewer/ReviewerCopilotPromptRunner.cs
@@ -83,6 +83,7 @@ internal sealed class ReviewerCopilotPromptRunner {
         args.Add("--no-ask-user");
         args.Add("--no-custom-instructions");
         args.Add("--no-auto-update");
+        args.Add("--disable-builtin-mcps");
         args.Add("--stream");
         args.Add("off");
         args.Add("--output-format");

--- a/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CodeHostAndInfrastructure.cs
@@ -1038,6 +1038,51 @@ internal static partial class Program {
         AssertContainsText(result.UsageSummary ?? string.Empty, "API: 2500 ms", "copilot prompt usage api");
     }
 
+    private static void TestCopilotPromptRunnerBuildsMcpDisabledArgs() {
+        var cliPath = Path.Combine(Path.GetPathRoot(Environment.CurrentDirectory) ?? Directory.GetCurrentDirectory(),
+            "copilot");
+        var binaryOptions = new IntelligenceX.Copilot.CopilotClientOptions();
+        var binaryArgs = ReviewerCopilotPromptRunner.BuildArgumentsForTests(binaryOptions, cliPath, "review prompt");
+
+        AssertContainsText(string.Join("\n", binaryArgs), "--disable-builtin-mcps",
+            "copilot binary prompt disables built-in MCPs");
+
+        var fallbackArgs = ReviewerCopilotPromptRunner.BuildArgumentsForTests(binaryOptions, cliPath, "review prompt",
+            disableBuiltinMcps: false);
+        AssertEqual(false, fallbackArgs.Contains("--disable-builtin-mcps"),
+            "copilot prompt fallback omits built-in MCP flag");
+
+        var ghOptions = new IntelligenceX.Copilot.CopilotClientOptions();
+        ghOptions.CliArgs.Add("copilot");
+        ghOptions.CliArgs.Add("--");
+        var ghArgs = ReviewerCopilotPromptRunner.BuildArgumentsForTests(ghOptions, cliPath, "review prompt");
+
+        AssertSequenceEqual(new[] {
+            "copilot",
+            "--",
+            "-p",
+            "review prompt",
+            "--silent",
+            "--no-ask-user",
+            "--no-custom-instructions",
+            "--no-auto-update",
+            "--disable-builtin-mcps",
+            "--stream",
+            "off",
+            "--output-format",
+            "json"
+        }, ghArgs, "copilot gh prompt args");
+    }
+
+    private static void TestCopilotPromptRunnerDetectsUnsupportedMcpFlag() {
+        AssertEqual(true, ReviewerCopilotPromptRunner.IsUnsupportedDisableBuiltinMcpsFlagForTests(
+            string.Empty, "error: unknown option '--disable-builtin-mcps'"),
+            "copilot prompt detects unknown MCP flag");
+        AssertEqual(false, ReviewerCopilotPromptRunner.IsUnsupportedDisableBuiltinMcpsFlagForTests(
+            string.Empty, "error: unknown option '--other-flag'"),
+            "copilot prompt ignores unrelated unknown flag");
+    }
+
     private static void TestCopilotGhLauncherBuildsWrapperCommand() {
         var settings = new ReviewSettings {
             CopilotLauncher = "gh",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -674,6 +674,10 @@ internal static partial class Program {
         failed += Run("Copilot model env overrides generic model", TestCopilotModelEnvOverridesGenericModel);
         failed += Run("Copilot default OpenAI model uses CLI default", TestCopilotDefaultOpenAiModelUsesCliDefault);
         failed += Run("Copilot prompt runner parses JSON output", TestCopilotPromptRunnerParsesJsonOutput);
+        failed += Run("Copilot prompt runner builds MCP-disabled args",
+            TestCopilotPromptRunnerBuildsMcpDisabledArgs);
+        failed += Run("Copilot prompt runner detects unsupported MCP flag",
+            TestCopilotPromptRunnerDetectsUnsupportedMcpFlag);
         failed += Run("Copilot gh launcher builds wrapper command", TestCopilotGhLauncherBuildsWrapperCommand);
         failed += Run("Copilot auto launcher uses binary",
             TestCopilotAutoLauncherUsesBinary);


### PR DESCRIPTION
## Summary
- disable Copilot CLI built-in MCP servers for reviewer prompt-mode executions
- document why prompt mode now avoids both long-running server sessions and hosted-runner MCP startup failures

## Validation
- dotnet build IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net8.0 /nr:false
- dotnet .\IntelligenceX.Tests\bin\Release\net8.0\IntelligenceX.Tests.dll
- dotnet build IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net10.0 --no-restore /nr:false
- dotnet .\IntelligenceX.Tests\bin\Release\net10.0\IntelligenceX.Tests.dll
- git diff --check

## Rollout note
This follows the PSTeams proof run where Copilot auth/status succeeded in GitHub Actions, prompt mode started, then exited after built-in GitHub MCP startup. The reviewer supplies the full prompt context itself, so Copilot tools are unnecessary for this CI path.
