### PR TITLE
Update PowerForge housekeeping workflow pin

### DIFF
--- a/.github/workflows/github-housekeeping.yml
+++ b/.github/workflows/github-housekeeping.yml
@@ -20,11 +20,11 @@ concurrency:
 
 jobs:
   housekeeping:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-housekeeping.yml@06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-housekeeping.yml@b8e8dba42c5ea4cec08253dfafb7673ff195d4e4
     with:
       config-path: ./.powerforge/github-housekeeping.json
       apply: ${{ (github.event_name == 'workflow_dispatch' && inputs.apply == 'true') || (github.event_name != 'workflow_dispatch' && vars.POWERFORGE_GITHUB_HOUSEKEEPING_APPLY == 'true') }}
-      powerforge-ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
+      powerforge-ref: b8e8dba42c5ea4cec08253dfafb7673ff195d4e4
       report-artifact-name: github-housekeeping-reports
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-housekeeping.yml
+++ b/.github/workflows/github-housekeeping.yml
@@ -20,11 +20,11 @@ concurrency:
 
 jobs:
   housekeeping:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-housekeeping.yml@b8e8dba42c5ea4cec08253dfafb7673ff195d4e4
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-housekeeping.yml@23bb7cb83ca9fda14c5972f58ec1667fa87511cc
     with:
       config-path: ./.powerforge/github-housekeeping.json
       apply: ${{ (github.event_name == 'workflow_dispatch' && inputs.apply == 'true') || (github.event_name != 'workflow_dispatch' && vars.POWERFORGE_GITHUB_HOUSEKEEPING_APPLY == 'true') }}
-      powerforge-ref: b8e8dba42c5ea4cec08253dfafb7673ff195d4e4
+      powerforge-ref: 23bb7cb83ca9fda14c5972f58ec1667fa87511cc
       report-artifact-name: github-housekeeping-reports
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update GitHub Housekeeping to the current PSPublishModule housekeeping workflow commit
- pick up the pinned nested setup-dotnet action required by the repository action policy

## Validation
- parsed .powerforge/github-housekeeping.json
- git diff --check