### PR TITLE
Make runner housekeeping no-op unconditional

### DIFF
--- a/.github/workflows/runner-housekeeping.yml
+++ b/.github/workflows/runner-housekeeping.yml
@@ -27,7 +27,6 @@ concurrency:
 
 jobs:
   skip-public-repository:
-    if: ${{ github.event.repository.private == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Skip runner housekeeping


### PR DESCRIPTION
## Summary
- makes the runner-housekeeping no-op job unconditional so the workflow always has at least one runnable job
- keeps the private cleanup job guarded by `github.event.repository.private`
- follows up PR #1325; post-merge dispatch still produced zero jobs and `startup_failure`

## Evidence
- `git diff --check`
- Post-merge dispatches after PR #1324 and #1325 still ended in `startup_failure` with zero jobs/logs, so this removes the condition from the no-op job entirely.

Automation: `powerforge-workflow-failure-sweeper`