### PR TITLE
Disable self-hosted cleanup on public repo

### DIFF
--- a/.github/workflows/runner-housekeeping.yml
+++ b/.github/workflows/runner-housekeeping.yml
@@ -31,16 +31,3 @@ jobs:
     steps:
       - name: Skip runner housekeeping
         run: echo "Self-hosted runner housekeeping is only enabled for private repositories."
-
-  cleanup-linux-runner:
-    if: ${{ github.event.repository.private }}
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-runner-housekeeping.yml@23bb7cb83ca9fda14c5972f58ec1667fa87511cc
-    with:
-      config-path: ./.powerforge/runner-housekeeping.json
-      apply: true
-      powerforge-ref: 23bb7cb83ca9fda14c5972f58ec1667fa87511cc
-      runner_labels_json: '["self-hosted","ubuntu"]'
-      runner-min-free-gb: ${{ github.event_name == 'workflow_dispatch' && (inputs.min_free_gb != '' && inputs.min_free_gb || '20') || (vars.IX_RUNNER_HOUSEKEEPING_MIN_FREE_GB != '' && vars.IX_RUNNER_HOUSEKEEPING_MIN_FREE_GB || '') }}
-      report-artifact-name: runner-housekeeping-reports
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- removes the reusable self-hosted cleanup job from IntelligenceX because the repository is public
- leaves the workflow as an explicit no-op so existing scheduled/dispatch/workflow_run triggers complete normally instead of failing at startup
- follows PRs #1324-#1326; post-merge dispatches still failed while the reusable cleanup job remained present

## Evidence
- `git diff --check`
- Post-merge dispatch after #1326: run `26677399208` still ended in `startup_failure` with zero jobs/logs.

Automation: `powerforge-workflow-failure-sweeper`