### PR TITLE
Add Codex diagnostics repair action to IX Tray

### DIFF
--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
@@ -292,7 +292,7 @@ public sealed class CodexLocalStateDiagnosticsService {
         using var transaction = connection.BeginTransaction();
         foreach (var row in rows) {
             cancellationToken.ThrowIfCancellationRequested();
-            var updates = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var updates = new List<(string Column, string OriginalValue, string NormalizedValue)>();
             foreach (var (column, value) in row.Values) {
                 if (string.IsNullOrWhiteSpace(value)) {
                     continue;
@@ -303,16 +303,17 @@ public sealed class CodexLocalStateDiagnosticsService {
                     continue;
                 }
 
-                updates[column] = normalized;
-                changedValues++;
+                updates.Add((column, value!, normalized));
             }
 
             if (updates.Count == 0) {
                 continue;
             }
 
-            UpdateThreadPathRow(connection, transaction, row.RowId, updates);
-            changedRows++;
+            if (UpdateThreadPathRow(connection, transaction, row.RowId, updates, activeExpr)) {
+                changedValues += updates.Count;
+                changedRows++;
+            }
         }
 
         transaction.Commit();
@@ -454,25 +455,30 @@ public sealed class CodexLocalStateDiagnosticsService {
         return rows;
     }
 
-    private static void UpdateThreadPathRow(
+    private static bool UpdateThreadPathRow(
         SqliteConnection connection,
         SqliteTransaction transaction,
         long rowId,
-        IReadOnlyDictionary<string, string> updates) {
-        var orderedUpdates = updates.ToArray();
+        IReadOnlyList<(string Column, string OriginalValue, string NormalizedValue)> updates,
+        string activeExpr) {
         using var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText = "UPDATE threads SET "
-                              + string.Join(", ", orderedUpdates.Select((item, index) => $"{QuoteIdentifier(item.Key)} = @p{index.ToString(CultureInfo.InvariantCulture)}"))
-                              + " WHERE rowid = @rowid;";
+                              + string.Join(", ", updates.Select((item, index) => $"{QuoteIdentifier(item.Column)} = @p{index.ToString(CultureInfo.InvariantCulture)}"))
+                              + " WHERE rowid = @rowid AND "
+                              + activeExpr
+                              + " AND "
+                              + string.Join(" AND ", updates.Select((item, index) => $"{QuoteIdentifier(item.Column)} = @old{index.ToString(CultureInfo.InvariantCulture)}"))
+                              + ";";
         var parameterIndex = 0;
-        foreach (var item in orderedUpdates) {
-            command.Parameters.AddWithValue("@p" + parameterIndex.ToString(CultureInfo.InvariantCulture), item.Value);
+        foreach (var item in updates) {
+            command.Parameters.AddWithValue("@p" + parameterIndex.ToString(CultureInfo.InvariantCulture), item.NormalizedValue);
+            command.Parameters.AddWithValue("@old" + parameterIndex.ToString(CultureInfo.InvariantCulture), item.OriginalValue);
             parameterIndex++;
         }
 
         command.Parameters.AddWithValue("@rowid", rowId);
-        command.ExecuteNonQuery();
+        return command.ExecuteNonQuery() == 1;
     }
 
     private static void BackupDatabase(SqliteConnection sourceConnection, string backupDb) {

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
@@ -459,14 +459,15 @@ public sealed class CodexLocalStateDiagnosticsService {
         SqliteTransaction transaction,
         long rowId,
         IReadOnlyDictionary<string, string> updates) {
+        var orderedUpdates = updates.ToArray();
         using var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText = "UPDATE threads SET "
-                              + string.Join(", ", updates.Keys.Select((column, index) => $"{QuoteIdentifier(column)} = @p{index.ToString(CultureInfo.InvariantCulture)}"))
+                              + string.Join(", ", orderedUpdates.Select((item, index) => $"{QuoteIdentifier(item.Key)} = @p{index.ToString(CultureInfo.InvariantCulture)}"))
                               + " WHERE rowid = @rowid;";
         var parameterIndex = 0;
-        foreach (var value in updates.Values) {
-            command.Parameters.AddWithValue("@p" + parameterIndex.ToString(CultureInfo.InvariantCulture), value);
+        foreach (var item in orderedUpdates) {
+            command.Parameters.AddWithValue("@p" + parameterIndex.ToString(CultureInfo.InvariantCulture), item.Value);
             parameterIndex++;
         }
 
@@ -612,7 +613,10 @@ public sealed class CodexLocalStateDiagnosticsService {
 
         return Path.Combine(
             root!,
-            "intelligencex-codex-hot-repair-" + DateTimeOffset.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture));
+            "intelligencex-codex-hot-repair-"
+            + DateTimeOffset.Now.ToString("yyyyMMdd-HHmmss-fff", CultureInfo.InvariantCulture)
+            + "-"
+            + Guid.NewGuid().ToString("N").Substring(0, 8));
     }
 
     private static string QuoteIdentifier(string value) {

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
@@ -83,6 +83,28 @@ public sealed class CodexLocalStateDiagnostics {
 }
 
 /// <summary>
+/// Result of a backup-first Codex local state path repair.
+/// </summary>
+public sealed class CodexLocalStatePathRepairResult {
+    /// <summary>Resolved Codex home directory.</summary>
+    public string CodexHome { get; init; } = string.Empty;
+    /// <summary>Resolved Codex SQLite state database path.</summary>
+    public string StateDatabasePath { get; init; } = string.Empty;
+    /// <summary>Whether the state database existed when repair was requested.</summary>
+    public bool DatabaseExists { get; init; }
+    /// <summary>Directory containing the SQLite backup created before mutation.</summary>
+    public string BackupDirectory { get; init; } = string.Empty;
+    /// <summary>Path to the SQLite backup created before mutation.</summary>
+    public string BackupDatabasePath { get; init; } = string.Empty;
+    /// <summary>Number of active thread path values inspected.</summary>
+    public int ScannedPathValueCount { get; init; }
+    /// <summary>Number of active thread path values rewritten.</summary>
+    public int ChangedPathValueCount { get; init; }
+    /// <summary>Number of active thread rows updated.</summary>
+    public int ChangedThreadRowCount { get; init; }
+}
+
+/// <summary>
 /// Reads local Codex Desktop/CLI state in a read-only way and summarizes issues
 /// that can make resume/navigation brittle.
 /// </summary>
@@ -198,6 +220,114 @@ public sealed class CodexLocalStateDiagnosticsService {
         };
     }
 
+    /// <summary>
+    /// Backs up the Codex SQLite state database, then rewrites active thread path
+    /// values from extended Windows paths to normal drive-rooted paths.
+    /// </summary>
+    /// <param name="codexHome">Optional Codex home override. Defaults to CODEX_HOME or ~/.codex.</param>
+    /// <param name="backupRoot">Optional backup root override. Defaults to Documents\Codex\codex-backups.</param>
+    /// <param name="cancellationToken">Cancellation token for the repair operation.</param>
+    /// <returns>A summary of the backed-up repair.</returns>
+    public Task<CodexLocalStatePathRepairResult> NormalizeActiveThreadPathsAsync(
+        string? codexHome = null,
+        string? backupRoot = null,
+        CancellationToken cancellationToken = default) {
+        return Task.Run(
+            () => NormalizeActiveThreadPaths(codexHome, backupRoot, cancellationToken),
+            cancellationToken);
+    }
+
+    private CodexLocalStatePathRepairResult NormalizeActiveThreadPaths(
+        string? codexHome,
+        string? backupRoot,
+        CancellationToken cancellationToken) {
+        var requestedHome = string.IsNullOrWhiteSpace(codexHome) ? ResolveDefaultCodexHome() : codexHome!.Trim();
+        var home = Path.GetFullPath(requestedHome);
+        var stateDb = Path.Combine(home, "state_5.sqlite");
+        if (!File.Exists(stateDb)) {
+            return new CodexLocalStatePathRepairResult {
+                CodexHome = home,
+                StateDatabasePath = stateDb,
+                DatabaseExists = false
+            };
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var backupDirectory = CreateBackupDirectory(backupRoot);
+        var backupDb = Path.Combine(backupDirectory, "state_5.sqlite");
+
+        var builder = new SqliteConnectionStringBuilder {
+            DataSource = stateDb,
+            Mode = SqliteOpenMode.ReadWrite
+        };
+        using var connection = new SqliteConnection(builder.ConnectionString);
+        connection.Open();
+        SetBusyTimeout(connection, 10000);
+        BackupDatabase(connection, backupDb);
+
+        var columns = GetTableColumns(stateDb, "threads");
+        var columnNames = columns
+            .Select(static column => column.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var pathColumns = columns
+            .Where(static column => IsTextColumn(column.Type) && IsPathColumn(column.Name))
+            .Select(static column => column.Name)
+            .ToArray();
+        if (pathColumns.Length == 0) {
+            return new CodexLocalStatePathRepairResult {
+                CodexHome = home,
+                StateDatabasePath = stateDb,
+                DatabaseExists = true,
+                BackupDirectory = backupDirectory,
+                BackupDatabasePath = backupDb
+            };
+        }
+
+        var activeExpr = BuildActiveThreadExpression(columnNames);
+        var rows = ReadActiveThreadPathRows(connection, pathColumns, activeExpr, cancellationToken);
+        var scannedValues = 0;
+        var changedValues = 0;
+        var changedRows = 0;
+
+        using var transaction = connection.BeginTransaction();
+        foreach (var row in rows) {
+            cancellationToken.ThrowIfCancellationRequested();
+            var updates = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (column, value) in row.Values) {
+                if (string.IsNullOrWhiteSpace(value)) {
+                    continue;
+                }
+
+                scannedValues++;
+                if (!TryNormalizeExtendedWindowsPath(value!, out var normalized)) {
+                    continue;
+                }
+
+                updates[column] = normalized;
+                changedValues++;
+            }
+
+            if (updates.Count == 0) {
+                continue;
+            }
+
+            UpdateThreadPathRow(connection, transaction, row.RowId, updates);
+            changedRows++;
+        }
+
+        transaction.Commit();
+        return new CodexLocalStatePathRepairResult {
+            CodexHome = home,
+            StateDatabasePath = stateDb,
+            DatabaseExists = true,
+            BackupDirectory = backupDirectory,
+            BackupDatabasePath = backupDb,
+            ScannedPathValueCount = scannedValues,
+            ChangedPathValueCount = changedValues,
+            ChangedThreadRowCount = changedRows
+        };
+    }
+
     private int CountExtendedPathRows(string stateDb, List<CodexLocalStateFinding> findings) {
         var total = 0;
         foreach (var (table, column) in EnumeratePathTextColumns(stateDb)) {
@@ -249,11 +379,7 @@ public sealed class CodexLocalStateDiagnosticsService {
             return (0, 0);
         }
 
-        var activeExpr = columns.Contains("archived")
-            ? "COALESCE(archived,0)=0"
-            : columns.Contains("archived_at")
-                ? "archived_at IS NULL"
-                : "1=1";
+        var activeExpr = BuildActiveThreadExpression(columns);
         var previewExpr = columns.Contains("first_user_message")
             ? $"length(first_user_message) > {DefaultPreviewLimit.ToString(CultureInfo.InvariantCulture)}"
             : "0";
@@ -299,6 +425,74 @@ public sealed class CodexLocalStateDiagnosticsService {
         }
 
         return columns;
+    }
+
+    private static IReadOnlyList<(long RowId, IReadOnlyList<(string Column, string? Value)> Values)> ReadActiveThreadPathRows(
+        SqliteConnection connection,
+        IReadOnlyList<string> pathColumns,
+        string activeExpr,
+        CancellationToken cancellationToken) {
+        var selectedColumns = string.Join(", ", pathColumns.Select(QuoteIdentifier));
+        using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT rowid AS __ix_rowid, {selectedColumns} FROM threads WHERE {activeExpr};";
+        using var reader = command.ExecuteReader();
+        var rowIdOrdinal = reader.GetOrdinal("__ix_rowid");
+        var columnOrdinals = pathColumns
+            .Select(column => (Column: column, Ordinal: reader.GetOrdinal(column)))
+            .ToArray();
+        var rows = new List<(long RowId, IReadOnlyList<(string Column, string? Value)> Values)>();
+        while (reader.Read()) {
+            cancellationToken.ThrowIfCancellationRequested();
+            var values = new List<(string Column, string? Value)>(columnOrdinals.Length);
+            foreach (var (column, ordinal) in columnOrdinals) {
+                values.Add((column, reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal)));
+            }
+
+            rows.Add((reader.GetInt64(rowIdOrdinal), values));
+        }
+
+        return rows;
+    }
+
+    private static void UpdateThreadPathRow(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        long rowId,
+        IReadOnlyDictionary<string, string> updates) {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "UPDATE threads SET "
+                              + string.Join(", ", updates.Keys.Select((column, index) => $"{QuoteIdentifier(column)} = @p{index.ToString(CultureInfo.InvariantCulture)}"))
+                              + " WHERE rowid = @rowid;";
+        var parameterIndex = 0;
+        foreach (var value in updates.Values) {
+            command.Parameters.AddWithValue("@p" + parameterIndex.ToString(CultureInfo.InvariantCulture), value);
+            parameterIndex++;
+        }
+
+        command.Parameters.AddWithValue("@rowid", rowId);
+        command.ExecuteNonQuery();
+    }
+
+    private static void BackupDatabase(SqliteConnection sourceConnection, string backupDb) {
+        var directory = Path.GetDirectoryName(backupDb);
+        if (!string.IsNullOrWhiteSpace(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        var builder = new SqliteConnectionStringBuilder {
+            DataSource = backupDb,
+            Mode = SqliteOpenMode.ReadWriteCreate
+        };
+        using var destination = new SqliteConnection(builder.ConnectionString);
+        destination.Open();
+        sourceConnection.BackupDatabase(destination);
+    }
+
+    private static void SetBusyTimeout(SqliteConnection connection, int milliseconds) {
+        using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA busy_timeout = " + milliseconds.ToString(CultureInfo.InvariantCulture) + ";";
+        command.ExecuteNonQuery();
     }
 
     private static int CountConfigExtendedPaths(string codexHome) {
@@ -373,6 +567,52 @@ public sealed class CodexLocalStateDiagnosticsService {
 
     private static bool IsPathColumn(string columnName) {
         return PathColumnHints.Any(hint => columnName.IndexOf(hint, StringComparison.OrdinalIgnoreCase) >= 0);
+    }
+
+    private static string BuildActiveThreadExpression(ISet<string> columns) {
+        return columns.Contains("archived")
+            ? "COALESCE(archived,0)=0"
+            : columns.Contains("archived_at")
+                ? "archived_at IS NULL"
+                : "1=1";
+    }
+
+    private static bool TryNormalizeExtendedWindowsPath(string value, out string normalized) {
+        normalized = value;
+        if (!value.StartsWith(ExtendedPathPrefix, StringComparison.Ordinal)) {
+            return false;
+        }
+
+        var withoutPrefix = value.Substring(ExtendedPathPrefix.Length);
+        if (!IsDriveRootedWindowsPath(withoutPrefix)) {
+            return false;
+        }
+
+        normalized = withoutPrefix;
+        return true;
+    }
+
+    private static bool IsDriveRootedWindowsPath(string value) {
+        return value.Length >= 3
+               && char.IsLetter(value[0])
+               && value[1] == ':'
+               && value[2] == '\\';
+    }
+
+    private static string CreateBackupDirectory(string? backupRoot) {
+        var root = backupRoot;
+        if (string.IsNullOrWhiteSpace(root)) {
+            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            if (string.IsNullOrWhiteSpace(documents)) {
+                documents = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Documents");
+            }
+
+            root = Path.Combine(documents, "Codex", "codex-backups");
+        }
+
+        return Path.Combine(
+            root!,
+            "intelligencex-codex-hot-repair-" + DateTimeOffset.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture));
     }
 
     private static string QuoteIdentifier(string value) {

--- a/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using DBAClientX;
 using IntelligenceX.Codex;
@@ -159,6 +160,89 @@ internal static partial class Program {
             AssertEqual(true, diagnostics.CanConnect, "codex migrations default can connect");
             AssertEqual(1, diagnostics.ExtendedPathCount, "codex migrations default extended path count");
             AssertEqual(true, diagnostics.Findings.Any(f => f.Key == "extended-paths:threads.cwd"), "codex migrations default cwd finding");
+        } finally {
+            TryDeleteCodexDiagnosticsDirectory(root);
+        }
+    }
+
+    private static void TestCodexLocalStateDiagnosticsNormalizesActiveThreadPaths() {
+        var root = CreateCodexDiagnosticsTempDirectory();
+        try {
+            var codexHome = Path.Combine(root, ".codex");
+            var backupRoot = Path.Combine(root, "backups");
+            Directory.CreateDirectory(codexHome);
+            var dbPath = Path.Combine(codexHome, "state_5.sqlite");
+            var sqlite = new SQLite();
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    title TEXT,
+                    first_user_message TEXT,
+                    rollout_path TEXT,
+                    cwd TEXT,
+                    archived INTEGER
+                );
+                """);
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                INSERT INTO threads (id, title, first_user_message, rollout_path, cwd, archived)
+                VALUES (@id, @title, @preview, @rollout_path, @cwd, @archived);
+                """,
+                new Dictionary<string, object?> {
+                    ["@id"] = "dddddddd-dddd-dddd-dddd-dddddddddddd",
+                    ["@title"] = "active",
+                    ["@preview"] = "active preview",
+                    ["@rollout_path"] = @"\\?\C:\Users\Example\.codex\sessions\rollout.jsonl",
+                    ["@cwd"] = @"\\?\C:\Support\GitHub\Example",
+                    ["@archived"] = 0
+                });
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                INSERT INTO threads (id, title, first_user_message, rollout_path, cwd, archived)
+                VALUES (@id, @title, @preview, @rollout_path, @cwd, @archived);
+                """,
+                new Dictionary<string, object?> {
+                    ["@id"] = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+                    ["@title"] = "archived",
+                    ["@preview"] = "archived preview",
+                    ["@rollout_path"] = @"\\?\C:\Users\Example\.codex\sessions\archived.jsonl",
+                    ["@cwd"] = @"\\?\C:\Support\GitHub\Archived",
+                    ["@archived"] = 1
+                });
+
+            var service = new CodexLocalStateDiagnosticsService();
+            var result = service.NormalizeActiveThreadPathsAsync(codexHome, backupRoot).GetAwaiter().GetResult();
+            var activeRolloutPath = Convert.ToString(sqlite.ExecuteScalar(
+                dbPath,
+                "SELECT rollout_path FROM threads WHERE id = @id;",
+                new Dictionary<string, object?> {
+                    ["@id"] = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+                }), CultureInfo.InvariantCulture);
+            var activeCwd = Convert.ToString(sqlite.ExecuteScalar(
+                dbPath,
+                "SELECT cwd FROM threads WHERE id = @id;",
+                new Dictionary<string, object?> {
+                    ["@id"] = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+                }), CultureInfo.InvariantCulture);
+            var archivedRolloutPath = Convert.ToString(sqlite.ExecuteScalar(
+                dbPath,
+                "SELECT rollout_path FROM threads WHERE id = @id;",
+                new Dictionary<string, object?> {
+                    ["@id"] = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+                }), CultureInfo.InvariantCulture);
+
+            AssertEqual(true, result.DatabaseExists, "codex path repair database exists");
+            AssertEqual(2, result.ScannedPathValueCount, "codex path repair scanned values");
+            AssertEqual(2, result.ChangedPathValueCount, "codex path repair changed values");
+            AssertEqual(1, result.ChangedThreadRowCount, "codex path repair changed rows");
+            AssertEqual(true, File.Exists(result.BackupDatabasePath), "codex path repair backup exists");
+            AssertEqual(@"C:\Users\Example\.codex\sessions\rollout.jsonl", activeRolloutPath, "codex path repair active rollout");
+            AssertEqual(@"C:\Support\GitHub\Example", activeCwd, "codex path repair active cwd");
+            AssertEqual(@"\\?\C:\Users\Example\.codex\sessions\archived.jsonl", archivedRolloutPath, "codex path repair archived unchanged");
         } finally {
             TryDeleteCodexDiagnosticsDirectory(root);
         }

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -359,6 +359,8 @@ internal static partial class Program {
             TestCodexLocalStateDiagnosticsIgnoresPathSyntaxInTextColumns);
         failed += Run("Codex local state diagnostics handles migration default values",
             TestCodexLocalStateDiagnosticsHandlesMigrationDefaultValues);
+        failed += Run("Codex local state diagnostics normalizes active thread paths",
+            TestCodexLocalStateDiagnosticsNormalizesActiveThreadPaths);
 #if !NET472
         failed += Run("GitHub owner scope resolver returns administered organizations with public repos", TestGitHubOwnerScopeResolverReturnsAdministeredOrganizationsWithPublicRepos);
         failed += Run("GitHub overview collector appends correlated owners for user runs", TestGitHubOverviewDataCollectorAppendsCorrelatedOwnersForUserRuns);

--- a/IntelligenceX.Tray/ViewModels/MainViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/MainViewModel.cs
@@ -74,6 +74,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
     private ProviderViewModel? _selectedProvider;
     private bool _isLoading;
     private bool _isCodexDiagnosticsLoading;
+    private bool _isCodexPathRepairRunning;
     private string _statusText = "Initializing...";
     private string _codexDiagnosticsStatusText = "Codex state not scanned";
     private string _codexDiagnosticsDetailText = "Waiting for first local state check.";
@@ -147,7 +148,8 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         GitHub.PropertyChanged += OnGitHubPropertyChanged;
 
         RefreshCommand = new RelayCommand(() => RefreshAsync(startupWarmup: false));
-        RefreshCodexDiagnosticsCommand = new RelayCommand(RefreshCodexDiagnosticsAsync, () => !IsCodexDiagnosticsLoading);
+        RefreshCodexDiagnosticsCommand = new RelayCommand(RefreshCodexDiagnosticsAsync, () => !IsCodexDiagnosticsLoading && !IsCodexPathRepairRunning);
+        RepairCodexPathsCommand = new RelayCommand(RepairCodexPathsAsync, () => !IsCodexDiagnosticsLoading && !IsCodexPathRepairRunning);
         RefreshGitHubCommand = new RelayCommand(RefreshGitHubCurrentAsync);
         OpenOpenAiCacheCommand = new RelayCommand(OpenOpenAiCacheAsync);
         OpenCodexHomeCommand = new RelayCommand(OpenCodexHomeAsync);
@@ -196,6 +198,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
                 OnPropertyChanged(nameof(CanToggleFavoriteSelectedProvider));
                 OnPropertyChanged(nameof(FavoriteSelectedProviderLabel));
                 OnPropertyChanged(nameof(FavoriteSelectedProviderActionLabel));
+                OnPropertyChanged(nameof(IsCodexProviderSelected));
                 ToggleSelectedProviderFavoriteCommand.RaiseCanExecuteChanged();
                 SaveSelectedProviderPreference(value?.ProviderId);
                 RefreshGitHubProfileIfReady();
@@ -206,6 +209,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
     private bool HasGitHubProvider => Providers.Any(provider => provider.ProviderId == "__github__");
     private bool HasUsageProviders => Providers.Any(provider => provider.ProviderId != "__github__");
     public bool IsGitHubTabSelected => SelectedProvider?.ProviderId == "__github__";
+    public bool IsCodexProviderSelected => string.Equals(SelectedProvider?.ProviderId, "codex", StringComparison.OrdinalIgnoreCase);
 
     public bool ShowUsageContent => SelectedProvider is { ProviderId: not "__github__" };
     public bool ShowGitHubContent => IsGitHubTabSelected || (!HasUsageProviders && HasGitHubProvider);
@@ -256,6 +260,18 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
             if (SetProperty(ref _isCodexDiagnosticsLoading, value)) {
                 OnPropertyChanged(nameof(CodexDiagnosticsActionLabel));
                 RefreshCodexDiagnosticsCommand.RaiseCanExecuteChanged();
+                RepairCodexPathsCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public bool IsCodexPathRepairRunning {
+        get => _isCodexPathRepairRunning;
+        private set {
+            if (SetProperty(ref _isCodexPathRepairRunning, value)) {
+                OnPropertyChanged(nameof(CodexDiagnosticsRepairActionLabel));
+                RefreshCodexDiagnosticsCommand.RaiseCanExecuteChanged();
+                RepairCodexPathsCommand.RaiseCanExecuteChanged();
             }
         }
     }
@@ -337,12 +353,92 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
 
     public string CodexDiagnosticsActionLabel => IsCodexDiagnosticsLoading ? "Checking" : "Check";
 
+    public string CodexDiagnosticsRepairActionLabel => IsCodexPathRepairRunning ? "Repairing" : "Repair paths";
+
     public Brush CodexDiagnosticsStatusBrush => _latestCodexDiagnostics?.Status switch {
         CodexLocalStateHealthStatus.Healthy => CodexHealthyBrush,
         CodexLocalStateHealthStatus.Warning => CodexWarningBrush,
         CodexLocalStateHealthStatus.Error => CodexErrorBrush,
         _ => CodexUnknownBrush
     };
+
+    public string CodexDiagnosticsScannedText => _latestCodexDiagnostics is null
+        ? "Not scanned"
+        : "Scanned " + _latestCodexDiagnostics.ScannedAtUtc.ToLocalTime().ToString("HH:mm:ss", CultureInfo.CurrentCulture);
+
+    public string CodexDiagnosticsThreadMetricText => _latestCodexDiagnostics?.ActiveThreadCount.ToString(CultureInfo.InvariantCulture) ?? "--";
+
+    public string CodexDiagnosticsPathMetricText {
+        get {
+            if (_latestCodexDiagnostics is null) {
+                return "--";
+            }
+
+            var sqlite = _latestCodexDiagnostics.ExtendedPathCount.ToString(CultureInfo.InvariantCulture);
+            var config = _latestCodexDiagnostics.ConfigExtendedPathCount.ToString(CultureInfo.InvariantCulture);
+            return sqlite + " SQLite / " + config + " config";
+        }
+    }
+
+    public string CodexDiagnosticsMetadataMetricText => _latestCodexDiagnostics is null
+        ? "--"
+        : _latestCodexDiagnostics.OversizedThreadMetadataCount.ToString(CultureInfo.InvariantCulture);
+
+    public string CodexDiagnosticsIntegrityText {
+        get {
+            if (_latestCodexDiagnostics is null) {
+                return "Not scanned";
+            }
+
+            if (!_latestCodexDiagnostics.DatabaseExists) {
+                return "State DB missing";
+            }
+
+            if (!_latestCodexDiagnostics.CanConnect) {
+                return "State DB unavailable";
+            }
+
+            var integrity = _latestCodexDiagnostics.IntegrityCheck ?? string.Empty;
+            var quick = _latestCodexDiagnostics.QuickCheck ?? string.Empty;
+            return string.Equals(integrity, "ok", StringComparison.OrdinalIgnoreCase)
+                   && string.Equals(quick, "ok", StringComparison.OrdinalIgnoreCase)
+                ? "SQLite checks ok"
+                : "SQLite checks need review";
+        }
+    }
+
+    public string CodexDiagnosticsPrimaryFindingText {
+        get {
+            var finding = _latestCodexDiagnostics?.Findings.FirstOrDefault();
+            return finding?.Message ?? "No local state findings in the latest scan.";
+        }
+    }
+
+    public string CodexDiagnosticsPrimaryFindingLabel {
+        get {
+            var finding = _latestCodexDiagnostics?.Findings.FirstOrDefault();
+            return finding?.Severity switch {
+                CodexLocalStateHealthStatus.Error => "Error",
+                CodexLocalStateHealthStatus.Warning => "Warning",
+                CodexLocalStateHealthStatus.Healthy => "Healthy",
+                _ => _latestCodexDiagnostics is null ? "Pending" : "Healthy"
+            };
+        }
+    }
+
+    public Brush CodexDiagnosticsPrimaryFindingBrush {
+        get {
+            var severity = _latestCodexDiagnostics?.Findings.FirstOrDefault()?.Severity
+                           ?? _latestCodexDiagnostics?.Status
+                           ?? CodexLocalStateHealthStatus.Unknown;
+            return severity switch {
+                CodexLocalStateHealthStatus.Healthy => CodexHealthyBrush,
+                CodexLocalStateHealthStatus.Warning => CodexWarningBrush,
+                CodexLocalStateHealthStatus.Error => CodexErrorBrush,
+                _ => CodexUnknownBrush
+            };
+        }
+    }
 
     public DateTimeOffset LastRefreshed {
         get => _lastRefreshed;
@@ -433,6 +529,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
 
     public RelayCommand RefreshCommand { get; }
     public RelayCommand RefreshCodexDiagnosticsCommand { get; }
+    public RelayCommand RepairCodexPathsCommand { get; }
     public RelayCommand RefreshGitHubCommand { get; }
     public RelayCommand OpenOpenAiCacheCommand { get; }
     public RelayCommand OpenCodexHomeCommand { get; }
@@ -1079,9 +1176,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
             _latestCodexDiagnostics = diagnostics;
             CodexDiagnosticsStatusText = diagnostics.StatusText;
             CodexDiagnosticsDetailText = diagnostics.DetailText;
-            OnPropertyChanged(nameof(CodexDiagnosticsIssueText));
-            OnPropertyChanged(nameof(CodexDiagnosticsDatabaseText));
-            OnPropertyChanged(nameof(CodexDiagnosticsStatusBrush));
+            OnCodexDiagnosticsSnapshotChanged();
         } catch (Exception ex) {
             _latestCodexDiagnostics = new CodexLocalStateDiagnostics {
                 CodexHome = CodexLocalStateDiagnosticsService.ResolveDefaultCodexHome(),
@@ -1097,12 +1192,77 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
             };
             CodexDiagnosticsStatusText = _latestCodexDiagnostics.StatusText;
             CodexDiagnosticsDetailText = _latestCodexDiagnostics.DetailText;
-            OnPropertyChanged(nameof(CodexDiagnosticsIssueText));
-            OnPropertyChanged(nameof(CodexDiagnosticsDatabaseText));
-            OnPropertyChanged(nameof(CodexDiagnosticsStatusBrush));
+            OnCodexDiagnosticsSnapshotChanged();
         } finally {
             IsCodexDiagnosticsLoading = false;
         }
+    }
+
+    private async Task RepairCodexPathsAsync() {
+        if (IsCodexPathRepairRunning) {
+            return;
+        }
+
+        IsCodexPathRepairRunning = true;
+        CodexDiagnosticsStatusText = "Repairing Codex paths...";
+        CodexDiagnosticsDetailText = "Creating a backup before updating active thread path values.";
+        try {
+            var result = await _codexDiagnosticsService.NormalizeActiveThreadPathsAsync().ConfigureAwait(true);
+            await RefreshCodexDiagnosticsAsync().ConfigureAwait(true);
+
+            if (!result.DatabaseExists) {
+                CodexDiagnosticsStatusText = "Codex state database missing";
+                CodexDiagnosticsDetailText = result.StateDatabasePath;
+                return;
+            }
+
+            CodexDiagnosticsStatusText = result.ChangedPathValueCount == 0
+                ? "Codex paths already normalized"
+                : "Codex paths repaired";
+            CodexDiagnosticsDetailText = BuildCodexPathRepairDetailText(result);
+            if (NotificationsEnabled) {
+                NotificationRequested?.Invoke(this, new TrayNotificationRequestedEventArgs(
+                    "Codex path repair complete",
+                    CodexDiagnosticsDetailText,
+                    isCritical: false,
+                    providerId: "codex"));
+            }
+        } catch (Exception ex) {
+            CodexDiagnosticsStatusText = "Codex path repair failed";
+            CodexDiagnosticsDetailText = ex.Message;
+            if (NotificationsEnabled) {
+                NotificationRequested?.Invoke(this, new TrayNotificationRequestedEventArgs(
+                    "Codex path repair failed",
+                    ex.Message,
+                    isCritical: true,
+                    providerId: "codex"));
+            }
+        } finally {
+            IsCodexPathRepairRunning = false;
+        }
+    }
+
+    private void OnCodexDiagnosticsSnapshotChanged() {
+        OnPropertyChanged(nameof(CodexDiagnosticsIssueText));
+        OnPropertyChanged(nameof(CodexDiagnosticsDatabaseText));
+        OnPropertyChanged(nameof(CodexDiagnosticsStatusBrush));
+        OnPropertyChanged(nameof(CodexDiagnosticsScannedText));
+        OnPropertyChanged(nameof(CodexDiagnosticsThreadMetricText));
+        OnPropertyChanged(nameof(CodexDiagnosticsPathMetricText));
+        OnPropertyChanged(nameof(CodexDiagnosticsMetadataMetricText));
+        OnPropertyChanged(nameof(CodexDiagnosticsIntegrityText));
+        OnPropertyChanged(nameof(CodexDiagnosticsPrimaryFindingText));
+        OnPropertyChanged(nameof(CodexDiagnosticsPrimaryFindingLabel));
+        OnPropertyChanged(nameof(CodexDiagnosticsPrimaryFindingBrush));
+    }
+
+    private static string BuildCodexPathRepairDetailText(CodexLocalStatePathRepairResult result) {
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "{0} active path value(s) repaired across {1} thread row(s). Backup: {2}",
+            result.ChangedPathValueCount,
+            result.ChangedThreadRowCount,
+            result.BackupDirectory);
     }
 
     private Task OpenCodexHomeAsync() {

--- a/IntelligenceX.Tray/Views/TrayPopupWindow.xaml
+++ b/IntelligenceX.Tray/Views/TrayPopupWindow.xaml
@@ -688,6 +688,156 @@
                             </Border>
                         </UniformGrid>
 
+                        <Border Style="{StaticResource CardStyle}"
+                                Padding="14,12"
+                                Visibility="{Binding DataContext.IsCodexProviderSelected, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource BoolToVis}}">
+                            <StackPanel>
+                                <Grid Margin="0,0,0,10">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Border Width="28"
+                                                Height="28"
+                                                CornerRadius="8"
+                                                Background="{StaticResource PulseGlassBrush}"
+                                                Margin="0,0,9,0">
+                                            <Viewbox Width="18" Height="18" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                <Path Data="{StaticResource IconShield}"
+                                                      Fill="{Binding DataContext.CodexDiagnosticsStatusBrush, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                      Stretch="Uniform" />
+                                            </Viewbox>
+                                        </Border>
+                                        <StackPanel VerticalAlignment="Center">
+                                            <TextBlock Text="LOCAL STATE"
+                                                       Style="{StaticResource SectionHeaderStyle}"
+                                                       Margin="0" />
+                                            <TextBlock Text="{Binding DataContext.CodexDiagnosticsScannedText, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                       FontFamily="{StaticResource AppFont}"
+                                                       FontSize="10"
+                                                       Foreground="{StaticResource TertiaryTextBrush}" />
+                                        </StackPanel>
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="1"
+                                                Orientation="Horizontal"
+                                                VerticalAlignment="Top">
+                                        <Button Style="{StaticResource LinkButtonStyle}"
+                                                Command="{Binding DataContext.RefreshCodexDiagnosticsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                ToolTip="Check local Codex state"
+                                                AutomationProperties.Name="Check local Codex state"
+                                                Margin="0,0,6,0">
+                                            <TextBlock Text="{Binding DataContext.CodexDiagnosticsActionLabel, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" />
+                                        </Button>
+                                        <Button Style="{StaticResource LinkButtonStyle}"
+                                                Command="{Binding DataContext.RepairCodexPathsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                ToolTip="Back up and repair active Codex thread paths"
+                                                AutomationProperties.Name="Repair Codex thread paths"
+                                                Margin="0,0,6,0">
+                                            <TextBlock Text="{Binding DataContext.CodexDiagnosticsRepairActionLabel, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" />
+                                        </Button>
+                                        <Button Style="{StaticResource LinkButtonStyle}"
+                                                Command="{Binding DataContext.OpenCodexHomeCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                ToolTip="Open Codex home"
+                                                AutomationProperties.Name="Open Codex home">
+                                            <TextBlock Text="Open home" />
+                                        </Button>
+                                    </StackPanel>
+                                </Grid>
+
+                                <UniformGrid Columns="4" Margin="0,0,0,10">
+                                    <Border CornerRadius="10"
+                                            Background="{StaticResource SubtleSurfaceMutedBrush}"
+                                            BorderBrush="{StaticResource BorderBrush}"
+                                            BorderThickness="1"
+                                            Padding="10,8"
+                                            Margin="0,0,6,0">
+                                        <StackPanel>
+                                            <TextBlock Text="Threads" Style="{StaticResource LabelTextStyle}" />
+                                            <TextBlock Text="{Binding DataContext.CodexDiagnosticsThreadMetricText, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                       Style="{StaticResource StatValueStyle}"
+                                                       FontSize="18" />
+                                        </StackPanel>
+                                    </Border>
+                                    <Border CornerRadius="10"
+                                            Background="{StaticResource SubtleSurfaceMutedBrush}"
+                                            BorderBrush="{StaticResource BorderBrush}"
+                                            BorderThickness="1"
+                                            Padding="10,8"
+                                            Margin="2,0,4,0">
+                                        <StackPanel>
+                                            <TextBlock Text="Paths" Style="{StaticResource LabelTextStyle}" />
+                                            <TextBlock Text="{Binding DataContext.CodexDiagnosticsPathMetricText, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                       FontFamily="{StaticResource AppFont}"
+                                                       FontSize="14"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       TextTrimming="CharacterEllipsis" />
+                                        </StackPanel>
+                                    </Border>
+                                    <Border CornerRadius="10"
+                                            Background="{StaticResource SubtleSurfaceMutedBrush}"
+                                            BorderBrush="{StaticResource BorderBrush}"
+                                            BorderThickness="1"
+                                            Padding="10,8"
+                                            Margin="4,0,2,0">
+                                        <StackPanel>
+                                            <TextBlock Text="Metadata" Style="{StaticResource LabelTextStyle}" />
+                                            <TextBlock Text="{Binding DataContext.CodexDiagnosticsMetadataMetricText, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                       Style="{StaticResource StatValueStyle}"
+                                                       FontSize="18" />
+                                        </StackPanel>
+                                    </Border>
+                                    <Border CornerRadius="10"
+                                            Background="{StaticResource SubtleSurfaceMutedBrush}"
+                                            BorderBrush="{StaticResource BorderBrush}"
+                                            BorderThickness="1"
+                                            Padding="10,8"
+                                            Margin="6,0,0,0">
+                                        <StackPanel>
+                                            <TextBlock Text="SQLite" Style="{StaticResource LabelTextStyle}" />
+                                            <TextBlock Text="{Binding DataContext.CodexDiagnosticsIntegrityText, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                       FontFamily="{StaticResource AppFont}"
+                                                       FontSize="14"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       TextTrimming="CharacterEllipsis" />
+                                        </StackPanel>
+                                    </Border>
+                                </UniformGrid>
+
+                                <Border CornerRadius="10"
+                                        Background="{StaticResource InsetPanelBrush}"
+                                        BorderBrush="{StaticResource BorderBrush}"
+                                        BorderThickness="1"
+                                        Padding="10,8">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Border Padding="8,4"
+                                                CornerRadius="10"
+                                                Background="{StaticResource SubtleSurfaceEmphasisBrush}"
+                                                Margin="0,0,10,0"
+                                                VerticalAlignment="Top">
+                                            <TextBlock Text="{Binding DataContext.CodexDiagnosticsPrimaryFindingLabel, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                       FontFamily="{StaticResource AppFont}"
+                                                       FontSize="10.5"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{Binding DataContext.CodexDiagnosticsPrimaryFindingBrush, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" />
+                                        </Border>
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding DataContext.CodexDiagnosticsPrimaryFindingText, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                   FontFamily="{StaticResource AppFont}"
+                                                   FontSize="11"
+                                                   Foreground="{StaticResource SecondaryTextBrush}"
+                                                   TextWrapping="Wrap" />
+                                    </Grid>
+                                </Border>
+                            </StackPanel>
+                        </Border>
+
                         <Border Style="{StaticResource CardStyle}" Padding="14,12">
                             <StackPanel>
                                 <Grid Margin="0,0,0,9">


### PR DESCRIPTION
## Summary
- add a Codex local-state card to the IX Tray provider view using existing tray styling
- add a backup-first SQLite repair action that normalizes active Codex thread paths from `\\?\C:\...` back to `C:\...`
- cover active-vs-archived path repair behavior in the local test harness

## Validation
- `dotnet build IntelligenceX.Storage.SQLite\IntelligenceX.Storage.SQLite.csproj -c Debug -m:1 /nr:false`
- `dotnet build IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net8.0 -m:1 /nr:false`
- `dotnet .\IntelligenceX.Tests\bin\Release\net8.0\IntelligenceX.Tests.dll`
- `dotnet build IntelligenceX.Tray\IntelligenceX.Tray.csproj -c Release -m:1 /nr:false`
- visual check: `artifacts\ix-tray-popup-current-20260527-validate.png`