### PR TITLE
Default IntelligenceX to GPT-5.5

### DIFF
--- a/.github/workflows/review-intelligencex-core.yml
+++ b/.github/workflows/review-intelligencex-core.yml
@@ -55,7 +55,7 @@ on:
       model:
         description: 'Model id (provider-specific)'
         required: false
-        default: 'gpt-5.4'
+        default: 'gpt-5.5'
         type: string
       openai_model:
         description: 'OpenAI model id (overrides model when provider=openai)'

--- a/.github/workflows/review-intelligencex.yml
+++ b/.github/workflows/review-intelligencex.yml
@@ -362,7 +362,7 @@ jobs:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       provider: ${{ inputs.provider || vars.IX_REVIEW_PROVIDER || 'openai' }}
       agent_profile: ${{ inputs.agent_profile != '' && inputs.agent_profile || ((inputs.provider != '' || inputs.model != '' || inputs.openai_model != '' || inputs.copilot_model != '') && 'none' || vars.IX_REVIEW_AGENT_PROFILE) }}
-      model: ${{ inputs.model || vars.IX_REVIEW_MODEL || 'gpt-5.4' }}
+      model: ${{ inputs.model || vars.IX_REVIEW_MODEL || 'gpt-5.5' }}
       openai_model: ${{ inputs.openai_model }}
       copilot_model: ${{ inputs.copilot_model || vars.IX_REVIEW_COPILOT_MODEL }}
       copilot_launcher: ${{ inputs.copilot_launcher || vars.IX_REVIEW_COPILOT_LAUNCHER }}

--- a/.intelligencex/reviewer.json
+++ b/.intelligencex/reviewer.json
@@ -57,7 +57,7 @@
     "reviewUsageBudgetAllowWeeklyLimit": true,
     "provider": "openai",
     "openaiTransport": "native",
-    "model": "gpt-5.4",
+    "model": "gpt-5.5",
     "profile": "balanced",
     "mode": "hybrid",
     "commentMode": "sticky",

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -62,7 +62,7 @@ GitHub Actions input/env aliases:
 {
   "review": {
     "provider": "openai",
-    "model": "gpt-5.4",
+    "model": "gpt-5.5",
     "mode": "inline",
     "length": "long",
     "outputStyle": "compact",
@@ -249,11 +249,11 @@ For backward compatibility, the loader also accepts `modelProfiles` and `authPro
   "review": {
     "agentProfile": "copilot-claude",
     "agentProfiles": {
-      "chatgpt-gpt54": {
+      "chatgpt-gpt55": {
         "provider": "openai",
         "authenticator": "chatgpt",
         "openaiTransport": "native",
-        "model": "gpt-5.4",
+        "model": "gpt-5.5",
         "openaiAccountId": "acct-review"
       },
       "copilot-gpt54": {
@@ -288,12 +288,12 @@ For swarm shadow runs, reviewer lanes and the aggregator can reference those sam
       "enabled": true,
       "shadowMode": true,
       "reviewers": [
-        { "id": "correctness", "agentProfile": "chatgpt-gpt54" },
+        { "id": "correctness", "agentProfile": "chatgpt-gpt55" },
         { "id": "compat", "agentProfile": "copilot-gpt54" },
         { "id": "tests", "agentProfile": "copilot-claude" }
       ],
       "aggregator": {
-        "agentProfile": "chatgpt-gpt54"
+        "agentProfile": "chatgpt-gpt55"
       }
     }
   }
@@ -324,10 +324,10 @@ All swarm settings are optional and default to off unless you explicitly enable 
       ],
       "maxParallel": 4,
       "publishSubreviews": false,
-      "aggregatorModel": "gpt-5.4",
+      "aggregatorModel": "gpt-5.5",
       "aggregator": {
         "provider": "openai",
-        "model": "gpt-5.4",
+        "model": "gpt-5.5",
         "reasoningEffort": "high"
       },
       "failOpenOnPartial": true,

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -256,7 +256,7 @@ For backward compatibility, the loader also accepts `modelProfiles` and `authPro
         "model": "gpt-5.5",
         "openaiAccountId": "acct-review"
       },
-      "copilot-openai-review": {
+      "copilot-gpt54": {
         "provider": "copilot",
         "authenticator": "copilot-cli",
         "model": "gpt-5.4",
@@ -281,8 +281,6 @@ For backward compatibility, the loader also accepts `modelProfiles` and `authPro
 
 The Copilot example intentionally keeps its OpenAI-family Copilot model on `gpt-5.4` to show that provider-specific profiles can
 choose a different model from the OpenAI default.
-Older examples may have named that profile `copilot-gpt54`; the profile ID is arbitrary, so keep or rename it as long as
-all `agentProfile` references match.
 
 For swarm shadow runs, reviewer lanes and the aggregator can reference those same profiles:
 
@@ -294,7 +292,7 @@ For swarm shadow runs, reviewer lanes and the aggregator can reference those sam
       "shadowMode": true,
       "reviewers": [
         { "id": "correctness", "agentProfile": "chatgpt-gpt55" },
-        { "id": "compat", "agentProfile": "copilot-openai-review" },
+        { "id": "compat", "agentProfile": "copilot-gpt54" },
         { "id": "tests", "agentProfile": "copilot-claude" }
       ],
       "aggregator": {

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -279,6 +279,9 @@ For backward compatibility, the loader also accepts `modelProfiles` and `authPro
 }
 ```
 
+The Copilot example intentionally keeps `copilot-gpt54` on `gpt-5.4` to show that provider-specific profiles can
+choose a different model from the OpenAI default.
+
 For swarm shadow runs, reviewer lanes and the aggregator can reference those same profiles:
 
 ```json

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -281,6 +281,8 @@ For backward compatibility, the loader also accepts `modelProfiles` and `authPro
 
 The Copilot example intentionally keeps its OpenAI-family Copilot model on `gpt-5.4` to show that provider-specific profiles can
 choose a different model from the OpenAI default.
+Older examples may have named that profile `copilot-gpt54`; the profile ID is arbitrary, so keep or rename it as long as
+all `agentProfile` references match.
 
 For swarm shadow runs, reviewer lanes and the aggregator can reference those same profiles:
 

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -256,7 +256,7 @@ For backward compatibility, the loader also accepts `modelProfiles` and `authPro
         "model": "gpt-5.5",
         "openaiAccountId": "acct-review"
       },
-      "copilot-gpt54": {
+      "copilot-openai-review": {
         "provider": "copilot",
         "authenticator": "copilot-cli",
         "model": "gpt-5.4",
@@ -279,7 +279,7 @@ For backward compatibility, the loader also accepts `modelProfiles` and `authPro
 }
 ```
 
-The Copilot example intentionally keeps `copilot-gpt54` on `gpt-5.4` to show that provider-specific profiles can
+The Copilot example intentionally keeps its OpenAI-family Copilot model on `gpt-5.4` to show that provider-specific profiles can
 choose a different model from the OpenAI default.
 
 For swarm shadow runs, reviewer lanes and the aggregator can reference those same profiles:
@@ -292,7 +292,7 @@ For swarm shadow runs, reviewer lanes and the aggregator can reference those sam
       "shadowMode": true,
       "reviewers": [
         { "id": "correctness", "agentProfile": "chatgpt-gpt55" },
-        { "id": "compat", "agentProfile": "copilot-gpt54" },
+        { "id": "compat", "agentProfile": "copilot-openai-review" },
         { "id": "tests", "agentProfile": "copilot-claude" }
       ],
       "aggregator": {

--- a/Docs/reviewer/overview.md
+++ b/Docs/reviewer/overview.md
@@ -71,7 +71,7 @@ flowchart LR
 
 **Default Mode + Model Policy**
 - Default review mode: `hybrid` (summary + inline when supported; falls back to summary-only).
-- Default provider/model: OpenAI with `gpt-5.4` unless configured otherwise; Claude and Copilot are opt-in.
+- Default provider/model: OpenAI with `gpt-5.5` unless configured otherwise; Claude and Copilot are opt-in.
 - Safe defaults: skip drafts; skip workflow changes unless allowed; no secrets/writes on untrusted PRs; core reviewer defaults fail-open only for transient errors, while the bundled GitHub workflow exports fail-open env defaults for provider/runtime failures so auth outages do not block CI; budget summary enabled; auto-resolve limited to bot threads with evidence; secrets audit on.
 
 ## Reusable workflow (quick start)
@@ -120,7 +120,7 @@ The reusable workflow maps `with:` inputs to environment variables the reviewer 
   "review": {
     "provider": "openai",
     "openaiTransport": "native",
-    "model": "gpt-5.4",
+    "model": "gpt-5.5",
     "mode": "inline",
     "length": "long",
     "reviewUsageSummary": true

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using IntelligenceX.Chat.App;
+using IntelligenceX.OpenAI;
 using Xunit;
 
 namespace IntelligenceX.Chat.App.Tests;
@@ -88,6 +89,21 @@ public sealed partial class UiShellAssetsTests {
         Assert.Contains("if (!shouldRenderHeaderStatusChip(value)) {", script, StringComparison.Ordinal);
         Assert.Contains("var structuredStartupStatus = resolveHeaderStatusChipFromStructuredStartupContext();", script, StringComparison.Ordinal);
         Assert.Contains("var fallbackStatus = resolveHeaderStatusChipFallbackStatus();", script, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Ensures the static shell source receives its initial model default from the C# catalog during composition.
+    /// </summary>
+    [Fact]
+    public void Load_InjectsCatalogBackedDefaultLocalModel() {
+        var scriptPath = Path.Combine(UiDirectory, "Shell.10.core.js");
+        var script = File.ReadAllText(scriptPath);
+        var html = UiShellAssets.Load();
+
+        Assert.Contains("var defaultLocalModel = \"{{IXCHAT_DEFAULT_LOCAL_MODEL}}\";", script, StringComparison.Ordinal);
+        Assert.Contains("model: defaultLocalModel", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("model: \"gpt-5.5\"", script, StringComparison.Ordinal);
+        Assert.Contains("var defaultLocalModel = \"" + OpenAIModelCatalog.DefaultModel + "\";", html, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
@@ -104,6 +104,7 @@ public sealed partial class UiShellAssetsTests {
         Assert.Contains("model: defaultLocalModel", script, StringComparison.Ordinal);
         Assert.DoesNotContain("model: \"gpt-5.5\"", script, StringComparison.Ordinal);
         Assert.Contains("var defaultLocalModel = \"" + OpenAIModelCatalog.DefaultModel + "\";", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("{{IXCHAT_DEFAULT_LOCAL_MODEL}}", html, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX;
 using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.OpenAI;
 
 namespace IntelligenceX.Chat.App;
 
@@ -226,7 +227,7 @@ internal sealed class ChatAppState {
     public string ThemePreset { get; set; } = "default";
     public string LocalProviderTransport { get; set; } = "native";
     public string? LocalProviderBaseUrl { get; set; }
-    public string LocalProviderModel { get; set; } = "gpt-5.4";
+    public string LocalProviderModel { get; set; } = OpenAIModelCatalog.DefaultModel;
     public string LocalProviderOpenAIAuthMode { get; set; } = "bearer";
     public string LocalProviderOpenAIBasicUsername { get; set; } = string.Empty;
     public string LocalProviderOpenAIAccountId { get; set; } = string.Empty;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -18,6 +18,7 @@ using IntelligenceX.Chat.App.Launch;
 using IntelligenceX.Chat.App.Rendering;
 using IntelligenceX.Chat.App.Theming;
 using IntelligenceX.Chat.Client;
+using IntelligenceX.OpenAI;
 using Microsoft.UI.Input;
 using Microsoft.UI;
 using Microsoft.UI.Dispatching;
@@ -55,7 +56,7 @@ public sealed partial class MainWindow : Window {
     private const string SystemConversationId = "chat-system";
     private const string SystemConversationTitle = "System";
     private const string DefaultConversationTitle = "New Chat";
-    private const string DefaultLocalModel = "gpt-5.4";
+    private const string DefaultLocalModel = OpenAIModelCatalog.DefaultModel;
     private const string TransportNative = "native";
     private const string TransportCompatibleHttp = "compatible-http";
     private const string TransportCopilotCli = "copilot-cli";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
@@ -23,6 +23,7 @@
     }
     return Math.floor(parsed);
   }
+  var defaultLocalModel = "{{IXCHAT_DEFAULT_LOCAL_MODEL}}";
 
   var menu = byId("menu");
   var promptEl = byId("prompt");
@@ -125,7 +126,7 @@
         transport: "native",
         baseUrl: "",
         modelsEndpoint: "",
-        model: "gpt-5.5",
+        model: defaultLocalModel,
         openAIAuthMode: "bearer",
         openAIBasicUsername: "",
         openAIAccountId: "",

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.10.core.js
@@ -125,7 +125,7 @@
         transport: "native",
         baseUrl: "",
         modelsEndpoint: "",
-        model: "gpt-5.4",
+        model: "gpt-5.5",
         openAIAuthMode: "bearer",
         openAIBasicUsername: "",
         openAIAccountId: "",

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/ShellTemplate.html
@@ -201,7 +201,7 @@
           <div class="options-subsection-title" id="optRuntimeSectionModelTitle">Model &amp; response controls</div>
           <div class="options-row" id="optLocalModelInputRow">
             <label class="options-label-inline" for="optLocalModelInput">Model</label>
-            <input id="optLocalModelInput" class="options-input options-input-sm" placeholder="e.g. gpt-5.4, gpt-5-mini, or llama3.2" />
+            <input id="optLocalModelInput" class="options-input options-input-sm" placeholder="e.g. gpt-5.5, gpt-5-mini, or llama3.2" />
           </div>
           <div class="options-subsection-title" id="optRuntimeSectionCatalogTitle">Model catalog</div>
           <div class="options-row" id="optLocalModelSelectRow">

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/UiShellAssets.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/UiShellAssets.cs
@@ -4,7 +4,9 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using IntelligenceX.Chat.App.Theming;
+using IntelligenceX.OpenAI;
 
 namespace IntelligenceX.Chat.App;
 
@@ -14,6 +16,7 @@ internal static class UiShellAssets {
     private const string CssSplitPattern = "Shell.*.css";
     private const string JsFile = "Shell.js";
     private const string JsSplitPattern = "Shell.*.js";
+    private const string DefaultLocalModelToken = "\"{{IXCHAT_DEFAULT_LOCAL_MODEL}}\"";
     private const int MaxDiagnosticsInFallback = 24;
 
     private static readonly string[] TemplateTokens = [
@@ -92,9 +95,16 @@ internal static class UiShellAssets {
             _cachedHtml = template
                 .Replace("/*{{IXCHAT_CSS}}*/", css, StringComparison.Ordinal)
                 .Replace("<!--{{IXCHAT_THEME_OPTIONS}}-->", ThemeContract.BuildThemeOptionTagsHtml(), StringComparison.Ordinal)
-                .Replace("//{{IXCHAT_JS}}", js, StringComparison.Ordinal);
+                .Replace("//{{IXCHAT_JS}}", ApplyCatalogBackedJavaScriptDefaults(js), StringComparison.Ordinal);
             return _cachedHtml;
         }
+    }
+
+    private static string ApplyCatalogBackedJavaScriptDefaults(string js) {
+        return js.Replace(
+            DefaultLocalModelToken,
+            JsonSerializer.Serialize(OpenAIModelCatalog.DefaultModel),
+            StringComparison.Ordinal);
     }
 
     private static string ReadTextOrEmpty(string path) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/UiShellAssets.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/UiShellAssets.cs
@@ -110,8 +110,8 @@ internal static class UiShellAssets {
 
     private static void ValidateCatalogBackedJavaScriptDefaults(string js, List<string> diagnostics) {
         var tokenCount = CountOccurrences(js, DefaultLocalModelToken);
-        if (tokenCount != 1) {
-            diagnostics.Add($"Expected exactly one default local model token in JavaScript, found {tokenCount}.");
+        if (tokenCount == 0) {
+            diagnostics.Add("Expected at least one default local model token in JavaScript, found none.");
         }
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/UiShellAssets.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/UiShellAssets.cs
@@ -85,6 +85,7 @@ internal static class UiShellAssets {
 
             ValidateTemplate(template, diagnostics);
             ValidateJavaScriptContracts(js, diagnostics);
+            ValidateCatalogBackedJavaScriptDefaults(js, diagnostics);
 
             if (string.IsNullOrWhiteSpace(template) || string.IsNullOrWhiteSpace(css) || string.IsNullOrWhiteSpace(js) || diagnostics.Count > 0) {
                 // Do not cache fallback diagnostics HTML. A transient startup packaging issue
@@ -105,6 +106,31 @@ internal static class UiShellAssets {
             DefaultLocalModelToken,
             JsonSerializer.Serialize(OpenAIModelCatalog.DefaultModel),
             StringComparison.Ordinal);
+    }
+
+    private static void ValidateCatalogBackedJavaScriptDefaults(string js, List<string> diagnostics) {
+        var tokenCount = CountOccurrences(js, DefaultLocalModelToken);
+        if (tokenCount != 1) {
+            diagnostics.Add($"Expected exactly one default local model token in JavaScript, found {tokenCount}.");
+        }
+    }
+
+    private static int CountOccurrences(string value, string token) {
+        if (string.IsNullOrEmpty(value) || string.IsNullOrEmpty(token)) {
+            return 0;
+        }
+
+        var count = 0;
+        var startIndex = 0;
+        while (true) {
+            var index = value.IndexOf(token, startIndex, StringComparison.Ordinal);
+            if (index < 0) {
+                return count;
+            }
+
+            count++;
+            startIndex = index + token.Length;
+        }
     }
 
     private static string ReadTextOrEmpty(string path) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
@@ -25,7 +25,7 @@ internal static partial class Program {
     private const int MaxToolRoundsLimit = ChatRequestOptionLimits.MaxToolRounds;
 
     private sealed class ReplOptions : IToolRuntimePolicySettings, IToolPackRuntimeSettings {
-        public string Model { get; set; } = "gpt-5.4";
+        public string Model { get; set; } = OpenAIModelCatalog.DefaultModel;
 
         public OpenAITransportKind OpenAITransport { get; set; } = OpenAITransportKind.Native;
         public string? OpenAIBaseUrl { get; set; }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.cs
@@ -621,7 +621,7 @@ internal static partial class Program {
         Console.WriteLine("  IntelligenceX.Chat.Host [options]");
         Console.WriteLine();
         Console.WriteLine("Options:");
-        Console.WriteLine("  --model <NAME>          OpenAI model (default: gpt-5.4)");
+        Console.WriteLine($"  --model <NAME>          OpenAI model (default: {OpenAIModelCatalog.DefaultModel})");
         Console.WriteLine("  --reasoning-effort <LEVEL>   Reasoning effort hint: minimal|low|medium|high|xhigh.");
         Console.WriteLine("  --reasoning-summary <LEVEL>  Reasoning summary hint: auto|concise|detailed|off.");
         Console.WriteLine("  --text-verbosity <LEVEL>     Text verbosity hint: low|medium|high.");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Profiles/ServiceProfile.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Profiles/ServiceProfile.cs
@@ -9,7 +9,7 @@ namespace IntelligenceX.Chat.Profiles;
 /// Serializable session profile (config preset) for the chat service.
 /// </summary>
 internal sealed class ServiceProfile {
-    public string Model { get; set; } = "gpt-5.4";
+    public string Model { get; set; } = OpenAIModelCatalog.DefaultModel;
 
     // Provider transport selection and transport-specific settings.
     public OpenAITransportKind OpenAITransport { get; set; } = OpenAITransportKind.Native;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Profiles/SqliteServiceProfileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Profiles/SqliteServiceProfileStore.cs
@@ -624,7 +624,7 @@ LIMIT 1;",
         }
 
         var profile = new ServiceProfile {
-            Model = ReadString(r, "model") ?? "gpt-5.4",
+            Model = ReadString(r, "model") ?? OpenAIModelCatalog.DefaultModel,
             OpenAITransport = transport,
             OpenAIBaseUrl = ReadString(r, "openai_base_url"),
             OpenAIAuthMode = authMode,
@@ -834,7 +834,7 @@ ON CONFLICT(name) DO UPDATE SET
         IReadOnlyList<string> extraRequiredInsertColumns) {
         var parameters = new Dictionary<string, object?> {
             ["@name"] = trimmed,
-            ["@model"] = string.IsNullOrWhiteSpace(profile.Model) ? "gpt-5.4" : profile.Model.Trim(),
+            ["@model"] = string.IsNullOrWhiteSpace(profile.Model) ? OpenAIModelCatalog.DefaultModel : profile.Model.Trim(),
             ["@transport_kind"] = transportKind,
             ["@openai_base_url"] = string.IsNullOrWhiteSpace(profile.OpenAIBaseUrl) ? null : profile.OpenAIBaseUrl.Trim(),
             ["@openai_auth_mode"] = authMode,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
@@ -22,7 +22,7 @@ using IntelligenceX.Tools.Common;
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
-    private const string DefaultRuntimeModel = "gpt-5.4";
+    private const string DefaultRuntimeModel = OpenAIModelCatalog.DefaultModel;
     private const string PluginLoadTimingWarningPrefix = "[plugin] load_timing ";
     private const string PluginLoadProgressWarningPrefix = "[plugin] load_progress ";
     private const string PackLoadProgressWarningPrefix = "[startup] pack_load_progress ";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -30,7 +30,7 @@ internal sealed partial class ServiceOptions : IToolRuntimePolicySettings, ITool
 
     public bool ShowHelp { get; set; }
     public string PipeName { get; set; } = "intelligencex.chat";
-    public string Model { get; set; } = "gpt-5.4";
+    public string Model { get; set; } = OpenAIModelCatalog.DefaultModel;
 
     // Provider selection for the underlying IntelligenceXClient used by the service.
     public OpenAITransportKind OpenAITransport { get; set; } = OpenAITransportKind.Native;
@@ -747,7 +747,7 @@ internal sealed partial class ServiceOptions : IToolRuntimePolicySettings, ITool
         Console.WriteLine();
         Console.WriteLine("Options:");
         Console.WriteLine("  --pipe <NAME>           Named pipe name (default: intelligencex.chat)");
-        Console.WriteLine("  --model <NAME>          OpenAI model (default: gpt-5.4)");
+        Console.WriteLine($"  --model <NAME>          OpenAI model (default: {OpenAIModelCatalog.DefaultModel})");
         Console.WriteLine("  --reasoning-effort <LEVEL>   Reasoning effort hint: minimal|low|medium|high|xhigh.");
         Console.WriteLine("  --reasoning-summary <LEVEL>  Reasoning summary hint: auto|concise|detailed|off.");
         Console.WriteLine("  --text-verbosity <LEVEL>     Text verbosity hint: low|medium|high.");

--- a/IntelligenceX.Chat/scenarios/chat-model-recommendation-not-self-report-1-turn.json
+++ b/IntelligenceX.Chat/scenarios/chat-model-recommendation-not-self-report-1-turn.json
@@ -9,7 +9,7 @@
       "name": "Model recommendation ask should not self-report runtime",
       "user": "What model should I use for DNS anomaly triage?",
       "assert_contains_any": ["depends", "recommend", "model", "dns", "triage"],
-      "assert_not_contains": ["This chat is running on", "gpt-5.3-codex", "gpt-5.4", "Runtime capability handshake"],
+      "assert_not_contains": ["This chat is running on", "gpt-5.3-codex", "gpt-5.4", "gpt-5.5", "Runtime capability handshake"],
       "forbid_tools": ["*"]
     }
   ]

--- a/IntelligenceX.Chat/scenarios/chat-tools-recommendation-not-self-report-1-turn.json
+++ b/IntelligenceX.Chat/scenarios/chat-tools-recommendation-not-self-report-1-turn.json
@@ -9,7 +9,7 @@
       "name": "Recommendation ask should not self-report runtime",
       "user": "What tools should I install for this workspace?",
       "assert_contains_any": ["depends", "workspace", "recommend", "use", "install"],
-      "assert_not_contains": ["This chat is running on", "gpt-5.3-codex", "gpt-5.4", "Runtime capability handshake"],
+      "assert_not_contains": ["This chat is running on", "gpt-5.3-codex", "gpt-5.4", "gpt-5.5", "Runtime capability handshake"],
       "forbid_tools": ["*"]
     }
   ]

--- a/IntelligenceX.Cli/Setup/Web/Assets/index.html
+++ b/IntelligenceX.Cli/Setup/Web/Assets/index.html
@@ -257,7 +257,7 @@
           <p class="hint" id="reviewModelProfileHint">Choose a named provider/model profile or switch to custom.</p>
 
           <label>Model</label>
-          <input id="reviewModel" list="reviewModelSuggestions" placeholder="gpt-5.4" />
+          <input id="reviewModel" list="reviewModelSuggestions" placeholder="gpt-5.5" />
           <datalist id="reviewModelSuggestions"></datalist>
           <div class="model-quick-picks" id="reviewModelQuickPicks"></div>
           <p class="hint" id="reviewModelHint">Set the review model for the selected provider. Switching providers resets incompatible defaults.</p>

--- a/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
+++ b/IntelligenceX.Cli/Setup/Web/Assets/wizard.js
@@ -161,8 +161,8 @@ const reviewModelProfile = $('reviewModelProfile');
 
 const PROVIDER_MODEL_CATALOG = {
   openai: [
-    { profileId: 'openai-default-review', profileLabel: 'OpenAI default review', id: 'gpt-5.4', label: 'gpt-5.4', description: 'Best default quality for reviewer runs.', isDefault: true },
-    { profileId: 'openai-fast-review', profileLabel: 'OpenAI fast review', id: 'gpt-5.4/fast', label: 'gpt-5.4/fast', description: 'Lower-latency default when you want faster PR turnaround.' },
+    { profileId: 'openai-default-review', profileLabel: 'OpenAI default review', id: 'gpt-5.5', label: 'gpt-5.5', description: 'Best default quality for reviewer runs.', isDefault: true },
+    { profileId: 'openai-fast-review', profileLabel: 'OpenAI fast review', id: 'gpt-5.5/fast', label: 'gpt-5.5/fast', description: 'Lower-latency default when you want faster PR turnaround.' },
     { profileId: 'openai-budget-review', profileLabel: 'OpenAI budget review', id: 'gpt-5-mini', label: 'gpt-5-mini', description: 'Cheaper review pass with solid quality for routine repos.' },
     { profileId: 'openai-nano-check', profileLabel: 'OpenAI nano check', id: 'gpt-5-nano', label: 'gpt-5-nano', description: 'Smallest budget option for lightweight checks or experimentation.' }
   ],
@@ -250,7 +250,7 @@ function syncProviderModelSelection(previousProvider, nextProvider) {
   const hint = $('reviewModelHint');
   if (hint) {
     hint.textContent = nextProvider === 'openai'
-      ? 'Set the review model for OpenAI runs. Use a named profile, quick pick, or custom model id. Default: gpt-5.4.'
+      ? 'Set the review model for OpenAI runs. Use a named profile, quick pick, or custom model id. Default: gpt-5.5.'
       : nextProvider === 'claude'
         ? 'Set the review model for Claude runs. Use a named profile, quick pick, or custom model id. Default: claude-opus-4-1.'
         : 'Copilot setup does not use the managed model field here.';

--- a/IntelligenceX.Cli/Setup/Wizard/WizardConfigEditor.cs
+++ b/IntelligenceX.Cli/Setup/Wizard/WizardConfigEditor.cs
@@ -10,7 +10,7 @@ internal static class WizardConfigEditor {
   ""review"": {
     ""provider"": ""openai"",
     ""openaiTransport"": ""native"",
-    ""model"": ""gpt-5.4"",
+    ""model"": ""gpt-5.5"",
     ""profile"": ""balanced"",
     ""mode"": ""hybrid"",
     ""commentMode"": ""sticky"",

--- a/IntelligenceX.PowerShell/CmdletInvokeIntelligenceXChat.cs
+++ b/IntelligenceX.PowerShell/CmdletInvokeIntelligenceXChat.cs
@@ -64,10 +64,10 @@ public sealed class CmdletInvokeIntelligenceXChat : IntelligenceXCmdlet {
     public SwitchParameter Dsl { get; set; }
 
     /// <summary>
-    /// <para type="description">Model identifier. Defaults to gpt-5.4.</para>
+    /// <para type="description">Model identifier. Defaults to the shared OpenAI default model.</para>
     /// </summary>
     [Parameter]
-    public string Model { get; set; } = "gpt-5.4";
+    public string Model { get; set; } = OpenAIModelCatalog.DefaultModel;
 
     /// <summary>
     /// <para type="description">Login method: ChatGpt, ApiKey, or None.</para>

--- a/IntelligenceX.Tests/Program.Core.cs
+++ b/IntelligenceX.Tests/Program.Core.cs
@@ -685,9 +685,9 @@ internal static partial class Program {
     }
 
     private static void TestOpenAiModelCatalogNormalizesFastModeSuffix() {
-        AssertEqual("gpt-5.4/fast", OpenAIModelCatalog.NormalizeModelId("openai/gpt-5.4/fast"),
+        AssertEqual("gpt-5.5/fast", OpenAIModelCatalog.NormalizeModelId("openai/gpt-5.5/fast"),
             "openai model normalize fast suffix");
-        AssertEqual("gpt-5.4", OpenAIModelCatalog.NormalizeModelId("openai/gpt-5.4"),
+        AssertEqual("gpt-5.5", OpenAIModelCatalog.NormalizeModelId("openai/gpt-5.5"),
             "openai model normalize provider prefix");
     }
 
@@ -706,6 +706,10 @@ internal static partial class Program {
         var models = method!.Invoke(null, Array.Empty<object>()) as IReadOnlyList<string>;
         AssertNotNull(models, "baseline fallback models");
         var baselineModels = models!;
+        AssertEqual(true, baselineModels.Contains("gpt-5.5", StringComparer.OrdinalIgnoreCase),
+            "baseline fallback models include gpt-5.5");
+        AssertEqual(true, baselineModels.Contains("gpt-5.4", StringComparer.OrdinalIgnoreCase),
+            "baseline fallback models keep gpt-5.4");
         AssertEqual(true, baselineModels.Contains("gpt-5-mini", StringComparer.OrdinalIgnoreCase),
             "baseline fallback models include gpt-5-mini");
         AssertEqual(true, baselineModels.Contains("gpt-5-nano", StringComparer.OrdinalIgnoreCase),

--- a/IntelligenceX.Tests/Program.Core.cs
+++ b/IntelligenceX.Tests/Program.Core.cs
@@ -687,6 +687,10 @@ internal static partial class Program {
     private static void TestOpenAiModelCatalogNormalizesFastModeSuffix() {
         AssertEqual("gpt-5.5/fast", OpenAIModelCatalog.NormalizeModelId("openai/gpt-5.5/fast"),
             "openai model normalize fast suffix");
+        AssertEqual("gpt-5.5/fast/spark", OpenAIModelCatalog.NormalizeModelId("openai/gpt-5.5/fast/spark"),
+            "openai model normalize compound mode suffix");
+        AssertEqual("gpt-5.5", OpenAIModelCatalog.NormalizeBaseModelId("openai/gpt-5.5/fast/spark"),
+            "openai model normalize pricing base from compound mode suffix");
         AssertEqual("gpt-5.5", OpenAIModelCatalog.NormalizeModelId("openai/gpt-5.5"),
             "openai model normalize provider prefix");
     }

--- a/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
+++ b/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
@@ -125,7 +125,7 @@ jobs:
     uses: evotecit/intelligencex/.github/workflows/review-intelligencex-core.yml@master
     with:
       provider: openai
-      model: gpt-5.4
+      model: gpt-5.5
 """;
 
         var content = SetupRunner.BuildWorkflowYamlFromSeedForTests(Array.Empty<string>(), seed);
@@ -223,7 +223,7 @@ jobs:
     uses: evotecit/intelligencex/.github/workflows/review-intelligencex-core.yml@master
     with:
       provider: openai
-      model: gpt-5.4
+      model: gpt-5.5
 """;
 
         var content = SetupRunner.BuildWorkflowYamlFromSeedForTests(Array.Empty<string>(), seed);
@@ -232,7 +232,7 @@ jobs:
         AssertContainsText(content, "openai_model:", "workflow template openai model input");
         AssertContainsText(content, "openai_model: ${{ inputs.openai_model }}",
             "workflow template openai model pass-through");
-        AssertContainsText(content, "model: gpt-5.4", "workflow template default model updated");
+        AssertContainsText(content, "model: gpt-5.5", "workflow template default model updated");
     }
 
     private static void TestReviewReusableWorkflowDispatchIncludesOpenAiModelInput() {

--- a/IntelligenceX.Tests/Program.Setup.cs
+++ b/IntelligenceX.Tests/Program.Setup.cs
@@ -234,8 +234,8 @@ internal static partial class Program {
     private static void TestSetupProviderCatalogReturnsRecommendedOpenAiModels() {
         var models = IntelligenceX.Cli.Setup.SetupProviderCatalog.GetRecommendedModels("openai");
         AssertEqual(true, models.Count >= 3, "setup provider catalog openai model count");
-        AssertEqual("gpt-5.4", models[0], "setup provider catalog openai default first");
-        AssertEqual(true, models.Contains("gpt-5.4/fast", StringComparer.OrdinalIgnoreCase),
+        AssertEqual("gpt-5.5", models[0], "setup provider catalog openai default first");
+        AssertEqual(true, models.Contains("gpt-5.5/fast", StringComparer.OrdinalIgnoreCase),
             "setup provider catalog openai fast present");
         AssertEqual(true, models.Contains("gpt-5-mini", StringComparer.OrdinalIgnoreCase),
             "setup provider catalog openai mini present");
@@ -252,7 +252,7 @@ internal static partial class Program {
     }
 
     private static void TestSetupProviderCatalogDescribesRecommendedModelProfiles() {
-        var openAiProfile = IntelligenceX.Cli.Setup.SetupProviderCatalog.TryGetRecommendedModelProfile("openai", "gpt-5.4");
+        var openAiProfile = IntelligenceX.Cli.Setup.SetupProviderCatalog.TryGetRecommendedModelProfile("openai", "gpt-5.5");
         AssertEqual(true, openAiProfile.HasValue, "setup provider catalog openai profile exists");
         AssertContainsText(openAiProfile?.Summary ?? string.Empty, "default quality", "setup provider catalog openai profile summary");
         AssertEqual(true, openAiProfile?.IsRecommendedDefault ?? false, "setup provider catalog openai default flag");

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -60,6 +60,24 @@ internal static partial class Program {
         AssertEqual("gpt-5.5/fast/spark", eventEstimate.Model, "api pricing normalizes openai compound mode suffix");
         AssertEqual(9.55m, eventEstimate.EstimatedCostUsd, "api pricing estimates gpt-5.5 compound mode from base model");
 
+        var fastEstimate = UsageTelemetryApiPricing.EstimateEvent(new UsageEventRecord(
+            "evt-fast-direct",
+            "openai",
+            "codex.logs",
+            "src-1",
+            new DateTimeOffset(2026, 03, 10, 11, 05, 0, TimeSpan.Zero)) {
+            Model = "gpt-5.5/fast",
+            InputTokens = 1_000_000,
+            CachedInputTokens = 100_000,
+            OutputTokens = 100_000,
+            ReasoningTokens = 50_000,
+            TotalTokens = 1_250_000,
+            TruthLevel = UsageTruthLevel.Exact
+        });
+        AssertEqual(true, fastEstimate.HasKnownPricing, "api pricing has explicit gpt-5.5 fast pricing");
+        AssertEqual("gpt-5.5/fast", fastEstimate.Model, "api pricing preserves explicit gpt-5.5 fast model");
+        AssertEqual(9.55m, fastEstimate.EstimatedCostUsd, "api pricing estimates explicit gpt-5.5 fast model");
+
         var displayCost = UsageTelemetryApiPricing.BuildDisplayCost(evt);
         AssertEqual(9.55m, displayCost.EstimatedFallbackCostUsd, "api pricing display cost includes gpt-5.5 fast");
         AssertEqual(1_250_000L, displayCost.CoveredTokens, "api pricing display cost covers gpt-5.5 fast tokens");

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -46,7 +46,7 @@ internal static partial class Program {
 
     private static void TestUsageTelemetryApiPricingCoversOpenAiModeSuffixes() {
         var evt = new UsageEventRecord("evt-fast", "openai", "codex.logs", "src-1", new DateTimeOffset(2026, 03, 10, 11, 0, 0, TimeSpan.Zero)) {
-            Model = "openai/gpt-5.5/fast",
+            Model = "openai/gpt-5.5/fast/spark",
             InputTokens = 1_000_000,
             CachedInputTokens = 100_000,
             OutputTokens = 100_000,
@@ -57,8 +57,8 @@ internal static partial class Program {
 
         var eventEstimate = UsageTelemetryApiPricing.EstimateEvent(evt);
         AssertEqual(true, eventEstimate.HasKnownPricing, "api pricing recognizes openai fast suffix");
-        AssertEqual("gpt-5.5/fast", eventEstimate.Model, "api pricing normalizes openai fast suffix");
-        AssertEqual(9.55m, eventEstimate.EstimatedCostUsd, "api pricing estimates gpt-5.5 fast from base model");
+        AssertEqual("gpt-5.5/fast/spark", eventEstimate.Model, "api pricing normalizes openai compound mode suffix");
+        AssertEqual(9.55m, eventEstimate.EstimatedCostUsd, "api pricing estimates gpt-5.5 compound mode from base model");
 
         var displayCost = UsageTelemetryApiPricing.BuildDisplayCost(evt);
         AssertEqual(9.55m, displayCost.EstimatedFallbackCostUsd, "api pricing display cost includes gpt-5.5 fast");

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -44,6 +44,28 @@ internal static partial class Program {
         AssertEqual(4_100_000L, estimate.CoveredTokens, "api pricing covered tokens");
     }
 
+    private static void TestUsageTelemetryApiPricingCoversOpenAiModeSuffixes() {
+        var evt = new UsageEventRecord("evt-fast", "openai", "codex.logs", "src-1", new DateTimeOffset(2026, 03, 10, 11, 0, 0, TimeSpan.Zero)) {
+            Model = "openai/gpt-5.5/fast",
+            InputTokens = 1_000_000,
+            CachedInputTokens = 100_000,
+            OutputTokens = 100_000,
+            ReasoningTokens = 50_000,
+            TotalTokens = 1_250_000,
+            TruthLevel = UsageTruthLevel.Exact
+        };
+
+        var eventEstimate = UsageTelemetryApiPricing.EstimateEvent(evt);
+        AssertEqual(true, eventEstimate.HasKnownPricing, "api pricing recognizes openai fast suffix");
+        AssertEqual("gpt-5.5/fast", eventEstimate.Model, "api pricing normalizes openai fast suffix");
+        AssertEqual(9.55m, eventEstimate.EstimatedCostUsd, "api pricing estimates gpt-5.5 fast from base model");
+
+        var displayCost = UsageTelemetryApiPricing.BuildDisplayCost(evt);
+        AssertEqual(9.55m, displayCost.EstimatedFallbackCostUsd, "api pricing display cost includes gpt-5.5 fast");
+        AssertEqual(1_250_000L, displayCost.CoveredTokens, "api pricing display cost covers gpt-5.5 fast tokens");
+        AssertEqual(0L, displayCost.UncoveredTokens, "api pricing display cost leaves no gpt-5.5 fast tokens uncovered");
+    }
+
     private static void TestProviderLimitForecastingFlagsOverLimitPace() {
         var now = new DateTimeOffset(2026, 03, 18, 12, 00, 00, TimeSpan.Zero);
         var snapshot = new ProviderLimitSnapshot(

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -64,6 +64,20 @@ internal static partial class Program {
         AssertEqual(9.55m, displayCost.EstimatedFallbackCostUsd, "api pricing display cost includes gpt-5.5 fast");
         AssertEqual(1_250_000L, displayCost.CoveredTokens, "api pricing display cost covers gpt-5.5 fast tokens");
         AssertEqual(0L, displayCost.UncoveredTokens, "api pricing display cost leaves no gpt-5.5 fast tokens uncovered");
+
+        var nonOpenAiEstimate = UsageTelemetryApiPricing.EstimateEvent(new UsageEventRecord(
+            "evt-third-party-fast",
+            "third-party",
+            "api.logs",
+            "src-1",
+            new DateTimeOffset(2026, 03, 10, 11, 15, 0, TimeSpan.Zero)) {
+            Model = "vendor/gpt-5.5/fast",
+            InputTokens = 1_000_000,
+            TotalTokens = 1_000_000,
+            TruthLevel = UsageTruthLevel.Exact
+        });
+        AssertEqual(false, nonOpenAiEstimate.HasKnownPricing, "api pricing does not apply OpenAI mode pricing to third-party slash ids");
+        AssertEqual("vendor/gpt-5.5/fast", nonOpenAiEstimate.Model, "api pricing preserves third-party slash id");
     }
 
     private static void TestProviderLimitForecastingFlagsOverLimitPace() {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -101,6 +101,8 @@ internal static partial class Program {
             TestUsageTelemetryOverviewBuilderBuildsCopilotActivitySectionWithoutTokens);
         failed += Run("Usage telemetry API pricing blends exact and estimated costs",
             TestUsageTelemetryApiPricingBlendsExactAndEstimatedCosts);
+        failed += Run("Usage telemetry API pricing covers OpenAI mode suffixes",
+            TestUsageTelemetryApiPricingCoversOpenAiModeSuffixes);
         failed += Run("Provider limit forecasting flags over-limit pace",
             TestProviderLimitForecastingFlagsOverLimitPace);
         failed += Run("Provider limit forecasting recognizes on-pace window",

--- a/IntelligenceX/Providers/OpenAI/OpenAIModelCatalog.cs
+++ b/IntelligenceX/Providers/OpenAI/OpenAIModelCatalog.cs
@@ -49,12 +49,36 @@ public static class OpenAIModelCatalog {
             return trimmed;
         }
 
-        var lastIndex = parts.Count - 1;
-        if (IsModeToken(parts[lastIndex]) && parts.Count >= 2) {
-            return parts[lastIndex - 1] + "/" + parts[lastIndex];
+        var firstModeIndex = parts.Count;
+        while (firstModeIndex > 0 && IsModeToken(parts[firstModeIndex - 1])) {
+            firstModeIndex--;
+        }
+        if (firstModeIndex > 0 && firstModeIndex < parts.Count) {
+            return string.Join("/", parts.GetRange(firstModeIndex - 1, parts.Count - firstModeIndex + 1));
         }
 
-        return parts[lastIndex];
+        return parts[parts.Count - 1];
+    }
+
+    /// <summary>
+    /// Returns the normalized base model id without known OpenAI mode suffixes such as <c>/fast</c> or <c>/spark</c>.
+    /// </summary>
+    public static string NormalizeBaseModelId(string? model, string? fallback = null) {
+        var normalized = NormalizeModelId(model, fallback).Trim();
+        var rawParts = normalized.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        var parts = new List<string>(rawParts.Length);
+        for (var i = 0; i < rawParts.Length; i++) {
+            var part = rawParts[i].Trim();
+            if (part.Length > 0) {
+                parts.Add(part);
+            }
+        }
+
+        while (parts.Count > 1 && IsModeToken(parts[parts.Count - 1])) {
+            parts.RemoveAt(parts.Count - 1);
+        }
+
+        return parts.Count == 0 ? DefaultModel : string.Join("/", parts);
     }
 
     internal static IReadOnlyList<string> GetBaselineFallbackModels() => BaselineFallbackModels;

--- a/IntelligenceX/Providers/OpenAI/OpenAIModelCatalog.cs
+++ b/IntelligenceX/Providers/OpenAI/OpenAIModelCatalog.cs
@@ -10,10 +10,11 @@ public static class OpenAIModelCatalog {
     /// <summary>
     /// Default OpenAI model for new IntelligenceX sessions and reviewer runs.
     /// </summary>
-    public const string DefaultModel = "gpt-5.4";
+    public const string DefaultModel = "gpt-5.5";
 
     private static readonly string[] BaselineFallbackModels = {
         DefaultModel,
+        "gpt-5.4",
         "gpt-5.4-codex",
         "gpt-5-mini",
         "gpt-5-nano",

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryApiPricing.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryApiPricing.cs
@@ -235,6 +235,15 @@ public static class UsageTelemetryApiPricing {
             return true;
         }
 
+        var modeSeparator = normalizedModelId.IndexOf('/');
+        if (modeSeparator > 0 && modeSeparator < normalizedModelId.Length - 1) {
+            var mode = normalizedModelId.Substring(modeSeparator + 1);
+            if (IsOpenAiPricingModeSuffix(mode) &&
+                ApiPricingByModel.TryGetValue(normalizedModelId.Substring(0, modeSeparator), out rate!)) {
+                return true;
+            }
+        }
+
         if (normalizedModelId.StartsWith("claude-opus-4-6", StringComparison.OrdinalIgnoreCase) ||
             normalizedModelId.StartsWith("claude-opus-4-5", StringComparison.OrdinalIgnoreCase) ||
             normalizedModelId.StartsWith("claude-opus-4", StringComparison.OrdinalIgnoreCase)) {
@@ -244,6 +253,11 @@ public static class UsageTelemetryApiPricing {
 
         rate = null!;
         return false;
+    }
+
+    private static bool IsOpenAiPricingModeSuffix(string value) {
+        return value.Equals("fast", StringComparison.OrdinalIgnoreCase) ||
+               value.Equals("spark", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? NormalizeOptional(string? value) {

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryApiPricing.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryApiPricing.cs
@@ -185,9 +185,9 @@ public static class UsageTelemetryApiPricing {
             throw new ArgumentNullException(nameof(record));
         }
 
-        var normalizedModel = NormalizePricingModelId(record.ProviderId, record.Model);
+        var normalizedModel = NormalizePricingModelId(record.ProviderId, record.Model, out var allowOpenAiModePricing);
         var totalTokens = record.TotalTokens ?? 0L;
-        if (!TryResolveApiPrice(normalizedModel, out var rate)) {
+        if (!TryResolveApiPrice(normalizedModel, allowOpenAiModePricing, out var rate)) {
             return new UsageTelemetryApiEventCostEstimate(
                 normalizedModel,
                 totalTokens,
@@ -221,24 +221,29 @@ public static class UsageTelemetryApiPricing {
         return tokens / 1_000_000m * usdPerMillion;
     }
 
-    private static string NormalizePricingModelId(string? providerId, string? model) {
+    private static string NormalizePricingModelId(string? providerId, string? model, out bool allowOpenAiModePricing) {
         var provider = NormalizeOptional(providerId)?.ToLowerInvariant();
         if (provider is "codex" or "openai" or "ix" or "openai-codex" or "chatgpt-codex") {
+            allowOpenAiModePricing = true;
             return OpenAIModelCatalog.NormalizeModelId(model, "unknown-model").Trim().ToLowerInvariant();
         }
 
+        allowOpenAiModePricing = false;
         return NormalizeOptional(model)?.ToLowerInvariant() ?? "unknown-model";
     }
 
-    private static bool TryResolveApiPrice(string normalizedModelId, out UsageTelemetryApiPrice rate) {
+    private static bool TryResolveApiPrice(string normalizedModelId, bool allowOpenAiModePricing, out UsageTelemetryApiPrice rate) {
         if (ApiPricingByModel.TryGetValue(normalizedModelId, out rate!)) {
             return true;
         }
 
-        var baseModelId = OpenAIModelCatalog.NormalizeBaseModelId(normalizedModelId, normalizedModelId).ToLowerInvariant();
-        if (!string.Equals(baseModelId, normalizedModelId, StringComparison.OrdinalIgnoreCase) &&
-            ApiPricingByModel.TryGetValue(baseModelId, out rate!)) {
-            return true;
+        if (allowOpenAiModePricing) {
+            // Known OpenAI mode suffixes currently share the base model price until a distinct SKU is published here.
+            var baseModelId = OpenAIModelCatalog.NormalizeBaseModelId(normalizedModelId, normalizedModelId).ToLowerInvariant();
+            if (!string.Equals(baseModelId, normalizedModelId, StringComparison.OrdinalIgnoreCase) &&
+                ApiPricingByModel.TryGetValue(baseModelId, out rate!)) {
+                return true;
+            }
         }
 
         if (normalizedModelId.StartsWith("claude-opus-4-6", StringComparison.OrdinalIgnoreCase) ||

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryApiPricing.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryApiPricing.cs
@@ -88,6 +88,7 @@ public static class UsageTelemetryApiPricing {
 
     private static readonly IReadOnlyDictionary<string, UsageTelemetryApiPrice> ApiPricingByModel =
         new Dictionary<string, UsageTelemetryApiPrice>(StringComparer.OrdinalIgnoreCase) {
+            ["gpt-5.5"] = new(5m, 0.50m, 30m),
             ["gpt-5.4"] = new(2.50m, 0.25m, 15m),
             ["gpt-5.4-codex"] = new(2.50m, 0.25m, 15m),
             ["gpt-5-mini"] = new(0.25m, 0.025m, 2m),

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryApiPricing.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryApiPricing.cs
@@ -89,6 +89,7 @@ public static class UsageTelemetryApiPricing {
     private static readonly IReadOnlyDictionary<string, UsageTelemetryApiPrice> ApiPricingByModel =
         new Dictionary<string, UsageTelemetryApiPrice>(StringComparer.OrdinalIgnoreCase) {
             ["gpt-5.5"] = new(5m, 0.50m, 30m),
+            ["gpt-5.5/fast"] = new(5m, 0.50m, 30m),
             ["gpt-5.4"] = new(2.50m, 0.25m, 15m),
             ["gpt-5.4-codex"] = new(2.50m, 0.25m, 15m),
             ["gpt-5-mini"] = new(0.25m, 0.025m, 2m),

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryApiPricing.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryApiPricing.cs
@@ -235,13 +235,10 @@ public static class UsageTelemetryApiPricing {
             return true;
         }
 
-        var modeSeparator = normalizedModelId.IndexOf('/');
-        if (modeSeparator > 0 && modeSeparator < normalizedModelId.Length - 1) {
-            var mode = normalizedModelId.Substring(modeSeparator + 1);
-            if (IsOpenAiPricingModeSuffix(mode) &&
-                ApiPricingByModel.TryGetValue(normalizedModelId.Substring(0, modeSeparator), out rate!)) {
-                return true;
-            }
+        var baseModelId = OpenAIModelCatalog.NormalizeBaseModelId(normalizedModelId, normalizedModelId).ToLowerInvariant();
+        if (!string.Equals(baseModelId, normalizedModelId, StringComparison.OrdinalIgnoreCase) &&
+            ApiPricingByModel.TryGetValue(baseModelId, out rate!)) {
+            return true;
         }
 
         if (normalizedModelId.StartsWith("claude-opus-4-6", StringComparison.OrdinalIgnoreCase) ||
@@ -253,11 +250,6 @@ public static class UsageTelemetryApiPricing {
 
         rate = null!;
         return false;
-    }
-
-    private static bool IsOpenAiPricingModeSuffix(string value) {
-        return value.Equals("fast", StringComparison.OrdinalIgnoreCase) ||
-               value.Equals("spark", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? NormalizeOptional(string? value) {


### PR DESCRIPTION
## Summary
- add GPT-5.5 as the shared OpenAI default model while retaining GPT-5.4 fallbacks
- switch the repository reviewer workflow/config defaults to GPT-5.5
- update setup wizard, chat defaults, reviewer docs, pricing estimates, and tests for the new default

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet build IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Release
- dotnet ./IntelligenceX.Tests/bin/Release/net8.0/IntelligenceX.Tests.dll
- dotnet ./IntelligenceX.Tests/bin/Release/net10.0/IntelligenceX.Tests.dll
- pwsh -NoLogo -NoProfile -File .agents/skills/intelligencex-analysis-gate/scripts/run-analysis-suite.ps1 -Mode fast
- git diff --check

## Notes
- Full dotnet test IntelligenceX.sln -c Release was also run; it failed in broader Chat/tool bootstrap and AD snapshot suites outside this model-default change path.
