### PR TITLE
Fix runner housekeeping startup on public repo

### DIFF
--- a/.github/workflows/runner-housekeeping.yml
+++ b/.github/workflows/runner-housekeeping.yml
@@ -26,14 +26,21 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  skip-public-repository:
+    if: ${{ !github.event.repository.private }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip runner housekeeping
+        run: echo "Self-hosted runner housekeeping is only enabled for private repositories."
+
   cleanup-linux-runner:
     if: ${{ github.event.repository.private }}
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-runner-housekeeping.yml@06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-runner-housekeeping.yml@23bb7cb83ca9fda14c5972f58ec1667fa87511cc
     with:
       config-path: ./.powerforge/runner-housekeeping.json
       apply: true
-      powerforge-ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
-      runner-labels: '["self-hosted","ubuntu"]'
+      powerforge-ref: 23bb7cb83ca9fda14c5972f58ec1667fa87511cc
+      runner_labels_json: '["self-hosted","ubuntu"]'
       runner-min-free-gb: ${{ github.event_name == 'workflow_dispatch' && (inputs.min_free_gb != '' && inputs.min_free_gb || '20') || (vars.IX_RUNNER_HOUSEKEEPING_MIN_FREE_GB != '' && vars.IX_RUNNER_HOUSEKEEPING_MIN_FREE_GB || '') }}
       report-artifact-name: runner-housekeeping-reports
     secrets:


### PR DESCRIPTION
## Summary
- adds an explicit no-op job for public repositories so `Self-Hosted Runner Housekeeping` no longer has only a private-repo cleanup job to skip
- repins the reusable runner housekeeping workflow and `powerforge-ref` to the stable PSPublishModule housekeeping SHA `23bb7cb83ca9fda14c5972f58ec1667fa87511cc`
- switches runner labels to the `runner_labels_json` input supported by the reusable workflow

## Evidence
- `git diff --check`
- Remote branch file contains the new public-repo no-op job.
- Pre-merge `workflow_dispatch` still reports the default-branch startup failure shape with zero jobs/logs, so final live validation should be a post-merge dispatch or next scheduled run.

Automation: `powerforge-workflow-failure-sweeper`