### PR TITLE
Address Codex follow-ups from PR 1317

### DIFF
--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Overview.cs
@@ -2777,6 +2777,46 @@ internal static partial class Program {
         }
     }
 
+    private static void TestUsageTelemetryOverviewReportExporterCarriesGitHubObservabilitySummary() {
+        var summary = new UsageSummarySnapshot {
+            Metric = UsageSummaryMetric.TotalTokens,
+            StartDayUtc = new DateTime(2025, 03, 14),
+            EndDayUtc = new DateTime(2026, 03, 12),
+            TotalValue = 0m,
+            TotalDays = 365,
+            ActiveDays = 71,
+            PeakDayUtc = new DateTime(2026, 03, 11),
+            PeakValue = 18m
+        };
+        var overview = new UsageTelemetryOverviewDocument(
+            title: "Usage Overview",
+            subtitle: "@przemyslawklys",
+            metric: UsageSummaryMetric.TotalTokens,
+            units: "tokens",
+            summary: summary,
+            cards: Array.Empty<UsageTelemetryOverviewCard>(),
+            heatmaps: Array.Empty<UsageTelemetryOverviewHeatmap>(),
+            providerSections: new[] { CreateSampleGitHubOverviewSection() });
+
+        var tempPath = Path.Combine(Path.GetTempPath(), "ix-report-exporter-github-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempPath);
+        try {
+            var reportPath = UsageTelemetryOverviewReportExporter.WriteBundle(
+                overview,
+                tempPath,
+                CreateSampleGitHubObservabilitySummary());
+
+            var html = File.ReadAllText(reportPath);
+            var wrappedHtml = File.ReadAllText(Path.Combine(tempPath, "github-wrapped.html"));
+            AssertContainsText(html, "Watched repo momentum", "overview report carries watched repository summary");
+            AssertContainsText(wrappedHtml, "Watched repo momentum", "wrapped report carries watched repository summary");
+        } finally {
+            if (Directory.Exists(tempPath)) {
+                Directory.Delete(tempPath, recursive: true);
+            }
+        }
+    }
+
     private static UsageTelemetryOverviewProviderSection CreateSampleGitHubOverviewSection() {
         return new UsageTelemetryOverviewProviderSection(
             key: "provider-github",

--- a/IntelligenceX.Tests/Program.Telemetry.Usage.Runtime.cs
+++ b/IntelligenceX.Tests/Program.Telemetry.Usage.Runtime.cs
@@ -51,6 +51,33 @@ internal static partial class Program {
         }
     }
 
+    private static void TestIntelligenceXClientSkipsUsageTelemetryWhenFactoryUnset() {
+        var dbDirectory = Path.Combine(Path.GetTempPath(), $"ix-usage-runtime-no-factory-{Guid.NewGuid():N}");
+        var dbPath = Path.Combine(dbDirectory, "usage.db");
+        Directory.CreateDirectory(dbDirectory);
+        try {
+            var options = new IntelligenceXClientOptions {
+                AutoInitialize = false,
+                TransportKind = OpenAITransportKind.CompatibleHttp,
+                EnableUsageTelemetry = true,
+                UsageTelemetryDatabasePath = dbPath
+            };
+            options.CompatibleHttpOptions.BaseUrl = "http://localhost:1234/v1";
+            options.CompatibleHttpOptions.AllowInsecureHttp = true;
+
+            using var client = IntelligenceXClient.ConnectAsync(options).GetAwaiter().GetResult();
+
+            AssertNotNull(client, "client without telemetry factory");
+            AssertEqual(false, File.Exists(dbPath), "client without telemetry factory should not create usage db");
+        } finally {
+            try {
+                Directory.Delete(dbDirectory, recursive: true);
+            } catch {
+                // best-effort cleanup
+            }
+        }
+    }
+
     private static void TestInternalIxUsageTelemetrySessionPersistsTurnsToSqlite() {
         var dbDirectory = Path.Combine(Path.GetTempPath(), $"ix-usage-runtime-{Guid.NewGuid():N}");
         var dbPath = Path.Combine(dbDirectory, "usage.db");

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -259,6 +259,8 @@ internal static partial class Program {
             TestUsageTelemetryGitHubWrappedCardPageModelBuilderAddsWatchedMomentumWhenProvided);
         failed += Run("Usage report bundle writer publishes shared assets",
             TestUsageTelemetryReportBundleWriterPublishesSharedAssets);
+        failed += Run("Usage telemetry overview report exporter carries GitHub observability summary",
+            TestUsageTelemetryOverviewReportExporterCarriesGitHubObservabilitySummary);
         failed += Run("IntelligenceX client emits turn completed telemetry",
             TestIntelligenceXClientEmitsTurnCompletedTelemetry);
         failed += Run("EasySession forwards telemetry labels", TestEasySessionForwardsTelemetryLabels);
@@ -270,6 +272,8 @@ internal static partial class Program {
             TestUsageTelemetryPathResolverHonorsEnvironmentOverrides);
         failed += Run("Usage telemetry path resolver disables when flag off",
             TestUsageTelemetryPathResolverDisablesWhenFlagOff);
+        failed += Run("IntelligenceX client skips usage telemetry when factory unset",
+            TestIntelligenceXClientSkipsUsageTelemetryWhenFactoryUnset);
         failed += Run("Internal IX usage telemetry session persists turns to sqlite",
             TestInternalIxUsageTelemetrySessionPersistsTurnsToSqlite);
         failed += Run("Internal IX usage telemetry session classifies native transport as ChatGPT",

--- a/IntelligenceX.Tray/ViewModels/MainViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/MainViewModel.cs
@@ -1797,6 +1797,9 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         _latestGitHubRepositoryClusterSummary = BuildGitHubRepositoryClusterSummary();
         GitHub.ApplyLocalActivityCorrelationSummary(_latestGitHubLocalActivityCorrelationSummary);
         GitHub.ApplyRepositoryClusterSummary(_latestGitHubRepositoryClusterSummary);
+        ApplyGitHubObservabilitySummary(
+            providers ?? Providers,
+            _latestGitHubObservabilitySummary);
         ApplyGitHubLocalActivityCorrelationSummary(
             providers ?? Providers,
             _latestGitHubLocalActivityCorrelationSummary);
@@ -1818,6 +1821,15 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         foreach (var provider in providers.Where(static provider =>
                      string.Equals(provider.ProviderId, "__all__", StringComparison.Ordinal))) {
             provider.ApplyGitHubLocalActivityCorrelationSummary(summary);
+        }
+    }
+
+    private static void ApplyGitHubObservabilitySummary(
+        IEnumerable<ProviderViewModel> providers,
+        GitHubObservabilitySummaryData summary) {
+        foreach (var provider in providers.Where(static provider =>
+                     string.Equals(provider.ProviderId, "__all__", StringComparison.Ordinal))) {
+            provider.ApplyGitHubObservabilitySummary(summary);
         }
     }
 

--- a/IntelligenceX.Tray/ViewModels/ProviderViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/ProviderViewModel.cs
@@ -170,6 +170,7 @@ public sealed class ProviderViewModel : ViewModelBase {
     private HashSet<string> _providerComparisonFavorites = new(StringComparer.OrdinalIgnoreCase);
     private GitCodeChurnSummaryData _codeChurnSummary = GitCodeChurnSummaryData.Empty;
     private GitCodeUsageCorrelationSummaryData _codeUsageCorrelationSummary = GitCodeUsageCorrelationSummaryData.Empty;
+    private GitHubObservabilitySummaryData _gitHubObservabilitySummary = GitHubObservabilitySummaryData.Empty;
     private GitHubLocalActivityCorrelationSummaryData _gitHubLocalActivityCorrelationSummary = GitHubLocalActivityCorrelationSummaryData.Empty;
     private GitHubRepositoryClusterSummaryData _gitHubRepositoryClusterSummary = GitHubRepositoryClusterSummaryData.Empty;
 
@@ -1281,6 +1282,10 @@ public sealed class ProviderViewModel : ViewModelBase {
         if (IsCombinedProvider) {
             RebuildSelectedRangeViews();
         }
+    }
+
+    internal void ApplyGitHubObservabilitySummary(GitHubObservabilitySummaryData? summary) {
+        _gitHubObservabilitySummary = summary ?? GitHubObservabilitySummaryData.Empty;
     }
 
     internal void ApplyGitHubRepositoryClusterSummary(GitHubRepositoryClusterSummaryData? summary) {
@@ -3204,7 +3209,11 @@ public sealed class ProviderViewModel : ViewModelBase {
                     Subtitle = "Tray explorer: " + TodayLabel + " | " + BuildFilterSummary(),
                     Metadata = BuildReportMetadata()
                 })).ConfigureAwait(true);
-            var reportPath = await Task.Run(() => UsageTelemetryOverviewReportExporter.WriteBundle(overview, outputDirectory)).ConfigureAwait(true);
+            var gitHubObservabilitySummary = _gitHubObservabilitySummary;
+            var reportPath = await Task.Run(() => UsageTelemetryOverviewReportExporter.WriteBundle(
+                overview,
+                outputDirectory,
+                gitHubObservabilitySummary)).ConfigureAwait(true);
 
             Process.Start(new ProcessStartInfo {
                 FileName = reportPath,

--- a/IntelligenceX/Providers/OpenAI/IntelligenceXClient.cs
+++ b/IntelligenceX/Providers/OpenAI/IntelligenceXClient.cs
@@ -149,7 +149,7 @@ public sealed class IntelligenceXClient : IDisposable
         }
 
         if (options.UsageTelemetrySessionFactory is null) {
-            throw new NotSupportedException("Persistent usage telemetry requires a storage provider. Reference IntelligenceX.Storage.SQLite and set UsageTelemetrySessionFactory to SqliteInternalIxUsageTelemetrySessionFactory.");
+            return null;
         }
 
         return options.UsageTelemetrySessionFactory.TryCreate(client, options);

--- a/IntelligenceX/Providers/OpenAI/IntelligenceXClientOptions.cs
+++ b/IntelligenceX/Providers/OpenAI/IntelligenceXClientOptions.cs
@@ -88,7 +88,7 @@ public sealed class IntelligenceXClientOptions {
     /// </summary>
     public string? UsageTelemetrySourcePath { get; set; }
     /// <summary>
-    /// Optional factory used to attach persistent usage telemetry storage.
+    /// Optional factory used to attach persistent usage telemetry storage. When omitted, telemetry persistence is skipped.
     /// </summary>
     public IIntelligenceXUsageTelemetrySessionFactory? UsageTelemetrySessionFactory { get; set; }
 

--- a/IntelligenceX/Visualization/Heatmaps/UsageTelemetryOverviewReportExporter.cs
+++ b/IntelligenceX/Visualization/Heatmaps/UsageTelemetryOverviewReportExporter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using IntelligenceX.Telemetry.GitHub;
 
 namespace IntelligenceX.Visualization.Heatmaps;
 
@@ -20,6 +21,22 @@ public static class UsageTelemetryOverviewReportExporter {
 
         Directory.CreateDirectory(outputDirectory);
         UsageTelemetryReportBundleWriter.WriteOverviewBundle(overview, outputDirectory);
+        return Path.Combine(outputDirectory, "index.html");
+    }
+
+    internal static string WriteBundle(
+        UsageTelemetryOverviewDocument overview,
+        string outputDirectory,
+        GitHubObservabilitySummaryData? gitHubObservabilitySummary) {
+        if (overview is null) {
+            throw new ArgumentNullException(nameof(overview));
+        }
+        if (string.IsNullOrWhiteSpace(outputDirectory)) {
+            throw new ArgumentException("Output directory cannot be null or whitespace.", nameof(outputDirectory));
+        }
+
+        Directory.CreateDirectory(outputDirectory);
+        UsageTelemetryReportBundleWriter.WriteOverviewBundle(overview, outputDirectory, gitHubObservabilitySummary);
         return Path.Combine(outputDirectory, "index.html");
     }
 }


### PR DESCRIPTION
## Summary
- address the two unresolved Codex review threads left on PR #1317
- let usage telemetry persistence degrade cleanly when a storage factory is not configured instead of failing client creation
- pass the tray-loaded GitHub observability summary into detailed usage report export so watched-repo sections are preserved without moving SQLite back into core

## Notes
- The separate type-forwarder review-body note was not applied because forwarding SQLite implementation types from `IntelligenceX` would reintroduce the direct SQLite/storage dependency that PR #1317 intentionally split out. This PR keeps core SQLite-free and preserves runtime compatibility for the common `EnableUsageTelemetry` case.

## Validation
- `git diff --check`
- `dotnet build IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net8.0 -v:minimal /nr:false`
- `dotnet run --project IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net8.0 --no-build`
- `dotnet build IntelligenceX.Tray\IntelligenceX.Tray.csproj -c Release -v:minimal /nr:false`

Addresses Codex comments from #1317:
- https://github.com/EvotecIT/IntelligenceX/pull/1317#discussion_r3303062928
- https://github.com/EvotecIT/IntelligenceX/pull/1317#discussion_r3303062936