### PR TITLE
Ignore starred prose in history blocker parsing

### DIFF
--- a/IntelligenceX.Reviewer/ReviewSummaryParser.cs
+++ b/IntelligenceX.Reviewer/ReviewSummaryParser.cs
@@ -352,7 +352,7 @@ internal static class ReviewSummaryParser {
             return false;
         }
         if (trimmed.StartsWith("-", StringComparison.Ordinal) ||
-            IsStarredChecklistEntry(trimmed) ||
+            IsStarredBulletEntry(trimmed) ||
             trimmed.StartsWith("[ ]", StringComparison.Ordinal) ||
             trimmed.StartsWith("[x]", StringComparison.OrdinalIgnoreCase)) {
             return true;
@@ -366,7 +366,7 @@ internal static class ReviewSummaryParser {
         return markerIndex > 0 && markerIndex <= 2;
     }
 
-    private static bool IsStarredChecklistEntry(string line) {
+    private static bool IsStarredBulletEntry(string line) {
         if (!line.StartsWith("*", StringComparison.Ordinal) || line.Length < 2 || !char.IsWhiteSpace(line[1])) {
             return false;
         }
@@ -376,13 +376,7 @@ internal static class ReviewSummaryParser {
             index++;
         }
 
-        if (index + 2 >= line.Length) {
-            return false;
-        }
-
-        return line[index] == '[' &&
-               (line[index + 1] == ' ' || line[index + 1] == 'x' || line[index + 1] == 'X') &&
-               line[index + 2] == ']';
+        return index < line.Length;
     }
 
     private static string CreateFindingFingerprint(string section, string text) {

--- a/IntelligenceX.Reviewer/ReviewSummaryParser.cs
+++ b/IntelligenceX.Reviewer/ReviewSummaryParser.cs
@@ -352,7 +352,7 @@ internal static class ReviewSummaryParser {
             return false;
         }
         if (trimmed.StartsWith("-", StringComparison.Ordinal) ||
-            IsStarredBulletEntry(trimmed) ||
+            IsWhitespaceSeparatedStarredBulletEntry(trimmed) ||
             trimmed.StartsWith("[ ]", StringComparison.Ordinal) ||
             trimmed.StartsWith("[x]", StringComparison.OrdinalIgnoreCase)) {
             return true;
@@ -366,7 +366,7 @@ internal static class ReviewSummaryParser {
         return markerIndex > 0 && markerIndex <= 2;
     }
 
-    private static bool IsStarredBulletEntry(string line) {
+    private static bool IsWhitespaceSeparatedStarredBulletEntry(string line) {
         if (!line.StartsWith("*", StringComparison.Ordinal) || line.Length < 2 || !char.IsWhiteSpace(line[1])) {
             return false;
         }
@@ -376,6 +376,7 @@ internal static class ReviewSummaryParser {
             index++;
         }
 
+        // Markdown list bullets require whitespace after '*'; emphasis prose like '*Impact:*' does not.
         return index < line.Length;
     }
 

--- a/IntelligenceX.Reviewer/ReviewSummaryParser.cs
+++ b/IntelligenceX.Reviewer/ReviewSummaryParser.cs
@@ -352,7 +352,8 @@ internal static class ReviewSummaryParser {
             return false;
         }
         if (trimmed.StartsWith("-", StringComparison.Ordinal) ||
-            trimmed.StartsWith("*", StringComparison.Ordinal) ||
+            trimmed.StartsWith("* [ ]", StringComparison.Ordinal) ||
+            trimmed.StartsWith("* [x]", StringComparison.OrdinalIgnoreCase) ||
             trimmed.StartsWith("[ ]", StringComparison.Ordinal) ||
             trimmed.StartsWith("[x]", StringComparison.OrdinalIgnoreCase)) {
             return true;

--- a/IntelligenceX.Reviewer/ReviewSummaryParser.cs
+++ b/IntelligenceX.Reviewer/ReviewSummaryParser.cs
@@ -353,6 +353,7 @@ internal static class ReviewSummaryParser {
         }
         if (trimmed.StartsWith("-", StringComparison.Ordinal) ||
             IsWhitespaceSeparatedStarredBulletEntry(trimmed) ||
+            IsStarredChecklistEntry(trimmed) ||
             trimmed.StartsWith("[ ]", StringComparison.Ordinal) ||
             trimmed.StartsWith("[x]", StringComparison.OrdinalIgnoreCase)) {
             return true;
@@ -377,7 +378,29 @@ internal static class ReviewSummaryParser {
         }
 
         // Markdown list bullets require whitespace after '*'; emphasis prose like '*Impact:*' does not.
-        return index < line.Length;
+        return index < line.Length && !IsChecklistMarkerAt(line, index);
+    }
+
+    private static bool IsStarredChecklistEntry(string line) {
+        if (!line.StartsWith("*", StringComparison.Ordinal) || line.Length < 2) {
+            return false;
+        }
+
+        var index = 1;
+        while (index < line.Length && char.IsWhiteSpace(line[index])) {
+            index++;
+        }
+
+        return IsChecklistMarkerAt(line, index);
+    }
+
+    private static bool IsChecklistMarkerAt(string line, int index) {
+        if (index + 2 >= line.Length || line[index] != '[') {
+            return false;
+        }
+
+        var marker = line[index + 1];
+        return (marker == ' ' || marker == 'x' || marker == 'X') && line[index + 2] == ']';
     }
 
     private static string CreateFindingFingerprint(string section, string text) {

--- a/IntelligenceX.Reviewer/ReviewSummaryParser.cs
+++ b/IntelligenceX.Reviewer/ReviewSummaryParser.cs
@@ -352,8 +352,7 @@ internal static class ReviewSummaryParser {
             return false;
         }
         if (trimmed.StartsWith("-", StringComparison.Ordinal) ||
-            trimmed.StartsWith("* [ ]", StringComparison.Ordinal) ||
-            trimmed.StartsWith("* [x]", StringComparison.OrdinalIgnoreCase) ||
+            IsStarredChecklistEntry(trimmed) ||
             trimmed.StartsWith("[ ]", StringComparison.Ordinal) ||
             trimmed.StartsWith("[x]", StringComparison.OrdinalIgnoreCase)) {
             return true;
@@ -365,6 +364,25 @@ internal static class ReviewSummaryParser {
 
         var markerIndex = trimmed.IndexOf(". ", StringComparison.Ordinal);
         return markerIndex > 0 && markerIndex <= 2;
+    }
+
+    private static bool IsStarredChecklistEntry(string line) {
+        if (!line.StartsWith("*", StringComparison.Ordinal) || line.Length < 2 || !char.IsWhiteSpace(line[1])) {
+            return false;
+        }
+
+        var index = 1;
+        while (index < line.Length && char.IsWhiteSpace(line[index])) {
+            index++;
+        }
+
+        if (index + 2 >= line.Length) {
+            return false;
+        }
+
+        return line[index] == '[' &&
+               (line[index + 1] == ' ' || line[index + 1] == 'x' || line[index + 1] == 'X') &&
+               line[index + 2] == ']';
     }
 
     private static string CreateFindingFingerprint(string section, string text) {

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -856,6 +856,8 @@ internal static partial class Program {
         failed += Run("Review summary parser merge blocker detection", TestReviewSummaryParserMergeBlockerDetection);
         failed += Run("Review summary parser ignores starred prose for parse incomplete",
             TestReviewSummaryParserIgnoresStarredProseForParseIncomplete);
+        failed += Run("Review summary parser keeps flexible starred checklist parse incomplete",
+            TestReviewSummaryParserKeepsFlexibleStarredChecklistAsParseIncomplete);
         failed += Run("Review summary parser merge blocker detection inline section labels",
             TestReviewSummaryParserMergeBlockerDetectionInlineSectionLabels);
         failed += Run("Review summary parser merge blocker detection heading inline section labels",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -854,6 +854,8 @@ internal static partial class Program {
         failed += Run("Review summary parser", TestReviewSummaryParser);
         failed += Run("Review summary parser finding extraction", TestReviewSummaryParserFindingExtraction);
         failed += Run("Review summary parser merge blocker detection", TestReviewSummaryParserMergeBlockerDetection);
+        failed += Run("Review summary parser ignores starred prose for parse incomplete",
+            TestReviewSummaryParserIgnoresStarredProseForParseIncomplete);
         failed += Run("Review summary parser merge blocker detection inline section labels",
             TestReviewSummaryParserMergeBlockerDetectionInlineSectionLabels);
         failed += Run("Review summary parser merge blocker detection heading inline section labels",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -858,6 +858,8 @@ internal static partial class Program {
             TestReviewSummaryParserIgnoresStarredProseForParseIncomplete);
         failed += Run("Review summary parser keeps flexible starred checklist parse incomplete",
             TestReviewSummaryParserKeepsFlexibleStarredChecklistAsParseIncomplete);
+        failed += Run("Review summary parser keeps plain starred bullet parse incomplete",
+            TestReviewSummaryParserKeepsPlainStarredBulletAsParseIncomplete);
         failed += Run("Review summary parser merge blocker detection inline section labels",
             TestReviewSummaryParserMergeBlockerDetectionInlineSectionLabels);
         failed += Run("Review summary parser merge blocker detection heading inline section labels",

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -860,6 +860,8 @@ internal static partial class Program {
             TestReviewSummaryParserKeepsFlexibleStarredChecklistAsParseIncomplete);
         failed += Run("Review summary parser keeps plain starred bullet parse incomplete",
             TestReviewSummaryParserKeepsPlainStarredBulletAsParseIncomplete);
+        failed += Run("Review summary parser keeps compact starred checklist parse incomplete",
+            TestReviewSummaryParserKeepsCompactStarredChecklistAsParseIncomplete);
         failed += Run("Review summary parser merge blocker detection inline section labels",
             TestReviewSummaryParserMergeBlockerDetectionInlineSectionLabels);
         failed += Run("Review summary parser merge blocker detection heading inline section labels",

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
@@ -872,6 +872,24 @@ internal static partial class Program {
         AssertEqual(true, parseIncomplete, "findings plain starred bullet keeps parse incomplete safety");
     }
 
+    private static void TestReviewSummaryParserKeepsCompactStarredChecklistAsParseIncomplete() {
+        var body = string.Join("\n", new[] {
+            "## Todo List ✅",
+            "*[ ] retry transport",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+
+        var findings = ReviewSummaryParser.ExtractMergeBlockerFindings(body, settings: null, maxItems: 10, hitLimit: out var hitLimit,
+            parseIncomplete: out var parseIncomplete);
+
+        AssertEqual(false, ReviewSummaryParser.HasMergeBlockers(body), "merge blockers compact starred checklist still bypasses normalization");
+        AssertEqual(0, findings.Count, "findings compact starred checklist count");
+        AssertEqual(false, hitLimit, "findings compact starred checklist does not hit limit");
+        AssertEqual(true, parseIncomplete, "findings compact starred checklist keeps parse incomplete safety");
+    }
+
     private static void TestReviewSummaryParserMergeBlockerDetectionCompactDefaults() {
         var settings = new ReviewSettings {
             OutputStyle = "compact"

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
@@ -836,6 +836,24 @@ internal static partial class Program {
         AssertEqual(false, parseIncomplete, "findings starred prose does not mark parse incomplete");
     }
 
+    private static void TestReviewSummaryParserKeepsFlexibleStarredChecklistAsParseIncomplete() {
+        var body = string.Join("\n", new[] {
+            "## Todo List ✅",
+            "*    [ ] retry transport",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+
+        var findings = ReviewSummaryParser.ExtractMergeBlockerFindings(body, settings: null, maxItems: 10, hitLimit: out var hitLimit,
+            parseIncomplete: out var parseIncomplete);
+
+        AssertEqual(false, ReviewSummaryParser.HasMergeBlockers(body), "merge blockers flexible starred checklist still bypasses normalization");
+        AssertEqual(0, findings.Count, "findings flexible starred checklist count");
+        AssertEqual(false, hitLimit, "findings flexible starred checklist does not hit limit");
+        AssertEqual(true, parseIncomplete, "findings flexible starred checklist keeps parse incomplete safety");
+    }
+
     private static void TestReviewSummaryParserMergeBlockerDetectionCompactDefaults() {
         var settings = new ReviewSettings {
             OutputStyle = "compact"

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
@@ -817,6 +817,25 @@ internal static partial class Program {
             "merge blockers do not match non-critical heading as critical section");
     }
 
+    private static void TestReviewSummaryParserIgnoresStarredProseForParseIncomplete() {
+        var body = string.Join("\n", new[] {
+            "## Todo List ✅",
+            "*Impact:* no follow-up work remains here.",
+            "None.",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+
+        var findings = ReviewSummaryParser.ExtractMergeBlockerFindings(body, settings: null, maxItems: 10, hitLimit: out var hitLimit,
+            parseIncomplete: out var parseIncomplete);
+
+        AssertEqual(false, ReviewSummaryParser.HasMergeBlockers(body), "merge blockers starred prose is non-blocking");
+        AssertEqual(0, findings.Count, "findings starred prose count");
+        AssertEqual(false, hitLimit, "findings starred prose does not hit limit");
+        AssertEqual(false, parseIncomplete, "findings starred prose does not mark parse incomplete");
+    }
+
     private static void TestReviewSummaryParserMergeBlockerDetectionCompactDefaults() {
         var settings = new ReviewSettings {
             OutputStyle = "compact"

--- a/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.ResolveAndFilters.Advanced.cs
@@ -854,6 +854,24 @@ internal static partial class Program {
         AssertEqual(true, parseIncomplete, "findings flexible starred checklist keeps parse incomplete safety");
     }
 
+    private static void TestReviewSummaryParserKeepsPlainStarredBulletAsParseIncomplete() {
+        var body = string.Join("\n", new[] {
+            "## Todo List ✅",
+            "* retry transport",
+            "",
+            "## Critical Issues ⚠️",
+            "None."
+        });
+
+        var findings = ReviewSummaryParser.ExtractMergeBlockerFindings(body, settings: null, maxItems: 10, hitLimit: out var hitLimit,
+            parseIncomplete: out var parseIncomplete);
+
+        AssertEqual(false, ReviewSummaryParser.HasMergeBlockers(body), "merge blockers plain starred bullet still bypasses normalization");
+        AssertEqual(0, findings.Count, "findings plain starred bullet count");
+        AssertEqual(false, hitLimit, "findings plain starred bullet does not hit limit");
+        AssertEqual(true, parseIncomplete, "findings plain starred bullet keeps parse incomplete safety");
+    }
+
     private static void TestReviewSummaryParserMergeBlockerDetectionCompactDefaults() {
         var settings = new ReviewSettings {
             OutputStyle = "compact"


### PR DESCRIPTION
## Summary
Tightens the review-summary parser so starred prose inside merge-blocker sections does not incorrectly flip `FindingsParseIncomplete`.

## Why
A late Codex review on #1291 correctly pointed out that `LooksLikeMergeBlockerEntry(...)` treated any `*`-prefixed line as blocker-like. That meant prose such as `*Impact:* ...` could suppress same-head inferred resolution by marking the latest round as parse-incomplete even when no blocker item existed.

## Changes
- Restrict starred merge-blocker heuristics to checklist-shaped entries only: `* [ ]` and `* [x]`.
- Keep existing safety behavior for malformed starred checklists.
- Add a regression test proving starred prose remains non-blocking and does not set `parseIncomplete`.

## Validation
- `dotnet build IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release`
- `dotnet .\IntelligenceX.Tests\bin\Release\net8.0\IntelligenceX.Tests.dll`
- `dotnet .\IntelligenceX.Tests\bin\Release\net10.0\IntelligenceX.Tests.dll`