### PR TITLE
Expand Codex diagnostics cleanup details

### DIFF
--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
@@ -41,6 +41,23 @@ public sealed record CodexLocalStateFinding(
     int Count = 0);
 
 /// <summary>
+/// Summarizes one local Codex storage area.
+/// </summary>
+/// <param name="Key">Stable area key.</param>
+/// <param name="Label">User-facing area label.</param>
+/// <param name="Path">Resolved filesystem path.</param>
+/// <param name="FileCount">Number of files in the area.</param>
+/// <param name="Bytes">Total byte size of files in the area.</param>
+/// <param name="Recommendation">Short operational recommendation.</param>
+public sealed record CodexLocalStateArea(
+    string Key,
+    string Label,
+    string Path,
+    int FileCount,
+    long Bytes,
+    string Recommendation);
+
+/// <summary>
 /// Snapshot of local Codex state health.
 /// </summary>
 public sealed class CodexLocalStateDiagnostics {
@@ -78,6 +95,8 @@ public sealed class CodexLocalStateDiagnostics {
     public bool DatabaseExists { get; init; }
     /// <summary>Whether the state database could be opened read-only.</summary>
     public bool CanConnect { get; init; }
+    /// <summary>Detailed local Codex storage areas.</summary>
+    public IReadOnlyList<CodexLocalStateArea> Areas { get; init; } = [];
     /// <summary>Detailed local state findings.</summary>
     public IReadOnlyList<CodexLocalStateFinding> Findings { get; init; } = [];
 }
@@ -105,12 +124,35 @@ public sealed class CodexLocalStatePathRepairResult {
 }
 
 /// <summary>
+/// Result of a backup-first local Codex cleanup operation.
+/// </summary>
+public sealed class CodexLocalStateCleanupResult {
+    /// <summary>Resolved Codex home directory.</summary>
+    public string CodexHome { get; init; } = string.Empty;
+    /// <summary>Directory containing cleanup archives created by this operation.</summary>
+    public string ArchiveDirectory { get; init; } = string.Empty;
+    /// <summary>Path repair result included in the cleanup.</summary>
+    public CodexLocalStatePathRepairResult PathRepair { get; init; } = new();
+    /// <summary>Number of log files moved to the archive.</summary>
+    public int ArchivedLogFileCount { get; init; }
+    /// <summary>Number of stale session files moved to the archive.</summary>
+    public int ArchivedSessionFileCount { get; init; }
+    /// <summary>Total log bytes moved to the archive.</summary>
+    public long ArchivedLogBytes { get; init; }
+    /// <summary>Total stale session bytes moved to the archive.</summary>
+    public long ArchivedSessionBytes { get; init; }
+}
+
+/// <summary>
 /// Reads local Codex Desktop/CLI state in a read-only way and summarizes issues
 /// that can make resume/navigation brittle.
 /// </summary>
 public sealed class CodexLocalStateDiagnosticsService {
     private const int DefaultTitleLimit = 120;
     private const int DefaultPreviewLimit = 240;
+    private const long LargeLogsWarningBytes = 256L * 1024L * 1024L;
+    private const long LargeSessionsWarningBytes = 1024L * 1024L * 1024L;
+    private const long LargeArchivedSessionsWarningBytes = 10L * 1024L * 1024L * 1024L;
     private const string ExtendedPathPrefix = @"\\?\";
     private static readonly string[] PathColumnHints = ["path", "cwd", "file", "folder", "dir", "root", "source", "workspace"];
 
@@ -160,6 +202,9 @@ public sealed class CodexLocalStateDiagnosticsService {
             activeThreadCount = metadata.ActiveThreads;
             oversizedMetadataCount = metadata.OversizedRows;
         }
+
+        var areas = CollectAreas(home, stateDb, sqliteDiagnostics.TotalFileSizeBytes);
+        AddAreaFindings(areas, findings);
 
         var configExtendedPathCount = CountConfigExtendedPaths(home);
         if (!sqliteDiagnostics.Exists) {
@@ -216,6 +261,7 @@ public sealed class CodexLocalStateDiagnosticsService {
             QuickCheck = sqliteDiagnostics.QuickCheck,
             DatabaseExists = sqliteDiagnostics.Exists,
             CanConnect = sqliteDiagnostics.CanConnect,
+            Areas = areas,
             Findings = findings
         };
     }
@@ -235,6 +281,66 @@ public sealed class CodexLocalStateDiagnosticsService {
         return Task.Run(
             () => NormalizeActiveThreadPaths(codexHome, backupRoot, cancellationToken),
             cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs safe backup-first cleanup: path normalization, stale session archiving,
+    /// and old log rotation. Files are moved to archives, never permanently deleted.
+    /// </summary>
+    /// <param name="codexHome">Optional Codex home override. Defaults to CODEX_HOME or ~/.codex.</param>
+    /// <param name="backupRoot">Optional backup root override. Defaults to Documents\Codex\codex-backups.</param>
+    /// <param name="cancellationToken">Cancellation token for the cleanup operation.</param>
+    /// <returns>A summary of archived files and repaired paths.</returns>
+    public Task<CodexLocalStateCleanupResult> CleanUpAsync(
+        string? codexHome = null,
+        string? backupRoot = null,
+        CancellationToken cancellationToken = default) {
+        return Task.Run(
+            () => CleanUp(codexHome, backupRoot, cancellationToken),
+            cancellationToken);
+    }
+
+    private CodexLocalStateCleanupResult CleanUp(
+        string? codexHome,
+        string? backupRoot,
+        CancellationToken cancellationToken) {
+        var requestedHome = string.IsNullOrWhiteSpace(codexHome) ? ResolveDefaultCodexHome() : codexHome!.Trim();
+        var home = Path.GetFullPath(requestedHome);
+        var archiveRoot = CreateArchiveDirectory(home);
+        var pathRepair = NormalizeActiveThreadPaths(home, backupRoot, cancellationToken);
+        var activeSessionPaths = ReadActiveSessionPaths(home);
+        var staleSessionArchive = Path.Combine(archiveRoot, "sessions");
+        var logArchive = Path.Combine(archiveRoot, "logs");
+        var staleSessionCutoffUtc = DateTime.UtcNow.AddDays(-14);
+        var logCutoffUtc = DateTime.UtcNow.AddHours(-2);
+
+        var sessionMove = ArchiveFiles(
+            Path.Combine(home, "sessions"),
+            staleSessionArchive,
+            file => IsSessionFile(file)
+                    && file.LastWriteTimeUtc < staleSessionCutoffUtc
+                    && !activeSessionPaths.Contains(file.FullName),
+            cancellationToken);
+        var logMove = ArchiveFiles(
+            Path.Combine(home, "logs"),
+            logArchive,
+            file => IsLogFile(file) && file.LastWriteTimeUtc < logCutoffUtc,
+            cancellationToken);
+        var rootLogMove = ArchiveSingleFile(
+            Path.Combine(home, "codex-tui.log"),
+            Path.Combine(logArchive, "codex-tui.log"),
+            file => file.LastWriteTimeUtc < logCutoffUtc,
+            cancellationToken);
+
+        return new CodexLocalStateCleanupResult {
+            CodexHome = home,
+            ArchiveDirectory = archiveRoot,
+            PathRepair = pathRepair,
+            ArchivedLogFileCount = logMove.Count + rootLogMove.Count,
+            ArchivedLogBytes = logMove.Bytes + rootLogMove.Bytes,
+            ArchivedSessionFileCount = sessionMove.Count,
+            ArchivedSessionBytes = sessionMove.Bytes
+        };
     }
 
     private CodexLocalStatePathRepairResult NormalizeActiveThreadPaths(
@@ -327,6 +433,303 @@ public sealed class CodexLocalStateDiagnosticsService {
             ChangedPathValueCount = changedValues,
             ChangedThreadRowCount = changedRows
         };
+    }
+
+    private static IReadOnlyList<CodexLocalStateArea> CollectAreas(string codexHome, string stateDb, long stateTotalBytes) {
+        var sessions = ScanDirectory(Path.Combine(codexHome, "sessions"));
+        var archivedSessions = ScanDirectory(Path.Combine(codexHome, "archived_sessions"));
+        var logs = ScanLogs(codexHome);
+        var backups = ScanDirectory(ResolveDefaultBackupRoot());
+        return [
+            new CodexLocalStateArea(
+                "state-db",
+                "SQLite state",
+                stateDb,
+                File.Exists(stateDb) ? 1 : 0,
+                stateTotalBytes,
+                stateTotalBytes > 0 ? "Keep; repair only with backup" : "No state database found"),
+            new CodexLocalStateArea(
+                "sessions",
+                "Sessions",
+                Path.Combine(codexHome, "sessions"),
+                sessions.Count,
+                sessions.Bytes,
+                sessions.Bytes > LargeSessionsWarningBytes ? "Archive stale inactive sessions" : "No cleanup required"),
+            new CodexLocalStateArea(
+                "archived-sessions",
+                "Archived sessions",
+                Path.Combine(codexHome, "archived_sessions"),
+                archivedSessions.Count,
+                archivedSessions.Bytes,
+                archivedSessions.Bytes > LargeArchivedSessionsWarningBytes ? "Review archive size before pruning" : "Keep archived copies"),
+            new CodexLocalStateArea(
+                "logs",
+                "Logs",
+                Path.Combine(codexHome, "logs"),
+                logs.Count,
+                logs.Bytes,
+                logs.Bytes > LargeLogsWarningBytes ? "Archive old log files" : "Log size is modest"),
+            new CodexLocalStateArea(
+                "backups",
+                "Backups",
+                ResolveDefaultBackupRoot(),
+                backups.Count,
+                backups.Bytes,
+                backups.Count > 0 ? "Keep for restore; prune manually when confident" : "No IX/Codex backups found")
+        ];
+    }
+
+    private static void AddAreaFindings(
+        IReadOnlyCollection<CodexLocalStateArea> areas,
+        ICollection<CodexLocalStateFinding> findings) {
+        var logs = areas.FirstOrDefault(static area => area.Key == "logs");
+        if (logs is not null && logs.Bytes > LargeLogsWarningBytes) {
+            findings.Add(new CodexLocalStateFinding(
+                "large-logs",
+                CodexLocalStateHealthStatus.Warning,
+                $"Codex logs use {FormatBytesInvariant(logs.Bytes)} across {logs.FileCount.ToString(CultureInfo.InvariantCulture)} file(s).",
+                logs.FileCount));
+        }
+
+        var sessions = areas.FirstOrDefault(static area => area.Key == "sessions");
+        if (sessions is not null && sessions.Bytes > LargeSessionsWarningBytes) {
+            findings.Add(new CodexLocalStateFinding(
+                "large-sessions",
+                CodexLocalStateHealthStatus.Warning,
+                $"Active session files use {FormatBytesInvariant(sessions.Bytes)}.",
+                sessions.FileCount));
+        }
+
+        var archivedSessions = areas.FirstOrDefault(static area => area.Key == "archived-sessions");
+        if (archivedSessions is not null && archivedSessions.Bytes > LargeArchivedSessionsWarningBytes) {
+            findings.Add(new CodexLocalStateFinding(
+                "large-archived-sessions",
+                CodexLocalStateHealthStatus.Warning,
+                $"Archived sessions use {FormatBytesInvariant(archivedSessions.Bytes)}.",
+                archivedSessions.FileCount));
+        }
+    }
+
+    private static (int Count, long Bytes) ScanDirectory(string path) {
+        if (!Directory.Exists(path)) {
+            return (0, 0);
+        }
+
+        var count = 0;
+        var bytes = 0L;
+        foreach (var file in EnumerateFilesSafe(path)) {
+            count++;
+            bytes += SafeLength(file);
+        }
+
+        return (count, bytes);
+    }
+
+    private static (int Count, long Bytes) ScanLogs(string codexHome) {
+        var files = new List<FileInfo>();
+        var rootLog = Path.Combine(codexHome, "codex-tui.log");
+        if (File.Exists(rootLog)) {
+            files.Add(new FileInfo(rootLog));
+        }
+
+        var logsRoot = Path.Combine(codexHome, "logs");
+        if (Directory.Exists(logsRoot)) {
+            files.AddRange(EnumerateFilesSafe(logsRoot));
+        }
+
+        return (files.Count, files.Sum(SafeLength));
+    }
+
+    private static ISet<string> ReadActiveSessionPaths(string codexHome) {
+        var stateDb = Path.Combine(codexHome, "state_5.sqlite");
+        if (!File.Exists(stateDb)) {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        try {
+            var columns = GetTableColumns(stateDb, "threads");
+            var columnNames = columns
+                .Select(static column => column.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var pathColumns = columns
+                .Where(static column => IsTextColumn(column.Type) && IsPathColumn(column.Name))
+                .Select(static column => column.Name)
+                .ToArray();
+            if (pathColumns.Length == 0) {
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            var activeExpr = BuildActiveThreadExpression(columnNames);
+            var selectedColumns = string.Join(", ", pathColumns.Select(QuoteIdentifier));
+            var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var builder = new SqliteConnectionStringBuilder {
+                DataSource = stateDb,
+                Mode = SqliteOpenMode.ReadOnly
+            };
+            using var connection = new SqliteConnection(builder.ConnectionString);
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = $"SELECT {selectedColumns} FROM threads WHERE {activeExpr};";
+            using var reader = command.ExecuteReader();
+            var ordinals = pathColumns.Select(reader.GetOrdinal).ToArray();
+            while (reader.Read()) {
+                foreach (var ordinal in ordinals) {
+                    if (!reader.IsDBNull(ordinal)) {
+                        result.Add(Path.GetFullPath(reader.GetString(ordinal)));
+                    }
+                }
+            }
+
+            return result;
+        } catch {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private static (int Count, long Bytes) ArchiveFiles(
+        string sourceRoot,
+        string archiveRoot,
+        Func<FileInfo, bool> shouldArchive,
+        CancellationToken cancellationToken) {
+        if (!Directory.Exists(sourceRoot)) {
+            return (0, 0);
+        }
+
+        var archived = 0;
+        var bytes = 0L;
+        var sourceFullPath = Path.GetFullPath(sourceRoot);
+        foreach (var file in EnumerateFilesSafe(sourceFullPath)) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!shouldArchive(file)) {
+                continue;
+            }
+
+            var length = SafeLength(file);
+            var relative = GetRelativePath(sourceFullPath, file.FullName);
+            var destination = Path.Combine(archiveRoot, relative);
+            var destinationDirectory = Path.GetDirectoryName(destination);
+            if (!string.IsNullOrWhiteSpace(destinationDirectory)) {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            destination = EnsureUniquePath(destination);
+            try {
+                file.MoveTo(destination);
+                archived++;
+                bytes += length;
+            } catch (IOException) {
+                // Active Codex files can be locked. Leave them in place for the next pass.
+            } catch (UnauthorizedAccessException) {
+                // Keep cleanup best-effort and archive-only.
+            }
+        }
+
+        return (archived, bytes);
+    }
+
+    private static (int Count, long Bytes) ArchiveSingleFile(
+        string sourcePath,
+        string destinationPath,
+        Func<FileInfo, bool> shouldArchive,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        var file = new FileInfo(sourcePath);
+        if (!file.Exists || !shouldArchive(file)) {
+            return (0, 0);
+        }
+
+        var destinationDirectory = Path.GetDirectoryName(destinationPath);
+        if (!string.IsNullOrWhiteSpace(destinationDirectory)) {
+            Directory.CreateDirectory(destinationDirectory);
+        }
+
+        var length = SafeLength(file);
+        try {
+            file.MoveTo(EnsureUniquePath(destinationPath));
+            return (1, length);
+        } catch (IOException) {
+            return (0, 0);
+        } catch (UnauthorizedAccessException) {
+            return (0, 0);
+        }
+    }
+
+    private static IEnumerable<FileInfo> EnumerateFilesSafe(string path) {
+        var pending = new Stack<string>();
+        pending.Push(path);
+        while (pending.Count > 0) {
+            var current = pending.Pop();
+            IEnumerable<string> directories;
+            IEnumerable<string> files;
+            try {
+                directories = Directory.EnumerateDirectories(current).ToArray();
+                files = Directory.EnumerateFiles(current).ToArray();
+            } catch (IOException) {
+                continue;
+            } catch (UnauthorizedAccessException) {
+                continue;
+            }
+
+            foreach (var directory in directories) {
+                pending.Push(directory);
+            }
+
+            foreach (var file in files) {
+                yield return new FileInfo(file);
+            }
+        }
+    }
+
+    private static bool IsSessionFile(FileInfo file) {
+        return string.Equals(file.Extension, ".jsonl", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(file.Extension, ".json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsLogFile(FileInfo file) {
+        return string.Equals(file.Extension, ".log", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(file.Extension, ".sqlite", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static long SafeLength(FileInfo file) {
+        try {
+            return file.Exists ? file.Length : 0L;
+        } catch (IOException) {
+            return 0L;
+        } catch (UnauthorizedAccessException) {
+            return 0L;
+        }
+    }
+
+    private static string EnsureUniquePath(string path) {
+        if (!File.Exists(path)) {
+            return path;
+        }
+
+        var directory = Path.GetDirectoryName(path) ?? string.Empty;
+        var name = Path.GetFileNameWithoutExtension(path);
+        var extension = Path.GetExtension(path);
+        for (var i = 1; i < 1000; i++) {
+            var candidate = Path.Combine(directory, name + "-" + i.ToString(CultureInfo.InvariantCulture) + extension);
+            if (!File.Exists(candidate)) {
+                return candidate;
+            }
+        }
+
+        return Path.Combine(directory, name + "-" + Guid.NewGuid().ToString("N") + extension);
+    }
+
+    private static string GetRelativePath(string basePath, string path) {
+        var baseUri = new Uri(AppendDirectorySeparator(Path.GetFullPath(basePath)));
+        var pathUri = new Uri(Path.GetFullPath(path));
+        return Uri.UnescapeDataString(baseUri.MakeRelativeUri(pathUri).ToString())
+            .Replace('/', Path.DirectorySeparatorChar);
+    }
+
+    private static string AppendDirectorySeparator(string path) {
+        return path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+               || path.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+            ? path
+            : path + Path.DirectorySeparatorChar;
     }
 
     private int CountExtendedPathRows(string stateDb, List<CodexLocalStateFinding> findings) {
@@ -607,15 +1010,7 @@ public sealed class CodexLocalStateDiagnosticsService {
     }
 
     private static string CreateBackupDirectory(string? backupRoot) {
-        var root = backupRoot;
-        if (string.IsNullOrWhiteSpace(root)) {
-            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            if (string.IsNullOrWhiteSpace(documents)) {
-                documents = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Documents");
-            }
-
-            root = Path.Combine(documents, "Codex", "codex-backups");
-        }
+        var root = string.IsNullOrWhiteSpace(backupRoot) ? ResolveDefaultBackupRoot() : backupRoot!;
 
         return Path.Combine(
             root!,
@@ -623,6 +1018,40 @@ public sealed class CodexLocalStateDiagnosticsService {
             + DateTimeOffset.Now.ToString("yyyyMMdd-HHmmss-fff", CultureInfo.InvariantCulture)
             + "-"
             + Guid.NewGuid().ToString("N").Substring(0, 8));
+    }
+
+    private static string CreateArchiveDirectory(string codexHome) {
+        return Path.Combine(
+            codexHome,
+            "archived_cleanup",
+            "intelligencex-codex-cleanup-"
+            + DateTimeOffset.Now.ToString("yyyyMMdd-HHmmss-fff", CultureInfo.InvariantCulture)
+            + "-"
+            + Guid.NewGuid().ToString("N").Substring(0, 8));
+    }
+
+    private static string ResolveDefaultBackupRoot() {
+        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        if (string.IsNullOrWhiteSpace(documents)) {
+            documents = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Documents");
+        }
+
+        return Path.Combine(documents, "Codex", "codex-backups");
+    }
+
+    private static string FormatBytesInvariant(long bytes) {
+        string[] suffixes = ["B", "KB", "MB", "GB", "TB"];
+        var value = Math.Max(0, bytes);
+        var suffixIndex = 0;
+        var display = (double)value;
+        while (display >= 1024d && suffixIndex < suffixes.Length - 1) {
+            display /= 1024d;
+            suffixIndex++;
+        }
+
+        return display >= 10d || suffixIndex == 0
+            ? display.ToString("0", CultureInfo.InvariantCulture) + " " + suffixes[suffixIndex]
+            : display.ToString("0.0", CultureInfo.InvariantCulture) + " " + suffixes[suffixIndex];
     }
 
     private static string QuoteIdentifier(string value) {

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
@@ -307,6 +307,7 @@ public sealed class CodexLocalStateDiagnosticsService {
         var requestedHome = string.IsNullOrWhiteSpace(codexHome) ? ResolveDefaultCodexHome() : codexHome!.Trim();
         var home = Path.GetFullPath(requestedHome);
         var archiveRoot = CreateArchiveDirectory(home);
+        Directory.CreateDirectory(archiveRoot);
         var pathRepair = NormalizeActiveThreadPaths(home, backupRoot, cancellationToken);
         var activeSessionPaths = ReadActiveSessionPaths(home);
         var staleSessionArchive = Path.Combine(archiveRoot, "sessions");
@@ -574,8 +575,9 @@ public sealed class CodexLocalStateDiagnosticsService {
             var ordinals = pathColumns.Select(reader.GetOrdinal).ToArray();
             while (reader.Read()) {
                 foreach (var ordinal in ordinals) {
-                    if (!reader.IsDBNull(ordinal)) {
-                        result.Add(Path.GetFullPath(reader.GetString(ordinal)));
+                    if (!reader.IsDBNull(ordinal)
+                        && TryResolveActiveSessionPath(reader.GetString(ordinal), out var activePath)) {
+                        result.Add(activePath);
                     }
                 }
             }
@@ -598,14 +600,23 @@ public sealed class CodexLocalStateDiagnosticsService {
         var archived = 0;
         var bytes = 0L;
         var sourceFullPath = Path.GetFullPath(sourceRoot);
+        if (IsReparsePoint(new DirectoryInfo(sourceFullPath))) {
+            return (0, 0);
+        }
+
         foreach (var file in EnumerateFilesSafe(sourceFullPath)) {
             cancellationToken.ThrowIfCancellationRequested();
+            var fileFullPath = Path.GetFullPath(file.FullName);
+            if (!IsDescendantPath(sourceFullPath, fileFullPath) || IsReparsePoint(file)) {
+                continue;
+            }
+
             if (!shouldArchive(file)) {
                 continue;
             }
 
             var length = SafeLength(file);
-            var relative = GetRelativePath(sourceFullPath, file.FullName);
+            var relative = GetRelativePath(sourceFullPath, fileFullPath);
             var destination = Path.Combine(archiveRoot, relative);
             var destinationDirectory = Path.GetDirectoryName(destination);
             if (!string.IsNullOrWhiteSpace(destinationDirectory)) {
@@ -656,7 +667,8 @@ public sealed class CodexLocalStateDiagnosticsService {
 
     private static IEnumerable<FileInfo> EnumerateFilesSafe(string path) {
         var pending = new Stack<string>();
-        pending.Push(path);
+        var root = Path.GetFullPath(path);
+        pending.Push(root);
         while (pending.Count > 0) {
             var current = pending.Pop();
             IEnumerable<string> directories;
@@ -671,12 +683,66 @@ public sealed class CodexLocalStateDiagnosticsService {
             }
 
             foreach (var directory in directories) {
-                pending.Push(directory);
+                var directoryInfo = new DirectoryInfo(directory);
+                if (IsReparsePoint(directoryInfo)) {
+                    continue;
+                }
+
+                var directoryFullPath = Path.GetFullPath(directoryInfo.FullName);
+                if (IsDescendantPath(root, directoryFullPath)) {
+                    pending.Push(directoryFullPath);
+                }
             }
 
             foreach (var file in files) {
-                yield return new FileInfo(file);
+                var fileInfo = new FileInfo(file);
+                if (!IsReparsePoint(fileInfo) && IsDescendantPath(root, fileInfo.FullName)) {
+                    yield return fileInfo;
+                }
             }
+        }
+    }
+
+    private static bool TryResolveActiveSessionPath(string? value, out string path) {
+        path = string.Empty;
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        var candidate = value!.Trim();
+        if (TryNormalizeExtendedWindowsPath(candidate, out var normalized)) {
+            candidate = normalized;
+        }
+
+        if (!Path.IsPathRooted(candidate)) {
+            return false;
+        }
+
+        try {
+            path = Path.GetFullPath(candidate);
+            return true;
+        } catch (ArgumentException) {
+            return false;
+        } catch (NotSupportedException) {
+            return false;
+        } catch (PathTooLongException) {
+            return false;
+        }
+    }
+
+    private static bool IsDescendantPath(string root, string path) {
+        var normalizedRoot = AppendDirectorySeparator(Path.GetFullPath(root));
+        var normalizedPath = Path.GetFullPath(path);
+        return normalizedPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsReparsePoint(FileSystemInfo info) {
+        try {
+            return info.Exists && (info.Attributes & FileAttributes.ReparsePoint) != 0;
+        } catch (IOException) {
+            return true;
+        } catch (UnauthorizedAccessException) {
+            return true;
         }
     }
 

--- a/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
@@ -325,7 +325,7 @@ internal static partial class Program {
                     ["@title"] = "active",
                     ["@preview"] = "active preview",
                     ["@rollout_path"] = activeSession,
-                    ["@cwd"] = root
+                    ["@cwd"] = string.Empty
                 });
 
             var service = new CodexLocalStateDiagnosticsService();
@@ -338,6 +338,38 @@ internal static partial class Program {
             AssertEqual(false, File.Exists(staleLog), "codex cleanup moved stale log");
             AssertEqual(true, Directory.Exists(result.ArchiveDirectory), "codex cleanup archive directory");
             AssertEqual(true, File.Exists(result.PathRepair.BackupDatabasePath), "codex cleanup path repair backup");
+        } finally {
+            TryDeleteCodexDiagnosticsDirectory(root);
+        }
+    }
+
+    private static void TestCodexLocalStateCleanupCreatesEmptyArchiveRoot() {
+        var root = CreateCodexDiagnosticsTempDirectory();
+        try {
+            var codexHome = Path.Combine(root, ".codex");
+            var backupRoot = Path.Combine(root, "backups");
+            Directory.CreateDirectory(codexHome);
+            var dbPath = Path.Combine(codexHome, "state_5.sqlite");
+            var sqlite = new SQLite();
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    title TEXT,
+                    first_user_message TEXT,
+                    rollout_path TEXT,
+                    cwd TEXT,
+                    archived INTEGER
+                );
+                """);
+
+            var service = new CodexLocalStateDiagnosticsService();
+            var result = service.CleanUpAsync(codexHome, backupRoot).GetAwaiter().GetResult();
+
+            AssertEqual(0, result.ArchivedSessionFileCount, "codex cleanup empty archive sessions");
+            AssertEqual(0, result.ArchivedLogFileCount, "codex cleanup empty archive logs");
+            AssertEqual(true, Directory.Exists(result.ArchiveDirectory), "codex cleanup empty archive directory");
         } finally {
             TryDeleteCodexDiagnosticsDirectory(root);
         }

--- a/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
@@ -248,6 +248,101 @@ internal static partial class Program {
         }
     }
 
+    private static void TestCodexLocalStateDiagnosticsReportsStorageAreas() {
+        var root = CreateCodexDiagnosticsTempDirectory();
+        try {
+            var codexHome = Path.Combine(root, ".codex");
+            Directory.CreateDirectory(Path.Combine(codexHome, "sessions"));
+            Directory.CreateDirectory(Path.Combine(codexHome, "logs"));
+            var dbPath = Path.Combine(codexHome, "state_5.sqlite");
+            var sqlite = new SQLite();
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    title TEXT,
+                    first_user_message TEXT,
+                    rollout_path TEXT,
+                    cwd TEXT,
+                    archived INTEGER
+                );
+                """);
+            File.WriteAllText(Path.Combine(codexHome, "sessions", "rollout.jsonl"), "session");
+            File.WriteAllText(Path.Combine(codexHome, "logs", "codex.log"), "log");
+
+            var service = new CodexLocalStateDiagnosticsService();
+            var diagnostics = service.CollectAsync(codexHome).GetAwaiter().GetResult();
+
+            AssertEqual(true, diagnostics.Areas.Any(a => a.Key == "state-db"), "codex areas include sqlite state");
+            AssertEqual(true, diagnostics.Areas.Any(a => a.Key == "sessions" && a.FileCount == 1), "codex areas include sessions");
+            AssertEqual(true, diagnostics.Areas.Any(a => a.Key == "logs" && a.FileCount == 1), "codex areas include logs");
+        } finally {
+            TryDeleteCodexDiagnosticsDirectory(root);
+        }
+    }
+
+    private static void TestCodexLocalStateCleanupArchivesStaleFiles() {
+        var root = CreateCodexDiagnosticsTempDirectory();
+        try {
+            var codexHome = Path.Combine(root, ".codex");
+            var backupRoot = Path.Combine(root, "backups");
+            var sessions = Path.Combine(codexHome, "sessions", "2026", "05", "01");
+            var logs = Path.Combine(codexHome, "logs");
+            Directory.CreateDirectory(sessions);
+            Directory.CreateDirectory(logs);
+            var dbPath = Path.Combine(codexHome, "state_5.sqlite");
+            var sqlite = new SQLite();
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    title TEXT,
+                    first_user_message TEXT,
+                    rollout_path TEXT,
+                    cwd TEXT,
+                    archived INTEGER
+                );
+                """);
+            var staleSession = Path.Combine(sessions, "old.jsonl");
+            var activeSession = Path.Combine(sessions, "active.jsonl");
+            var staleLog = Path.Combine(logs, "old.log");
+            File.WriteAllText(staleSession, "old-session");
+            File.WriteAllText(activeSession, "active-session");
+            File.WriteAllText(staleLog, "old-log");
+            File.SetLastWriteTimeUtc(staleSession, DateTime.UtcNow.AddDays(-20));
+            File.SetLastWriteTimeUtc(activeSession, DateTime.UtcNow.AddDays(-20));
+            File.SetLastWriteTimeUtc(staleLog, DateTime.UtcNow.AddHours(-4));
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                INSERT INTO threads (id, title, first_user_message, rollout_path, cwd, archived)
+                VALUES (@id, @title, @preview, @rollout_path, @cwd, 0);
+                """,
+                new Dictionary<string, object?> {
+                    ["@id"] = "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                    ["@title"] = "active",
+                    ["@preview"] = "active preview",
+                    ["@rollout_path"] = activeSession,
+                    ["@cwd"] = root
+                });
+
+            var service = new CodexLocalStateDiagnosticsService();
+            var result = service.CleanUpAsync(codexHome, backupRoot).GetAwaiter().GetResult();
+
+            AssertEqual(1, result.ArchivedSessionFileCount, "codex cleanup archived stale inactive session");
+            AssertEqual(1, result.ArchivedLogFileCount, "codex cleanup archived stale log");
+            AssertEqual(false, File.Exists(staleSession), "codex cleanup moved stale session");
+            AssertEqual(true, File.Exists(activeSession), "codex cleanup kept active session");
+            AssertEqual(false, File.Exists(staleLog), "codex cleanup moved stale log");
+            AssertEqual(true, Directory.Exists(result.ArchiveDirectory), "codex cleanup archive directory");
+            AssertEqual(true, File.Exists(result.PathRepair.BackupDatabasePath), "codex cleanup path repair backup");
+        } finally {
+            TryDeleteCodexDiagnosticsDirectory(root);
+        }
+    }
+
     private static string CreateCodexDiagnosticsTempDirectory() {
         var path = Path.Combine(Path.GetTempPath(), "ix-codex-diagnostics-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(path);

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -365,6 +365,8 @@ internal static partial class Program {
             TestCodexLocalStateDiagnosticsReportsStorageAreas);
         failed += Run("Codex local state cleanup archives stale files",
             TestCodexLocalStateCleanupArchivesStaleFiles);
+        failed += Run("Codex local state cleanup creates empty archive root",
+            TestCodexLocalStateCleanupCreatesEmptyArchiveRoot);
 #if !NET472
         failed += Run("GitHub owner scope resolver returns administered organizations with public repos", TestGitHubOwnerScopeResolverReturnsAdministeredOrganizationsWithPublicRepos);
         failed += Run("GitHub overview collector appends correlated owners for user runs", TestGitHubOverviewDataCollectorAppendsCorrelatedOwnersForUserRuns);

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -361,6 +361,10 @@ internal static partial class Program {
             TestCodexLocalStateDiagnosticsHandlesMigrationDefaultValues);
         failed += Run("Codex local state diagnostics normalizes active thread paths",
             TestCodexLocalStateDiagnosticsNormalizesActiveThreadPaths);
+        failed += Run("Codex local state diagnostics reports storage areas",
+            TestCodexLocalStateDiagnosticsReportsStorageAreas);
+        failed += Run("Codex local state cleanup archives stale files",
+            TestCodexLocalStateCleanupArchivesStaleFiles);
 #if !NET472
         failed += Run("GitHub owner scope resolver returns administered organizations with public repos", TestGitHubOwnerScopeResolverReturnsAdministeredOrganizationsWithPublicRepos);
         failed += Run("GitHub overview collector appends correlated owners for user runs", TestGitHubOverviewDataCollectorAppendsCorrelatedOwnersForUserRuns);

--- a/IntelligenceX.Tray/App.xaml.cs
+++ b/IntelligenceX.Tray/App.xaml.cs
@@ -102,7 +102,7 @@ public partial class App : Application {
                 DispatcherPriority.Background);
             if (openOnStartup) {
                 Dispatcher.InvokeAsync(
-                    () => ShowPopup(TimeSpan.FromSeconds(30)),
+                    ShowPopup,
                     DispatcherPriority.ApplicationIdle);
             }
         } catch (Exception ex) {
@@ -162,7 +162,7 @@ public partial class App : Application {
         }
 
         Dispatcher.BeginInvoke(
-            new Action(() => ShowPopup(TimeSpan.FromSeconds(10))),
+            new Action(ShowPopup),
             DispatcherPriority.ApplicationIdle);
     }
 
@@ -454,12 +454,12 @@ public partial class App : Application {
         }
     }
 
-    private void ShowPopup(TimeSpan? suppressDeactivateFor = null) {
+    private void ShowPopup() {
         if (_popupWindow is null) {
             return;
         }
 
-        _popupWindow.PrepareForTrayOpen(suppressDeactivateFor);
+        _popupWindow.PrepareForTrayOpen();
         _suppressTrayToggleUntilUtc = DateTimeOffset.UtcNow.AddMilliseconds(500);
         PositionPopupForOpen();
         _popupWindow.Show();

--- a/IntelligenceX.Tray/ViewModels/MainViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/MainViewModel.cs
@@ -18,6 +18,19 @@ using IntelligenceX.Tray.Services;
 
 namespace IntelligenceX.Tray.ViewModels;
 
+public sealed record CodexLocalStateAreaViewModel(
+    string Label,
+    string SizeText,
+    string FileCountText,
+    string Path,
+    string Recommendation);
+
+public sealed record CodexLocalStateFindingViewModel(
+    string SeverityLabel,
+    string Message,
+    string CountText,
+    Brush SeverityBrush);
+
 public sealed class MainViewModel : ViewModelBase, IDisposable {
     private const int DefaultRefreshIntervalSeconds = 120;
     private const int StartupWarmRefreshFreshnessSeconds = 900;
@@ -75,6 +88,8 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
     private bool _isLoading;
     private bool _isCodexDiagnosticsLoading;
     private bool _isCodexPathRepairRunning;
+    private bool _isCodexCleanupRunning;
+    private bool _isCodexDiagnosticsDetailsExpanded;
     private string _statusText = "Initializing...";
     private string _codexDiagnosticsStatusText = "Codex state not scanned";
     private string _codexDiagnosticsDetailText = "Waiting for first local state check.";
@@ -148,8 +163,10 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         GitHub.PropertyChanged += OnGitHubPropertyChanged;
 
         RefreshCommand = new RelayCommand(() => RefreshAsync(startupWarmup: false));
-        RefreshCodexDiagnosticsCommand = new RelayCommand(RefreshCodexDiagnosticsAsync, () => !IsCodexDiagnosticsLoading && !IsCodexPathRepairRunning);
-        RepairCodexPathsCommand = new RelayCommand(RepairCodexPathsAsync, () => !IsCodexDiagnosticsLoading && !IsCodexPathRepairRunning);
+        RefreshCodexDiagnosticsCommand = new RelayCommand(RefreshCodexDiagnosticsAsync, CanRunCodexMaintenance);
+        RepairCodexPathsCommand = new RelayCommand(RepairCodexPathsAsync, CanRunCodexMaintenance);
+        CleanUpCodexStateCommand = new RelayCommand(CleanUpCodexStateAsync, CanRunCodexMaintenance);
+        ToggleCodexDiagnosticsDetailsCommand = new RelayCommand(ToggleCodexDiagnosticsDetails);
         RefreshGitHubCommand = new RelayCommand(RefreshGitHubCurrentAsync);
         OpenOpenAiCacheCommand = new RelayCommand(OpenOpenAiCacheAsync);
         OpenCodexHomeCommand = new RelayCommand(OpenCodexHomeAsync);
@@ -187,6 +204,8 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
     public event EventHandler? AccentPresetChanged;
 
     public ObservableCollection<ProviderViewModel> Providers { get; } = [];
+    public ObservableCollection<CodexLocalStateAreaViewModel> CodexDiagnosticsAreas { get; } = [];
+    public ObservableCollection<CodexLocalStateFindingViewModel> CodexDiagnosticsFindings { get; } = [];
     public GitHubViewModel GitHub { get; }
 
     public ProviderViewModel? SelectedProvider {
@@ -199,6 +218,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
                 OnPropertyChanged(nameof(FavoriteSelectedProviderLabel));
                 OnPropertyChanged(nameof(FavoriteSelectedProviderActionLabel));
                 OnPropertyChanged(nameof(IsCodexProviderSelected));
+                OnPropertyChanged(nameof(IsCodexDiagnosticsDetailsVisible));
                 ToggleSelectedProviderFavoriteCommand.RaiseCanExecuteChanged();
                 SaveSelectedProviderPreference(value?.ProviderId);
                 RefreshGitHubProfileIfReady();
@@ -210,6 +230,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
     private bool HasUsageProviders => Providers.Any(provider => provider.ProviderId != "__github__");
     public bool IsGitHubTabSelected => SelectedProvider?.ProviderId == "__github__";
     public bool IsCodexProviderSelected => string.Equals(SelectedProvider?.ProviderId, "codex", StringComparison.OrdinalIgnoreCase);
+    public bool IsCodexDiagnosticsDetailsVisible => IsCodexProviderSelected && IsCodexDiagnosticsDetailsExpanded;
 
     public bool ShowUsageContent => SelectedProvider is { ProviderId: not "__github__" };
     public bool ShowGitHubContent => IsGitHubTabSelected || (!HasUsageProviders && HasGitHubProvider);
@@ -259,8 +280,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         private set {
             if (SetProperty(ref _isCodexDiagnosticsLoading, value)) {
                 OnPropertyChanged(nameof(CodexDiagnosticsActionLabel));
-                RefreshCodexDiagnosticsCommand.RaiseCanExecuteChanged();
-                RepairCodexPathsCommand.RaiseCanExecuteChanged();
+                RaiseCodexMaintenanceCanExecuteChanged();
             }
         }
     }
@@ -270,8 +290,27 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         private set {
             if (SetProperty(ref _isCodexPathRepairRunning, value)) {
                 OnPropertyChanged(nameof(CodexDiagnosticsRepairActionLabel));
-                RefreshCodexDiagnosticsCommand.RaiseCanExecuteChanged();
-                RepairCodexPathsCommand.RaiseCanExecuteChanged();
+                RaiseCodexMaintenanceCanExecuteChanged();
+            }
+        }
+    }
+
+    public bool IsCodexCleanupRunning {
+        get => _isCodexCleanupRunning;
+        private set {
+            if (SetProperty(ref _isCodexCleanupRunning, value)) {
+                OnPropertyChanged(nameof(CodexDiagnosticsCleanupActionLabel));
+                RaiseCodexMaintenanceCanExecuteChanged();
+            }
+        }
+    }
+
+    public bool IsCodexDiagnosticsDetailsExpanded {
+        get => _isCodexDiagnosticsDetailsExpanded;
+        private set {
+            if (SetProperty(ref _isCodexDiagnosticsDetailsExpanded, value)) {
+                OnPropertyChanged(nameof(IsCodexDiagnosticsDetailsVisible));
+                OnPropertyChanged(nameof(CodexDiagnosticsDetailsActionLabel));
             }
         }
     }
@@ -354,6 +393,10 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
     public string CodexDiagnosticsActionLabel => IsCodexDiagnosticsLoading ? "Checking" : "Check";
 
     public string CodexDiagnosticsRepairActionLabel => IsCodexPathRepairRunning ? "Repairing" : "Repair paths";
+
+    public string CodexDiagnosticsCleanupActionLabel => IsCodexCleanupRunning ? "Cleaning" : "Clean up";
+
+    public string CodexDiagnosticsDetailsActionLabel => IsCodexDiagnosticsDetailsExpanded ? "Hide" : "Details";
 
     public Brush CodexDiagnosticsStatusBrush => _latestCodexDiagnostics?.Status switch {
         CodexLocalStateHealthStatus.Healthy => CodexHealthyBrush,
@@ -530,6 +573,8 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
     public RelayCommand RefreshCommand { get; }
     public RelayCommand RefreshCodexDiagnosticsCommand { get; }
     public RelayCommand RepairCodexPathsCommand { get; }
+    public RelayCommand CleanUpCodexStateCommand { get; }
+    public RelayCommand ToggleCodexDiagnosticsDetailsCommand { get; }
     public RelayCommand RefreshGitHubCommand { get; }
     public RelayCommand OpenOpenAiCacheCommand { get; }
     public RelayCommand OpenCodexHomeCommand { get; }
@@ -1242,7 +1287,73 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         }
     }
 
+    private async Task CleanUpCodexStateAsync() {
+        if (IsCodexCleanupRunning) {
+            return;
+        }
+
+        IsCodexCleanupRunning = true;
+        CodexDiagnosticsStatusText = "Cleaning Codex state...";
+        CodexDiagnosticsDetailText = "Creating backups, repairing paths, archiving stale sessions, and rotating old logs.";
+        try {
+            var result = await _codexDiagnosticsService.CleanUpAsync().ConfigureAwait(true);
+            await RefreshCodexDiagnosticsAsync().ConfigureAwait(true);
+
+            CodexDiagnosticsStatusText = "Codex cleanup complete";
+            CodexDiagnosticsDetailText = BuildCodexCleanupDetailText(result);
+            if (NotificationsEnabled) {
+                NotificationRequested?.Invoke(this, new TrayNotificationRequestedEventArgs(
+                    "Codex cleanup complete",
+                    CodexDiagnosticsDetailText,
+                    isCritical: false,
+                    providerId: "codex"));
+            }
+        } catch (Exception ex) {
+            CodexDiagnosticsStatusText = "Codex cleanup failed";
+            CodexDiagnosticsDetailText = ex.Message;
+            if (NotificationsEnabled) {
+                NotificationRequested?.Invoke(this, new TrayNotificationRequestedEventArgs(
+                    "Codex cleanup failed",
+                    ex.Message,
+                    isCritical: true,
+                    providerId: "codex"));
+            }
+        } finally {
+            IsCodexCleanupRunning = false;
+        }
+    }
+
+    private Task ToggleCodexDiagnosticsDetails() {
+        IsCodexDiagnosticsDetailsExpanded = !IsCodexDiagnosticsDetailsExpanded;
+        if (IsCodexDiagnosticsDetailsExpanded && !IsCodexProviderSelected) {
+            FocusProvider("codex");
+        }
+
+        return Task.CompletedTask;
+    }
+
     private void OnCodexDiagnosticsSnapshotChanged() {
+        CodexDiagnosticsAreas.Clear();
+        CodexDiagnosticsFindings.Clear();
+        if (_latestCodexDiagnostics is not null) {
+            foreach (var area in _latestCodexDiagnostics.Areas) {
+                CodexDiagnosticsAreas.Add(new CodexLocalStateAreaViewModel(
+                    area.Label,
+                    FormatBytes(area.Bytes),
+                    area.FileCount.ToString(CultureInfo.InvariantCulture) + " files",
+                    area.Path,
+                    area.Recommendation));
+            }
+
+            foreach (var finding in _latestCodexDiagnostics.Findings.Take(5)) {
+                CodexDiagnosticsFindings.Add(new CodexLocalStateFindingViewModel(
+                    BuildCodexFindingSeverityLabel(finding.Severity),
+                    finding.Message,
+                    finding.Count > 0 ? finding.Count.ToString(CultureInfo.InvariantCulture) : string.Empty,
+                    BuildCodexFindingBrush(finding.Severity)));
+            }
+        }
+
         OnPropertyChanged(nameof(CodexDiagnosticsIssueText));
         OnPropertyChanged(nameof(CodexDiagnosticsDatabaseText));
         OnPropertyChanged(nameof(CodexDiagnosticsStatusBrush));
@@ -1256,6 +1367,16 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         OnPropertyChanged(nameof(CodexDiagnosticsPrimaryFindingBrush));
     }
 
+    private bool CanRunCodexMaintenance() {
+        return !IsCodexDiagnosticsLoading && !IsCodexPathRepairRunning && !IsCodexCleanupRunning;
+    }
+
+    private void RaiseCodexMaintenanceCanExecuteChanged() {
+        RefreshCodexDiagnosticsCommand.RaiseCanExecuteChanged();
+        RepairCodexPathsCommand.RaiseCanExecuteChanged();
+        CleanUpCodexStateCommand.RaiseCanExecuteChanged();
+    }
+
     private static string BuildCodexPathRepairDetailText(CodexLocalStatePathRepairResult result) {
         return string.Format(
             CultureInfo.InvariantCulture,
@@ -1263,6 +1384,36 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
             result.ChangedPathValueCount,
             result.ChangedThreadRowCount,
             result.BackupDirectory);
+    }
+
+    private static string BuildCodexCleanupDetailText(CodexLocalStateCleanupResult result) {
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "Repaired {0} path value(s), archived {1} log file(s) ({2}) and {3} stale session file(s) ({4}). Archive: {5}",
+            result.PathRepair.ChangedPathValueCount,
+            result.ArchivedLogFileCount,
+            FormatBytes(result.ArchivedLogBytes),
+            result.ArchivedSessionFileCount,
+            FormatBytes(result.ArchivedSessionBytes),
+            result.ArchiveDirectory);
+    }
+
+    private static string BuildCodexFindingSeverityLabel(CodexLocalStateHealthStatus severity) {
+        return severity switch {
+            CodexLocalStateHealthStatus.Error => "Error",
+            CodexLocalStateHealthStatus.Warning => "Warning",
+            CodexLocalStateHealthStatus.Healthy => "Healthy",
+            _ => "Info"
+        };
+    }
+
+    private static Brush BuildCodexFindingBrush(CodexLocalStateHealthStatus severity) {
+        return severity switch {
+            CodexLocalStateHealthStatus.Healthy => CodexHealthyBrush,
+            CodexLocalStateHealthStatus.Warning => CodexWarningBrush,
+            CodexLocalStateHealthStatus.Error => CodexErrorBrush,
+            _ => CodexUnknownBrush
+        };
     }
 
     private Task OpenCodexHomeAsync() {

--- a/IntelligenceX.Tray/Views/TrayPopupWindow.xaml
+++ b/IntelligenceX.Tray/Views/TrayPopupWindow.xaml
@@ -12,7 +12,6 @@
         Topmost="False"
         ResizeMode="NoResize"
         SizeChanged="OnWindowSizeChanged"
-        Deactivated="OnDeactivated"
         Closing="OnWindowClosing">
 
     <Window.Resources>
@@ -368,21 +367,10 @@
                                 Orientation="Horizontal"
                                 VerticalAlignment="Center">
                         <Button Style="{StaticResource RefreshButtonStyle}"
-                                Command="{Binding RefreshCodexDiagnosticsCommand}"
-                                ToolTip="Check local Codex state"
-                                AutomationProperties.Name="Check local Codex state"
-                                Margin="0,0,6,0">
-                            <TextBlock Text="{Binding CodexDiagnosticsActionLabel}"
-                                       FontFamily="{StaticResource AppFont}"
-                                       FontSize="10.5"
-                                       FontWeight="SemiBold"
-                                       Foreground="{StaticResource PrimaryTextBrush}" />
-                        </Button>
-                        <Button Style="{StaticResource RefreshButtonStyle}"
-                                Command="{Binding OpenCodexHomeCommand}"
-                                ToolTip="Open Codex home"
-                                AutomationProperties.Name="Open Codex home">
-                            <TextBlock Text="Open"
+                                Command="{Binding ToggleCodexDiagnosticsDetailsCommand}"
+                                ToolTip="Show or hide Codex local-state details"
+                                AutomationProperties.Name="Toggle Codex local-state details">
+                            <TextBlock Text="{Binding CodexDiagnosticsDetailsActionLabel}"
                                        FontFamily="{StaticResource AppFont}"
                                        FontSize="10.5"
                                        FontWeight="SemiBold"
@@ -690,7 +678,7 @@
 
                         <Border Style="{StaticResource CardStyle}"
                                 Padding="14,12"
-                                Visibility="{Binding DataContext.IsCodexProviderSelected, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource BoolToVis}}">
+                                Visibility="{Binding DataContext.IsCodexDiagnosticsDetailsVisible, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource BoolToVis}}">
                             <StackPanel>
                                 <Grid Margin="0,0,0,10">
                                     <Grid.ColumnDefinitions>
@@ -719,9 +707,10 @@
                                                        Foreground="{StaticResource TertiaryTextBrush}" />
                                         </StackPanel>
                                     </StackPanel>
-                                    <StackPanel Grid.Column="1"
-                                                Orientation="Horizontal"
-                                                VerticalAlignment="Top">
+                                    <WrapPanel Grid.Column="1"
+                                               Orientation="Horizontal"
+                                               VerticalAlignment="Top"
+                                               HorizontalAlignment="Right">
                                         <Button Style="{StaticResource LinkButtonStyle}"
                                                 Command="{Binding DataContext.RefreshCodexDiagnosticsCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                 ToolTip="Check local Codex state"
@@ -737,12 +726,19 @@
                                             <TextBlock Text="{Binding DataContext.CodexDiagnosticsRepairActionLabel, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" />
                                         </Button>
                                         <Button Style="{StaticResource LinkButtonStyle}"
+                                                Command="{Binding DataContext.CleanUpCodexStateCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                ToolTip="Back up, repair paths, archive stale sessions, and rotate old logs"
+                                                AutomationProperties.Name="Clean up Codex local state"
+                                                Margin="0,0,6,0">
+                                            <TextBlock Text="{Binding DataContext.CodexDiagnosticsCleanupActionLabel, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" />
+                                        </Button>
+                                        <Button Style="{StaticResource LinkButtonStyle}"
                                                 Command="{Binding DataContext.OpenCodexHomeCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                                 ToolTip="Open Codex home"
                                                 AutomationProperties.Name="Open Codex home">
                                             <TextBlock Text="Open home" />
                                         </Button>
-                                    </StackPanel>
+                                    </WrapPanel>
                                 </Grid>
 
                                 <UniformGrid Columns="4" Margin="0,0,0,10">
@@ -810,7 +806,8 @@
                                         Background="{StaticResource InsetPanelBrush}"
                                         BorderBrush="{StaticResource BorderBrush}"
                                         BorderThickness="1"
-                                        Padding="10,8">
+                                        Padding="10,8"
+                                        Margin="0,0,0,10">
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
@@ -835,6 +832,109 @@
                                                    TextWrapping="Wrap" />
                                     </Grid>
                                 </Border>
+
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <Border Grid.Column="0"
+                                            CornerRadius="10"
+                                            Background="{StaticResource SubtleSurfaceMutedBrush}"
+                                            BorderBrush="{StaticResource BorderBrush}"
+                                            BorderThickness="1"
+                                            Padding="10,8"
+                                            Margin="0,0,5,0">
+                                        <StackPanel>
+                                            <TextBlock Text="STORAGE"
+                                                       Style="{StaticResource SectionHeaderStyle}"
+                                                       Margin="0,0,0,6" />
+                                            <ItemsControl ItemsSource="{Binding DataContext.CodexDiagnosticsAreas, RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Grid Margin="0,0,0,7">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <StackPanel>
+                                                                <TextBlock Text="{Binding Label}"
+                                                                           FontFamily="{StaticResource AppFont}"
+                                                                           FontSize="11"
+                                                                           FontWeight="SemiBold"
+                                                                           Foreground="{StaticResource PrimaryTextBrush}" />
+                                                                <TextBlock Text="{Binding Recommendation}"
+                                                                           FontFamily="{StaticResource AppFont}"
+                                                                           FontSize="10"
+                                                                           Foreground="{StaticResource TertiaryTextBrush}"
+                                                                           TextTrimming="CharacterEllipsis" />
+                                                            </StackPanel>
+                                                            <StackPanel Grid.Column="1"
+                                                                        HorizontalAlignment="Right"
+                                                                        Margin="8,0,0,0">
+                                                                <TextBlock Text="{Binding SizeText}"
+                                                                           FontFamily="{StaticResource AppFont}"
+                                                                           FontSize="11"
+                                                                           FontWeight="SemiBold"
+                                                                           Foreground="{StaticResource PrimaryTextBrush}"
+                                                                           HorizontalAlignment="Right" />
+                                                                <TextBlock Text="{Binding FileCountText}"
+                                                                           FontFamily="{StaticResource AppFont}"
+                                                                           FontSize="10"
+                                                                           Foreground="{StaticResource TertiaryTextBrush}"
+                                                                           HorizontalAlignment="Right" />
+                                                            </StackPanel>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <Border Grid.Column="1"
+                                            CornerRadius="10"
+                                            Background="{StaticResource SubtleSurfaceMutedBrush}"
+                                            BorderBrush="{StaticResource BorderBrush}"
+                                            BorderThickness="1"
+                                            Padding="10,8"
+                                            Margin="5,0,0,0">
+                                        <StackPanel>
+                                            <TextBlock Text="FINDINGS"
+                                                       Style="{StaticResource SectionHeaderStyle}"
+                                                       Margin="0,0,0,6" />
+                                            <ItemsControl ItemsSource="{Binding DataContext.CodexDiagnosticsFindings, RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Grid Margin="0,0,0,7">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto" />
+                                                                <ColumnDefinition Width="*" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <Border Padding="6,3"
+                                                                    CornerRadius="8"
+                                                                    Background="{StaticResource InsetPanelBrush}"
+                                                                    Margin="0,0,8,0"
+                                                                    VerticalAlignment="Top">
+                                                                <TextBlock Text="{Binding SeverityLabel}"
+                                                                           FontFamily="{StaticResource AppFont}"
+                                                                           FontSize="9.5"
+                                                                           FontWeight="SemiBold"
+                                                                           Foreground="{Binding SeverityBrush}" />
+                                                            </Border>
+                                                            <TextBlock Grid.Column="1"
+                                                                       Text="{Binding Message}"
+                                                                       FontFamily="{StaticResource AppFont}"
+                                                                       FontSize="10.5"
+                                                                       Foreground="{StaticResource SecondaryTextBrush}"
+                                                                       TextWrapping="Wrap" />
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </Border>
+                                </Grid>
                             </StackPanel>
                         </Border>
 

--- a/IntelligenceX.Tray/Views/TrayPopupWindow.xaml.cs
+++ b/IntelligenceX.Tray/Views/TrayPopupWindow.xaml.cs
@@ -25,8 +25,6 @@ public partial class TrayPopupWindow : Window {
     private const double ProviderTabsScrollStep = 180d;
 
     private bool _isPrimed;
-    private DateTimeOffset _suppressDeactivateUntilUtc;
-
     public event EventHandler? ManualPlacementCommitted;
     public event EventHandler? MinimizeRequested;
     public event EventHandler? CloseRequested;
@@ -66,15 +64,6 @@ public partial class TrayPopupWindow : Window {
 
     public void PrepareForTrayOpen(TimeSpan? suppressDeactivateFor = null) {
         ApplyAdaptiveSizing();
-        _suppressDeactivateUntilUtc = DateTimeOffset.UtcNow + (suppressDeactivateFor ?? TimeSpan.FromMilliseconds(450));
-    }
-
-    private void OnDeactivated(object? sender, EventArgs e) {
-        if (DateTimeOffset.UtcNow < _suppressDeactivateUntilUtc) {
-            return;
-        }
-
-        Hide();
     }
 
     private void OnProviderTabClick(object sender, RoutedEventArgs e) {

--- a/IntelligenceX.Tray/Views/TrayPopupWindow.xaml.cs
+++ b/IntelligenceX.Tray/Views/TrayPopupWindow.xaml.cs
@@ -45,7 +45,7 @@ public partial class TrayPopupWindow : Window {
         var originalLeft = Left;
         var originalTop = Top;
         try {
-            PrepareForTrayOpen(TimeSpan.FromMilliseconds(900));
+            PrepareForTrayOpen();
             ShowActivated = false;
             Opacity = 0;
             Left = -10000;
@@ -62,7 +62,7 @@ public partial class TrayPopupWindow : Window {
         }
     }
 
-    public void PrepareForTrayOpen(TimeSpan? suppressDeactivateFor = null) {
+    public void PrepareForTrayOpen() {
         ApplyAdaptiveSizing();
     }
 
@@ -350,7 +350,7 @@ public partial class TrayPopupWindow : Window {
             return;
         }
 
-        PrepareForTrayOpen(TimeSpan.FromMinutes(2));
+        PrepareForTrayOpen();
         try {
             var dialog = new SaveFileDialog {
                 Filter = "PNG images (*.png)|*.png|All files (*.*)|*.*",


### PR DESCRIPTION
## Summary
- expand Codex local-state diagnostics with detailed storage/finding rows for SQLite state, sessions, archived sessions, logs, and backups
- add a backup-first, archive-only Codex cleanup action that includes path repair plus stale inactive session/log archiving
- collapse detailed local-state UI behind a Details/Hide toggle and stop hiding the tray popup on focus loss

## Validation
- dotnet build IntelligenceX.Storage.SQLite\IntelligenceX.Storage.SQLite.csproj -c Debug -m:1 /nr:false
- dotnet build IntelligenceX.Tray\IntelligenceX.Tray.csproj -c Release -f net10.0-windows10.0.19041.0 -m:1 /nr:false
- dotnet build IntelligenceX.Tests\IntelligenceX.Tests.csproj -c Release -f net8.0 -m:1 /nr:false
- dotnet .\IntelligenceX.Tests\bin\Release\net8.0\IntelligenceX.Tests.dll
- git diff --check