### PR TITLE
Fix public runner housekeeping condition

### DIFF
--- a/.github/workflows/runner-housekeeping.yml
+++ b/.github/workflows/runner-housekeeping.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   skip-public-repository:
-    if: ${{ !github.event.repository.private }}
+    if: ${{ github.event.repository.private == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Skip runner housekeeping


### PR DESCRIPTION
## Summary
- replaces the public-repo no-op job condition with an explicit boolean comparison
- follows up PR #1324, whose post-merge dispatch still produced `startup_failure` before any jobs were created

## Evidence
- `git diff --check`
- Post-merge dispatch of PR #1324 result: `Self-Hosted Runner Housekeeping` run `26677107454` still ended in `startup_failure` with zero jobs/logs.

Automation: `powerforge-workflow-failure-sweeper`