### PR TITLE
Fix Codex diagnostics on live SQLite metadata

### DIFF
--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX;
+using Microsoft.Data.Sqlite;
 
 namespace IntelligenceX.Codex;
 
@@ -232,25 +233,17 @@ public sealed class CodexLocalStateDiagnosticsService {
                 continue;
             }
 
-            foreach (var column in ToRows(_sqlite.Query(stateDb, $"PRAGMA table_info({QuoteString(table)});"))) {
-                var columnName = Convert.ToString(column["name"], CultureInfo.InvariantCulture);
-                var columnType = Convert.ToString(column["type"], CultureInfo.InvariantCulture);
-                if (string.IsNullOrWhiteSpace(columnName)) {
-                    continue;
-                }
-
-                if (IsTextColumn(columnType) && IsPathColumn(columnName)) {
-                    columns.Add((table, columnName));
-                }
-            }
+            columns.AddRange(GetTableColumns(stateDb, table)
+                .Where(static column => IsTextColumn(column.Type) && IsPathColumn(column.Name))
+                .Select(column => (table, column.Name)));
         }
 
         return columns;
     }
 
     private (int ActiveThreads, int OversizedRows) CountThreadMetadata(string stateDb) {
-        var columns = ToRows(_sqlite.Query(stateDb, "PRAGMA table_info('threads');"))
-            .Select(static row => Convert.ToString(row["name"], CultureInfo.InvariantCulture) ?? string.Empty)
+        var columns = GetTableColumns(stateDb, "threads")
+            .Select(static column => column.Name)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         if (!columns.Contains("title")) {
             return (0, 0);
@@ -280,6 +273,32 @@ public sealed class CodexLocalStateDiagnosticsService {
         return (
             Convert.ToInt32(row["active_count"], CultureInfo.InvariantCulture),
             Convert.ToInt32(row["oversized_count"], CultureInfo.InvariantCulture));
+    }
+
+    private static IReadOnlyList<(string Name, string Type)> GetTableColumns(string stateDb, string table) {
+        var columns = new List<(string Name, string Type)>();
+        var builder = new SqliteConnectionStringBuilder {
+            DataSource = stateDb,
+            Mode = SqliteOpenMode.ReadOnly
+        };
+        using var connection = new SqliteConnection(builder.ConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = $"PRAGMA table_info({QuoteString(table)});";
+        using var reader = command.ExecuteReader();
+        var nameOrdinal = reader.GetOrdinal("name");
+        var typeOrdinal = reader.GetOrdinal("type");
+        while (reader.Read()) {
+            var name = reader.IsDBNull(nameOrdinal) ? string.Empty : reader.GetString(nameOrdinal);
+            if (string.IsNullOrWhiteSpace(name)) {
+                continue;
+            }
+
+            var type = reader.IsDBNull(typeOrdinal) ? string.Empty : reader.GetString(typeOrdinal);
+            columns.Add((name, type));
+        }
+
+        return columns;
     }
 
     private static int CountConfigExtendedPaths(string codexHome) {

--- a/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
@@ -112,6 +112,58 @@ internal static partial class Program {
         }
     }
 
+    private static void TestCodexLocalStateDiagnosticsHandlesMigrationDefaultValues() {
+        var root = CreateCodexDiagnosticsTempDirectory();
+        try {
+            var codexHome = Path.Combine(root, ".codex");
+            Directory.CreateDirectory(codexHome);
+            var dbPath = Path.Combine(codexHome, "state_5.sqlite");
+            var sqlite = new SQLite();
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                CREATE TABLE _sqlx_migrations (
+                    version BIGINT PRIMARY KEY,
+                    description TEXT NOT NULL,
+                    installed_on TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                """);
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    title TEXT,
+                    first_user_message TEXT,
+                    cwd TEXT,
+                    archived INTEGER
+                );
+                """);
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                INSERT INTO threads (id, title, first_user_message, cwd, archived)
+                VALUES (@id, @title, @preview, @cwd, 0);
+                """,
+                new Dictionary<string, object?> {
+                    ["@id"] = "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                    ["@title"] = "short title",
+                    ["@preview"] = "short preview",
+                    ["@cwd"] = @"\\?\C:\Support\GitHub\Example"
+                });
+
+            var service = new CodexLocalStateDiagnosticsService();
+            var diagnostics = service.CollectAsync(codexHome).GetAwaiter().GetResult();
+
+            AssertEqual(CodexLocalStateHealthStatus.Warning, diagnostics.Status, "codex migrations default status");
+            AssertEqual(true, diagnostics.CanConnect, "codex migrations default can connect");
+            AssertEqual(1, diagnostics.ExtendedPathCount, "codex migrations default extended path count");
+            AssertEqual(true, diagnostics.Findings.Any(f => f.Key == "extended-paths:threads.cwd"), "codex migrations default cwd finding");
+        } finally {
+            TryDeleteCodexDiagnosticsDirectory(root);
+        }
+    }
+
     private static string CreateCodexDiagnosticsTempDirectory() {
         var path = Path.Combine(Path.GetTempPath(), "ix-codex-diagnostics-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(path);

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -353,6 +353,8 @@ internal static partial class Program {
             TestCodexLocalStateDiagnosticsFlagsExtendedPathsAndMetadata);
         failed += Run("Codex local state diagnostics ignores path syntax in text columns",
             TestCodexLocalStateDiagnosticsIgnoresPathSyntaxInTextColumns);
+        failed += Run("Codex local state diagnostics handles migration default values",
+            TestCodexLocalStateDiagnosticsHandlesMigrationDefaultValues);
 #if !NET472
         failed += Run("GitHub owner scope resolver returns administered organizations with public repos", TestGitHubOwnerScopeResolverReturnsAdministeredOrganizationsWithPublicRepos);
         failed += Run("GitHub overview collector appends correlated owners for user runs", TestGitHubOverviewDataCollectorAppendsCorrelatedOwnersForUserRuns);


### PR DESCRIPTION
## Summary
- read Codex SQLite table metadata directly with `Microsoft.Data.Sqlite` so `PRAGMA table_info` rows with `DEFAULT CURRENT_TIMESTAMP` do not fail through DBAClientX `DataTable` projection
- keep DBAClientX for normal diagnostics queries while using the direct metadata reader only for schema discovery
- add a regression test with `_sqlx_migrations.installed_on DEFAULT CURRENT_TIMESTAMP` and an extended-path `threads.cwd` value

## Validation
- `dotnet build IntelligenceX.Storage.SQLite\IntelligenceX.Storage.SQLite.csproj -c Release -v:minimal /nr:false`
- `dotnet build IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net8.0 -v:minimal /nr:false`
- `dotnet run --project IntelligenceX.Tests\IntelligenceX.Tests.csproj -f net8.0 --no-build`
- `git diff --check`
- live local Codex check against `C:\Users\przemyslaw.klys.EVOTEC\.codex\state_5.sqlite`: IX and keep-codex-fast both report `threads.rollout_path=4`, `threads.cwd=29`, and `thread_metadata_repair_candidates=22`