### PR TITLE
Align website deploy PowerForge engine

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -26,7 +26,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 10757f12978162b54ac314b512a3a77e227502fd
+      powerforge_ref: 2b3adb4ffe114132d85520ca2dc8c7b9b3fad642
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- align deploy workflow PowerForge engine ref with the website CI engine ref
- keep the reusable deploy workflow pinned to the last working revision

## Reason
The post-#1300 deploy now reaches the website pipeline but fails link-purpose audit on changelog release assets. The newer PowerForge renderer includes the release tag in changelog asset labels, avoiding repeated identical labels across different release URLs.

## Validation
- git diff --check
- inspected deploy run 25373020365 and downloaded doctor-summary.json
