### PR TITLE
Fix reviewer history same-head reconciliation

### DIFF
--- a/IntelligenceX.Reviewer/ReviewHistoryArtifacts.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryArtifacts.cs
@@ -108,6 +108,8 @@ internal static class ReviewHistoryArtifacts {
                 sameHeadAsCurrent = round.SameHeadAsCurrent,
                 hasMergeBlockers = round.HasMergeBlockers,
                 mergeBlockerStatus = round.MergeBlockerStatus,
+                findingsHitLimit = round.FindingsHitLimit,
+                findingsParseIncomplete = round.FindingsParseIncomplete,
                 findings = BuildFindingItems(round.Findings)
             });
         }
@@ -204,7 +206,14 @@ internal static class ReviewHistoryArtifacts {
             sb.Append(EscapeInline(round.Source));
             sb.Append("`, blockers `");
             sb.Append(EscapeInline(round.HasMergeBlockers ? "yes" : "no"));
-            sb.AppendLine("`");
+            sb.Append("`");
+            if (round.FindingsHitLimit) {
+                sb.Append(", findings hit history cap");
+            }
+            if (round.FindingsParseIncomplete) {
+                sb.Append(", findings parse incomplete");
+            }
+            sb.AppendLine();
         }
     }
 

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -283,12 +283,22 @@ internal static class ReviewHistoryBuilder {
             return Array.Empty<ReviewHistoryFinding>();
         }
 
+        var latestIndices = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var index = 0; index < findings.Count; index++) {
+            var finding = findings[index];
+            if (string.IsNullOrWhiteSpace(finding.Fingerprint)) {
+                continue;
+            }
+
+            latestIndices[finding.Fingerprint] = index;
+        }
+
         var open = new List<ReviewHistoryFinding>(findings.Count);
-        var seenFingerprints = new HashSet<string>(StringComparer.Ordinal);
-        for (var index = findings.Count - 1; index >= 0; index--) {
+        for (var index = 0; index < findings.Count; index++) {
             var finding = findings[index];
             if (!string.IsNullOrWhiteSpace(finding.Fingerprint) &&
-                !seenFingerprints.Add(finding.Fingerprint)) {
+                latestIndices.TryGetValue(finding.Fingerprint, out var latestIndex) &&
+                latestIndex != index) {
                 continue;
             }
 
@@ -298,8 +308,6 @@ internal static class ReviewHistoryBuilder {
 
             open.Add(finding);
         }
-
-        open.Reverse();
         return open;
     }
 

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -260,7 +260,8 @@ internal static class ReviewHistoryBuilder {
     }
 
     private static bool LatestRoundHasUnparseableMergeBlockers(ReviewHistoryRound latestRound) {
-        return latestRound.HasMergeBlockers && latestRound.Findings.Count == 0;
+        return latestRound.HasMergeBlockers &&
+               (latestRound.Findings.Count == 0 || latestRound.FindingsParseIncomplete);
     }
 
     private static bool RoundsShareReviewedHead(ReviewHistoryRound previousRound, ReviewHistoryRound latestRound) {
@@ -306,12 +307,14 @@ internal static class ReviewHistoryBuilder {
         ReviewSettings settings, int sequence = 1) {
         ReviewSummaryParser.TryGetReviewedCommit(existingSummary.Body, out var reviewedCommit);
         var findings = ReviewSummaryParser.ExtractMergeBlockerFindings(existingSummary.Body, settings, settings.History.MaxItems,
-            out var findingsHitLimit);
+            out var findingsHitLimit, out var findingsParseIncomplete);
         var hasMergeBlockers = ReviewSummaryParser.HasMergeBlockers(existingSummary.Body, settings);
         var mergeBlockerStatus = findings.Count == 0
             ? hasMergeBlockers
                 ? "present, but markdown items could not be normalized."
                 : "none."
+            : findingsParseIncomplete
+                ? $"{findings.Count} normalized item(s), but additional merge-blocker lines could not be normalized."
             : $"{findings.Count} normalized item(s).";
         return new ReviewHistoryRound {
             Sequence = sequence,
@@ -324,6 +327,7 @@ internal static class ReviewHistoryBuilder {
             HasMergeBlockers = hasMergeBlockers,
             MergeBlockerStatus = mergeBlockerStatus,
             FindingsHitLimit = findingsHitLimit,
+            FindingsParseIncomplete = findingsParseIncomplete,
             Findings = ConvertFindings(findings)
         };
     }
@@ -366,6 +370,9 @@ internal static class ReviewHistoryBuilder {
             : "- Prior-head IX merge blockers from sticky summary (candidates only; revalidate against current diff or active threads before treating as blockers):");
         foreach (var item in round.Findings) {
             lines.Add($"  - [{NormalizeSectionLabel(item.Section)}] {item.Text}");
+        }
+        if (round.FindingsParseIncomplete) {
+            lines.Add("  - Additional merge-blocker lines were present but could not be normalized; do not infer missing same-head findings as resolved from this round alone.");
         }
     }
 

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -300,7 +300,8 @@ internal static class ReviewHistoryBuilder {
     private static ReviewHistoryRound? BuildStickySummaryRound(IssueComment existingSummary, string? currentHeadSha,
         ReviewSettings settings, int sequence = 1) {
         ReviewSummaryParser.TryGetReviewedCommit(existingSummary.Body, out var reviewedCommit);
-        var findings = ReviewSummaryParser.ExtractMergeBlockerFindings(existingSummary.Body, settings, settings.History.MaxItems);
+        var findings = ReviewSummaryParser.ExtractMergeBlockerFindings(existingSummary.Body, settings, settings.History.MaxItems,
+            out var findingsHitLimit);
         var hasMergeBlockers = ReviewSummaryParser.HasMergeBlockers(existingSummary.Body, settings);
         var mergeBlockerStatus = findings.Count == 0
             ? hasMergeBlockers
@@ -317,7 +318,7 @@ internal static class ReviewHistoryBuilder {
                                 currentHeadSha.StartsWith(reviewedCommit!, StringComparison.OrdinalIgnoreCase),
             HasMergeBlockers = hasMergeBlockers,
             MergeBlockerStatus = mergeBlockerStatus,
-            FindingsHitLimit = findings.Count >= settings.History.MaxItems,
+            FindingsHitLimit = findingsHitLimit,
             Findings = ConvertFindings(findings)
         };
     }

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -159,19 +159,7 @@ internal static class ReviewHistoryBuilder {
 
         var latestSameHeadRound = FindLatestSameHeadRound(rounds);
         if (latestSameHeadRound is not null) {
-            var seenFingerprints = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var state in latestSameHeadRound.Findings) {
-                if (!string.Equals(state.Status, "open", StringComparison.OrdinalIgnoreCase)) {
-                    continue;
-                }
-
-                if (!string.IsNullOrWhiteSpace(state.Fingerprint) &&
-                    !seenFingerprints.Add(state.Fingerprint)) {
-                    continue;
-                }
-
-                openFindings.Add(state);
-            }
+            openFindings.AddRange(CollectLatestRoundOpenFindings(latestSameHeadRound.Findings));
         }
 
         AppendResolvedSinceLastRound(resolvedSinceLastRound, rounds);
@@ -282,6 +270,31 @@ internal static class ReviewHistoryBuilder {
             map[finding.Fingerprint] = finding;
         }
         return map;
+    }
+
+    private static IReadOnlyList<ReviewHistoryFinding> CollectLatestRoundOpenFindings(IReadOnlyList<ReviewHistoryFinding> findings) {
+        if (findings.Count == 0) {
+            return Array.Empty<ReviewHistoryFinding>();
+        }
+
+        var open = new List<ReviewHistoryFinding>(findings.Count);
+        var seenFingerprints = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = findings.Count - 1; index >= 0; index--) {
+            var finding = findings[index];
+            if (!string.IsNullOrWhiteSpace(finding.Fingerprint) &&
+                !seenFingerprints.Add(finding.Fingerprint)) {
+                continue;
+            }
+
+            if (!string.Equals(finding.Status, "open", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            open.Add(finding);
+        }
+
+        open.Reverse();
+        return open;
     }
 
     private static ReviewHistoryRound? BuildStickySummaryRound(IssueComment existingSummary, string? currentHeadSha,

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -229,7 +229,8 @@ internal static class ReviewHistoryBuilder {
 
             if (!latestFindings.TryGetValue(finding.Fingerprint, out var latestFinding)) {
                 if (RoundsShareReviewedHead(previousRound, latestRound) &&
-                    !latestRound.FindingsHitLimit) {
+                    !latestRound.FindingsHitLimit &&
+                    !LatestRoundHasUnparseableMergeBlockers(latestRound)) {
                     resolvedSinceLastRound.Add(new ReviewHistoryFinding {
                         Fingerprint = finding.Fingerprint,
                         Section = finding.Section,
@@ -256,6 +257,10 @@ internal static class ReviewHistoryBuilder {
         }
 
         return null;
+    }
+
+    private static bool LatestRoundHasUnparseableMergeBlockers(ReviewHistoryRound latestRound) {
+        return latestRound.HasMergeBlockers && latestRound.Findings.Count == 0;
     }
 
     private static bool RoundsShareReviewedHead(ReviewHistoryRound previousRound, ReviewHistoryRound latestRound) {

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -148,7 +148,6 @@ internal static class ReviewHistoryBuilder {
         }
 
         ownedSummaries.Reverse();
-        var currentHeadFindingsByFingerprint = new Dictionary<string, ReviewHistoryFinding>(StringComparer.Ordinal);
         for (var index = 0; index < ownedSummaries.Count; index++) {
             var round = BuildStickySummaryRound(ownedSummaries[index], currentHeadSha, settings, index + 1);
             if (round is null) {
@@ -156,17 +155,14 @@ internal static class ReviewHistoryBuilder {
             }
 
             rounds.Add(round);
-            if (!round.SameHeadAsCurrent) {
-                continue;
-            }
-            foreach (var finding in round.Findings) {
-                currentHeadFindingsByFingerprint[finding.Fingerprint] = finding;
-            }
         }
 
-        foreach (var state in currentHeadFindingsByFingerprint.Values) {
-            if (string.Equals(state.Status, "open", StringComparison.OrdinalIgnoreCase)) {
-                openFindings.Add(state);
+        var latestSameHeadRound = FindLatestSameHeadRound(rounds);
+        if (latestSameHeadRound is not null) {
+            foreach (var state in latestSameHeadRound.Findings) {
+                if (string.Equals(state.Status, "open", StringComparison.OrdinalIgnoreCase)) {
+                    openFindings.Add(state);
+                }
             }
         }
 
@@ -236,6 +232,14 @@ internal static class ReviewHistoryBuilder {
             }
 
             if (!latestFindings.TryGetValue(finding.Fingerprint, out var latestFinding)) {
+                if (RoundsShareReviewedHead(previousRound, latestRound)) {
+                    resolvedSinceLastRound.Add(new ReviewHistoryFinding {
+                        Fingerprint = finding.Fingerprint,
+                        Section = finding.Section,
+                        Text = finding.Text,
+                        Status = "resolved"
+                    });
+                }
                 continue;
             }
 
@@ -245,6 +249,22 @@ internal static class ReviewHistoryBuilder {
 
             resolvedSinceLastRound.Add(latestFinding);
         }
+    }
+
+    private static ReviewHistoryRound? FindLatestSameHeadRound(IReadOnlyList<ReviewHistoryRound> rounds) {
+        for (var index = rounds.Count - 1; index >= 0; index--) {
+            if (rounds[index].SameHeadAsCurrent) {
+                return rounds[index];
+            }
+        }
+
+        return null;
+    }
+
+    private static bool RoundsShareReviewedHead(ReviewHistoryRound previousRound, ReviewHistoryRound latestRound) {
+        return !string.IsNullOrWhiteSpace(previousRound.ReviewedSha) &&
+               !string.IsNullOrWhiteSpace(latestRound.ReviewedSha) &&
+               string.Equals(previousRound.ReviewedSha, latestRound.ReviewedSha, StringComparison.OrdinalIgnoreCase);
     }
 
     private static Dictionary<string, ReviewHistoryFinding> ToFindingMap(IReadOnlyList<ReviewHistoryFinding> findings) {

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -159,10 +159,18 @@ internal static class ReviewHistoryBuilder {
 
         var latestSameHeadRound = FindLatestSameHeadRound(rounds);
         if (latestSameHeadRound is not null) {
+            var seenFingerprints = new HashSet<string>(StringComparer.Ordinal);
             foreach (var state in latestSameHeadRound.Findings) {
-                if (string.Equals(state.Status, "open", StringComparison.OrdinalIgnoreCase)) {
-                    openFindings.Add(state);
+                if (!string.Equals(state.Status, "open", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
                 }
+
+                if (!string.IsNullOrWhiteSpace(state.Fingerprint) &&
+                    !seenFingerprints.Add(state.Fingerprint)) {
+                    continue;
+                }
+
+                openFindings.Add(state);
             }
         }
 
@@ -232,7 +240,8 @@ internal static class ReviewHistoryBuilder {
             }
 
             if (!latestFindings.TryGetValue(finding.Fingerprint, out var latestFinding)) {
-                if (RoundsShareReviewedHead(previousRound, latestRound)) {
+                if (RoundsShareReviewedHead(previousRound, latestRound) &&
+                    !latestRound.FindingsHitLimit) {
                     resolvedSinceLastRound.Add(new ReviewHistoryFinding {
                         Fingerprint = finding.Fingerprint,
                         Section = finding.Section,
@@ -295,6 +304,7 @@ internal static class ReviewHistoryBuilder {
                                 currentHeadSha.StartsWith(reviewedCommit!, StringComparison.OrdinalIgnoreCase),
             HasMergeBlockers = hasMergeBlockers,
             MergeBlockerStatus = mergeBlockerStatus,
+            FindingsHitLimit = findings.Count >= settings.History.MaxItems,
             Findings = ConvertFindings(findings)
         };
     }

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -90,11 +90,14 @@ internal static class ReviewHistoryBuilder {
         }
 
         var lines = new List<string>();
+        var latestSameHeadRound = FindLatestSameHeadRound(snapshot.Rounds);
         if (snapshot.OpenFindings.Count > 0) {
             lines.Add("Open on current head:");
             foreach (var finding in snapshot.OpenFindings) {
                 lines.Add($"- [{NormalizeSectionLabel(finding.Section)}] {finding.Text}");
             }
+        } else if (latestSameHeadRound is not null && latestSameHeadRound.FindingsParseIncomplete) {
+            lines.Add("Open on current head: unknown; merge-blocker lines could not be fully normalized.");
         } else {
             lines.Add("Open on current head: none.");
         }
@@ -318,7 +321,9 @@ internal static class ReviewHistoryBuilder {
             out var findingsHitLimit, out var findingsParseIncomplete);
         var hasMergeBlockers = ReviewSummaryParser.HasMergeBlockers(existingSummary.Body, settings);
         var mergeBlockerStatus = findings.Count == 0
-            ? hasMergeBlockers
+            ? findingsParseIncomplete
+                ? "unknown; merge-blocker lines were present but could not be normalized."
+                : hasMergeBlockers
                 ? "present, but markdown items could not be normalized."
                 : "none."
             : findingsParseIncomplete

--- a/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
+++ b/IntelligenceX.Reviewer/ReviewHistoryBuilder.cs
@@ -222,7 +222,7 @@ internal static class ReviewHistoryBuilder {
         var latestRound = rounds[rounds.Count - 1];
         var previousRound = rounds[rounds.Count - 2];
         var latestFindings = ToFindingMap(latestRound.Findings);
-        foreach (var finding in previousRound.Findings) {
+        foreach (var finding in ToFindingMap(previousRound.Findings).Values) {
             if (!string.Equals(finding.Status, "open", StringComparison.OrdinalIgnoreCase)) {
                 continue;
             }
@@ -260,8 +260,8 @@ internal static class ReviewHistoryBuilder {
     }
 
     private static bool LatestRoundHasUnparseableMergeBlockers(ReviewHistoryRound latestRound) {
-        return latestRound.HasMergeBlockers &&
-               (latestRound.Findings.Count == 0 || latestRound.FindingsParseIncomplete);
+        return latestRound.FindingsParseIncomplete ||
+               (latestRound.HasMergeBlockers && latestRound.Findings.Count == 0);
     }
 
     private static bool RoundsShareReviewedHead(ReviewHistoryRound previousRound, ReviewHistoryRound latestRound) {

--- a/IntelligenceX.Reviewer/ReviewHistorySnapshot.cs
+++ b/IntelligenceX.Reviewer/ReviewHistorySnapshot.cs
@@ -23,6 +23,7 @@ internal sealed class ReviewHistoryRound {
     public bool HasMergeBlockers { get; init; }
     public string MergeBlockerStatus { get; init; } = string.Empty;
     public bool FindingsHitLimit { get; init; }
+    public bool FindingsParseIncomplete { get; init; }
     public IReadOnlyList<ReviewHistoryFinding> Findings { get; init; } = Array.Empty<ReviewHistoryFinding>();
 }
 

--- a/IntelligenceX.Reviewer/ReviewHistorySnapshot.cs
+++ b/IntelligenceX.Reviewer/ReviewHistorySnapshot.cs
@@ -22,6 +22,7 @@ internal sealed class ReviewHistoryRound {
     public bool SameHeadAsCurrent { get; init; }
     public bool HasMergeBlockers { get; init; }
     public string MergeBlockerStatus { get; init; } = string.Empty;
+    public bool FindingsHitLimit { get; init; }
     public IReadOnlyList<ReviewHistoryFinding> Findings { get; init; } = Array.Empty<ReviewHistoryFinding>();
 }
 

--- a/IntelligenceX.Reviewer/ReviewSummaryParser.cs
+++ b/IntelligenceX.Reviewer/ReviewSummaryParser.cs
@@ -147,8 +147,14 @@ internal static class ReviewSummaryParser {
 
     internal static IReadOnlyList<ReviewSummaryFinding> ExtractMergeBlockerFindings(string? body, ReviewSettings? settings,
         int maxItems, out bool hitLimit) {
+        return ExtractMergeBlockerFindings(body, settings, maxItems, out hitLimit, out _);
+    }
+
+    internal static IReadOnlyList<ReviewSummaryFinding> ExtractMergeBlockerFindings(string? body, ReviewSettings? settings,
+        int maxItems, out bool hitLimit, out bool parseIncomplete) {
         var findings = new List<ReviewSummaryFinding>();
         hitLimit = false;
+        parseIncomplete = false;
         if (string.IsNullOrWhiteSpace(body) || maxItems <= 0) {
             return findings;
         }
@@ -176,6 +182,9 @@ internal static class ReviewSummaryParser {
             }
 
             if (!TryNormalizeFinding(trimmed, currentSection, out var finding)) {
+                if (LooksLikeMergeBlockerEntry(trimmed)) {
+                    parseIncomplete = true;
+                }
                 continue;
             }
 
@@ -324,6 +333,37 @@ internal static class ReviewSummaryParser {
 
         finding = new ReviewSummaryFinding(CreateFindingFingerprint(section, normalizedItem), section, normalizedItem, status);
         return true;
+    }
+
+    private static bool LooksLikeMergeBlockerEntry(string line) {
+        if (string.IsNullOrWhiteSpace(line)) {
+            return false;
+        }
+
+        var trimmed = line.Trim();
+        if (trimmed.StartsWith("<!--", StringComparison.Ordinal)) {
+            return false;
+        }
+        if (IsNoneLine(trimmed) || IsPlaceholderLine(trimmed)) {
+            return false;
+        }
+        if (trimmed.StartsWith("*Rationale:", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("*Why", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+        if (trimmed.StartsWith("-", StringComparison.Ordinal) ||
+            trimmed.StartsWith("*", StringComparison.Ordinal) ||
+            trimmed.StartsWith("[ ]", StringComparison.Ordinal) ||
+            trimmed.StartsWith("[x]", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        if (!char.IsDigit(trimmed[0])) {
+            return false;
+        }
+
+        var markerIndex = trimmed.IndexOf(". ", StringComparison.Ordinal);
+        return markerIndex > 0 && markerIndex <= 2;
     }
 
     private static string CreateFindingFingerprint(string section, string text) {

--- a/IntelligenceX.Reviewer/ReviewSummaryParser.cs
+++ b/IntelligenceX.Reviewer/ReviewSummaryParser.cs
@@ -142,7 +142,13 @@ internal static class ReviewSummaryParser {
 
     internal static IReadOnlyList<ReviewSummaryFinding> ExtractMergeBlockerFindings(string? body, ReviewSettings? settings = null,
         int maxItems = 10) {
+        return ExtractMergeBlockerFindings(body, settings, maxItems, out _);
+    }
+
+    internal static IReadOnlyList<ReviewSummaryFinding> ExtractMergeBlockerFindings(string? body, ReviewSettings? settings,
+        int maxItems, out bool hitLimit) {
         var findings = new List<ReviewSummaryFinding>();
+        hitLimit = false;
         if (string.IsNullOrWhiteSpace(body) || maxItems <= 0) {
             return findings;
         }
@@ -173,10 +179,12 @@ internal static class ReviewSummaryParser {
                 continue;
             }
 
-            findings.Add(finding);
             if (findings.Count >= maxItems) {
+                hitLimit = true;
                 break;
             }
+
+            findings.Add(finding);
         }
 
         return findings;

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -808,6 +808,8 @@ internal static partial class Program {
         failed += Run("Review history builder includes sticky summary and thread snapshot",
             TestReviewHistoryBuilderIncludesStickySummaryAndThreadSnapshot);
         failed += Run("Review history builder builds comment block", TestReviewHistoryBuilderBuildsCommentBlock);
+        failed += Run("Review history builder uses latest same-head round",
+            TestReviewHistoryBuilderUsesLatestSameHeadRound);
         failed += Run("Review summary stability drops history progress block",
             TestReviewSummaryStabilityDropsHistoryProgressBlock);
         failed += Run("Review history artifacts render json and markdown",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -812,6 +812,10 @@ internal static partial class Program {
             TestReviewHistoryBuilderUsesLatestSameHeadRound);
         failed += Run("Review history builder does not resolve across different heads",
             TestReviewHistoryBuilderDoesNotResolveAcrossDifferentHeads);
+        failed += Run("Review history builder dedupes latest same-head open findings",
+            TestReviewHistoryBuilderDedupesLatestSameHeadOpenFindings);
+        failed += Run("Review history builder does not resolve missing finding when latest same-head hits limit",
+            TestReviewHistoryBuilderDoesNotResolveMissingFindingWhenLatestSameHeadHitsLimit);
         failed += Run("Review summary stability drops history progress block",
             TestReviewSummaryStabilityDropsHistoryProgressBlock);
         failed += Run("Review history artifacts render json and markdown",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -816,6 +816,8 @@ internal static partial class Program {
             TestReviewHistoryBuilderDedupesLatestSameHeadOpenFindings);
         failed += Run("Review history builder does not resolve missing finding when latest same-head hits limit",
             TestReviewHistoryBuilderDoesNotResolveMissingFindingWhenLatestSameHeadHitsLimit);
+        failed += Run("Review history builder latest same-head uses resolved status precedence",
+            TestReviewHistoryBuilderLatestSameHeadUsesResolvedStatusPrecedence);
         failed += Run("Review summary stability drops history progress block",
             TestReviewSummaryStabilityDropsHistoryProgressBlock);
         failed += Run("Review history artifacts render json and markdown",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -824,6 +824,10 @@ internal static partial class Program {
             TestReviewHistoryBuilderDoesNotResolveWhenLatestSameHeadBlockersAreUnparseable);
         failed += Run("Review history builder does not resolve when latest same-head blockers are partially unparseable",
             TestReviewHistoryBuilderDoesNotResolveWhenLatestSameHeadBlockersArePartiallyUnparseable);
+        failed += Run("Review history builder does not resolve when parse-incomplete latest round evades blocker detection",
+            TestReviewHistoryBuilderDoesNotResolveWhenLatestSameHeadParseIncompleteWithoutDetectedBlockers);
+        failed += Run("Review history builder does not infer resolution from previously resolved duplicate",
+            TestReviewHistoryBuilderDoesNotInferResolutionFromPreviouslyResolvedDuplicate);
         failed += Run("Review summary stability drops history progress block",
             TestReviewSummaryStabilityDropsHistoryProgressBlock);
         failed += Run("Review history artifacts render json and markdown",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -822,6 +822,8 @@ internal static partial class Program {
             TestReviewHistoryBuilderResolvesExactCapWhenLatestRoundIsComplete);
         failed += Run("Review history builder does not resolve when latest same-head blockers are unparseable",
             TestReviewHistoryBuilderDoesNotResolveWhenLatestSameHeadBlockersAreUnparseable);
+        failed += Run("Review history builder does not resolve when latest same-head blockers are partially unparseable",
+            TestReviewHistoryBuilderDoesNotResolveWhenLatestSameHeadBlockersArePartiallyUnparseable);
         failed += Run("Review summary stability drops history progress block",
             TestReviewSummaryStabilityDropsHistoryProgressBlock);
         failed += Run("Review history artifacts render json and markdown",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -818,6 +818,8 @@ internal static partial class Program {
             TestReviewHistoryBuilderDoesNotResolveMissingFindingWhenLatestSameHeadHitsLimit);
         failed += Run("Review history builder latest same-head uses resolved status precedence",
             TestReviewHistoryBuilderLatestSameHeadUsesResolvedStatusPrecedence);
+        failed += Run("Review history builder resolves exact cap when latest round is complete",
+            TestReviewHistoryBuilderResolvesExactCapWhenLatestRoundIsComplete);
         failed += Run("Review summary stability drops history progress block",
             TestReviewSummaryStabilityDropsHistoryProgressBlock);
         failed += Run("Review history artifacts render json and markdown",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -810,6 +810,8 @@ internal static partial class Program {
         failed += Run("Review history builder builds comment block", TestReviewHistoryBuilderBuildsCommentBlock);
         failed += Run("Review history builder uses latest same-head round",
             TestReviewHistoryBuilderUsesLatestSameHeadRound);
+        failed += Run("Review history builder does not resolve across different heads",
+            TestReviewHistoryBuilderDoesNotResolveAcrossDifferentHeads);
         failed += Run("Review summary stability drops history progress block",
             TestReviewSummaryStabilityDropsHistoryProgressBlock);
         failed += Run("Review history artifacts render json and markdown",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -820,6 +820,8 @@ internal static partial class Program {
             TestReviewHistoryBuilderLatestSameHeadUsesResolvedStatusPrecedence);
         failed += Run("Review history builder resolves exact cap when latest round is complete",
             TestReviewHistoryBuilderResolvesExactCapWhenLatestRoundIsComplete);
+        failed += Run("Review history builder does not resolve when latest same-head blockers are unparseable",
+            TestReviewHistoryBuilderDoesNotResolveWhenLatestSameHeadBlockersAreUnparseable);
         failed += Run("Review summary stability drops history progress block",
             TestReviewSummaryStabilityDropsHistoryProgressBlock);
         failed += Run("Review history artifacts render json and markdown",

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -754,6 +754,81 @@ internal static partial class Program {
             "review history cross-head block does not surface prior-head finding as resolved");
     }
 
+    private static void TestReviewHistoryBuilderDedupesLatestSameHeadOpenFindings() {
+        var settings = new ReviewSettings();
+        settings.History.Enabled = true;
+
+        var body = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            $"Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Retry the alternate transport.",
+            "- [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var issueComments = new[] {
+            new IssueComment(10, body, "intelligencex-review")
+        };
+
+        var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "abc1234", Array.Empty<PullRequestReviewThread>(), settings);
+        var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+
+        AssertEqual(1, snapshot.OpenFindings.Count, "review history dedupes same-head open findings");
+        AssertEqual("Retry the alternate transport.", snapshot.OpenFindings[0].Text,
+            "review history deduped same-head finding text");
+        AssertEqual(1, CountOccurrences(block, "Retry the alternate transport."),
+            "review history deduped same-head finding appears once in comment block");
+    }
+
+    private static void TestReviewHistoryBuilderDoesNotResolveMissingFindingWhenLatestSameHeadHitsLimit() {
+        var settings = new ReviewSettings();
+        settings.History.Enabled = true;
+        settings.History.MaxItems = 1;
+
+        var olderBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            $"Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var newerBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            $"Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Add a new blocker ahead of the older one.",
+            "- [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var issueComments = new[] {
+            new IssueComment(20, newerBody, "intelligencex-review"),
+            new IssueComment(10, olderBody, "intelligencex-review")
+        };
+
+        var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "abc1234", Array.Empty<PullRequestReviewThread>(), settings);
+        var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+
+        AssertEqual(1, snapshot.OpenFindings.Count, "review history capped same-head snapshot keeps extracted open finding");
+        AssertEqual(0, snapshot.ResolvedSinceLastRound.Count,
+            "review history capped same-head snapshot does not infer missing finding resolved");
+        AssertContainsText(block, "Resolved since last round: none newly resolved.",
+            "review history capped same-head block avoids false resolved line");
+        AssertDoesNotContainText(block, "[todo] Retry the alternate transport.",
+            "review history capped same-head block does not falsely report hidden finding resolved");
+    }
+
     private static void TestReviewSummaryStabilityDropsHistoryProgressBlock() {
         var context = BuildContext();
         var settings = new ReviewSettings {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -924,6 +924,8 @@ internal static partial class Program {
     private static void TestReviewHistoryBuilderDoesNotResolveWhenLatestSameHeadBlockersAreUnparseable() {
         var settings = new ReviewSettings();
         settings.History.Enabled = true;
+        settings.MergeBlockerRequireSectionMatch = true;
+        settings.MergeBlockerRequireAllSections = true;
 
         var olderBody = string.Join("\n", new[] {
             ReviewFormatter.SummaryMarker,
@@ -941,16 +943,19 @@ internal static partial class Program {
             "## IntelligenceX Review",
             "Reviewed commit: `abc1234`",
             "",
-            "## Todo List ✅",
-            "Blockers remain but the checklist formatting is malformed.",
-            "",
-            "## Critical Issues ⚠️",
-            "None."
+            "## Todo-ish Notes",
+            "- [ ] Blockers remain but the expected merge-blocker section header is malformed."
         });
         var issueComments = new[] {
             new IssueComment(20, newerBody, "intelligencex-review"),
             new IssueComment(10, olderBody, "intelligencex-review")
         };
+        var extracted = ReviewSummaryParser.ExtractMergeBlockerFindings(newerBody, settings, settings.History.MaxItems);
+
+        AssertTrue(ReviewSummaryParser.HasMergeBlockers(newerBody, settings),
+            "review history unparseable same-head latest summary still reports merge blockers");
+        AssertEqual(0, extracted.Count,
+            "review history unparseable same-head latest summary yields no normalized findings");
 
         var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "abc1234", Array.Empty<PullRequestReviewThread>(), settings);
         var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -972,6 +972,69 @@ internal static partial class Program {
             "review history unparseable same-head block does not surface prior finding as resolved");
     }
 
+    private static void TestReviewHistoryBuilderDoesNotResolveWhenLatestSameHeadBlockersArePartiallyUnparseable() {
+        var settings = new ReviewSettings();
+        settings.History.Enabled = true;
+
+        var olderBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var newerBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Add a new blocker ahead of the older one.",
+            "* [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var issueComments = new[] {
+            new IssueComment(20, newerBody, "intelligencex-review"),
+            new IssueComment(10, olderBody, "intelligencex-review")
+        };
+        var extracted = ReviewSummaryParser.ExtractMergeBlockerFindings(newerBody, settings, settings.History.MaxItems,
+            out var hitLimit, out var parseIncomplete);
+
+        AssertEqual(false, hitLimit, "review history partial-parse latest summary does not hit findings limit");
+        AssertEqual(true, parseIncomplete,
+            "review history partial-parse latest summary reports incomplete merge-blocker parsing");
+        AssertEqual(1, extracted.Count,
+            "review history partial-parse latest summary still keeps normalized findings");
+
+        var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "abc1234", Array.Empty<PullRequestReviewThread>(), settings);
+        var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+        var rendered = ReviewHistoryBuilder.Render(snapshot);
+
+        AssertEqual(1, snapshot.OpenFindings.Count,
+            "review history partial-parse same-head snapshot keeps normalized current finding");
+        AssertEqual("Add a new blocker ahead of the older one.", snapshot.OpenFindings[0].Text,
+            "review history partial-parse same-head snapshot keeps normalized open finding text");
+        AssertEqual(0, snapshot.ResolvedSinceLastRound.Count,
+            "review history partial-parse same-head snapshot does not infer malformed missing finding resolved");
+        AssertEqual(true, snapshot.Rounds[1].FindingsParseIncomplete,
+            "review history partial-parse same-head round records incomplete parsing");
+        AssertContainsText(block, "[todo] Add a new blocker ahead of the older one.",
+            "review history partial-parse same-head block includes normalized current finding");
+        AssertContainsText(rendered,
+            "Additional merge-blocker lines were present but could not be normalized",
+            "review history partial-parse same-head snapshot warns about incomplete normalization");
+        AssertDoesNotContainText(block, "Resolved since last round:",
+            "review history partial-parse same-head block omits resolved section when nothing was resolved");
+        AssertDoesNotContainText(block, "[todo] Retry the alternate transport.",
+            "review history partial-parse same-head block does not falsely report malformed missing finding resolved");
+    }
+
     private static void TestReviewSummaryStabilityDropsHistoryProgressBlock() {
         var context = BuildContext();
         var settings = new ReviewSettings {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -831,6 +831,51 @@ internal static partial class Program {
             "review history capped same-head block does not falsely report hidden finding resolved");
     }
 
+    private static void TestReviewHistoryBuilderLatestSameHeadUsesResolvedStatusPrecedence() {
+        var settings = new ReviewSettings();
+        settings.History.Enabled = true;
+
+        var olderBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var newerBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Retry the alternate transport.",
+            "- [x] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var issueComments = new[] {
+            new IssueComment(20, newerBody, "intelligencex-review"),
+            new IssueComment(10, olderBody, "intelligencex-review")
+        };
+
+        var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "abc1234", Array.Empty<PullRequestReviewThread>(), settings);
+        var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+
+        AssertEqual(0, snapshot.OpenFindings.Count,
+            "review history latest same-head snapshot suppresses finding resolved later in same round");
+        AssertEqual(1, snapshot.ResolvedSinceLastRound.Count,
+            "review history latest same-head snapshot keeps resolved finding when latest round checks it off");
+        AssertContainsText(block, "Open on current head: none.",
+            "review history latest same-head block has no current open finding after later resolution");
+        AssertContainsText(block, "[todo] Retry the alternate transport.",
+            "review history latest same-head block reports the resolved finding once");
+    }
+
     private static void TestReviewSummaryStabilityDropsHistoryProgressBlock() {
         var context = BuildContext();
         var settings = new ReviewSettings {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -710,6 +710,50 @@ internal static partial class Program {
             "review history latest same-head block resolved stale finding");
     }
 
+    private static void TestReviewHistoryBuilderDoesNotResolveAcrossDifferentHeads() {
+        var settings = new ReviewSettings();
+        settings.History.Enabled = true;
+
+        var olderHeadBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            $"Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var newerHeadBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            $"Reviewed commit: `def5678`",
+            "",
+            "## Todo List ✅",
+            "None.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var issueComments = new[] {
+            new IssueComment(20, newerHeadBody, "intelligencex-review"),
+            new IssueComment(10, olderHeadBody, "intelligencex-review")
+        };
+
+        var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "def5678", Array.Empty<PullRequestReviewThread>(), settings);
+        var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+
+        AssertEqual(0, snapshot.OpenFindings.Count, "review history cross-head snapshot has no current same-head open findings");
+        AssertEqual(0, snapshot.ResolvedSinceLastRound.Count,
+            "review history cross-head snapshot does not mark disappeared finding resolved");
+        AssertContainsText(block, "Open on current head: none.", "review history cross-head block no open findings");
+        AssertContainsText(block, "Resolved since last round: none newly resolved.",
+            "review history cross-head block no resolved findings");
+        AssertDoesNotContainText(block, "Retry the alternate transport.",
+            "review history cross-head block does not surface prior-head finding as resolved");
+    }
+
     private static void TestReviewSummaryStabilityDropsHistoryProgressBlock() {
         var context = BuildContext();
         var settings = new ReviewSettings {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -921,6 +921,52 @@ internal static partial class Program {
             "review history exact-cap complete block includes resolved finding text");
     }
 
+    private static void TestReviewHistoryBuilderDoesNotResolveWhenLatestSameHeadBlockersAreUnparseable() {
+        var settings = new ReviewSettings();
+        settings.History.Enabled = true;
+
+        var olderBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var newerBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "Blockers remain but the checklist formatting is malformed.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var issueComments = new[] {
+            new IssueComment(20, newerBody, "intelligencex-review"),
+            new IssueComment(10, olderBody, "intelligencex-review")
+        };
+
+        var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "abc1234", Array.Empty<PullRequestReviewThread>(), settings);
+        var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+
+        AssertEqual(0, snapshot.OpenFindings.Count,
+            "review history unparseable same-head snapshot has no normalized open findings");
+        AssertEqual(0, snapshot.ResolvedSinceLastRound.Count,
+            "review history unparseable same-head snapshot does not infer missing finding resolved");
+        AssertContainsText(block, "Open on current head: none.",
+            "review history unparseable same-head block reports no normalized open findings");
+        AssertContainsText(block, "Resolved since last round: none newly resolved.",
+            "review history unparseable same-head block does not claim the missing finding resolved");
+        AssertDoesNotContainText(block, "[todo] Retry the alternate transport.",
+            "review history unparseable same-head block does not surface prior finding as resolved");
+    }
+
     private static void TestReviewSummaryStabilityDropsHistoryProgressBlock() {
         var context = BuildContext();
         var settings = new ReviewSettings {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -664,6 +664,52 @@ internal static partial class Program {
         AssertContainsText(block, "[critical] Cover the stale thread path.", "review history comment block resolved item");
     }
 
+    private static void TestReviewHistoryBuilderUsesLatestSameHeadRound() {
+        var settings = new ReviewSettings();
+        settings.History.Enabled = true;
+
+        var firstSameHeadBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            $"Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var latestSameHeadBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            $"Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "None.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var issueComments = new[] {
+            new IssueComment(20, latestSameHeadBody, "intelligencex-review"),
+            new IssueComment(10, firstSameHeadBody, "intelligencex-review")
+        };
+
+        var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "abc1234", Array.Empty<PullRequestReviewThread>(), settings);
+        var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+
+        AssertEqual(2, snapshot.Rounds.Count, "review history latest same-head round count");
+        AssertEqual(0, snapshot.OpenFindings.Count, "review history latest same-head round supersedes prior stale finding");
+        AssertEqual(1, snapshot.ResolvedSinceLastRound.Count,
+            "review history latest same-head round marks disappeared stale finding resolved");
+        AssertEqual("Retry the alternate transport.", snapshot.ResolvedSinceLastRound[0].Text,
+            "review history resolved stale same-head finding text");
+        AssertContainsText(block, "Open on current head: none.", "review history latest same-head block no open findings");
+        AssertContainsText(block, "Resolved since last round:", "review history latest same-head block resolved label");
+        AssertContainsText(block, "[todo] Retry the alternate transport.",
+            "review history latest same-head block resolved stale finding");
+    }
+
     private static void TestReviewSummaryStabilityDropsHistoryProgressBlock() {
         var context = BuildContext();
         var settings = new ReviewSettings {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -1075,13 +1075,19 @@ internal static partial class Program {
         };
         var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "abc1234", Array.Empty<PullRequestReviewThread>(), settings);
         var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+        var rendered = ReviewHistoryBuilder.Render(snapshot);
 
         AssertEqual(0, snapshot.ResolvedSinceLastRound.Count,
             "review history parse-incomplete same-head snapshot does not infer missing finding resolved");
-        AssertContainsText(block, "Resolved since last round: none newly resolved.",
-            "review history parse-incomplete same-head block does not claim a resolution");
+        AssertEqual("unknown; merge-blocker lines were present but could not be normalized.",
+            snapshot.Rounds[1].MergeBlockerStatus,
+            "review history parse-incomplete same-head round surfaces unknown merge-blocker state");
+        AssertContainsText(block, "Open on current head: unknown; merge-blocker lines could not be fully normalized.",
+            "review history parse-incomplete same-head block surfaces unknown current-head status");
         AssertDoesNotContainText(block, "[todo] Retry the alternate transport.",
             "review history parse-incomplete same-head block does not surface malformed missing finding as resolved");
+        AssertContainsText(rendered, "- IX merge blockers in sticky summary: unknown; merge-blocker lines were present but could not be normalized.",
+            "review history parse-incomplete same-head render preserves unknown merge-blocker status");
     }
 
     private static void TestReviewHistoryBuilderDoesNotInferResolutionFromPreviouslyResolvedDuplicate() {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -876,6 +876,51 @@ internal static partial class Program {
             "review history latest same-head block reports the resolved finding once");
     }
 
+    private static void TestReviewHistoryBuilderResolvesExactCapWhenLatestRoundIsComplete() {
+        var settings = new ReviewSettings();
+        settings.History.Enabled = true;
+        settings.History.MaxItems = 1;
+
+        var olderBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var newerBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [x] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var issueComments = new[] {
+            new IssueComment(20, newerBody, "intelligencex-review"),
+            new IssueComment(10, olderBody, "intelligencex-review")
+        };
+
+        var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "abc1234", Array.Empty<PullRequestReviewThread>(), settings);
+        var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+
+        AssertEqual(0, snapshot.OpenFindings.Count,
+            "review history exact-cap complete snapshot has no current open findings");
+        AssertEqual(1, snapshot.ResolvedSinceLastRound.Count,
+            "review history exact-cap complete snapshot still reports legitimate same-head resolution");
+        AssertContainsText(block, "Resolved since last round:",
+            "review history exact-cap complete block includes resolved section");
+        AssertContainsText(block, "[todo] Retry the alternate transport.",
+            "review history exact-cap complete block includes resolved finding text");
+    }
+
     private static void TestReviewSummaryStabilityDropsHistoryProgressBlock() {
         var context = BuildContext();
         var settings = new ReviewSettings {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -1035,6 +1035,98 @@ internal static partial class Program {
             "review history partial-parse same-head block does not falsely report malformed missing finding resolved");
     }
 
+    private static void TestReviewHistoryBuilderDoesNotResolveWhenLatestSameHeadParseIncompleteWithoutDetectedBlockers() {
+        var settings = new ReviewSettings();
+        settings.History.Enabled = true;
+
+        var olderBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var newerBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "* [ ] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        _ = ReviewSummaryParser.ExtractMergeBlockerFindings(newerBody, settings, settings.History.MaxItems,
+            out _, out var parseIncomplete);
+
+        AssertEqual(false, ReviewSummaryParser.HasMergeBlockers(newerBody, settings),
+            "review history parse-incomplete latest summary can evade merge-blocker detection");
+        AssertEqual(true, parseIncomplete,
+            "review history parse-incomplete latest summary still records incomplete parsing");
+
+        var issueComments = new[] {
+            new IssueComment(20, newerBody, "intelligencex-review"),
+            new IssueComment(10, olderBody, "intelligencex-review")
+        };
+        var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "abc1234", Array.Empty<PullRequestReviewThread>(), settings);
+        var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+
+        AssertEqual(0, snapshot.ResolvedSinceLastRound.Count,
+            "review history parse-incomplete same-head snapshot does not infer missing finding resolved");
+        AssertContainsText(block, "Resolved since last round: none newly resolved.",
+            "review history parse-incomplete same-head block does not claim a resolution");
+        AssertDoesNotContainText(block, "[todo] Retry the alternate transport.",
+            "review history parse-incomplete same-head block does not surface malformed missing finding as resolved");
+    }
+
+    private static void TestReviewHistoryBuilderDoesNotInferResolutionFromPreviouslyResolvedDuplicate() {
+        var settings = new ReviewSettings();
+        settings.History.Enabled = true;
+
+        var olderBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "- [ ] Retry the alternate transport.",
+            "- [x] Retry the alternate transport.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var newerBody = string.Join("\n", new[] {
+            ReviewFormatter.SummaryMarker,
+            "## IntelligenceX Review",
+            "Reviewed commit: `abc1234`",
+            "",
+            "## Todo List ✅",
+            "None.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+        var issueComments = new[] {
+            new IssueComment(20, newerBody, "intelligencex-review"),
+            new IssueComment(10, olderBody, "intelligencex-review")
+        };
+
+        var snapshot = ReviewHistoryBuilder.BuildSnapshot(issueComments, "abc1234", Array.Empty<PullRequestReviewThread>(), settings);
+        var block = ReviewHistoryBuilder.BuildCommentBlock(snapshot);
+
+        AssertEqual(0, snapshot.ResolvedSinceLastRound.Count,
+            "review history duplicate previous statuses do not emit a fresh resolved finding");
+        AssertContainsText(block, "Resolved since last round: none newly resolved.",
+            "review history duplicate previous statuses block does not claim a new resolution");
+        AssertDoesNotContainText(block, "[todo] Retry the alternate transport.",
+            "review history duplicate previous statuses block does not surface already-resolved duplicate as newly resolved");
+    }
+
     private static void TestReviewSummaryStabilityDropsHistoryProgressBlock() {
         var context = BuildContext();
         var settings = new ReviewSettings {

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -823,8 +823,10 @@ internal static partial class Program {
         AssertEqual(1, snapshot.OpenFindings.Count, "review history capped same-head snapshot keeps extracted open finding");
         AssertEqual(0, snapshot.ResolvedSinceLastRound.Count,
             "review history capped same-head snapshot does not infer missing finding resolved");
-        AssertContainsText(block, "Resolved since last round: none newly resolved.",
-            "review history capped same-head block avoids false resolved line");
+        AssertContainsText(block, "[todo] Add a new blocker ahead of the older one.",
+            "review history capped same-head block keeps current extracted open finding");
+        AssertDoesNotContainText(block, "Resolved since last round:",
+            "review history capped same-head block omits resolved section when nothing was resolved");
         AssertDoesNotContainText(block, "[todo] Retry the alternate transport.",
             "review history capped same-head block does not falsely report hidden finding resolved");
     }

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.cs
@@ -952,7 +952,7 @@ internal static partial class Program {
         };
         var extracted = ReviewSummaryParser.ExtractMergeBlockerFindings(newerBody, settings, settings.History.MaxItems);
 
-        AssertTrue(ReviewSummaryParser.HasMergeBlockers(newerBody, settings),
+        AssertEqual(true, ReviewSummaryParser.HasMergeBlockers(newerBody, settings),
             "review history unparseable same-head latest summary still reports merge blockers");
         AssertEqual(0, extracted.Count,
             "review history unparseable same-head latest summary yields no normalized findings");


### PR DESCRIPTION
## Summary
- use only the latest same-head sticky summary round when deriving current open history findings
- mark prior same-head findings as resolved when a newer rerun on the same reviewed commit no longer carries them
- add a regression test that models the stale same-head rerun case and wire it into the reviewer harness

## Validation
- dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release
- dotnet .\IntelligenceX.Tests\bin\Release\net8.0\IntelligenceX.Tests.dll
- dotnet .\IntelligenceX.Tests\bin\Release\net10.0\IntelligenceX.Tests.dll
