### PR TITLE
Restore website deploy workflow pin

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@6665d9631a76bd33ba83e16c23adaa68d3b5d701
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@2b3adb4ffe114132d85520ca2dc8c7b9b3fad642
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json


### PR DESCRIPTION
## Summary
- restore the website deploy reusable workflow pin to the last working PSPublishModule revision
- keep the #1297 CodeQL and website-CI pin updates intact

## Reason
The post-merge master deploy failed in the updated PSPublishModule deploy guardrail before deployment with: Cannot bind argument to parameter 'Visited' because it is an empty collection.

## Validation
- git diff --check
- inspected failing master deploy run 25372631918
