### PR TITLE
Prepare IX Tray Store submission flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,11 @@ _pkginfo.txt
 *.appx
 *.appxbundle
 *.appxupload
+*.appinstaller
+*.msix
+*.msixbundle
+*.msixupload
+Build/store.submit.tray.local.json
 
 # Visual Studio cache files
 # files ending in .cache can be ignored
@@ -386,6 +391,8 @@ build/*
 !Build/powerforge.dotnetpublish.json
 !Build/Run-Project.ps1
 !Build/run.profiles.json
+!Build/Store/
+!Build/Store/Prepare-TrayStoreSubmission.ps1
 !Build/store.submit.tray.example.json
 !Build/workspace.validation.json
 

--- a/Build/README.md
+++ b/Build/README.md
@@ -74,15 +74,17 @@ pwsh ./Build/Run-Project.ps1 -Target Cli -ExtraArgs setup,wizard
 Tray Store package:
 
 ```powershell
-pwsh ./Build/Build-Project.ps1 -ToolsOnly -Targets IntelligenceX.Tray -Runtimes win-x64 -Frameworks net10.0-windows10.0.19041.0 -Styles FrameworkDependent
-dotnet exec C:\Support\GitHub\PSPublishModule\PowerForge.Cli\bin\Release\net10.0\PowerForge.Cli.dll store submit --config ./Build/store.submit.tray.example.json --target IntelligenceX.Tray.Store --plan
+pwsh ./Build/Store/Prepare-TrayStoreSubmission.ps1 -SubmissionMode None
+pwsh ./Build/Store/Prepare-TrayStoreSubmission.ps1 -SkipBuild -SubmissionMode Plan
 ```
 
 Notes:
 - the packaging project is `Installer/IntelligenceX.Tray.Store/IntelligenceX.Tray.Store.wapproj`
 - `Build\powerforge.dotnetpublish.json` enables typed App Installer generation for tray MSIX outputs, including prompt/background update settings
+- Store submission selects `*.msixupload` artifacts from `Artifacts/DotNetPublish/manifest.json`, which requires PSPublishModule/PowerForge `3.0.22` or newer
 - the checked-in Store manifest identity/publisher is placeholder metadata for local packaging validation and must be replaced with the real Partner Center identity before production submission
-- `Build/store.submit.tray.example.json` is only an example; fill in the real `SellerId`, `TenantId`, `ClientId`, secret, and Partner Center `ApplicationId`
+- copy `Build/store.submit.tray.example.json` to ignored `Build/store.submit.tray.local.json`, then fill in the real `SellerId`, `TenantId`, `ClientId`, secret environment variable, and Partner Center `ApplicationId`
+- the detailed Store playbook lives in `InternalDocs/build/tray-store-publishing.md`
 
 `TestimoXRoot` is now resolved centrally for normal builds:
 - `Directory.Build.props` picks up `TESTIMOX_ROOT` when set.

--- a/Build/Store/Prepare-TrayStoreSubmission.ps1
+++ b/Build/Store/Prepare-TrayStoreSubmission.ps1
@@ -1,0 +1,74 @@
+param(
+    [ValidateSet('win-x64', 'win-arm64')] [string[]] $Runtimes = @('win-x64', 'win-arm64'),
+    [ValidateSet('None', 'Plan', 'Validate', 'Submit')] [string] $SubmissionMode = 'Plan',
+    [string] $SubmitConfigPath = 'Build/store.submit.tray.local.json',
+    [switch] $UseExampleSubmitConfig,
+    [switch] $SkipBuild,
+    [switch] $KeepStoreOutput
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Get-Item (Join-Path $PSScriptRoot '..\..')).FullName
+
+if (-not $SkipBuild) {
+    $storeOutputRoot = Join-Path $repoRoot 'Artifacts\DotNetPublish\Store\IntelligenceX.Tray.Store'
+    if (-not $KeepStoreOutput -and (Test-Path -LiteralPath $storeOutputRoot)) {
+        $resolvedStoreOutputRoot = [System.IO.Path]::GetFullPath($storeOutputRoot)
+        if (-not $resolvedStoreOutputRoot.StartsWith($repoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Refusing to clean Store output outside the repo: $resolvedStoreOutputRoot"
+        }
+
+        Remove-Item -LiteralPath $resolvedStoreOutputRoot -Recurse -Force
+    }
+
+    Write-Host 'Building IX Tray Store package artifacts...'
+    & pwsh (Join-Path $repoRoot 'Build\Build-Project.ps1') `
+        -SkipWorkspaceBuild `
+        -ToolsOnly `
+        -Targets IntelligenceX.Tray `
+        -Runtimes $Runtimes `
+        -Frameworks net10.0-windows10.0.19041.0 `
+        -Styles FrameworkDependent `
+        -ToolOutputs Store
+    if ($LASTEXITCODE -ne 0) {
+        throw "IX Tray Store package build failed with exit code $LASTEXITCODE."
+    }
+}
+
+if ($SubmissionMode -ne 'None') {
+    if ($UseExampleSubmitConfig) {
+        $SubmitConfigPath = 'Build/store.submit.tray.example.json'
+    }
+
+    $resolvedSubmitConfigPath = if ([System.IO.Path]::IsPathRooted($SubmitConfigPath)) {
+        [System.IO.Path]::GetFullPath($SubmitConfigPath)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $SubmitConfigPath))
+    }
+
+    if (-not (Test-Path -LiteralPath $resolvedSubmitConfigPath)) {
+        throw "Store submit config not found: $resolvedSubmitConfigPath. Copy Build/store.submit.tray.example.json to Build/store.submit.tray.local.json and fill Partner Center values."
+    }
+
+    . (Join-Path $repoRoot 'Build\Internal\Resolve-PowerForgeCli.ps1')
+    $cli = Resolve-PowerForgeCliInvocation -RepoRoot $repoRoot
+    $submitArgs = @($cli.Prefix) + @(
+        'store', 'submit',
+        '--config', $resolvedSubmitConfigPath,
+        '--target', 'IntelligenceX.Tray.Store'
+    )
+
+    if ($SubmissionMode -eq 'Plan') {
+        $submitArgs += '--plan'
+    } elseif ($SubmissionMode -eq 'Validate') {
+        $submitArgs += '--validate'
+    }
+
+    Write-Host "Running Store submission $SubmissionMode for IX Tray..."
+    & $cli.Command @submitArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "PowerForge Store submission $SubmissionMode failed with exit code $LASTEXITCODE."
+    }
+}

--- a/Build/store.submit.tray.example.json
+++ b/Build/store.submit.tray.example.json
@@ -11,9 +11,15 @@
   "Targets": [
     {
       "Name": "IntelligenceX.Tray.Store",
+      "Description": "Submit FrameworkDependent Store upload artifacts selected from the DotNetPublish manifest.",
       "Provider": "PackagedApp",
       "ApplicationId": "9NBLGGH00000",
-      "SourceDirectory": "../Installer/IntelligenceX.Tray.Store/AppPackages",
+      "ManifestPath": "../Artifacts/DotNetPublish/manifest.json",
+      "ManifestRoot": "..",
+      "StorePackageId": "IntelligenceX.Tray.Store",
+      "SourceTarget": "IntelligenceX.Tray",
+      "Framework": "net10.0-windows10.0.19041.0",
+      "Style": "FrameworkDependent",
       "PackagePatterns": [ "*.msixupload" ],
       "ZipPath": "../Artifacts/StoreSubmit/IntelligenceX.Tray/submission.zip",
       "Commit": true,

--- a/InternalDocs/build/build-publish.md
+++ b/InternalDocs/build/build-publish.md
@@ -182,14 +182,17 @@ pwsh ./Build/Build-Project.ps1 -ToolsOnly -Targets IntelligenceX.Tray -Runtimes 
 Tray Store package:
 
 ```powershell
-pwsh ./Build/Build-Project.ps1 -ToolsOnly -Targets IntelligenceX.Tray -Runtimes win-x64 -Frameworks net10.0-windows10.0.19041.0 -Styles FrameworkDependent
-dotnet exec C:\Support\GitHub\PSPublishModule\PowerForge.Cli\bin\Release\net10.0\PowerForge.Cli.dll store submit --config ./Build/store.submit.tray.example.json --target IntelligenceX.Tray.Store --plan
+pwsh ./Build/Store/Prepare-TrayStoreSubmission.ps1 -SubmissionMode None
+pwsh ./Build/Store/Prepare-TrayStoreSubmission.ps1 -SkipBuild -SubmissionMode Plan
 ```
 
 Store notes:
 - the packaging project is `Installer/IntelligenceX.Tray.Store/IntelligenceX.Tray.Store.wapproj`
 - PowerForge now routes `*.wapproj` Store builds through Visual Studio MSBuild automatically
+- Store submission selects `*.msixupload` artifacts from `Artifacts/DotNetPublish/manifest.json`, which requires PSPublishModule/PowerForge `3.0.22` or newer
 - the checked-in app manifest uses placeholder identity/publisher values for local validation; replace them with the real Partner Center identity before submitting
+- copy `Build/store.submit.tray.example.json` to ignored `Build/store.submit.tray.local.json` and keep Partner Center credentials out of source control
+- use `InternalDocs/build/tray-store-publishing.md` for the full readiness and production-submit checklist
 
 Portable app bundle (recommended for end users):
 

--- a/InternalDocs/build/tray-store-publishing.md
+++ b/InternalDocs/build/tray-store-publishing.md
@@ -1,0 +1,97 @@
+# IX Tray Microsoft Store Publishing
+
+This playbook prepares the packaged IX Tray app for Microsoft Store submission. It keeps the app binary build, MSIX upload artifact, Partner Center submission config, and production identity checks separate so release operators can see which layer is still missing.
+
+## Current lane
+
+- App project: `IntelligenceX.Tray/IntelligenceX.Tray.csproj`
+- Store packaging project: `Installer/IntelligenceX.Tray.Store/IntelligenceX.Tray.Store.wapproj`
+- Store manifest: `Installer/IntelligenceX.Tray.Store/Package.appxmanifest`
+- PowerForge Store package config: `Build/powerforge.dotnetpublish.json` -> `StorePackages[]` -> `IntelligenceX.Tray.Store`
+- Partner Center submit template: `Build/store.submit.tray.example.json` (manifest-based artifact selection; requires PSPublishModule/PowerForge `3.0.22` or newer)
+- Local submit config: `Build/store.submit.tray.local.json` (ignored)
+- Front-door helper: `Build/Store/Prepare-TrayStoreSubmission.ps1`
+
+## One-time Partner Center setup
+
+1. Reserve the app name in Partner Center.
+2. Replace `Package.appxmanifest` identity values with the Partner Center package identity and publisher.
+3. Keep the package version in four-part form and leave the fourth part as `0` for Store packages.
+4. Create or associate a Microsoft Entra application for Store submission automation.
+5. Add the Entra app to Partner Center with the needed submission role.
+6. Copy `Build/store.submit.tray.example.json` to `Build/store.submit.tray.local.json`.
+7. Fill `SellerId`, `TenantId`, `ClientId`, `ClientSecretEnvVar`, and `ApplicationId` in the local file. Store the secret only in the environment variable named by `ClientSecretEnvVar`.
+
+Microsoft's current Store/MSIX docs call out the same release gates: test packages with Windows App Certification Kit, use Partner Center identity metadata when building Store packages, keep Windows 10/11 package version part four as `0`, and authenticate Store submission API calls with Microsoft Entra client credentials.
+
+## Local readiness
+
+The helper is intentionally thin: it invokes the PowerForge Store build and optionally calls `powerforge store submit`. Use the release gates below for identity, asset, WACK, and Partner Center readiness.
+
+To exercise the wrapper without building or submitting:
+
+```powershell
+pwsh ./Build/Store/Prepare-TrayStoreSubmission.ps1 -SkipBuild -SubmissionMode None
+```
+
+## Build Store upload artifacts
+
+Build the Store package artifacts through the same PowerForge lane the release wrapper uses:
+
+```powershell
+pwsh ./Build/Store/Prepare-TrayStoreSubmission.ps1 -SubmissionMode None
+```
+
+This builds `FrameworkDependent` Store upload packages for `win-x64` and `win-arm64` by default and cleans the IX Tray Store output root first. The later submit step selects artifacts from `Artifacts/DotNetPublish/manifest.json`, not by recursively scanning Store output folders.
+
+To build only x64:
+
+```powershell
+pwsh ./Build/Store/Prepare-TrayStoreSubmission.ps1 -Runtimes win-x64 -SubmissionMode None
+```
+
+## Submission dry run
+
+After `Build/store.submit.tray.local.json` is filled with real Partner Center values:
+
+```powershell
+pwsh ./Build/Store/Prepare-TrayStoreSubmission.ps1 -SkipBuild -SubmissionMode Plan
+```
+
+Use `-SubmissionMode Validate` for a validation call without commit when supported by the current PowerForge provider.
+
+## Production submit
+
+Only use this after the package was built from the intended commit, the upload artifact was inspected, WACK has passed, and the Partner Center draft metadata/listing is ready:
+
+```powershell
+pwsh ./Build/Store/Prepare-TrayStoreSubmission.ps1 -SkipBuild -SubmissionMode Submit
+```
+
+## Manual PowerForge commands
+
+The helper wraps these commands:
+
+```powershell
+pwsh ./Build/Build-Project.ps1 -SkipWorkspaceBuild -ToolsOnly -Targets IntelligenceX.Tray -Runtimes win-x64,win-arm64 -Frameworks net10.0-windows10.0.19041.0 -Styles FrameworkDependent -ToolOutputs Store
+powerforge store submit --config ./Build/store.submit.tray.local.json --target IntelligenceX.Tray.Store --plan
+```
+
+## Release gates
+
+- `Package.appxmanifest` identity and publisher match Partner Center.
+- `Package.appxmanifest` version is monotonic and ends in `.0`.
+- Store assets exist at the expected base dimensions.
+- `Build/store.submit.tray.local.json` has no placeholder Partner Center values.
+- Store build records the expected `*.msixupload` files in `Artifacts/DotNetPublish/manifest.json`.
+- Windows App Certification Kit passes on the upload package.
+- Manual smoke install/open was done on clean Windows hardware or VM.
+- `runFullTrust` justification and submission notes are ready in Partner Center.
+
+## Microsoft references
+
+- [App package requirements for MSIX apps](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/msix/app-package-requirements)
+- [Package identity overview](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/package-identity-overview)
+- [Sign an MSIX package](https://learn.microsoft.com/en-us/windows/msix/package/signing-package-overview)
+- [Manage Microsoft Entra applications in Partner Center](https://learn.microsoft.com/en-us/windows/apps/publish/partner-center/manage-azure-ad-applications-in-partner-center)
+- [Manage app submissions with Microsoft Store services](https://learn.microsoft.com/en-us/windows/uwp/monetize/manage-app-submissions)


### PR DESCRIPTION
## Summary

- add a thin IX Tray Store submission wrapper that delegates Store build and submit work to PowerForge
- update the Store submit example to select `*.msixupload` artifacts from the DotNetPublish manifest instead of a hardcoded source directory
- document the Store publishing lane, local Partner Center config, release gates, and the PSPublishModule/PowerForge `3.0.22` requirement
- ignore local Store submission secrets and generated MSIX/App Installer outputs

## Why

PSPublishModule now has manifest-based Store submission artifact selection. IX can keep PowerShell thin: build Store packages through `Build-Project.ps1`, then call `powerforge store submit` with a manifest-backed config.

## Validation

- `Find-Module -Name PSPublishModule` -> `3.0.22` published on PSGallery
- PowerShell parser check for `Build/Store/Prepare-TrayStoreSubmission.ps1`
- `pwsh -NoProfile -File ./Build/Store/Prepare-TrayStoreSubmission.ps1 -SkipBuild -SubmissionMode None`
- manifest-backed `Plan` proof with ignored dummy DotNetPublish manifest and `*.msixupload` files selected by PowerForge
- `git diff --check`
