### PR TITLE
Add conversation explorer to tray usage reports

### DIFF
--- a/IntelligenceX.Cli/Telemetry/UsageTelemetryCliRunner.cs
+++ b/IntelligenceX.Cli/Telemetry/UsageTelemetryCliRunner.cs
@@ -1199,6 +1199,10 @@ internal static class UsageTelemetryCliRunner {
             ? new JsonObject()
             : CloneJsonObject(overview.Metadata);
         metadata.Add("scanContext", BuildQuickReportScanContext(options, dbPath, scanResult, roots));
+        var conversations = BuildQuickReportConversationMetadata(scanResult, options);
+        if (conversations is not null) {
+            metadata.Add("conversations", conversations);
+        }
 
         return new UsageTelemetryOverviewDocument(
             overview.Title,
@@ -1210,6 +1214,107 @@ internal static class UsageTelemetryCliRunner {
             overview.Heatmaps,
             overview.ProviderSections,
             metadata);
+    }
+
+    private static JsonObject? BuildQuickReportConversationMetadata(
+        UsageTelemetryQuickReportResult scanResult,
+        ReportOptions options) {
+        var rawEvents = (scanResult?.RawEvents ?? new List<UsageEventRecord>())
+            .Where(record => MatchesProvider(record.ProviderId, options.ProviderId))
+            .Where(record => MatchesAccount(record, options.AccountFilter))
+            .Where(record => MatchesPerson(record, options.PersonFilter))
+            .OrderBy(static record => record.TimestampUtc)
+            .ToArray();
+        if (rawEvents.Length == 0) {
+            return null;
+        }
+
+        var conversations = UsageConversationSummaryBuilder.Build(rawEvents);
+        if (conversations.Count == 0) {
+            return null;
+        }
+
+        var items = new JsonArray();
+        foreach (var conversation in conversations.Take(25)) {
+            var models = new JsonArray();
+            foreach (var model in conversation.Models) {
+                models.Add(model);
+            }
+
+            var surfaces = new JsonArray();
+            foreach (var surface in conversation.Surfaces) {
+                surfaces.Add(surface);
+            }
+
+            items.Add(new JsonObject()
+                .Add("conversationKey", conversation.ConversationKey)
+                .Add("providerId", conversation.ProviderId)
+                .Add("provider", UsageTelemetryProviderCatalog.ResolveDisplayTitle(conversation.ProviderId))
+                .Add("providerAccountId", conversation.ProviderAccountId)
+                .Add("account", NormalizeConversationAccount(conversation.AccountLabel, conversation.ProviderAccountId) ?? "Unknown account")
+                .Add("sessionId", conversation.SessionId)
+                .Add("title", conversation.ConversationTitle)
+                .Add("workspacePath", conversation.WorkspacePath)
+                .Add("workspace", conversation.WorkspaceName)
+                .Add("repository", conversation.RepositoryName)
+                .Add("label", FormatSessionSnippet(conversation.SessionId))
+                .Add("startedLocal", conversation.StartedUtc.ToLocalTime().ToString("MMM d HH:mm", CultureInfo.CurrentCulture))
+                .Add("startedUtc", conversation.StartedUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture))
+                .Add("lastSeenLocal", conversation.LastSeenUtc.ToLocalTime().ToString("MMM d HH:mm", CultureInfo.CurrentCulture))
+                .Add("lastSeenUtc", conversation.LastSeenUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture))
+                .Add("durationMs", (long)conversation.Duration.TotalMilliseconds)
+                .Add("duration", HeatmapDisplayText.FormatDuration(conversation.Duration))
+                .Add("activeDurationMs", (long)conversation.ActiveDuration.TotalMilliseconds)
+                .Add("activeDuration", HeatmapDisplayText.FormatDuration(conversation.ActiveDuration))
+                .Add("turnCount", conversation.TurnCount)
+                .Add("compactCount", conversation.CompactCount)
+                .Add("inputTokens", conversation.InputTokens)
+                .Add("outputTokens", conversation.OutputTokens)
+                .Add("cachedTokens", conversation.CachedInputTokens)
+                .Add("reasoningTokens", conversation.ReasoningTokens)
+                .Add("totalTokens", conversation.TotalTokens)
+                .Add("apiEquivalentCostUsd", (double)conversation.CostUsd)
+                .Add("costApproximate", conversation.CostUsesEstimatedFallback)
+                .Add("models", models)
+                .Add("surfaces", surfaces));
+        }
+
+        return new JsonObject()
+            .Add("totalCount", conversations.Count)
+            .Add("shownCount", items.Count)
+            .Add("tokenTotal", conversations.Sum(static conversation => conversation.TotalTokens))
+            .Add("turnCount", conversations.Sum(static conversation => (long)conversation.TurnCount))
+            .Add("compactCount", conversations.Sum(static conversation => (long)conversation.CompactCount))
+            .Add("items", items);
+    }
+
+    private static string FormatSessionSnippet(string value) {
+        var normalized = NormalizeOptional(value) ?? "unknown";
+        if (normalized.Length <= 18) {
+            return normalized;
+        }
+
+        return normalized[..8] + "..." + normalized[^6..];
+    }
+
+    private static string? NormalizeConversationAccount(string? accountLabel, string? providerAccountId) {
+        var normalized = NormalizeOptional(accountLabel);
+        if (normalized is null || string.Equals(normalized, "unknown-account", StringComparison.OrdinalIgnoreCase)) {
+            normalized = NormalizeOptional(providerAccountId);
+            if (normalized is null || string.Equals(normalized, "unknown-account", StringComparison.OrdinalIgnoreCase)) {
+                return null;
+            }
+        }
+
+        if (normalized.StartsWith("acct:", StringComparison.OrdinalIgnoreCase)) {
+            return normalized["acct:".Length..];
+        }
+
+        if (normalized.StartsWith("label:", StringComparison.OrdinalIgnoreCase)) {
+            return normalized["label:".Length..];
+        }
+
+        return normalized;
     }
 
     private static UsageTelemetryOverviewDocument ApplyQuickReportDiagnosticsInsights(

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -776,6 +776,86 @@ internal static partial class Program {
         AssertContainsText(html, "data-detail-cost", "overview conversation pulse detail cost metric shell");
     }
 
+    private static void TestUsageTelemetryOverviewHtmlRendererUsesShownConversationShare() {
+        var items = new JsonArray()
+            .Add(new JsonObject()
+                .Add("label", "session-01")
+                .Add("title", "Largest visible session")
+                .Add("repository", "EvotecIT/IntelligenceX")
+                .Add("workspace", "IntelligenceX")
+                .Add("account", "work@evotec.pl")
+                .Add("startedLocal", "Mar 20 09:00")
+                .Add("duration", "45m")
+                .Add("turnCount", 9)
+                .Add("totalTokens", 60));
+
+        for (var i = 2; i <= 11; i++) {
+            items.Add(new JsonObject()
+                .Add("label", "session-" + i.ToString("00"))
+                .Add("title", "Visible session " + i)
+                .Add("repository", "EvotecIT/IntelligenceX")
+                .Add("workspace", "IntelligenceX")
+                .Add("account", "work@evotec.pl")
+                .Add("startedLocal", "Mar 20 10:00")
+                .Add("duration", "12m")
+                .Add("turnCount", 2)
+                .Add("totalTokens", 5));
+        }
+
+        items.Add(new JsonObject()
+            .Add("label", "session-12")
+            .Add("title", "Visible session 12")
+            .Add("repository", "EvotecIT/IntelligenceX")
+            .Add("workspace", "IntelligenceX")
+            .Add("account", "work@evotec.pl")
+            .Add("startedLocal", "Mar 20 10:30")
+            .Add("duration", "14m")
+            .Add("turnCount", 3)
+            .Add("totalTokens", 10));
+        items.Add(new JsonObject()
+            .Add("label", "session-13")
+            .Add("title", "Hidden tail session")
+            .Add("repository", "EvotecIT/IntelligenceX")
+            .Add("workspace", "IntelligenceX")
+            .Add("account", "work@evotec.pl")
+            .Add("startedLocal", "Mar 20 11:00")
+            .Add("duration", "20m")
+            .Add("turnCount", 4)
+            .Add("totalTokens", 80));
+
+        var metadata = new JsonObject()
+            .Add("conversations", new JsonObject()
+                .Add("totalCount", 13)
+                .Add("shownCount", 13)
+                .Add("tokenTotal", 200)
+                .Add("turnCount", 36)
+                .Add("compactCount", 0)
+                .Add("items", items));
+        var overview = new UsageTelemetryOverviewDocument(
+            title: "Usage Overview",
+            subtitle: "Tray explorer",
+            metric: UsageSummaryMetric.TotalTokens,
+            units: "tokens",
+            summary: new UsageSummarySnapshot {
+                Metric = UsageSummaryMetric.TotalTokens,
+                StartDayUtc = new DateTime(2026, 03, 20),
+                EndDayUtc = new DateTime(2026, 03, 20),
+                TotalValue = 200m,
+                TotalDays = 1,
+                ActiveDays = 1,
+                PeakDayUtc = new DateTime(2026, 03, 20),
+                PeakValue = 200m
+            },
+            cards: Array.Empty<UsageTelemetryOverviewCard>(),
+            heatmaps: Array.Empty<UsageTelemetryOverviewHeatmap>(),
+            providerSections: Array.Empty<UsageTelemetryOverviewProviderSection>(),
+            metadata: metadata);
+
+        var html = UsageTelemetryOverviewHtmlRenderer.Render(overview);
+        AssertContainsText(html, "Top 12 cover 60% of conversation tokens", "overview conversation pulse visible coverage headline");
+        AssertContainsText(html, "50% of shown total", "overview conversation pulse row share uses displayed subset total");
+    }
+
     private static void TestUsageTelemetryBreakdownHtmlRendererUsesSharedAssets() {
         var heatmap = new HeatmapDocument(
             title: "By telemetry source",

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -683,6 +683,83 @@ internal static partial class Program {
         AssertContainsText(html, "Quick-scan dedupe", "overview provider diagnostics dedupe insight");
     }
 
+    private static void TestUsageTelemetryOverviewHtmlRendererBuildsConversationPulse() {
+        var items = new JsonArray()
+            .Add(new JsonObject()
+                .Add("label", "session-a")
+                .Add("title", "Audit usage context")
+                .Add("repository", "EvotecIT/IntelligenceX")
+                .Add("workspace", "IntelligenceX")
+                .Add("account", "work@evotec.pl")
+                .Add("startedLocal", "Mar 18 14:00")
+                .Add("duration", "1h 05m")
+                .Add("activeDuration", "4m 12s")
+                .Add("turnCount", 7)
+                .Add("compactCount", 2)
+                .Add("totalTokens", 12_345_678)
+                .Add("apiEquivalentCostUsd", 12.34d)
+                .Add("costApproximate", true)
+                .Add("models", new JsonArray().Add("gpt-5.4"))
+                .Add("surfaces", new JsonArray().Add("cli")));
+        var metadata = new JsonObject()
+            .Add("conversations", new JsonObject()
+                .Add("totalCount", 1)
+                .Add("shownCount", 1)
+                .Add("tokenTotal", 12_345_678)
+                .Add("turnCount", 7)
+                .Add("compactCount", 2)
+                .Add("items", items));
+        var overview = new UsageTelemetryOverviewDocument(
+            title: "Usage Overview",
+            subtitle: "Tray explorer",
+            metric: UsageSummaryMetric.TotalTokens,
+            units: "tokens",
+            summary: new UsageSummarySnapshot {
+                Metric = UsageSummaryMetric.TotalTokens,
+                StartDayUtc = new DateTime(2026, 03, 18),
+                EndDayUtc = new DateTime(2026, 03, 18),
+                TotalValue = 12_345_678m,
+                TotalDays = 1,
+                ActiveDays = 1,
+                PeakDayUtc = new DateTime(2026, 03, 18),
+                PeakValue = 12_345_678m
+            },
+            cards: Array.Empty<UsageTelemetryOverviewCard>(),
+            heatmaps: Array.Empty<UsageTelemetryOverviewHeatmap>(),
+            providerSections: Array.Empty<UsageTelemetryOverviewProviderSection>(),
+            metadata: metadata);
+
+        var html = UsageTelemetryOverviewHtmlRenderer.Render(overview);
+        AssertContainsText(html, "Conversation usage", "overview conversation pulse title");
+        AssertContainsText(html, "Raw sessions", "overview conversation pulse feature kicker");
+        AssertContainsText(html, "Audit usage context", "overview conversation pulse session title");
+        AssertContainsText(html, "EvotecIT/IntelligenceX", "overview conversation pulse repository");
+        AssertContainsText(html, "session-a", "overview conversation pulse session label");
+        AssertContainsText(html, "12.3M tokens", "overview conversation pulse token value");
+        AssertContainsText(html, "span 1h 05m", "overview conversation pulse wall duration");
+        AssertContainsText(html, "active 4m 12s", "overview conversation pulse active duration");
+        AssertContainsText(html, "7 turns", "overview conversation pulse turn count");
+        AssertContainsText(html, "2 compacts", "overview conversation pulse compact count");
+        AssertContainsText(html, "work@evotec.pl", "overview conversation pulse account");
+        AssertContainsText(html, "gpt-5.4", "overview conversation pulse model");
+        AssertContainsText(html, "~$12.34", "overview conversation pulse estimated cost");
+        AssertContainsText(html, "Selected conversation", "overview conversation pulse detail card");
+        AssertContainsText(html, "data-conversation-button", "overview conversation pulse selectable row");
+        AssertContainsText(html, "data-conversation-sort=\"tokens\"", "overview conversation pulse sort tabs");
+        AssertContainsText(html, "data-conversation-search", "overview conversation pulse search input");
+        AssertContainsText(html, "data-conversation-filter-group=\"named\"", "overview conversation pulse quick filters");
+        AssertContainsText(html, "data-conversation-filter-group=\"profile\"", "overview conversation pulse signal filters");
+        AssertContainsText(html, "data-conversation-reset", "overview conversation pulse reset control");
+        AssertContainsText(html, "data-conversation-active-chips", "overview conversation pulse active filters");
+        AssertContainsText(html, "name=\"conversation-search\"", "overview conversation pulse search name");
+        AssertContainsText(html, "data-conversation-snapshot-count", "overview conversation pulse snapshot count");
+        AssertContainsText(html, "data-conversation-snapshot-cost", "overview conversation pulse snapshot cost");
+        AssertContainsText(html, "data-conversation-snapshot-context", "overview conversation pulse snapshot context");
+        AssertContainsText(html, "data-conversation-context-list", "overview conversation pulse context breakdown");
+        AssertContainsText(html, "data-conversation-context-lens=\"cost\"", "overview conversation pulse context cost lens");
+        AssertContainsText(html, "Context Breakdown", "overview conversation pulse context breakdown title");
+    }
+
     private static void TestUsageTelemetryBreakdownHtmlRendererUsesSharedAssets() {
         var heatmap = new HeatmapDocument(
             title: "By telemetry source",

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -695,18 +695,31 @@ internal static partial class Program {
                 .Add("duration", "1h 05m")
                 .Add("activeDuration", "4m 12s")
                 .Add("turnCount", 7)
-                .Add("compactCount", 2)
                 .Add("totalTokens", 12_345_678)
+                .Add("models", new JsonArray().Add("gpt-5.4"))
+                .Add("surfaces", new JsonArray().Add("cli")))
+            .Add(new JsonObject()
+                .Add("label", "session-b")
+                .Add("title", "Compact-heavy follow-up")
+                .Add("repository", "EvotecIT/IntelligenceX")
+                .Add("workspace", "IntelligenceX")
+                .Add("account", "work@evotec.pl")
+                .Add("startedLocal", "Mar 18 16:00")
+                .Add("duration", "18m")
+                .Add("activeDuration", "5m")
+                .Add("turnCount", 4)
+                .Add("compactCount", 2)
+                .Add("totalTokens", 2_500_000)
                 .Add("apiEquivalentCostUsd", 12.34d)
                 .Add("costApproximate", true)
                 .Add("models", new JsonArray().Add("gpt-5.4"))
                 .Add("surfaces", new JsonArray().Add("cli")));
         var metadata = new JsonObject()
             .Add("conversations", new JsonObject()
-                .Add("totalCount", 1)
-                .Add("shownCount", 1)
-                .Add("tokenTotal", 12_345_678)
-                .Add("turnCount", 7)
+                .Add("totalCount", 2)
+                .Add("shownCount", 2)
+                .Add("tokenTotal", 14_845_678)
+                .Add("turnCount", 11)
                 .Add("compactCount", 2)
                 .Add("items", items));
         var overview = new UsageTelemetryOverviewDocument(
@@ -758,6 +771,9 @@ internal static partial class Program {
         AssertContainsText(html, "data-conversation-context-list", "overview conversation pulse context breakdown");
         AssertContainsText(html, "data-conversation-context-lens=\"cost\"", "overview conversation pulse context cost lens");
         AssertContainsText(html, "Context Breakdown", "overview conversation pulse context breakdown title");
+        AssertContainsText(html, "data-detail-active", "overview conversation pulse detail active metric shell");
+        AssertContainsText(html, "data-detail-compacts", "overview conversation pulse detail compact metric shell");
+        AssertContainsText(html, "data-detail-cost", "overview conversation pulse detail cost metric shell");
     }
 
     private static void TestUsageTelemetryBreakdownHtmlRendererUsesSharedAssets() {

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Persistence.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Persistence.cs
@@ -122,6 +122,11 @@ internal static partial class Program {
                     .Add("payload", new JsonObject()
                         .Add("model", "gpt-5.4-codex"))),
                 SerializeJsonLine(new JsonObject()
+                    .Add("timestamp", "2026-03-11T12:00:01.500Z")
+                    .Add("type", "event_msg")
+                    .Add("payload", new JsonObject()
+                        .Add("type", "context_compacted"))),
+                SerializeJsonLine(new JsonObject()
                     .Add("timestamp", "2026-03-11T12:00:02Z")
                     .Add("type", "event_msg")
                     .Add("payload", new JsonObject()
@@ -152,6 +157,7 @@ internal static partial class Program {
             AssertEqual(40L, records[0].OutputTokens, "codex output tokens");
             AssertEqual(5L, records[0].ReasoningTokens, "codex reasoning tokens");
             AssertEqual(140L, records[0].TotalTokens, "codex total tokens");
+            AssertEqual(1, records[0].CompactCount, "codex compact count");
             AssertEqual(UsageTruthLevel.Exact, records[0].TruthLevel, "codex truth level");
         } finally {
             TryDeleteUsageTelemetryTempDirectory(tempDir);

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.cs
@@ -35,6 +35,89 @@ internal static partial class Program {
         AssertEqual("raw|codex|raw_ignore", keys[2], "tertiary dedupe key");
     }
 
+    private static void TestUsageConversationSummaryBuilderGroupsRawConversationRows() {
+        var started = new DateTimeOffset(2026, 4, 19, 9, 0, 0, TimeSpan.Zero);
+        var records = new[] {
+            new UsageEventRecord("ev_a1", "codex", "codex.session-log", "src_1", started) {
+                ProviderAccountId = "acct_a",
+                AccountLabel = "Primary",
+                SessionId = "session-a",
+                ThreadId = "session-a",
+                ConversationTitle = "Analyze token usage",
+                WorkspacePath = @"C:\Support\GitHub\IntelligenceX",
+                RepositoryName = "EvotecIT/IntelligenceX",
+                TurnId = "turn-1",
+                Model = "gpt-5.4",
+                Surface = "cli",
+                InputTokens = 100,
+                OutputTokens = 10,
+                TotalTokens = 110,
+                DurationMs = 12_000,
+                CompactCount = 1
+            },
+            new UsageEventRecord("ev_a2", "codex", "codex.session-log", "src_1", started.AddMinutes(10)) {
+                ProviderAccountId = "acct_a",
+                AccountLabel = "Primary",
+                SessionId = "session-a",
+                ThreadId = "session-a",
+                TurnId = "turn-2",
+                Model = "gpt-5.4",
+                Surface = "cli",
+                InputTokens = 50,
+                CachedInputTokens = 25,
+                OutputTokens = 25,
+                ReasoningTokens = 5,
+                TotalTokens = 75,
+                DurationMs = 8_000,
+                CompactCount = 2
+            },
+            new UsageEventRecord("ev_b1", "codex", "codex.session-log", "src_1", started.AddHours(1)) {
+                ProviderAccountId = "acct_a",
+                AccountLabel = "Primary",
+                SessionId = "session-b",
+                ThreadId = "session-b",
+                TurnId = "turn-1",
+                Model = "gpt-5.2-codex",
+                Surface = "cli",
+                TotalTokens = 500,
+                DurationMs = 42000
+            },
+            new UsageEventRecord("ev_ignored", "codex", "codex.session-log", "src_1", started.AddHours(2)) {
+                ProviderAccountId = "acct_a",
+                AccountLabel = "Primary",
+                Model = "gpt-5.4",
+                Surface = "cli",
+                TotalTokens = 999
+            }
+        };
+
+        var summaries = UsageConversationSummaryBuilder.Build(records);
+
+        AssertEqual(2, summaries.Count, "conversation summary count");
+        AssertEqual("session-b", summaries[0].SessionId, "conversation summaries sort by token weight");
+        AssertEqual(500L, summaries[0].TotalTokens, "conversation summary top total");
+        AssertEqual(TimeSpan.FromSeconds(42), summaries[0].Duration, "conversation summary single-row duration fallback");
+        AssertEqual(TimeSpan.FromSeconds(42), summaries[0].ActiveDuration, "conversation summary single-row active duration");
+
+        var sessionA = summaries.Single(summary => summary.SessionId == "session-a");
+        AssertEqual(185L, sessionA.TotalTokens, "conversation summary total tokens");
+        AssertEqual(150L, sessionA.InputTokens, "conversation summary input tokens");
+        AssertEqual(25L, sessionA.CachedInputTokens, "conversation summary cached tokens");
+        AssertEqual(35L, sessionA.OutputTokens, "conversation summary output tokens");
+        AssertEqual(5L, sessionA.ReasoningTokens, "conversation summary reasoning tokens");
+        AssertEqual(3, sessionA.CompactCount, "conversation summary compact count");
+        AssertEqual(2, sessionA.TurnCount, "conversation summary turn count");
+        AssertEqual(TimeSpan.FromMinutes(10), sessionA.Duration, "conversation summary wall duration");
+        AssertEqual(TimeSpan.FromSeconds(20), sessionA.ActiveDuration, "conversation summary active duration");
+        AssertEqual("Primary", sessionA.AccountLabel, "conversation summary account label");
+        AssertEqual("Analyze token usage", sessionA.ConversationTitle, "conversation summary title");
+        AssertEqual(@"C:\Support\GitHub\IntelligenceX", sessionA.WorkspacePath, "conversation summary workspace path");
+        AssertEqual("IntelligenceX", sessionA.WorkspaceName, "conversation summary workspace name");
+        AssertEqual("EvotecIT/IntelligenceX", sessionA.RepositoryName, "conversation summary repository");
+        AssertEqual("gpt-5.4", sessionA.Models[0], "conversation summary top model");
+        AssertEqual("cli", sessionA.Surfaces[0], "conversation summary top surface");
+    }
+
     private static void TestUsageTelemetryStoreMergesResponseDuplicates() {
         var store = new InMemoryUsageEventStore();
         var first = new UsageEventRecord(
@@ -154,8 +237,9 @@ internal static partial class Program {
         File.WriteAllText(
             sessionPath,
             string.Join(Environment.NewLine, new[] {
-                "{\"timestamp\":\"2026-03-11T15:02:44.663Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"" + sessionId + "\"}}",
+                "{\"timestamp\":\"2026-03-11T15:02:44.663Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"" + sessionId + "\",\"cwd\":\"C:\\\\Support\\\\GitHub\\\\IntelligenceX\",\"git\":{\"repository_url\":\"https://github.com/EvotecIT/IntelligenceX.git\"}}}",
                 "{\"timestamp\":\"2026-03-11T15:02:44.700Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.3-codex\"}}",
+                "{\"timestamp\":\"2026-03-11T15:02:45.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_name_updated\",\"thread_id\":\"" + sessionId + "\",\"thread_name\":\"Audit usage context\"}}",
                 "{\"timestamp\":\"2026-03-11T15:02:49.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":8509,\"cached_input_tokens\":7424,\"output_tokens\":282,\"reasoning_output_tokens\":173,\"total_tokens\":8791},\"last_token_usage\":{\"input_tokens\":8509,\"cached_input_tokens\":7424,\"output_tokens\":282,\"reasoning_output_tokens\":173,\"total_tokens\":8791}}}}",
                 "{\"timestamp\":\"2026-03-11T15:02:50.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":8509,\"cached_input_tokens\":7424,\"output_tokens\":282,\"reasoning_output_tokens\":173,\"total_tokens\":8791},\"last_token_usage\":{\"input_tokens\":8509,\"cached_input_tokens\":7424,\"output_tokens\":282,\"reasoning_output_tokens\":173,\"total_tokens\":8791}}}}",
                 "{\"timestamp\":\"2026-03-11T15:02:55.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":21126,\"cached_input_tokens\":14848,\"output_tokens\":699,\"reasoning_output_tokens\":292,\"total_tokens\":21825},\"last_token_usage\":{\"input_tokens\":12617,\"cached_input_tokens\":7424,\"output_tokens\":417,\"reasoning_output_tokens\":119,\"total_tokens\":13034}}}}"
@@ -172,6 +256,9 @@ internal static partial class Program {
         AssertEqual(2, result.Count, "codex imported record count");
         AssertEqual("acct_codex_primary", result[0].ProviderAccountId, "codex account id");
         AssertEqual(sessionId, result[0].SessionId, "codex session id");
+        AssertEqual("Audit usage context", result[0].ConversationTitle, "codex session title");
+        AssertEqual(@"C:\Support\GitHub\IntelligenceX", result[0].WorkspacePath, "codex workspace path");
+        AssertEqual("EvotecIT/IntelligenceX", result[0].RepositoryName, "codex repository name");
         AssertEqual("gpt-5.3-codex", result[0].Model, "codex model");
         AssertEqual("cli", result[0].Surface, "codex surface");
         AssertEqual(8509L, result[0].InputTokens, "codex first input");

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -29,6 +29,8 @@ internal static partial class Program {
         failed += Run("EasySession forwards usage telemetry settings", TestEasySessionBuildClientOptionsCarriesUsageTelemetrySettings);
         failed += Run("Usage telemetry stable source root id normalizes paths", TestUsageTelemetryStableSourceRootIdNormalizesPaths);
         failed += Run("Usage telemetry dedupe prefers account session turn", TestUsageTelemetryDedupePrefersAccountSessionTurn);
+        failed += Run("Usage conversation summary builder groups raw conversation rows",
+            TestUsageConversationSummaryBuilderGroupsRawConversationRows);
         failed += Run("Usage telemetry store merges response duplicates", TestUsageTelemetryStoreMergesResponseDuplicates);
         failed += Run("Usage telemetry source root store orders roots", TestUsageTelemetrySourceRootStoreOrdersRoots);
         failed += Run("Usage telemetry sqlite store merges response duplicates", TestUsageTelemetrySqliteStoreMergesResponseDuplicates);
@@ -127,6 +129,8 @@ internal static partial class Program {
             TestGitHubWrappedCardHtmlRendererBuildsCompactCard);
         failed += Run("Usage overview html renderer builds provider diagnostics",
             TestUsageTelemetryOverviewHtmlRendererBuildsProviderDiagnostics);
+        failed += Run("Usage overview html renderer builds conversation pulse",
+            TestUsageTelemetryOverviewHtmlRendererBuildsConversationPulse);
         failed += Run("Popup placement math converts pixels to DIPs",
             TestPopupPlacementMathConvertsPixelsToDips);
         failed += Run("Popup placement math clamps within work area",

--- a/IntelligenceX.Tray/Services/TrayUsageSnapshotStore.cs
+++ b/IntelligenceX.Tray/Services/TrayUsageSnapshotStore.cs
@@ -34,6 +34,9 @@ public sealed class TrayUsageSnapshotStore {
                 .Cast<SourceRootRecord>()
                 .ToList();
             var events = persisted.Events.Select(static item => item.ToUsageEvent()).ToList();
+            var rawEvents = persisted.RawEvents.Count > 0
+                ? persisted.RawEvents.Select(static item => item.ToUsageEvent()).ToList()
+                : events;
             var discoveredProviderIds = persisted.DiscoveredProviderIds
                 .Where(static item => !string.IsNullOrWhiteSpace(item))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -43,6 +46,7 @@ public sealed class TrayUsageSnapshotStore {
                 discoveredProviderIds,
                 sourceRoots,
                 events,
+                rawEvents,
                 persisted.Health?.ToSnapshotHealth()
                 ?? BuildFallbackHealth(sourceRoots, events, discoveredProviderIds));
         } catch {
@@ -55,7 +59,8 @@ public sealed class TrayUsageSnapshotStore {
         IReadOnlyList<UsageEventRecord> events,
         IReadOnlyList<string>? discoveredProviderIds = null,
         IReadOnlyList<SourceRootRecord>? sourceRoots = null,
-        UsageTelemetrySnapshotHealth? health = null) {
+        UsageTelemetrySnapshotHealth? health = null,
+        IReadOnlyList<UsageEventRecord>? rawEvents = null) {
         ArgumentNullException.ThrowIfNull(events);
         if (events.Count == 0) {
             return;
@@ -77,6 +82,7 @@ public sealed class TrayUsageSnapshotStore {
                 .Select(static item => PersistedSourceRoot.FromSourceRoot(item))
                 .ToList(),
             Events = events.Select(static item => PersistedUsageEvent.FromUsageEvent(item)).ToList(),
+            RawEvents = (rawEvents ?? events).Select(static item => PersistedUsageEvent.FromUsageEvent(item)).ToList(),
             Health = health is null ? null : PersistedSnapshotHealth.FromSnapshotHealth(health)
         };
         var json = JsonSerializer.Serialize(payload, SerializerOptions);
@@ -88,6 +94,7 @@ public sealed class TrayUsageSnapshotStore {
         List<string> DiscoveredProviderIds,
         List<SourceRootRecord> SourceRoots,
         List<UsageEventRecord> Events,
+        List<UsageEventRecord> RawEvents,
         UsageTelemetrySnapshotHealth? Health);
 
     private sealed class PersistedUsageSnapshot {
@@ -95,6 +102,7 @@ public sealed class TrayUsageSnapshotStore {
         public List<string> DiscoveredProviderIds { get; set; } = [];
         public List<PersistedSourceRoot> SourceRoots { get; set; } = [];
         public List<PersistedUsageEvent> Events { get; set; } = [];
+        public List<PersistedUsageEvent> RawEvents { get; set; } = [];
         public PersistedSnapshotHealth? Health { get; set; }
     }
 
@@ -305,6 +313,9 @@ public sealed class TrayUsageSnapshotStore {
         public string? MachineId { get; set; }
         public string? SessionId { get; set; }
         public string? ThreadId { get; set; }
+        public string? ConversationTitle { get; set; }
+        public string? WorkspacePath { get; set; }
+        public string? RepositoryName { get; set; }
         public string? TurnId { get; set; }
         public string? ResponseId { get; set; }
         public string? Model { get; set; }
@@ -314,6 +325,7 @@ public sealed class TrayUsageSnapshotStore {
         public long? OutputTokens { get; set; }
         public long? ReasoningTokens { get; set; }
         public long? TotalTokens { get; set; }
+        public int? CompactCount { get; set; }
         public long? DurationMs { get; set; }
         public decimal? CostUsd { get; set; }
         public UsageTruthLevel TruthLevel { get; set; }
@@ -332,6 +344,9 @@ public sealed class TrayUsageSnapshotStore {
                 MachineId = usageEvent.MachineId,
                 SessionId = usageEvent.SessionId,
                 ThreadId = usageEvent.ThreadId,
+                ConversationTitle = usageEvent.ConversationTitle,
+                WorkspacePath = usageEvent.WorkspacePath,
+                RepositoryName = usageEvent.RepositoryName,
                 TurnId = usageEvent.TurnId,
                 ResponseId = usageEvent.ResponseId,
                 Model = usageEvent.Model,
@@ -341,6 +356,7 @@ public sealed class TrayUsageSnapshotStore {
                 OutputTokens = usageEvent.OutputTokens,
                 ReasoningTokens = usageEvent.ReasoningTokens,
                 TotalTokens = usageEvent.TotalTokens,
+                CompactCount = usageEvent.CompactCount,
                 DurationMs = usageEvent.DurationMs,
                 CostUsd = usageEvent.CostUsd,
                 TruthLevel = usageEvent.TruthLevel,
@@ -356,6 +372,9 @@ public sealed class TrayUsageSnapshotStore {
                 MachineId = MachineId,
                 SessionId = SessionId,
                 ThreadId = ThreadId,
+                ConversationTitle = ConversationTitle,
+                WorkspacePath = WorkspacePath,
+                RepositoryName = RepositoryName,
                 TurnId = TurnId,
                 ResponseId = ResponseId,
                 Model = Model,
@@ -365,6 +384,7 @@ public sealed class TrayUsageSnapshotStore {
                 OutputTokens = OutputTokens,
                 ReasoningTokens = ReasoningTokens,
                 TotalTokens = TotalTokens,
+                CompactCount = CompactCount,
                 DurationMs = DurationMs,
                 CostUsd = CostUsd,
                 TruthLevel = TruthLevel,

--- a/IntelligenceX.Tray/ViewModels/ConversationUsageViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/ConversationUsageViewModel.cs
@@ -1,0 +1,25 @@
+namespace IntelligenceX.Tray.ViewModels;
+
+public sealed class ConversationUsageViewModel {
+    public string ConversationKey { get; set; } = string.Empty;
+    public string ProviderText { get; set; } = string.Empty;
+    public string SessionText { get; set; } = string.Empty;
+    public string TitleText { get; set; } = string.Empty;
+    public string WorkspaceText { get; set; } = string.Empty;
+    public string RepositoryText { get; set; } = string.Empty;
+    public string AccountText { get; set; } = string.Empty;
+    public string StartedText { get; set; } = string.Empty;
+    public string LastSeenText { get; set; } = string.Empty;
+    public string DurationText { get; set; } = string.Empty;
+    public string ActiveDurationText { get; set; } = string.Empty;
+    public string TurnsText { get; set; } = string.Empty;
+    public string TokensText { get; set; } = string.Empty;
+    public string InputText { get; set; } = string.Empty;
+    public string OutputText { get; set; } = string.Empty;
+    public string CachedText { get; set; } = string.Empty;
+    public string ReasoningText { get; set; } = string.Empty;
+    public string CostText { get; set; } = string.Empty;
+    public string ModelsText { get; set; } = string.Empty;
+    public string SurfaceText { get; set; } = string.Empty;
+    public string CompactCountText { get; set; } = "--";
+}

--- a/IntelligenceX.Tray/ViewModels/MainViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/MainViewModel.cs
@@ -496,6 +496,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
             var refreshData = await Task.Run(async () => {
                 var snapshot = await _usageService.ScanAsync(progress: scanProgress, startupWarmup: startupWarmup);
                 var events = snapshot.Events;
+                var rawEvents = snapshot.RawEvents.Count > 0 ? snapshot.RawEvents : snapshot.Events;
 
                 var byProvider = events
                     .GroupBy(e => e.ProviderId?.Trim()?.ToLowerInvariant() ?? "unknown")
@@ -503,7 +504,15 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
                     .OrderBy(g => ProviderMetadata.Resolve(g.Key).SortOrder)
                     .ToList();
 
-                var info = $"{events.Count} events, {byProvider.Count} providers";
+                var rawByProvider = rawEvents
+                    .GroupBy(e => e.ProviderId?.Trim()?.ToLowerInvariant() ?? "unknown")
+                    .Where(g => !string.IsNullOrWhiteSpace(g.Key))
+                    .ToDictionary(
+                        static group => group.Key,
+                        static group => group.ToList(),
+                        StringComparer.OrdinalIgnoreCase);
+
+                var info = $"{events.Count} rollups, {byProvider.Count} providers";
                 if (snapshot.ScanDurationMs > 0) {
                     info += $" ({snapshot.ScanDurationMs / 1000.0:F1}s)";
                 }
@@ -514,7 +523,11 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
 
                 return new RefreshComputationResult(
                     events.ToList(),
-                    byProvider.Select(group => new ProviderRefreshData(group.Key, group.ToList())).ToList(),
+                    rawEvents.ToList(),
+                    byProvider.Select(group => new ProviderRefreshData(
+                        group.Key,
+                        group.ToList(),
+                        rawByProvider.TryGetValue(group.Key, out var providerRawEvents) ? providerRawEvents : [])).ToList(),
                     snapshot.ScannedAtUtc,
                     info,
                     snapshot.DiscoveredProviderIds,
@@ -567,7 +580,8 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
                 refreshData.AllEvents,
                 refreshData.DiscoveredProviderIds,
                 refreshData.SourceRoots,
-                refreshData.Health);
+                refreshData.Health,
+                refreshData.RawEvents);
 
             _previousProviderSnapshots = new Dictionary<string, ProviderRefreshSnapshot>(currentProviderSnapshots, StringComparer.OrdinalIgnoreCase);
             if (!startupWarmup) {
@@ -1576,6 +1590,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
                 serviceSnapshot.DiscoveredProviderIds.ToList(),
                 serviceSnapshot.SourceRoots.ToList(),
                 serviceSnapshot.Events.ToList(),
+                serviceSnapshot.RawEvents.ToList(),
                 serviceSnapshot.Health);
             if (ShouldPreferCachedSnapshot(serviceCache, cachedSnapshot)) {
                 cachedSnapshot = serviceCache;
@@ -1584,7 +1599,8 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
                     serviceSnapshot.Events,
                     serviceSnapshot.DiscoveredProviderIds,
                     serviceSnapshot.SourceRoots,
-                    serviceSnapshot.Health);
+                    serviceSnapshot.Health,
+                    serviceSnapshot.RawEvents);
             }
         }
 
@@ -1596,7 +1612,12 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
             .GroupBy(e => e.ProviderId?.Trim()?.ToLowerInvariant() ?? "unknown")
             .Where(static group => !string.IsNullOrWhiteSpace(group.Key))
             .OrderBy(group => ProviderMetadata.Resolve(group.Key).SortOrder)
-            .Select(group => new ProviderRefreshData(group.Key, group.ToList()))
+            .Select(group => new ProviderRefreshData(
+                group.Key,
+                group.ToList(),
+                cachedSnapshot.RawEvents
+                    .Where(rawEvent => string.Equals(rawEvent.ProviderId, group.Key, StringComparison.OrdinalIgnoreCase))
+                    .ToList()))
             .ToList();
         var mergedProviderData = BuildMergedProviderData(byProvider, cachedSnapshot.DiscoveredProviderIds);
         var providerSnapshots = mergedProviderData.ToDictionary(
@@ -1685,14 +1706,14 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         }
 
         var currentProviderData = _displayedProviderEvents
-            .Select(static pair => new ProviderRefreshData(pair.Key, pair.Value))
+            .Select(static pair => new ProviderRefreshData(pair.Key, pair.Value, pair.Value))
             .ToList();
         foreach (var (providerId, events) in providerEventsById) {
             var existingIndex = currentProviderData.FindIndex(group => string.Equals(group.ProviderId, providerId, StringComparison.OrdinalIgnoreCase));
             if (existingIndex >= 0) {
-                currentProviderData[existingIndex] = new ProviderRefreshData(providerId, events);
+                currentProviderData[existingIndex] = new ProviderRefreshData(providerId, events, events);
             } else {
-                currentProviderData.Add(new ProviderRefreshData(providerId, events));
+                currentProviderData.Add(new ProviderRefreshData(providerId, events, events));
             }
         }
 
@@ -1746,7 +1767,10 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         var newProviders = new List<ProviderViewModel>();
         var shouldShowCombinedProvider = providerData.Count > 0 || allEvents.Count > 0;
         if (shouldShowCombinedProvider) {
-            var allVm = BuildCombinedProviderViewModel(allEvents, scannedAtUtc);
+            var allVm = BuildCombinedProviderViewModel(
+                allEvents,
+                providerData.SelectMany(static group => group.RawEvents).ToList(),
+                scannedAtUtc);
             ApplyUsageHealth(allVm, usageHealth, providerId: null);
             allVm.ApplyUsageScopeSummary(null);
             allVm.ApplyRefreshDelta(
@@ -1757,7 +1781,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         }
 
         foreach (var group in providerData) {
-            var vm = BuildProviderViewModel(group.ProviderId, group.Events);
+            var vm = BuildProviderViewModel(group.ProviderId, group.Events, group.RawEvents);
             vm.LastUpdated = scannedAtUtc;
             vm.IsFavorite = IsFavoriteProvider(group.ProviderId);
             ApplyUsageHealth(vm, usageHealth, group.ProviderId);
@@ -1810,16 +1834,20 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         RefreshProviderSelectionState();
     }
 
-    private static ProviderViewModel BuildProviderViewModel(string providerId, List<UsageEventRecord> events) {
+    private static ProviderViewModel BuildProviderViewModel(string providerId, List<UsageEventRecord> events, List<UsageEventRecord>? rawEvents = null) {
         var vm = new ProviderViewModel();
         var info = ProviderMetadata.Resolve(providerId);
         vm.ApplyProviderInfo(info);
         vm.ApplyUsageEvents(events);
+        vm.ApplyConversationEvents(rawEvents ?? events);
         return vm;
     }
 
-    private static ProviderViewModel BuildCombinedProviderViewModel(List<UsageEventRecord> events, DateTimeOffset scannedAtUtc) {
-        var allVm = BuildProviderViewModel("__all__", events);
+    private static ProviderViewModel BuildCombinedProviderViewModel(
+        List<UsageEventRecord> events,
+        List<UsageEventRecord> rawEvents,
+        DateTimeOffset scannedAtUtc) {
+        var allVm = BuildProviderViewModel("__all__", events, rawEvents);
         allVm.DisplayName = "All";
         allVm.ShortName = "All";
         allVm.IconKey = "IconIx";
@@ -1900,7 +1928,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
 
     private static string BuildOverallUsageHealthDetail(UsageTelemetrySnapshotHealth health) {
         var parts = new List<string> {
-            health.EventsCount.ToString(CultureInfo.InvariantCulture) + " events"
+            health.EventsCount.ToString(CultureInfo.InvariantCulture) + " rollups"
         };
         if (health.ReusedArtifacts > 0) {
             parts.Add(health.ReusedArtifacts.ToString(CultureInfo.InvariantCulture) + " cached artifacts");
@@ -1938,7 +1966,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
 
     private static string BuildProviderUsageHealthDetail(UsageTelemetryProviderHealth providerHealth) {
         var parts = new List<string> {
-            providerHealth.EventsCount.ToString(CultureInfo.InvariantCulture) + " events"
+            providerHealth.EventsCount.ToString(CultureInfo.InvariantCulture) + " rollups"
         };
         if (providerHealth.ReusedArtifacts > 0) {
             parts.Add(providerHealth.ReusedArtifacts.ToString(CultureInfo.InvariantCulture) + " cached artifacts");
@@ -1992,7 +2020,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
 
         return mergedProviderIds
             .Select(providerId => providerData.FirstOrDefault(group => string.Equals(group.ProviderId, providerId, StringComparison.OrdinalIgnoreCase))
-                                  ?? new ProviderRefreshData(providerId, []))
+                                  ?? new ProviderRefreshData(providerId, [], []))
             .ToList();
     }
 
@@ -2085,7 +2113,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
             }
 
             if (eventDelta != 0) {
-                parts.Add(FormatSignedCompact(eventDelta, eventDelta >= 0 ? " events" : " events"));
+                parts.Add(FormatSignedCompact(eventDelta, eventDelta >= 0 ? " rollups" : " rollups"));
             }
 
             if (costDelta != 0m) {
@@ -2207,7 +2235,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         cts?.Dispose();
     }
 
-    private sealed record ProviderRefreshData(string ProviderId, List<UsageEventRecord> Events);
+    private sealed record ProviderRefreshData(string ProviderId, List<UsageEventRecord> Events, List<UsageEventRecord> RawEvents);
 
     private sealed record ProviderRefreshSnapshot(long TotalTokens, int EventCount, decimal CostUsd) {
         public static ProviderRefreshSnapshot FromEvents(IEnumerable<UsageEventRecord> events) {
@@ -2221,6 +2249,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
 
     private sealed record RefreshComputationResult(
         List<UsageEventRecord> AllEvents,
+        List<UsageEventRecord> RawEvents,
         List<ProviderRefreshData> ByProvider,
         DateTimeOffset ScannedAtUtc,
         string ScanInfo,

--- a/IntelligenceX.Tray/ViewModels/ProviderViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/ProviderViewModel.cs
@@ -105,6 +105,9 @@ public sealed class ProviderViewModel : ViewModelBase {
     private string _weeklyLabel = "7 days";
     private string _monthlyLabel = "30 days";
     private readonly List<UsageEventRecord> _usageEvents = [];
+    private readonly List<UsageEventRecord> _conversationEvents = [];
+    private readonly List<UsageConversationSummary> _conversationSummaryData = [];
+    private readonly List<ConversationUsageViewModel> _conversationSummaries = [];
     private ProviderTimeRange _selectedRange = ProviderTimeRange.Today;
     private string _actionStatusMessage = string.Empty;
     private string _selectedAccountFilter = ProviderFilterDefaults.AllAccounts;
@@ -150,6 +153,10 @@ public sealed class ProviderViewModel : ViewModelBase {
         SurfaceBreakdown.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasSurfaceBreakdown));
         ModelDaySummaries.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasModelDaySummaries));
         RecentActivity.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasRecentActivity));
+        Conversations.CollectionChanged += (_, _) => {
+            OnPropertyChanged(nameof(HasConversationStats));
+            OnPropertyChanged(nameof(ConversationStatsSummaryText));
+        };
         ProviderComparison.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasProviderComparison));
         CombinedOverviewCards.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasCombinedOverviewCards));
         CodeChurnBars.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasCodeChurnBars));
@@ -263,7 +270,7 @@ public sealed class ProviderViewModel : ViewModelBase {
                 return "No new activity since the previous refresh.";
             }
 
-            var summary = "+" + NewEventsSinceRefresh.ToString("N0", CultureInfo.CurrentCulture) + " new events";
+            var summary = "+" + NewEventsSinceRefresh.ToString("N0", CultureInfo.CurrentCulture) + " new rollups";
             if (NewTokensSinceRefresh > 0) {
                 summary += " • +" + FormatTokens(NewTokensSinceRefresh) + " tokens";
             }
@@ -490,8 +497,13 @@ public sealed class ProviderViewModel : ViewModelBase {
 
     public int TodayEventCount {
         get => _todayEventCount;
-        set => SetProperty(ref _todayEventCount, value);
+        set {
+            if (SetProperty(ref _todayEventCount, value)) {
+                OnPropertyChanged(nameof(TodayRollupCountText));
+            }
+        }
     }
+    public string TodayRollupCountText => FormatCountLabel(TodayEventCount, "rollup", "rollups");
 
     // -- 7-day --
     public long WeeklyTotalTokens {
@@ -761,6 +773,7 @@ public sealed class ProviderViewModel : ViewModelBase {
     public bool HasSurfaceBreakdown => SurfaceBreakdown.Count > 0;
     public bool HasModelDaySummaries => ModelDaySummaries.Count > 0;
     public bool HasRecentActivity => RecentActivity.Count > 0;
+    public bool HasConversationStats => _conversationSummaryData.Count > 0;
     public bool IsCombinedProvider => string.Equals(ProviderId, "__all__", StringComparison.Ordinal);
     public bool HasProviderComparison => IsCombinedProvider && ProviderComparison.Count > 0;
     public bool HasCombinedOverviewCards => IsCombinedProvider && CombinedOverviewCards.Count > 0;
@@ -795,6 +808,8 @@ public sealed class ProviderViewModel : ViewModelBase {
     public ObservableCollection<ProviderComparisonEntryViewModel> ProviderComparison { get; } = [];
     public ObservableCollection<ProviderOverviewCardViewModel> CombinedOverviewCards { get; } = [];
     public ObservableCollection<RecentUsageItemViewModel> RecentActivity { get; } = [];
+    public ObservableCollection<ConversationUsageViewModel> Conversations { get; } = [];
+    public string ConversationStatsSummaryText => BuildConversationStatsSummaryText();
     public string CodeChurnRepositoryText => NormalizeOptional(_codeChurnSummary.RepositoryName) ?? "Local repository";
     public string CodeChurnAddedText => "+" + FormatTokens(_codeChurnSummary.RecentAddedLines);
     public string CodeChurnDeletedText => "-" + FormatTokens(_codeChurnSummary.RecentDeletedLines);
@@ -840,7 +855,7 @@ public sealed class ProviderViewModel : ViewModelBase {
         }
     }
 
-    public string FilteredEventCountLabel => FilteredEventCount.ToString("N0", CultureInfo.CurrentCulture) + " matching events";
+    public string FilteredEventCountLabel => FormatCountLabel(FilteredEventCount, "matching rollup", "matching rollups");
 
     public RecentUsageItemViewModel? SelectedEvent {
         get => _selectedEvent;
@@ -910,8 +925,17 @@ public sealed class ProviderViewModel : ViewModelBase {
     public void ApplyUsageEvents(IEnumerable<UsageEventRecord> events) {
         _usageEvents.Clear();
         _usageEvents.AddRange(events ?? Array.Empty<UsageEventRecord>());
+        if (_conversationEvents.Count == 0) {
+            _conversationEvents.AddRange(_usageEvents);
+        }
         RebuildFilterOptions();
         RebuildStaticWindows();
+        RebuildSelectedRangeViews();
+    }
+
+    public void ApplyConversationEvents(IEnumerable<UsageEventRecord> events) {
+        _conversationEvents.Clear();
+        _conversationEvents.AddRange(events ?? Array.Empty<UsageEventRecord>());
         RebuildSelectedRangeViews();
     }
 
@@ -1368,6 +1392,7 @@ public sealed class ProviderViewModel : ViewModelBase {
             InputColor);
         PopulateProviderComparison(rangeEvents);
         PopulateCombinedOverview(rangeEvents);
+        PopulateConversationStats(ApplyFilters(GetConversationRangeEvents(SelectedRange)));
         PopulateRecentActivity(rangeEvents);
 
         ActionStatusMessage = string.Empty;
@@ -1539,8 +1564,29 @@ public sealed class ProviderViewModel : ViewModelBase {
         };
     }
 
+    private List<UsageEventRecord> GetConversationRangeEvents(ProviderTimeRange range) {
+        var today = DateTime.Now.Date;
+        return range switch {
+            ProviderTimeRange.Today => FilterConversationByWindow(today, today),
+            ProviderTimeRange.Last7Days => FilterConversationByWindow(today.AddDays(-6), today),
+            ProviderTimeRange.Last30Days => FilterConversationByWindow(today.AddDays(-29), today),
+            ProviderTimeRange.AllTime => _conversationEvents.OrderByDescending(static e => e.TimestampUtc).ToList(),
+            _ => _conversationEvents.OrderByDescending(static e => e.TimestampUtc).ToList()
+        };
+    }
+
     private List<UsageEventRecord> FilterByWindow(DateTime startDay, DateTime endDay) {
         return _usageEvents
+            .Where(e => {
+                var localDay = e.TimestampUtc.ToLocalTime().Date;
+                return localDay >= startDay && localDay <= endDay;
+            })
+            .OrderByDescending(static e => e.TimestampUtc)
+            .ToList();
+    }
+
+    private List<UsageEventRecord> FilterConversationByWindow(DateTime startDay, DateTime endDay) {
+        return _conversationEvents
             .Where(e => {
                 var localDay = e.TimestampUtc.ToLocalTime().Date;
                 return localDay >= startDay && localDay <= endDay;
@@ -1701,6 +1747,25 @@ public sealed class ProviderViewModel : ViewModelBase {
             : RecentActivity.FirstOrDefault();
     }
 
+    private void PopulateConversationStats(IReadOnlyList<UsageEventRecord> events) {
+        Conversations.Clear();
+        _conversationSummaryData.Clear();
+        _conversationSummaries.Clear();
+        var summaries = UsageConversationSummaryBuilder.Build(events).ToList();
+        var viewModels = summaries
+            .Select(static summary => BuildConversationViewModel(summary))
+            .ToList();
+
+        _conversationSummaryData.AddRange(summaries);
+        _conversationSummaries.AddRange(viewModels);
+        foreach (var item in viewModels.Take(10)) {
+            Conversations.Add(item);
+        }
+
+        OnPropertyChanged(nameof(HasConversationStats));
+        OnPropertyChanged(nameof(ConversationStatsSummaryText));
+    }
+
     private void PopulateProviderComparison(IReadOnlyList<UsageEventRecord> events) {
         ProviderComparison.Clear();
         if (!IsCombinedProvider) {
@@ -1750,7 +1815,7 @@ public sealed class ProviderViewModel : ViewModelBase {
                 ShortName = group.Info.ShortName,
                 TokensText = FormatTokens(group.Tokens),
                 CostText = FormatCostDisplay(group.CostRollup.TotalCostUsd, group.CostRollup.UsesEstimatedFallback),
-                EventCountText = group.Events.ToString("N0", CultureInfo.CurrentCulture) + " events",
+                EventCountText = FormatCountLabel(group.Events, "rollup", "rollups"),
                 HealthText = healthInfo?.SummaryText ?? "Usage snapshot only",
                 HealthBrush = healthInfo?.SummaryBrush ?? FrozenBrush(Color.FromRgb(144, 144, 184)),
                 DeltaText = deltaInfo?.SummaryText ?? "No previous refresh baseline",
@@ -1793,7 +1858,7 @@ public sealed class ProviderViewModel : ViewModelBase {
                 : "Top: "
                   + leadingProvider.Info.DisplayName
                   + " • " + FormatTokens(leadingProvider.Tokens)
-                  + " • " + leadingProvider.Events.ToString("N0", CultureInfo.CurrentCulture) + " events",
+                  + " • " + FormatCountLabel(leadingProvider.Events, "rollup", "rollups"),
             AccentBrush = FrozenBrush(leadingProvider is null ? TotalColor : leadingProvider.Info.TotalColor)
         });
 
@@ -2130,7 +2195,7 @@ public sealed class ProviderViewModel : ViewModelBase {
 
     private Task ApplySelectedEventFilterAsync(FilterDimension dimension) {
         if (SelectedEvent is null) {
-            ActionStatusMessage = "Select an event first.";
+            ActionStatusMessage = "Select a rollup first.";
             return Task.CompletedTask;
         }
 
@@ -2153,7 +2218,7 @@ public sealed class ProviderViewModel : ViewModelBase {
         };
 
         if (string.IsNullOrWhiteSpace(value) || value.StartsWith("Unknown ", StringComparison.OrdinalIgnoreCase)) {
-            ActionStatusMessage = "The selected event does not include a usable " + dimensionLabel + ".";
+            ActionStatusMessage = "The selected rollup does not include a usable " + dimensionLabel + ".";
             return Task.CompletedTask;
         }
 
@@ -2176,13 +2241,13 @@ public sealed class ProviderViewModel : ViewModelBase {
                 $"{DisplayName} usage summary",
                 $"Range: {TodayLabel}",
                 $"Filters: {BuildFilterSummary()}",
-                $"Events: {TodayEventCount}",
+                $"Rollups: {TodayEventCount}",
                 $"Tokens: {TodayTotalTokensFormatted}",
                 $"Input: {TodayInputTokensFormatted}",
                 $"Output: {TodayOutputTokensFormatted}",
                 $"Cached: {TodayCachedTokensFormatted}",
                 $"Reasoning: {TodayReasoningTokensFormatted}",
-                $"Cost: {TodayCostFormatted}"
+                $"API equivalent: {TodayCostFormatted}"
             };
 
             if (HasSurfaceBreakdown) {
@@ -2203,6 +2268,41 @@ public sealed class ProviderViewModel : ViewModelBase {
             if (HasModelDaySummaries) {
                 lines.Add("Local models by day:");
                 lines.AddRange(ModelDaySummaries.Select(entry => $"  {entry.DayLabel}: {entry.TotalTokensText} • {entry.ModelsText}"));
+            }
+
+            if (_conversationSummaryData.Count > 0) {
+                var compactCount = _conversationSummaryData.Sum(static conversation => conversation.CompactCount);
+                lines.Add("Conversations:");
+                lines.Add("  " + FormatCountLabel(_conversationSummaryData.Count, "conversation", "conversations"));
+                lines.Add("  " + FormatCountLabel(_conversationSummaryData.Sum(static conversation => conversation.TurnCount), "turn", "turns"));
+                if (compactCount > 0) {
+                    lines.Add("  " + FormatCountLabel(compactCount, "compact", "compacts"));
+                }
+
+                lines.Add("Top conversations:");
+                lines.AddRange(_conversationSummaryData
+                    .Take(5)
+                    .Select(static conversation => {
+                        var parts = new List<string> {
+                            FormatTokens(conversation.TotalTokens),
+                            "span " + HeatmapDisplayText.FormatDuration(conversation.Duration),
+                            "active " + HeatmapDisplayText.FormatDuration(conversation.ActiveDuration),
+                            FormatCountLabel(conversation.TurnCount, "turn", "turns")
+                        };
+                        if (conversation.CompactCount > 0) {
+                            parts.Add(FormatCountLabel(conversation.CompactCount, "compact", "compacts"));
+                        }
+                        if (conversation.Models.Count > 0) {
+                            parts.Add(string.Join(", ", conversation.Models));
+                        }
+                        var contextLabel = conversation.RepositoryName ?? conversation.WorkspaceName;
+                        if (!string.IsNullOrWhiteSpace(contextLabel)) {
+                            parts.Add(contextLabel);
+                        }
+
+                        var title = conversation.ConversationTitle ?? FormatSessionSnippet(conversation.SessionId);
+                        return "  " + title + ": " + string.Join(" • ", parts);
+                    }));
             }
 
             if (HasDataScopeSection) {
@@ -2248,13 +2348,13 @@ public sealed class ProviderViewModel : ViewModelBase {
 
     private Task CopySelectedEventAsync() {
         if (SelectedEvent is null) {
-            ActionStatusMessage = "Select an event first.";
+            ActionStatusMessage = "Select a rollup first.";
             return Task.CompletedTask;
         }
 
         try {
             var lines = new List<string> {
-                $"{DisplayName} event details",
+                $"{DisplayName} rollup details",
                 $"Model: {SelectedEvent.ModelText}",
                 $"Surface: {SelectedEvent.SurfaceText}",
                 $"Account: {SelectedEvent.AccountText}",
@@ -2265,11 +2365,11 @@ public sealed class ProviderViewModel : ViewModelBase {
                 $"Output: {SelectedEvent.OutputText}",
                 $"Cached: {SelectedEvent.CachedText}",
                 $"Reasoning: {SelectedEvent.ReasoningText}",
-                $"Cost: {SelectedEvent.CostText}"
+                $"API equivalent: {SelectedEvent.CostText}"
             };
 
             Clipboard.SetText(string.Join(Environment.NewLine, lines));
-            ActionStatusMessage = "Copied selected event details to clipboard.";
+            ActionStatusMessage = "Copied selected rollup details to clipboard.";
         } catch (Exception ex) {
             ActionStatusMessage = "Copy failed: " + ex.Message;
         }
@@ -2279,7 +2379,7 @@ public sealed class ProviderViewModel : ViewModelBase {
 
     private Task CopySelectedEventJsonAsync() {
         if (SelectedEvent is null) {
-            ActionStatusMessage = "Select an event first.";
+            ActionStatusMessage = "Select a rollup first.";
             return Task.CompletedTask;
         }
 
@@ -2296,13 +2396,13 @@ public sealed class ProviderViewModel : ViewModelBase {
                 outputTokens = SelectedEvent.OutputText,
                 cachedTokens = SelectedEvent.CachedText,
                 reasoningTokens = SelectedEvent.ReasoningText,
-                cost = SelectedEvent.CostText
+                apiEquivalentCost = SelectedEvent.CostText
             };
 
             Clipboard.SetText(JsonSerializer.Serialize(payload, new JsonSerializerOptions {
                 WriteIndented = true
             }));
-            ActionStatusMessage = "Copied selected event JSON to clipboard.";
+            ActionStatusMessage = "Copied selected rollup JSON to clipboard.";
         } catch (Exception ex) {
             ActionStatusMessage = "JSON copy failed: " + ex.Message;
         }
@@ -2331,13 +2431,13 @@ public sealed class ProviderViewModel : ViewModelBase {
                     surface = SelectedSurfaceFilter
                 },
                 summary = new {
-                    events = TodayEventCount,
+                    rollups = TodayEventCount,
                     totalTokens = TodayTotalTokens,
                     inputTokens = TodayInputTokens,
                     outputTokens = TodayOutputTokens,
                     cachedTokens = TodayCachedTokens,
                     reasoningTokens = TodayReasoningTokens,
-                    costUsd = TodayCostUsd,
+                    apiEquivalentCostUsd = TodayCostUsd,
                     costApproximate = TodayCostUsesEstimate
                 },
                 dataScope = HasDataScopeSection
@@ -2380,7 +2480,38 @@ public sealed class ProviderViewModel : ViewModelBase {
                     totalTokens = entry.TotalTokensText,
                     models = entry.ModelsText
                 }),
-                events = events.Select(e => {
+                conversations = _conversationSummaryData.Select(conversation => new {
+                    conversationKey = conversation.ConversationKey,
+                    providerId = conversation.ProviderId,
+                    provider = UsageTelemetryProviderCatalog.ResolveDisplayTitle(conversation.ProviderId),
+                    providerAccountId = conversation.ProviderAccountId,
+                    account = conversation.AccountLabel,
+                    sessionId = conversation.SessionId,
+                    title = conversation.ConversationTitle,
+                    workspacePath = conversation.WorkspacePath,
+                    workspace = conversation.WorkspaceName,
+                    repository = conversation.RepositoryName,
+                    startedLocal = conversation.StartedUtc.ToLocalTime().ToString("O", CultureInfo.InvariantCulture),
+                    startedUtc = conversation.StartedUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
+                    lastSeenLocal = conversation.LastSeenUtc.ToLocalTime().ToString("O", CultureInfo.InvariantCulture),
+                    lastSeenUtc = conversation.LastSeenUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
+                    durationMs = (long)conversation.Duration.TotalMilliseconds,
+                    duration = HeatmapDisplayText.FormatDuration(conversation.Duration),
+                    activeDurationMs = (long)conversation.ActiveDuration.TotalMilliseconds,
+                    activeDuration = HeatmapDisplayText.FormatDuration(conversation.ActiveDuration),
+                    turnCount = conversation.TurnCount,
+                    compactCount = conversation.CompactCount,
+                    models = conversation.Models,
+                    surfaces = conversation.Surfaces,
+                    inputTokens = conversation.InputTokens,
+                    outputTokens = conversation.OutputTokens,
+                    cachedTokens = conversation.CachedInputTokens,
+                    reasoningTokens = conversation.ReasoningTokens,
+                    totalTokens = conversation.TotalTokens,
+                    apiEquivalentCostUsd = conversation.CostUsd,
+                    costApproximate = conversation.CostUsesEstimatedFallback
+                }),
+                rollups = events.Select(e => {
                     var displayCost = UsageTelemetryApiPricing.BuildDisplayCost(e);
                     return new {
                         timestampLocal = e.TimestampUtc.ToLocalTime().ToString("O", CultureInfo.InvariantCulture),
@@ -2393,7 +2524,7 @@ public sealed class ProviderViewModel : ViewModelBase {
                         cachedTokens = e.CachedInputTokens,
                         reasoningTokens = e.ReasoningTokens,
                         totalTokens = e.TotalTokens,
-                        costUsd = displayCost.TotalCostUsd,
+                        apiEquivalentCostUsd = displayCost.TotalCostUsd,
                         costApproximate = displayCost.UsesEstimatedFallback
                     };
                 })
@@ -2420,7 +2551,7 @@ public sealed class ProviderViewModel : ViewModelBase {
             }
 
             var builder = new StringBuilder();
-            builder.AppendLine("timestamp_local,timestamp_utc,account,model,surface,input_tokens,output_tokens,cached_tokens,reasoning_tokens,total_tokens,cost_usd");
+            builder.AppendLine("timestamp_local,timestamp_utc,account,model,surface,input_tokens,output_tokens,cached_tokens,reasoning_tokens,total_tokens,api_equivalent_cost_usd");
             foreach (var usageEvent in ApplyFilters(GetRangeEvents(SelectedRange))) {
                 builder.AppendLine(string.Join(",",
                     EscapeCsv(usageEvent.TimestampUtc.ToLocalTime().ToString("O", CultureInfo.InvariantCulture)),
@@ -2436,6 +2567,41 @@ public sealed class ProviderViewModel : ViewModelBase {
                     EscapeCsv(FormatExportCost(usageEvent))));
             }
 
+            if (_conversationSummaryData.Count > 0) {
+                builder.AppendLine();
+                builder.AppendLine("conversation_key,provider,provider_id,account,provider_account_id,session_id,title,workspace_path,workspace,repository,started_local,started_utc,last_seen_local,last_seen_utc,duration_ms,active_duration_ms,turn_count,compact_count,models,surfaces,input_tokens,output_tokens,cached_tokens,reasoning_tokens,total_tokens,api_equivalent_cost_usd,cost_approximate");
+                foreach (var conversation in _conversationSummaryData) {
+                    builder.AppendLine(string.Join(",",
+                        EscapeCsv(conversation.ConversationKey),
+                        EscapeCsv(UsageTelemetryProviderCatalog.ResolveDisplayTitle(conversation.ProviderId)),
+                        EscapeCsv(conversation.ProviderId),
+                        EscapeCsv(conversation.AccountLabel),
+                        EscapeCsv(conversation.ProviderAccountId),
+                        EscapeCsv(conversation.SessionId),
+                        EscapeCsv(conversation.ConversationTitle),
+                        EscapeCsv(conversation.WorkspacePath),
+                        EscapeCsv(conversation.WorkspaceName),
+                        EscapeCsv(conversation.RepositoryName),
+                        EscapeCsv(conversation.StartedUtc.ToLocalTime().ToString("O", CultureInfo.InvariantCulture)),
+                        EscapeCsv(conversation.StartedUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture)),
+                        EscapeCsv(conversation.LastSeenUtc.ToLocalTime().ToString("O", CultureInfo.InvariantCulture)),
+                        EscapeCsv(conversation.LastSeenUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture)),
+                        EscapeCsv((long)conversation.Duration.TotalMilliseconds),
+                        EscapeCsv((long)conversation.ActiveDuration.TotalMilliseconds),
+                        EscapeCsv(conversation.TurnCount),
+                        EscapeCsv(conversation.CompactCount),
+                        EscapeCsv(string.Join(" | ", conversation.Models)),
+                        EscapeCsv(string.Join(" | ", conversation.Surfaces)),
+                        EscapeCsv(conversation.InputTokens),
+                        EscapeCsv(conversation.OutputTokens),
+                        EscapeCsv(conversation.CachedInputTokens),
+                        EscapeCsv(conversation.ReasoningTokens),
+                        EscapeCsv(conversation.TotalTokens),
+                        EscapeCsv(FormatExportCost(conversation.CostUsd, conversation.CostUsesEstimatedFallback)),
+                        EscapeCsv(conversation.CostUsesEstimatedFallback)));
+                }
+            }
+
             await File.WriteAllTextAsync(dialog.FileName, builder.ToString()).ConfigureAwait(true);
             ActionStatusMessage = "Exported CSV to " + dialog.FileName;
         } catch (Exception ex) {
@@ -2447,7 +2613,7 @@ public sealed class ProviderViewModel : ViewModelBase {
         try {
             var events = ApplyFilters(GetRangeEvents(SelectedRange));
             if (events.Count == 0) {
-                ActionStatusMessage = "No events are available for the current range and filters.";
+                ActionStatusMessage = "No rollups are available for the current range and filters.";
                 return;
             }
 
@@ -2493,7 +2659,7 @@ public sealed class ProviderViewModel : ViewModelBase {
             parts.Add(FormatCostDisplay(displayCost.TotalCostUsd, displayCost.UsesEstimatedFallback));
         }
 
-        return parts.Count == 0 ? "No token or cost data" : string.Join(" • ", parts);
+        return parts.Count == 0 ? "No token or API-equivalent cost data" : string.Join(" • ", parts);
     }
 
     private static string BuildEventKey(UsageEventRecord usageEvent) {
@@ -2506,16 +2672,84 @@ public sealed class ProviderViewModel : ViewModelBase {
             FormatExportCost(usageEvent));
     }
 
+    private static string FormatSessionSnippet(string value) {
+        var normalized = NormalizeOptional(value) ?? "unknown-session";
+        if (normalized.Length <= 18) {
+            return normalized;
+        }
+
+        return normalized[..8] + "..." + normalized[^6..];
+    }
+
+    private static ConversationUsageViewModel BuildConversationViewModel(UsageConversationSummary summary) {
+        var models = summary.Models.Count == 0 ? "Unknown model" : string.Join(", ", summary.Models);
+        var surfaces = summary.Surfaces.Count == 0 ? "Unknown surface" : string.Join(", ", summary.Surfaces);
+
+        return new ConversationUsageViewModel {
+            ConversationKey = summary.ConversationKey,
+            ProviderText = UsageTelemetryProviderCatalog.ResolveDisplayTitle(summary.ProviderId),
+            SessionText = FormatSessionSnippet(summary.SessionId),
+            TitleText = summary.ConversationTitle ?? "Untitled session",
+            WorkspaceText = summary.WorkspaceName ?? "Unknown workspace",
+            RepositoryText = summary.RepositoryName ?? summary.WorkspaceName ?? "Unknown repo",
+            AccountText = summary.AccountLabel ?? summary.ProviderAccountId ?? "Unknown account",
+            StartedText = summary.StartedUtc.ToLocalTime().ToString("MMM d HH:mm", CultureInfo.CurrentCulture),
+            LastSeenText = summary.LastSeenUtc.ToLocalTime().ToString("MMM d HH:mm", CultureInfo.CurrentCulture),
+            DurationText = HeatmapDisplayText.FormatDuration(summary.Duration),
+            ActiveDurationText = HeatmapDisplayText.FormatDuration(summary.ActiveDuration),
+            TurnsText = FormatCountLabel(summary.TurnCount, "turn", "turns"),
+            TokensText = FormatTokens(summary.TotalTokens),
+            InputText = FormatTokens(summary.InputTokens),
+            OutputText = FormatTokens(summary.OutputTokens),
+            CachedText = FormatTokens(summary.CachedInputTokens),
+            ReasoningText = FormatTokens(summary.ReasoningTokens),
+            CostText = FormatCostDisplay(summary.CostUsd, summary.CostUsesEstimatedFallback),
+            ModelsText = models,
+            SurfaceText = surfaces,
+            CompactCountText = summary.CompactCount > 0
+                ? summary.CompactCount.ToString("N0", CultureInfo.CurrentCulture)
+                : "0"
+        };
+    }
+
+    private string BuildConversationStatsSummaryText() {
+        if (_conversationSummaryData.Count == 0) {
+            return "No per-conversation rows are available for this range.";
+        }
+
+        var turnCount = _conversationSummaryData.Sum(static conversation => conversation.TurnCount);
+        var compactCount = _conversationSummaryData.Sum(static conversation => conversation.CompactCount);
+        var tokenCount = _conversationSummaryData.Sum(static conversation => conversation.TotalTokens);
+        var summaryParts = new List<string> {
+            FormatTokens(tokenCount),
+            FormatCountLabel(turnCount, "turn", "turns")
+        };
+        if (compactCount > 0) {
+            summaryParts.Add(FormatCountLabel(compactCount, "compact", "compacts"));
+        }
+
+        var summarySuffix = " • " + string.Join(" • ", summaryParts);
+        if (_conversationSummaryData.Count == Conversations.Count) {
+            return FormatCountLabel(Conversations.Count, "conversation", "conversations")
+                   + summarySuffix;
+        }
+
+        return Conversations.Count.ToString("N0", CultureInfo.CurrentCulture)
+               + " of "
+               + FormatCountLabel(_conversationSummaryData.Count, "conversation", "conversations")
+               + summarySuffix
+               + "; exports include all.";
+    }
+
     private static string? NormalizeOptional(string? value) {
         var trimmed = value?.Trim();
         return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
     }
 
     private JsonObject? BuildReportMetadata() {
-        if (!HasUsageHealthSection) {
-            if (!HasDataScopeSection) {
-                return null;
-            }
+        var hasConversationSummary = _conversationSummaryData.Count > 0;
+        if (!HasUsageHealthSection && !HasDataScopeSection && !hasConversationSummary) {
+            return null;
         }
 
         var metadata = new JsonObject();
@@ -2549,7 +2783,69 @@ public sealed class ProviderViewModel : ViewModelBase {
             metadata.Add("dataScope", dataScope);
         }
 
+        if (hasConversationSummary) {
+            metadata.Add("conversations", BuildReportConversationMetadata());
+        }
+
         return metadata;
+    }
+
+    private JsonObject BuildReportConversationMetadata() {
+        var conversations = _conversationSummaryData;
+        var items = new JsonArray();
+        foreach (var conversation in conversations.Take(25)) {
+            var models = new JsonArray();
+            foreach (var model in conversation.Models) {
+                models.Add(model);
+            }
+
+            var surfaces = new JsonArray();
+            foreach (var surface in conversation.Surfaces) {
+                surfaces.Add(surface);
+            }
+
+            var account = conversation.AccountLabel ?? conversation.ProviderAccountId ?? "Unknown account";
+            var label = FormatSessionSnippet(conversation.SessionId);
+            items.Add(new JsonObject()
+                .Add("conversationKey", conversation.ConversationKey)
+                .Add("providerId", conversation.ProviderId)
+                .Add("provider", UsageTelemetryProviderCatalog.ResolveDisplayTitle(conversation.ProviderId))
+                .Add("providerAccountId", conversation.ProviderAccountId)
+                .Add("account", account)
+                .Add("sessionId", conversation.SessionId)
+                .Add("title", conversation.ConversationTitle)
+                .Add("workspacePath", conversation.WorkspacePath)
+                .Add("workspace", conversation.WorkspaceName)
+                .Add("repository", conversation.RepositoryName)
+                .Add("label", label)
+                .Add("startedLocal", conversation.StartedUtc.ToLocalTime().ToString("MMM d HH:mm", CultureInfo.CurrentCulture))
+                .Add("startedUtc", conversation.StartedUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture))
+                .Add("lastSeenLocal", conversation.LastSeenUtc.ToLocalTime().ToString("MMM d HH:mm", CultureInfo.CurrentCulture))
+                .Add("lastSeenUtc", conversation.LastSeenUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture))
+                .Add("durationMs", (long)conversation.Duration.TotalMilliseconds)
+                .Add("duration", HeatmapDisplayText.FormatDuration(conversation.Duration))
+                .Add("activeDurationMs", (long)conversation.ActiveDuration.TotalMilliseconds)
+                .Add("activeDuration", HeatmapDisplayText.FormatDuration(conversation.ActiveDuration))
+                .Add("turnCount", conversation.TurnCount)
+                .Add("compactCount", conversation.CompactCount)
+                .Add("inputTokens", conversation.InputTokens)
+                .Add("outputTokens", conversation.OutputTokens)
+                .Add("cachedTokens", conversation.CachedInputTokens)
+                .Add("reasoningTokens", conversation.ReasoningTokens)
+                .Add("totalTokens", conversation.TotalTokens)
+                .Add("apiEquivalentCostUsd", (double)conversation.CostUsd)
+                .Add("costApproximate", conversation.CostUsesEstimatedFallback)
+                .Add("models", models)
+                .Add("surfaces", surfaces));
+        }
+
+        return new JsonObject()
+            .Add("totalCount", conversations.Count)
+            .Add("shownCount", items.Count)
+            .Add("tokenTotal", conversations.Sum(static conversation => conversation.TotalTokens))
+            .Add("turnCount", conversations.Sum(static conversation => (long)conversation.TurnCount))
+            .Add("compactCount", conversations.Sum(static conversation => (long)conversation.CompactCount))
+            .Add("items", items);
     }
 
     private static string? NormalizeAccountLabel(string? value, string? providerAccountId = null) {
@@ -2595,6 +2891,12 @@ public sealed class ProviderViewModel : ViewModelBase {
         return decimal.Truncate(value) == value
             ? value.ToString("N0", CultureInfo.InvariantCulture)
             : value.ToString("0.##", CultureInfo.InvariantCulture);
+    }
+
+    private static string FormatCountLabel(int count, string singular, string plural) {
+        return count.ToString("N0", CultureInfo.CurrentCulture)
+               + " "
+               + (count == 1 ? singular : plural);
     }
 
     private static void ResetFilterOptions(ObservableCollection<string> target, string allLabel, IReadOnlyList<string> values) {
@@ -2690,8 +2992,16 @@ public sealed class ProviderViewModel : ViewModelBase {
             return string.Empty;
         }
 
-        return (displayCost.UsesEstimatedFallback ? "~" : string.Empty)
-               + displayCost.TotalCostUsd.ToString("0.####", CultureInfo.InvariantCulture);
+        return FormatExportCost(displayCost.TotalCostUsd, displayCost.UsesEstimatedFallback);
+    }
+
+    private static string FormatExportCost(decimal costUsd, bool approximate) {
+        if (costUsd <= 0m) {
+            return string.Empty;
+        }
+
+        return (approximate ? "~" : string.Empty)
+               + costUsd.ToString("0.####", CultureInfo.InvariantCulture);
     }
 
     private static string FormatCostDisplay(decimal costUsd, bool approximate) {

--- a/IntelligenceX.Tray/Views/TrayPopupWindow.xaml
+++ b/IntelligenceX.Tray/Views/TrayPopupWindow.xaml
@@ -197,7 +197,8 @@
                 <ScrollViewer VerticalScrollBarVisibility="Auto"
                               HorizontalScrollBarVisibility="Disabled"
                               Visibility="{Binding ShowUsageContent, Converter={StaticResource BoolToVis}}">
-                    <StackPanel DataContext="{Binding SelectedProvider}"
+                    <StackPanel x:Name="ProviderContentPanel"
+                                DataContext="{Binding SelectedProvider}"
                                 Margin="16,12,16,8">
 
                         <Border Style="{StaticResource CardStyle}">
@@ -219,6 +220,11 @@
                                                 Command="{Binding ExportJsonCommand}"
                                                 Margin="0,0,6,6">
                                             <TextBlock FontFamily="{StaticResource AppFont}" FontSize="10.5" Text="JSON" />
+                                        </Button>
+                                        <Button Style="{StaticResource LinkButtonStyle}"
+                                                Click="OnSavePngButtonClick"
+                                                Margin="0,0,6,6">
+                                            <TextBlock FontFamily="{StaticResource AppFont}" FontSize="10.5" Text="PNG" />
                                         </Button>
                                         <Button Style="{StaticResource LinkButtonStyle}"
                                                 Command="{Binding ClearFiltersCommand}"
@@ -296,7 +302,7 @@
                                                   SelectedItem="{Binding SelectedSurfaceFilter, Mode=TwoWay}" />
                                     </StackPanel>
                                 </Grid>
-                                <TextBlock Text="Usage sections below react to the selected range, while live limits stay current."
+                                <TextBlock Text="Usage sections below react to the selected range. Rollups are daily quick-scan rows; live limits stay current."
                                            FontFamily="{StaticResource AppFont}"
                                            FontSize="10"
                                            Foreground="{StaticResource TertiaryTextBrush}"
@@ -624,8 +630,7 @@
                                                FontFamily="{StaticResource AppFont}"
                                                FontSize="10"
                                                Foreground="{StaticResource TertiaryTextBrush}">
-                                        <Run Text="{Binding TodayEventCount, Mode=OneWay}" />
-                                        <Run Text=" events" />
+                                        <Run Text="{Binding TodayRollupCountText, Mode=OneWay}" />
                                     </TextBlock>
                                 </Grid>
 
@@ -685,7 +690,7 @@
                                                    Style="{StaticResource StatValueStyle}" />
                                     </StackPanel>
                                     <StackPanel Grid.Row="0" Grid.Column="2" Margin="0,0,0,8">
-                                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Cost" />
+                                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="API equiv." />
                                         <TextBlock Text="{Binding TodayCostFormatted}"
                                                    Style="{StaticResource StatValueStyle}" />
                                     </StackPanel>
@@ -725,14 +730,14 @@
                                                       IsChecked="{Binding IsProviderComparisonCostSortSelected, Mode=OneWay}"
                                                       Click="OnProviderComparisonSortChipClick"
                                                       Tag="Cost">
-                                            <TextBlock Text="Cost" />
+                                            <TextBlock Text="API equiv." />
                                         </ToggleButton>
                                         <ToggleButton Style="{StaticResource RangeChipStyle}"
                                                       IsChecked="{Binding IsProviderComparisonEventsSortSelected, Mode=OneWay}"
                                                       Click="OnProviderComparisonSortChipClick"
                                                       Tag="Events"
                                                       Margin="0">
-                                            <TextBlock Text="Events" />
+                                            <TextBlock Text="Rollups" />
                                         </ToggleButton>
                                     </StackPanel>
                                 </Grid>
@@ -1771,7 +1776,7 @@
                                                Style="{StaticResource StatValueStyle}" FontSize="12" />
                                     <TextBlock Style="{StaticResource LabelTextStyle}" Margin="0,0,0,4">
                                         <Run Text="{Binding WeeklyCostFormatted, Mode=OneWay}" />
-                                        <Run Text=" cost" />
+                                        <Run Text=" API equiv." />
                                     </TextBlock>
                                 </StackPanel>
                             </Border>
@@ -1786,7 +1791,7 @@
                                                Style="{StaticResource StatValueStyle}" FontSize="12" />
                                     <TextBlock Style="{StaticResource LabelTextStyle}" Margin="0,0,0,4">
                                         <Run Text="{Binding MonthlyCostFormatted, Mode=OneWay}" />
-                                        <Run Text=" cost" />
+                                        <Run Text=" API equiv." />
                                     </TextBlock>
                                 </StackPanel>
                             </Border>
@@ -2015,7 +2020,124 @@
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock Text="EVENTS" Style="{StaticResource SectionHeaderStyle}" Margin="0" />
+                                    <TextBlock Text="CONVERSATIONS" Style="{StaticResource SectionHeaderStyle}" Margin="0" />
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding ConversationStatsSummaryText}"
+                                               FontFamily="{StaticResource AppFont}"
+                                               FontSize="10.5"
+                                               Foreground="{StaticResource TertiaryTextBrush}"
+                                               TextTrimming="CharacterEllipsis"
+                                               MaxWidth="300" />
+                                </Grid>
+                                <Grid Margin="0,0,0,6">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="88" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="86" />
+                                        <ColumnDefinition Width="72" />
+                                        <ColumnDefinition Width="74" />
+                                        <ColumnDefinition Width="56" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="Started" FontFamily="{StaticResource AppFont}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource TertiaryTextBrush}" />
+                                    <TextBlock Grid.Column="1" Text="Session / context" FontFamily="{StaticResource AppFont}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource TertiaryTextBrush}" />
+                                    <TextBlock Grid.Column="2" Text="Span / active" FontFamily="{StaticResource AppFont}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource TertiaryTextBrush}" />
+                                    <TextBlock Grid.Column="3" Text="Turns" FontFamily="{StaticResource AppFont}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource TertiaryTextBrush}" />
+                                    <TextBlock Grid.Column="4" Text="Tokens" FontFamily="{StaticResource AppFont}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource TertiaryTextBrush}" HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Column="5" Text="Compacts" FontFamily="{StaticResource AppFont}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource TertiaryTextBrush}" HorizontalAlignment="Right" />
+                                </Grid>
+                                <ItemsControl ItemsSource="{Binding Conversations}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="{x:Type vm:ConversationUsageViewModel}">
+                                            <Grid Margin="0,0,0,8">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="88" />
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="86" />
+                                                    <ColumnDefinition Width="72" />
+                                                    <ColumnDefinition Width="74" />
+                                                    <ColumnDefinition Width="56" />
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Grid.Column="0"
+                                                           Text="{Binding StartedText}"
+                                                           FontFamily="{StaticResource AppFont}"
+                                                           FontSize="10.5"
+                                                           Foreground="{StaticResource SecondaryTextBrush}"
+                                                           Margin="0,0,8,0" />
+                                                <StackPanel Grid.Column="1" Margin="0,0,8,0">
+                                                    <TextBlock Text="{Binding TitleText}"
+                                                               FontFamily="{StaticResource AppFont}"
+                                                               FontSize="11"
+                                                               FontWeight="SemiBold"
+                                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                    <TextBlock Text="{Binding SessionText}"
+                                                               FontFamily="{StaticResource AppFont}"
+                                                               FontSize="9.5"
+                                                               Foreground="{StaticResource TertiaryTextBrush}"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                    <TextBlock Text="{Binding RepositoryText}"
+                                                               FontFamily="{StaticResource AppFont}"
+                                                               FontSize="10"
+                                                               Foreground="{StaticResource SecondaryTextBrush}"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                    <TextBlock Text="{Binding ModelsText}"
+                                                               FontFamily="{StaticResource AppFont}"
+                                                               FontSize="10"
+                                                               Foreground="{StaticResource TertiaryTextBrush}"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                </StackPanel>
+                                                <StackPanel Grid.Column="2" Margin="0,0,8,0">
+                                                    <TextBlock Text="{Binding DurationText}"
+                                                               FontFamily="{StaticResource AppFont}"
+                                                               FontSize="10.5"
+                                                               Foreground="{StaticResource SecondaryTextBrush}" />
+                                                    <TextBlock Text="{Binding ActiveDurationText}"
+                                                               FontFamily="{StaticResource AppFont}"
+                                                               FontSize="9.5"
+                                                               Foreground="{StaticResource TertiaryTextBrush}" />
+                                                </StackPanel>
+                                                <TextBlock Grid.Column="3"
+                                                           Text="{Binding TurnsText}"
+                                                           FontFamily="{StaticResource AppFont}"
+                                                           FontSize="10.5"
+                                                           Foreground="{StaticResource SecondaryTextBrush}"
+                                                           Margin="0,0,8,0" />
+                                                <TextBlock Grid.Column="4"
+                                                           Text="{Binding TokensText}"
+                                                           FontFamily="{StaticResource AppFont}"
+                                                           FontSize="10.5"
+                                                           FontWeight="SemiBold"
+                                                           Foreground="{StaticResource SecondaryTextBrush}"
+                                                           HorizontalAlignment="Right"
+                                                           Margin="0,0,8,0" />
+                                                <TextBlock Grid.Column="5"
+                                                           Text="{Binding CompactCountText}"
+                                                           FontFamily="{StaticResource AppFont}"
+                                                           FontSize="10.5"
+                                                           Foreground="{StaticResource TertiaryTextBrush}"
+                                                           HorizontalAlignment="Right" />
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                                <TextBlock Text="No conversations in the selected range"
+                                           FontFamily="{StaticResource AppFont}"
+                                           FontSize="11"
+                                           Foreground="{StaticResource TertiaryTextBrush}"
+                                           HorizontalAlignment="Center"
+                                           Margin="0,4"
+                                           Visibility="{Binding HasConversationStats, Converter={StaticResource InverseBoolToVis}}" />
+                            </StackPanel>
+                        </Border>
+
+                        <Border Style="{StaticResource CardStyle}">
+                            <StackPanel>
+                                <Grid Margin="0,0,0,8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Text="ROLLUPS" Style="{StaticResource SectionHeaderStyle}" Margin="0" />
                                     <StackPanel Grid.Column="1" Orientation="Horizontal">
                                         <Button Style="{StaticResource LinkButtonStyle}"
                                                 Command="{Binding CopySelectedEventJsonCommand}"
@@ -2044,7 +2166,7 @@
                                                       IsChecked="{Binding IsHighestCostSortSelected, Mode=OneWay}"
                                                       Click="OnEventSortChipClick"
                                                       Tag="HighestCost">
-                                            <TextBlock Text="Cost" />
+                                            <TextBlock Text="API equiv." />
                                         </ToggleButton>
                                         <ToggleButton Style="{StaticResource RangeChipStyle}"
                                                       IsChecked="{Binding IsModelSortSelected, Mode=OneWay}"
@@ -2097,7 +2219,7 @@
                                                Foreground="{StaticResource TertiaryTextBrush}"
                                                HorizontalAlignment="Right" />
                                     <TextBlock Grid.Column="5"
-                                               Text="Cost"
+                                               Text="API equiv."
                                                FontFamily="{StaticResource AppFont}"
                                                FontSize="10"
                                                FontWeight="SemiBold"
@@ -2171,7 +2293,7 @@
                                         </DataTemplate>
                                     </ListBox.ItemTemplate>
                                 </ListBox>
-                                <TextBlock Text="No events in the selected range"
+                                <TextBlock Text="No rollups in the selected range"
                                            FontFamily="{StaticResource AppFont}"
                                            FontSize="11"
                                            Foreground="{StaticResource TertiaryTextBrush}"
@@ -2191,7 +2313,7 @@
                                                 <ColumnDefinition Width="*" />
                                                 <ColumnDefinition Width="Auto" />
                                             </Grid.ColumnDefinitions>
-                                            <TextBlock Text="Selected Event"
+                                            <TextBlock Text="Selected Rollup"
                                                        FontFamily="{StaticResource AppFont}"
                                                        FontSize="10"
                                                        FontWeight="Bold"
@@ -2293,7 +2415,7 @@
                                                 <TextBlock Text="{Binding ReasoningText}" Style="{StaticResource StatValueStyle}" />
                                             </StackPanel>
                                             <StackPanel Grid.Row="1" Grid.Column="2">
-                                                <TextBlock Text="Cost" Style="{StaticResource LabelTextStyle}" />
+                                                <TextBlock Text="API equiv." Style="{StaticResource LabelTextStyle}" />
                                                 <TextBlock Text="{Binding CostText}" Style="{StaticResource StatValueStyle}" />
                                             </StackPanel>
                                         </Grid>

--- a/IntelligenceX.Tray/Views/TrayPopupWindow.xaml.cs
+++ b/IntelligenceX.Tray/Views/TrayPopupWindow.xaml.cs
@@ -257,18 +257,8 @@ public partial class TrayPopupWindow : Window {
         }
 
         var dpi = VisualTreeHelper.GetDpi(element);
-        var exportScale = 1d;
-        exportScale = Math.Min(exportScale, MaxExportPixelWidth / Math.Max(1d, width * dpi.DpiScaleX));
-        exportScale = Math.Min(exportScale, MaxExportPixelHeight / Math.Max(1d, height * dpi.DpiScaleY));
-
-        var nativePixelCount = width * dpi.DpiScaleX * height * dpi.DpiScaleY;
-        if (nativePixelCount > MaxExportPixelCount) {
-            exportScale = Math.Min(exportScale, Math.Sqrt(MaxExportPixelCount / nativePixelCount));
-        }
-
-        if (exportScale < MinExportScale) {
-            throw new InvalidOperationException("The selected content is too large to export safely as a single PNG.");
-        }
+        // Clamp oversized exports before allocating the bitmap so tall provider panels cannot exhaust UI-thread memory.
+        var exportScale = CalculateSafePngExportScale(width, height, dpi);
 
         var pixelWidth = Math.Max(1, (int)Math.Ceiling(width * dpi.DpiScaleX * exportScale));
         var pixelHeight = Math.Max(1, (int)Math.Ceiling(height * dpi.DpiScaleY * exportScale));
@@ -299,6 +289,23 @@ public partial class TrayPopupWindow : Window {
         encoder.Frames.Add(BitmapFrame.Create(bitmap));
         using var stream = File.Create(fileName);
         encoder.Save(stream);
+    }
+
+    private static double CalculateSafePngExportScale(double width, double height, DpiScale dpi) {
+        var exportScale = 1d;
+        exportScale = Math.Min(exportScale, MaxExportPixelWidth / Math.Max(1d, width * dpi.DpiScaleX));
+        exportScale = Math.Min(exportScale, MaxExportPixelHeight / Math.Max(1d, height * dpi.DpiScaleY));
+
+        var nativePixelCount = width * dpi.DpiScaleX * height * dpi.DpiScaleY;
+        if (nativePixelCount > MaxExportPixelCount) {
+            exportScale = Math.Min(exportScale, Math.Sqrt(MaxExportPixelCount / nativePixelCount));
+        }
+
+        if (exportScale < MinExportScale) {
+            throw new InvalidOperationException("The selected content is too large to export safely as a single PNG.");
+        }
+
+        return exportScale;
     }
 
     private static string BuildPngFileName(ProviderViewModel provider) {

--- a/IntelligenceX.Tray/Views/TrayPopupWindow.xaml.cs
+++ b/IntelligenceX.Tray/Views/TrayPopupWindow.xaml.cs
@@ -18,6 +18,10 @@ public partial class TrayPopupWindow : Window {
     private const double MaximumPopupWidth = 560;
     private const double MinimumPopupHeight = 640;
     private const double MaximumPopupHeight = 840;
+    private const int MaxExportPixelWidth = 8192;
+    private const int MaxExportPixelHeight = 32768;
+    private const long MaxExportPixelCount = 40_000_000;
+    private const double MinExportScale = 0.2d;
 
     private bool _isPrimed;
     private DateTimeOffset _suppressDeactivateUntilUtc;
@@ -253,13 +257,26 @@ public partial class TrayPopupWindow : Window {
         }
 
         var dpi = VisualTreeHelper.GetDpi(element);
-        var pixelWidth = Math.Max(1, (int)Math.Ceiling(width * dpi.DpiScaleX));
-        var pixelHeight = Math.Max(1, (int)Math.Ceiling(height * dpi.DpiScaleY));
+        var exportScale = 1d;
+        exportScale = Math.Min(exportScale, MaxExportPixelWidth / Math.Max(1d, width * dpi.DpiScaleX));
+        exportScale = Math.Min(exportScale, MaxExportPixelHeight / Math.Max(1d, height * dpi.DpiScaleY));
+
+        var nativePixelCount = width * dpi.DpiScaleX * height * dpi.DpiScaleY;
+        if (nativePixelCount > MaxExportPixelCount) {
+            exportScale = Math.Min(exportScale, Math.Sqrt(MaxExportPixelCount / nativePixelCount));
+        }
+
+        if (exportScale < MinExportScale) {
+            throw new InvalidOperationException("The selected content is too large to export safely as a single PNG.");
+        }
+
+        var pixelWidth = Math.Max(1, (int)Math.Ceiling(width * dpi.DpiScaleX * exportScale));
+        var pixelHeight = Math.Max(1, (int)Math.Ceiling(height * dpi.DpiScaleY * exportScale));
         var bitmap = new RenderTargetBitmap(
             pixelWidth,
             pixelHeight,
-            96d * dpi.DpiScaleX,
-            96d * dpi.DpiScaleY,
+            96d * dpi.DpiScaleX * exportScale,
+            96d * dpi.DpiScaleY * exportScale,
             PixelFormats.Pbgra32);
 
         var visual = new DrawingVisual();

--- a/IntelligenceX.Tray/Views/TrayPopupWindow.xaml.cs
+++ b/IntelligenceX.Tray/Views/TrayPopupWindow.xaml.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -5,7 +7,9 @@ using System.Diagnostics;
 using System.ComponentModel;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using IntelligenceX.Tray.ViewModels;
+using Microsoft.Win32;
 
 namespace IntelligenceX.Tray.Views;
 
@@ -192,6 +196,28 @@ public partial class TrayPopupWindow : Window {
         CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 
+    private void OnSavePngButtonClick(object sender, RoutedEventArgs e) {
+        if (ProviderContentPanel.DataContext is not ProviderViewModel provider) {
+            return;
+        }
+
+        PrepareForTrayOpen(TimeSpan.FromMinutes(2));
+        try {
+            var dialog = new SaveFileDialog {
+                Filter = "PNG images (*.png)|*.png|All files (*.*)|*.*",
+                FileName = BuildPngFileName(provider)
+            };
+            if (dialog.ShowDialog(this) != true) {
+                return;
+            }
+
+            SaveElementAsPng(ProviderContentPanel, dialog.FileName);
+            provider.ActionStatusMessage = "Saved PNG to " + dialog.FileName;
+        } catch (Exception ex) {
+            provider.ActionStatusMessage = "PNG save failed: " + ex.Message;
+        }
+    }
+
     private void OnWindowClosing(object? sender, CancelEventArgs e) {
         CloseInterceptRequested?.Invoke(this, e);
     }
@@ -215,6 +241,65 @@ public partial class TrayPopupWindow : Window {
 
     private static double Clamp(double value, double minimum, double maximum) {
         return Math.Max(minimum, Math.Min(maximum, value));
+    }
+
+    private void SaveElementAsPng(FrameworkElement element, string fileName) {
+        element.UpdateLayout();
+
+        var width = Math.Ceiling(element.ActualWidth);
+        var height = Math.Ceiling(element.ActualHeight);
+        if (width <= 0d || height <= 0d) {
+            throw new InvalidOperationException("Nothing visible to export.");
+        }
+
+        var dpi = VisualTreeHelper.GetDpi(element);
+        var pixelWidth = Math.Max(1, (int)Math.Ceiling(width * dpi.DpiScaleX));
+        var pixelHeight = Math.Max(1, (int)Math.Ceiling(height * dpi.DpiScaleY));
+        var bitmap = new RenderTargetBitmap(
+            pixelWidth,
+            pixelHeight,
+            96d * dpi.DpiScaleX,
+            96d * dpi.DpiScaleY,
+            PixelFormats.Pbgra32);
+
+        var visual = new DrawingVisual();
+        using (var context = visual.RenderOpen()) {
+            var background = TryFindResource("BackgroundBrush") as Brush ?? Brushes.Transparent;
+            context.DrawRectangle(background, null, new Rect(0d, 0d, width, height));
+            context.DrawRectangle(
+                new VisualBrush(element) {
+                    AlignmentX = AlignmentX.Left,
+                    AlignmentY = AlignmentY.Top,
+                    Stretch = Stretch.None
+                },
+                null,
+                new Rect(0d, 0d, width, height));
+        }
+
+        bitmap.Render(visual);
+
+        var encoder = new PngBitmapEncoder();
+        encoder.Frames.Add(BitmapFrame.Create(bitmap));
+        using var stream = File.Create(fileName);
+        encoder.Save(stream);
+    }
+
+    private static string BuildPngFileName(ProviderViewModel provider) {
+        return SanitizeFileSegment(provider.DisplayName)
+               + "-"
+               + provider.SelectedRange.ToString().ToLowerInvariant()
+               + "-"
+               + DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture)
+               + ".png";
+    }
+
+    private static string SanitizeFileSegment(string? value) {
+        var segment = string.IsNullOrWhiteSpace(value) ? "usage" : value.Trim();
+        foreach (var invalid in Path.GetInvalidFileNameChars()) {
+            segment = segment.Replace(invalid, '-');
+        }
+
+        return string.IsNullOrWhiteSpace(segment) ? "usage" : segment;
     }
 
     private static bool IsDragSourceInteractive(DependencyObject? source) {

--- a/IntelligenceX/Telemetry/Usage/Codex/CodexSessionImport.cs
+++ b/IntelligenceX/Telemetry/Usage/Codex/CodexSessionImport.cs
@@ -26,10 +26,14 @@ internal static class CodexSessionImport {
 
         var records = new List<UsageEventRecord>();
         var currentModel = default(string);
+        var conversationTitle = default(string);
+        var workspacePath = default(string);
+        var repositoryName = default(string);
         var sessionId = CodexSessionImportSupport.TryExtractSessionIdFromFileName(filePath);
         var resolvedAccount = CodexSessionImportSupport.ResolveAccount(filePath, root.Path);
         CodexSessionImportSupport.CodexNormalizedUsage? previousTotals = null;
         CodexSessionImportSupport.CodexNormalizedUsage? previousLastUsage = null;
+        var pendingCompactCount = 0;
         var lineNumber = 0;
 
         foreach (var rawLine in UsageTelemetryQuickReportSupport.ReadLinesShared(filePath)) {
@@ -53,16 +57,38 @@ internal static class CodexSessionImport {
             if (string.Equals(type, "session_meta", StringComparison.OrdinalIgnoreCase)) {
                 sessionId = CodexSessionImportSupport.ExtractSessionId(payload) ?? sessionId;
                 currentModel = CodexSessionImportSupport.ExtractModel(payload) ?? currentModel;
+                workspacePath = NormalizeOptional(payload?.GetString("cwd")) ?? workspacePath;
+                repositoryName = ExtractRepositoryName(payload?.GetObject("git")) ?? repositoryName;
                 continue;
             }
 
             if (string.Equals(type, "turn_context", StringComparison.OrdinalIgnoreCase)) {
                 currentModel = CodexSessionImportSupport.ExtractModel(payload) ?? currentModel;
+                workspacePath = NormalizeOptional(payload?.GetString("cwd")) ?? workspacePath;
                 continue;
             }
 
-            if (!string.Equals(type, "event_msg", StringComparison.OrdinalIgnoreCase) ||
-                !string.Equals(payload?.GetString("type"), "token_count", StringComparison.OrdinalIgnoreCase)) {
+            if (!string.Equals(type, "event_msg", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            var payloadType = payload?.GetString("type");
+            if (string.Equals(payloadType, "context_compacted", StringComparison.OrdinalIgnoreCase)) {
+                pendingCompactCount++;
+                continue;
+            }
+
+            if (string.Equals(payloadType, "thread_name_updated", StringComparison.OrdinalIgnoreCase)) {
+                sessionId = NormalizeOptional(payload?.GetString("thread_id"))
+                            ?? NormalizeOptional(payload?.GetString("threadId"))
+                            ?? sessionId;
+                conversationTitle = NormalizeOptional(payload?.GetString("thread_name"))
+                                    ?? NormalizeOptional(payload?.GetString("threadName"))
+                                    ?? conversationTitle;
+                continue;
+            }
+
+            if (!string.Equals(payloadType, "token_count", StringComparison.OrdinalIgnoreCase)) {
                 continue;
             }
 
@@ -125,7 +151,9 @@ internal static class CodexSessionImport {
                 OutputTokens = usage.OutputTokens,
                 ReasoningTokens = usage.ReasoningTokens,
                 TotalTokens = usage.TotalTokens,
+                CompactCount = pendingCompactCount > 0 ? pendingCompactCount : null,
             };
+            pendingCompactCount = 0;
             UsageTelemetryImportSupport.ApplyImportedEventMetadata(
                 record,
                 root,
@@ -140,9 +168,63 @@ internal static class CodexSessionImport {
                 model: model,
                 surface: "cli",
                 rawHash: rawHash);
+            record.ConversationTitle = conversationTitle;
+            record.WorkspacePath = workspacePath;
+            record.RepositoryName = repositoryName;
             records.Add(record);
         }
 
+        foreach (var record in records) {
+            record.ConversationTitle ??= conversationTitle;
+            record.WorkspacePath ??= workspacePath;
+            record.RepositoryName ??= repositoryName;
+        }
+
         return records;
+    }
+
+    private static string? ExtractRepositoryName(JsonObject? git) {
+        var repositoryUrl = NormalizeOptional(git?.GetString("repository_url"))
+                            ?? NormalizeOptional(git?.GetString("repositoryUrl"));
+        if (repositoryUrl is null) {
+            return null;
+        }
+
+        var normalized = repositoryUrl.Trim().TrimEnd('/');
+        if (normalized.EndsWith(".git", StringComparison.OrdinalIgnoreCase)) {
+            normalized = normalized.Substring(0, normalized.Length - 4);
+        }
+
+        string? path = null;
+        if (Uri.TryCreate(normalized, UriKind.Absolute, out var uri)) {
+            path = uri.AbsolutePath;
+        } else {
+            var colonIndex = normalized.IndexOf(':');
+            if (colonIndex >= 0 && !LooksLikeWindowsDrive(normalized, colonIndex)) {
+                path = normalized.Substring(colonIndex + 1);
+            }
+        }
+
+        path ??= normalized;
+        path = path.Replace('\\', '/').Trim('/');
+        if (string.IsNullOrWhiteSpace(path)) {
+            return null;
+        }
+
+        var parts = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length >= 2) {
+            return parts[parts.Length - 2] + "/" + parts[parts.Length - 1];
+        }
+
+        return parts.Length == 1 ? parts[0] : null;
+    }
+
+    private static bool LooksLikeWindowsDrive(string value, int colonIndex) {
+        return colonIndex == 1 && value.Length > 1 && char.IsLetter(value[0]);
+    }
+
+    private static string? NormalizeOptional(string? value) {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
     }
 }

--- a/IntelligenceX/Telemetry/Usage/CodexSessionUsageAdapter.cs
+++ b/IntelligenceX/Telemetry/Usage/CodexSessionUsageAdapter.cs
@@ -12,7 +12,7 @@ public sealed class CodexSessionUsageAdapter : IUsageTelemetryAdapter {
     /// </summary>
     public const string StableAdapterId = "codex.session-log";
 
-    private const string ParserVersion = "codex.session-log/v2";
+    private const string ParserVersion = "codex.session-log/v4";
 
     /// <inheritdoc />
     public string AdapterId => StableAdapterId;

--- a/IntelligenceX/Telemetry/Usage/LmStudio/LmStudioConversationImport.cs
+++ b/IntelligenceX/Telemetry/Usage/LmStudio/LmStudioConversationImport.cs
@@ -43,6 +43,7 @@ internal static class LmStudioConversationImport {
         var sessionId = LmStudioConversationImportSupport.NormalizeOptional(LmStudioConversationImportSupport.ExtractSessionId(filePath))
                         ?? LmStudioConversationImportSupport.NormalizeOptional(conversation.GetString("name"))
                         ?? "lmstudio-session";
+        var conversationTitle = LmStudioConversationImportSupport.NormalizeOptional(conversation.GetString("name"));
         var fallbackTimestampUtc = LmStudioConversationImportSupport.TryReadUnixTimeMilliseconds(conversation, "assistantLastMessagedAt")
                                    ?? LmStudioConversationImportSupport.TryReadUnixTimeMilliseconds(conversation, "userLastMessagedAt")
                                    ?? LmStudioConversationImportSupport.TryReadUnixTimeMilliseconds(conversation, "createdAt")
@@ -127,6 +128,7 @@ internal static class LmStudioConversationImport {
                     surface: "chat",
                     durationMs: usageValue.DurationMs,
                     rawHash: UsageTelemetryIdentity.ComputeStableHash(rawPayload));
+                record.ConversationTitle = conversationTitle;
                 records.Add(record);
             }
         }

--- a/IntelligenceX/Telemetry/Usage/SqliteUsageTelemetryStores.cs
+++ b/IntelligenceX/Telemetry/Usage/SqliteUsageTelemetryStores.cs
@@ -954,6 +954,9 @@ SELECT
   machine_id,
   session_id,
   thread_id,
+  conversation_title,
+  workspace_path,
+  repository_name,
   turn_id,
   response_id,
   timestamp_utc,
@@ -964,6 +967,7 @@ SELECT
   output_tokens,
   reasoning_tokens,
   total_tokens,
+  compact_count,
   duration_ms,
   cost_usd,
   truth_level,
@@ -999,6 +1003,9 @@ SELECT
   machine_id,
   session_id,
   thread_id,
+  conversation_title,
+  workspace_path,
+  repository_name,
   turn_id,
   response_id,
   timestamp_utc,
@@ -1009,6 +1016,7 @@ SELECT
   output_tokens,
   reasoning_tokens,
   total_tokens,
+  compact_count,
   duration_ms,
   cost_usd,
   truth_level,
@@ -1045,6 +1053,9 @@ INSERT INTO ix_usage_events (
   machine_id,
   session_id,
   thread_id,
+  conversation_title,
+  workspace_path,
+  repository_name,
   turn_id,
   response_id,
   timestamp_utc,
@@ -1055,6 +1066,7 @@ INSERT INTO ix_usage_events (
   output_tokens,
   reasoning_tokens,
   total_tokens,
+  compact_count,
   duration_ms,
   cost_usd,
   truth_level,
@@ -1072,6 +1084,9 @@ VALUES (
   @machine_id,
   @session_id,
   @thread_id,
+  @conversation_title,
+  @workspace_path,
+  @repository_name,
   @turn_id,
   @response_id,
   @timestamp_utc,
@@ -1082,6 +1097,7 @@ VALUES (
   @output_tokens,
   @reasoning_tokens,
   @total_tokens,
+  @compact_count,
   @duration_ms,
   @cost_usd,
   @truth_level,
@@ -1098,6 +1114,9 @@ ON CONFLICT(canonical_event_id) DO UPDATE SET
   machine_id = excluded.machine_id,
   session_id = excluded.session_id,
   thread_id = excluded.thread_id,
+  conversation_title = excluded.conversation_title,
+  workspace_path = excluded.workspace_path,
+  repository_name = excluded.repository_name,
   turn_id = excluded.turn_id,
   response_id = excluded.response_id,
   timestamp_utc = excluded.timestamp_utc,
@@ -1108,6 +1127,7 @@ ON CONFLICT(canonical_event_id) DO UPDATE SET
   output_tokens = excluded.output_tokens,
   reasoning_tokens = excluded.reasoning_tokens,
   total_tokens = excluded.total_tokens,
+  compact_count = excluded.compact_count,
   duration_ms = excluded.duration_ms,
   cost_usd = excluded.cost_usd,
   truth_level = excluded.truth_level,
@@ -1125,6 +1145,9 @@ ON CONFLICT(canonical_event_id) DO UPDATE SET
                 ["@machine_id"] = SqliteUsageTelemetrySchema.Normalize(record.MachineId),
                 ["@session_id"] = SqliteUsageTelemetrySchema.Normalize(record.SessionId),
                 ["@thread_id"] = SqliteUsageTelemetrySchema.Normalize(record.ThreadId),
+                ["@conversation_title"] = SqliteUsageTelemetrySchema.Normalize(record.ConversationTitle),
+                ["@workspace_path"] = SqliteUsageTelemetrySchema.Normalize(record.WorkspacePath),
+                ["@repository_name"] = SqliteUsageTelemetrySchema.Normalize(record.RepositoryName),
                 ["@turn_id"] = SqliteUsageTelemetrySchema.Normalize(record.TurnId),
                 ["@response_id"] = SqliteUsageTelemetrySchema.Normalize(record.ResponseId),
                 ["@timestamp_utc"] = record.TimestampUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
@@ -1135,6 +1158,7 @@ ON CONFLICT(canonical_event_id) DO UPDATE SET
                 ["@output_tokens"] = record.OutputTokens,
                 ["@reasoning_tokens"] = record.ReasoningTokens,
                 ["@total_tokens"] = record.TotalTokens,
+                ["@compact_count"] = record.CompactCount,
                 ["@duration_ms"] = record.DurationMs,
                 ["@cost_usd"] = record.CostUsd,
                 ["@truth_level"] = record.TruthLevel.ToString(),
@@ -1187,6 +1211,9 @@ ON CONFLICT(dedupe_key) DO UPDATE SET
             MachineId = SqliteUsageTelemetrySchema.ReadOptionalString(row, "machine_id"),
             SessionId = SqliteUsageTelemetrySchema.ReadOptionalString(row, "session_id"),
             ThreadId = SqliteUsageTelemetrySchema.ReadOptionalString(row, "thread_id"),
+            ConversationTitle = SqliteUsageTelemetrySchema.ReadOptionalString(row, "conversation_title"),
+            WorkspacePath = SqliteUsageTelemetrySchema.ReadOptionalString(row, "workspace_path"),
+            RepositoryName = SqliteUsageTelemetrySchema.ReadOptionalString(row, "repository_name"),
             TurnId = SqliteUsageTelemetrySchema.ReadOptionalString(row, "turn_id"),
             ResponseId = SqliteUsageTelemetrySchema.ReadOptionalString(row, "response_id"),
             Model = SqliteUsageTelemetrySchema.ReadOptionalString(row, "model"),
@@ -1196,6 +1223,7 @@ ON CONFLICT(dedupe_key) DO UPDATE SET
             OutputTokens = SqliteUsageTelemetrySchema.ReadNullableInt64(row, "output_tokens"),
             ReasoningTokens = SqliteUsageTelemetrySchema.ReadNullableInt64(row, "reasoning_tokens"),
             TotalTokens = SqliteUsageTelemetrySchema.ReadNullableInt64(row, "total_tokens"),
+            CompactCount = ReadNullableInt32(row, "compact_count"),
             DurationMs = SqliteUsageTelemetrySchema.ReadNullableInt64(row, "duration_ms"),
             CostUsd = SqliteUsageTelemetrySchema.ReadNullableDecimal(row, "cost_usd"),
             TruthLevel = truthLevel,
@@ -1217,6 +1245,9 @@ ON CONFLICT(dedupe_key) DO UPDATE SET
             MachineId = record.MachineId,
             SessionId = record.SessionId,
             ThreadId = record.ThreadId,
+            ConversationTitle = record.ConversationTitle,
+            WorkspacePath = record.WorkspacePath,
+            RepositoryName = record.RepositoryName,
             TurnId = record.TurnId,
             ResponseId = record.ResponseId,
             Model = record.Model,
@@ -1226,6 +1257,7 @@ ON CONFLICT(dedupe_key) DO UPDATE SET
             OutputTokens = record.OutputTokens,
             ReasoningTokens = record.ReasoningTokens,
             TotalTokens = record.TotalTokens,
+            CompactCount = record.CompactCount,
             DurationMs = record.DurationMs,
             CostUsd = record.CostUsd,
             TruthLevel = record.TruthLevel,
@@ -1241,6 +1273,9 @@ ON CONFLICT(dedupe_key) DO UPDATE SET
         updated |= MergeString(existing.MachineId, incoming.MachineId, value => existing.MachineId = value);
         updated |= MergeString(existing.SessionId, incoming.SessionId, value => existing.SessionId = value);
         updated |= MergeString(existing.ThreadId, incoming.ThreadId, value => existing.ThreadId = value);
+        updated |= MergeString(existing.ConversationTitle, incoming.ConversationTitle, value => existing.ConversationTitle = value);
+        updated |= MergeString(existing.WorkspacePath, incoming.WorkspacePath, value => existing.WorkspacePath = value);
+        updated |= MergeString(existing.RepositoryName, incoming.RepositoryName, value => existing.RepositoryName = value);
         updated |= MergeString(existing.TurnId, incoming.TurnId, value => existing.TurnId = value);
         updated |= MergeString(existing.ResponseId, incoming.ResponseId, value => existing.ResponseId = value);
         updated |= MergeString(existing.Model, incoming.Model, value => existing.Model = value);
@@ -1250,6 +1285,7 @@ ON CONFLICT(dedupe_key) DO UPDATE SET
         updated |= MergeNullableInt64(existing.OutputTokens, incoming.OutputTokens, value => existing.OutputTokens = value);
         updated |= MergeNullableInt64(existing.ReasoningTokens, incoming.ReasoningTokens, value => existing.ReasoningTokens = value);
         updated |= MergeNullableInt64(existing.TotalTokens, incoming.TotalTokens, value => existing.TotalTokens = value);
+        updated |= MergeNullableInt32(existing.CompactCount, incoming.CompactCount, value => existing.CompactCount = value);
         updated |= MergeNullableInt64(existing.DurationMs, incoming.DurationMs, value => existing.DurationMs = value);
         updated |= MergeNullableDecimal(existing.CostUsd, incoming.CostUsd, value => existing.CostUsd = value);
         updated |= MergeTruthLevel(existing.TruthLevel, incoming.TruthLevel, value => existing.TruthLevel = value);
@@ -1285,6 +1321,24 @@ ON CONFLICT(dedupe_key) DO UPDATE SET
 
         apply(incoming);
         return true;
+    }
+
+    private static bool MergeNullableInt32(int? target, int? incoming, Action<int?> apply) {
+        if (target.HasValue || !incoming.HasValue) {
+            return false;
+        }
+
+        apply(incoming);
+        return true;
+    }
+
+    private static int? ReadNullableInt32(DataRow row, string columnName) {
+        var value = SqliteUsageTelemetrySchema.ReadNullableInt64(row, columnName);
+        if (!value.HasValue) {
+            return null;
+        }
+
+        return value.Value > int.MaxValue ? int.MaxValue : (int)value.Value;
     }
 
     private static bool MergeNullableDecimal(decimal? target, decimal? incoming, Action<decimal?> apply) {
@@ -1361,6 +1415,9 @@ CREATE TABLE IF NOT EXISTS ix_usage_events (
   machine_id TEXT NULL,
   session_id TEXT NULL,
   thread_id TEXT NULL,
+  conversation_title TEXT NULL,
+  workspace_path TEXT NULL,
+  repository_name TEXT NULL,
   turn_id TEXT NULL,
   response_id TEXT NULL,
   timestamp_utc TEXT NOT NULL,
@@ -1371,6 +1428,7 @@ CREATE TABLE IF NOT EXISTS ix_usage_events (
   output_tokens INTEGER NULL,
   reasoning_tokens INTEGER NULL,
   total_tokens INTEGER NULL,
+  compact_count INTEGER NULL,
   duration_ms INTEGER NULL,
   cost_usd REAL NULL,
   truth_level TEXT NOT NULL,
@@ -1402,6 +1460,26 @@ CREATE INDEX IF NOT EXISTS ix_usage_events_session ON ix_usage_events(provider_i
 CREATE INDEX IF NOT EXISTS ix_usage_events_response ON ix_usage_events(provider_id, response_id);");
         try {
             db.ExecuteNonQuery(fullPath, "ALTER TABLE ix_usage_events ADD COLUMN person_label TEXT NULL;");
+        } catch {
+            // Ignore when the column already exists.
+        }
+        try {
+            db.ExecuteNonQuery(fullPath, "ALTER TABLE ix_usage_events ADD COLUMN compact_count INTEGER NULL;");
+        } catch {
+            // Ignore when the column already exists.
+        }
+        try {
+            db.ExecuteNonQuery(fullPath, "ALTER TABLE ix_usage_events ADD COLUMN conversation_title TEXT NULL;");
+        } catch {
+            // Ignore when the column already exists.
+        }
+        try {
+            db.ExecuteNonQuery(fullPath, "ALTER TABLE ix_usage_events ADD COLUMN workspace_path TEXT NULL;");
+        } catch {
+            // Ignore when the column already exists.
+        }
+        try {
+            db.ExecuteNonQuery(fullPath, "ALTER TABLE ix_usage_events ADD COLUMN repository_name TEXT NULL;");
         } catch {
             // Ignore when the column already exists.
         }

--- a/IntelligenceX/Telemetry/Usage/UsageConversationSummary.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageConversationSummary.cs
@@ -50,8 +50,19 @@ internal static class UsageConversationSummaryBuilder {
     }
 
     private static UsageConversationSummary BuildSummary(string key, IReadOnlyList<UsageEventRecord> records) {
-        var first = records.OrderBy(static item => item.TimestampUtc).First();
-        var last = records.OrderByDescending(static item => item.TimestampUtc).First();
+        var first = records[0];
+        var last = records[0];
+        for (var i = 1; i < records.Count; i++) {
+            var record = records[i];
+            if (record.TimestampUtc < first.TimestampUtc) {
+                first = record;
+            }
+
+            if (record.TimestampUtc > last.TimestampUtc) {
+                last = record;
+            }
+        }
+
         var totalDurationMs = records.Sum(static item => item.DurationMs ?? 0L);
         var activeDuration = TimeSpan.FromMilliseconds(Math.Max(0L, totalDurationMs));
         var wallDuration = last.TimestampUtc - first.TimestampUtc;
@@ -166,7 +177,10 @@ internal static class UsageConversationSummaryBuilder {
             return null;
         }
 
-        var name = Path.GetFileName(trimmed);
+        var separatorIndex = trimmed.LastIndexOfAny(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '/', '\\' });
+        var name = separatorIndex >= 0 && separatorIndex + 1 < trimmed.Length
+            ? trimmed.Substring(separatorIndex + 1)
+            : trimmed;
         return NormalizeOptional(name) ?? trimmed;
     }
 }

--- a/IntelligenceX/Telemetry/Usage/UsageConversationSummary.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageConversationSummary.cs
@@ -1,0 +1,172 @@
+using System.Globalization;
+
+namespace IntelligenceX.Telemetry.Usage;
+
+internal sealed record UsageConversationSummary(
+    string ConversationKey,
+    string ProviderId,
+    string? ProviderAccountId,
+    string? AccountLabel,
+    string SessionId,
+    string? ConversationTitle,
+    string? WorkspacePath,
+    string? WorkspaceName,
+    string? RepositoryName,
+    DateTimeOffset StartedUtc,
+    DateTimeOffset LastSeenUtc,
+    TimeSpan Duration,
+    TimeSpan ActiveDuration,
+    int TurnCount,
+    int CompactCount,
+    long InputTokens,
+    long CachedInputTokens,
+    long OutputTokens,
+    long ReasoningTokens,
+    long TotalTokens,
+    decimal CostUsd,
+    bool CostUsesEstimatedFallback,
+    IReadOnlyList<string> Models,
+    IReadOnlyList<string> Surfaces);
+
+internal static class UsageConversationSummaryBuilder {
+    public static IReadOnlyList<UsageConversationSummary> Build(IEnumerable<UsageEventRecord> events) {
+        if (events is null) {
+            return Array.Empty<UsageConversationSummary>();
+        }
+
+        return events
+            .Select(static usageEvent => new {
+                Event = usageEvent,
+                Key = BuildConversationKey(usageEvent),
+                Session = NormalizeOptional(usageEvent.ThreadId) ?? NormalizeOptional(usageEvent.SessionId)
+            })
+            .Where(static item => item.Key is not null && item.Session is not null)
+            .GroupBy(static item => item.Key!, StringComparer.OrdinalIgnoreCase)
+            .Select(group => BuildSummary(group.Key, group.Select(static item => item.Event).ToList()))
+            .OrderByDescending(static item => item.TotalTokens)
+            .ThenByDescending(static item => item.LastSeenUtc)
+            .ThenBy(static item => item.ConversationKey, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static UsageConversationSummary BuildSummary(string key, IReadOnlyList<UsageEventRecord> records) {
+        var first = records.OrderBy(static item => item.TimestampUtc).First();
+        var last = records.OrderByDescending(static item => item.TimestampUtc).First();
+        var totalDurationMs = records.Sum(static item => item.DurationMs ?? 0L);
+        var activeDuration = TimeSpan.FromMilliseconds(Math.Max(0L, totalDurationMs));
+        var wallDuration = last.TimestampUtc - first.TimestampUtc;
+        var displayDuration = wallDuration > TimeSpan.Zero
+            ? wallDuration
+            : activeDuration;
+        var displayCost = UsageTelemetryApiPricing.BuildDisplayCost(records);
+        var accountLabel = records
+            .Select(static item => NormalizeAccountLabel(item.AccountLabel, item.ProviderAccountId))
+            .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+        var providerAccountId = records
+            .Select(static item => NormalizeOptional(item.ProviderAccountId))
+            .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+        var sessionId = NormalizeOptional(first.ThreadId) ?? NormalizeOptional(first.SessionId) ?? key;
+        var conversationTitle = records
+            .Select(static item => NormalizeOptional(item.ConversationTitle))
+            .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+        var workspacePath = records
+            .Select(static item => NormalizeOptional(item.WorkspacePath))
+            .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+        var repositoryName = records
+            .Select(static item => NormalizeOptional(item.RepositoryName))
+            .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+        var turnCount = records
+            .Select(static item => NormalizeOptional(item.TurnId) ?? NormalizeOptional(item.ResponseId) ?? item.EventId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+
+        return new UsageConversationSummary(
+            key,
+            first.ProviderId,
+            providerAccountId,
+            accountLabel,
+            sessionId,
+            conversationTitle,
+            workspacePath,
+            BuildWorkspaceName(workspacePath),
+            repositoryName,
+            first.TimestampUtc,
+            last.TimestampUtc,
+            displayDuration,
+            activeDuration,
+            turnCount,
+            records.Sum(static item => item.CompactCount ?? 0),
+            records.Sum(static item => item.InputTokens ?? 0L),
+            records.Sum(static item => item.CachedInputTokens ?? 0L),
+            records.Sum(static item => item.OutputTokens ?? 0L),
+            records.Sum(static item => item.ReasoningTokens ?? 0L),
+            records.Sum(static item => item.TotalTokens ?? 0L),
+            displayCost.TotalCostUsd,
+            displayCost.UsesEstimatedFallback,
+            BuildTopLabels(records.Select(static item => NormalizeOptional(item.Model)), 3),
+            BuildTopLabels(records.Select(static item => NormalizeSurfaceLabel(item.Surface)), 2));
+    }
+
+    private static string? BuildConversationKey(UsageEventRecord usageEvent) {
+        var session = NormalizeOptional(usageEvent.ThreadId) ?? NormalizeOptional(usageEvent.SessionId);
+        if (string.IsNullOrWhiteSpace(session)) {
+            return null;
+        }
+
+        return string.Join("|",
+            NormalizeOptional(usageEvent.ProviderId) ?? "unknown-provider",
+            NormalizeOptional(usageEvent.ProviderAccountId)
+            ?? NormalizeOptional(usageEvent.AccountLabel)
+            ?? "unknown-account",
+            session);
+    }
+
+    private static IReadOnlyList<string> BuildTopLabels(IEnumerable<string?> labels, int maxLabels) {
+        return labels
+            .Select(NormalizeOptional)
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .GroupBy(static value => value!, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => new {
+                Label = group.First()!,
+                Count = group.Count()
+            })
+            .OrderByDescending(static item => item.Count)
+            .ThenBy(static item => item.Label, StringComparer.CurrentCultureIgnoreCase)
+            .Take(Math.Max(1, maxLabels))
+            .Select(static item => item.Label)
+            .ToArray();
+    }
+
+    private static string? NormalizeOptional(string? value) {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+
+    private static string? NormalizeAccountLabel(string? accountLabel, string? accountId) {
+        return NormalizeOptional(accountLabel) ?? NormalizeOptional(accountId);
+    }
+
+    private static string? NormalizeSurfaceLabel(string? surface) {
+        var normalized = NormalizeOptional(surface);
+        if (normalized is null) {
+            return null;
+        }
+
+        return normalized.Replace('-', ' ').Replace('_', ' ');
+    }
+
+    private static string? BuildWorkspaceName(string? workspacePath) {
+        var normalized = NormalizeOptional(workspacePath);
+        if (normalized is null) {
+            return null;
+        }
+
+        var trimmed = normalized.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '/', '\\');
+        if (string.IsNullOrWhiteSpace(trimmed)) {
+            return null;
+        }
+
+        var name = Path.GetFileName(trimmed);
+        return NormalizeOptional(name) ?? trimmed;
+    }
+}

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryEventMerge.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryEventMerge.cs
@@ -20,6 +20,9 @@ internal static class UsageTelemetryEventMerge {
             MachineId = record.MachineId,
             SessionId = record.SessionId,
             ThreadId = record.ThreadId,
+            ConversationTitle = record.ConversationTitle,
+            WorkspacePath = record.WorkspacePath,
+            RepositoryName = record.RepositoryName,
             TurnId = record.TurnId,
             ResponseId = record.ResponseId,
             Model = record.Model,
@@ -29,6 +32,7 @@ internal static class UsageTelemetryEventMerge {
             OutputTokens = record.OutputTokens,
             ReasoningTokens = record.ReasoningTokens,
             TotalTokens = record.TotalTokens,
+            CompactCount = record.CompactCount,
             DurationMs = record.DurationMs,
             CostUsd = record.CostUsd,
             TruthLevel = record.TruthLevel,
@@ -51,6 +55,9 @@ internal static class UsageTelemetryEventMerge {
         updated |= MergeString(existing.MachineId, incoming.MachineId, value => existing.MachineId = value);
         updated |= MergeString(existing.SessionId, incoming.SessionId, value => existing.SessionId = value);
         updated |= MergeString(existing.ThreadId, incoming.ThreadId, value => existing.ThreadId = value);
+        updated |= MergeString(existing.ConversationTitle, incoming.ConversationTitle, value => existing.ConversationTitle = value);
+        updated |= MergeString(existing.WorkspacePath, incoming.WorkspacePath, value => existing.WorkspacePath = value);
+        updated |= MergeString(existing.RepositoryName, incoming.RepositoryName, value => existing.RepositoryName = value);
         updated |= MergeString(existing.TurnId, incoming.TurnId, value => existing.TurnId = value);
         updated |= MergeString(existing.ResponseId, incoming.ResponseId, value => existing.ResponseId = value);
         updated |= MergeString(existing.Model, incoming.Model, value => existing.Model = value);
@@ -60,6 +67,7 @@ internal static class UsageTelemetryEventMerge {
         updated |= MergeNullableInt64(existing.OutputTokens, incoming.OutputTokens, value => existing.OutputTokens = value);
         updated |= MergeNullableInt64(existing.ReasoningTokens, incoming.ReasoningTokens, value => existing.ReasoningTokens = value);
         updated |= MergeNullableInt64(existing.TotalTokens, incoming.TotalTokens, value => existing.TotalTokens = value);
+        updated |= MergeNullableInt32(existing.CompactCount, incoming.CompactCount, value => existing.CompactCount = value);
         updated |= MergeNullableInt64(existing.DurationMs, incoming.DurationMs, value => existing.DurationMs = value);
         updated |= MergeNullableDecimal(existing.CostUsd, incoming.CostUsd, value => existing.CostUsd = value);
         updated |= MergeTruthLevel(existing.TruthLevel, incoming.TruthLevel, value => existing.TruthLevel = value);
@@ -89,6 +97,15 @@ internal static class UsageTelemetryEventMerge {
     }
 
     private static bool MergeNullableInt64(long? target, long? incoming, Action<long?> apply) {
+        if (target.HasValue || !incoming.HasValue) {
+            return false;
+        }
+
+        apply(incoming);
+        return true;
+    }
+
+    private static bool MergeNullableInt32(int? target, int? incoming, Action<int?> apply) {
         if (target.HasValue || !incoming.HasValue) {
             return false;
         }

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryModels.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryModels.cs
@@ -356,6 +356,21 @@ public sealed class UsageEventRecord {
     public string? ThreadId { get; set; }
 
     /// <summary>
+    /// Gets or sets the provider conversation title when available.
+    /// </summary>
+    public string? ConversationTitle { get; set; }
+
+    /// <summary>
+    /// Gets or sets the workspace path associated with the conversation when available.
+    /// </summary>
+    public string? WorkspacePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the repository name associated with the conversation when available.
+    /// </summary>
+    public string? RepositoryName { get; set; }
+
+    /// <summary>
     /// Gets or sets the provider turn identifier when available.
     /// </summary>
     public string? TurnId { get; set; }
@@ -404,6 +419,11 @@ public sealed class UsageEventRecord {
     /// Gets or sets the total token count.
     /// </summary>
     public long? TotalTokens { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of context compactions associated with this event.
+    /// </summary>
+    public int? CompactCount { get; set; }
 
     /// <summary>
     /// Gets or sets the elapsed duration in milliseconds.

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryQuickReportScanner.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryQuickReportScanner.cs
@@ -116,6 +116,11 @@ public sealed class UsageTelemetryQuickReportResult {
     public List<UsageEventRecord> Events { get; } = new();
 
     /// <summary>
+    /// Gets deduplicated per-turn usage records before day-level quick-report merging.
+    /// </summary>
+    public List<UsageEventRecord> RawEvents { get; } = new();
+
+    /// <summary>
     /// Gets or sets the number of source roots considered by the scan.
     /// </summary>
     public int RootsConsidered { get; set; }
@@ -159,7 +164,7 @@ public sealed class UsageTelemetryQuickReportScanner {
         new UsageTelemetryQuickReportProviderDefinition(
             "codex",
             "codex.quick-report",
-            "codex.quick-report/v2",
+            "codex.quick-report/v6",
             CodexQuickReportImport.EnumerateCandidateFiles,
             static (root, filePath, options, cancellationToken, definition) =>
                 CodexQuickReportImport.ParseFile(root, filePath, options, definition.AdapterId, definition.ProviderId, cancellationToken)),
@@ -257,6 +262,7 @@ public sealed class UsageTelemetryQuickReportScanner {
         result.ProviderDiagnostics.AddRange(providerDiagnostics.Values
             .OrderBy(static item => UsageTelemetryProviderCatalog.ResolveSortOrder(item.ProviderId))
             .ThenBy(static item => item.ProviderId, StringComparer.OrdinalIgnoreCase));
+        result.RawEvents.AddRange(OrderRawRecords(deduped));
         result.Events.AddRange(MergeRecords(deduped));
         return Task.FromResult(result);
     }
@@ -267,6 +273,15 @@ public sealed class UsageTelemetryQuickReportScanner {
     /// <param name="artifacts">Cached raw artifacts with quick-report state.</param>
     /// <returns>Merged usage events restored from cached quick-report state.</returns>
     internal static IReadOnlyList<UsageEventRecord> RestoreFromCachedArtifacts(IEnumerable<RawArtifactDescriptor> artifacts) {
+        return MergeRecords(RestoreRawFromCachedArtifacts(artifacts));
+    }
+
+    /// <summary>
+    /// Rehydrates cached quick-report artifacts into deduplicated per-turn usage events.
+    /// </summary>
+    /// <param name="artifacts">Cached raw artifacts with quick-report state.</param>
+    /// <returns>Deduplicated usage events restored from cached quick-report state.</returns>
+    internal static IReadOnlyList<UsageEventRecord> RestoreRawFromCachedArtifacts(IEnumerable<RawArtifactDescriptor> artifacts) {
         if (artifacts is null) {
             return Array.Empty<UsageEventRecord>();
         }
@@ -288,7 +303,7 @@ public sealed class UsageTelemetryQuickReportScanner {
             return Array.Empty<UsageEventRecord>();
         }
 
-        return MergeRecords(DeduplicateRecords(records));
+        return OrderRawRecords(DeduplicateRecords(records));
     }
 
     private static void ScanRoot(
@@ -515,6 +530,9 @@ public sealed class UsageTelemetryQuickReportScanner {
                 .Add("machineId", record.MachineId)
                 .Add("sessionId", record.SessionId)
                 .Add("threadId", record.ThreadId)
+                .Add("conversationTitle", record.ConversationTitle)
+                .Add("workspacePath", record.WorkspacePath)
+                .Add("repositoryName", record.RepositoryName)
                 .Add("turnId", record.TurnId)
                 .Add("responseId", record.ResponseId)
                 .Add("model", record.Model)
@@ -526,6 +544,7 @@ public sealed class UsageTelemetryQuickReportScanner {
             AddOptionalInt64(obj, "outputTokens", record.OutputTokens);
             AddOptionalInt64(obj, "reasoningTokens", record.ReasoningTokens);
             AddOptionalInt64(obj, "totalTokens", record.TotalTokens);
+            AddOptionalInt64(obj, "compactCount", record.CompactCount.HasValue ? (long?)record.CompactCount.Value : null);
 
             array.Add(obj);
         }
@@ -560,6 +579,9 @@ public sealed class UsageTelemetryQuickReportScanner {
                 MachineId = NormalizeOptional(obj.GetString("machineId")),
                 SessionId = NormalizeOptional(obj.GetString("sessionId")),
                 ThreadId = NormalizeOptional(obj.GetString("threadId")),
+                ConversationTitle = NormalizeOptional(obj.GetString("conversationTitle")),
+                WorkspacePath = NormalizeOptional(obj.GetString("workspacePath")),
+                RepositoryName = NormalizeOptional(obj.GetString("repositoryName")),
                 TurnId = NormalizeOptional(obj.GetString("turnId")),
                 ResponseId = NormalizeOptional(obj.GetString("responseId")),
                 Model = NormalizeOptional(obj.GetString("model")),
@@ -570,6 +592,7 @@ public sealed class UsageTelemetryQuickReportScanner {
                 OutputTokens = obj.GetInt64("outputTokens"),
                 ReasoningTokens = obj.GetInt64("reasoningTokens"),
                 TotalTokens = obj.GetInt64("totalTokens"),
+                CompactCount = ReadOptionalInt32(obj, "compactCount"),
                 TruthLevel = UsageTruthLevel.Exact
             });
         }
@@ -605,6 +628,16 @@ public sealed class UsageTelemetryQuickReportScanner {
         return deduplicated;
     }
 
+    private static IReadOnlyList<UsageEventRecord> OrderRawRecords(IEnumerable<UsageEventRecord> records) {
+        return records
+            .OrderBy(static record => record.TimestampUtc)
+            .ThenBy(static record => record.ProviderId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static record => record.SessionId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static record => record.TurnId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static record => record.EventId, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
     private static UsageEventRecord CloneRecord(UsageEventRecord record) {
         return new UsageEventRecord(
             record.EventId,
@@ -618,6 +651,9 @@ public sealed class UsageTelemetryQuickReportScanner {
             MachineId = record.MachineId,
             SessionId = record.SessionId,
             ThreadId = record.ThreadId,
+            ConversationTitle = record.ConversationTitle,
+            WorkspacePath = record.WorkspacePath,
+            RepositoryName = record.RepositoryName,
             TurnId = record.TurnId,
             ResponseId = record.ResponseId,
             Model = record.Model,
@@ -627,6 +663,7 @@ public sealed class UsageTelemetryQuickReportScanner {
             OutputTokens = record.OutputTokens,
             ReasoningTokens = record.ReasoningTokens,
             TotalTokens = record.TotalTokens,
+            CompactCount = record.CompactCount,
             DurationMs = record.DurationMs,
             CostUsd = record.CostUsd,
             TruthLevel = record.TruthLevel,
@@ -641,6 +678,9 @@ public sealed class UsageTelemetryQuickReportScanner {
         canonical.MachineId = NormalizeOptional(canonical.MachineId) ?? NormalizeOptional(duplicate.MachineId);
         canonical.SessionId = NormalizeOptional(canonical.SessionId) ?? NormalizeOptional(duplicate.SessionId);
         canonical.ThreadId = NormalizeOptional(canonical.ThreadId) ?? NormalizeOptional(duplicate.ThreadId);
+        canonical.ConversationTitle = NormalizeOptional(canonical.ConversationTitle) ?? NormalizeOptional(duplicate.ConversationTitle);
+        canonical.WorkspacePath = NormalizeOptional(canonical.WorkspacePath) ?? NormalizeOptional(duplicate.WorkspacePath);
+        canonical.RepositoryName = NormalizeOptional(canonical.RepositoryName) ?? NormalizeOptional(duplicate.RepositoryName);
         canonical.TurnId = NormalizeOptional(canonical.TurnId) ?? NormalizeOptional(duplicate.TurnId);
         canonical.ResponseId = NormalizeOptional(canonical.ResponseId) ?? NormalizeOptional(duplicate.ResponseId);
         canonical.Model = NormalizeOptional(canonical.Model) ?? NormalizeOptional(duplicate.Model);
@@ -651,6 +691,7 @@ public sealed class UsageTelemetryQuickReportScanner {
         canonical.OutputTokens = MergeMax(canonical.OutputTokens, duplicate.OutputTokens);
         canonical.ReasoningTokens = MergeMax(canonical.ReasoningTokens, duplicate.ReasoningTokens);
         canonical.TotalTokens = MergeMax(canonical.TotalTokens, duplicate.TotalTokens);
+        canonical.CompactCount = MergeMax(canonical.CompactCount, duplicate.CompactCount);
         canonical.DurationMs = MergeMax(canonical.DurationMs, duplicate.DurationMs);
         canonical.CostUsd = MergeMax(canonical.CostUsd, duplicate.CostUsd);
         if (duplicate.TruthLevel > canonical.TruthLevel) {
@@ -681,6 +722,17 @@ public sealed class UsageTelemetryQuickReportScanner {
         return Math.Max(current.Value, incoming.Value);
     }
 
+    private static int? MergeMax(int? current, int? incoming) {
+        if (!current.HasValue) {
+            return incoming;
+        }
+        if (!incoming.HasValue) {
+            return current;
+        }
+
+        return Math.Max(current.Value, incoming.Value);
+    }
+
     private static decimal? MergeMax(decimal? current, decimal? incoming) {
         if (!current.HasValue) {
             return incoming;
@@ -698,6 +750,15 @@ public sealed class UsageTelemetryQuickReportScanner {
         }
 
         obj.Add(key, value.Value);
+    }
+
+    private static int? ReadOptionalInt32(JsonObject obj, string key) {
+        var value = obj.GetInt64(key);
+        if (!value.HasValue || value.Value <= 0L) {
+            return null;
+        }
+
+        return value.Value > int.MaxValue ? int.MaxValue : (int)value.Value;
     }
 
     private static IReadOnlyList<UsageEventRecord> MergeRecords(IEnumerable<UsageEventRecord> records) {
@@ -729,6 +790,7 @@ public sealed class UsageTelemetryQuickReportScanner {
                     OutputTokens = materialized.Sum(static item => item.OutputTokens ?? 0L),
                     ReasoningTokens = materialized.Sum(static item => item.ReasoningTokens ?? 0L),
                     TotalTokens = materialized.Sum(static item => item.TotalTokens ?? 0L),
+                    CompactCount = materialized.Sum(static item => item.CompactCount ?? 0),
                     TruthLevel = UsageTruthLevel.Exact
                 };
             })

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetrySnapshotService.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetrySnapshotService.cs
@@ -58,6 +58,7 @@ public sealed class UsageTelemetrySnapshotService {
             return null;
         }
 
+        var rawEvents = UsageTelemetryQuickReportScanner.RestoreRawFromCachedArtifacts(artifacts);
         var events = UsageTelemetryQuickReportScanner.RestoreFromCachedArtifacts(artifacts);
         if (events.Count == 0) {
             return null;
@@ -82,7 +83,8 @@ public sealed class UsageTelemetrySnapshotService {
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray(),
             sourceRoots: enabledRoots,
-            health: BuildCachedSnapshotHealth(allRoots, enabledRoots, artifacts, events));
+            health: BuildCachedSnapshotHealth(allRoots, enabledRoots, artifacts, events),
+            rawEvents: rawEvents);
     }
 
     /// <summary>
@@ -178,7 +180,11 @@ public sealed class UsageTelemetrySnapshotService {
                 allEvents,
                 providerResults,
                 errors,
-                rootsByProvider.Select(static group => group.Key).ToArray()));
+                rootsByProvider.Select(static group => group.Key).ToArray()),
+            rawEvents: providerResults
+                .SelectMany(static result => result.RawEvents)
+                .OrderBy(static usageEvent => usageEvent.TimestampUtc)
+                .ToArray());
     }
 
     private IReadOnlyList<SourceRootRecord> DiscoverAllRoots() {
@@ -268,10 +274,11 @@ public sealed class UsageTelemetrySnapshotService {
             var result = await scanner
                 .ScanAsync(providerRoots.ToArray(), options, cancellationToken)
                 .ConfigureAwait(false);
-            return new ProviderScanResult(providerRoots.Key, result.Events.ToList(), result, null);
+            return new ProviderScanResult(providerRoots.Key, result.Events.ToList(), result.RawEvents.ToList(), result, null);
         } catch (Exception ex) {
             return new ProviderScanResult(
                 providerRoots.Key,
+                Array.Empty<UsageEventRecord>(),
                 Array.Empty<UsageEventRecord>(),
                 new UsageTelemetryQuickReportResult(),
                 ex.Message);
@@ -281,6 +288,7 @@ public sealed class UsageTelemetrySnapshotService {
     private sealed record ProviderScanResult(
         string ProviderId,
         IReadOnlyList<UsageEventRecord> Events,
+        IReadOnlyList<UsageEventRecord> RawEvents,
         UsageTelemetryQuickReportResult ScannerResult,
         string? ErrorMessage);
 
@@ -646,8 +654,10 @@ public sealed class UsageTelemetrySnapshot {
         IReadOnlyList<string> errors,
         IReadOnlyList<string>? discoveredProviderIds = null,
         IReadOnlyList<SourceRootRecord>? sourceRoots = null,
-        UsageTelemetrySnapshotHealth? health = null) {
+        UsageTelemetrySnapshotHealth? health = null,
+        IReadOnlyList<UsageEventRecord>? rawEvents = null) {
         Events = events ?? Array.Empty<UsageEventRecord>();
+        RawEvents = rawEvents ?? Events;
         ScannedAtUtc = scannedAtUtc;
         RootsFound = Math.Max(0, rootsFound);
         ScanDurationMs = Math.Max(0L, scanDurationMs);
@@ -661,6 +671,11 @@ public sealed class UsageTelemetrySnapshot {
     /// Gets the discovered usage events.
     /// </summary>
     public IReadOnlyList<UsageEventRecord> Events { get; }
+
+    /// <summary>
+    /// Gets deduplicated per-turn usage events before display rollup merging.
+    /// </summary>
+    public IReadOnlyList<UsageEventRecord> RawEvents { get; }
 
     /// <summary>
     /// Gets the snapshot capture time.

--- a/IntelligenceX/Visualization/Heatmaps/Assets/report.css
+++ b/IntelligenceX/Visualization/Heatmaps/Assets/report.css
@@ -98,6 +98,103 @@
     .mini-copy { margin-top:6px; color:var(--muted); font-size:13px; }
     .provider-insights { display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:16px; margin-top:16px; }
     .provider-insights.tight { grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:14px; }
+    .conversation-pulse-section .conversation-insights { grid-template-columns:minmax(240px,.58fr) minmax(540px,1.42fr); align-items:start; }
+    .conversation-summary-panel { align-self:start; padding:8px 0 0; min-width:0; max-width:410px; }
+    .conversation-pulse-section .provider-feature-headline { font-size:22px; line-height:1.15; letter-spacing:0; }
+    .conversation-summary-panel .provider-feature-copy { max-width:52ch; }
+    .conversation-pulse-section .insight-card { min-height:0; }
+    .conversation-list-card { min-width:0; padding:16px 16px 10px; border:1px solid var(--line); border-radius:var(--report-radius-card); background:var(--panel-soft); }
+    .conversation-list-headline { margin-top:10px; font-size:24px; line-height:1.1; font-weight:800; letter-spacing:0; overflow-wrap:anywhere; }
+    .conversation-toolbar { display:flex; flex-wrap:wrap; gap:10px; align-items:end; margin-top:14px; }
+    .conversation-search { display:grid; gap:6px; min-width:min(100%,340px); flex:1 1 320px; }
+    .conversation-search-label { color:var(--muted); font-size:11px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
+    .conversation-search-input { width:100%; padding:10px 12px; border:1px solid var(--line); border-radius:8px; background:var(--panel-subtle); color:var(--ink); font:inherit; }
+    .conversation-search-input::placeholder { color:var(--muted); }
+    .conversation-search-input:focus-visible { outline:2px solid var(--accent-strong); outline-offset:2px; }
+    .conversation-toolbar-actions { display:flex; flex-wrap:wrap; gap:8px; align-items:center; }
+    .conversation-search-count { min-height:40px; display:inline-flex; align-items:center; padding:0 12px; border:1px solid var(--line); border-radius:999px; background:var(--panel-subtle); color:var(--muted); font-size:12px; font-weight:700; }
+    .conversation-reset-button { min-height:40px; display:inline-flex; align-items:center; justify-content:center; padding:0 14px; border:1px solid var(--line); border-radius:999px; background:var(--button-bg); color:var(--ink); font:700 12px/1.1 inherit; cursor:pointer; }
+    .conversation-reset-button:hover { background:var(--panel-subtle); border-color:var(--accent-strong); }
+    .conversation-reset-button:focus-visible { outline:2px solid var(--accent-strong); outline-offset:2px; }
+    .conversation-filter-groups { display:grid; gap:10px; margin-top:12px; }
+    .conversation-filter-group { display:grid; gap:6px; }
+    .conversation-filter-label { color:var(--muted); font-size:11px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
+    .conversation-filter-chips { display:flex; flex-wrap:wrap; gap:8px; }
+    .conversation-filter-chip { display:inline-flex; align-items:center; justify-content:center; padding:8px 11px; border:1px solid var(--line); border-radius:999px; background:var(--button-bg); color:var(--ink); font:600 12px/1.2 inherit; cursor:pointer; }
+    .conversation-filter-chip:hover { background:var(--panel-subtle); border-color:var(--accent-strong); }
+    .conversation-filter-chip.active { background:var(--button-active); color:var(--button-active-text); border-color:var(--button-active); }
+    .conversation-filter-chip:focus-visible { outline:2px solid var(--accent-strong); outline-offset:2px; }
+    .conversation-active-bar { display:grid; gap:8px; margin-top:12px; padding:12px 14px; border:1px solid var(--line); border-radius:12px; background:rgba(255,255,255,.02); }
+    .conversation-active-label { color:var(--muted); font-size:11px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
+    .conversation-active-copy { font-size:13px; line-height:1.4; color:var(--text); }
+    .conversation-active-chips { display:flex; flex-wrap:wrap; gap:8px; }
+    .conversation-active-chip { display:inline-flex; align-items:center; gap:8px; min-height:32px; padding:6px 10px; border:1px solid var(--line); border-radius:999px; background:var(--panel-subtle); color:var(--ink); font:600 12px/1.2 inherit; cursor:pointer; }
+    .conversation-active-chip:hover { background:rgba(255,255,255,.045); border-color:var(--accent-strong); }
+    .conversation-active-chip:focus-visible { outline:2px solid var(--accent-strong); outline-offset:2px; }
+    .conversation-active-chip-action { color:var(--muted); font-size:11px; font-weight:700; }
+    .conversation-snapshot-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:10px; margin-top:12px; }
+    .conversation-snapshot-card { min-width:0; padding:12px 14px; border:1px solid var(--line); border-radius:12px; background:rgba(255,255,255,.02); }
+    .conversation-snapshot-label { color:var(--muted); font-size:11px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
+    .conversation-snapshot-value { margin-top:6px; font-size:20px; line-height:1.1; font-weight:800; overflow-wrap:anywhere; }
+    .conversation-snapshot-copy { margin-top:8px; color:var(--muted); font-size:12px; line-height:1.4; overflow-wrap:anywhere; }
+    .conversation-context-shell { display:grid; gap:12px; margin-top:12px; padding:14px; border:1px solid var(--line); border-radius:12px; background:rgba(255,255,255,.02); }
+    .conversation-context-header { display:flex; flex-wrap:wrap; justify-content:space-between; gap:12px; align-items:flex-start; }
+    .conversation-context-kicker { color:var(--muted); font-size:11px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
+    .conversation-context-copy { color:var(--muted); font-size:13px; line-height:1.4; }
+    .conversation-context-lenses { display:flex; flex-wrap:wrap; gap:8px; }
+    .conversation-context-lens { min-width:0; }
+    .conversation-context-list { display:grid; gap:8px; }
+    .conversation-context-row { width:100%; display:grid; grid-template-columns:minmax(0,1fr) auto; gap:12px; align-items:center; padding:11px 12px; border:1px solid var(--line); border-radius:10px; background:var(--panel-subtle); color:var(--ink); text-align:left; cursor:pointer; appearance:none; font:inherit; }
+    .conversation-context-row:hover { border-color:var(--accent-strong); background:rgba(255,255,255,.045); }
+    .conversation-context-row.active { border-color:var(--button-active); background:rgba(106,115,255,.14); }
+    .conversation-context-row:focus-visible { outline:2px solid var(--accent-strong); outline-offset:2px; }
+    .conversation-context-main { min-width:0; display:grid; gap:5px; }
+    .conversation-context-name { font-size:14px; font-weight:700; overflow-wrap:anywhere; }
+    .conversation-context-meta { color:var(--muted); font-size:12px; line-height:1.35; overflow-wrap:anywhere; }
+    .conversation-context-value { text-align:right; display:grid; gap:4px; justify-items:end; }
+    .conversation-context-tokens { font-size:14px; font-weight:800; }
+    .conversation-context-share { color:var(--muted); font-size:12px; }
+    .conversation-context-empty { padding:12px; border:1px dashed var(--line); border-radius:10px; color:var(--muted); font-size:12px; line-height:1.45; }
+    .conversation-sort-toolbar { display:flex; flex-wrap:wrap; gap:8px; margin-top:14px; }
+    .conversation-explorer { display:grid; grid-template-columns:minmax(0,1.18fr) minmax(300px,.82fr); gap:16px; margin-top:14px; align-items:start; }
+    .conversation-list { display:grid; gap:0; min-width:0; }
+    .conversation-row { display:grid; grid-template-columns:42px minmax(0,1fr); gap:14px; align-items:start; width:100%; padding:14px 0; border:0; border-top:1px solid var(--line); background:none; color:inherit; text-align:left; cursor:pointer; appearance:none; font:inherit; }
+    .conversation-row:hover { background:rgba(255,255,255,.02); }
+    .conversation-row.active { background:rgba(255,255,255,.025); }
+    .conversation-row:focus-visible { outline:2px solid var(--accent-strong); outline-offset:2px; border-radius:8px; }
+    .conversation-rank { color:var(--muted); font-size:12px; font-weight:800; padding-top:4px; }
+    .conversation-row-head { display:grid; grid-template-columns:minmax(0,1fr) auto; gap:14px; align-items:start; }
+    .conversation-title { min-width:0; font-weight:800; }
+    .conversation-title span { display:block; overflow-wrap:anywhere; }
+    .conversation-session { margin-top:5px; color:var(--muted); font-size:12px; overflow-wrap:anywhere; }
+    .conversation-session code { color:var(--muted); font:600 12px/1.2 ui-monospace,SFMono-Regular,Consolas,monospace; }
+    .conversation-chips { display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; }
+    .conversation-chips span { max-width:100%; border:1px solid var(--line); border-radius:999px; padding:3px 8px; color:var(--text); background:var(--panel-subtle); font-size:12px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+    .conversation-facts { display:grid; grid-template-columns:repeat(3,minmax(120px,1fr)); gap:8px; margin-top:10px; }
+    .conversation-fact { min-width:0; padding:8px 10px; border:1px solid var(--line); border-radius:8px; background:rgba(255,255,255,.02); }
+    .conversation-fact-label { color:var(--muted); font-size:11px; text-transform:uppercase; letter-spacing:.04em; }
+    .conversation-fact-value { margin-top:4px; font-size:13px; line-height:1.25; overflow-wrap:anywhere; }
+    .conversation-bar { margin-top:11px; width:100%; height:6px; border-radius:999px; background:var(--row-bar-bg); overflow:hidden; }
+    .conversation-bar-fill { height:100%; min-width:3px; border-radius:999px; background:linear-gradient(90deg,#8ddf9d 0%,#40c463 100%); }
+    .conversation-tokens { text-align:right; min-width:92px; }
+    .conversation-tokens strong { display:block; font-size:16px; line-height:1.1; }
+    .conversation-tokens span { display:block; margin-top:4px; color:var(--muted); font-size:12px; }
+    .conversation-detail-card { position:sticky; top:20px; min-width:0; padding:16px; border:1px solid var(--line); border-radius:16px; background:rgba(255,255,255,.02); }
+    .conversation-detail-kicker { color:var(--muted); font-size:11px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
+    .conversation-detail-header { display:grid; grid-template-columns:auto minmax(0,1fr); gap:12px; align-items:start; margin-top:10px; }
+    .conversation-detail-rank { display:inline-flex; align-items:center; justify-content:center; min-width:42px; height:32px; padding:0 10px; border-radius:999px; border:1px solid var(--line); color:var(--text); background:var(--panel-subtle); font-size:12px; font-weight:800; }
+    .conversation-detail-title { font-size:20px; line-height:1.12; font-weight:800; overflow-wrap:anywhere; }
+    .conversation-detail-session { margin-top:5px; color:var(--muted); font-size:12px; overflow-wrap:anywhere; }
+    .conversation-detail-metrics { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:10px; margin-top:14px; }
+    .conversation-detail-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:10px; margin-top:12px; }
+    .conversation-detail-metric { min-width:0; padding:10px 12px; border:1px solid var(--line); border-radius:10px; background:rgba(255,255,255,.025); }
+    .conversation-detail-label { color:var(--muted); font-size:11px; text-transform:uppercase; letter-spacing:.04em; }
+    .conversation-detail-value { margin-top:4px; font-size:14px; line-height:1.25; overflow-wrap:anywhere; }
+    .conversation-detail-chips { display:flex; flex-wrap:wrap; gap:6px; margin-top:12px; }
+    .conversation-detail-chips span { max-width:100%; border:1px solid var(--line); border-radius:999px; padding:4px 9px; background:var(--panel-subtle); font-size:12px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+    .conversation-detail-summary { margin-top:12px; padding-top:12px; border-top:1px solid var(--line); }
+    .conversation-detail-summary-copy { color:var(--muted); font-size:13px; line-height:1.45; overflow-wrap:anywhere; }
+    .conversation-empty { align-self:start; padding:18px 16px; border:1px dashed var(--line); border-radius:14px; background:rgba(255,255,255,.02); color:var(--muted); font-size:13px; line-height:1.45; }
     .insight-card { min-height:140px; padding:16px 16px 14px; border:1px solid var(--line); border-radius:var(--report-radius-card); background:var(--panel-soft); }
     .insight-title { color:var(--muted); font-size:12px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; margin-bottom:12px; }
     .rank-list { display:grid; gap:10px; }
@@ -161,5 +258,5 @@
     .summary-row-meta { margin-top:4px; color:var(--muted); font-size:12px; }
     .footnote { margin-top:24px; color:var(--muted); font-size:13px; }
     @media (max-width: 1380px) { .github-impact-shell .provider-insights.tight { grid-template-columns:1fr; } }
-    @media (max-width: 1080px) { .hero, .provider-header, .provider-token-mix-header, .supporting-header, .supporting-toolbar { flex-direction:column; align-items:flex-start; } .hero-meta, .provider-metrics { min-width:0; width:100%; } .hero-stat, .provider-metric { text-align:left; } .hero-chip-group { justify-content:flex-start; } .provider-footer, .provider-spotlight { grid-template-columns:repeat(2,minmax(180px,1fr)); } .provider-insights, .provider-summary-grid, .provider-feature-grid, .github-impact-shell .provider-insights.tight { grid-template-columns:1fr; } .provider-note, .provider-legend { margin-left:0; } .provider-compare-grid { grid-template-columns:1fr; } .provider-compare-arrow { width:36px; height:36px; margin:0 auto; } .github-impact-toolbar { align-items:flex-start; } }
-    @media (max-width: 680px) { .hero-meta, .provider-metrics, .provider-footer, .provider-spotlight { grid-template-columns:1fr; gap:14px; } .provider-title { font-size:32px; } .provider-feature-card, .provider-compare-card, .insight-card { padding:14px; } .provider-feature-headline, .provider-compare-value { font-size:22px; line-height:1.08; } .provider-feature-copy, .provider-compare-subtitle { font-size:12px; } .provider-feature-row-head { grid-template-columns:minmax(0,1fr); gap:6px; } .provider-feature-row-value { text-align:left; } .rank-row { grid-template-columns:24px minmax(0,1fr); gap:8px; align-items:start; } .rank-label { font-size:16px; } .rank-value { grid-column:2; text-align:left; font-size:14px; } .rank-note { margin-left:32px; } .estimate-total { flex-direction:column; align-items:flex-start; } .estimate-copy { max-width:none; text-align:left; } .provider-note-chip { font-size:11px; } .provider-dataset-tabs, .github-lens-switcher, .github-repo-sort-tabs { width:100%; gap:8px; } .provider-dataset-tab, .github-lens-tab, .github-repo-sort-tab { min-width:0; flex:1 1 calc(50% - 8px); padding:8px 10px; font-size:11px; letter-spacing:.03em; } .provider-dataset-link { margin-left:0; flex-basis:100%; } .github-impact-toolbar { gap:10px; } .github-repo-sorter { gap:8px; } .github-repo-sort-kicker { width:100%; margin-right:0; } .supporting-viewer { padding:16px; } .supporting-title { font-size:20px; } .supporting-guide { font-size:12px; max-width:none; } .supporting-copy { font-size:13px; max-width:none; } .supporting-links { width:100%; gap:8px; margin-bottom:12px; flex:1 1 auto; justify-content:flex-start; } .supporting-link { min-width:0; flex:1 1 132px; padding:8px 10px; font-size:11px; letter-spacing:.03em; } .supporting-family-chips { margin-top:8px; } }
+    @media (max-width: 1080px) { .hero, .provider-header, .provider-token-mix-header, .supporting-header, .supporting-toolbar { flex-direction:column; align-items:flex-start; } .hero-meta, .provider-metrics { min-width:0; width:100%; } .hero-stat, .provider-metric { text-align:left; } .hero-chip-group { justify-content:flex-start; } .provider-footer, .provider-spotlight { grid-template-columns:repeat(2,minmax(180px,1fr)); } .provider-insights, .provider-summary-grid, .provider-feature-grid, .github-impact-shell .provider-insights.tight, .conversation-pulse-section .conversation-insights, .conversation-explorer { grid-template-columns:1fr; } .provider-note, .provider-legend { margin-left:0; } .provider-compare-grid { grid-template-columns:1fr; } .provider-compare-arrow { width:36px; height:36px; margin:0 auto; } .github-impact-toolbar { align-items:flex-start; } .conversation-detail-card { position:static; top:auto; } }
+    @media (max-width: 680px) { .hero-meta, .provider-metrics, .provider-footer, .provider-spotlight { grid-template-columns:1fr; gap:14px; } .provider-title { font-size:32px; } .provider-feature-card, .provider-compare-card, .insight-card, .conversation-list-card { padding:14px; } .provider-feature-headline, .provider-compare-value, .conversation-list-headline { font-size:22px; line-height:1.08; } .provider-feature-copy, .provider-compare-subtitle { font-size:12px; } .provider-feature-row-head { grid-template-columns:minmax(0,1fr); gap:6px; } .provider-feature-row-value { text-align:left; } .rank-row { grid-template-columns:24px minmax(0,1fr); gap:8px; align-items:start; } .rank-label { font-size:16px; } .rank-value { grid-column:2; text-align:left; font-size:14px; } .rank-note { margin-left:32px; } .conversation-toolbar { align-items:stretch; } .conversation-search, .conversation-toolbar-actions { min-width:0; flex-basis:100%; } .conversation-search-count, .conversation-reset-button { min-height:36px; } .conversation-row { grid-template-columns:30px minmax(0,1fr); gap:10px; } .conversation-row-head { grid-template-columns:minmax(0,1fr); gap:8px; } .conversation-tokens { text-align:left; min-width:0; } .conversation-facts, .conversation-detail-grid, .conversation-detail-metrics { grid-template-columns:repeat(2,minmax(0,1fr)); } .estimate-total { flex-direction:column; align-items:flex-start; } .estimate-copy { max-width:none; text-align:left; } .provider-note-chip { font-size:11px; } .provider-dataset-tabs, .github-lens-switcher, .github-repo-sort-tabs { width:100%; gap:8px; } .provider-dataset-tab, .github-lens-tab, .github-repo-sort-tab { min-width:0; flex:1 1 calc(50% - 8px); padding:8px 10px; font-size:11px; letter-spacing:.03em; } .provider-dataset-link { margin-left:0; flex-basis:100%; } .github-impact-toolbar { gap:10px; } .github-repo-sorter { gap:8px; } .github-repo-sort-kicker { width:100%; margin-right:0; } .supporting-viewer { padding:16px; } .supporting-title { font-size:20px; } .supporting-guide { font-size:12px; max-width:none; } .supporting-copy { font-size:13px; max-width:none; } .supporting-links { width:100%; gap:8px; margin-bottom:12px; flex:1 1 auto; justify-content:flex-start; } .supporting-link { min-width:0; flex:1 1 132px; padding:8px 10px; font-size:11px; letter-spacing:.03em; } .supporting-family-chips { margin-top:8px; } }

--- a/IntelligenceX/Visualization/Heatmaps/Assets/report.js
+++ b/IntelligenceX/Visualization/Heatmaps/Assets/report.js
@@ -16,7 +16,49 @@
       compactMode: 'summary'
     })
     : null;
+  const ixConversationSortButtons = document.querySelectorAll('[data-conversation-sort]');
+  const ixConversationSearchInput = document.querySelector('[data-conversation-search]');
+  const ixConversationCount = document.querySelector('[data-conversation-count]');
+  const ixConversationEmpty = document.querySelector('[data-conversation-empty]');
+  const ixConversationFilterButtons = document.querySelectorAll('[data-conversation-filter-group]');
+  const ixConversationResetButton = document.querySelector('[data-conversation-reset]');
+  const ixConversationActiveText = document.querySelector('[data-conversation-active-text]');
+  const ixConversationActiveChips = document.querySelector('[data-conversation-active-chips]');
+  const ixConversationSnapshotCount = document.querySelector('[data-conversation-snapshot-count]');
+  const ixConversationSnapshotCountCopy = document.querySelector('[data-conversation-snapshot-count-copy]');
+  const ixConversationSnapshotTokens = document.querySelector('[data-conversation-snapshot-tokens]');
+  const ixConversationSnapshotTokensCopy = document.querySelector('[data-conversation-snapshot-tokens-copy]');
+  const ixConversationSnapshotCost = document.querySelector('[data-conversation-snapshot-cost]');
+  const ixConversationSnapshotCostCopy = document.querySelector('[data-conversation-snapshot-cost-copy]');
+  const ixConversationSnapshotDuration = document.querySelector('[data-conversation-snapshot-duration]');
+  const ixConversationSnapshotDurationCopy = document.querySelector('[data-conversation-snapshot-duration-copy]');
+  const ixConversationSnapshotContext = document.querySelector('[data-conversation-snapshot-context]');
+  const ixConversationSnapshotContextCopy = document.querySelector('[data-conversation-snapshot-context-copy]');
+  const ixConversationContextList = document.querySelector('[data-conversation-context-list]');
+  const ixConversationContextCopy = document.querySelector('[data-conversation-context-copy]');
+  const ixConversationContextLensButtons = document.querySelectorAll('[data-conversation-context-lens]');
   let ixAccentController = null;
+  const ixConversationState = {
+    sort: 'tokens',
+    contextLens: 'tokens',
+    query: '',
+    named: '',
+    profile: '',
+    account: '',
+    context: ''
+  };
+  const ixConversationSortLabels = {
+    tokens: 'Tokens',
+    cost: 'Cost',
+    duration: 'Duration',
+    turns: 'Turns',
+    compacts: 'Compacts'
+  };
+  const ixConversationIntegerFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+  const ixConversationCompactFormatter = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 });
+  const ixConversationPercentFormatter = new Intl.NumberFormat(undefined, { style: 'percent', maximumFractionDigits: 0 });
+  const ixConversationDecimalFormatter = new Intl.NumberFormat(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+  const ixConversationCurrencyFormatter = new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
   if (window.IntelligenceXReportRuntime) {
     const ixThemeController = window.IntelligenceXReportRuntime.initThemeController({
       themeKey: ixBootstrap.themeKey || 'ix-usage-report-theme',
@@ -67,6 +109,657 @@
       });
     });
   });
+  function ixBuildConversationSummary(detail) {
+    const parts = [];
+    if (detail.tokens) parts.push(`${detail.tokens} tokens`);
+    if (detail.share) parts.push(detail.share);
+    if (detail.span) parts.push(detail.span);
+    if (detail.active) parts.push(detail.active);
+    if (detail.turns) parts.push(detail.turns);
+    if (detail.compacts) parts.push(detail.compacts);
+    if (detail.cost) parts.push(detail.cost);
+    return parts.join(' • ');
+  }
+  function ixRenderConversationChips(host, detail) {
+    if (!host) return;
+    host.innerHTML = '';
+    const values = [];
+    if (detail.repository) values.push(detail.repository);
+    if (detail.workspace && detail.workspace.toLowerCase() !== (detail.repository || '').toLowerCase()) values.push(detail.workspace);
+    if (!detail.repository && !detail.workspace && detail.context) values.push(detail.context);
+    if (detail.account) values.push(detail.account);
+    if (detail.model) values.push(detail.model);
+    if (detail.surface) values.push(detail.surface);
+    values.forEach(value => {
+      const chip = document.createElement('span');
+      chip.textContent = value;
+      host.appendChild(chip);
+    });
+  }
+  function ixSetConversationCount(visibleCount, totalCount) {
+    if (!ixConversationCount) return;
+    if (visibleCount === totalCount) {
+      ixConversationCount.textContent = `${visibleCount} visible`;
+      return;
+    }
+    ixConversationCount.textContent = `${visibleCount} of ${totalCount} visible`;
+  }
+  function ixApplyConversationSelection(button) {
+    const detailShell = document.querySelector('[data-conversation-detail]');
+    if (!detailShell) return;
+    if (!button) {
+      detailShell.classList.add('hidden');
+      if (ixConversationEmpty) ixConversationEmpty.classList.remove('hidden');
+      return;
+    }
+    detailShell.classList.remove('hidden');
+    if (ixConversationEmpty) ixConversationEmpty.classList.add('hidden');
+    const detail = {
+      rank: button.getAttribute('data-detail-rank') || '',
+      title: button.getAttribute('data-detail-title') || '',
+      sessionLabel: button.getAttribute('data-detail-sessionlabel') || '',
+      sessionCode: button.getAttribute('data-detail-sessioncode') || '',
+      tokens: button.getAttribute('data-detail-tokens') || '',
+      share: button.getAttribute('data-detail-share') || '',
+      started: button.getAttribute('data-detail-started') || '',
+      span: button.getAttribute('data-detail-span') || '',
+      active: button.getAttribute('data-detail-active') || '',
+      turns: button.getAttribute('data-detail-turns') || '',
+      compacts: button.getAttribute('data-detail-compacts') || '',
+      cost: button.getAttribute('data-detail-cost') || '',
+      context: button.getAttribute('data-detail-context') || '',
+      repository: button.getAttribute('data-detail-repository') || '',
+      workspace: button.getAttribute('data-detail-workspace') || '',
+      account: button.getAttribute('data-detail-account') || '',
+      model: button.getAttribute('data-detail-model') || '',
+      surface: button.getAttribute('data-detail-surface') || ''
+    };
+    document.querySelectorAll('[data-conversation-button]').forEach(other => {
+      const active = other === button;
+      other.classList.toggle('active', active);
+      other.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+    const sessionText = [detail.sessionLabel, detail.sessionCode].filter(Boolean).join(' ');
+    const bindings = [
+      ['[data-detail-rank]', detail.rank],
+      ['[data-detail-title]', detail.title],
+      ['[data-detail-session]', sessionText],
+      ['[data-detail-tokens]', detail.tokens],
+      ['[data-detail-share]', detail.share],
+      ['[data-detail-started]', detail.started],
+      ['[data-detail-span]', detail.span],
+      ['[data-detail-active]', detail.active],
+      ['[data-detail-turns]', detail.turns],
+      ['[data-detail-compacts]', detail.compacts],
+      ['[data-detail-cost]', detail.cost],
+      ['[data-detail-summary]', ixBuildConversationSummary(detail)]
+    ];
+    bindings.forEach(([selector, value]) => {
+      const node = detailShell.querySelector(selector);
+      if (!node) return;
+      node.textContent = value || 'n/a';
+    });
+    ixRenderConversationChips(detailShell.querySelector('[data-detail-chip-host]'), detail);
+    detailShell.querySelectorAll('.conversation-detail-metric').forEach(metric => {
+      const valueNode = metric.querySelector('.conversation-detail-value');
+      const text = valueNode ? (valueNode.textContent || '').trim().toLowerCase() : '';
+      metric.classList.toggle('hidden', !text || text === 'n/a');
+    });
+  }
+  function ixConversationSearchText(button) {
+    return [
+      button.getAttribute('data-detail-title') || '',
+      button.getAttribute('data-detail-sessioncode') || '',
+      button.getAttribute('data-detail-sessionlabel') || '',
+      button.getAttribute('data-detail-repository') || '',
+      button.getAttribute('data-detail-workspace') || '',
+      button.getAttribute('data-detail-account') || '',
+      button.getAttribute('data-detail-context') || ''
+    ].join(' ').toLowerCase();
+  }
+  function ixConversationIsNamed(button) {
+    const title = (button.getAttribute('data-detail-title') || '').trim();
+    return !!title && !/^Session \d+$/i.test(title);
+  }
+  function ixConversationHasActiveOverrides() {
+    return !!((ixConversationState.query || '').trim()
+      || ixConversationState.named
+      || ixConversationState.profile
+      || ixConversationState.account
+      || ixConversationState.context
+      || ixConversationState.sort !== 'tokens'
+      || ixConversationState.contextLens !== 'tokens');
+  }
+  function ixResetConversationView() {
+    ixConversationState.sort = 'tokens';
+    ixConversationState.contextLens = 'tokens';
+    ixConversationState.query = '';
+    ixConversationState.named = '';
+    ixConversationState.profile = '';
+    ixConversationState.account = '';
+    ixConversationState.context = '';
+    if (ixConversationSearchInput) {
+      ixConversationSearchInput.value = '';
+    }
+  }
+  function ixConversationStateToUrl() {
+    if (!window.history || !window.URL) return;
+    const url = new URL(window.location.href);
+    const params = url.searchParams;
+    const normalizedQuery = (ixConversationState.query || '').trim();
+    if (normalizedQuery) params.set('conversationSearch', normalizedQuery);
+    else params.delete('conversationSearch');
+    if (ixConversationState.named) params.set('conversationNamed', ixConversationState.named);
+    else params.delete('conversationNamed');
+    if (ixConversationState.profile) params.set('conversationProfile', ixConversationState.profile);
+    else params.delete('conversationProfile');
+    if (ixConversationState.account) params.set('conversationAccount', ixConversationState.account);
+    else params.delete('conversationAccount');
+    if (ixConversationState.context) params.set('conversationContext', ixConversationState.context);
+    else params.delete('conversationContext');
+    if (ixConversationState.sort && ixConversationState.sort !== 'tokens') params.set('conversationSort', ixConversationState.sort);
+    else params.delete('conversationSort');
+    if (ixConversationState.contextLens && ixConversationState.contextLens !== 'tokens') params.set('conversationContextLens', ixConversationState.contextLens);
+    else params.delete('conversationContextLens');
+    window.history.replaceState(null, '', url.toString());
+  }
+  function ixRestoreConversationStateFromUrl() {
+    if (!window.URLSearchParams) return;
+    const params = new URLSearchParams(window.location.search);
+    const sort = params.get('conversationSort') || 'tokens';
+    ixConversationState.sort = Object.prototype.hasOwnProperty.call(ixConversationSortLabels, sort) ? sort : 'tokens';
+    ixConversationState.query = params.get('conversationSearch') || '';
+    const named = params.get('conversationNamed') || '';
+    ixConversationState.named = named === 'named' || named === 'unnamed' ? named : '';
+    const profile = params.get('conversationProfile') || '';
+    ixConversationState.profile = profile === 'bursty' || profile === 'marathon' || profile === 'compact-heavy' ? profile : '';
+    ixConversationState.account = params.get('conversationAccount') || '';
+    ixConversationState.context = params.get('conversationContext') || '';
+    const contextLens = params.get('conversationContextLens') || '';
+    ixConversationState.contextLens = contextLens === 'cost' || contextLens === 'count' ? contextLens : 'tokens';
+    if (ixConversationSearchInput) {
+      ixConversationSearchInput.value = ixConversationState.query;
+    }
+  }
+  function ixConversationProfileMatches(button, profile) {
+    const tokens = ixConversationSortValue(button, 'tokens');
+    const duration = ixConversationSortValue(button, 'duration');
+    const turns = ixConversationSortValue(button, 'turns');
+    const compacts = ixConversationSortValue(button, 'compacts');
+    const hours = duration > 0 ? duration / 3600000 : 0;
+    const tokensPerHour = hours > 0 ? tokens / hours : tokens;
+    const compactRatio = turns > 0 ? compacts / turns : 0;
+
+    if (profile === 'bursty') {
+      return tokens >= 5_000_000 && (duration <= 4 * 3600000 || tokensPerHour >= 2_000_000);
+    }
+    if (profile === 'marathon') {
+      return duration >= 24 * 3600000;
+    }
+    if (profile === 'compact-heavy') {
+      return compacts >= 3 || (turns >= 8 && compactRatio >= 0.2);
+    }
+    return true;
+  }
+  function ixConversationMatchesFilters(button) {
+    if (ixConversationState.named === 'named' && !ixConversationIsNamed(button)) {
+      return false;
+    }
+    if (ixConversationState.named === 'unnamed' && ixConversationIsNamed(button)) {
+      return false;
+    }
+    if (ixConversationState.profile && !ixConversationProfileMatches(button, ixConversationState.profile)) {
+      return false;
+    }
+    if (ixConversationState.account) {
+      const account = (button.getAttribute('data-detail-account') || '').trim().toLowerCase();
+      if (account !== ixConversationState.account.toLowerCase()) {
+        return false;
+      }
+    }
+    if (ixConversationState.context) {
+      const context = ((button.getAttribute('data-detail-repository') || '')
+        || (button.getAttribute('data-detail-workspace') || '')
+        || (button.getAttribute('data-detail-context') || '')).trim().toLowerCase();
+      if (context !== ixConversationState.context.toLowerCase()) {
+        return false;
+      }
+    }
+    return true;
+  }
+  function ixApplyConversationFilterButtonState() {
+    ixConversationFilterButtons.forEach(button => {
+      const group = button.getAttribute('data-conversation-filter-group') || '';
+      const value = button.getAttribute('data-conversation-filter-value') || '';
+      const active = !!group && ixConversationState[group] === value;
+      button.classList.toggle('active', active);
+      button.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+  }
+  function ixConversationSortValue(button, mode) {
+    const attr = {
+      tokens: 'data-detail-sorttokens',
+      cost: 'data-detail-sortcost',
+      duration: 'data-detail-sortduration',
+      turns: 'data-detail-sortturns',
+      compacts: 'data-detail-sortcompacts'
+    }[mode] || 'data-detail-sorttokens';
+    const value = Number(button.getAttribute(attr) || '0');
+    return Number.isFinite(value) ? value : 0;
+  }
+  function ixFormatConversationCompactNumber(value) {
+    if (!Number.isFinite(value) || value <= 0) return '0';
+    if (value < 1000) return ixConversationIntegerFormatter.format(value);
+    return ixConversationCompactFormatter.format(value);
+  }
+  function ixFormatConversationDuration(ms) {
+    if (!Number.isFinite(ms) || ms <= 0) return 'n/a';
+    const minutes = ms / 60000;
+    if (minutes < 60) {
+      return `${ixConversationIntegerFormatter.format(Math.max(1, Math.round(minutes)))} min`;
+    }
+    const hours = minutes / 60;
+    if (hours < 24) {
+      return `${ixConversationDecimalFormatter.format(hours)} hr`;
+    }
+    const days = hours / 24;
+    return `${ixConversationDecimalFormatter.format(days)} d`;
+  }
+  function ixFormatConversationPercent(value) {
+    if (!Number.isFinite(value) || value <= 0) return '0%';
+    return ixConversationPercentFormatter.format(value);
+  }
+  function ixFormatConversationCurrency(value) {
+    if (!Number.isFinite(value) || value <= 0) return '$0';
+    if (value >= 1000) {
+      return `${ixConversationCurrencyFormatter.format(value).replace(/\.00$/, '')}`;
+    }
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value);
+  }
+  function ixConversationContextLabel(row) {
+    return (row.getAttribute('data-detail-repository') || '')
+      || (row.getAttribute('data-detail-workspace') || '')
+      || (row.getAttribute('data-detail-context') || '')
+      || 'No repo or workspace';
+  }
+  function ixConversationContextEntries(rows) {
+    const contextMap = new Map();
+    rows.forEach(row => {
+      const label = ixConversationContextLabel(row);
+      const entry = contextMap.get(label) || { label, tokens: 0, cost: 0, count: 0 };
+      entry.tokens += ixConversationSortValue(row, 'tokens');
+      entry.cost += ixConversationSortValue(row, 'cost');
+      entry.count += 1;
+      contextMap.set(label, entry);
+    });
+    return Array.from(contextMap.values()).sort((left, right) => {
+      const lens = ixConversationState.contextLens || 'tokens';
+      const leftValue = lens === 'cost' ? left.cost : (lens === 'count' ? left.count : left.tokens);
+      const rightValue = lens === 'cost' ? right.cost : (lens === 'count' ? right.count : right.tokens);
+      if (rightValue !== leftValue) return rightValue - leftValue;
+      if (right.count !== left.count) return right.count - left.count;
+      return left.label.localeCompare(right.label);
+    });
+  }
+  function ixReindexConversationRows(rows) {
+    rows.forEach((row, index) => {
+      const rank = `#${index + 1}`;
+      row.setAttribute('data-detail-rank', rank);
+      const rankNode = row.querySelector('.conversation-rank');
+      if (rankNode) rankNode.textContent = rank;
+    });
+  }
+  function ixRenderConversationSnapshot(visibleRows, allRows) {
+    const lens = ixConversationState.contextLens || 'tokens';
+    const totalVisible = visibleRows.length;
+    const visibleTokens = visibleRows.reduce((sum, row) => sum + ixConversationSortValue(row, 'tokens'), 0);
+    const allTokens = allRows.reduce((sum, row) => sum + ixConversationSortValue(row, 'tokens'), 0);
+    const visibleCost = visibleRows.reduce((sum, row) => sum + ixConversationSortValue(row, 'cost'), 0);
+    const allCost = allRows.reduce((sum, row) => sum + ixConversationSortValue(row, 'cost'), 0);
+    const visibleDuration = visibleRows.reduce((sum, row) => sum + ixConversationSortValue(row, 'duration'), 0);
+    const visibleTurns = visibleRows.reduce((sum, row) => sum + ixConversationSortValue(row, 'turns'), 0);
+    const namedCount = visibleRows.filter(ixConversationIsNamed).length;
+    const compactedCount = visibleRows.filter(row => ixConversationSortValue(row, 'compacts') > 0).length;
+    const averageDuration = totalVisible > 0 ? visibleDuration / totalVisible : 0;
+    const averageTurns = totalVisible > 0 ? visibleTurns / totalVisible : 0;
+    const contextEntries = ixConversationContextEntries(visibleRows);
+    const topContext = contextEntries[0] || { label: 'No repo or workspace', tokens: 0, count: 0 };
+
+    if (ixConversationSnapshotCount) {
+      ixConversationSnapshotCount.textContent = ixConversationIntegerFormatter.format(totalVisible);
+    }
+    if (ixConversationSnapshotCountCopy) {
+      if (!totalVisible) {
+        ixConversationSnapshotCountCopy.textContent = 'Adjust the search or filters to bring conversations back.';
+      } else {
+        ixConversationSnapshotCountCopy.textContent = `${ixConversationIntegerFormatter.format(namedCount)} named • ${ixConversationIntegerFormatter.format(compactedCount)} compacted`;
+      }
+    }
+    if (ixConversationSnapshotTokens) {
+      ixConversationSnapshotTokens.textContent = ixFormatConversationCompactNumber(visibleTokens);
+    }
+    if (ixConversationSnapshotTokensCopy) {
+      const share = allTokens > 0 ? visibleTokens / allTokens : 0;
+      ixConversationSnapshotTokensCopy.textContent = totalVisible
+        ? `${ixFormatConversationPercent(share)} of the currently loaded conversation tokens`
+        : 'No token volume in the current slice.';
+    }
+    if (ixConversationSnapshotCost) {
+      ixConversationSnapshotCost.textContent = ixFormatConversationCurrency(visibleCost);
+    }
+    if (ixConversationSnapshotCostCopy) {
+      const share = allCost > 0 ? visibleCost / allCost : 0;
+      ixConversationSnapshotCostCopy.textContent = totalVisible
+        ? `${ixFormatConversationPercent(share)} of the currently loaded conversation cost`
+        : 'No cost recorded in the current slice.';
+    }
+    if (ixConversationSnapshotDuration) {
+      ixConversationSnapshotDuration.textContent = ixFormatConversationDuration(averageDuration);
+    }
+    if (ixConversationSnapshotDurationCopy) {
+      ixConversationSnapshotDurationCopy.textContent = totalVisible
+        ? `${ixConversationDecimalFormatter.format(averageTurns)} average turns per conversation`
+        : 'Average span appears once at least one conversation is visible.';
+    }
+    if (ixConversationSnapshotContext) {
+      ixConversationSnapshotContext.textContent = totalVisible ? topContext.label : 'No repo or workspace';
+    }
+    if (ixConversationSnapshotContextCopy) {
+      if (!totalVisible || topContext.count === 0) {
+        ixConversationSnapshotContextCopy.textContent = 'No conversation context is available in the current slice.';
+      } else {
+        const share = lens === 'cost'
+          ? (visibleCost > 0 ? topContext.cost / visibleCost : 0)
+          : (lens === 'count'
+            ? (totalVisible > 0 ? topContext.count / totalVisible : 0)
+            : (visibleTokens > 0 ? topContext.tokens / visibleTokens : 0));
+        const shareLabel = lens === 'cost'
+          ? 'of visible cost'
+          : (lens === 'count' ? 'of visible conversations' : 'of visible tokens');
+        ixConversationSnapshotContextCopy.textContent = `${ixConversationIntegerFormatter.format(topContext.count)} conversations • ${ixFormatConversationPercent(share)} ${shareLabel}`;
+      }
+    }
+  }
+  function ixRenderConversationContextBreakdown(visibleRows) {
+    if (!ixConversationContextList) return;
+    ixConversationContextList.innerHTML = '';
+    const lens = ixConversationState.contextLens || 'tokens';
+    ixConversationContextLensButtons.forEach(button => {
+      const active = (button.getAttribute('data-conversation-context-lens') || 'tokens') === lens;
+      button.classList.toggle('active', active);
+      button.setAttribute('aria-selected', active ? 'true' : 'false');
+    });
+    if (!visibleRows.length) {
+      if (ixConversationContextCopy) {
+        ixConversationContextCopy.textContent = 'No visible conversations yet. Clear a filter or widen the search.';
+      }
+      const empty = document.createElement('div');
+      empty.className = 'conversation-context-empty';
+      empty.textContent = 'No repo or workspace breakdown is available until conversations are visible.';
+      ixConversationContextList.appendChild(empty);
+      return;
+    }
+
+    const contextEntries = ixConversationContextEntries(visibleRows);
+    if (!contextEntries.length) {
+      if (ixConversationContextCopy) {
+        ixConversationContextCopy.textContent = 'This slice does not include any repo or workspace metadata.';
+      }
+      const empty = document.createElement('div');
+      empty.className = 'conversation-context-empty';
+      empty.textContent = 'No repo or workspace metadata is attached to the current conversations.';
+      ixConversationContextList.appendChild(empty);
+      return;
+    }
+
+    if (ixConversationContextCopy) {
+      ixConversationContextCopy.textContent = lens === 'cost'
+        ? 'Click a repo or workspace to focus the list on where cost is landing.'
+        : (lens === 'count'
+          ? 'Click a repo or workspace to focus the list on where conversations cluster.'
+          : 'Click a repo or workspace to focus the list on token-heavy contexts.');
+    }
+
+    const visibleTokens = visibleRows.reduce((sum, row) => sum + ixConversationSortValue(row, 'tokens'), 0);
+    const visibleCost = visibleRows.reduce((sum, row) => sum + ixConversationSortValue(row, 'cost'), 0);
+    contextEntries.slice(0, 6).forEach(entry => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'conversation-context-row';
+      const isActive = (ixConversationState.context || '').toLowerCase() === entry.label.toLowerCase();
+      button.classList.toggle('active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+
+      const main = document.createElement('div');
+      main.className = 'conversation-context-main';
+      const name = document.createElement('div');
+      name.className = 'conversation-context-name';
+      name.textContent = entry.label;
+      const meta = document.createElement('div');
+      meta.className = 'conversation-context-meta';
+      meta.textContent = `${ixConversationIntegerFormatter.format(entry.count)} conversations`;
+      main.appendChild(name);
+      main.appendChild(meta);
+
+      const value = document.createElement('div');
+      value.className = 'conversation-context-value';
+      const tokens = document.createElement('div');
+      tokens.className = 'conversation-context-tokens';
+      tokens.textContent = lens === 'cost'
+        ? ixFormatConversationCurrency(entry.cost)
+        : (lens === 'count'
+          ? ixConversationIntegerFormatter.format(entry.count)
+          : ixFormatConversationCompactNumber(entry.tokens));
+      const share = document.createElement('div');
+      share.className = 'conversation-context-share';
+      share.textContent = lens === 'cost'
+        ? `${ixFormatConversationPercent(visibleCost > 0 ? entry.cost / visibleCost : 0)} of visible cost`
+        : (lens === 'count'
+          ? `${ixFormatConversationPercent(visibleRows.length > 0 ? entry.count / visibleRows.length : 0)} of visible conversations`
+          : `${ixFormatConversationPercent(visibleTokens > 0 ? entry.tokens / visibleTokens : 0)} of visible tokens`);
+      value.appendChild(tokens);
+      value.appendChild(share);
+
+      button.appendChild(main);
+      button.appendChild(value);
+      button.addEventListener('click', () => {
+        ixConversationState.context = isActive ? '' : entry.label;
+        ixApplyConversationView();
+      });
+      ixConversationContextList.appendChild(button);
+    });
+
+    if (contextEntries.length > 6) {
+      const extra = document.createElement('div');
+      extra.className = 'conversation-context-empty';
+      extra.textContent = `${ixConversationIntegerFormatter.format(contextEntries.length - 6)} more contexts remain in this slice. Use search or filters to narrow further.`;
+      ixConversationContextList.appendChild(extra);
+    }
+  }
+  function ixConversationFilterDescriptors() {
+    const descriptors = [];
+    const normalizedQuery = (ixConversationState.query || '').trim();
+    if (normalizedQuery) {
+      descriptors.push({
+        key: 'query',
+        value: normalizedQuery,
+        label: `Search: ${normalizedQuery}`
+      });
+    }
+    if (ixConversationState.named === 'named') {
+      descriptors.push({ key: 'named', value: 'named', label: 'Named Only' });
+    }
+    if (ixConversationState.named === 'unnamed') {
+      descriptors.push({ key: 'named', value: 'unnamed', label: 'Unnamed Only' });
+    }
+    if (ixConversationState.profile === 'bursty') {
+      descriptors.push({ key: 'profile', value: 'bursty', label: 'Signal: Bursty' });
+    }
+    if (ixConversationState.profile === 'marathon') {
+      descriptors.push({ key: 'profile', value: 'marathon', label: 'Signal: Marathon' });
+    }
+    if (ixConversationState.profile === 'compact-heavy') {
+      descriptors.push({ key: 'profile', value: 'compact-heavy', label: 'Signal: Compact-Heavy' });
+    }
+    if (ixConversationState.account) {
+      descriptors.push({
+        key: 'account',
+        value: ixConversationState.account,
+        label: `Account: ${ixConversationState.account}`
+      });
+    }
+    if (ixConversationState.context) {
+      descriptors.push({
+        key: 'context',
+        value: ixConversationState.context,
+        label: `Repo/Workspace: ${ixConversationState.context}`
+      });
+    }
+    if (ixConversationState.contextLens === 'cost') {
+      descriptors.push({ key: 'contextLens', value: 'cost', label: 'Context Lens: Cost' });
+    }
+    if (ixConversationState.contextLens === 'count') {
+      descriptors.push({ key: 'contextLens', value: 'count', label: 'Context Lens: Conversations' });
+    }
+    if (ixConversationState.sort !== 'tokens') {
+      descriptors.push({
+        key: 'sort',
+        value: ixConversationState.sort,
+        label: `Sort: ${ixConversationSortLabels[ixConversationState.sort] || 'Tokens'}`
+      });
+    }
+    return descriptors;
+  }
+  function ixClearConversationDescriptor(descriptor) {
+    if (!descriptor) return;
+    if (descriptor.key === 'query') {
+      ixConversationState.query = '';
+      if (ixConversationSearchInput) {
+        ixConversationSearchInput.value = '';
+      }
+    } else if (descriptor.key === 'contextLens') {
+      ixConversationState.contextLens = 'tokens';
+    } else if (descriptor.key === 'sort') {
+      ixConversationState.sort = 'tokens';
+    } else if (Object.prototype.hasOwnProperty.call(ixConversationState, descriptor.key)) {
+      ixConversationState[descriptor.key] = '';
+    }
+    ixApplyConversationView();
+  }
+  function ixRenderConversationState(visibleCount, totalCount) {
+    const descriptors = ixConversationFilterDescriptors();
+    if (ixConversationActiveText) {
+      if (visibleCount === 0) {
+        ixConversationActiveText.textContent = 'No conversations match the current search and filters.';
+      } else if (!descriptors.length) {
+        ixConversationActiveText.textContent = `Showing all ${totalCount} conversations by token share.`;
+      } else {
+        ixConversationActiveText.textContent = `Showing ${visibleCount} of ${totalCount} conversations with the current view settings.`;
+      }
+    }
+    if (ixConversationActiveChips) {
+      ixConversationActiveChips.innerHTML = '';
+      descriptors.forEach(descriptor => {
+        const chip = document.createElement('button');
+        chip.type = 'button';
+        chip.className = 'conversation-active-chip';
+        chip.setAttribute('aria-label', `Remove ${descriptor.label}`);
+        const label = document.createElement('span');
+        label.textContent = descriptor.label;
+        const action = document.createElement('span');
+        action.className = 'conversation-active-chip-action';
+        action.textContent = 'Clear';
+        chip.appendChild(label);
+        chip.appendChild(action);
+        chip.addEventListener('click', () => ixClearConversationDescriptor(descriptor));
+        ixConversationActiveChips.appendChild(chip);
+      });
+    }
+    if (ixConversationResetButton) {
+      ixConversationResetButton.classList.toggle('hidden', !ixConversationHasActiveOverrides());
+    }
+  }
+  function ixApplyConversationView() {
+    const list = document.querySelector('.conversation-list');
+    if (!list) return;
+    const rows = Array.from(list.querySelectorAll('[data-conversation-button]'));
+    if (!rows.length) return;
+    const selected = list.querySelector('[data-conversation-button].active');
+    const normalizedQuery = (ixConversationState.query || '').trim().toLowerCase();
+    const visibleRows = rows.filter(row =>
+      (!normalizedQuery || ixConversationSearchText(row).includes(normalizedQuery))
+      && ixConversationMatchesFilters(row));
+    const hiddenRows = rows.filter(row => !visibleRows.includes(row));
+    visibleRows.sort((left, right) => {
+      const delta = ixConversationSortValue(right, ixConversationState.sort) - ixConversationSortValue(left, ixConversationState.sort);
+      if (delta !== 0) return delta;
+      const leftRank = Number((left.getAttribute('data-detail-rank') || '#0').replace('#', '')) || 0;
+      const rightRank = Number((right.getAttribute('data-detail-rank') || '#0').replace('#', '')) || 0;
+      return leftRank - rightRank;
+    });
+    const orderedRows = visibleRows.concat(hiddenRows);
+    const fragment = document.createDocumentFragment();
+    orderedRows.forEach(row => {
+      row.classList.toggle('hidden', !visibleRows.includes(row));
+      fragment.appendChild(row);
+    });
+    list.appendChild(fragment);
+    ixReindexConversationRows(visibleRows);
+    ixSetConversationCount(visibleRows.length, rows.length);
+    ixRenderConversationState(visibleRows.length, rows.length);
+    ixRenderConversationSnapshot(visibleRows, rows);
+    ixRenderConversationContextBreakdown(visibleRows);
+    ixConversationStateToUrl();
+    ixConversationSortButtons.forEach(button => {
+      const active = (button.getAttribute('data-conversation-sort') || 'tokens') === ixConversationState.sort;
+      button.classList.toggle('active', active);
+      button.setAttribute('aria-selected', active ? 'true' : 'false');
+    });
+    ixApplyConversationFilterButtonState();
+    const nextSelection = selected && visibleRows.includes(selected)
+      ? selected
+      : (visibleRows[0] || null);
+    ixApplyConversationSelection(nextSelection);
+  }
+  document.querySelectorAll('[data-conversation-button]').forEach(button => {
+    button.addEventListener('click', () => ixApplyConversationSelection(button));
+  });
+  ixConversationSortButtons.forEach(button => {
+    button.addEventListener('click', () => {
+      ixConversationState.sort = button.getAttribute('data-conversation-sort') || 'tokens';
+      ixApplyConversationView();
+    });
+  });
+  if (ixConversationSearchInput) {
+    ixConversationSearchInput.addEventListener('input', () => {
+      ixConversationState.query = ixConversationSearchInput.value || '';
+      ixApplyConversationView();
+    });
+  }
+  ixConversationFilterButtons.forEach(button => {
+    button.addEventListener('click', () => {
+      const group = button.getAttribute('data-conversation-filter-group') || '';
+      const value = button.getAttribute('data-conversation-filter-value') || '';
+      if (!group) return;
+      ixConversationState[group] = ixConversationState[group] === value ? '' : value;
+      ixApplyConversationView();
+    });
+  });
+  ixConversationContextLensButtons.forEach(button => {
+    button.addEventListener('click', () => {
+      ixConversationState.contextLens = button.getAttribute('data-conversation-context-lens') || 'tokens';
+      ixApplyConversationView();
+    });
+  });
+  if (ixConversationResetButton) {
+    ixConversationResetButton.addEventListener('click', () => {
+      ixResetConversationView();
+      ixApplyConversationView();
+    });
+  }
+  ixRestoreConversationStateFromUrl();
+  ixReindexConversationRows(Array.from(document.querySelectorAll('[data-conversation-button]')));
+  ixApplyConversationView();
   document.querySelectorAll('.github-lens-tab').forEach(button => {
     button.addEventListener('click', () => {
       const shell = button.closest('.github-impact-shell');

--- a/IntelligenceX/Visualization/Heatmaps/Assets/report.js
+++ b/IntelligenceX/Visualization/Heatmaps/Assets/report.js
@@ -318,9 +318,7 @@
       }
     }
     if (ixConversationState.context) {
-      const context = ((button.getAttribute('data-detail-repository') || '')
-        || (button.getAttribute('data-detail-workspace') || '')
-        || (button.getAttribute('data-detail-context') || '')).trim().toLowerCase();
+      const context = ixConversationContextLabel(button).trim().toLowerCase();
       if (context !== ixConversationState.context.toLowerCase()) {
         return false;
       }

--- a/IntelligenceX/Visualization/Heatmaps/UsageTelemetryOverviewHtmlRenderer.cs
+++ b/IntelligenceX/Visualization/Heatmaps/UsageTelemetryOverviewHtmlRenderer.cs
@@ -280,16 +280,16 @@ internal static class UsageTelemetryOverviewHtmlRenderer {
         sb.AppendLine("              <div class=\"conversation-filter-group\">");
         sb.AppendLine("                <div class=\"conversation-filter-label\">Quick filters</div>");
         sb.AppendLine("                <div class=\"conversation-filter-chips\">");
-        AppendConversationFilterChip(sb, "named", "Named only", "named", true);
-        AppendConversationFilterChip(sb, "named", "Unnamed only", "unnamed", false);
+        AppendConversationFilterChip(sb, "named", "Named only", "named");
+        AppendConversationFilterChip(sb, "named", "Unnamed only", "unnamed");
         sb.AppendLine("                </div>");
         sb.AppendLine("              </div>");
         sb.AppendLine("              <div class=\"conversation-filter-group\">");
         sb.AppendLine("                <div class=\"conversation-filter-label\">Session signals</div>");
         sb.AppendLine("                <div class=\"conversation-filter-chips\">");
-        AppendConversationFilterChip(sb, "profile", "Bursty", "bursty", false);
-        AppendConversationFilterChip(sb, "profile", "Marathon", "marathon", false);
-        AppendConversationFilterChip(sb, "profile", "Compact-heavy", "compact-heavy", false);
+        AppendConversationFilterChip(sb, "profile", "Bursty", "bursty");
+        AppendConversationFilterChip(sb, "profile", "Marathon", "marathon");
+        AppendConversationFilterChip(sb, "profile", "Compact-heavy", "compact-heavy");
         sb.AppendLine("                </div>");
         sb.AppendLine("              </div>");
         if (topAccounts.Length > 0) {
@@ -297,7 +297,7 @@ internal static class UsageTelemetryOverviewHtmlRenderer {
             sb.AppendLine("                <div class=\"conversation-filter-label\">Accounts</div>");
             sb.AppendLine("                <div class=\"conversation-filter-chips\">");
             foreach (var account in topAccounts) {
-                AppendConversationFilterChip(sb, "account", account, account, false);
+                AppendConversationFilterChip(sb, "account", account, account);
             }
             sb.AppendLine("                </div>");
             sb.AppendLine("              </div>");
@@ -307,7 +307,7 @@ internal static class UsageTelemetryOverviewHtmlRenderer {
             sb.AppendLine("                <div class=\"conversation-filter-label\">Repos and workspaces</div>");
             sb.AppendLine("                <div class=\"conversation-filter-chips\">");
             foreach (var context in topContexts) {
-                AppendConversationFilterChip(sb, "context", context, context, false);
+                AppendConversationFilterChip(sb, "context", context, context);
             }
             sb.AppendLine("                </div>");
             sb.AppendLine("              </div>");
@@ -315,16 +315,12 @@ internal static class UsageTelemetryOverviewHtmlRenderer {
         sb.AppendLine("            </div>");
     }
 
-    private static void AppendConversationFilterChip(StringBuilder sb, string group, string label, string value, bool isNegated) {
+    private static void AppendConversationFilterChip(StringBuilder sb, string group, string label, string value) {
         sb.Append("                  <button type=\"button\" class=\"conversation-filter-chip\" data-conversation-filter-group=\"")
             .Append(Html(group))
             .Append("\" data-conversation-filter-value=\"")
             .Append(Html(value))
-            .Append("\"");
-        if (isNegated) {
-            sb.Append(" data-conversation-filter-negated=\"true\"");
-        }
-        sb.Append(">")
+            .Append("\">")
             .Append(Html(label))
             .AppendLine("</button>");
     }
@@ -433,14 +429,10 @@ internal static class UsageTelemetryOverviewHtmlRenderer {
     }
 
     private static void AppendConversationDetailMetric(StringBuilder sb, string label, string? value, string valueAttribute) {
-        if (string.IsNullOrWhiteSpace(value)) {
-            return;
-        }
-
         sb.AppendLine("                  <div class=\"conversation-detail-metric\">");
         sb.Append("                    <div class=\"conversation-detail-label\">").Append(Html(label)).AppendLine("</div>");
         sb.Append("                    <div class=\"conversation-detail-value\" ").Append(valueAttribute).Append(">")
-            .Append(Html(value!))
+            .Append(Html(value ?? "n/a"))
             .AppendLine("</div>");
         sb.AppendLine("                  </div>");
     }

--- a/IntelligenceX/Visualization/Heatmaps/UsageTelemetryOverviewHtmlRenderer.cs
+++ b/IntelligenceX/Visualization/Heatmaps/UsageTelemetryOverviewHtmlRenderer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using IntelligenceX.Telemetry.Git;
 using IntelligenceX.Telemetry.GitHub;
@@ -22,6 +23,9 @@ internal static class UsageTelemetryOverviewHtmlRenderer {
         var sb = new StringBuilder(24 * 1024);
         UsageTelemetryReportPageShellHtmlRenderer.AppendOverviewHeader(sb, page);
         UsageTelemetryReportDiagnosticsHtmlRenderer.Append(sb, page.Diagnostics);
+        if (page.ConversationPulse is not null) {
+            AppendConversationPulseSection(sb, page.ConversationPulse);
+        }
         if (page.CodeChurn is not null) {
             AppendCodeChurnSection(sb, page.CodeChurn);
         }
@@ -49,6 +53,428 @@ internal static class UsageTelemetryOverviewHtmlRenderer {
 
     private static void AppendProviderSection(StringBuilder sb, UsageTelemetryOverviewSectionPageModel model) {
         UsageTelemetryProviderSectionHtmlRenderer.AppendSection(sb, model);
+    }
+
+    private static void AppendConversationPulseSection(StringBuilder sb, UsageTelemetryConversationPulsePageModel model) {
+        sb.AppendLine("    <section class=\"provider-section conversation-pulse-section\" id=\"conversation-usage\">");
+        sb.AppendLine("      <div class=\"provider-shell\">");
+        sb.AppendLine("        <div class=\"provider-header\">");
+        sb.AppendLine("          <div>");
+        sb.Append("            <h2 class=\"provider-title\">").Append(Html(model.Title)).AppendLine("</h2>");
+        sb.Append("            <div class=\"provider-subtitle\">").Append(Html(model.Subtitle)).AppendLine("</div>");
+        sb.AppendLine("          </div>");
+        sb.AppendLine("          <div class=\"provider-metrics\">");
+        foreach (var stat in model.Stats) {
+            sb.AppendLine("            <div class=\"provider-metric\">");
+            sb.Append("              <div class=\"metric-label\">").Append(Html(stat.Label)).AppendLine("</div>");
+            sb.Append("              <div class=\"metric-value\">").Append(Html(stat.Value)).AppendLine("</div>");
+            sb.AppendLine("            </div>");
+        }
+        sb.AppendLine("          </div>");
+        sb.AppendLine("        </div>");
+        sb.AppendLine("        <div class=\"provider-insights tight conversation-insights\">");
+        sb.AppendLine("          <aside class=\"conversation-summary-panel\">");
+        sb.AppendLine("            <div class=\"provider-feature-kicker\">Raw sessions</div>");
+        sb.Append("            <div class=\"provider-feature-headline\">").Append(Html(model.Headline)).AppendLine("</div>");
+        if (!string.IsNullOrWhiteSpace(model.Note)) {
+            sb.Append("            <div class=\"provider-feature-copy\">").Append(Html(model.Note!)).AppendLine("</div>");
+        }
+        sb.AppendLine("          </aside>");
+        AppendConversationRows(sb, model);
+        sb.AppendLine("        </div>");
+        sb.AppendLine("      </div>");
+        sb.AppendLine("    </section>");
+    }
+
+    private static void AppendConversationRows(StringBuilder sb, UsageTelemetryConversationPulsePageModel model) {
+        sb.AppendLine("          <article class=\"conversation-list-card\">");
+        sb.Append("            <div class=\"provider-feature-kicker\">").Append(Html(model.Conversations.Title)).AppendLine("</div>");
+        if (!string.IsNullOrWhiteSpace(model.Conversations.Headline)) {
+            sb.Append("            <div class=\"conversation-list-headline\">").Append(Html(model.Conversations.Headline!)).AppendLine("</div>");
+        }
+        if (!string.IsNullOrWhiteSpace(model.Conversations.Note)) {
+            sb.Append("            <div class=\"provider-feature-copy\">").Append(Html(model.Conversations.Note!)).AppendLine("</div>");
+        }
+
+        if (model.Rows.Count == 0) {
+            sb.AppendLine("            <div class=\"estimate-note\">No detailed rows available.</div>");
+        } else {
+            sb.AppendLine("            <div class=\"conversation-toolbar\">");
+            sb.AppendLine("              <label class=\"conversation-search\" aria-label=\"Search conversations\">");
+            sb.AppendLine("                <span class=\"conversation-search-label\">Search</span>");
+            sb.AppendLine("                <input type=\"search\" class=\"conversation-search-input\" data-conversation-search name=\"conversation-search\" placeholder=\"Search title, repo, workspace, account, or session...\" autocomplete=\"off\" spellcheck=\"false\">");
+            sb.AppendLine("              </label>");
+            sb.AppendLine("              <div class=\"conversation-toolbar-actions\">");
+            sb.Append("                <div class=\"conversation-search-count\" data-conversation-count>")
+                .Append(Html(model.Rows.Count.ToString(System.Globalization.CultureInfo.InvariantCulture) + " visible"))
+                .AppendLine("</div>");
+            sb.AppendLine("                <button type=\"button\" class=\"conversation-reset-button hidden\" data-conversation-reset aria-label=\"Clear conversation search and filters\">Clear All</button>");
+            sb.AppendLine("              </div>");
+            sb.AppendLine("            </div>");
+            AppendConversationQuickFilters(sb, model.Rows);
+            sb.AppendLine("            <div class=\"conversation-active-bar\" data-conversation-active>");
+            sb.AppendLine("              <div class=\"conversation-active-label\">Current view</div>");
+            sb.AppendLine("              <div class=\"conversation-active-copy\" data-conversation-active-text>Showing all conversations by token share.</div>");
+            sb.AppendLine("              <div class=\"conversation-active-chips\" data-conversation-active-chips></div>");
+            sb.AppendLine("            </div>");
+            sb.AppendLine("            <div class=\"conversation-snapshot-grid\" data-conversation-snapshot>");
+            AppendConversationSnapshotCard(sb, "Conversations", "0", "No conversations loaded yet.", "count");
+            AppendConversationSnapshotCard(sb, "Tokens In View", "0", "Token share for the current slice.", "tokens");
+            AppendConversationSnapshotCard(sb, "Cost In View", "$0", "Estimated and exact cost in this slice.", "cost");
+            AppendConversationSnapshotCard(sb, "Average Span", "n/a", "Average session length in this slice.", "duration");
+            AppendConversationSnapshotCard(sb, "Top Context", "No repo or workspace", "No conversation context is available yet.", "context");
+            sb.AppendLine("            </div>");
+            sb.AppendLine("            <div class=\"conversation-context-shell\" data-conversation-context-shell>");
+            sb.AppendLine("              <div class=\"conversation-context-header\">");
+            sb.AppendLine("                <div>");
+            sb.AppendLine("                  <div class=\"conversation-context-kicker\">Context Breakdown</div>");
+            sb.AppendLine("                  <div class=\"conversation-context-copy\" data-conversation-context-copy>Which repo or workspace dominates the current slice.</div>");
+            sb.AppendLine("                </div>");
+            sb.AppendLine("                <div class=\"conversation-context-lenses\" role=\"tablist\" aria-label=\"Context breakdown lens\">");
+            AppendConversationContextLensTab(sb, "tokens", "Tokens", true);
+            AppendConversationContextLensTab(sb, "cost", "Cost", false);
+            AppendConversationContextLensTab(sb, "count", "Conversations", false);
+            sb.AppendLine("                </div>");
+            sb.AppendLine("              </div>");
+            sb.AppendLine("              <div class=\"conversation-context-list\" data-conversation-context-list>");
+            sb.AppendLine("                <div class=\"conversation-context-empty\">No repo or workspace data yet.</div>");
+            sb.AppendLine("              </div>");
+            sb.AppendLine("            </div>");
+            sb.AppendLine("            <div class=\"conversation-sort-toolbar\" role=\"tablist\" aria-label=\"Conversation sorting\">");
+            AppendConversationSortTab(sb, "tokens", "Tokens", true);
+            AppendConversationSortTab(sb, "cost", "Cost", false);
+            AppendConversationSortTab(sb, "duration", "Duration", false);
+            AppendConversationSortTab(sb, "turns", "Turns", false);
+            AppendConversationSortTab(sb, "compacts", "Compacts", false);
+            sb.AppendLine("            </div>");
+            sb.AppendLine("            <div class=\"conversation-explorer\">");
+            sb.AppendLine("              <div class=\"conversation-list\">");
+            foreach (var row in model.Rows) {
+                sb.Append("                <button type=\"button\" class=\"conversation-row");
+                if (row.Rank == 1) {
+                    sb.Append(" active");
+                }
+                sb.AppendLine("\" data-conversation-button");
+                AppendConversationRowDataset(sb, "rank", "#" + row.Rank.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                AppendConversationRowDataset(sb, "title", row.TitleText);
+                AppendConversationRowDataset(sb, "sessionLabel", row.SessionLabel);
+                AppendConversationRowDataset(sb, "sessionCode", row.SessionCode);
+                AppendConversationRowDataset(sb, "tokens", row.TokenText);
+                AppendConversationRowDataset(sb, "share", row.ShareText);
+                AppendConversationRowDataset(sb, "started", row.StartedText);
+                AppendConversationRowDataset(sb, "span", row.SpanText);
+                AppendConversationRowDataset(sb, "active", row.ActiveText);
+                AppendConversationRowDataset(sb, "turns", row.TurnText);
+                AppendConversationRowDataset(sb, "compacts", row.CompactText);
+                AppendConversationRowDataset(sb, "cost", row.CostText);
+                AppendConversationRowDataset(sb, "context", row.ContextText);
+                AppendConversationRowDataset(sb, "repository", row.RepositoryText);
+                AppendConversationRowDataset(sb, "workspace", row.WorkspaceText);
+                AppendConversationRowDataset(sb, "account", row.AccountText);
+                AppendConversationRowDataset(sb, "model", row.ModelText);
+                AppendConversationRowDataset(sb, "surface", row.SurfaceText);
+                AppendConversationRowDataset(sb, "sortTokens", row.TotalTokensRaw.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                AppendConversationRowDataset(sb, "sortCost", row.CostUsdRaw.ToString("0.######", System.Globalization.CultureInfo.InvariantCulture));
+                AppendConversationRowDataset(sb, "sortDuration", row.DurationMs.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                AppendConversationRowDataset(sb, "sortTurns", row.TurnCountRaw.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                AppendConversationRowDataset(sb, "sortCompacts", row.CompactCountRaw.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                sb.AppendLine("                  aria-pressed=\"" + (row.Rank == 1 ? "true" : "false") + "\">");
+                sb.Append("                  <div class=\"conversation-rank\">#").Append(row.Rank.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine("</div>");
+                sb.AppendLine("                  <div class=\"conversation-main\">");
+                sb.AppendLine("                    <div class=\"conversation-row-head\">");
+                sb.AppendLine("                      <div class=\"conversation-title-block\">");
+                sb.Append("                        <div class=\"conversation-title\"><span>").Append(Html(row.TitleText)).AppendLine("</span></div>");
+                sb.Append("                        <div class=\"conversation-session\">").Append(Html(row.SessionLabel)).Append(" <code>")
+                    .Append(Html(row.SessionCode)).AppendLine("</code></div>");
+                sb.AppendLine("                      </div>");
+                sb.AppendLine("                      <div class=\"conversation-tokens\">");
+                sb.Append("                        <strong>").Append(Html(row.TokenText)).AppendLine("</strong>");
+                sb.Append("                        <span>").Append(Html(row.ShareText)).AppendLine("</span>");
+                sb.AppendLine("                      </div>");
+                sb.AppendLine("                    </div>");
+                sb.AppendLine("                    <div class=\"conversation-chips\">");
+                if (!string.IsNullOrWhiteSpace(row.RepositoryText)) {
+                    AppendConversationChip(sb, row.RepositoryText!);
+                }
+                if (!string.IsNullOrWhiteSpace(row.WorkspaceText) &&
+                    !string.Equals(row.WorkspaceText, row.RepositoryText, StringComparison.OrdinalIgnoreCase)) {
+                    AppendConversationChip(sb, row.WorkspaceText!);
+                }
+                if (string.IsNullOrWhiteSpace(row.RepositoryText) && string.IsNullOrWhiteSpace(row.WorkspaceText) && !string.IsNullOrWhiteSpace(row.ContextText)) {
+                    AppendConversationChip(sb, row.ContextText!);
+                }
+                AppendConversationChip(sb, row.AccountText);
+                AppendConversationChip(sb, row.ModelText);
+                AppendConversationChip(sb, row.SurfaceText);
+                sb.AppendLine("                    </div>");
+                sb.AppendLine("                    <div class=\"conversation-facts\">");
+                AppendConversationFact(sb, "Started", row.StartedText);
+                AppendConversationFact(sb, "Span", row.SpanText);
+                if (!string.IsNullOrWhiteSpace(row.ActiveText)) {
+                    AppendConversationFact(sb, "Active", row.ActiveText!);
+                }
+                AppendConversationFact(sb, "Turns", row.TurnText);
+                if (!string.IsNullOrWhiteSpace(row.CompactText)) {
+                    AppendConversationFact(sb, "Compacts", row.CompactText!);
+                }
+                if (!string.IsNullOrWhiteSpace(row.CostText)) {
+                    AppendConversationFact(sb, "Cost", row.CostText!);
+                }
+                sb.AppendLine("                    </div>");
+                sb.AppendLine("                    <div class=\"conversation-bar\">");
+                sb.Append("                      <div class=\"conversation-bar-fill\" style=\"width:")
+                    .Append(row.RatioPercent.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture))
+                    .AppendLine("%\"></div>");
+                sb.AppendLine("                    </div>");
+                sb.AppendLine("                  </div>");
+                sb.AppendLine("                </button>");
+            }
+            sb.AppendLine("              </div>");
+            AppendConversationDetailPanel(sb, model.Rows[0]);
+            sb.AppendLine("              <div class=\"conversation-empty hidden\" data-conversation-empty>No conversations match this filter yet. Try a broader search.</div>");
+            sb.AppendLine("            </div>");
+        }
+
+        sb.AppendLine("          </article>");
+    }
+
+    private static void AppendConversationChip(StringBuilder sb, string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return;
+        }
+
+        sb.Append("                    <span>").Append(Html(value)).AppendLine("</span>");
+    }
+
+    private static void AppendConversationFact(StringBuilder sb, string label, string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return;
+        }
+
+        sb.AppendLine("                    <div class=\"conversation-fact\">");
+        sb.Append("                      <div class=\"conversation-fact-label\">").Append(Html(label)).AppendLine("</div>");
+        sb.Append("                      <div class=\"conversation-fact-value\">").Append(Html(value)).AppendLine("</div>");
+        sb.AppendLine("                    </div>");
+    }
+
+    private static void AppendConversationQuickFilters(StringBuilder sb, IReadOnlyList<UsageTelemetryConversationPulseRowPageModel> rows) {
+        var topAccounts = rows
+            .GroupBy(static row => row.AccountText, StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(static group => group.Count())
+            .ThenBy(static group => group.Key, StringComparer.OrdinalIgnoreCase)
+            .Take(3)
+            .Select(static group => group.Key)
+            .ToArray();
+        var topContexts = rows
+            .Select(static row => row.RepositoryText ?? row.WorkspaceText ?? row.ContextText)
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Cast<string>()
+            .GroupBy(static value => value, StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(static group => group.Count())
+            .ThenBy(static group => group.Key, StringComparer.OrdinalIgnoreCase)
+            .Take(4)
+            .Select(static group => group.Key)
+            .ToArray();
+
+        sb.AppendLine("            <div class=\"conversation-filter-groups\">");
+        sb.AppendLine("              <div class=\"conversation-filter-group\">");
+        sb.AppendLine("                <div class=\"conversation-filter-label\">Quick filters</div>");
+        sb.AppendLine("                <div class=\"conversation-filter-chips\">");
+        AppendConversationFilterChip(sb, "named", "Named only", "named", true);
+        AppendConversationFilterChip(sb, "named", "Unnamed only", "unnamed", false);
+        sb.AppendLine("                </div>");
+        sb.AppendLine("              </div>");
+        sb.AppendLine("              <div class=\"conversation-filter-group\">");
+        sb.AppendLine("                <div class=\"conversation-filter-label\">Session signals</div>");
+        sb.AppendLine("                <div class=\"conversation-filter-chips\">");
+        AppendConversationFilterChip(sb, "profile", "Bursty", "bursty", false);
+        AppendConversationFilterChip(sb, "profile", "Marathon", "marathon", false);
+        AppendConversationFilterChip(sb, "profile", "Compact-heavy", "compact-heavy", false);
+        sb.AppendLine("                </div>");
+        sb.AppendLine("              </div>");
+        if (topAccounts.Length > 0) {
+            sb.AppendLine("              <div class=\"conversation-filter-group\">");
+            sb.AppendLine("                <div class=\"conversation-filter-label\">Accounts</div>");
+            sb.AppendLine("                <div class=\"conversation-filter-chips\">");
+            foreach (var account in topAccounts) {
+                AppendConversationFilterChip(sb, "account", account, account, false);
+            }
+            sb.AppendLine("                </div>");
+            sb.AppendLine("              </div>");
+        }
+        if (topContexts.Length > 0) {
+            sb.AppendLine("              <div class=\"conversation-filter-group\">");
+            sb.AppendLine("                <div class=\"conversation-filter-label\">Repos and workspaces</div>");
+            sb.AppendLine("                <div class=\"conversation-filter-chips\">");
+            foreach (var context in topContexts) {
+                AppendConversationFilterChip(sb, "context", context, context, false);
+            }
+            sb.AppendLine("                </div>");
+            sb.AppendLine("              </div>");
+        }
+        sb.AppendLine("            </div>");
+    }
+
+    private static void AppendConversationFilterChip(StringBuilder sb, string group, string label, string value, bool isNegated) {
+        sb.Append("                  <button type=\"button\" class=\"conversation-filter-chip\" data-conversation-filter-group=\"")
+            .Append(Html(group))
+            .Append("\" data-conversation-filter-value=\"")
+            .Append(Html(value))
+            .Append("\"");
+        if (isNegated) {
+            sb.Append(" data-conversation-filter-negated=\"true\"");
+        }
+        sb.Append(">")
+            .Append(Html(label))
+            .AppendLine("</button>");
+    }
+
+    private static void AppendConversationSortTab(StringBuilder sb, string key, string label, bool isActive) {
+        sb.Append("              <button type=\"button\" class=\"provider-dataset-tab conversation-sort-tab");
+        if (isActive) {
+            sb.Append(" active");
+        }
+        sb.Append("\" data-conversation-sort=\"")
+            .Append(Html(key))
+            .Append("\" role=\"tab\" aria-selected=\"")
+            .Append(isActive ? "true" : "false")
+            .Append("\">")
+            .Append(Html(label))
+            .AppendLine("</button>");
+    }
+
+    private static void AppendConversationContextLensTab(StringBuilder sb, string key, string label, bool isActive) {
+        sb.Append("                  <button type=\"button\" class=\"provider-dataset-tab conversation-context-lens");
+        if (isActive) {
+            sb.Append(" active");
+        }
+        sb.Append("\" data-conversation-context-lens=\"")
+            .Append(Html(key))
+            .Append("\" role=\"tab\" aria-selected=\"")
+            .Append(isActive ? "true" : "false")
+            .Append("\">")
+            .Append(Html(label))
+            .AppendLine("</button>");
+    }
+
+    private static void AppendConversationSnapshotCard(StringBuilder sb, string label, string value, string copy, string key) {
+        sb.AppendLine("              <div class=\"conversation-snapshot-card\">");
+        sb.Append("                <div class=\"conversation-snapshot-label\">").Append(Html(label)).AppendLine("</div>");
+        sb.Append("                <div class=\"conversation-snapshot-value\" data-conversation-snapshot-")
+            .Append(Html(key))
+            .Append(">")
+            .Append(Html(value))
+            .AppendLine("</div>");
+        sb.Append("                <div class=\"conversation-snapshot-copy\" data-conversation-snapshot-")
+            .Append(Html(key))
+            .Append("-copy>")
+            .Append(Html(copy))
+            .AppendLine("</div>");
+        sb.AppendLine("              </div>");
+    }
+
+    private static void AppendConversationRowDataset(StringBuilder sb, string name, string? value) {
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(value)) {
+            return;
+        }
+
+        sb.Append(" data-detail-")
+            .Append(Html(name))
+            .Append("=\"")
+            .Append(Html(value!))
+            .Append("\"");
+    }
+
+    private static void AppendConversationDetailPanel(StringBuilder sb, UsageTelemetryConversationPulseRowPageModel row) {
+        sb.AppendLine("              <aside class=\"conversation-detail-card\" data-conversation-detail>");
+        sb.AppendLine("                <div class=\"conversation-detail-kicker\">Selected conversation</div>");
+        sb.AppendLine("                <div class=\"conversation-detail-header\">");
+        sb.Append("                  <div class=\"conversation-detail-rank\" data-detail-rank>")
+            .Append(Html("#" + row.Rank.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+            .AppendLine("</div>");
+        sb.AppendLine("                  <div class=\"conversation-detail-title-block\">");
+        sb.Append("                    <div class=\"conversation-detail-title\" data-detail-title>").Append(Html(row.TitleText)).AppendLine("</div>");
+        sb.Append("                    <div class=\"conversation-detail-session\" data-detail-session>")
+            .Append(Html(row.SessionLabel + " " + row.SessionCode))
+            .AppendLine("</div>");
+        sb.AppendLine("                  </div>");
+        sb.AppendLine("                </div>");
+        sb.AppendLine("                <div class=\"conversation-detail-metrics\">");
+        AppendConversationDetailMetric(sb, "Tokens", row.TokenText, "data-detail-tokens");
+        AppendConversationDetailMetric(sb, "Share", row.ShareText, "data-detail-share");
+        sb.AppendLine("                </div>");
+        sb.AppendLine("                <div class=\"conversation-detail-chips\" data-detail-chip-host>");
+        AppendConversationDetailChip(sb, row.RepositoryText);
+        if (!string.IsNullOrWhiteSpace(row.WorkspaceText) &&
+            !string.Equals(row.WorkspaceText, row.RepositoryText, StringComparison.OrdinalIgnoreCase)) {
+            AppendConversationDetailChip(sb, row.WorkspaceText);
+        }
+        if (string.IsNullOrWhiteSpace(row.RepositoryText) && string.IsNullOrWhiteSpace(row.WorkspaceText)) {
+            AppendConversationDetailChip(sb, row.ContextText);
+        }
+        AppendConversationDetailChip(sb, row.AccountText);
+        AppendConversationDetailChip(sb, row.ModelText);
+        AppendConversationDetailChip(sb, row.SurfaceText);
+        sb.AppendLine("                </div>");
+        sb.AppendLine("                <div class=\"conversation-detail-grid\">");
+        AppendConversationDetailMetric(sb, "Started", row.StartedText, "data-detail-started");
+        AppendConversationDetailMetric(sb, "Span", row.SpanText, "data-detail-span");
+        AppendConversationDetailMetric(sb, "Active", row.ActiveText, "data-detail-active");
+        AppendConversationDetailMetric(sb, "Turns", row.TurnText, "data-detail-turns");
+        AppendConversationDetailMetric(sb, "Compacts", row.CompactText, "data-detail-compacts");
+        AppendConversationDetailMetric(sb, "Cost", row.CostText, "data-detail-cost");
+        sb.AppendLine("                </div>");
+        sb.AppendLine("                <div class=\"conversation-detail-summary\">");
+        sb.Append("                  <div class=\"conversation-detail-summary-copy\" data-detail-summary>")
+            .Append(Html(BuildConversationDetailSummary(row)))
+            .AppendLine("</div>");
+        sb.AppendLine("                </div>");
+        sb.AppendLine("              </aside>");
+    }
+
+    private static void AppendConversationDetailMetric(StringBuilder sb, string label, string? value, string valueAttribute) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return;
+        }
+
+        sb.AppendLine("                  <div class=\"conversation-detail-metric\">");
+        sb.Append("                    <div class=\"conversation-detail-label\">").Append(Html(label)).AppendLine("</div>");
+        sb.Append("                    <div class=\"conversation-detail-value\" ").Append(valueAttribute).Append(">")
+            .Append(Html(value!))
+            .AppendLine("</div>");
+        sb.AppendLine("                  </div>");
+    }
+
+    private static void AppendConversationDetailChip(StringBuilder sb, string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return;
+        }
+
+        sb.Append("                  <span>").Append(Html(value!)).AppendLine("</span>");
+    }
+
+    private static string BuildConversationDetailSummary(UsageTelemetryConversationPulseRowPageModel row) {
+        var parts = new List<string> {
+            row.TokenText + " tokens",
+            row.ShareText
+        };
+        if (!string.IsNullOrWhiteSpace(row.SpanText)) {
+            parts.Add(row.SpanText);
+        }
+        if (!string.IsNullOrWhiteSpace(row.ActiveText)) {
+            parts.Add(row.ActiveText!);
+        }
+        if (!string.IsNullOrWhiteSpace(row.TurnText)) {
+            parts.Add(row.TurnText);
+        }
+        if (!string.IsNullOrWhiteSpace(row.CompactText)) {
+            parts.Add(row.CompactText!);
+        }
+        if (!string.IsNullOrWhiteSpace(row.CostText)) {
+            parts.Add(row.CostText!);
+        }
+
+        return string.Join(" • ", parts);
     }
 
     private static void AppendCodeChurnSection(StringBuilder sb, UsageTelemetryCodeChurnPageModel model) {

--- a/IntelligenceX/Visualization/Heatmaps/UsageTelemetryReportPageModelBuilders.cs
+++ b/IntelligenceX/Visualization/Heatmaps/UsageTelemetryReportPageModelBuilders.cs
@@ -31,6 +31,7 @@ internal static class UsageTelemetryReportPageModelBuilders {
         var gitHubLocalAlignment = BuildGitHubWatchedLocalAlignmentInsight(gitHubLocalAlignmentSummary);
         var gitHubRepoClusterSummary = GitHubRepositoryClusterSummaryBuilder.Build(gitHubObservabilitySummary, gitHubLocalAlignmentSummary);
         var gitHubRepoClusters = BuildGitHubWatchedRepoClusterInsight(gitHubRepoClusterSummary);
+        var conversationPulse = BuildConversationPulseSection(overview.Metadata);
 
         var sectionSwitches = new List<UsageTelemetrySectionSwitchModel>();
         if (overview.ProviderSections.Count > 1) {
@@ -72,6 +73,7 @@ internal static class UsageTelemetryReportPageModelBuilders {
             ChurnUsageCorrelation: churnUsageCorrelation,
             GitHubLocalAlignment: BuildGitHubLocalAlignmentSection(gitHubLocalAlignmentSummary, gitHubLocalAlignment),
             GitHubRepoClusters: BuildGitHubRepoClusterSection(gitHubRepoClusterSummary, gitHubRepoClusters),
+            ConversationPulse: conversationPulse,
             SectionSwitches: sectionSwitches,
             Sections: sections,
             SupportingBreakdowns: supportingBreakdowns,
@@ -205,6 +207,197 @@ internal static class UsageTelemetryReportPageModelBuilders {
             TopRepositoriesByHealth: topRepositoriesByHealth,
             TopLanguages: topLanguages,
             OwnerSections: ownerSections);
+    }
+
+    private static UsageTelemetryConversationPulsePageModel? BuildConversationPulseSection(JsonObject? metadata) {
+        var conversations = metadata?.GetObject("conversations");
+        var items = conversations?.GetArray("items");
+        if (items is null || items.Count == 0) {
+            return null;
+        }
+
+        var itemObjects = items
+            .Select(static value => value.AsObject())
+            .Where(static value => value is not null)
+            .Cast<JsonObject>()
+            .ToArray();
+        if (itemObjects.Length == 0) {
+            return null;
+        }
+
+        var totalCount = conversations?.GetInt64("totalCount") ?? itemObjects.Length;
+        var shownCount = conversations?.GetInt64("shownCount") ?? itemObjects.Length;
+        var tokenTotal = conversations?.GetInt64("tokenTotal") ?? itemObjects.Sum(static item => item.GetInt64("totalTokens") ?? 0L);
+        var turnCount = conversations?.GetInt64("turnCount") ?? itemObjects.Sum(static item => item.GetInt64("turnCount") ?? 0L);
+        var compactCount = conversations?.GetInt64("compactCount") ?? itemObjects.Sum(static item => item.GetInt64("compactCount") ?? 0L);
+        var maxTokens = Math.Max(1L, itemObjects.Max(static item => item.GetInt64("totalTokens") ?? 0L));
+        var displayItems = itemObjects.Take(12).ToArray();
+        var rowModels = displayItems
+            .Select((item, index) => BuildConversationPulseRowModel(item, index + 1, maxTokens, Math.Max(1L, tokenTotal)))
+            .ToArray();
+        var rows = rowModels
+            .Select(static row => new UsageTelemetryOverviewInsightRow(
+                row.SessionCode,
+                row.TokenText + " tokens",
+                BuildConversationRowSubtitle(row),
+                row.RatioPercent / 100d))
+            .ToArray();
+        var displayCount = Math.Min(displayItems.Length, shownCount);
+        var displayTokenTotal = displayItems.Sum(static item => item.GetInt64("totalTokens") ?? 0L);
+        var note = displayCount < totalCount
+            ? "Showing the top " + displayCount.ToString(CultureInfo.InvariantCulture) + " conversations here; JSON and CSV exports keep every conversation."
+            : "Built from raw session rows before provider rollups are aggregated.";
+        var topShare = tokenTotal <= 0
+            ? "0%"
+            : FormatPercent(displayTokenTotal / (double)Math.Max(1L, tokenTotal));
+
+        return new UsageTelemetryConversationPulsePageModel(
+            Title: "Conversation usage",
+            Subtitle: "Raw sessions behind this tray report",
+            Headline: "Top " + displayCount.ToString(CultureInfo.InvariantCulture) + " cover " + topShare + " of conversation tokens",
+            Note: note,
+            Stats: new[] {
+                new UsageTelemetryHeroStatModel("Conversations", totalCount.ToString(CultureInfo.InvariantCulture)),
+                new UsageTelemetryHeroStatModel("Tokens", FormatCompact((double)tokenTotal)),
+                new UsageTelemetryHeroStatModel("Turns", turnCount.ToString(CultureInfo.InvariantCulture)),
+                new UsageTelemetryHeroStatModel("Compacts", compactCount.ToString(CultureInfo.InvariantCulture))
+            },
+            Conversations: new UsageTelemetryOverviewInsightSection(
+                key: "conversation-usage",
+                title: "Top conversations",
+                headline: "Largest session: " + FormatCompact((double)maxTokens) + " tokens",
+                note: "Ranked by token volume. Duration is wall time; active time appears only when captured.",
+                rows: rows),
+            Rows: rowModels);
+    }
+
+    private static UsageTelemetryConversationPulseRowPageModel BuildConversationPulseRowModel(
+        JsonObject item,
+        int rank,
+        long maxTokens,
+        long tokenTotal) {
+        var totalTokens = item.GetInt64("totalTokens") ?? 0L;
+        var label = NormalizeOptional(item.GetString("label"))
+                    ?? NormalizeOptional(item.GetString("sessionId"))
+                    ?? "Conversation";
+        var title = NormalizeOptional(item.GetString("title"));
+        var repository = NormalizeOptional(item.GetString("repository"));
+        var workspace = NormalizeOptional(item.GetString("workspace"));
+        var context = repository ?? workspace;
+        var duration = NormalizeOptional(item.GetString("duration"));
+        var durationMs = item.GetInt64("durationMs") ?? 0L;
+        var activeDurationMs = item.GetInt64("activeDurationMs");
+        var activeDuration = NormalizeOptional(item.GetString("activeDuration"));
+        var turnCount = item.GetInt64("turnCount") ?? 0L;
+        var compactCount = item.GetInt64("compactCount") ?? 0L;
+        var cost = item.GetDouble("apiEquivalentCostUsd") ?? 0d;
+        string? costText = null;
+        if (cost > 0d) {
+            var approximate = item.GetBoolean("costApproximate");
+            costText = (approximate ? "~$" : "$") + cost.ToString(cost >= 100d ? "0" : "0.##", CultureInfo.InvariantCulture);
+        }
+
+        var provider = NormalizeOptional(item.GetString("provider")) ?? NormalizeOptional(item.GetString("providerId")) ?? "Provider";
+        var account = NormalizeConversationAccount(item.GetString("account"), provider);
+        var models = BuildConversationList(item.GetArray("models")) ?? "model n/a";
+        var surfaces = BuildConversationList(item.GetArray("surfaces")) ?? "surface n/a";
+        return new UsageTelemetryConversationPulseRowPageModel(
+            Rank: rank,
+            SessionLabel: "Session " + rank.ToString(CultureInfo.InvariantCulture),
+            SessionCode: label,
+            TitleText: title ?? "Session " + rank.ToString(CultureInfo.InvariantCulture),
+            ContextText: context,
+            RepositoryText: repository,
+            WorkspaceText: workspace,
+            TotalTokensRaw: totalTokens,
+            DurationMs: Math.Max(0L, durationMs),
+            TurnCountRaw: (int)Math.Max(0L, turnCount),
+            CompactCountRaw: (int)Math.Max(0L, compactCount),
+            CostUsdRaw: Math.Max(0d, cost),
+            TokenText: FormatCompact((double)totalTokens),
+            ShareText: FormatPercent(totalTokens / (double)Math.Max(1L, tokenTotal)) + " of shown total",
+            StartedText: NormalizeOptional(item.GetString("startedLocal")) ?? "time n/a",
+            SpanText: string.IsNullOrWhiteSpace(duration) ? "span n/a" : "span " + duration,
+            ActiveText: (activeDurationMs is null || activeDurationMs > 0) && !string.IsNullOrWhiteSpace(activeDuration)
+                ? "active " + activeDuration
+                : null,
+            TurnText: turnCount > 0
+                ? turnCount.ToString(CultureInfo.InvariantCulture) + " turns"
+                : "turns n/a",
+            CompactText: compactCount > 0
+                ? compactCount.ToString(CultureInfo.InvariantCulture) + " compacts"
+                : null,
+            AccountText: account,
+            ModelText: models,
+            SurfaceText: surfaces,
+            CostText: costText,
+            RatioPercent: totalTokens <= 0 ? 0d : Math.Min(100d, totalTokens / (double)Math.Max(1L, maxTokens) * 100d));
+    }
+
+    private static string BuildConversationRowSubtitle(UsageTelemetryConversationPulseRowPageModel row) {
+        var parts = new List<string> {
+            row.StartedText,
+            row.SpanText,
+            row.TurnText,
+            row.AccountText,
+            row.ModelText,
+            row.SurfaceText
+        };
+        if (!string.IsNullOrWhiteSpace(row.ContextText)) {
+            parts.Insert(1, row.ContextText!);
+        }
+        if (!string.IsNullOrWhiteSpace(row.ActiveText)) {
+            parts.Insert(2, row.ActiveText!);
+        }
+        if (!string.IsNullOrWhiteSpace(row.CompactText)) {
+            parts.Insert(3, row.CompactText!);
+        }
+        if (!string.IsNullOrWhiteSpace(row.CostText)) {
+            parts.Add(row.CostText!);
+        }
+
+        return string.Join(" • ", parts);
+    }
+
+    private static string? BuildConversationList(JsonArray? values) {
+        if (values is null || values.Count == 0) {
+            return null;
+        }
+
+        var labels = values
+            .Select(static value => NormalizeOptional(value.AsString()))
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Cast<string>()
+            .Take(3)
+            .ToArray();
+        return labels.Length == 0 ? null : string.Join(", ", labels);
+    }
+
+    private static string NormalizeConversationAccount(string? value, string provider) {
+        var normalized = NormalizeOptional(value);
+        if (string.IsNullOrWhiteSpace(normalized) ||
+            string.Equals(normalized, "unknown-account", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalized, "Unknown account", StringComparison.OrdinalIgnoreCase)) {
+            return provider + " account";
+        }
+
+        var account = normalized!;
+        if (Guid.TryParse(account, out _)) {
+            return provider + " account " + account.Substring(0, Math.Min(8, account.Length));
+        }
+
+        if (account.Length > 36 && account.Count(static ch => ch == '-') >= 4) {
+            return provider + " account " + account.Substring(0, Math.Min(8, account.Length));
+        }
+
+        return account;
+    }
+
+    private static string FormatPercent(double ratio) {
+        var percent = Math.Max(0d, Math.Min(100d, ratio * 100d));
+        return percent >= 10d
+            ? percent.ToString("0", CultureInfo.InvariantCulture) + "%"
+            : percent.ToString("0.#", CultureInfo.InvariantCulture) + "%";
     }
 
     private static IReadOnlyList<UsageTelemetryOverviewInsightSection> BuildProviderHealthInsights(
@@ -1282,6 +1475,10 @@ internal static class UsageTelemetryReportPageModelBuilders {
         }
 
         return startDayUtc.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) + " to " + endDayUtc.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+
+    private static string? NormalizeOptional(string? value) {
+        return HeatmapText.NormalizeOptionalText(value);
     }
 
     private static string FormatCompact(decimal value) {

--- a/IntelligenceX/Visualization/Heatmaps/UsageTelemetryReportPageModelBuilders.cs
+++ b/IntelligenceX/Visualization/Heatmaps/UsageTelemetryReportPageModelBuilders.cs
@@ -232,8 +232,9 @@ internal static class UsageTelemetryReportPageModelBuilders {
         var compactCount = conversations?.GetInt64("compactCount") ?? itemObjects.Sum(static item => item.GetInt64("compactCount") ?? 0L);
         var maxTokens = Math.Max(1L, itemObjects.Max(static item => item.GetInt64("totalTokens") ?? 0L));
         var displayItems = itemObjects.Take(12).ToArray();
+        var displayTokenTotal = displayItems.Sum(static item => item.GetInt64("totalTokens") ?? 0L);
         var rowModels = displayItems
-            .Select((item, index) => BuildConversationPulseRowModel(item, index + 1, maxTokens, Math.Max(1L, tokenTotal)))
+            .Select((item, index) => BuildConversationPulseRowModel(item, index + 1, maxTokens, Math.Max(1L, displayTokenTotal)))
             .ToArray();
         var rows = rowModels
             .Select(static row => new UsageTelemetryOverviewInsightRow(
@@ -243,7 +244,6 @@ internal static class UsageTelemetryReportPageModelBuilders {
                 row.RatioPercent / 100d))
             .ToArray();
         var displayCount = Math.Min(displayItems.Length, shownCount);
-        var displayTokenTotal = displayItems.Sum(static item => item.GetInt64("totalTokens") ?? 0L);
         var note = displayCount < totalCount
             ? "Showing the top " + displayCount.ToString(CultureInfo.InvariantCulture) + " conversations here; JSON and CSV exports keep every conversation."
             : "Built from raw session rows before provider rollups are aggregated.";

--- a/IntelligenceX/Visualization/Heatmaps/UsageTelemetryReportPageModels.cs
+++ b/IntelligenceX/Visualization/Heatmaps/UsageTelemetryReportPageModels.cs
@@ -11,6 +11,7 @@ internal sealed record UsageTelemetryOverviewPageModel(
     UsageTelemetryChurnUsageSignalPageModel? ChurnUsageCorrelation,
     UsageTelemetryGitHubLocalPulsePageModel? GitHubLocalAlignment,
     UsageTelemetryGitHubRepoClusterPageModel? GitHubRepoClusters,
+    UsageTelemetryConversationPulsePageModel? ConversationPulse,
     IReadOnlyList<UsageTelemetrySectionSwitchModel> SectionSwitches,
     IReadOnlyList<UsageTelemetryOverviewSectionPageModel> Sections,
     IReadOnlyList<UsageTelemetrySupportingBreakdownModel> SupportingBreakdowns,
@@ -51,6 +52,41 @@ internal sealed record UsageTelemetryGitHubRepoClusterPageModel(
     string? Note,
     IReadOnlyList<UsageTelemetryHeroStatModel> Stats,
     UsageTelemetryOverviewInsightSection Clusters);
+
+internal sealed record UsageTelemetryConversationPulsePageModel(
+    string Title,
+    string Subtitle,
+    string Headline,
+    string? Note,
+    IReadOnlyList<UsageTelemetryHeroStatModel> Stats,
+    UsageTelemetryOverviewInsightSection Conversations,
+    IReadOnlyList<UsageTelemetryConversationPulseRowPageModel> Rows);
+
+internal sealed record UsageTelemetryConversationPulseRowPageModel(
+    int Rank,
+    string SessionLabel,
+    string SessionCode,
+    string TitleText,
+    string? ContextText,
+    string? RepositoryText,
+    string? WorkspaceText,
+    long TotalTokensRaw,
+    long DurationMs,
+    int TurnCountRaw,
+    int CompactCountRaw,
+    double CostUsdRaw,
+    string TokenText,
+    string ShareText,
+    string StartedText,
+    string SpanText,
+    string? ActiveText,
+    string TurnText,
+    string? CompactText,
+    string AccountText,
+    string ModelText,
+    string SurfaceText,
+    string? CostText,
+    double RatioPercent);
 
 internal sealed record UsageTelemetrySectionSwitchModel(string Key, string Label);
 


### PR DESCRIPTION
## Summary
- add conversation-level usage aggregation and persist conversation metadata through imports, quick reports, and sqlite storage
- surface conversation usage in the tray popup with new view models and richer session context
- overhaul the web usage explorer with searchable conversation rows, detail panels, context breakdowns, signal filters, and token/cost/count lenses

## Testing
- dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release
- regenerated the real usage report in AppData/Local/Temp/ix-real-usage-report-20260419-200255 for manual verification
