### PR TITLE
Refresh IntelligenceX website SEO engine pin

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@feaee913e8c88cda888db3e2dbca320c1c472f6c
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@7c122532aae02d8690e2d2fb5013076157748080
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -26,7 +26,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 63583b4091cca3b9b6fcbc9cb71f3bb278c8b4ae
+      powerforge_ref: 7c122532aae02d8690e2d2fb5013076157748080
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -9,11 +9,11 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@feaee913e8c88cda888db3e2dbca320c1c472f6c
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@7c122532aae02d8690e2d2fb5013076157748080
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 63583b4091cca3b9b6fcbc9cb71f3bb278c8b4ae
+      powerforge_ref: 7c122532aae02d8690e2d2fb5013076157748080

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -254,7 +254,7 @@
       "navCanonicalRequired": true,
       "navRequiredLinks": "/,/docs/,/api/,/api/powershell/,/showcase/,/blog/",
       "minNavCoveragePercent": 99,
-      "requiredRoutes": "/,/docs/,/404.html,/api/,/api/powershell/,/blog/,/search/,/sitemap/,/showcase/",
+      "requiredRoutes": "/,/docs/,/404.html,/api/,/api/powershell/,/blog/,/search/,/sitemap/,/sitemap.xml,/showcase/",
       "failOnCategories": "budget,nav,link,asset,rendered-console-error,rendered-request-failure",
       "failOnIssueCodes": "media-img-dimensions,heading-order,head-render-blocking",
       "maxHeadBlockingResources": 2,


### PR DESCRIPTION
## Summary
- align IntelligenceX website deploy and CI workflows to the current PowerForge.Web ref
- add `/sitemap.xml` to the website doctor required-route guard

## Root cause
The live IntelligenceX API index still exposes the older no-trailing-slash canonical URL. The current PowerForge engine has the fix, so this refresh ensures the next website deployment uses the fixed generator and protects the root sitemap route in CI.

## Validation
- `powerforge-web build --config .\site.json --out .\_site --clean`
- `powerforge-web sitemap --site-root .\_site --base-url https://intelligencex.dev ...`
- route-only `powerforge-web doctor` passed for `/sitemap.xml`
- checked generated `_site\robots.txt` advertises `https://intelligencex.dev/sitemap.xml`