### PR TITLE
Address reviewer follow-up fixes

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -82,7 +82,7 @@ jobs:
           INTELLIGENCEX_RELEASE_PR_BODY: ${{ inputs.pr_body }}
           INTELLIGENCEX_RELEASE_PR_LABELS: ${{ inputs.pr_labels }}
           INTELLIGENCEX_RELEASE_REPO_SLUG: ${{ inputs.repo_slug || github.repository }}
-          OPENAI_MODEL: gpt-5.4
+          OPENAI_MODEL: gpt-5.5
           OPENAI_TRANSPORT: native
         shell: bash
         run: bash -euo pipefail scripts/release-notes.sh

--- a/Docs/reviewer/configuration.md
+++ b/Docs/reviewer/configuration.md
@@ -259,7 +259,7 @@ For backward compatibility, the loader also accepts `modelProfiles` and `authPro
       "copilot-gpt54": {
         "provider": "copilot",
         "authenticator": "copilot-cli",
-        "model": "gpt-5.4",
+        "model": "gpt-5.5",
         "copilot": {
           "launcher": "auto",
           "autoInstall": true,
@@ -279,7 +279,7 @@ For backward compatibility, the loader also accepts `modelProfiles` and `authPro
 }
 ```
 
-The Copilot example intentionally keeps its OpenAI-family Copilot model on `gpt-5.4` to show that provider-specific profiles can
+The Copilot example intentionally keeps its OpenAI-family Copilot model on `gpt-5.5` to show that provider-specific profiles can
 choose a different model from the OpenAI default.
 
 For swarm shadow runs, reviewer lanes and the aggregator can reference those same profiles:

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ChatAppStateDefaultsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ChatAppStateDefaultsTests.cs
@@ -21,4 +21,32 @@ public sealed class ChatAppStateDefaultsTests {
         Assert.Empty(state.PendingTurns);
         Assert.Empty(state.QueuedTurnsAfterLogin);
     }
+
+    /// <summary>
+    /// Ensures old persisted disabled image-generation state keeps emitting an explicit disable override.
+    /// </summary>
+    [Fact]
+    public void ResolveLocalProviderImageGenerationOverrideActive_MigratesLegacyPersistedDisable() {
+        var state = new ChatAppState {
+            LocalProviderImageGenerationEnabled = false,
+            LocalProviderImageGenerationOverrideActive = false,
+            LocalProviderImageGenerationOverrideActiveWasPresent = false
+        };
+
+        Assert.True(MainWindow.ResolveLocalProviderImageGenerationOverrideActive(state, isLoadedProfile: true));
+    }
+
+    /// <summary>
+    /// Ensures new persisted state can intentionally keep image-generation override unset.
+    /// </summary>
+    [Fact]
+    public void ResolveLocalProviderImageGenerationOverrideActive_PreservesNewPersistedUnsetDisable() {
+        var state = new ChatAppState {
+            LocalProviderImageGenerationEnabled = false,
+            LocalProviderImageGenerationOverrideActive = false,
+            LocalProviderImageGenerationOverrideActiveWasPresent = true
+        };
+
+        Assert.False(MainWindow.ResolveLocalProviderImageGenerationOverrideActive(state, isLoadedProfile: true));
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowLocalProviderTransportTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/MainWindowLocalProviderTransportTests.cs
@@ -38,4 +38,40 @@ public sealed class MainWindowLocalProviderTransportTests {
         Assert.False(parsed);
         Assert.Equal("native", transport);
     }
+
+    /// <summary>
+    /// Ensures an explicit disable-only image-generation apply is still emitted to service launch options.
+    /// </summary>
+    [Fact]
+    public void HasImageGenerationLaunchOverrides_PreservesExplicitDisableOnlyOverride() {
+        var hasOverrides = MainWindow.HasImageGenerationLaunchOverrides(
+            imageGenerationOverrideActive: true,
+            imageGenerationEnabled: false,
+            imageQuality: string.Empty,
+            imageSize: string.Empty,
+            imageOutputFormat: string.Empty,
+            imageOutputCompression: null,
+            imageBackground: string.Empty,
+            imageOutputDirectory: string.Empty);
+
+        Assert.True(hasOverrides);
+    }
+
+    /// <summary>
+    /// Ensures the default image-generation state remains unset when no override was applied.
+    /// </summary>
+    [Fact]
+    public void HasImageGenerationLaunchOverrides_OmitsUnsetDefaultDisable() {
+        var hasOverrides = MainWindow.HasImageGenerationLaunchOverrides(
+            imageGenerationOverrideActive: false,
+            imageGenerationEnabled: false,
+            imageQuality: string.Empty,
+            imageSize: string.Empty,
+            imageOutputFormat: string.Empty,
+            imageOutputCompression: null,
+            imageBackground: string.Empty,
+            imageOutputDirectory: string.Empty);
+
+        Assert.False(hasOverrides);
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ServiceLaunchArgumentsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ServiceLaunchArgumentsTests.cs
@@ -284,6 +284,23 @@ public sealed class ServiceLaunchArgumentsTests {
     }
 
     /// <summary>
+    /// Ensures absent image-generation overrides do not disable native/env defaults.
+    /// </summary>
+    [Fact]
+    public void Build_OmitsImageGenerationFlags_WhenOverridesAreUnset() {
+        var args = ServiceLaunchArguments.Build(
+            "intelligencex.chat",
+            detachedServiceMode: true,
+            parentProcessId: 12345,
+            new ServiceLaunchArguments.ProfileOptions());
+
+        Assert.DoesNotContain("--enable-image-generation", args);
+        Assert.DoesNotContain("--disable-image-generation", args);
+        Assert.DoesNotContain("--image-generation-quality", args);
+        Assert.DoesNotContain("--clear-image-generation-output-compression", args);
+    }
+
+    /// <summary>
     /// Ensures repeatable plugin paths are forwarded, while empty/duplicate entries are ignored.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ServiceLaunchArgumentsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ServiceLaunchArgumentsTests.cs
@@ -301,6 +301,23 @@ public sealed class ServiceLaunchArgumentsTests {
     }
 
     /// <summary>
+    /// Ensures an explicit image-generation disable override is preserved.
+    /// </summary>
+    [Fact]
+    public void Build_IncludesDisableImageGenerationFlag_WhenExplicitlyDisabled() {
+        var args = ServiceLaunchArguments.Build(
+            "intelligencex.chat",
+            detachedServiceMode: true,
+            parentProcessId: 12345,
+            new ServiceLaunchArguments.ProfileOptions {
+                ImageGenerationEnabled = false
+            });
+
+        Assert.DoesNotContain("--enable-image-generation", args);
+        Assert.Contains("--disable-image-generation", args);
+    }
+
+    /// <summary>
     /// Ensures repeatable plugin paths are forwarded, while empty/duplicate entries are ignored.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
@@ -884,14 +884,20 @@ public sealed partial class UiShellAssetsTests {
     }
 
     /// <summary>
-    /// Ensures applying unrelated local-provider settings does not force image-generation overrides active.
+    /// Ensures unrelated local-provider applies preserve active image-generation overrides without forcing new ones.
     /// </summary>
     [Fact]
     public void Load_DoesNotForceImageGenerationOverrideForEveryLocalProviderApply() {
         var bindingsPath = Path.Combine(UiDirectory, "Shell.20.bindings.js");
         var script = File.ReadAllText(bindingsPath);
 
-        Assert.Contains("var imageGenerationOverrideActive = imageGenerationEnabled !== (local.imageGenerationEnabled === true)", script, StringComparison.Ordinal);
+        Assert.Contains("var localProviderImageGenerationDraftTouched = false;", script, StringComparison.Ordinal);
+        Assert.Contains("function markLocalProviderImageGenerationDraftChanged()", script, StringComparison.Ordinal);
+        Assert.Contains("var imageGenerationSettingsChanged = imageGenerationEnabled !== (local.imageGenerationEnabled === true)", script, StringComparison.Ordinal);
+        Assert.Contains("var imageGenerationOverrideActive = imageGenerationSettingsChanged", script, StringComparison.Ordinal);
+        Assert.Contains("|| (local.imageGenerationOverrideActive === true && !localProviderImageGenerationDraftTouched);", script, StringComparison.Ordinal);
+        Assert.Contains("localProviderImageGenerationDraftTouched = false;", script, StringComparison.Ordinal);
+        Assert.Contains("markLocalProviderImageGenerationDraftChanged();", script, StringComparison.Ordinal);
         Assert.DoesNotContain("var currentImageGenerationOverrideActive = local.imageGenerationOverrideActive === true;", script, StringComparison.Ordinal);
         Assert.Contains("state.options.localModel.imageGenerationOverrideActive = imageGenerationOverrideActive;", script, StringComparison.Ordinal);
         Assert.Contains("imageGenerationOverrideActive: imageGenerationOverrideActive,", script, StringComparison.Ordinal);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
@@ -891,8 +891,8 @@ public sealed partial class UiShellAssetsTests {
         var bindingsPath = Path.Combine(UiDirectory, "Shell.20.bindings.js");
         var script = File.ReadAllText(bindingsPath);
 
-        Assert.Contains("var currentImageGenerationOverrideActive = local.imageGenerationOverrideActive === true;", script, StringComparison.Ordinal);
-        Assert.Contains("var imageGenerationOverrideActive = currentImageGenerationOverrideActive", script, StringComparison.Ordinal);
+        Assert.Contains("var imageGenerationOverrideActive = imageGenerationEnabled !== (local.imageGenerationEnabled === true)", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("var currentImageGenerationOverrideActive = local.imageGenerationOverrideActive === true;", script, StringComparison.Ordinal);
         Assert.Contains("state.options.localModel.imageGenerationOverrideActive = imageGenerationOverrideActive;", script, StringComparison.Ordinal);
         Assert.Contains("imageGenerationOverrideActive: imageGenerationOverrideActive,", script, StringComparison.Ordinal);
         Assert.DoesNotContain("imageGenerationOverrideActive: true,", script, StringComparison.Ordinal);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/UiShellAssetsTests.cs
@@ -884,6 +884,21 @@ public sealed partial class UiShellAssetsTests {
     }
 
     /// <summary>
+    /// Ensures applying unrelated local-provider settings does not force image-generation overrides active.
+    /// </summary>
+    [Fact]
+    public void Load_DoesNotForceImageGenerationOverrideForEveryLocalProviderApply() {
+        var bindingsPath = Path.Combine(UiDirectory, "Shell.20.bindings.js");
+        var script = File.ReadAllText(bindingsPath);
+
+        Assert.Contains("var currentImageGenerationOverrideActive = local.imageGenerationOverrideActive === true;", script, StringComparison.Ordinal);
+        Assert.Contains("var imageGenerationOverrideActive = currentImageGenerationOverrideActive", script, StringComparison.Ordinal);
+        Assert.Contains("state.options.localModel.imageGenerationOverrideActive = imageGenerationOverrideActive;", script, StringComparison.Ordinal);
+        Assert.Contains("imageGenerationOverrideActive: imageGenerationOverrideActive,", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("imageGenerationOverrideActive: true,", script, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Ensures options conversations expose inline model override selection (without prompt dialogs)
     /// and post explicit set_conversation_model events.
     /// </summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX;
@@ -71,7 +72,15 @@ internal sealed class ChatAppStateStore : IDisposable {
         }
 
         try {
+            using var document = JsonDocument.Parse(json);
+            var hasImageGenerationOverrideActive =
+                document.RootElement.ValueKind == JsonValueKind.Object &&
+                document.RootElement.TryGetProperty("localProviderImageGenerationOverrideActive", out _);
             var state = JsonSerializer.Deserialize<ChatAppState>(json, _json);
+            if (state is not null) {
+                state.LocalProviderImageGenerationOverrideActiveWasPresent = hasImageGenerationOverrideActive;
+            }
+
             return Task.FromResult(state);
         } catch (Exception ex) {
             throw new InvalidOperationException($"Failed to parse app profile '{profileName}'.", ex);
@@ -242,6 +251,8 @@ internal sealed class ChatAppState {
     public double? LocalProviderTemperature { get; set; }
     public bool LocalProviderImageGenerationEnabled { get; set; }
     public bool LocalProviderImageGenerationOverrideActive { get; set; }
+    [JsonIgnore]
+    internal bool LocalProviderImageGenerationOverrideActiveWasPresent { get; set; }
     public string LocalProviderImageGenerationQuality { get; set; } = string.Empty;
     public string LocalProviderImageGenerationSize { get; set; } = string.Empty;
     public string LocalProviderImageGenerationOutputFormat { get; set; } = string.Empty;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
@@ -241,6 +241,7 @@ internal sealed class ChatAppState {
     public string LocalProviderTextVerbosity { get; set; } = string.Empty;
     public double? LocalProviderTemperature { get; set; }
     public bool LocalProviderImageGenerationEnabled { get; set; }
+    public bool LocalProviderImageGenerationOverrideActive { get; set; }
     public string LocalProviderImageGenerationQuality { get; set; } = string.Empty;
     public string LocalProviderImageGenerationSize { get; set; } = string.Empty;
     public string LocalProviderImageGenerationOutputFormat { get; set; } = string.Empty;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -780,14 +780,15 @@ public sealed partial class MainWindow : Window {
         var imageOutputFormat = (_localProviderImageGenerationOutputFormat ?? string.Empty).Trim();
         var imageBackground = (_localProviderImageGenerationBackground ?? string.Empty).Trim();
         var imageOutputDirectory = (_localProviderImageGenerationOutputDirectory ?? string.Empty).Trim();
-        var hasImageGenerationOverrides = _localProviderImageGenerationOverrideActive
-                                      || _localProviderImageGenerationEnabled
-                                      || imageQuality.Length > 0
-                                      || imageSize.Length > 0
-                                      || imageOutputFormat.Length > 0
-                                      || _localProviderImageGenerationOutputCompression.HasValue
-                                      || imageBackground.Length > 0
-                                      || imageOutputDirectory.Length > 0;
+        var hasImageGenerationOverrides = HasImageGenerationLaunchOverrides(
+            _localProviderImageGenerationOverrideActive,
+            _localProviderImageGenerationEnabled,
+            imageQuality,
+            imageSize,
+            imageOutputFormat,
+            _localProviderImageGenerationOutputCompression,
+            imageBackground,
+            imageOutputDirectory);
 
         return new ServiceLaunchProfileOptions {
             LoadProfileName = profileName,
@@ -815,6 +816,24 @@ public sealed partial class MainWindow : Window {
             PackToggles = BuildRuntimePackTogglesFromSessionPolicy()
         };
     }
+
+    internal static bool HasImageGenerationLaunchOverrides(
+        bool imageGenerationOverrideActive,
+        bool imageGenerationEnabled,
+        string? imageQuality,
+        string? imageSize,
+        string? imageOutputFormat,
+        int? imageOutputCompression,
+        string? imageBackground,
+        string? imageOutputDirectory) =>
+        imageGenerationOverrideActive ||
+        imageGenerationEnabled ||
+        !string.IsNullOrWhiteSpace(imageQuality) ||
+        !string.IsNullOrWhiteSpace(imageSize) ||
+        !string.IsNullOrWhiteSpace(imageOutputFormat) ||
+        imageOutputCompression.HasValue ||
+        !string.IsNullOrWhiteSpace(imageBackground) ||
+        !string.IsNullOrWhiteSpace(imageOutputDirectory);
 
     private ServiceLaunchArguments.PackToggle[]? BuildRuntimePackTogglesFromSessionPolicy() {
         var packs = RuntimeToolingMetadataResolver.ResolveEffectivePacks(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -772,6 +772,13 @@ public sealed partial class MainWindow : Window {
         var imageOutputFormat = (_localProviderImageGenerationOutputFormat ?? string.Empty).Trim();
         var imageBackground = (_localProviderImageGenerationBackground ?? string.Empty).Trim();
         var imageOutputDirectory = (_localProviderImageGenerationOutputDirectory ?? string.Empty).Trim();
+        var hasImageGenerationOverrides = _localProviderImageGenerationEnabled
+                                      || imageQuality.Length > 0
+                                      || imageSize.Length > 0
+                                      || imageOutputFormat.Length > 0
+                                      || _localProviderImageGenerationOutputCompression.HasValue
+                                      || imageBackground.Length > 0
+                                      || imageOutputDirectory.Length > 0;
 
         return new ServiceLaunchProfileOptions {
             LoadProfileName = profileName,
@@ -788,14 +795,14 @@ public sealed partial class MainWindow : Window {
             ReasoningSummary = reasoningSummary.Length == 0 ? null : reasoningSummary,
             TextVerbosity = textVerbosity.Length == 0 ? null : textVerbosity,
             Temperature = _localProviderTemperature,
-            ImageGenerationEnabled = _localProviderImageGenerationEnabled,
-            ImageGenerationQuality = imageQuality,
-            ImageGenerationSize = imageSize,
-            ImageGenerationOutputFormat = imageOutputFormat,
-            ImageGenerationOutputCompression = _localProviderImageGenerationOutputCompression,
-            ClearImageGenerationOutputCompression = _localProviderImageGenerationOutputCompression is null,
-            ImageGenerationBackground = imageBackground,
-            ImageGenerationOutputDirectory = imageOutputDirectory,
+            ImageGenerationEnabled = hasImageGenerationOverrides ? _localProviderImageGenerationEnabled : null,
+            ImageGenerationQuality = hasImageGenerationOverrides ? imageQuality : null,
+            ImageGenerationSize = hasImageGenerationOverrides ? imageSize : null,
+            ImageGenerationOutputFormat = hasImageGenerationOverrides ? imageOutputFormat : null,
+            ImageGenerationOutputCompression = hasImageGenerationOverrides ? _localProviderImageGenerationOutputCompression : null,
+            ClearImageGenerationOutputCompression = hasImageGenerationOverrides && _localProviderImageGenerationOutputCompression is null,
+            ImageGenerationBackground = hasImageGenerationOverrides ? imageBackground : null,
+            ImageGenerationOutputDirectory = hasImageGenerationOverrides ? imageOutputDirectory : null,
             PackToggles = BuildRuntimePackTogglesFromSessionPolicy()
         };
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.LocalModels.cs
@@ -174,6 +174,7 @@ public sealed partial class MainWindow : Window {
             textVerbosityValue: _localProviderTextVerbosity,
             temperatureValue: _localProviderTemperature?.ToString("0.###", CultureInfo.InvariantCulture),
             imageGenerationEnabled: _localProviderImageGenerationEnabled,
+            imageGenerationOverrideActive: _localProviderImageGenerationOverrideActive,
             imageGenerationQualityValue: _localProviderImageGenerationQuality,
             imageGenerationSizeValue: _localProviderImageGenerationSize,
             imageGenerationOutputFormatValue: _localProviderImageGenerationOutputFormat,
@@ -263,7 +264,7 @@ public sealed partial class MainWindow : Window {
     private async Task ApplyLocalProviderAsync(string? transportValue, string? baseUrlValue, string? modelValue, string? openAIAuthModeValue,
         string? openAIBasicUsernameValue, string? openAIBasicPasswordValue, string? openAIAccountIdValue, int? activeNativeAccountSlotValue,
         string? activeSlotAccountIdValue, string? reasoningEffortValue, string? reasoningSummaryValue, string? textVerbosityValue,
-        string? temperatureValue, bool imageGenerationEnabled, string? imageGenerationQualityValue, string? imageGenerationSizeValue,
+        string? temperatureValue, bool imageGenerationEnabled, bool imageGenerationOverrideActive, string? imageGenerationQualityValue, string? imageGenerationSizeValue,
         string? imageGenerationOutputFormatValue, int? imageGenerationOutputCompressionValue, bool clearImageGenerationOutputCompression,
         string? imageGenerationBackgroundValue,
         string? imageGenerationOutputDirectoryValue, string? apiKeyValue, bool clearBasicAuth, bool clearApiKey, bool forceModelRefresh,
@@ -293,6 +294,7 @@ public sealed partial class MainWindow : Window {
             TextVerbosity: textVerbosityValue,
             Temperature: temperatureValue,
             ImageGenerationEnabled: imageGenerationEnabled,
+            ImageGenerationOverrideActive: imageGenerationOverrideActive,
             ImageGenerationQuality: imageGenerationQualityValue,
             ImageGenerationSize: imageGenerationSizeValue,
             ImageGenerationOutputFormat: imageGenerationOutputFormatValue,
@@ -411,6 +413,7 @@ public sealed partial class MainWindow : Window {
         var previousTextVerbosity = _localProviderTextVerbosity;
         var previousTemperature = _localProviderTemperature;
         var previousImageGenerationEnabled = _localProviderImageGenerationEnabled;
+        var previousImageGenerationOverrideActive = _localProviderImageGenerationOverrideActive;
         var previousImageGenerationQuality = _localProviderImageGenerationQuality;
         var previousImageGenerationSize = _localProviderImageGenerationSize;
         var previousImageGenerationOutputFormat = _localProviderImageGenerationOutputFormat;
@@ -463,6 +466,7 @@ public sealed partial class MainWindow : Window {
         _localProviderTextVerbosity = normalizedTextVerbosity;
         _localProviderTemperature = normalizedTemperature;
         _localProviderImageGenerationEnabled = request.ImageGenerationEnabled;
+        _localProviderImageGenerationOverrideActive = request.ImageGenerationOverrideActive;
         _localProviderImageGenerationQuality = normalizedImageGenerationQuality;
         _localProviderImageGenerationSize = normalizedImageGenerationSize;
         _localProviderImageGenerationOutputFormat = normalizedImageGenerationOutputFormat;
@@ -495,6 +499,7 @@ public sealed partial class MainWindow : Window {
         _appState.LocalProviderTextVerbosity = _localProviderTextVerbosity;
         _appState.LocalProviderTemperature = _localProviderTemperature;
         _appState.LocalProviderImageGenerationEnabled = _localProviderImageGenerationEnabled;
+        _appState.LocalProviderImageGenerationOverrideActive = _localProviderImageGenerationOverrideActive;
         _appState.LocalProviderImageGenerationQuality = _localProviderImageGenerationQuality;
         _appState.LocalProviderImageGenerationSize = _localProviderImageGenerationSize;
         _appState.LocalProviderImageGenerationOutputFormat = _localProviderImageGenerationOutputFormat;
@@ -514,6 +519,7 @@ public sealed partial class MainWindow : Window {
             _localProviderTextVerbosity = previousTextVerbosity;
             _localProviderTemperature = previousTemperature;
             _localProviderImageGenerationEnabled = previousImageGenerationEnabled;
+            _localProviderImageGenerationOverrideActive = previousImageGenerationOverrideActive;
             _localProviderImageGenerationQuality = previousImageGenerationQuality;
             _localProviderImageGenerationSize = previousImageGenerationSize;
             _localProviderImageGenerationOutputFormat = previousImageGenerationOutputFormat;
@@ -539,6 +545,7 @@ public sealed partial class MainWindow : Window {
             _appState.LocalProviderTextVerbosity = _localProviderTextVerbosity;
             _appState.LocalProviderTemperature = _localProviderTemperature;
             _appState.LocalProviderImageGenerationEnabled = _localProviderImageGenerationEnabled;
+            _appState.LocalProviderImageGenerationOverrideActive = _localProviderImageGenerationOverrideActive;
             _appState.LocalProviderImageGenerationQuality = _localProviderImageGenerationQuality;
             _appState.LocalProviderImageGenerationSize = _localProviderImageGenerationSize;
             _appState.LocalProviderImageGenerationOutputFormat = _localProviderImageGenerationOutputFormat;
@@ -720,6 +727,7 @@ public sealed partial class MainWindow : Window {
                     TextVerbosity: null,
                     Temperature: null,
                     ImageGenerationEnabled: false,
+                    ImageGenerationOverrideActive: false,
                     ImageGenerationQuality: null,
                     ImageGenerationSize: null,
                     ImageGenerationOutputFormat: null,
@@ -772,7 +780,8 @@ public sealed partial class MainWindow : Window {
         var imageOutputFormat = (_localProviderImageGenerationOutputFormat ?? string.Empty).Trim();
         var imageBackground = (_localProviderImageGenerationBackground ?? string.Empty).Trim();
         var imageOutputDirectory = (_localProviderImageGenerationOutputDirectory ?? string.Empty).Trim();
-        var hasImageGenerationOverrides = _localProviderImageGenerationEnabled
+        var hasImageGenerationOverrides = _localProviderImageGenerationOverrideActive
+                                      || _localProviderImageGenerationEnabled
                                       || imageQuality.Length > 0
                                       || imageSize.Length > 0
                                       || imageOutputFormat.Length > 0

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.LiveRequestAndStartupWarnings.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.LiveRequestAndStartupWarnings.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using IntelligenceX.Chat.Abstractions.Policy;
@@ -388,7 +389,7 @@ public sealed partial class MainWindow : Window {
         var bounded = Math.Max(0, milliseconds);
         var elapsed = TimeSpan.FromMilliseconds(bounded);
         if (elapsed.TotalSeconds >= 1) {
-            return $"{elapsed.TotalSeconds:0.0}s";
+            return elapsed.TotalSeconds.ToString("0.0", CultureInfo.InvariantCulture) + "s";
         }
 
         return $"{Math.Max(1, bounded)}ms";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
@@ -430,6 +430,7 @@ public sealed partial class MainWindow : Window {
                         var clearImageGenerationOutputCompression = TryGetBoolean(root, "clearImageGenerationOutputCompression") ?? false;
                         var imageGenerationBackground = TryGetString(root, "imageGenerationBackground");
                         var imageGenerationOutputDirectory = TryGetString(root, "imageGenerationOutputDirectory");
+                        // Existing UI payloads always represent an explicit apply action, so absence keeps the override active.
                         var imageGenerationOverrideActive = TryGetBoolean(root, "imageGenerationOverrideActive") ?? true;
                         var apiKey = TryGetString(root, "apiKey");
                         var clearBasicAuth = TryGetBoolean(root, "clearBasicAuth");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.cs
@@ -430,6 +430,7 @@ public sealed partial class MainWindow : Window {
                         var clearImageGenerationOutputCompression = TryGetBoolean(root, "clearImageGenerationOutputCompression") ?? false;
                         var imageGenerationBackground = TryGetString(root, "imageGenerationBackground");
                         var imageGenerationOutputDirectory = TryGetString(root, "imageGenerationOutputDirectory");
+                        var imageGenerationOverrideActive = TryGetBoolean(root, "imageGenerationOverrideActive") ?? true;
                         var apiKey = TryGetString(root, "apiKey");
                         var clearBasicAuth = TryGetBoolean(root, "clearBasicAuth");
                         var clearApiKey = TryGetBoolean(root, "clearApiKey");
@@ -450,6 +451,7 @@ public sealed partial class MainWindow : Window {
                                 textVerbosity,
                                 temperature,
                                 imageGenerationEnabled,
+                                imageGenerationOverrideActive,
                                 imageGenerationQuality,
                                 imageGenerationSize,
                                 imageGenerationOutputFormat,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.PersistenceHelpers.cs
@@ -64,6 +64,7 @@ public sealed partial class MainWindow : Window {
             _appState.LocalProviderTextVerbosity = _localProviderTextVerbosity;
             _appState.LocalProviderTemperature = _localProviderTemperature;
             _appState.LocalProviderImageGenerationEnabled = _localProviderImageGenerationEnabled;
+            _appState.LocalProviderImageGenerationOverrideActive = _localProviderImageGenerationOverrideActive;
             _appState.LocalProviderImageGenerationQuality = _localProviderImageGenerationQuality;
             _appState.LocalProviderImageGenerationSize = _localProviderImageGenerationSize;
             _appState.LocalProviderImageGenerationOutputFormat = _localProviderImageGenerationOutputFormat;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.cs
@@ -1182,6 +1182,7 @@ public sealed partial class MainWindow : Window {
         _localProviderTextVerbosity = NormalizeLocalProviderTextVerbosity(_appState.LocalProviderTextVerbosity);
         _localProviderTemperature = NormalizeLocalProviderTemperature(_appState.LocalProviderTemperature);
         _localProviderImageGenerationEnabled = _appState.LocalProviderImageGenerationEnabled;
+        _localProviderImageGenerationOverrideActive = _appState.LocalProviderImageGenerationOverrideActive;
         _localProviderImageGenerationQuality = NormalizeLocalProviderImageGenerationQuality(_appState.LocalProviderImageGenerationQuality);
         _localProviderImageGenerationSize = NormalizeLocalProviderImageGenerationSize(_appState.LocalProviderImageGenerationSize);
         _localProviderImageGenerationOutputFormat = NormalizeLocalProviderImageGenerationOutputFormat(_appState.LocalProviderImageGenerationOutputFormat);
@@ -1199,6 +1200,7 @@ public sealed partial class MainWindow : Window {
         _appState.LocalProviderTextVerbosity = _localProviderTextVerbosity;
         _appState.LocalProviderTemperature = _localProviderTemperature;
         _appState.LocalProviderImageGenerationEnabled = _localProviderImageGenerationEnabled;
+        _appState.LocalProviderImageGenerationOverrideActive = _localProviderImageGenerationOverrideActive;
         _appState.LocalProviderImageGenerationQuality = _localProviderImageGenerationQuality;
         _appState.LocalProviderImageGenerationSize = _localProviderImageGenerationSize;
         _appState.LocalProviderImageGenerationOutputFormat = _localProviderImageGenerationOutputFormat;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.cs
@@ -1182,7 +1182,7 @@ public sealed partial class MainWindow : Window {
         _localProviderTextVerbosity = NormalizeLocalProviderTextVerbosity(_appState.LocalProviderTextVerbosity);
         _localProviderTemperature = NormalizeLocalProviderTemperature(_appState.LocalProviderTemperature);
         _localProviderImageGenerationEnabled = _appState.LocalProviderImageGenerationEnabled;
-        _localProviderImageGenerationOverrideActive = _appState.LocalProviderImageGenerationOverrideActive;
+        _localProviderImageGenerationOverrideActive = ResolveLocalProviderImageGenerationOverrideActive(_appState, loaded is not null);
         _localProviderImageGenerationQuality = NormalizeLocalProviderImageGenerationQuality(_appState.LocalProviderImageGenerationQuality);
         _localProviderImageGenerationSize = NormalizeLocalProviderImageGenerationSize(_appState.LocalProviderImageGenerationSize);
         _localProviderImageGenerationOutputFormat = NormalizeLocalProviderImageGenerationOutputFormat(_appState.LocalProviderImageGenerationOutputFormat);
@@ -1293,6 +1293,17 @@ public sealed partial class MainWindow : Window {
         await RenderTranscriptAsync().ConfigureAwait(false);
         await ApplyThemeFromStateAsync().ConfigureAwait(false);
         await PublishOptionsStateAsync().ConfigureAwait(false);
+    }
+
+    internal static bool ResolveLocalProviderImageGenerationOverrideActive(ChatAppState state, bool isLoadedProfile) {
+        if (state is null) {
+            return false;
+        }
+
+        return state.LocalProviderImageGenerationOverrideActive ||
+               isLoadedProfile &&
+               !state.LocalProviderImageGenerationOverrideActiveWasPresent &&
+               !state.LocalProviderImageGenerationEnabled;
     }
 
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.UiState.cs
@@ -590,6 +590,7 @@ public sealed partial class MainWindow : Window {
                 textVerbosity = _localProviderTextVerbosity,
                 temperature = _localProviderTemperature,
                 imageGenerationEnabled = _localProviderImageGenerationEnabled,
+                imageGenerationOverrideActive = _localProviderImageGenerationOverrideActive,
                 imageGenerationQuality = _localProviderImageGenerationQuality,
                 imageGenerationSize = _localProviderImageGenerationSize,
                 imageGenerationOutputFormat = _localProviderImageGenerationOutputFormat,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -332,6 +332,7 @@ public sealed partial class MainWindow : Window {
     private string _localProviderTextVerbosity = string.Empty;
     private double? _localProviderTemperature;
     private bool _localProviderImageGenerationEnabled;
+    private bool _localProviderImageGenerationOverrideActive;
     private string _localProviderImageGenerationQuality = string.Empty;
     private string _localProviderImageGenerationSize = string.Empty;
     private string _localProviderImageGenerationOutputFormat = string.Empty;
@@ -599,6 +600,7 @@ public sealed partial class MainWindow : Window {
         string? TextVerbosity,
         string? Temperature,
         bool ImageGenerationEnabled,
+        bool ImageGenerationOverrideActive,
         string? ImageGenerationQuality,
         string? ImageGenerationSize,
         string? ImageGenerationOutputFormat,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -1421,6 +1421,15 @@
     var imageGenerationOutputCompression = (byId("optImageGenerationOutputCompression").value || "").trim();
     var imageGenerationBackground = (byId("optImageGenerationBackground").value || "").trim();
     var imageGenerationOutputDirectory = (byId("optImageGenerationOutputDirectory").value || "").trim();
+    var currentImageGenerationOverrideActive = local.imageGenerationOverrideActive === true;
+    var imageGenerationOverrideActive = currentImageGenerationOverrideActive
+      || imageGenerationEnabled !== (local.imageGenerationEnabled === true)
+      || imageGenerationQuality !== String(local.imageGenerationQuality || "").trim()
+      || imageGenerationSize !== String(local.imageGenerationSize || "").trim()
+      || imageGenerationOutputFormat !== String(local.imageGenerationOutputFormat || "").trim()
+      || imageGenerationOutputCompression !== String(local.imageGenerationOutputCompression == null ? "" : local.imageGenerationOutputCompression).trim()
+      || imageGenerationBackground !== String(local.imageGenerationBackground || "").trim()
+      || imageGenerationOutputDirectory !== String(local.imageGenerationOutputDirectory || "").trim();
     var reasoningSupport = resolveReasoningSupportForDraft(transport, baseUrl);
     if (!reasoningSupport.supported) {
       reasoningEffort = "";
@@ -1511,6 +1520,7 @@
       state.options.localModel.imageGenerationOutputCompression = imageGenerationOutputCompression;
       state.options.localModel.imageGenerationBackground = imageGenerationBackground;
       state.options.localModel.imageGenerationOutputDirectory = imageGenerationOutputDirectory;
+      state.options.localModel.imageGenerationOverrideActive = imageGenerationOverrideActive;
       state.options.localModel.isApplying = true;
       var runtimeApply = state.options.localModel.runtimeApply;
       if (!runtimeApply || typeof runtimeApply !== "object") {
@@ -1542,7 +1552,7 @@
       textVerbosity: textVerbosity,
       temperature: temperature,
       imageGenerationEnabled: imageGenerationEnabled,
-      imageGenerationOverrideActive: true,
+      imageGenerationOverrideActive: imageGenerationOverrideActive,
       imageGenerationQuality: imageGenerationQuality,
       imageGenerationSize: imageGenerationSize,
       imageGenerationOutputFormat: imageGenerationOutputFormat,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -1331,6 +1331,7 @@
   var localProviderAutoApplyDelayMs = 220;
   var pendingLocalProviderApply = null;
   var localProviderApplyRequestId = 0;
+  var localProviderImageGenerationDraftTouched = false;
 
   function normalizeRuntimeApplyRequestId(value) {
     var parsed = Number(value);
@@ -1397,6 +1398,11 @@
     renderLocalModelOptions();
   }
 
+  function markLocalProviderImageGenerationDraftChanged() {
+    localProviderImageGenerationDraftTouched = true;
+    markLocalProviderDraftChanged();
+  }
+
   function applyLocalProviderSettings(forceRefresh, clearApiKey, clearBasicAuth) {
     clearScheduledLocalProviderApply();
     var local = ((state.options || {}).localModel || {});
@@ -1421,13 +1427,15 @@
     var imageGenerationOutputCompression = (byId("optImageGenerationOutputCompression").value || "").trim();
     var imageGenerationBackground = (byId("optImageGenerationBackground").value || "").trim();
     var imageGenerationOutputDirectory = (byId("optImageGenerationOutputDirectory").value || "").trim();
-    var imageGenerationOverrideActive = imageGenerationEnabled !== (local.imageGenerationEnabled === true)
+    var imageGenerationSettingsChanged = imageGenerationEnabled !== (local.imageGenerationEnabled === true)
       || imageGenerationQuality !== String(local.imageGenerationQuality || "").trim()
       || imageGenerationSize !== String(local.imageGenerationSize || "").trim()
       || imageGenerationOutputFormat !== String(local.imageGenerationOutputFormat || "").trim()
       || imageGenerationOutputCompression !== String(local.imageGenerationOutputCompression == null ? "" : local.imageGenerationOutputCompression).trim()
       || imageGenerationBackground !== String(local.imageGenerationBackground || "").trim()
       || imageGenerationOutputDirectory !== String(local.imageGenerationOutputDirectory || "").trim();
+    var imageGenerationOverrideActive = imageGenerationSettingsChanged
+      || (local.imageGenerationOverrideActive === true && !localProviderImageGenerationDraftTouched);
     var reasoningSupport = resolveReasoningSupportForDraft(transport, baseUrl);
     if (!reasoningSupport.supported) {
       reasoningEffort = "";
@@ -1519,6 +1527,7 @@
       state.options.localModel.imageGenerationBackground = imageGenerationBackground;
       state.options.localModel.imageGenerationOutputDirectory = imageGenerationOutputDirectory;
       state.options.localModel.imageGenerationOverrideActive = imageGenerationOverrideActive;
+      localProviderImageGenerationDraftTouched = false;
       state.options.localModel.isApplying = true;
       var runtimeApply = state.options.localModel.runtimeApply;
       if (!runtimeApply || typeof runtimeApply !== "object") {
@@ -1814,31 +1823,31 @@
   });
 
   byId("optImageGenerationEnabled").addEventListener("change", function() {
-    markLocalProviderDraftChanged();
+    markLocalProviderImageGenerationDraftChanged();
   });
 
   byId("optImageGenerationQuality").addEventListener("change", function() {
-    markLocalProviderDraftChanged();
+    markLocalProviderImageGenerationDraftChanged();
   });
 
   byId("optImageGenerationSize").addEventListener("change", function() {
-    markLocalProviderDraftChanged();
+    markLocalProviderImageGenerationDraftChanged();
   });
 
   byId("optImageGenerationOutputFormat").addEventListener("change", function() {
-    markLocalProviderDraftChanged();
+    markLocalProviderImageGenerationDraftChanged();
   });
 
   byId("optImageGenerationOutputCompression").addEventListener("change", function() {
-    markLocalProviderDraftChanged();
+    markLocalProviderImageGenerationDraftChanged();
   });
 
   byId("optImageGenerationBackground").addEventListener("change", function() {
-    markLocalProviderDraftChanged();
+    markLocalProviderImageGenerationDraftChanged();
   });
 
   byId("optImageGenerationOutputDirectory").addEventListener("change", function() {
-    markLocalProviderDraftChanged();
+    markLocalProviderImageGenerationDraftChanged();
   });
 
   byId("optLocalBasicUsername").addEventListener("change", function() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -1421,9 +1421,7 @@
     var imageGenerationOutputCompression = (byId("optImageGenerationOutputCompression").value || "").trim();
     var imageGenerationBackground = (byId("optImageGenerationBackground").value || "").trim();
     var imageGenerationOutputDirectory = (byId("optImageGenerationOutputDirectory").value || "").trim();
-    var currentImageGenerationOverrideActive = local.imageGenerationOverrideActive === true;
-    var imageGenerationOverrideActive = currentImageGenerationOverrideActive
-      || imageGenerationEnabled !== (local.imageGenerationEnabled === true)
+    var imageGenerationOverrideActive = imageGenerationEnabled !== (local.imageGenerationEnabled === true)
       || imageGenerationQuality !== String(local.imageGenerationQuality || "").trim()
       || imageGenerationSize !== String(local.imageGenerationSize || "").trim()
       || imageGenerationOutputFormat !== String(local.imageGenerationOutputFormat || "").trim()

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/Ui/Shell.20.bindings.js
@@ -1542,6 +1542,7 @@
       textVerbosity: textVerbosity,
       temperature: temperature,
       imageGenerationEnabled: imageGenerationEnabled,
+      imageGenerationOverrideActive: true,
       imageGenerationQuality: imageGenerationQuality,
       imageGenerationSize: imageGenerationSize,
       imageGenerationOutputFormat: imageGenerationOutputFormat,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
@@ -597,6 +597,7 @@ internal static partial class Program {
             TextVerbosity = profile.TextVerbosity;
             Temperature = profile.Temperature;
             EnableImageGeneration = profile.EnableImageGeneration;
+            ImageGenerationEnabledOverride = profile.EnableImageGeneration;
             ImageGenerationQuality = profile.ImageGenerationQuality;
             ImageGenerationSize = profile.ImageGenerationSize;
             ImageGenerationOutputFormat = profile.ImageGenerationOutputFormat;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
@@ -39,6 +39,7 @@ internal static partial class Program {
         public TextVerbosity? TextVerbosity { get; set; }
         public double? Temperature { get; set; }
         public bool EnableImageGeneration { get; set; }
+        public bool? ImageGenerationEnabledOverride { get; set; }
         public string? ImageGenerationQuality { get; set; }
         public string? ImageGenerationSize { get; set; }
         public string? ImageGenerationOutputFormat { get; set; }
@@ -207,9 +208,11 @@ internal static partial class Program {
                         break;
                     case "--enable-image-generation":
                         options.EnableImageGeneration = true;
+                        options.ImageGenerationEnabledOverride = true;
                         break;
                     case "--disable-image-generation":
                         options.EnableImageGeneration = false;
+                        options.ImageGenerationEnabledOverride = false;
                         break;
                     case "--image-generation-quality":
                         if (!TryGetValue(args, ref i, out var imageQuality, out error)) {
@@ -677,6 +680,7 @@ internal static partial class Program {
                 TextVerbosity = TextVerbosity,
                 Temperature = Temperature,
                 EnableImageGeneration = EnableImageGeneration,
+                ImageGenerationEnabledOverride = ImageGenerationEnabledOverride,
                 ImageGenerationQuality = ImageGenerationQuality,
                 ImageGenerationSize = ImageGenerationSize,
                 ImageGenerationOutputFormat = ImageGenerationOutputFormat,
@@ -763,6 +767,7 @@ internal static partial class Program {
             TextVerbosity = source.TextVerbosity;
             Temperature = source.Temperature;
             EnableImageGeneration = source.EnableImageGeneration;
+            ImageGenerationEnabledOverride = source.ImageGenerationEnabledOverride;
             ImageGenerationQuality = source.ImageGenerationQuality;
             ImageGenerationSize = source.ImageGenerationSize;
             ImageGenerationOutputFormat = source.ImageGenerationOutputFormat;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
@@ -167,15 +167,7 @@ internal static partial class Program {
                 ReasoningSummary = _options.ReasoningSummary,
                 TextVerbosity = _options.TextVerbosity,
                 Temperature = _options.Temperature,
-                ImageGeneration = new ImageGenerationOptions {
-                    Enabled = _options.EnableImageGeneration,
-                    Quality = _options.ImageGenerationQuality,
-                    Size = _options.ImageGenerationSize,
-                    OutputFormat = _options.ImageGenerationOutputFormat,
-                    OutputCompression = _options.ImageGenerationOutputCompression,
-                    Background = _options.ImageGenerationBackground,
-                    OutputDirectory = _options.ImageGenerationOutputDirectory
-                },
+                ImageGeneration = BuildImageGenerationOptions(),
                 ParallelToolCalls = _options.ParallelToolCalls,
                 Tools = toolDefs.Count == 0 ? null : toolDefs,
                 ToolChoice = toolDefs.Count == 0 ? null : ToolChoice.Auto,
@@ -533,6 +525,22 @@ internal static partial class Program {
                 reportedCalls.Add(call);
                 reportedOutputs.Add(protocolOutputs[index]);
             }
+        }
+
+        private ImageGenerationOptions? BuildImageGenerationOptions() {
+            if (!_options.EnableImageGeneration) {
+                return null;
+            }
+
+            return new ImageGenerationOptions {
+                Enabled = true,
+                Quality = _options.ImageGenerationQuality,
+                Size = _options.ImageGenerationSize,
+                OutputFormat = _options.ImageGenerationOutputFormat,
+                OutputCompression = _options.ImageGenerationOutputCompression,
+                Background = _options.ImageGenerationBackground,
+                OutputDirectory = _options.ImageGenerationOutputDirectory
+            };
         }
 
         private bool ShouldSuppressReportedDuplicateReadOnlySignature(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
@@ -528,12 +528,12 @@ internal static partial class Program {
         }
 
         private ImageGenerationOptions? BuildImageGenerationOptions() {
-            if (!_options.EnableImageGeneration) {
+            if (!HasImageGenerationOptions()) {
                 return null;
             }
 
             return new ImageGenerationOptions {
-                Enabled = true,
+                Enabled = _options.ImageGenerationEnabledOverride ?? _options.EnableImageGeneration || HasImageGenerationSettingOverrides(),
                 Quality = _options.ImageGenerationQuality,
                 Size = _options.ImageGenerationSize,
                 OutputFormat = _options.ImageGenerationOutputFormat,
@@ -542,6 +542,19 @@ internal static partial class Program {
                 OutputDirectory = _options.ImageGenerationOutputDirectory
             };
         }
+
+        private bool HasImageGenerationOptions() =>
+            _options.ImageGenerationEnabledOverride.HasValue ||
+            _options.EnableImageGeneration ||
+            HasImageGenerationSettingOverrides();
+
+        private bool HasImageGenerationSettingOverrides() =>
+            !string.IsNullOrWhiteSpace(_options.ImageGenerationQuality) ||
+            !string.IsNullOrWhiteSpace(_options.ImageGenerationSize) ||
+            !string.IsNullOrWhiteSpace(_options.ImageGenerationOutputFormat) ||
+            _options.ImageGenerationOutputCompression.HasValue ||
+            !string.IsNullOrWhiteSpace(_options.ImageGenerationBackground) ||
+            !string.IsNullOrWhiteSpace(_options.ImageGenerationOutputDirectory);
 
         private bool ShouldSuppressReportedDuplicateReadOnlySignature(
             ToolCall call,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Session.cs
@@ -533,7 +533,9 @@ internal static partial class Program {
             }
 
             return new ImageGenerationOptions {
-                Enabled = _options.ImageGenerationEnabledOverride ?? _options.EnableImageGeneration || HasImageGenerationSettingOverrides(),
+                Enabled = _options.ImageGenerationEnabledOverride.HasValue
+                    ? _options.ImageGenerationEnabledOverride.Value
+                    : _options.EnableImageGeneration || HasImageGenerationSettingOverrides(),
                 Quality = _options.ImageGenerationQuality,
                 Size = _options.ImageGenerationSize,
                 OutputFormat = _options.ImageGenerationOutputFormat,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.cs
@@ -153,7 +153,9 @@ internal static partial class Program {
                 TransportKind = options.OpenAITransport,
                 DefaultModel = options.Model
             };
-            clientOptions.NativeOptions.ImageGeneration.Enabled = options.EnableImageGeneration;
+            if (options.ImageGenerationEnabledOverride.HasValue) {
+                clientOptions.NativeOptions.ImageGeneration.Enabled = options.ImageGenerationEnabledOverride.Value;
+            }
             clientOptions.NativeOptions.ImageGeneration.Quality = options.ImageGenerationQuality;
             clientOptions.NativeOptions.ImageGeneration.Size = options.ImageGenerationSize;
             clientOptions.NativeOptions.ImageGeneration.OutputFormat = options.ImageGenerationOutputFormat;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ModelResolution.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ModelResolution.cs
@@ -513,8 +513,7 @@ internal sealed partial class ChatServiceSession {
             OutputCompression = NormalizeImageGenerationOutputCompression(
                 requestOptions?.ImageGenerationOutputCompression ?? _options.ImageGenerationOutputCompression),
             Background = NormalizeOptional(requestOptions?.ImageGenerationBackground) ?? NormalizeOptional(_options.ImageGenerationBackground),
-            OutputDirectory = NormalizeOptional(requestOptions?.ImageGenerationOutputDirectory) ??
-                              NormalizeOptional(_options.ImageGenerationOutputDirectory)
+            OutputDirectory = NormalizeOptional(_options.ImageGenerationOutputDirectory)
         };
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
@@ -69,7 +69,10 @@ internal sealed partial class ChatServiceSession {
             var accountId = (_options.OpenAIAccountId ?? string.Empty).Trim();
             opts.NativeOptions.AuthAccountId = accountId.Length == 0 ? null : accountId;
             if (HasImageGenerationOverrides(_options)) {
-                opts.NativeOptions.ImageGeneration.Enabled = _options.EnableImageGeneration;
+                if (_options.ImageGenerationEnabledOverride.HasValue) {
+                    opts.NativeOptions.ImageGeneration.Enabled = _options.ImageGenerationEnabledOverride.Value;
+                }
+
                 opts.NativeOptions.ImageGeneration.Quality = _options.ImageGenerationQuality;
                 opts.NativeOptions.ImageGeneration.Size = _options.ImageGenerationSize;
                 opts.NativeOptions.ImageGeneration.OutputFormat = _options.ImageGenerationOutputFormat;
@@ -110,7 +113,7 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static bool HasImageGenerationOverrides(ServiceOptions options) =>
-        options.EnableImageGeneration ||
+        options.ImageGenerationEnabledOverride.HasValue ||
         !string.IsNullOrWhiteSpace(options.ImageGenerationQuality) ||
         !string.IsNullOrWhiteSpace(options.ImageGenerationSize) ||
         !string.IsNullOrWhiteSpace(options.ImageGenerationOutputFormat) ||
@@ -547,6 +550,7 @@ internal sealed partial class ChatServiceSession {
 
             if (request.ImageGenerationEnabled.HasValue) {
                 _options.EnableImageGeneration = request.ImageGenerationEnabled.Value;
+                _options.ImageGenerationEnabledOverride = request.ImageGenerationEnabled.Value;
             }
             if (request.ImageGenerationQuality is not null) {
                 _options.ImageGenerationQuality = NormalizeRuntimeOptionalValue(request.ImageGenerationQuality);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
@@ -68,13 +68,15 @@ internal sealed partial class ChatServiceSession {
         if (opts.TransportKind == OpenAITransportKind.Native) {
             var accountId = (_options.OpenAIAccountId ?? string.Empty).Trim();
             opts.NativeOptions.AuthAccountId = accountId.Length == 0 ? null : accountId;
-            opts.NativeOptions.ImageGeneration.Enabled = _options.EnableImageGeneration;
-            opts.NativeOptions.ImageGeneration.Quality = _options.ImageGenerationQuality;
-            opts.NativeOptions.ImageGeneration.Size = _options.ImageGenerationSize;
-            opts.NativeOptions.ImageGeneration.OutputFormat = _options.ImageGenerationOutputFormat;
-            opts.NativeOptions.ImageGeneration.OutputCompression = _options.ImageGenerationOutputCompression;
-            opts.NativeOptions.ImageGeneration.Background = _options.ImageGenerationBackground;
-            opts.NativeOptions.ImageGeneration.OutputDirectory = _options.ImageGenerationOutputDirectory;
+            if (HasImageGenerationOverrides(_options)) {
+                opts.NativeOptions.ImageGeneration.Enabled = _options.EnableImageGeneration;
+                opts.NativeOptions.ImageGeneration.Quality = _options.ImageGenerationQuality;
+                opts.NativeOptions.ImageGeneration.Size = _options.ImageGenerationSize;
+                opts.NativeOptions.ImageGeneration.OutputFormat = _options.ImageGenerationOutputFormat;
+                opts.NativeOptions.ImageGeneration.OutputCompression = _options.ImageGenerationOutputCompression;
+                opts.NativeOptions.ImageGeneration.Background = _options.ImageGenerationBackground;
+                opts.NativeOptions.ImageGeneration.OutputDirectory = _options.ImageGenerationOutputDirectory;
+            }
         }
 
         if (opts.TransportKind == OpenAITransportKind.CompatibleHttp) {
@@ -106,6 +108,15 @@ internal sealed partial class ChatServiceSession {
         opts.Validate();
         return await IntelligenceXClient.ConnectAsync(opts, cancellationToken).ConfigureAwait(false);
     }
+
+    private static bool HasImageGenerationOverrides(ServiceOptions options) =>
+        options.EnableImageGeneration ||
+        !string.IsNullOrWhiteSpace(options.ImageGenerationQuality) ||
+        !string.IsNullOrWhiteSpace(options.ImageGenerationSize) ||
+        !string.IsNullOrWhiteSpace(options.ImageGenerationOutputFormat) ||
+        options.ImageGenerationOutputCompression.HasValue ||
+        !string.IsNullOrWhiteSpace(options.ImageGenerationBackground) ||
+        !string.IsNullOrWhiteSpace(options.ImageGenerationOutputDirectory);
 
     private string ResolveStateDbPath() {
         return string.IsNullOrWhiteSpace(_options.StateDbPath)

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.Profiles.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.Profiles.cs
@@ -36,6 +36,7 @@ internal sealed partial class ServiceOptions : IToolRuntimePolicySettings, ITool
         TextVerbosity = profile.TextVerbosity;
         Temperature = profile.Temperature;
         EnableImageGeneration = profile.EnableImageGeneration;
+        ImageGenerationEnabledOverride = profile.EnableImageGeneration;
         ImageGenerationQuality = profile.ImageGenerationQuality;
         ImageGenerationSize = profile.ImageGenerationSize;
         ImageGenerationOutputFormat = profile.ImageGenerationOutputFormat;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -49,6 +49,7 @@ internal sealed partial class ServiceOptions : IToolRuntimePolicySettings, ITool
     public TextVerbosity? TextVerbosity { get; set; }
     public double? Temperature { get; set; }
     public bool EnableImageGeneration { get; set; }
+    public bool? ImageGenerationEnabledOverride { get; set; }
     public string? ImageGenerationQuality { get; set; }
     public string? ImageGenerationSize { get; set; }
     public string? ImageGenerationOutputFormat { get; set; }
@@ -246,10 +247,12 @@ internal sealed partial class ServiceOptions : IToolRuntimePolicySettings, ITool
             }
             if (arg is "--enable-image-generation") {
                 options.EnableImageGeneration = true;
+                options.ImageGenerationEnabledOverride = true;
                 continue;
             }
             if (arg is "--disable-image-generation") {
                 options.EnableImageGeneration = false;
+                options.ImageGenerationEnabledOverride = false;
                 continue;
             }
             if (arg is "--image-generation-quality") {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatFallbackArchitectureGuardrailTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatFallbackArchitectureGuardrailTests.cs
@@ -139,6 +139,24 @@ public sealed class ChatFallbackArchitectureGuardrailTests {
     }
 
     [Fact]
+    public void ChatHost_ImageGenerationOptionsHonorsExplicitEnabledOverrideFirst() {
+        var source = File.ReadAllText(GetHostSourceFilePath("Program.Session.cs"));
+
+        Assert.Contains(
+            "Enabled = _options.ImageGenerationEnabledOverride.HasValue",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "? _options.ImageGenerationEnabledOverride.Value",
+            source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Enabled = _options.ImageGenerationEnabledOverride ?? _options.EnableImageGeneration || HasImageGenerationSettingOverrides()",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ToolingDiscovery_ShouldNotContainHardcodedBuiltInAssemblyAllowlistNames() {
         var source = File.ReadAllText(GetToolingSourceFilePath("ToolPackBootstrap.RegistryAndReflection.cs"));
         var disallowedAssemblyNames = new[] {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostOptionsProfileBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/HostOptionsProfileBootstrapTests.cs
@@ -83,6 +83,27 @@ public sealed class HostOptionsProfileBootstrapTests {
     }
 
     [Fact]
+    public void ApplyProfile_ReplacesImageGenerationRuntimeOverrideWithProfileValue() {
+        var options = CreateHostOptionsInstance();
+        Assert.NotNull(options);
+
+        var replOptionsType = options!.GetType();
+        var applyProfile = replOptionsType.GetMethod("ApplyProfile", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(applyProfile);
+
+        SetBoolProperty(options, "EnableImageGeneration", true);
+        SetNullableBoolProperty(options, "ImageGenerationEnabledOverride", true);
+
+        var profile = new ServiceProfile {
+            EnableImageGeneration = false
+        };
+
+        applyProfile!.Invoke(options, new object?[] { profile });
+        Assert.False(ReadBoolProperty(options, "EnableImageGeneration"));
+        Assert.False(ReadNullableBoolProperty(options, "ImageGenerationEnabledOverride") ?? true);
+    }
+
+    [Fact]
     public void ApplyProfile_PropagatesExplicitRoutingMetadataRequirement() {
         var options = CreateHostOptionsInstance();
         Assert.NotNull(options);
@@ -465,6 +486,25 @@ public sealed class HostOptionsProfileBootstrapTests {
         var value = property!.GetValue(instance);
         Assert.IsType<bool>(value);
         return (bool)value!;
+    }
+
+    private static bool? ReadNullableBoolProperty(object instance, string propertyName) {
+        var property = instance.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(property);
+        var value = property!.GetValue(instance);
+        return value is null ? null : Assert.IsType<bool>(value);
+    }
+
+    private static void SetBoolProperty(object instance, string propertyName, bool value) {
+        var property = instance.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(property);
+        property!.SetValue(instance, value);
+    }
+
+    private static void SetNullableBoolProperty(object instance, string propertyName, bool? value) {
+        var property = instance.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(property);
+        property!.SetValue(instance, value);
     }
 
     private static int ReadIntProperty(object instance, string propertyName) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ServiceOptionsProfileBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ServiceOptionsProfileBootstrapTests.cs
@@ -182,6 +182,24 @@ public sealed partial class ServiceOptionsProfileBootstrapTests {
     }
 
     [Fact]
+    public void ApplyProfile_ReplacesImageGenerationRuntimeOverrideWithProfileValue() {
+        var options = new ServiceOptions {
+            EnableImageGeneration = true,
+            ImageGenerationEnabledOverride = true
+        };
+        var profile = new ServiceProfile {
+            EnableImageGeneration = false
+        };
+
+        var method = typeof(ServiceOptions).GetMethod("ApplyProfile", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(options, new object[] { profile });
+
+        Assert.False(options.EnableImageGeneration);
+        Assert.False(options.ImageGenerationEnabledOverride ?? true);
+    }
+
+    [Fact]
     public void ToProfile_ClampsExecutionLaneValuesToParserBounds() {
         var options = new ServiceOptions {
             SessionExecutionQueueLimit = 99_999,

--- a/IntelligenceX.Cli/Templates/release-notes.yml
+++ b/IntelligenceX.Cli/Templates/release-notes.yml
@@ -82,7 +82,7 @@ jobs:
           INTELLIGENCEX_RELEASE_PR_BODY: ${{ inputs.pr_body }}
           INTELLIGENCEX_RELEASE_PR_LABELS: ${{ inputs.pr_labels }}
           INTELLIGENCEX_RELEASE_REPO_SLUG: ${{ inputs.repo_slug || github.repository }}
-          OPENAI_MODEL: gpt-5.4
+          OPENAI_MODEL: gpt-5.5
           OPENAI_TRANSPORT: native
         shell: bash
         run: |

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -513,6 +513,58 @@ internal static partial class Program {
         AssertEqual(0.01m, merged[0].CostUsd ?? 0m, "cached startup merge newer-first preserves cost metadata");
     }
 
+    private static void TestUsageTelemetryCachedStartupMergePreservesNewestDuplicateRollupTimestamp() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("raw-1", "codex", "codex.logs", "src-1", cachedScannedAt.AddMinutes(10)) {
+                InputTokens = 120,
+                OutputTokens = 40,
+                TotalTokens = 160,
+                CompactCount = 2
+            }
+        };
+        var rawRollup = UsageTelemetryQuickReportScanner.BuildMergedEventsFromRawRecords(rawRecords)[0];
+        var staleRollup = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", cachedScannedAt) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 100,
+            OutputTokens = 30,
+            TotalTokens = 130,
+            CompactCount = 1
+        };
+        var refreshedRollup = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", cachedScannedAt.AddMinutes(10)) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 120,
+            OutputTokens = 40,
+            TotalTokens = 160,
+            CompactCount = 2
+        };
+        var middleDuplicate = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", cachedScannedAt.AddMinutes(5)) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 100,
+            OutputTokens = 30,
+            TotalTokens = 130,
+            CompactCount = 1
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { staleRollup, refreshedRollup, middleDuplicate },
+            serviceEvents: Array.Empty<UsageEventRecord>(),
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        AssertEqual(1, merged.Count, "cached startup merge newest duplicate timestamp count");
+        AssertEqual(120L, merged[0].InputTokens ?? 0L, "cached startup merge newest duplicate timestamp input");
+        AssertEqual(160L, merged[0].TotalTokens ?? 0L, "cached startup merge newest duplicate timestamp total");
+        AssertEqual(rawRollup.TimestampUtc, merged[0].TimestampUtc, "cached startup merge newest duplicate timestamp");
+    }
+
     private static void TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata() {
         var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
         var serviceScannedAt = cachedScannedAt.AddMinutes(5);

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -277,6 +277,120 @@ internal static partial class Program {
         AssertEqual(0.05m, merged[0].CostUsd ?? 0m, "cached startup merge keeps fallback cost when raw rollup has none");
     }
 
+    private static void TestUsageTelemetryCachedStartupMergeDeduplicatesEquivalentRollupsWithMetadata() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("raw-1", "codex", "codex.logs", "src-1", cachedScannedAt) {
+                InputTokens = 100,
+                OutputTokens = 40,
+                TotalTokens = 140
+            }
+        };
+        var rawRollup = UsageTelemetryQuickReportScanner.BuildMergedEventsFromRawRecords(rawRecords)[0];
+        var fallbackRollup = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", rawRollup.TimestampUtc) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = rawRollup.InputTokens,
+            OutputTokens = rawRollup.OutputTokens,
+            TotalTokens = rawRollup.TotalTokens,
+            DurationMs = 250,
+            CostUsd = 0.02m
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { fallbackRollup },
+            serviceEvents: Array.Empty<UsageEventRecord>(),
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        AssertEqual(1, merged.Count, "cached startup merge metadata duplicate rollup count");
+        AssertEqual(100L, merged[0].InputTokens ?? 0L, "cached startup merge avoids duplicate input tokens");
+        AssertEqual(140L, merged[0].TotalTokens ?? 0L, "cached startup merge avoids duplicate total tokens");
+        AssertEqual(250L, merged[0].DurationMs ?? 0L, "cached startup merge preserves duplicate duration metadata");
+        AssertEqual(0.02m, merged[0].CostUsd ?? 0m, "cached startup merge preserves duplicate cost metadata");
+    }
+
+    private static void TestUsageTelemetryCachedStartupMergeDeduplicatesOriginalContributionAfterAggregateChanges() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("raw-1", "codex", "codex.logs", "src-1", cachedScannedAt) {
+                InputTokens = 50,
+                TotalTokens = 50
+            }
+        };
+        var rawRollup = UsageTelemetryQuickReportScanner.BuildMergedEventsFromRawRecords(rawRecords)[0];
+        var firstContribution = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", rawRollup.TimestampUtc) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 50,
+            TotalTokens = 50
+        };
+        var secondContribution = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", rawRollup.TimestampUtc.AddMinutes(1)) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 25,
+            TotalTokens = 25
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { firstContribution, secondContribution },
+            serviceEvents: Array.Empty<UsageEventRecord>(),
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        AssertEqual(1, merged.Count, "cached startup merge duplicate after aggregate count");
+        AssertEqual(75L, merged[0].InputTokens ?? 0L, "cached startup merge deduplicates against original contribution");
+        AssertEqual(75L, merged[0].TotalTokens ?? 0L, "cached startup merge keeps distinct contribution total once");
+    }
+
+    private static void TestUsageTelemetryCachedStartupMergeKeepsDominatingUpdatedRollup() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("raw-1", "codex", "codex.logs", "src-1", cachedScannedAt) {
+                InputTokens = 120,
+                CachedInputTokens = 20,
+                OutputTokens = 40,
+                TotalTokens = 160,
+                CompactCount = 2
+            }
+        };
+        var rawRollup = UsageTelemetryQuickReportScanner.BuildMergedEventsFromRawRecords(rawRecords)[0];
+        var staleRollup = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", rawRollup.TimestampUtc) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 100,
+            CachedInputTokens = 10,
+            OutputTokens = 30,
+            TotalTokens = 130,
+            CompactCount = 1,
+            CostUsd = 0.01m
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { staleRollup },
+            serviceEvents: Array.Empty<UsageEventRecord>(),
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        AssertEqual(1, merged.Count, "cached startup merge updated rollup count");
+        AssertEqual(120L, merged[0].InputTokens ?? 0L, "cached startup merge keeps dominating input tokens");
+        AssertEqual(160L, merged[0].TotalTokens ?? 0L, "cached startup merge keeps dominating total tokens");
+        AssertEqual(2, merged[0].CompactCount ?? 0, "cached startup merge keeps dominating compact count");
+        AssertEqual(0.01m, merged[0].CostUsd ?? 0m, "cached startup merge preserves updated rollup cost metadata");
+    }
+
     private static void TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata() {
         var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
         var serviceScannedAt = cachedScannedAt.AddMinutes(5);

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -277,6 +277,52 @@ internal static partial class Program {
         AssertEqual(0.05m, merged[0].CostUsd ?? 0m, "cached startup merge keeps fallback cost when raw rollup has none");
     }
 
+    private static void TestUsageTelemetryCachedStartupMergeSumsDistinctRollupCosts() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("raw-1", "codex", "codex.logs", "src-1", cachedScannedAt) {
+                InputTokens = 100,
+                OutputTokens = 40,
+                TotalTokens = 140,
+                CompactCount = 1
+            }
+        };
+        var rawRollup = UsageTelemetryQuickReportScanner.BuildMergedEventsFromRawRecords(rawRecords)[0];
+        var firstContribution = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", cachedScannedAt) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 50,
+            OutputTokens = 20,
+            TotalTokens = 70,
+            CompactCount = 1,
+            CostUsd = 0.05m
+        };
+        var secondContribution = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", cachedScannedAt.AddMinutes(1)) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 25,
+            OutputTokens = 10,
+            TotalTokens = 35,
+            CompactCount = 1,
+            CostUsd = 0.02m
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { firstContribution, secondContribution },
+            serviceEvents: Array.Empty<UsageEventRecord>(),
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        AssertEqual(1, merged.Count, "cached startup merge distinct rollup cost count");
+        AssertEqual(125L, merged[0].InputTokens ?? 0L, "cached startup merge distinct cost input");
+        AssertEqual(175L, merged[0].TotalTokens ?? 0L, "cached startup merge distinct cost total");
+        AssertEqual(0.07m, merged[0].CostUsd ?? 0m, "cached startup merge sums distinct rollup costs");
+    }
+
     private static void TestUsageTelemetryCachedStartupMergeDeduplicatesEquivalentRollupsWithMetadata() {
         var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
         var serviceScannedAt = cachedScannedAt.AddMinutes(5);

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -391,6 +391,44 @@ internal static partial class Program {
         AssertEqual(0.01m, merged[0].CostUsd ?? 0m, "cached startup merge preserves updated rollup cost metadata");
     }
 
+    private static void TestUsageTelemetryCachedStartupMergeDeduplicatesRefreshedRollupTimestamp() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("raw-1", "codex", "codex.logs", "src-1", cachedScannedAt.AddMinutes(10)) {
+                InputTokens = 120,
+                OutputTokens = 40,
+                TotalTokens = 160,
+                CompactCount = 2
+            }
+        };
+        var rawRollup = UsageTelemetryQuickReportScanner.BuildMergedEventsFromRawRecords(rawRecords)[0];
+        var staleRollup = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", cachedScannedAt) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 100,
+            OutputTokens = 30,
+            TotalTokens = 130,
+            CompactCount = 1,
+            CostUsd = 0.01m
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { staleRollup },
+            serviceEvents: Array.Empty<UsageEventRecord>(),
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        AssertEqual(1, merged.Count, "cached startup merge refreshed timestamp rollup count");
+        AssertEqual(120L, merged[0].InputTokens ?? 0L, "cached startup merge refreshed timestamp keeps dominating input");
+        AssertEqual(160L, merged[0].TotalTokens ?? 0L, "cached startup merge refreshed timestamp avoids double counting total");
+        AssertEqual(2, merged[0].CompactCount ?? 0, "cached startup merge refreshed timestamp keeps dominating compact count");
+        AssertEqual(0.01m, merged[0].CostUsd ?? 0m, "cached startup merge refreshed timestamp preserves cost metadata");
+    }
+
     private static void TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata() {
         var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
         var serviceScannedAt = cachedScannedAt.AddMinutes(5);

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -429,6 +429,44 @@ internal static partial class Program {
         AssertEqual(0.01m, merged[0].CostUsd ?? 0m, "cached startup merge refreshed timestamp preserves cost metadata");
     }
 
+    private static void TestUsageTelemetryCachedStartupMergeDeduplicatesRefreshedRollupWhenNewerSeenFirst() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("raw-1", "codex", "codex.logs", "src-1", cachedScannedAt) {
+                InputTokens = 100,
+                OutputTokens = 30,
+                TotalTokens = 130,
+                CompactCount = 1
+            }
+        };
+        var rawRollup = UsageTelemetryQuickReportScanner.BuildMergedEventsFromRawRecords(rawRecords)[0];
+        var refreshedRollup = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", cachedScannedAt.AddMinutes(10)) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 120,
+            OutputTokens = 40,
+            TotalTokens = 160,
+            CompactCount = 2,
+            CostUsd = 0.01m
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { refreshedRollup },
+            serviceEvents: Array.Empty<UsageEventRecord>(),
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        AssertEqual(1, merged.Count, "cached startup merge newer-first refreshed rollup count");
+        AssertEqual(120L, merged[0].InputTokens ?? 0L, "cached startup merge newer-first keeps dominating input");
+        AssertEqual(160L, merged[0].TotalTokens ?? 0L, "cached startup merge newer-first avoids double counting total");
+        AssertEqual(2, merged[0].CompactCount ?? 0, "cached startup merge newer-first keeps dominating compact count");
+        AssertEqual(0.01m, merged[0].CostUsd ?? 0m, "cached startup merge newer-first preserves cost metadata");
+    }
+
     private static void TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata() {
         var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
         var serviceScannedAt = cachedScannedAt.AddMinutes(5);

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -699,6 +699,109 @@ internal static partial class Program {
         AssertEqual(serviceScannedAt, main.TimestampUtc, "cached startup merge older dominating fallback newest timestamp");
     }
 
+    private static void TestUsageTelemetryCachedStartupMergePreservesDuplicateMetadataAndTruth() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("other-raw", "codex", "codex.logs", "src-2", cachedScannedAt.AddMinutes(10)) {
+                InputTokens = 10,
+                TotalTokens = 10
+            }
+        };
+        var cachedRollup = new UsageEventRecord("rollup-main", "codex", "codex.logs", "src-1", cachedScannedAt) {
+            ProviderAccountId = "acc-work",
+            AccountLabel = "work",
+            SessionId = "session-a",
+            ConversationTitle = "Daily usage",
+            WorkspacePath = @"C:\Support\GitHub\IntelligenceX",
+            RepositoryName = "IntelligenceX",
+            Model = "gpt-5.5",
+            Surface = "cli",
+            InputTokens = 120,
+            OutputTokens = 40,
+            TotalTokens = 160,
+            CompactCount = 1,
+            TruthLevel = UsageTruthLevel.Exact
+        };
+        var serviceRollup = new UsageEventRecord("rollup-main", "codex", "codex.logs", "src-1", serviceScannedAt) {
+            Model = "gpt-5.5",
+            Surface = "cli",
+            InputTokens = 120,
+            OutputTokens = 40,
+            TotalTokens = 160,
+            CompactCount = 1,
+            TruthLevel = UsageTruthLevel.Estimated
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { cachedRollup },
+            serviceEvents: new[] { serviceRollup },
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        var main = merged.FirstOrDefault(static item => string.Equals(item.EventId, "rollup-main", StringComparison.OrdinalIgnoreCase));
+        AssertNotNull(main, "cached startup merge duplicate metadata rollup exists");
+        AssertEqual(2, merged.Count, "cached startup merge duplicate metadata count");
+        AssertEqual(serviceScannedAt, main!.TimestampUtc, "cached startup merge duplicate metadata newest timestamp");
+        AssertEqual("acc-work", main.ProviderAccountId, "cached startup merge duplicate metadata provider account");
+        AssertEqual("work", main.AccountLabel, "cached startup merge duplicate metadata account label");
+        AssertEqual("session-a", main.SessionId, "cached startup merge duplicate metadata session");
+        AssertEqual("Daily usage", main.ConversationTitle, "cached startup merge duplicate metadata conversation");
+        AssertEqual(@"C:\Support\GitHub\IntelligenceX", main.WorkspacePath, "cached startup merge duplicate metadata workspace");
+        AssertEqual("IntelligenceX", main.RepositoryName, "cached startup merge duplicate metadata repository");
+        AssertEqual(UsageTruthLevel.Exact, main.TruthLevel, "cached startup merge duplicate metadata truth");
+    }
+
+    private static void TestUsageTelemetryCachedStartupMergeDeduplicatesEqualCompactOlderDominatingFallbackRollup() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("other-raw", "codex", "codex.logs", "src-2", cachedScannedAt.AddMinutes(10)) {
+                InputTokens = 10,
+                TotalTokens = 10
+            }
+        };
+        var cachedRollup = new UsageEventRecord("rollup-main", "codex", "codex.logs", "src-1", cachedScannedAt) {
+            Model = "gpt-5.5",
+            Surface = "cli",
+            InputTokens = 120,
+            OutputTokens = 40,
+            TotalTokens = 160,
+            CompactCount = 1,
+            CostUsd = 0.04m
+        };
+        var serviceRollup = new UsageEventRecord("rollup-main", "codex", "codex.logs", "src-1", serviceScannedAt) {
+            Model = "gpt-5.5",
+            Surface = "cli",
+            InputTokens = 100,
+            OutputTokens = 30,
+            TotalTokens = 130,
+            CompactCount = 1,
+            CostUsd = 0.02m
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { cachedRollup },
+            serviceEvents: new[] { serviceRollup },
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        var main = merged.FirstOrDefault(static item => string.Equals(item.EventId, "rollup-main", StringComparison.OrdinalIgnoreCase));
+        AssertNotNull(main, "cached startup merge equal compact older dominating fallback rollup exists");
+        AssertEqual(2, merged.Count, "cached startup merge equal compact older dominating fallback rollup count");
+        AssertEqual(120L, main!.InputTokens ?? 0L, "cached startup merge equal compact older dominating fallback input");
+        AssertEqual(160L, main.TotalTokens ?? 0L, "cached startup merge equal compact older dominating fallback total");
+        AssertEqual(1, main.CompactCount ?? 0, "cached startup merge equal compact older dominating fallback compact count");
+        AssertEqual(0.04m, main.CostUsd ?? 0m, "cached startup merge equal compact older dominating fallback cost");
+        AssertEqual(serviceScannedAt, main.TimestampUtc, "cached startup merge equal compact older dominating fallback newest timestamp");
+    }
+
     private static void TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata() {
         var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
         var serviceScannedAt = cachedScannedAt.AddMinutes(5);

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -605,6 +605,100 @@ internal static partial class Program {
         AssertEqual(rawRollup.TimestampUtc, merged[0].TimestampUtc, "cached startup merge older dominating preserves newest timestamp");
     }
 
+    private static void TestUsageTelemetryCachedStartupMergeDeduplicatesAllPrimaryMatches() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("raw-1", "codex", "codex.logs", "src-1", cachedScannedAt.AddMinutes(10)) {
+                InputTokens = 100,
+                OutputTokens = 40,
+                TotalTokens = 140,
+                CompactCount = 1,
+                CostUsd = 0.04m
+            }
+        };
+        var rawRollup = UsageTelemetryQuickReportScanner.BuildMergedEventsFromRawRecords(rawRecords)[0];
+        var firstDuplicate = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", cachedScannedAt) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 80,
+            OutputTokens = 30,
+            TotalTokens = 110,
+            CompactCount = 1,
+            CostUsd = 0.02m
+        };
+        var secondDuplicate = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", cachedScannedAt.AddMinutes(1)) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 60,
+            OutputTokens = 20,
+            TotalTokens = 80,
+            CompactCount = 1,
+            CostUsd = 0.03m
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { firstDuplicate },
+            serviceEvents: new[] { secondDuplicate },
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        AssertEqual(1, merged.Count, "cached startup merge all primary duplicate matches count");
+        AssertEqual(100L, merged[0].InputTokens ?? 0L, "cached startup merge all primary duplicate matches input");
+        AssertEqual(140L, merged[0].TotalTokens ?? 0L, "cached startup merge all primary duplicate matches total");
+        AssertEqual(0.03m, merged[0].CostUsd ?? 0m, "cached startup merge all primary duplicate matches cost");
+    }
+
+    private static void TestUsageTelemetryCachedStartupMergeDeduplicatesOlderDominatingFallbackRollup() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("other-raw", "codex", "codex.logs", "src-2", cachedScannedAt.AddMinutes(10)) {
+                InputTokens = 10,
+                TotalTokens = 10
+            }
+        };
+        var cachedRollup = new UsageEventRecord("rollup-main", "codex", "codex.logs", "src-1", cachedScannedAt) {
+            Model = "gpt-5.5",
+            Surface = "cli",
+            InputTokens = 120,
+            OutputTokens = 40,
+            TotalTokens = 160,
+            CompactCount = 2,
+            CostUsd = 0.04m
+        };
+        var serviceRollup = new UsageEventRecord("rollup-main", "codex", "codex.logs", "src-1", serviceScannedAt) {
+            Model = "gpt-5.5",
+            Surface = "cli",
+            InputTokens = 100,
+            OutputTokens = 30,
+            TotalTokens = 130,
+            CompactCount = 1,
+            CostUsd = 0.02m
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { cachedRollup },
+            serviceEvents: new[] { serviceRollup },
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        var main = merged.FirstOrDefault(static item => string.Equals(item.EventId, "rollup-main", StringComparison.OrdinalIgnoreCase));
+        AssertNotNull(main, "cached startup merge older dominating fallback rollup exists");
+        AssertEqual(2, merged.Count, "cached startup merge older dominating fallback rollup count");
+        AssertEqual(120L, main!.InputTokens ?? 0L, "cached startup merge older dominating fallback input");
+        AssertEqual(160L, main.TotalTokens ?? 0L, "cached startup merge older dominating fallback total");
+        AssertEqual(2, main.CompactCount ?? 0, "cached startup merge older dominating fallback compact count");
+        AssertEqual(0.04m, main.CostUsd ?? 0m, "cached startup merge older dominating fallback cost");
+        AssertEqual(serviceScannedAt, main.TimestampUtc, "cached startup merge older dominating fallback newest timestamp");
+    }
+
     private static void TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata() {
         var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
         var serviceScannedAt = cachedScannedAt.AddMinutes(5);

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -236,6 +236,47 @@ internal static partial class Program {
         AssertEqual(300L, merged.Sum(static item => item.TotalTokens ?? 0L), "cached startup merge preserves partial raw and full fallback totals");
     }
 
+    private static void TestUsageTelemetryCachedStartupMergeSumsOverlappingRollups() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("raw-1", "codex", "codex.logs", "src-1", cachedScannedAt) {
+                InputTokens = 100,
+                CachedInputTokens = 25,
+                OutputTokens = 40,
+                TotalTokens = 140,
+                CompactCount = 1,
+                CostUsd = 0.10m
+            }
+        };
+        var rawRollup = UsageTelemetryQuickReportScanner.BuildMergedEventsFromRawRecords(rawRecords)[0];
+        var fallbackRollup = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", cachedScannedAt) {
+            InputTokens = 50,
+            CachedInputTokens = 10,
+            OutputTokens = 20,
+            TotalTokens = 70,
+            CompactCount = 2,
+            CostUsd = 0.05m
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { fallbackRollup },
+            serviceEvents: Array.Empty<UsageEventRecord>(),
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        AssertEqual(1, merged.Count, "cached startup merge overlapping rollup count");
+        AssertEqual(150L, merged[0].InputTokens ?? 0L, "cached startup merge sums input tokens");
+        AssertEqual(35L, merged[0].CachedInputTokens ?? 0L, "cached startup merge sums cached input tokens");
+        AssertEqual(60L, merged[0].OutputTokens ?? 0L, "cached startup merge sums output tokens");
+        AssertEqual(210L, merged[0].TotalTokens ?? 0L, "cached startup merge sums total tokens");
+        AssertEqual(3, merged[0].CompactCount ?? 0, "cached startup merge sums compact count");
+        AssertEqual(0.05m, merged[0].CostUsd ?? 0m, "cached startup merge keeps fallback cost when raw rollup has none");
+    }
+
     private static void TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata() {
         var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
         var serviceScannedAt = cachedScannedAt.AddMinutes(5);

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -565,6 +565,46 @@ internal static partial class Program {
         AssertEqual(rawRollup.TimestampUtc, merged[0].TimestampUtc, "cached startup merge newest duplicate timestamp");
     }
 
+    private static void TestUsageTelemetryCachedStartupMergeDeduplicatesOlderDominatingRollup() {
+        var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
+        var serviceScannedAt = cachedScannedAt.AddMinutes(5);
+        var rawRecords = new[] {
+            new UsageEventRecord("raw-1", "codex", "codex.logs", "src-1", cachedScannedAt.AddMinutes(10)) {
+                InputTokens = 100,
+                OutputTokens = 30,
+                TotalTokens = 130,
+                CompactCount = 1,
+                CostUsd = 0.02m
+            }
+        };
+        var rawRollup = UsageTelemetryQuickReportScanner.BuildMergedEventsFromRawRecords(rawRecords)[0];
+        var olderDominatingRollup = new UsageEventRecord(rawRollup.EventId, "codex", "codex.logs", "src-1", cachedScannedAt) {
+            Model = rawRollup.Model,
+            Surface = rawRollup.Surface,
+            InputTokens = 120,
+            OutputTokens = 40,
+            TotalTokens = 160,
+            CompactCount = 2,
+            CostUsd = 0.04m
+        };
+
+        var merged = UsageTelemetryCachedSnapshotMerge.SelectStartupEvents(
+            cachedEvents: new[] { olderDominatingRollup },
+            serviceEvents: Array.Empty<UsageEventRecord>(),
+            mergedRawEvents: rawRecords,
+            hasCachedRawEvents: true,
+            hasServiceRawEvents: true,
+            cachedScannedAt,
+            serviceScannedAt);
+
+        AssertEqual(1, merged.Count, "cached startup merge older dominating rollup count");
+        AssertEqual(120L, merged[0].InputTokens ?? 0L, "cached startup merge older dominating input");
+        AssertEqual(160L, merged[0].TotalTokens ?? 0L, "cached startup merge older dominating total");
+        AssertEqual(2, merged[0].CompactCount ?? 0, "cached startup merge older dominating compact count");
+        AssertEqual(0.04m, merged[0].CostUsd ?? 0m, "cached startup merge older dominating cost avoids double count");
+        AssertEqual(rawRollup.TimestampUtc, merged[0].TimestampUtc, "cached startup merge older dominating preserves newest timestamp");
+    }
+
     private static void TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata() {
         var cachedScannedAt = new DateTimeOffset(2026, 03, 10, 9, 0, 0, TimeSpan.Zero);
         var serviceScannedAt = cachedScannedAt.AddMinutes(5);

--- a/IntelligenceX.Tests/Program.Treatment.cs
+++ b/IntelligenceX.Tests/Program.Treatment.cs
@@ -83,6 +83,40 @@ internal static partial class Program {
         }
     }
 
+    private static void TestTreatmentPromptBuilderPrefersWorkspaceForLocalArtifacts() {
+        var workspace = Path.Combine(Path.GetTempPath(), "ix-treatment-workspace-" + Guid.NewGuid().ToString("N"));
+        var workingDirectory = Path.Combine(Path.GetTempPath(), "ix-treatment-working-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspace);
+        Directory.CreateDirectory(workingDirectory);
+        try {
+            File.WriteAllText(Path.Combine(workspace, "evidence.md"), "workspace evidence");
+            File.WriteAllText(Path.Combine(workingDirectory, "evidence.md"), "working-directory evidence");
+            var request = new TreatmentRequest {
+                Prompt = "Read the evidence.",
+                Workspace = workspace,
+                WorkingDirectory = workingDirectory,
+                Inputs = new[] {
+                    new TreatmentInputArtifact {
+                        Id = "evidence",
+                        MediaType = "text/markdown",
+                        Path = "evidence.md"
+                    }
+                }
+            };
+
+            var prompt = TreatmentPromptBuilder.Build(request);
+
+            AssertContainsText(prompt, "resolvedPath: evidence.md", "workspace artifact relative path");
+            AssertContainsText(prompt, "workspace evidence", "workspace artifact content");
+            AssertDoesNotContainText(prompt, "working-directory evidence", "working directory artifact ignored when workspace exists");
+            AssertDoesNotContainText(prompt, workspace, "workspace prompt omits absolute path");
+            AssertDoesNotContainText(prompt, workingDirectory, "workspace prompt omits working directory path");
+        } finally {
+            Directory.Delete(workspace, recursive: true);
+            Directory.Delete(workingDirectory, recursive: true);
+        }
+    }
+
     private static void TestTreatmentPromptBuilderHonorsInlineLocalFileLimit() {
         var directory = Path.Combine(Path.GetTempPath(), "ix-treatment-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
@@ -327,6 +361,34 @@ internal static partial class Program {
         } finally {
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    private static void TestOpenAIChatTreatmentProviderHandlesRelativeImageUris() {
+        var client = new FakeTreatmentChatClient(new TreatmentChatResponse(
+            "turn-relative-image-uri",
+            "completed",
+            new[] {
+                new TreatmentChatOutput("out-1", "text", "ok")
+            }));
+        var provider = new OpenAIChatTreatmentProvider(client);
+        var request = new TreatmentRequest {
+            Prompt = "Use the image.",
+            Inputs = new[] {
+                new TreatmentInputArtifact {
+                    Id = "relative-image",
+                    Uri = new Uri("images/source.png", UriKind.Relative)
+                }
+            }
+        };
+
+        provider.RunAsync(request).GetAwaiter().GetResult();
+
+        var items = CallChatInputToJson(client.Input!);
+        AssertEqual(2, items.Count, "relative image uri input item count");
+        var image = items[1].AsObject();
+        AssertNotNull(image, "relative image uri item");
+        AssertEqual("image", image!.GetString("type"), "relative image uri item type");
+        AssertEqual("images/source.png", image.GetString("url"), "relative image uri preserved as url");
     }
 
     private sealed class FakeTreatmentChatClient : ITreatmentChatClient {

--- a/IntelligenceX.Tests/Program.Treatment.cs
+++ b/IntelligenceX.Tests/Program.Treatment.cs
@@ -376,7 +376,7 @@ internal static partial class Program {
             Inputs = new[] {
                 new TreatmentInputArtifact {
                     Id = "relative-image",
-                    Uri = new Uri("images/source.png", UriKind.Relative)
+                    Uri = new Uri("images/source.png?download=1#view", UriKind.Relative)
                 }
             }
         };
@@ -388,7 +388,7 @@ internal static partial class Program {
         var image = items[1].AsObject();
         AssertNotNull(image, "relative image uri item");
         AssertEqual("image", image!.GetString("type"), "relative image uri item type");
-        AssertEqual("images/source.png", image.GetString("url"), "relative image uri preserved as url");
+        AssertEqual("images/source.png?download=1#view", image.GetString("url"), "relative image uri preserved as url");
     }
 
     private sealed class FakeTreatmentChatClient : ITreatmentChatClient {

--- a/IntelligenceX.Tests/Program.Treatment.cs
+++ b/IntelligenceX.Tests/Program.Treatment.cs
@@ -364,6 +364,8 @@ internal static partial class Program {
     }
 
     private static void TestOpenAIChatTreatmentProviderHandlesRelativeImageUris() {
+        var directory = Path.Combine(Path.GetTempPath(), "ix-treatment-image-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
         var client = new FakeTreatmentChatClient(new TreatmentChatResponse(
             "turn-relative-image-uri",
             "completed",
@@ -373,6 +375,7 @@ internal static partial class Program {
         var provider = new OpenAIChatTreatmentProvider(client);
         var request = new TreatmentRequest {
             Prompt = "Use the image.",
+            WorkingDirectory = directory,
             Inputs = new[] {
                 new TreatmentInputArtifact {
                     Id = "relative-image",
@@ -381,14 +384,19 @@ internal static partial class Program {
             }
         };
 
-        provider.RunAsync(request).GetAwaiter().GetResult();
+        try {
+            provider.RunAsync(request).GetAwaiter().GetResult();
 
-        var items = CallChatInputToJson(client.Input!);
-        AssertEqual(2, items.Count, "relative image uri input item count");
-        var image = items[1].AsObject();
-        AssertNotNull(image, "relative image uri item");
-        AssertEqual("image", image!.GetString("type"), "relative image uri item type");
-        AssertEqual("images/source.png?download=1#view", image.GetString("url"), "relative image uri preserved as url");
+            var expectedPath = Path.Combine(directory, "images", "source.png");
+            var items = CallChatInputToJson(client.Input!);
+            AssertEqual(2, items.Count, "relative image uri input item count");
+            var image = items[1].AsObject();
+            AssertNotNull(image, "relative image uri item");
+            AssertEqual("image", image!.GetString("type"), "relative image uri item type");
+            AssertEqual(expectedPath, image.GetString("path"), "relative image uri resolved as local path");
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
     }
 
     private sealed class FakeTreatmentChatClient : ITreatmentChatClient {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -129,6 +129,10 @@ internal static partial class Program {
             TestUsageTelemetryCachedStartupMergePreservesNewestDuplicateRollupTimestamp);
         failed += Run("Usage telemetry cached startup merge deduplicates older dominating rollup",
             TestUsageTelemetryCachedStartupMergeDeduplicatesOlderDominatingRollup);
+        failed += Run("Usage telemetry cached startup merge deduplicates all primary matches",
+            TestUsageTelemetryCachedStartupMergeDeduplicatesAllPrimaryMatches);
+        failed += Run("Usage telemetry cached startup merge deduplicates older dominating fallback rollup",
+            TestUsageTelemetryCachedStartupMergeDeduplicatesOlderDominatingFallbackRollup);
         failed += Run("Usage telemetry cached startup merge prefers newest source root metadata",
             TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata);
         failed += Run("Usage telemetry cached startup merge keeps complete health over partial service health",

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -121,6 +121,8 @@ internal static partial class Program {
             TestUsageTelemetryCachedStartupMergeKeepsDominatingUpdatedRollup);
         failed += Run("Usage telemetry cached startup merge deduplicates refreshed rollup timestamp",
             TestUsageTelemetryCachedStartupMergeDeduplicatesRefreshedRollupTimestamp);
+        failed += Run("Usage telemetry cached startup merge deduplicates refreshed rollup when newer seen first",
+            TestUsageTelemetryCachedStartupMergeDeduplicatesRefreshedRollupWhenNewerSeenFirst);
         failed += Run("Usage telemetry cached startup merge prefers newest source root metadata",
             TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata);
         failed += Run("Usage telemetry cached startup merge keeps complete health over partial service health",

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -113,6 +113,12 @@ internal static partial class Program {
             TestUsageTelemetryCachedStartupMergeKeepsPartialRawFallbackRollups);
         failed += Run("Usage telemetry cached startup merge sums overlapping rollups",
             TestUsageTelemetryCachedStartupMergeSumsOverlappingRollups);
+        failed += Run("Usage telemetry cached startup merge deduplicates equivalent rollups with metadata",
+            TestUsageTelemetryCachedStartupMergeDeduplicatesEquivalentRollupsWithMetadata);
+        failed += Run("Usage telemetry cached startup merge deduplicates original contribution after aggregate changes",
+            TestUsageTelemetryCachedStartupMergeDeduplicatesOriginalContributionAfterAggregateChanges);
+        failed += Run("Usage telemetry cached startup merge keeps dominating updated rollup",
+            TestUsageTelemetryCachedStartupMergeKeepsDominatingUpdatedRollup);
         failed += Run("Usage telemetry cached startup merge prefers newest source root metadata",
             TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata);
         failed += Run("Usage telemetry cached startup merge keeps complete health over partial service health",

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -113,6 +113,8 @@ internal static partial class Program {
             TestUsageTelemetryCachedStartupMergeKeepsPartialRawFallbackRollups);
         failed += Run("Usage telemetry cached startup merge sums overlapping rollups",
             TestUsageTelemetryCachedStartupMergeSumsOverlappingRollups);
+        failed += Run("Usage telemetry cached startup merge sums distinct rollup costs",
+            TestUsageTelemetryCachedStartupMergeSumsDistinctRollupCosts);
         failed += Run("Usage telemetry cached startup merge deduplicates equivalent rollups with metadata",
             TestUsageTelemetryCachedStartupMergeDeduplicatesEquivalentRollupsWithMetadata);
         failed += Run("Usage telemetry cached startup merge deduplicates original contribution after aggregate changes",

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -111,6 +111,8 @@ internal static partial class Program {
             TestUsageTelemetryCachedStartupMergeAvoidsIncompleteRawOverlap);
         failed += Run("Usage telemetry cached startup merge keeps partial raw fallback rollups",
             TestUsageTelemetryCachedStartupMergeKeepsPartialRawFallbackRollups);
+        failed += Run("Usage telemetry cached startup merge sums overlapping rollups",
+            TestUsageTelemetryCachedStartupMergeSumsOverlappingRollups);
         failed += Run("Usage telemetry cached startup merge prefers newest source root metadata",
             TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata);
         failed += Run("Usage telemetry cached startup merge keeps complete health over partial service health",
@@ -424,6 +426,7 @@ internal static partial class Program {
         failed += Run("Treatment prompt builder includes artifacts and contract", TestTreatmentPromptBuilderIncludesArtifactsAndContract);
         failed += Run("Treatment prompt builder rejects empty request", TestTreatmentPromptBuilderRejectsEmptyRequest);
         failed += Run("Treatment prompt builder inlines local text artifacts", TestTreatmentPromptBuilderInlinesLocalTextArtifacts);
+        failed += Run("Treatment prompt builder prefers workspace for local artifacts", TestTreatmentPromptBuilderPrefersWorkspaceForLocalArtifacts);
         failed += Run("Treatment prompt builder honors inline local file limit", TestTreatmentPromptBuilderHonorsInlineLocalFileLimit);
         failed += Run("Treatment prompt builder handles null metadata and parameterized media type", TestTreatmentPromptBuilderHandlesNullMetadataAndParameterizedMediaType);
         failed += Run("Treatment prompt builder reports traversal as warning", TestTreatmentPromptBuilderReportsTraversalAsWarning);
@@ -432,6 +435,7 @@ internal static partial class Program {
         failed += Run("OpenAI treatment provider parses array JSON", TestOpenAIChatTreatmentProviderParsesArrayJson);
         failed += Run("OpenAI treatment provider maps image assets", TestOpenAIChatTreatmentProviderMapsImageAssets);
         failed += Run("OpenAI treatment provider skips unsupported implicit images", TestOpenAIChatTreatmentProviderSkipsUnsupportedImplicitImages);
+        failed += Run("OpenAI treatment provider handles relative image URIs", TestOpenAIChatTreatmentProviderHandlesRelativeImageUris);
         failed += Run("Native request body normalizes tool replay items", TestNativeRequestBodyNormalizesToolReplayInputItems);
         failed += Run("Native request body normalizes type-missing replay items", TestNativeRequestBodyNormalizesTypeMissingToolReplayItems);
         failed += Run("Native request body filters unpaired tool replay items", TestNativeRequestBodyFiltersUnpairedToolReplayItems);

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -119,6 +119,8 @@ internal static partial class Program {
             TestUsageTelemetryCachedStartupMergeDeduplicatesOriginalContributionAfterAggregateChanges);
         failed += Run("Usage telemetry cached startup merge keeps dominating updated rollup",
             TestUsageTelemetryCachedStartupMergeKeepsDominatingUpdatedRollup);
+        failed += Run("Usage telemetry cached startup merge deduplicates refreshed rollup timestamp",
+            TestUsageTelemetryCachedStartupMergeDeduplicatesRefreshedRollupTimestamp);
         failed += Run("Usage telemetry cached startup merge prefers newest source root metadata",
             TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata);
         failed += Run("Usage telemetry cached startup merge keeps complete health over partial service health",

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -127,6 +127,8 @@ internal static partial class Program {
             TestUsageTelemetryCachedStartupMergeDeduplicatesRefreshedRollupWhenNewerSeenFirst);
         failed += Run("Usage telemetry cached startup merge preserves newest duplicate rollup timestamp",
             TestUsageTelemetryCachedStartupMergePreservesNewestDuplicateRollupTimestamp);
+        failed += Run("Usage telemetry cached startup merge deduplicates older dominating rollup",
+            TestUsageTelemetryCachedStartupMergeDeduplicatesOlderDominatingRollup);
         failed += Run("Usage telemetry cached startup merge prefers newest source root metadata",
             TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata);
         failed += Run("Usage telemetry cached startup merge keeps complete health over partial service health",

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -133,6 +133,10 @@ internal static partial class Program {
             TestUsageTelemetryCachedStartupMergeDeduplicatesAllPrimaryMatches);
         failed += Run("Usage telemetry cached startup merge deduplicates older dominating fallback rollup",
             TestUsageTelemetryCachedStartupMergeDeduplicatesOlderDominatingFallbackRollup);
+        failed += Run("Usage telemetry cached startup merge preserves duplicate metadata and truth",
+            TestUsageTelemetryCachedStartupMergePreservesDuplicateMetadataAndTruth);
+        failed += Run("Usage telemetry cached startup merge deduplicates equal compact older dominating fallback rollup",
+            TestUsageTelemetryCachedStartupMergeDeduplicatesEqualCompactOlderDominatingFallbackRollup);
         failed += Run("Usage telemetry cached startup merge prefers newest source root metadata",
             TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata);
         failed += Run("Usage telemetry cached startup merge keeps complete health over partial service health",

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -125,6 +125,8 @@ internal static partial class Program {
             TestUsageTelemetryCachedStartupMergeDeduplicatesRefreshedRollupTimestamp);
         failed += Run("Usage telemetry cached startup merge deduplicates refreshed rollup when newer seen first",
             TestUsageTelemetryCachedStartupMergeDeduplicatesRefreshedRollupWhenNewerSeenFirst);
+        failed += Run("Usage telemetry cached startup merge preserves newest duplicate rollup timestamp",
+            TestUsageTelemetryCachedStartupMergePreservesNewestDuplicateRollupTimestamp);
         failed += Run("Usage telemetry cached startup merge prefers newest source root metadata",
             TestUsageTelemetryCachedStartupMergePrefersNewestSourceRootMetadata);
         failed += Run("Usage telemetry cached startup merge keeps complete health over partial service health",

--- a/IntelligenceX.Tray/ViewModels/MainViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/MainViewModel.cs
@@ -726,16 +726,16 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
             return true;
         }
 
-        if (IsStartupQuietWindowActive()) {
-            return false;
-        }
-
         if (!_usageChangeWatcher.HasActiveWatchers) {
             return true;
         }
 
         if (HasPendingUsageChanges()) {
             return true;
+        }
+
+        if (IsStartupQuietWindowActive()) {
+            return false;
         }
 
         if (_lastUsageRootDiscoveryUtc == default) {

--- a/IntelligenceX.Tray/ViewModels/ProviderViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/ProviderViewModel.cs
@@ -464,9 +464,7 @@ public sealed class ProviderViewModel : ViewModelBase {
         ? PulseModelBreakdown[0].TotalTokensFormatted + " • " + PulseModelBreakdown[0].SharePercentText
         : "Waiting for today's model signal";
     public string PulseCachedSavingsValue => PulseCachedTokens > 0 ? FormatTokens(PulseCachedTokens) : "--";
-    public string PulseCachedSavingsDetail => PulseInputTokens > 0
-        ? FormatPulsePercent(Math.Min(1d, Math.Max(0d, (double)PulseCachedTokens / PulseInputTokens))) + " of today's input"
-        : "Cached input appears when token telemetry includes it.";
+    public string PulseCachedSavingsDetail => BuildPulseCachedSavingsDetail();
     public string PulseTokenMixText => "Fresh input " + PulseFreshInputFormatted
                                   + " • cached " + FormatTokens(PulseCachedTokens)
                                   + " • output " + PulseVisibleOutputFormatted
@@ -1784,9 +1782,11 @@ public sealed class ProviderViewModel : ViewModelBase {
     }
 
     private string BuildPulseInsightText() {
-        if (IsCombinedProvider && ProviderComparison.Count > 0) {
-            var leader = ProviderComparison[0];
-            return leader.DisplayName + " leads this view with " + leader.TokensText + " across " + leader.EventCountText + ".";
+        if (IsCombinedProvider) {
+            var combinedInsight = BuildCombinedTodayPulseInsightText();
+            if (!string.IsNullOrWhiteSpace(combinedInsight)) {
+                return combinedInsight!;
+            }
         }
 
         if (PulseTotalTokens <= 0) {
@@ -1816,6 +1816,47 @@ public sealed class ProviderViewModel : ViewModelBase {
         }
 
         return "No local activity today yet.";
+    }
+
+    private string BuildPulseCachedSavingsDetail() {
+        if (PulseCachedTokens <= 0 || PulseInputTokens <= 0) {
+            return "Cached input appears when token telemetry includes it.";
+        }
+
+        if (!CanDescribePulseCachedInputAsSubset()) {
+            return "Cached input is reported separately by provider telemetry.";
+        }
+
+        return FormatPulsePercent(Math.Min(1d, Math.Max(0d, (double)PulseCachedTokens / PulseInputTokens))) + " of today's input";
+    }
+
+    private bool CanDescribePulseCachedInputAsSubset() {
+        var today = DateTime.Now.Date;
+        var events = FilterByWindow(today, today)
+            .Where(static usageEvent => (usageEvent.CachedInputTokens ?? 0L) > 0)
+            .ToList();
+        return events.Count > 0 &&
+               events.All(static usageEvent => UsageTelemetryApiPricing.ShouldTreatCachedInputAsInputSubset(usageEvent.ProviderId));
+    }
+
+    private string? BuildCombinedTodayPulseInsightText() {
+        var today = DateTime.Now.Date;
+        var leader = FilterByWindow(today, today)
+            .GroupBy(static usageEvent => usageEvent.ProviderId?.Trim()?.ToLowerInvariant() ?? "unknown")
+            .Where(static group => !string.IsNullOrWhiteSpace(group.Key))
+            .Select(static group => new {
+                Info = ProviderMetadata.Resolve(group.Key),
+                Events = group.Count(),
+                Tokens = group.Sum(static usageEvent => usageEvent.TotalTokens ?? 0L)
+            })
+            .Where(static group => group.Tokens > 0 || group.Events > 0)
+            .OrderByDescending(static group => group.Tokens)
+            .ThenByDescending(static group => group.Events)
+            .FirstOrDefault();
+
+        return leader is null
+            ? null
+            : leader.Info.DisplayName + " leads today with " + FormatTokens(leader.Tokens) + " across " + FormatCountLabel(leader.Events, "rollup", "rollups") + ".";
     }
 
     private string BuildPulseLimitChipText() {

--- a/IntelligenceX.Tray/ViewModels/ProviderViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/ProviderViewModel.cs
@@ -113,6 +113,7 @@ public sealed class ProviderViewModel : ViewModelBase {
     private bool _pulseCostUsesEstimate;
     private int _pulseEventCount;
     private long _pulsePreviousDayTokens;
+    private bool _pulseCachedInputSubsetDescribable;
     private string? _pulseProviderMetricOverride;
 
     // 7-day rolling
@@ -1575,6 +1576,7 @@ public sealed class ProviderViewModel : ViewModelBase {
         _pulseReasoningTokens = pulseEvents.Sum(e => e.ReasoningTokens ?? 0L);
         _pulseFreshInputTokens = pulseEvents.Sum(GetPulseFreshInputTokens);
         _pulseVisibleOutputTokens = pulseEvents.Sum(GetPulseVisibleOutputTokens);
+        _pulseCachedInputSubsetDescribable = CanDescribeCachedInputAsSubset(pulseEvents);
         ApplyDisplayCost(
             UsageTelemetryApiPricing.BuildDisplayCost(pulseEvents),
             value => _pulseCostUsd = value,
@@ -1823,16 +1825,15 @@ public sealed class ProviderViewModel : ViewModelBase {
             return "Cached input appears when token telemetry includes it.";
         }
 
-        if (!CanDescribePulseCachedInputAsSubset()) {
+        if (!_pulseCachedInputSubsetDescribable) {
             return "Cached input is reported separately by provider telemetry.";
         }
 
         return FormatPulsePercent(Math.Min(1d, Math.Max(0d, (double)PulseCachedTokens / PulseInputTokens))) + " of today's input";
     }
 
-    private bool CanDescribePulseCachedInputAsSubset() {
-        var today = DateTime.Now.Date;
-        var events = FilterByWindow(today, today)
+    private static bool CanDescribeCachedInputAsSubset(IEnumerable<UsageEventRecord> pulseEvents) {
+        var events = pulseEvents
             .Where(static usageEvent => (usageEvent.CachedInputTokens ?? 0L) > 0)
             .ToList();
         return events.Count > 0 &&

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
@@ -80,6 +80,10 @@ internal static class UsageTelemetryCachedSnapshotMerge {
                 continue;
             }
 
+            if (HasSameRollupContribution(existing, usageEvent)) {
+                continue;
+            }
+
             MergeUsageEventInto(existing, usageEvent);
         }
 
@@ -125,44 +129,66 @@ internal static class UsageTelemetryCachedSnapshotMerge {
     }
 
     private static void MergeUsageEventInto(UsageEventRecord existing, UsageEventRecord incoming) {
-        existing.InputTokens = MaxNullable(existing.InputTokens, incoming.InputTokens);
-        existing.CachedInputTokens = MaxNullable(existing.CachedInputTokens, incoming.CachedInputTokens);
-        existing.OutputTokens = MaxNullable(existing.OutputTokens, incoming.OutputTokens);
-        existing.ReasoningTokens = MaxNullable(existing.ReasoningTokens, incoming.ReasoningTokens);
-        existing.TotalTokens = MaxNullable(existing.TotalTokens, incoming.TotalTokens);
-        existing.CompactCount = MaxNullable(existing.CompactCount, incoming.CompactCount);
+        existing.InputTokens = SumNullable(existing.InputTokens, incoming.InputTokens);
+        existing.CachedInputTokens = SumNullable(existing.CachedInputTokens, incoming.CachedInputTokens);
+        existing.OutputTokens = SumNullable(existing.OutputTokens, incoming.OutputTokens);
+        existing.ReasoningTokens = SumNullable(existing.ReasoningTokens, incoming.ReasoningTokens);
+        existing.TotalTokens = SumNullable(existing.TotalTokens, incoming.TotalTokens);
+        existing.CompactCount = SumNullable(existing.CompactCount, incoming.CompactCount);
         existing.DurationMs = MaxNullable(existing.DurationMs, incoming.DurationMs);
-        existing.CostUsd = MaxNullable(existing.CostUsd, incoming.CostUsd);
+        existing.CostUsd = SumNullable(existing.CostUsd, incoming.CostUsd);
         if (incoming.TruthLevel > existing.TruthLevel) {
             existing.TruthLevel = incoming.TruthLevel;
         }
     }
 
+    private static bool HasSameRollupContribution(UsageEventRecord existing, UsageEventRecord incoming) =>
+        existing.InputTokens == incoming.InputTokens &&
+        existing.CachedInputTokens == incoming.CachedInputTokens &&
+        existing.OutputTokens == incoming.OutputTokens &&
+        existing.ReasoningTokens == incoming.ReasoningTokens &&
+        existing.TotalTokens == incoming.TotalTokens &&
+        existing.CompactCount == incoming.CompactCount &&
+        existing.DurationMs == incoming.DurationMs &&
+        existing.CostUsd == incoming.CostUsd;
+
+    private static long? SumNullable(long? existing, long? incoming) {
+        if (!existing.HasValue) {
+            return incoming;
+        }
+
+        if (!incoming.HasValue) {
+            return existing;
+        }
+
+        return existing.Value + incoming.Value;
+    }
+
+    private static int? SumNullable(int? existing, int? incoming) {
+        if (!existing.HasValue) {
+            return incoming;
+        }
+
+        if (!incoming.HasValue) {
+            return existing;
+        }
+
+        return existing.Value + incoming.Value;
+    }
+
+    private static decimal? SumNullable(decimal? existing, decimal? incoming) {
+        if (!existing.HasValue) {
+            return incoming;
+        }
+
+        if (!incoming.HasValue) {
+            return existing;
+        }
+
+        return existing.Value + incoming.Value;
+    }
+
     private static long? MaxNullable(long? existing, long? incoming) {
-        if (!existing.HasValue) {
-            return incoming;
-        }
-
-        if (!incoming.HasValue) {
-            return existing;
-        }
-
-        return Math.Max(existing.Value, incoming.Value);
-    }
-
-    private static int? MaxNullable(int? existing, int? incoming) {
-        if (!existing.HasValue) {
-            return incoming;
-        }
-
-        if (!incoming.HasValue) {
-            return existing;
-        }
-
-        return Math.Max(existing.Value, incoming.Value);
-    }
-
-    private static decimal? MaxNullable(decimal? existing, decimal? incoming) {
         if (!existing.HasValue) {
             return incoming;
         }

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
@@ -69,6 +69,12 @@ internal static class UsageTelemetryCachedSnapshotMerge {
     private static IReadOnlyList<UsageEventRecord> MergeRollups(
         IEnumerable<UsageEventRecord> primaryEvents,
         IEnumerable<UsageEventRecord> fallbackEvents) {
+        var primaryEventList = primaryEvents.ToList();
+        var primaryEventIds = new HashSet<string>(
+            primaryEventList
+                .Where(static usageEvent => usageEvent is not null && !string.IsNullOrWhiteSpace(usageEvent.EventId))
+                .Select(static usageEvent => usageEvent.EventId),
+            StringComparer.OrdinalIgnoreCase);
         var mergedById = new Dictionary<string, UsageEventRecord>(StringComparer.OrdinalIgnoreCase);
         var contributionsById = new Dictionary<string, List<UsageEventRecord>>(StringComparer.OrdinalIgnoreCase);
         foreach (var usageEvent in fallbackEvents) {
@@ -77,16 +83,19 @@ internal static class UsageTelemetryCachedSnapshotMerge {
                 contributionsById,
                 usageEvent,
                 allowDominatingCoverage: true,
-                allowOlderExistingDominance: true);
+                allowOlderExistingDominance: true,
+                allowEqualOlderExistingDominance: usageEvent is not null &&
+                                                   !primaryEventIds.Contains(usageEvent.EventId));
         }
 
-        foreach (var usageEvent in primaryEvents) {
+        foreach (var usageEvent in primaryEventList) {
             MergeRollupContribution(
                 mergedById,
                 contributionsById,
                 usageEvent,
                 allowDominatingCoverage: true,
-                allowOlderExistingDominance: true);
+                allowOlderExistingDominance: true,
+                allowEqualOlderExistingDominance: false);
         }
 
         return mergedById.Values
@@ -102,7 +111,8 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         IDictionary<string, List<UsageEventRecord>> contributionsById,
         UsageEventRecord usageEvent,
         bool allowDominatingCoverage,
-        bool allowOlderExistingDominance) {
+        bool allowOlderExistingDominance,
+        bool allowEqualOlderExistingDominance) {
         if (usageEvent is null || string.IsNullOrWhiteSpace(usageEvent.EventId)) {
             return;
         }
@@ -112,7 +122,12 @@ internal static class UsageTelemetryCachedSnapshotMerge {
             contributionsById[usageEvent.EventId] = contributions;
         }
 
-        if (TryMergeExistingContribution(contributions, usageEvent, allowDominatingCoverage, allowOlderExistingDominance)) {
+        if (TryMergeExistingContribution(
+                contributions,
+                usageEvent,
+                allowDominatingCoverage,
+                allowOlderExistingDominance,
+                allowEqualOlderExistingDominance)) {
             mergedById[usageEvent.EventId] = RebuildMergedUsageEvent(contributions);
             return;
         }
@@ -158,12 +173,18 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         List<UsageEventRecord> contributions,
         UsageEventRecord incoming,
         bool allowDominatingCoverage,
-        bool allowOlderExistingDominance) {
+        bool allowOlderExistingDominance,
+        bool allowEqualOlderExistingDominance) {
         var matchedIndex = -1;
         UsageEventRecord? merged = null;
         for (var i = 0; i < contributions.Count; i++) {
             var existing = contributions[i];
-            if (!IsDuplicateContribution(existing, merged ?? incoming, allowDominatingCoverage, allowOlderExistingDominance)) {
+            if (!IsDuplicateContribution(
+                    existing,
+                    merged ?? incoming,
+                    allowDominatingCoverage,
+                    allowOlderExistingDominance,
+                    allowEqualOlderExistingDominance)) {
                 continue;
             }
 
@@ -185,11 +206,16 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         UsageEventRecord existing,
         UsageEventRecord incoming,
         bool allowDominatingCoverage,
-        bool allowOlderExistingDominance) =>
+        bool allowOlderExistingDominance,
+        bool allowEqualOlderExistingDominance) =>
         HasSameRollupCoverage(existing, incoming) ||
         allowDominatingCoverage &&
         HasSameRollupIdentity(existing, incoming) &&
-        HasCompatibleDominatingRollupCoverage(existing, incoming, allowOlderExistingDominance);
+        HasCompatibleDominatingRollupCoverage(
+            existing,
+            incoming,
+            allowOlderExistingDominance,
+            allowEqualOlderExistingDominance);
 
     private static UsageEventRecord RebuildMergedUsageEvent(IReadOnlyList<UsageEventRecord> contributions) {
         var merged = CloneUsageEvent(contributions[0]);
@@ -224,6 +250,8 @@ internal static class UsageTelemetryCachedSnapshotMerge {
 
     private static UsageEventRecord MergeDuplicateContribution(UsageEventRecord existing, UsageEventRecord incoming) {
         var merged = CloneUsageEvent(existing.TimestampUtc >= incoming.TimestampUtc ? existing : incoming);
+        MergeDuplicateMetadata(merged, existing);
+        MergeDuplicateMetadata(merged, incoming);
         merged.InputTokens = MaxNullable(existing.InputTokens, incoming.InputTokens);
         merged.CachedInputTokens = MaxNullable(existing.CachedInputTokens, incoming.CachedInputTokens);
         merged.OutputTokens = MaxNullable(existing.OutputTokens, incoming.OutputTokens);
@@ -232,11 +260,26 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         merged.CompactCount = MaxNullable(existing.CompactCount, incoming.CompactCount);
         merged.DurationMs = MaxNullable(existing.DurationMs, incoming.DurationMs);
         merged.CostUsd = MaxNullable(existing.CostUsd, incoming.CostUsd);
-        if (incoming.TruthLevel > merged.TruthLevel) {
-            merged.TruthLevel = incoming.TruthLevel;
-        }
+        merged.TruthLevel = StrongestTruthLevel(existing.TruthLevel, incoming.TruthLevel);
 
         return merged;
+    }
+
+    private static void MergeDuplicateMetadata(UsageEventRecord target, UsageEventRecord source) {
+        target.ProviderAccountId = PreferExistingString(target.ProviderAccountId, source.ProviderAccountId);
+        target.AccountLabel = PreferExistingString(target.AccountLabel, source.AccountLabel);
+        target.PersonLabel = PreferExistingString(target.PersonLabel, source.PersonLabel);
+        target.MachineId = PreferExistingString(target.MachineId, source.MachineId);
+        target.SessionId = PreferExistingString(target.SessionId, source.SessionId);
+        target.ThreadId = PreferExistingString(target.ThreadId, source.ThreadId);
+        target.ConversationTitle = PreferExistingString(target.ConversationTitle, source.ConversationTitle);
+        target.WorkspacePath = PreferExistingString(target.WorkspacePath, source.WorkspacePath);
+        target.RepositoryName = PreferExistingString(target.RepositoryName, source.RepositoryName);
+        target.TurnId = PreferExistingString(target.TurnId, source.TurnId);
+        target.ResponseId = PreferExistingString(target.ResponseId, source.ResponseId);
+        target.Model = PreferExistingString(target.Model, source.Model);
+        target.Surface = PreferExistingString(target.Surface, source.Surface);
+        target.RawHash = PreferExistingString(target.RawHash, source.RawHash);
     }
 
     private static bool HasSameRollupCoverage(UsageEventRecord existing, UsageEventRecord incoming) =>
@@ -264,11 +307,12 @@ internal static class UsageTelemetryCachedSnapshotMerge {
     private static bool HasCompatibleDominatingRollupCoverage(
         UsageEventRecord existing,
         UsageEventRecord incoming,
-        bool allowOlderExistingDominance) =>
+        bool allowOlderExistingDominance,
+        bool allowEqualOlderExistingDominance) =>
         (incoming.TimestampUtc >= existing.TimestampUtc &&
          CoverageDominates(incoming, existing)) ||
         ((existing.TimestampUtc >= incoming.TimestampUtc ||
-          allowOlderExistingDominance && HasStrongerAggregateEvidence(existing, incoming)) &&
+          allowOlderExistingDominance && HasStrongerAggregateEvidence(existing, incoming, allowEqualOlderExistingDominance)) &&
          CoverageDominates(existing, incoming));
 
     private static bool CoverageDominates(UsageEventRecord candidate, UsageEventRecord other) =>
@@ -279,8 +323,13 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         NullableGreaterOrEqual(candidate.TotalTokens, other.TotalTokens) &&
         NullableGreaterOrEqual(candidate.CompactCount, other.CompactCount);
 
-    private static bool HasStrongerAggregateEvidence(UsageEventRecord candidate, UsageEventRecord other) =>
-        NullableGreater(candidate.CompactCount, other.CompactCount);
+    private static bool HasStrongerAggregateEvidence(
+        UsageEventRecord candidate,
+        UsageEventRecord other,
+        bool allowEqual) =>
+        allowEqual
+            ? NullableGreaterOrEqual(candidate.CompactCount, other.CompactCount)
+            : NullableGreater(candidate.CompactCount, other.CompactCount);
 
     private static long? SumNullable(long? existing, long? incoming) {
         if (!existing.HasValue) {
@@ -362,4 +411,10 @@ internal static class UsageTelemetryCachedSnapshotMerge {
 
     private static bool NullableGreater(int? candidate, int? other) =>
         (candidate ?? 0) > (other ?? 0);
+
+    private static string? PreferExistingString(string? existing, string? incoming) =>
+        string.IsNullOrWhiteSpace(existing) ? incoming : existing;
+
+    private static UsageTruthLevel StrongestTruthLevel(UsageTruthLevel existing, UsageTruthLevel incoming) =>
+        incoming > existing ? incoming : existing;
 }

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
@@ -71,23 +71,22 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         IEnumerable<UsageEventRecord> fallbackEvents) {
         var mergedById = new Dictionary<string, UsageEventRecord>(StringComparer.OrdinalIgnoreCase);
         var contributionsById = new Dictionary<string, List<UsageEventRecord>>(StringComparer.OrdinalIgnoreCase);
-        foreach (var usageEvent in fallbackEvents.Concat(primaryEvents)) {
-            if (usageEvent is null || string.IsNullOrWhiteSpace(usageEvent.EventId)) {
-                continue;
-            }
+        foreach (var usageEvent in fallbackEvents) {
+            MergeRollupContribution(
+                mergedById,
+                contributionsById,
+                usageEvent,
+                allowDominatingCoverage: true,
+                allowOlderExistingDominance: false);
+        }
 
-            if (!contributionsById.TryGetValue(usageEvent.EventId, out var contributions)) {
-                contributions = new List<UsageEventRecord>();
-                contributionsById[usageEvent.EventId] = contributions;
-            }
-
-            if (TryMergeExistingContribution(contributions, usageEvent)) {
-                mergedById[usageEvent.EventId] = RebuildMergedUsageEvent(contributions);
-                continue;
-            }
-
-            contributions.Add(CloneUsageEvent(usageEvent));
-            mergedById[usageEvent.EventId] = RebuildMergedUsageEvent(contributions);
+        foreach (var usageEvent in primaryEvents) {
+            MergeRollupContribution(
+                mergedById,
+                contributionsById,
+                usageEvent,
+                allowDominatingCoverage: true,
+                allowOlderExistingDominance: true);
         }
 
         return mergedById.Values
@@ -96,6 +95,30 @@ internal static class UsageTelemetryCachedSnapshotMerge {
             .ThenBy(static usageEvent => usageEvent.Model, StringComparer.OrdinalIgnoreCase)
             .ThenBy(static usageEvent => usageEvent.EventId, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    private static void MergeRollupContribution(
+        IDictionary<string, UsageEventRecord> mergedById,
+        IDictionary<string, List<UsageEventRecord>> contributionsById,
+        UsageEventRecord usageEvent,
+        bool allowDominatingCoverage,
+        bool allowOlderExistingDominance) {
+        if (usageEvent is null || string.IsNullOrWhiteSpace(usageEvent.EventId)) {
+            return;
+        }
+
+        if (!contributionsById.TryGetValue(usageEvent.EventId, out var contributions)) {
+            contributions = new List<UsageEventRecord>();
+            contributionsById[usageEvent.EventId] = contributions;
+        }
+
+        if (TryMergeExistingContribution(contributions, usageEvent, allowDominatingCoverage, allowOlderExistingDominance)) {
+            mergedById[usageEvent.EventId] = RebuildMergedUsageEvent(contributions);
+            return;
+        }
+
+        contributions.Add(CloneUsageEvent(usageEvent));
+        mergedById[usageEvent.EventId] = RebuildMergedUsageEvent(contributions);
     }
 
     private static UsageEventRecord CloneUsageEvent(UsageEventRecord usageEvent) {
@@ -131,11 +154,17 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         };
     }
 
-    private static bool TryMergeExistingContribution(List<UsageEventRecord> contributions, UsageEventRecord incoming) {
+    private static bool TryMergeExistingContribution(
+        List<UsageEventRecord> contributions,
+        UsageEventRecord incoming,
+        bool allowDominatingCoverage,
+        bool allowOlderExistingDominance) {
         for (var i = 0; i < contributions.Count; i++) {
             var existing = contributions[i];
             if (HasSameRollupCoverage(existing, incoming) ||
-                HasSameRollupIdentity(existing, incoming) && HasCompatibleDominatingRollupCoverage(existing, incoming)) {
+                allowDominatingCoverage &&
+                HasSameRollupIdentity(existing, incoming) &&
+                HasCompatibleDominatingRollupCoverage(existing, incoming, allowOlderExistingDominance)) {
                 contributions[i] = MergeDuplicateContribution(existing, incoming);
                 return true;
             }
@@ -214,9 +243,12 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         string.Equals(existing.Model ?? string.Empty, incoming.Model ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.Surface ?? string.Empty, incoming.Surface ?? string.Empty, StringComparison.OrdinalIgnoreCase);
 
-    private static bool HasCompatibleDominatingRollupCoverage(UsageEventRecord existing, UsageEventRecord incoming) =>
+    private static bool HasCompatibleDominatingRollupCoverage(
+        UsageEventRecord existing,
+        UsageEventRecord incoming,
+        bool allowOlderExistingDominance) =>
         CoverageDominates(incoming, existing) ||
-        existing.TimestampUtc >= incoming.TimestampUtc &&
+        (allowOlderExistingDominance || existing.TimestampUtc >= incoming.TimestampUtc) &&
         CoverageDominates(existing, incoming);
 
     private static bool CoverageDominates(UsageEventRecord candidate, UsageEventRecord other) =>

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
@@ -77,7 +77,7 @@ internal static class UsageTelemetryCachedSnapshotMerge {
                 contributionsById,
                 usageEvent,
                 allowDominatingCoverage: true,
-                allowOlderExistingDominance: false);
+                allowOlderExistingDominance: true);
         }
 
         foreach (var usageEvent in primaryEvents) {
@@ -159,19 +159,37 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         UsageEventRecord incoming,
         bool allowDominatingCoverage,
         bool allowOlderExistingDominance) {
+        var matchedIndex = -1;
+        UsageEventRecord? merged = null;
         for (var i = 0; i < contributions.Count; i++) {
             var existing = contributions[i];
-            if (HasSameRollupCoverage(existing, incoming) ||
-                allowDominatingCoverage &&
-                HasSameRollupIdentity(existing, incoming) &&
-                HasCompatibleDominatingRollupCoverage(existing, incoming, allowOlderExistingDominance)) {
-                contributions[i] = MergeDuplicateContribution(existing, incoming);
-                return true;
+            if (!IsDuplicateContribution(existing, merged ?? incoming, allowDominatingCoverage, allowOlderExistingDominance)) {
+                continue;
+            }
+
+            merged = MergeDuplicateContribution(existing, merged ?? incoming);
+            if (matchedIndex < 0) {
+                matchedIndex = i;
+                contributions[i] = merged;
+            } else {
+                contributions[matchedIndex] = merged;
+                contributions.RemoveAt(i);
+                i--;
             }
         }
 
-        return false;
+        return matchedIndex >= 0;
     }
+
+    private static bool IsDuplicateContribution(
+        UsageEventRecord existing,
+        UsageEventRecord incoming,
+        bool allowDominatingCoverage,
+        bool allowOlderExistingDominance) =>
+        HasSameRollupCoverage(existing, incoming) ||
+        allowDominatingCoverage &&
+        HasSameRollupIdentity(existing, incoming) &&
+        HasCompatibleDominatingRollupCoverage(existing, incoming, allowOlderExistingDominance);
 
     private static UsageEventRecord RebuildMergedUsageEvent(IReadOnlyList<UsageEventRecord> contributions) {
         var merged = CloneUsageEvent(contributions[0]);
@@ -247,9 +265,11 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         UsageEventRecord existing,
         UsageEventRecord incoming,
         bool allowOlderExistingDominance) =>
-        CoverageDominates(incoming, existing) ||
-        (allowOlderExistingDominance || existing.TimestampUtc >= incoming.TimestampUtc) &&
-        CoverageDominates(existing, incoming);
+        (incoming.TimestampUtc >= existing.TimestampUtc &&
+         CoverageDominates(incoming, existing)) ||
+        ((existing.TimestampUtc >= incoming.TimestampUtc ||
+          allowOlderExistingDominance && HasStrongerAggregateEvidence(existing, incoming)) &&
+         CoverageDominates(existing, incoming));
 
     private static bool CoverageDominates(UsageEventRecord candidate, UsageEventRecord other) =>
         NullableGreaterOrEqual(candidate.InputTokens, other.InputTokens) &&
@@ -258,6 +278,9 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         NullableGreaterOrEqual(candidate.ReasoningTokens, other.ReasoningTokens) &&
         NullableGreaterOrEqual(candidate.TotalTokens, other.TotalTokens) &&
         NullableGreaterOrEqual(candidate.CompactCount, other.CompactCount);
+
+    private static bool HasStrongerAggregateEvidence(UsageEventRecord candidate, UsageEventRecord other) =>
+        NullableGreater(candidate.CompactCount, other.CompactCount);
 
     private static long? SumNullable(long? existing, long? incoming) {
         if (!existing.HasValue) {
@@ -336,4 +359,7 @@ internal static class UsageTelemetryCachedSnapshotMerge {
 
     private static bool NullableGreaterOrEqual(int? candidate, int? other) =>
         (candidate ?? 0) >= (other ?? 0);
+
+    private static bool NullableGreater(int? candidate, int? other) =>
+        (candidate ?? 0) > (other ?? 0);
 }

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
@@ -135,7 +135,8 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         for (var i = 0; i < contributions.Count; i++) {
             var existing = contributions[i];
             if (HasSameRollupCoverage(existing, incoming) ||
-                HasSameRollupIdentity(existing, incoming) && HasDominatingRollupCoverage(existing, incoming)) {
+                HasSameRollupIdentity(existing, incoming) && HasDominatingRollupCoverage(existing, incoming) ||
+                HasSameRollupIdentityIgnoringTimestamp(existing, incoming) && CoverageDominates(incoming, existing)) {
                 MergeDuplicateContributionInto(existing, incoming);
                 return true;
             }
@@ -203,6 +204,13 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         string.Equals(existing.AdapterId, incoming.AdapterId, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.SourceRootId, incoming.SourceRootId, StringComparison.OrdinalIgnoreCase) &&
         existing.TimestampUtc == incoming.TimestampUtc &&
+        HasSameRollupIdentityIgnoringTimestamp(existing, incoming);
+
+    private static bool HasSameRollupIdentityIgnoringTimestamp(UsageEventRecord existing, UsageEventRecord incoming) =>
+        string.Equals(existing.EventId, incoming.EventId, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.ProviderId, incoming.ProviderId, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.AdapterId, incoming.AdapterId, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.SourceRootId, incoming.SourceRootId, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.ProviderAccountId ?? string.Empty, incoming.ProviderAccountId ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.AccountLabel ?? string.Empty, incoming.AccountLabel ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.SessionId ?? string.Empty, incoming.SessionId ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
@@ -135,8 +135,7 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         for (var i = 0; i < contributions.Count; i++) {
             var existing = contributions[i];
             if (HasSameRollupCoverage(existing, incoming) ||
-                HasSameRollupIdentityWithTimestamp(existing, incoming) && HasDominatingRollupCoverage(existing, incoming) ||
-                HasSameRollupIdentity(existing, incoming) && CoverageDominates(incoming, existing)) {
+                HasSameRollupIdentity(existing, incoming) && HasCompatibleDominatingRollupCoverage(existing, incoming)) {
                 MergeDuplicateContributionInto(existing, incoming);
                 return true;
             }
@@ -198,14 +197,6 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         existing.TotalTokens == incoming.TotalTokens &&
         existing.CompactCount == incoming.CompactCount;
 
-    private static bool HasSameRollupIdentityWithTimestamp(UsageEventRecord existing, UsageEventRecord incoming) =>
-        string.Equals(existing.EventId, incoming.EventId, StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(existing.ProviderId, incoming.ProviderId, StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(existing.AdapterId, incoming.AdapterId, StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(existing.SourceRootId, incoming.SourceRootId, StringComparison.OrdinalIgnoreCase) &&
-        existing.TimestampUtc == incoming.TimestampUtc &&
-        HasSameRollupIdentity(existing, incoming);
-
     private static bool HasSameRollupIdentity(UsageEventRecord existing, UsageEventRecord incoming) =>
         string.Equals(existing.EventId, incoming.EventId, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.ProviderId, incoming.ProviderId, StringComparison.OrdinalIgnoreCase) &&
@@ -218,11 +209,12 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         string.Equals(existing.TurnId ?? string.Empty, incoming.TurnId ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.ResponseId ?? string.Empty, incoming.ResponseId ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.Model ?? string.Empty, incoming.Model ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(existing.Surface ?? string.Empty, incoming.Surface ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(existing.RawHash ?? string.Empty, incoming.RawHash ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        string.Equals(existing.Surface ?? string.Empty, incoming.Surface ?? string.Empty, StringComparison.OrdinalIgnoreCase);
 
-    private static bool HasDominatingRollupCoverage(UsageEventRecord existing, UsageEventRecord incoming) =>
-        CoverageDominates(existing, incoming) || CoverageDominates(incoming, existing);
+    private static bool HasCompatibleDominatingRollupCoverage(UsageEventRecord existing, UsageEventRecord incoming) =>
+        CoverageDominates(incoming, existing) ||
+        existing.TimestampUtc >= incoming.TimestampUtc &&
+        CoverageDominates(existing, incoming);
 
     private static bool CoverageDominates(UsageEventRecord candidate, UsageEventRecord other) =>
         NullableGreaterOrEqual(candidate.InputTokens, other.InputTokens) &&
@@ -305,8 +297,8 @@ internal static class UsageTelemetryCachedSnapshotMerge {
     }
 
     private static bool NullableGreaterOrEqual(long? candidate, long? other) =>
-        !other.HasValue || candidate.HasValue && candidate.Value >= other.Value;
+        (candidate ?? 0L) >= (other ?? 0L);
 
     private static bool NullableGreaterOrEqual(int? candidate, int? other) =>
-        !other.HasValue || candidate.HasValue && candidate.Value >= other.Value;
+        (candidate ?? 0) >= (other ?? 0);
 }

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
@@ -169,7 +169,7 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         existing.TotalTokens = SumNullable(existing.TotalTokens, incoming.TotalTokens);
         existing.CompactCount = SumNullable(existing.CompactCount, incoming.CompactCount);
         existing.DurationMs = MaxNullable(existing.DurationMs, incoming.DurationMs);
-        existing.CostUsd = MaxNullable(existing.CostUsd, incoming.CostUsd);
+        existing.CostUsd = SumNullable(existing.CostUsd, incoming.CostUsd);
         if (incoming.TruthLevel > existing.TruthLevel) {
             existing.TruthLevel = incoming.TruthLevel;
         }

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
@@ -136,7 +136,7 @@ internal static class UsageTelemetryCachedSnapshotMerge {
             var existing = contributions[i];
             if (HasSameRollupCoverage(existing, incoming) ||
                 HasSameRollupIdentity(existing, incoming) && HasCompatibleDominatingRollupCoverage(existing, incoming)) {
-                MergeDuplicateContributionInto(existing, incoming);
+                contributions[i] = MergeDuplicateContribution(existing, incoming);
                 return true;
             }
         }
@@ -175,18 +175,21 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         }
     }
 
-    private static void MergeDuplicateContributionInto(UsageEventRecord existing, UsageEventRecord incoming) {
-        existing.InputTokens = MaxNullable(existing.InputTokens, incoming.InputTokens);
-        existing.CachedInputTokens = MaxNullable(existing.CachedInputTokens, incoming.CachedInputTokens);
-        existing.OutputTokens = MaxNullable(existing.OutputTokens, incoming.OutputTokens);
-        existing.ReasoningTokens = MaxNullable(existing.ReasoningTokens, incoming.ReasoningTokens);
-        existing.TotalTokens = MaxNullable(existing.TotalTokens, incoming.TotalTokens);
-        existing.CompactCount = MaxNullable(existing.CompactCount, incoming.CompactCount);
-        existing.DurationMs = MaxNullable(existing.DurationMs, incoming.DurationMs);
-        existing.CostUsd = MaxNullable(existing.CostUsd, incoming.CostUsd);
-        if (incoming.TruthLevel > existing.TruthLevel) {
-            existing.TruthLevel = incoming.TruthLevel;
+    private static UsageEventRecord MergeDuplicateContribution(UsageEventRecord existing, UsageEventRecord incoming) {
+        var merged = CloneUsageEvent(existing.TimestampUtc >= incoming.TimestampUtc ? existing : incoming);
+        merged.InputTokens = MaxNullable(existing.InputTokens, incoming.InputTokens);
+        merged.CachedInputTokens = MaxNullable(existing.CachedInputTokens, incoming.CachedInputTokens);
+        merged.OutputTokens = MaxNullable(existing.OutputTokens, incoming.OutputTokens);
+        merged.ReasoningTokens = MaxNullable(existing.ReasoningTokens, incoming.ReasoningTokens);
+        merged.TotalTokens = MaxNullable(existing.TotalTokens, incoming.TotalTokens);
+        merged.CompactCount = MaxNullable(existing.CompactCount, incoming.CompactCount);
+        merged.DurationMs = MaxNullable(existing.DurationMs, incoming.DurationMs);
+        merged.CostUsd = MaxNullable(existing.CostUsd, incoming.CostUsd);
+        if (incoming.TruthLevel > merged.TruthLevel) {
+            merged.TruthLevel = incoming.TruthLevel;
         }
+
+        return merged;
     }
 
     private static bool HasSameRollupCoverage(UsageEventRecord existing, UsageEventRecord incoming) =>

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
@@ -70,21 +70,24 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         IEnumerable<UsageEventRecord> primaryEvents,
         IEnumerable<UsageEventRecord> fallbackEvents) {
         var mergedById = new Dictionary<string, UsageEventRecord>(StringComparer.OrdinalIgnoreCase);
+        var contributionsById = new Dictionary<string, List<UsageEventRecord>>(StringComparer.OrdinalIgnoreCase);
         foreach (var usageEvent in fallbackEvents.Concat(primaryEvents)) {
             if (usageEvent is null || string.IsNullOrWhiteSpace(usageEvent.EventId)) {
                 continue;
             }
 
-            if (!mergedById.TryGetValue(usageEvent.EventId, out var existing)) {
-                mergedById[usageEvent.EventId] = CloneUsageEvent(usageEvent);
+            if (!contributionsById.TryGetValue(usageEvent.EventId, out var contributions)) {
+                contributions = new List<UsageEventRecord>();
+                contributionsById[usageEvent.EventId] = contributions;
+            }
+
+            if (TryMergeExistingContribution(contributions, usageEvent)) {
+                mergedById[usageEvent.EventId] = RebuildMergedUsageEvent(contributions);
                 continue;
             }
 
-            if (HasSameRollupContribution(existing, usageEvent)) {
-                continue;
-            }
-
-            MergeUsageEventInto(existing, usageEvent);
+            contributions.Add(CloneUsageEvent(usageEvent));
+            mergedById[usageEvent.EventId] = RebuildMergedUsageEvent(contributions);
         }
 
         return mergedById.Values
@@ -128,6 +131,36 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         };
     }
 
+    private static bool TryMergeExistingContribution(List<UsageEventRecord> contributions, UsageEventRecord incoming) {
+        for (var i = 0; i < contributions.Count; i++) {
+            var existing = contributions[i];
+            if (HasSameRollupCoverage(existing, incoming) ||
+                HasSameRollupIdentity(existing, incoming) && HasDominatingRollupCoverage(existing, incoming)) {
+                MergeDuplicateContributionInto(existing, incoming);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static UsageEventRecord RebuildMergedUsageEvent(IReadOnlyList<UsageEventRecord> contributions) {
+        var merged = CloneUsageEvent(contributions[0]);
+        merged.InputTokens = null;
+        merged.CachedInputTokens = null;
+        merged.OutputTokens = null;
+        merged.ReasoningTokens = null;
+        merged.TotalTokens = null;
+        merged.CompactCount = null;
+        merged.DurationMs = null;
+        merged.CostUsd = null;
+        for (var i = 0; i < contributions.Count; i++) {
+            MergeUsageEventInto(merged, contributions[i]);
+        }
+
+        return merged;
+    }
+
     private static void MergeUsageEventInto(UsageEventRecord existing, UsageEventRecord incoming) {
         existing.InputTokens = SumNullable(existing.InputTokens, incoming.InputTokens);
         existing.CachedInputTokens = SumNullable(existing.CachedInputTokens, incoming.CachedInputTokens);
@@ -136,21 +169,60 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         existing.TotalTokens = SumNullable(existing.TotalTokens, incoming.TotalTokens);
         existing.CompactCount = SumNullable(existing.CompactCount, incoming.CompactCount);
         existing.DurationMs = MaxNullable(existing.DurationMs, incoming.DurationMs);
-        existing.CostUsd = SumNullable(existing.CostUsd, incoming.CostUsd);
+        existing.CostUsd = MaxNullable(existing.CostUsd, incoming.CostUsd);
         if (incoming.TruthLevel > existing.TruthLevel) {
             existing.TruthLevel = incoming.TruthLevel;
         }
     }
 
-    private static bool HasSameRollupContribution(UsageEventRecord existing, UsageEventRecord incoming) =>
+    private static void MergeDuplicateContributionInto(UsageEventRecord existing, UsageEventRecord incoming) {
+        existing.InputTokens = MaxNullable(existing.InputTokens, incoming.InputTokens);
+        existing.CachedInputTokens = MaxNullable(existing.CachedInputTokens, incoming.CachedInputTokens);
+        existing.OutputTokens = MaxNullable(existing.OutputTokens, incoming.OutputTokens);
+        existing.ReasoningTokens = MaxNullable(existing.ReasoningTokens, incoming.ReasoningTokens);
+        existing.TotalTokens = MaxNullable(existing.TotalTokens, incoming.TotalTokens);
+        existing.CompactCount = MaxNullable(existing.CompactCount, incoming.CompactCount);
+        existing.DurationMs = MaxNullable(existing.DurationMs, incoming.DurationMs);
+        existing.CostUsd = MaxNullable(existing.CostUsd, incoming.CostUsd);
+        if (incoming.TruthLevel > existing.TruthLevel) {
+            existing.TruthLevel = incoming.TruthLevel;
+        }
+    }
+
+    private static bool HasSameRollupCoverage(UsageEventRecord existing, UsageEventRecord incoming) =>
         existing.InputTokens == incoming.InputTokens &&
         existing.CachedInputTokens == incoming.CachedInputTokens &&
         existing.OutputTokens == incoming.OutputTokens &&
         existing.ReasoningTokens == incoming.ReasoningTokens &&
         existing.TotalTokens == incoming.TotalTokens &&
-        existing.CompactCount == incoming.CompactCount &&
-        existing.DurationMs == incoming.DurationMs &&
-        existing.CostUsd == incoming.CostUsd;
+        existing.CompactCount == incoming.CompactCount;
+
+    private static bool HasSameRollupIdentity(UsageEventRecord existing, UsageEventRecord incoming) =>
+        string.Equals(existing.EventId, incoming.EventId, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.ProviderId, incoming.ProviderId, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.AdapterId, incoming.AdapterId, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.SourceRootId, incoming.SourceRootId, StringComparison.OrdinalIgnoreCase) &&
+        existing.TimestampUtc == incoming.TimestampUtc &&
+        string.Equals(existing.ProviderAccountId ?? string.Empty, incoming.ProviderAccountId ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.AccountLabel ?? string.Empty, incoming.AccountLabel ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.SessionId ?? string.Empty, incoming.SessionId ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.ThreadId ?? string.Empty, incoming.ThreadId ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.TurnId ?? string.Empty, incoming.TurnId ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.ResponseId ?? string.Empty, incoming.ResponseId ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.Model ?? string.Empty, incoming.Model ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.Surface ?? string.Empty, incoming.Surface ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(existing.RawHash ?? string.Empty, incoming.RawHash ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+
+    private static bool HasDominatingRollupCoverage(UsageEventRecord existing, UsageEventRecord incoming) =>
+        CoverageDominates(existing, incoming) || CoverageDominates(incoming, existing);
+
+    private static bool CoverageDominates(UsageEventRecord candidate, UsageEventRecord other) =>
+        NullableGreaterOrEqual(candidate.InputTokens, other.InputTokens) &&
+        NullableGreaterOrEqual(candidate.CachedInputTokens, other.CachedInputTokens) &&
+        NullableGreaterOrEqual(candidate.OutputTokens, other.OutputTokens) &&
+        NullableGreaterOrEqual(candidate.ReasoningTokens, other.ReasoningTokens) &&
+        NullableGreaterOrEqual(candidate.TotalTokens, other.TotalTokens) &&
+        NullableGreaterOrEqual(candidate.CompactCount, other.CompactCount);
 
     private static long? SumNullable(long? existing, long? incoming) {
         if (!existing.HasValue) {
@@ -199,4 +271,34 @@ internal static class UsageTelemetryCachedSnapshotMerge {
 
         return Math.Max(existing.Value, incoming.Value);
     }
+
+    private static int? MaxNullable(int? existing, int? incoming) {
+        if (!existing.HasValue) {
+            return incoming;
+        }
+
+        if (!incoming.HasValue) {
+            return existing;
+        }
+
+        return Math.Max(existing.Value, incoming.Value);
+    }
+
+    private static decimal? MaxNullable(decimal? existing, decimal? incoming) {
+        if (!existing.HasValue) {
+            return incoming;
+        }
+
+        if (!incoming.HasValue) {
+            return existing;
+        }
+
+        return Math.Max(existing.Value, incoming.Value);
+    }
+
+    private static bool NullableGreaterOrEqual(long? candidate, long? other) =>
+        !other.HasValue || candidate.HasValue && candidate.Value >= other.Value;
+
+    private static bool NullableGreaterOrEqual(int? candidate, int? other) =>
+        !other.HasValue || candidate.HasValue && candidate.Value >= other.Value;
 }

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetryCachedSnapshotMerge.cs
@@ -135,8 +135,8 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         for (var i = 0; i < contributions.Count; i++) {
             var existing = contributions[i];
             if (HasSameRollupCoverage(existing, incoming) ||
-                HasSameRollupIdentity(existing, incoming) && HasDominatingRollupCoverage(existing, incoming) ||
-                HasSameRollupIdentityIgnoringTimestamp(existing, incoming) && CoverageDominates(incoming, existing)) {
+                HasSameRollupIdentityWithTimestamp(existing, incoming) && HasDominatingRollupCoverage(existing, incoming) ||
+                HasSameRollupIdentity(existing, incoming) && CoverageDominates(incoming, existing)) {
                 MergeDuplicateContributionInto(existing, incoming);
                 return true;
             }
@@ -198,15 +198,15 @@ internal static class UsageTelemetryCachedSnapshotMerge {
         existing.TotalTokens == incoming.TotalTokens &&
         existing.CompactCount == incoming.CompactCount;
 
-    private static bool HasSameRollupIdentity(UsageEventRecord existing, UsageEventRecord incoming) =>
+    private static bool HasSameRollupIdentityWithTimestamp(UsageEventRecord existing, UsageEventRecord incoming) =>
         string.Equals(existing.EventId, incoming.EventId, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.ProviderId, incoming.ProviderId, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.AdapterId, incoming.AdapterId, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.SourceRootId, incoming.SourceRootId, StringComparison.OrdinalIgnoreCase) &&
         existing.TimestampUtc == incoming.TimestampUtc &&
-        HasSameRollupIdentityIgnoringTimestamp(existing, incoming);
+        HasSameRollupIdentity(existing, incoming);
 
-    private static bool HasSameRollupIdentityIgnoringTimestamp(UsageEventRecord existing, UsageEventRecord incoming) =>
+    private static bool HasSameRollupIdentity(UsageEventRecord existing, UsageEventRecord incoming) =>
         string.Equals(existing.EventId, incoming.EventId, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.ProviderId, incoming.ProviderId, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(existing.AdapterId, incoming.AdapterId, StringComparison.OrdinalIgnoreCase) &&

--- a/IntelligenceX/Telemetry/Usage/UsageTelemetrySnapshotService.cs
+++ b/IntelligenceX/Telemetry/Usage/UsageTelemetrySnapshotService.cs
@@ -181,12 +181,10 @@ public sealed class UsageTelemetrySnapshotService {
                 providerResults,
                 errors,
                 rootsByProvider.Select(static group => group.Key).ToArray()),
-            rawEvents: startupWarmup
-                ? Array.Empty<UsageEventRecord>()
-                : providerResults
-                    .SelectMany(static result => result.RawEvents)
-                    .OrderBy(static usageEvent => usageEvent.TimestampUtc)
-                    .ToArray());
+            rawEvents: providerResults
+                .SelectMany(static result => result.RawEvents)
+                .OrderBy(static usageEvent => usageEvent.TimestampUtc)
+                .ToArray());
     }
 
     private IReadOnlyList<SourceRootRecord> DiscoverAllRoots() {

--- a/IntelligenceX/Treatment/OpenAIChatTreatmentProvider.cs
+++ b/IntelligenceX/Treatment/OpenAIChatTreatmentProvider.cs
@@ -117,7 +117,13 @@ public sealed class OpenAIChatTreatmentProvider : ITreatmentProvider {
             return null;
         }
 
-        return uri.IsAbsoluteUri ? uri.AbsolutePath : uri.OriginalString;
+        if (uri.IsAbsoluteUri) {
+            return uri.AbsolutePath;
+        }
+
+        var value = uri.OriginalString;
+        var queryIndex = value.IndexOfAny(new[] { '?', '#' });
+        return queryIndex < 0 ? value : value.Substring(0, queryIndex);
     }
 
     private static bool IsSupportedImageMediaType(string mediaType) =>

--- a/IntelligenceX/Treatment/OpenAIChatTreatmentProvider.cs
+++ b/IntelligenceX/Treatment/OpenAIChatTreatmentProvider.cs
@@ -104,12 +104,20 @@ public sealed class OpenAIChatTreatmentProvider : ITreatmentProvider {
             return true;
         }
 
-        var extension = Path.GetExtension(artifact.Path ?? artifact.Uri?.AbsolutePath ?? string.Empty);
+        var extension = Path.GetExtension(artifact.Path ?? GetUriExtensionPath(artifact.Uri) ?? string.Empty);
         return extension.Equals(".png", StringComparison.OrdinalIgnoreCase) ||
                extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase) ||
                extension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase) ||
                extension.Equals(".gif", StringComparison.OrdinalIgnoreCase) ||
                extension.Equals(".webp", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? GetUriExtensionPath(Uri? uri) {
+        if (uri is null) {
+            return null;
+        }
+
+        return uri.IsAbsoluteUri ? uri.AbsolutePath : uri.OriginalString;
     }
 
     private static bool IsSupportedImageMediaType(string mediaType) =>
@@ -120,9 +128,14 @@ public sealed class OpenAIChatTreatmentProvider : ITreatmentProvider {
         mediaType.Equals("image/webp", StringComparison.OrdinalIgnoreCase);
 
     private static string ResolveLocalArtifactPath(string path, TreatmentRequest request) {
-        var baseDirectory = request.WorkingDirectory ?? request.Workspace;
+        var baseDirectory = ResolveLocalArtifactBaseDirectory(request);
         return TreatmentLocalInputReader.ResolvePath(path, baseDirectory);
     }
+
+    private static string? ResolveLocalArtifactBaseDirectory(TreatmentRequest request) =>
+        !string.IsNullOrWhiteSpace(request.Workspace)
+            ? request.Workspace
+            : request.WorkingDirectory;
 
     private static string NormalizeMediaType(string? mediaType) {
         if (string.IsNullOrWhiteSpace(mediaType)) {

--- a/IntelligenceX/Treatment/OpenAIChatTreatmentProvider.cs
+++ b/IntelligenceX/Treatment/OpenAIChatTreatmentProvider.cs
@@ -93,7 +93,11 @@ public sealed class OpenAIChatTreatmentProvider : ITreatmentProvider {
             if (!string.IsNullOrWhiteSpace(artifact.Path)) {
                 input.AddImagePath(ResolveLocalArtifactPath(artifact.Path!, request));
             } else if (artifact.Uri is not null) {
-                input.AddImageUrl(artifact.Uri.ToString());
+                if (TryGetRelativeUriPath(artifact.Uri, out var relativePath)) {
+                    input.AddImagePath(ResolveLocalArtifactPath(relativePath!, request));
+                } else {
+                    input.AddImageUrl(artifact.Uri.ToString());
+                }
             }
         }
     }
@@ -124,6 +128,16 @@ public sealed class OpenAIChatTreatmentProvider : ITreatmentProvider {
         var value = uri.OriginalString;
         var queryIndex = value.IndexOfAny(new[] { '?', '#' });
         return queryIndex < 0 ? value : value.Substring(0, queryIndex);
+    }
+
+    private static bool TryGetRelativeUriPath(Uri uri, out string? path) {
+        path = null;
+        if (uri.IsAbsoluteUri) {
+            return false;
+        }
+
+        path = GetUriExtensionPath(uri);
+        return !string.IsNullOrWhiteSpace(path);
     }
 
     private static bool IsSupportedImageMediaType(string mediaType) =>

--- a/IntelligenceX/Treatment/TreatmentPromptBuilder.cs
+++ b/IntelligenceX/Treatment/TreatmentPromptBuilder.cs
@@ -110,11 +110,16 @@ public static class TreatmentPromptBuilder {
 
     private static TreatmentPromptBuildOptions CreateDefaultOptions(TreatmentRequest request) {
         return new TreatmentPromptBuildOptions {
-            BaseDirectory = request.WorkingDirectory ?? request.Workspace,
+            BaseDirectory = ResolveLocalArtifactBaseDirectory(request),
             InlineLocalFiles = request.InlineLocalInputFiles,
             MaxInlineFileCharacters = request.MaxInlineFileCharacters ?? 120000
         };
     }
+
+    private static string? ResolveLocalArtifactBaseDirectory(TreatmentRequest request) =>
+        !string.IsNullOrWhiteSpace(request.Workspace)
+            ? request.Workspace
+            : request.WorkingDirectory;
 
     private static void AppendInput(StringBuilder sb, TreatmentInputArtifact input, int index, TreatmentPromptBuildOptions options) {
         if (input is null) {


### PR DESCRIPTION
## Summary
- Fix valid unresolved review-thread findings from the five most recent merged PRs (#1311, #1310, #1309, #1307); #1308 had no active unresolved threads.
- Keep treatment local artifact reads rooted to `Workspace`, handle relative image URIs safely, preserve startup raw events, sum distinct overlapping rollups without double-counting identical raw coverage, and allow startup full-refresh retries for watcher/dirty states.
- Tighten tray pulse wording for today-scoped provider leadership and subset-aware cached input percentages.
- Stop default image-generation launch/service/host paths from forcing disabled overrides, and keep request-level image output directories from overriding trusted service config.
- Move reviewer-facing 5.4 references to `gpt-5.5`.

## Validation
- `git diff --check`
- `dotnet build IntelligenceX.CI.slnf -c Release`
- `dotnet build IntelligenceX.Chat\IntelligenceX.Chat.Service\IntelligenceX.Chat.Service.csproj -c Release`
- `dotnet build IntelligenceX.Chat\IntelligenceX.Chat.Host\IntelligenceX.Chat.Host.csproj -c Release`
- `dotnet build IntelligenceX.Chat\IntelligenceX.Chat.App\IntelligenceX.Chat.App.csproj -c Release`
- `dotnet test IntelligenceX.Chat\IntelligenceX.Chat.App.Tests\IntelligenceX.Chat.App.Tests.csproj -c Release`
- `dotnet .\IntelligenceX.Tests\bin\Release\net8.0\IntelligenceX.Tests.dll`
- `dotnet .\IntelligenceX.Tests\bin\Release\net10.0\IntelligenceX.Tests.dll`
