### PR TITLE
Fix reviewer auth gate and PKI package drift

### DIFF
--- a/.github/workflows/review-intelligencex-core.yml
+++ b/.github/workflows/review-intelligencex-core.yml
@@ -1002,7 +1002,8 @@ jobs:
               if [ -z "$exit_code" ] || [ "$exit_code" = "0" ]; then
                 return
               fi
-              if [ -f "$log_path" ] && grep -Eiq 'OpenAI auth bundle is missing|OpenAI auth bundle is missing or no longer valid|OpenAI auth refresh token was already used|Interactive ChatGPT sign-in cannot run inside GitHub Actions' "$log_path"; then
+              auth_pattern='refresh_token_reused|refresh token has already been used|invalid_grant|signing in again|Interactive ChatGPT sign-in cannot run inside GitHub Actions|Failed to decode INTELLIGENCEX_AUTH_B64|Set INTELLIGENCEX_AUTH_B64|No OpenAI auth bundle found|OpenAI auth bundle expired|OpenAI auth bundle could not be loaded|OpenAI auth bundle is stale|OpenAI auth bundle is missing'
+              if [ -f "$log_path" ] && grep -Eiq "$auth_pattern" "$log_path"; then
                 echo "::error title=IntelligenceX reviewer auth failure::$stage exited with $exit_code and requires OpenAI auth remediation."
                 gate_failed=1
               else

--- a/.github/workflows/review-intelligencex-core.yml
+++ b/.github/workflows/review-intelligencex-core.yml
@@ -993,8 +993,26 @@ jobs:
         shell: bash
         run: |
           if [ ! -f IntelligenceX.Cli/IntelligenceX.Cli.csproj ]; then
-            echo "Reviewer failure policy gate skipped: IntelligenceX.Cli source project is not available in this checkout."
-            exit 0
+            echo "Reviewer failure policy gate using shell fallback because IntelligenceX.Cli source project is not available in this checkout."
+            gate_failed=0
+            evaluate_log() {
+              stage="$1"
+              exit_code="$2"
+              log_path="$3"
+              if [ -z "$exit_code" ] || [ "$exit_code" = "0" ]; then
+                return
+              fi
+              if [ -f "$log_path" ] && grep -Eiq 'OpenAI auth bundle is missing|OpenAI auth bundle is missing or no longer valid|OpenAI auth refresh token was already used|Interactive ChatGPT sign-in cannot run inside GitHub Actions' "$log_path"; then
+                echo "::error title=IntelligenceX reviewer auth failure::$stage exited with $exit_code and requires OpenAI auth remediation."
+                gate_failed=1
+              else
+                echo "$stage exited with $exit_code and remains fail-open by policy."
+              fi
+            }
+            evaluate_log "Source reviewer" "${{ steps.reviewer_run_source.outputs.exit_code }}" artifacts/reviewer-run-source.log
+            evaluate_log "Release reviewer (unix)" "${{ steps.reviewer_run_release_unix.outputs.exit_code }}" artifacts/reviewer-run-release-unix.log
+            evaluate_log "Release reviewer (windows)" "${{ steps.reviewer_run_release_windows.outputs.exit_code }}" artifacts/reviewer-run-release-windows.log
+            exit "$gate_failed"
           fi
           dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj -c Release -f net8.0 -- ci reviewer-failure-gate \
             --source-reviewer-exit "${{ steps.reviewer_run_source.outputs.exit_code }}" \

--- a/.github/workflows/review-intelligencex-core.yml
+++ b/.github/workflows/review-intelligencex-core.yml
@@ -1002,7 +1002,7 @@ jobs:
               if [ -z "$exit_code" ] || [ "$exit_code" = "0" ]; then
                 return
               fi
-              auth_pattern='refresh_token_reused|refresh token has already been used|invalid_grant|signing in again|Interactive ChatGPT sign-in cannot run inside GitHub Actions|Failed to decode INTELLIGENCEX_AUTH_B64|Set INTELLIGENCEX_AUTH_B64|No OpenAI auth bundle found|OpenAI auth bundle expired|OpenAI auth bundle could not be loaded|OpenAI auth bundle is stale|OpenAI auth bundle is missing'
+              auth_pattern='refresh_token_reused|refresh token has already been used|OpenAI auth refresh failed|token refresh|invalid_grant|signing in again|Interactive ChatGPT sign-in cannot run inside GitHub Actions|Failed to decode INTELLIGENCEX_AUTH_B64|Set INTELLIGENCEX_AUTH_B64|No OpenAI auth bundle found|OpenAI auth bundle expired|OpenAI auth bundle could not be loaded|OpenAI auth bundle is stale|OpenAI auth bundle is missing'
               if [ -f "$log_path" ] && grep -Eiq "$auth_pattern" "$log_path"; then
                 echo "::error title=IntelligenceX reviewer auth failure::$stage exited with $exit_code and requires OpenAI auth remediation."
                 gate_failed=1

--- a/.github/workflows/review-intelligencex-core.yml
+++ b/.github/workflows/review-intelligencex-core.yml
@@ -987,3 +987,19 @@ jobs:
         with:
           name: intelligencex-reviewer-artifacts
           path: artifacts/reviewer
+
+      - name: Enforce reviewer runtime failure policy
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [ ! -f IntelligenceX.Cli/IntelligenceX.Cli.csproj ]; then
+            echo "Reviewer failure policy gate skipped: IntelligenceX.Cli source project is not available in this checkout."
+            exit 0
+          fi
+          dotnet run --project IntelligenceX.Cli/IntelligenceX.Cli.csproj -c Release -f net8.0 -- ci reviewer-failure-gate \
+            --source-reviewer-exit "${{ steps.reviewer_run_source.outputs.exit_code }}" \
+            --source-log artifacts/reviewer-run-source.log \
+            --release-unix-exit "${{ steps.reviewer_run_release_unix.outputs.exit_code }}" \
+            --release-unix-log artifacts/reviewer-run-release-unix.log \
+            --release-windows-exit "${{ steps.reviewer_run_release_windows.outputs.exit_code }}" \
+            --release-windows-log artifacts/reviewer-run-release-windows.log

--- a/Docs/reviewer/overview.md
+++ b/Docs/reviewer/overview.md
@@ -72,7 +72,7 @@ flowchart LR
 **Default Mode + Model Policy**
 - Default review mode: `hybrid` (summary + inline when supported; falls back to summary-only).
 - Default provider/model: OpenAI with `gpt-5.5` unless configured otherwise; Claude and Copilot are opt-in.
-- Safe defaults: skip drafts; skip workflow changes unless allowed; no secrets/writes on untrusted PRs; core reviewer defaults fail-open only for transient errors, while the bundled GitHub workflow exports fail-open env defaults for provider/runtime failures so auth outages do not block CI; budget summary enabled; auto-resolve limited to bot threads with evidence; secrets audit on.
+- Safe defaults: skip drafts; skip workflow changes unless allowed; no secrets/writes on untrusted PRs; core reviewer defaults fail-open only for transient errors, while the bundled GitHub workflow keeps selected provider/runtime failures fail-open but fails the required check for auth-bundle failures that need secret refresh; budget summary enabled; auto-resolve limited to bot threads with evidence; secrets audit on.
 
 ## Reusable workflow (quick start)
 

--- a/IntelligenceX.Chat/Directory.Build.props
+++ b/IntelligenceX.Chat/Directory.Build.props
@@ -17,9 +17,9 @@
     <DbaClientXRepoRoot Condition="'$(DbaClientXRepoRoot)' == '' and Exists('$(DbaClientXRepoRootCandidate2)DbaClientX.SQLite\\DbaClientX.SQLite.csproj')">$(DbaClientXRepoRootCandidate2)</DbaClientXRepoRoot>
     <DbaClientXRepoRoot Condition="'$(DbaClientXRepoRoot)' == ''">$(DbaClientXRepoRootCandidate1)</DbaClientXRepoRoot>
 
-    <OfficeImoMarkdownNuGetVersion Condition="'$(OfficeImoMarkdownNuGetVersion)' == ''">0.6.6</OfficeImoMarkdownNuGetVersion>
-    <OfficeImoMarkdownRendererNuGetVersion Condition="'$(OfficeImoMarkdownRendererNuGetVersion)' == ''">0.2.6</OfficeImoMarkdownRendererNuGetVersion>
-    <OfficeImoExcelNuGetVersion Condition="'$(OfficeImoExcelNuGetVersion)' == ''">0.6.19</OfficeImoExcelNuGetVersion>
-    <OfficeImoWordMarkdownNuGetVersion Condition="'$(OfficeImoWordMarkdownNuGetVersion)' == ''">1.0.13</OfficeImoWordMarkdownNuGetVersion>
+    <OfficeImoMarkdownNuGetVersion Condition="'$(OfficeImoMarkdownNuGetVersion)' == ''">0.6.28</OfficeImoMarkdownNuGetVersion>
+    <OfficeImoMarkdownRendererNuGetVersion Condition="'$(OfficeImoMarkdownRendererNuGetVersion)' == ''">0.2.28</OfficeImoMarkdownRendererNuGetVersion>
+    <OfficeImoExcelNuGetVersion Condition="'$(OfficeImoExcelNuGetVersion)' == ''">0.6.41</OfficeImoExcelNuGetVersion>
+    <OfficeImoWordMarkdownNuGetVersion Condition="'$(OfficeImoWordMarkdownNuGetVersion)' == ''">1.0.37</OfficeImoWordMarkdownNuGetVersion>
   </PropertyGroup>
 </Project>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/LocalExportArtifactWriterTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/LocalExportArtifactWriterTests.cs
@@ -326,10 +326,10 @@ public sealed partial class LocalExportArtifactWriterTests {
     }
 
     /// <summary>
-    /// Ensures full-transcript export normalization preserves the shared adjacent ordered-list spacing repair.
+    /// Ensures full-transcript export normalization keeps adjacent ordered-list items stable for current OfficeIMO rendering.
     /// </summary>
     [Fact]
-    public void NormalizeTranscriptMarkdownForExport_InsertsBlankLineBetweenAdjacentOrderedItems() {
+    public void NormalizeTranscriptMarkdownForExport_PreservesAdjacentOrderedItems() {
         const string markdown = """
             ### Assistant (10:22:14)
             1. First check
@@ -339,7 +339,7 @@ public sealed partial class LocalExportArtifactWriterTests {
         var normalized = TranscriptMarkdownPreparation.PrepareTranscriptMarkdownForExport(markdown)
             .Replace("\r\n", "\n", StringComparison.Ordinal);
 
-        Assert.Contains("1. First check\n\n2. Second check", normalized, StringComparison.Ordinal);
+        Assert.Contains("1. First check\n2. Second check", normalized, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/OfficeImoMarkdownRuntimeContractTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/OfficeImoMarkdownRuntimeContractTests.cs
@@ -99,10 +99,10 @@ public sealed class OfficeImoMarkdownRuntimeContractTests {
         var propsPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Directory.Build.props"));
         var props = LoadMsBuildProperties(propsPath);
 
-        Assert.Equal("0.6.6", props["OfficeImoMarkdownNuGetVersion"]);
-        Assert.Equal("0.2.6", props["OfficeImoMarkdownRendererNuGetVersion"]);
-        Assert.Equal("0.6.19", props["OfficeImoExcelNuGetVersion"]);
-        Assert.Equal("1.0.13", props["OfficeImoWordMarkdownNuGetVersion"]);
+        Assert.Equal("0.6.28", props["OfficeImoMarkdownNuGetVersion"]);
+        Assert.Equal("0.2.28", props["OfficeImoMarkdownRendererNuGetVersion"]);
+        Assert.Equal("0.6.41", props["OfficeImoExcelNuGetVersion"]);
+        Assert.Equal("1.0.37", props["OfficeImoWordMarkdownNuGetVersion"]);
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterRenderingTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptHtmlFormatterRenderingTests.cs
@@ -135,7 +135,7 @@ public sealed partial class TranscriptHtmlFormatterTests {
     }
 
     /// <summary>
-    /// Ensures transcript rendering applies the shared adjacent ordered-list spacing repair before HTML conversion.
+    /// Ensures transcript rendering keeps adjacent ordered items as separate HTML list entries.
     /// </summary>
     [Fact]
     public void Format_RendersAdjacentOrderedItemsAsSeparateListEntries() {
@@ -145,8 +145,8 @@ public sealed partial class TranscriptHtmlFormatterTests {
             ("Assistant", "1. First check\n2. Second check", now)
         }, "HH:mm:ss", options);
 
-        Assert.Contains("<li>First check</li>", html, StringComparison.Ordinal);
-        Assert.Contains("<li>Second check</li>", html, StringComparison.Ordinal);
+        Assert.Contains("<li><p>First check</p></li>", html, StringComparison.Ordinal);
+        Assert.Contains("<li><p>Second check</p></li>", html, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownContractIntegrationTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/TranscriptMarkdownContractIntegrationTests.cs
@@ -12,7 +12,8 @@ namespace IntelligenceX.Chat.App.Tests;
 /// </summary>
 public sealed class TranscriptMarkdownContractIntegrationTests {
     /// <summary>
-    /// Ensures render-body and markdown-export preparation agree on the shared normalization contract when no export-only cleanup is required.
+    /// Ensures render-body and markdown-export preparation agree on the shared normalization contract when no
+    /// render-only or export-only cleanup is required.
     /// </summary>
     [Fact]
     public void RenderAndExportPreparation_ShareCoreNormalization_WhenNoExportOnlyCleanupIsNeeded() {
@@ -21,9 +22,6 @@ public sealed class TranscriptMarkdownContractIntegrationTests {
         }
 
         const string markdown = """
-            1. First check
-            2. Second check
-
             - Signal **Only total count checked, not origin split -> **Why it matters:**external/custom rules can drift ->**Next action:**break down origins.**
             - TestimoX rules available ****359****
             """;
@@ -36,7 +34,6 @@ public sealed class TranscriptMarkdownContractIntegrationTests {
             .TrimEnd();
 
         Assert.Equal(preparedForRender, preparedForExport);
-        Assert.Contains("1. First check\n\n2. Second check", preparedForRender, StringComparison.Ordinal);
         Assert.Contains("**Only total count checked, not origin split** -> **Why it matters:** external/custom rules can drift", preparedForRender, StringComparison.Ordinal);
         Assert.Contains("**359**", preparedForRender, StringComparison.Ordinal);
     }
@@ -137,8 +134,8 @@ public sealed class TranscriptMarkdownContractIntegrationTests {
             markdown,
             OfficeImoMarkdownRuntimeContract.CreateTranscriptRendererOptions());
 
-        Assert.Contains("<li>First check</li>", html, StringComparison.Ordinal);
-        Assert.Contains("<li>Second check</li>", html, StringComparison.Ordinal);
+        Assert.Contains("<li><p>First check</p></li>", html, StringComparison.Ordinal);
+        Assert.Contains("<li><p>Second check</p></li>", html, StringComparison.Ordinal);
         Assert.Contains("<strong>359</strong>", html, StringComparison.Ordinal);
         Assert.DoesNotContain("****359****", html, StringComparison.Ordinal);
     }

--- a/IntelligenceX.Cli/Ci/CiReviewerFailureGateCommand.cs
+++ b/IntelligenceX.Cli/Ci/CiReviewerFailureGateCommand.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using IntelligenceX.Reviewer;
+
+namespace IntelligenceX.Cli.Ci;
+
+internal static class CiReviewerFailureGateCommand {
+    public static async Task<int> RunAsync(string[] args) {
+        var options = ParseArgs(args);
+        if (options.ShowHelp) {
+            PrintHelp();
+            return 0;
+        }
+        if (options.Error is not null) {
+            Console.Error.WriteLine(options.Error);
+            return 1;
+        }
+
+        var source = await EvaluateAsync("Source reviewer", options.SourceReviewerExit, options.SourceLogPath)
+            .ConfigureAwait(false);
+        if (source.ShouldFail) {
+            return 1;
+        }
+
+        var releaseUnix = await EvaluateAsync("Release reviewer (unix)", options.ReleaseUnixExit, options.ReleaseUnixLogPath)
+            .ConfigureAwait(false);
+        if (releaseUnix.ShouldFail) {
+            return 1;
+        }
+
+        var releaseWindows = await EvaluateAsync("Release reviewer (windows)", options.ReleaseWindowsExit, options.ReleaseWindowsLogPath)
+            .ConfigureAwait(false);
+        return releaseWindows.ShouldFail ? 1 : 0;
+    }
+
+    private static async Task<GateResult> EvaluateAsync(string stage, string? exitCode, string? logPath) {
+        if (!HasNonZeroExit(exitCode)) {
+            return GateResult.Pass;
+        }
+
+        var logText = string.Empty;
+        if (!string.IsNullOrWhiteSpace(logPath) && File.Exists(logPath)) {
+            logText = await File.ReadAllTextAsync(logPath).ConfigureAwait(false);
+        }
+
+        var failure = ReviewDiagnostics.ClassifyWorkflowFailureLog(logText);
+        if (!failure.ShouldFailWorkflow) {
+            Console.WriteLine($"{stage} exited with {exitCode}, classified as '{failure.Kind}', and remains fail-open by policy.");
+            return GateResult.Pass;
+        }
+
+        Console.Error.WriteLine($"{stage} exited with {exitCode}, classified as '{failure.Kind}', and must fail this required check.");
+        Console.Error.WriteLine(failure.Detail);
+        return GateResult.Fail;
+    }
+
+    private static bool HasNonZeroExit(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        return !value.Trim().Equals("0", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Options ParseArgs(string[] args) {
+        var options = new Options();
+        for (var i = 0; i < args.Length; i++) {
+            var arg = args[i];
+            switch (arg.ToLowerInvariant()) {
+                case "help":
+                case "-h":
+                case "--help":
+                    options.ShowHelp = true;
+                    return options;
+                case "--source-reviewer-exit":
+                    options.SourceReviewerExit = ReadOptionalValue(args, ref i, arg, options);
+                    break;
+                case "--source-log":
+                    options.SourceLogPath = ReadOptionalValue(args, ref i, arg, options);
+                    break;
+                case "--release-unix-exit":
+                    options.ReleaseUnixExit = ReadOptionalValue(args, ref i, arg, options);
+                    break;
+                case "--release-unix-log":
+                    options.ReleaseUnixLogPath = ReadOptionalValue(args, ref i, arg, options);
+                    break;
+                case "--release-windows-exit":
+                    options.ReleaseWindowsExit = ReadOptionalValue(args, ref i, arg, options);
+                    break;
+                case "--release-windows-log":
+                    options.ReleaseWindowsLogPath = ReadOptionalValue(args, ref i, arg, options);
+                    break;
+                default:
+                    options.Error = $"Unknown option '{arg}' for reviewer-failure-gate.";
+                    return options;
+            }
+        }
+
+        return options;
+    }
+
+    private static string? ReadOptionalValue(string[] args, ref int index, string name, Options options) {
+        if (index + 1 >= args.Length) {
+            options.Error = $"Missing value for {name}.";
+            return null;
+        }
+
+        index++;
+        var value = args[index];
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static void PrintHelp() {
+        Console.WriteLine("Fail required reviewer CI checks for non-passable reviewer runtime failures.");
+        Console.WriteLine();
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  intelligencex ci reviewer-failure-gate [--source-reviewer-exit <n>] [--source-log <path>] [release options]");
+    }
+
+    private readonly record struct GateResult(bool ShouldFail) {
+        public static GateResult Pass { get; } = new(false);
+        public static GateResult Fail { get; } = new(true);
+    }
+
+    private sealed class Options {
+        public bool ShowHelp { get; set; }
+        public string? Error { get; set; }
+        public string? SourceReviewerExit { get; set; }
+        public string? SourceLogPath { get; set; }
+        public string? ReleaseUnixExit { get; set; }
+        public string? ReleaseUnixLogPath { get; set; }
+        public string? ReleaseWindowsExit { get; set; }
+        public string? ReleaseWindowsLogPath { get; set; }
+    }
+}

--- a/IntelligenceX.Cli/Ci/CiReviewerFailureGateCommand.cs
+++ b/IntelligenceX.Cli/Ci/CiReviewerFailureGateCommand.cs
@@ -112,7 +112,7 @@ internal static class CiReviewerFailureGateCommand {
     }
 
     private static void PrintHelp() {
-        Console.WriteLine("Fail required reviewer CI checks for non-passable reviewer runtime failures.");
+        Console.WriteLine("Fail required reviewer CI checks for non-passable reviewer failures such as auth-remediation failures.");
         Console.WriteLine();
         Console.WriteLine("Usage:");
         Console.WriteLine("  intelligencex ci reviewer-failure-gate [--source-reviewer-exit <n>] [--source-log <path>] [release options]");

--- a/IntelligenceX.Cli/Ci/CiReviewerRunSummaryCommand.cs
+++ b/IntelligenceX.Cli/Ci/CiReviewerRunSummaryCommand.cs
@@ -55,7 +55,7 @@ internal static class CiReviewerRunSummaryCommand {
             HasNonZeroExit(options.SourceReviewerExit) ||
             HasNonZeroExit(options.ReleaseUnixExit) ||
             HasNonZeroExit(options.ReleaseWindowsExit)) {
-            builder.AppendLine("> Reviewer or analysis execution produced a non-zero exit code, but the job is fail-open by policy. The PR comment contains the user-facing failure summary when a PR number is available.");
+            builder.AppendLine("> Reviewer or analysis execution produced a non-zero exit code. Selected runtime failures remain fail-open by policy; non-passable reviewer failures are enforced by the final reviewer failure policy gate. The PR comment contains the user-facing failure summary when a PR number is available.");
             builder.AppendLine();
         }
 

--- a/IntelligenceX.Cli/Ci/CiRunner.cs
+++ b/IntelligenceX.Cli/Ci/CiRunner.cs
@@ -21,6 +21,7 @@ internal static class CiRunner {
             "changed-files" => CiChangedFilesCommand.RunAsync(rest),
             "repository-quality" => CiRepositoryQualityCommand.RunAsync(rest),
             "review-fail-open-summary" => CiReviewFailOpenSummaryCommand.RunAsync(rest),
+            "reviewer-failure-gate" => CiReviewerFailureGateCommand.RunAsync(rest),
             "reviewer-run-summary" => CiReviewerRunSummaryCommand.RunAsync(rest),
             "tune-reviewer-budgets" => CiTuneReviewerBudgetsCommand.RunAsync(rest),
             "verify-managed-workflow" => CiVerifyManagedWorkflowCommand.RunAsync(rest),
@@ -46,6 +47,7 @@ internal static class CiRunner {
         Console.WriteLine("                              [--framework <tfm>] [--strict <true|false>] [--gate-new-only <true|false>] [--out <path>]");
         Console.WriteLine("  intelligencex ci review-fail-open-summary --reviewer-source <source|release> [--repo <owner/name>] [--pr-number <n>]");
         Console.WriteLine("                              [--source-log <path>] [--release-unix-log <path>] [--release-windows-log <path>]");
+        Console.WriteLine("  intelligencex ci reviewer-failure-gate [--source-reviewer-exit <n>] [--source-log <path>] [release options]");
         Console.WriteLine("  intelligencex ci reviewer-run-summary [--summary <path>] [--*-outcome <value>] [--*-exit <value>]");
         Console.WriteLine("  intelligencex ci tune-reviewer-budgets --changed-files <path> [--changed-threshold <n>] [--catalog-threshold <n>]");
         Console.WriteLine("                              [--max-files <n>] [--max-patch-chars <n>] [--out-env <path>]");

--- a/IntelligenceX.Reviewer/ReviewDiagnostics.cs
+++ b/IntelligenceX.Reviewer/ReviewDiagnostics.cs
@@ -107,7 +107,12 @@ internal static class ReviewDiagnostics {
     private const string AuthRefreshTokenReusedSummary = "OpenAI auth refresh token was already used; sign in again";
     private const string UsageBudgetGuardPrefix = "Usage budget guard blocked review run:";
 
-    internal readonly record struct WorkflowFailureInfo(string Kind, string Label, string Detail, bool RequiresAuthRemediation);
+    internal readonly record struct WorkflowFailureInfo(
+        string Kind,
+        string Label,
+        string Detail,
+        bool RequiresAuthRemediation,
+        bool ShouldFailWorkflow);
 
     /// <summary>
     /// Categorizes reviewer failures for reporting and retry logic.
@@ -372,6 +377,7 @@ internal static class ReviewDiagnostics {
                 "usage-budget-guard",
                 "Usage budget guard blocked the review",
                 ExtractUsageBudgetGuardDetail(text),
+                false,
                 false);
         }
 
@@ -381,6 +387,7 @@ internal static class ReviewDiagnostics {
                 "openai-auth-refresh-reused",
                 "OpenAI auth refresh token was already used",
                 "OpenAI auth refresh token was already used; sign in again.",
+                true,
                 true);
         }
 
@@ -393,6 +400,7 @@ internal static class ReviewDiagnostics {
                 "openai-auth",
                 "OpenAI auth bundle is missing or stale",
                 "OpenAI auth bundle is missing or no longer valid; sign in again.",
+                true,
                 true);
         }
 
@@ -400,6 +408,7 @@ internal static class ReviewDiagnostics {
             "reviewer-runtime",
             "Reviewer runtime failed",
             "Reviewer execution failed after the workflow created the progress summary.",
+            false,
             false);
     }
 
@@ -420,12 +429,18 @@ internal static class ReviewDiagnostics {
 
     internal static string BuildWorkflowFailOpenSummaryBody(PullRequestContext context, string reviewerSource,
         string remediationRepo, WorkflowFailureInfo failure) {
+        var heading = failure.ShouldFailWorkflow
+            ? "## IntelligenceX Review (failed)"
+            : "## IntelligenceX Review (failed open)";
+        var warning = failure.ShouldFailWorkflow
+            ? "ERROR: Reviewer execution failed and this workflow will fail."
+            : "WARNING: Reviewer execution failed and this workflow was allowed to pass open.";
         var lines = new List<string> {
             WorkflowSummaryMarker,
-            "## IntelligenceX Review (failed open)",
+            heading,
             $"Reviewing this pull request: **{context.Title.Replace("\r", string.Empty).Replace("\n", " ")}**",
             string.Empty,
-            "WARNING: Reviewer execution failed and this workflow was allowed to pass open.",
+            warning,
             string.Empty,
             $"- Reviewer source: {reviewerSource}",
             $"- Failure type: {failure.Label}"

--- a/IntelligenceX.Reviewer/ReviewDiagnostics.cs
+++ b/IntelligenceX.Reviewer/ReviewDiagnostics.cs
@@ -391,11 +391,7 @@ internal static class ReviewDiagnostics {
                 true);
         }
 
-        if (text.IndexOf("OAuth token request failed", StringComparison.OrdinalIgnoreCase) >= 0 ||
-            text.IndexOf("invalid_grant", StringComparison.OrdinalIgnoreCase) >= 0 ||
-            text.IndexOf("auth bundle", StringComparison.OrdinalIgnoreCase) >= 0 ||
-            text.IndexOf("INTELLIGENCEX_AUTH_B64", StringComparison.OrdinalIgnoreCase) >= 0 ||
-            text.IndexOf("signing in again", StringComparison.OrdinalIgnoreCase) >= 0) {
+        if (IsOpenAiAuthRemediationFailureLog(text)) {
             return new WorkflowFailureInfo(
                 "openai-auth",
                 "OpenAI auth bundle is missing or stale",
@@ -410,6 +406,30 @@ internal static class ReviewDiagnostics {
             "Reviewer execution failed after the workflow created the progress summary.",
             false,
             false);
+    }
+
+    private static bool IsOpenAiAuthRemediationFailureLog(string text) {
+        if (text.IndexOf("invalid_grant", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            text.IndexOf("signing in again", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            text.IndexOf("Interactive ChatGPT sign-in cannot run inside GitHub Actions", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            text.IndexOf("Failed to decode INTELLIGENCEX_AUTH_B64", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            text.IndexOf("Set INTELLIGENCEX_AUTH_B64", StringComparison.OrdinalIgnoreCase) >= 0) {
+            return true;
+        }
+
+        if (text.IndexOf("OAuth token request failed", StringComparison.OrdinalIgnoreCase) >= 0 &&
+            (text.IndexOf("invalid_grant", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             text.IndexOf("refresh_token_reused", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             text.IndexOf("signing in again", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             text.IndexOf("refresh token has already been used", StringComparison.OrdinalIgnoreCase) >= 0)) {
+            return true;
+        }
+
+        return text.IndexOf("No OpenAI auth bundle found", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("OpenAI auth bundle expired", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("OpenAI auth bundle could not be loaded", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("OpenAI auth bundle is stale", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("OpenAI auth bundle is missing", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private static string ExtractUsageBudgetGuardDetail(string text) {

--- a/IntelligenceX.Reviewer/ReviewDiagnostics.cs
+++ b/IntelligenceX.Reviewer/ReviewDiagnostics.cs
@@ -410,6 +410,8 @@ internal static class ReviewDiagnostics {
 
     private static bool IsOpenAiAuthRemediationFailureLog(string text) {
         if (text.IndexOf("invalid_grant", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            text.IndexOf("OpenAI auth refresh failed", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            text.IndexOf("token refresh", StringComparison.OrdinalIgnoreCase) >= 0 ||
             text.IndexOf("signing in again", StringComparison.OrdinalIgnoreCase) >= 0 ||
             text.IndexOf("Interactive ChatGPT sign-in cannot run inside GitHub Actions", StringComparison.OrdinalIgnoreCase) >= 0 ||
             text.IndexOf("Failed to decode INTELLIGENCEX_AUTH_B64", StringComparison.OrdinalIgnoreCase) >= 0 ||

--- a/IntelligenceX.Tests/Program.Cli.CiPathSafety.cs
+++ b/IntelligenceX.Tests/Program.Cli.CiPathSafety.cs
@@ -252,14 +252,16 @@ internal static partial class Program {
             AssertEqual(0, exit, "review-fail-open-summary exit code");
             AssertEqual(1, patchHits, "review-fail-open-summary updates existing comment");
             AssertEqual(false, string.IsNullOrWhiteSpace(updatedBody), "review-fail-open-summary updates trusted comment body");
-            AssertContainsText(updatedBody ?? string.Empty, "## IntelligenceX Review (failed open)",
-                "review-fail-open-summary uses fail-open heading");
+            AssertContainsText(updatedBody ?? string.Empty, "## IntelligenceX Review (failed)",
+                "review-fail-open-summary uses blocking heading for auth failures");
             AssertContainsText(updatedBody ?? string.Empty, "Reviewing this pull request: **Workflow hardening**",
                 "review-fail-open-summary uses PR title");
             AssertContainsText(updatedBody ?? string.Empty, "- Reviewer source: source",
                 "review-fail-open-summary records reviewer source");
             AssertContainsText(updatedBody ?? string.Empty, "intelligencex auth login --set-github-secret --repo owner/repo",
                 "review-fail-open-summary includes reauth guidance");
+            AssertEqual(false, (updatedBody ?? string.Empty).Contains("was allowed to pass open", StringComparison.OrdinalIgnoreCase),
+                "review-fail-open-summary does not claim auth failures pass open");
         } finally {
             try { Directory.Delete(root, recursive: true); } catch { }
         }
@@ -439,7 +441,7 @@ internal static partial class Program {
             var content = File.ReadAllText(summaryPath);
             AssertContainsText(content, "## IntelligenceX Reviewer", "reviewer-run-summary heading");
             AssertContainsText(content, "| Source reviewer | `failure` | `1` |", "reviewer-run-summary source reviewer row");
-            AssertContainsText(content, "fail-open by policy", "reviewer-run-summary fail-open note");
+            AssertContainsText(content, "final reviewer failure policy gate", "reviewer-run-summary failure policy note");
             AssertContainsText(content, "Sticky comment deletion is treated as an intentional reset",
                 "reviewer-run-summary sticky deletion policy note");
 
@@ -465,6 +467,32 @@ internal static partial class Program {
                 "reviewer-run-summary analysis pre-run row");
             AssertContainsText(analysisOnlyContent, "Reviewer or analysis execution produced a non-zero exit code",
                 "reviewer-run-summary analysis pre-run fail-open note");
+        } finally {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    private static void TestCiReviewerFailureGateFailsAuthFailureOnly() {
+        var root = Path.Combine(Path.GetTempPath(), "ix-ci-reviewer-failure-gate-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try {
+            var authLogPath = Path.Combine(root, "auth.log");
+            File.WriteAllText(authLogPath, "OpenAI auth bundle is missing or no longer valid; sign in again.");
+            var authExit = CiReviewerFailureGateCommand.RunAsync(new[] {
+                    "--source-reviewer-exit", "1",
+                    "--source-log", authLogPath
+                })
+                .GetAwaiter().GetResult();
+            AssertEqual(1, authExit, "reviewer-failure-gate fails auth remediation failures");
+
+            var runtimeLogPath = Path.Combine(root, "runtime.log");
+            File.WriteAllText(runtimeLogPath, "Unhandled exception: reviewer-runtime");
+            var runtimeExit = CiReviewerFailureGateCommand.RunAsync(new[] {
+                    "--source-reviewer-exit", "1",
+                    "--source-log", runtimeLogPath
+                })
+                .GetAwaiter().GetResult();
+            AssertEqual(0, runtimeExit, "reviewer-failure-gate leaves runtime failures fail-open");
         } finally {
             try { Directory.Delete(root, recursive: true); } catch { }
         }

--- a/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
@@ -247,6 +247,14 @@ internal static partial class Program {
         AssertEqual(true, failure.ShouldFailWorkflow, "workflow auth failure fails required check");
     }
 
+    private static void TestWorkflowFailOpenLogClassificationUsesTokenRefreshSummary() {
+        var failure = ReviewDiagnostics.ClassifyWorkflowFailureLog(
+            "OpenAI auth refresh failed; sign in again. The token refresh request failed.");
+        AssertEqual("openai-auth", failure.Kind, "workflow auth refresh summary failure kind");
+        AssertEqual(true, failure.RequiresAuthRemediation, "workflow auth refresh summary remediation flag");
+        AssertEqual(true, failure.ShouldFailWorkflow, "workflow auth refresh summary fails required check");
+    }
+
     private static void TestWorkflowFailOpenLogClassificationPrefersUsageBudgetGuard() {
         var failure = ReviewDiagnostics.ClassifyWorkflowFailureLog(
             "Usage budget guard blocked review run: credits exhausted (balance 0); weekly limit exhausted.\n"

--- a/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
@@ -258,6 +258,19 @@ internal static partial class Program {
         AssertEqual(false, failure.ShouldFailWorkflow, "workflow budget failure remains passable by policy");
     }
 
+    private static void TestWorkflowFailOpenLogClassificationIgnoresGenericAuthBundleDiagnostics() {
+        var failure = ReviewDiagnostics.ClassifyWorkflowFailureLog(
+            "Provider request failed.\n"
+            + "Category: Unknown (transient)\n"
+            + "Secrets audit:\n"
+            + "- OpenAI auth bundle 'openai-codex' from /tmp/intelligencex-reviewer/auth.json\n"
+            + "Cause: TimeoutException: provider timed out.");
+
+        AssertEqual("reviewer-runtime", failure.Kind, "workflow generic auth bundle diagnostic failure kind");
+        AssertEqual(false, failure.RequiresAuthRemediation, "workflow generic auth bundle diagnostic omits auth remediation");
+        AssertEqual(false, failure.ShouldFailWorkflow, "workflow generic auth bundle diagnostic remains passable");
+    }
+
     private static void TestWorkflowFailOpenSummaryBodyUsesRuntimeGuidance() {
         var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Workflow hardening", null, false, "head", "base",
             Array.Empty<string>(), "owner/repo", false, null);

--- a/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.CleanupAndThreads.RetryAndGate.cs
@@ -244,6 +244,7 @@ internal static partial class Program {
         AssertEqual("openai-auth-refresh-reused", failure.Kind, "workflow failure kind");
         AssertEqual("OpenAI auth refresh token was already used", failure.Label, "workflow failure label");
         AssertEqual(true, failure.RequiresAuthRemediation, "workflow failure remediation flag");
+        AssertEqual(true, failure.ShouldFailWorkflow, "workflow auth failure fails required check");
     }
 
     private static void TestWorkflowFailOpenLogClassificationPrefersUsageBudgetGuard() {
@@ -254,6 +255,7 @@ internal static partial class Program {
         AssertEqual("Usage budget guard blocked the review", failure.Label, "workflow budget failure label");
         AssertContainsText(failure.Detail, "credits exhausted", "workflow budget failure detail");
         AssertEqual(false, failure.RequiresAuthRemediation, "workflow budget failure omits auth remediation");
+        AssertEqual(false, failure.ShouldFailWorkflow, "workflow budget failure remains passable by policy");
     }
 
     private static void TestWorkflowFailOpenSummaryBodyUsesRuntimeGuidance() {
@@ -268,6 +270,21 @@ internal static partial class Program {
         AssertContainsText(body, "Check the `review / review` workflow logs for the runtime failure", "workflow fail-open runtime guidance");
         AssertEqual(false, body.Contains("intelligencex auth login --set-github-secret", StringComparison.OrdinalIgnoreCase),
             "workflow fail-open runtime guidance omits auth remediation");
+    }
+
+    private static void TestWorkflowFailureSummaryBodyUsesAuthFailureGate() {
+        var context = new PullRequestContext("owner/repo", "owner", "repo", 1, "Workflow hardening", null, false, "head", "base",
+            Array.Empty<string>(), "owner/repo", false, null);
+        var failure = ReviewDiagnostics.ClassifyWorkflowFailureLog("OpenAI auth bundle is missing or no longer valid; sign in again.");
+        var body = ReviewDiagnostics.BuildWorkflowFailOpenSummaryBody(context, "source", "owner/repo", failure);
+
+        AssertContainsText(body, "## IntelligenceX Review (failed)", "workflow auth failure heading");
+        AssertContainsText(body, "ERROR: Reviewer execution failed and this workflow will fail.",
+            "workflow auth failure does not claim fail-open");
+        AssertContainsText(body, "intelligencex auth login --set-github-secret --repo owner/repo",
+            "workflow auth failure keeps remediation guidance");
+        AssertEqual(false, body.Contains("was allowed to pass open", StringComparison.OrdinalIgnoreCase),
+            "workflow auth failure does not say it passed open");
     }
 
     private static void TestFailureSummaryCommentUpdate() {

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -85,6 +85,7 @@ internal static partial class Program {
         failed += Run("Workflow fail-open log classification uses auth refresh label", TestWorkflowFailOpenLogClassificationUsesAuthRefreshLabel);
         failed += Run("Workflow fail-open log classification prefers usage budget guard", TestWorkflowFailOpenLogClassificationPrefersUsageBudgetGuard);
         failed += Run("Workflow fail-open summary body uses runtime guidance", TestWorkflowFailOpenSummaryBodyUsesRuntimeGuidance);
+        failed += Run("Workflow failure summary body uses auth failure gate", TestWorkflowFailureSummaryBodyUsesAuthFailureGate);
         failed += Run("Failure summary comment update", TestFailureSummaryCommentUpdate);
         failed += Run("Review fail-open only transient", TestReviewFailOpenTransientOnly);
         failed += Run("Review fail-open decision", TestReviewFailOpenDecision);

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -83,6 +83,7 @@ internal static partial class Program {
         failed += Run("Build auth remediation command quotes repo when needed", TestBuildAuthRemediationCommandQuotesRepoWhenNeeded);
         failed += Run("Build auth remediation command escapes embedded quotes", TestBuildAuthRemediationCommandEscapesEmbeddedQuotes);
         failed += Run("Workflow fail-open log classification uses auth refresh label", TestWorkflowFailOpenLogClassificationUsesAuthRefreshLabel);
+        failed += Run("Workflow fail-open log classification uses token refresh summary", TestWorkflowFailOpenLogClassificationUsesTokenRefreshSummary);
         failed += Run("Workflow fail-open log classification prefers usage budget guard", TestWorkflowFailOpenLogClassificationPrefersUsageBudgetGuard);
         failed += Run("Workflow fail-open log classification ignores generic auth bundle diagnostics", TestWorkflowFailOpenLogClassificationIgnoresGenericAuthBundleDiagnostics);
         failed += Run("Workflow fail-open summary body uses runtime guidance", TestWorkflowFailOpenSummaryBodyUsesRuntimeGuidance);

--- a/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
+++ b/IntelligenceX.Tests/Program.Reviewer.MainHarness.cs
@@ -84,6 +84,7 @@ internal static partial class Program {
         failed += Run("Build auth remediation command escapes embedded quotes", TestBuildAuthRemediationCommandEscapesEmbeddedQuotes);
         failed += Run("Workflow fail-open log classification uses auth refresh label", TestWorkflowFailOpenLogClassificationUsesAuthRefreshLabel);
         failed += Run("Workflow fail-open log classification prefers usage budget guard", TestWorkflowFailOpenLogClassificationPrefersUsageBudgetGuard);
+        failed += Run("Workflow fail-open log classification ignores generic auth bundle diagnostics", TestWorkflowFailOpenLogClassificationIgnoresGenericAuthBundleDiagnostics);
         failed += Run("Workflow fail-open summary body uses runtime guidance", TestWorkflowFailOpenSummaryBodyUsesRuntimeGuidance);
         failed += Run("Workflow failure summary body uses auth failure gate", TestWorkflowFailureSummaryBodyUsesAuthFailureGate);
         failed += Run("Failure summary comment update", TestFailureSummaryCommentUpdate);

--- a/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
+++ b/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
@@ -501,6 +501,12 @@ jobs:
             "reusable workflow enforces auth failures when CLI source is unavailable");
         AssertContainsText(content, "OpenAI auth bundle is missing",
             "reusable workflow shell fallback detects stale auth bundle logs");
+        AssertContainsText(content, "refresh_token_reused",
+            "reusable workflow shell fallback detects reused refresh token logs");
+        AssertContainsText(content, "invalid_grant",
+            "reusable workflow shell fallback detects invalid grant logs");
+        AssertContainsText(content, "Failed to decode INTELLIGENCEX_AUTH_B64",
+            "reusable workflow shell fallback detects invalid auth bundle secret logs");
         AssertContainsText(content, "::error title=IntelligenceX reviewer auth failure::",
             "reusable workflow shell fallback fails required checks for auth remediation");
         AssertContainsText(content, "--source-reviewer-exit \"${{ steps.reviewer_run_source.outputs.exit_code }}\"",

--- a/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
+++ b/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
@@ -493,6 +493,16 @@ jobs:
             "reusable workflow uploads durable reviewer artifacts");
         AssertContainsText(content, "path: artifacts/reviewer",
             "reusable workflow uploads reviewer artifact directory");
+        AssertContainsText(content, "Enforce reviewer runtime failure policy",
+            "reusable workflow has a final reviewer failure policy gate");
+        AssertContainsText(content, "ci reviewer-failure-gate",
+            "reusable workflow delegates reviewer failure policy to the CLI helper");
+        AssertContainsText(content, "--source-reviewer-exit \"${{ steps.reviewer_run_source.outputs.exit_code }}\"",
+            "reusable workflow passes source reviewer exit code to failure gate");
+        AssertEqual(true,
+            content.IndexOf("Enforce reviewer runtime failure policy", StringComparison.Ordinal) >
+            content.IndexOf("Upload reviewer artifacts", StringComparison.Ordinal),
+            "reusable workflow runs reviewer failure policy after reporting and artifact upload");
         AssertEqual(false, content.Contains("&review_inputs", StringComparison.Ordinal),
             "reusable workflow should avoid YAML anchors in workflow schema");
         AssertEqual(false, content.Contains("*review_inputs", StringComparison.Ordinal),

--- a/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
+++ b/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
@@ -497,6 +497,12 @@ jobs:
             "reusable workflow has a final reviewer failure policy gate");
         AssertContainsText(content, "ci reviewer-failure-gate",
             "reusable workflow delegates reviewer failure policy to the CLI helper");
+        AssertContainsText(content, "Reviewer failure policy gate using shell fallback",
+            "reusable workflow enforces auth failures when CLI source is unavailable");
+        AssertContainsText(content, "OpenAI auth bundle is missing",
+            "reusable workflow shell fallback detects stale auth bundle logs");
+        AssertContainsText(content, "::error title=IntelligenceX reviewer auth failure::",
+            "reusable workflow shell fallback fails required checks for auth remediation");
         AssertContainsText(content, "--source-reviewer-exit \"${{ steps.reviewer_run_source.outputs.exit_code }}\"",
             "reusable workflow passes source reviewer exit code to failure gate");
         AssertEqual(true,

--- a/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
+++ b/IntelligenceX.Tests/Program.Setup.GitHubAndWorkflow.cs
@@ -503,6 +503,10 @@ jobs:
             "reusable workflow shell fallback detects stale auth bundle logs");
         AssertContainsText(content, "refresh_token_reused",
             "reusable workflow shell fallback detects reused refresh token logs");
+        AssertContainsText(content, "OpenAI auth refresh failed",
+            "reusable workflow shell fallback detects auth refresh summary logs");
+        AssertContainsText(content, "token refresh",
+            "reusable workflow shell fallback detects token refresh failure logs");
         AssertContainsText(content, "invalid_grant",
             "reusable workflow shell fallback detects invalid grant logs");
         AssertContainsText(content, "Failed to decode INTELLIGENCEX_AUTH_B64",

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -753,6 +753,7 @@ internal static partial class Program {
         failed += Run("CI review-fail-open-summary prefers reviewer token over GitHub token", TestCiReviewFailOpenSummaryPrefersReviewerTokenOverGitHubToken);
         failed += Run("CI review-fail-open-summary skips when PR number unavailable", TestCiReviewFailOpenSummarySkipsWhenPrNumberUnavailable);
         failed += Run("CI reviewer-run-summary writes Actions summary", TestCiReviewerRunSummaryWritesActionsSummary);
+        failed += Run("CI reviewer-failure-gate fails auth failure only", TestCiReviewerFailureGateFailsAuthFailureOnly);
         failed += Run("CI verify-managed-workflow validates only managed block", TestCiVerifyManagedWorkflowValidatesOnlyManagedBlock);
         failed += Run("CI repository-quality reads workflow dispatch inputs", TestCiRepositoryQualityReadsWorkflowDispatchInputs);
         failed += Run("CI repository-quality bootstrap passes when baseline artifact exists", TestCiRepositoryQualityBootstrapPassesWhenBaselineArtifactExists);

--- a/IntelligenceX.Tools/Directory.Build.props
+++ b/IntelligenceX.Tools/Directory.Build.props
@@ -40,7 +40,7 @@
     <!-- Public package fallbacks for CI/consumers when local engine sources are unavailable. -->
     <MailozaurrNuGetVersion Condition="'$(MailozaurrNuGetVersion)'==''">2.0.8</MailozaurrNuGetVersion>
     <EventViewerXNuGetVersion Condition="'$(EventViewerXNuGetVersion)'==''">3.3.4</EventViewerXNuGetVersion>
-    <OfficeImoReaderNuGetVersion Condition="'$(OfficeImoReaderNuGetVersion)'==''">0.1.35</OfficeImoReaderNuGetVersion>
+    <OfficeImoReaderNuGetVersion Condition="'$(OfficeImoReaderNuGetVersion)'==''">0.1.36</OfficeImoReaderNuGetVersion>
     <DnsClientXNuGetVersion Condition="'$(DnsClientXNuGetVersion)'==''">1.0.8</DnsClientXNuGetVersion>
     <OfficeImoRepoRootInput>$(OfficeImoRepoRoot)</OfficeImoRepoRootInput>
     <OfficeImoRepoRootInputNormalized Condition="'$(OfficeImoRepoRootInput)' != ''">$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetFullPath('$(OfficeImoRepoRootInput)\\'))))</OfficeImoRepoRootInputNormalized>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiPostureTool.cs
@@ -123,12 +123,8 @@ public sealed class AdPkiPostureTool : ActiveDirectoryToolBase, ITool {
             IncludeDetails: includeDetails,
             InsecureEndpointsOnly: insecureEndpointsOnly,
             Summary: summaryRows,
-            RocaConfirmed: includeDetails
-                ? Array.Empty<AdPkiToolSupport.PkiFindingRow>()
-                : Array.Empty<AdPkiToolSupport.PkiFindingRow>(),
-            RocaSuspected: includeDetails
-                ? Array.Empty<AdPkiToolSupport.PkiFindingRow>()
-                : Array.Empty<AdPkiToolSupport.PkiFindingRow>(),
+            RocaConfirmed: Array.Empty<AdPkiToolSupport.PkiFindingRow>(),
+            RocaSuspected: Array.Empty<AdPkiToolSupport.PkiFindingRow>(),
             WeakRsaComponents: includeDetails
                 ? AdPkiToolSupport.ToFindingRows(weakCryptoFindings, maxDetailsPerCategory)
                 : Array.Empty<AdPkiToolSupport.PkiFindingRow>(),
@@ -169,4 +165,3 @@ public sealed class AdPkiPostureTool : ActiveDirectoryToolBase, ITool {
             .ToLowerInvariant();
     }
 }
-

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiPostureTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiPostureTool.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using ADPlayground.Pki;
+using CertNoob.Pki;
 using IntelligenceX.Json;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
@@ -11,14 +11,14 @@ using IntelligenceX.Tools.Common;
 namespace IntelligenceX.Tools.ADPlayground;
 
 /// <summary>
-/// Returns consolidated PKI posture findings (ROCA/weak RSA/enrollment endpoint HTTPS) for a forest (read-only).
+/// Returns consolidated PKI posture findings (ROCA availability, weak crypto, enrollment endpoint HTTPS) for a forest (read-only).
 /// </summary>
 public sealed class AdPkiPostureTool : ActiveDirectoryToolBase, ITool {
     private const int MaxViewTop = 5000;
 
     private static readonly ToolDefinition DefinitionValue = new(
         "ad_pki_posture",
-        "Get consolidated PKI posture findings (ROCA confirmed/suspected, weak RSA, insecure enrollment endpoints) for a forest (read-only).",
+        "Get consolidated PKI posture findings (ROCA availability, weak crypto, insecure enrollment endpoints) for a forest (read-only).",
         ToolSchema.Object(
                 ("forest_name", ToolSchema.String("Optional forest DNS name. When omitted, uses current forest.")),
                 ("include_details", ToolSchema.Boolean("When true, include detailed finding rows in output payload. Default true.")),
@@ -38,11 +38,11 @@ public sealed class AdPkiPostureTool : ActiveDirectoryToolBase, ITool {
         bool IncludeDetails,
         bool InsecureEndpointsOnly,
         IReadOnlyList<PkiPostureSummaryRow> Summary,
-        IReadOnlyList<RocaConfirmedEvaluator.Item> RocaConfirmed,
-        IReadOnlyList<RocaSuspectedEvaluator.Item> RocaSuspected,
-        IReadOnlyList<WeakRsaComponentEvaluator.Item> WeakRsaComponents,
-        IReadOnlyList<EnrollmentHttpsRequiredEvaluator.Endpoint> InsecureEnrollmentEndpoints,
-        IReadOnlyList<EnrollmentHttpsRequiredEvaluator.Endpoint> EnrollmentEndpoints);
+        IReadOnlyList<AdPkiToolSupport.PkiFindingRow> RocaConfirmed,
+        IReadOnlyList<AdPkiToolSupport.PkiFindingRow> RocaSuspected,
+        IReadOnlyList<AdPkiToolSupport.PkiFindingRow> WeakRsaComponents,
+        IReadOnlyList<AdPkiToolSupport.PkiEndpointRow> InsecureEnrollmentEndpoints,
+        IReadOnlyList<AdPkiToolSupport.PkiEndpointRow> EnrollmentEndpoints);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AdPkiPostureTool"/> class.
@@ -62,57 +62,61 @@ public sealed class AdPkiPostureTool : ActiveDirectoryToolBase, ITool {
         var maxDetailsPerCategory = ToolArgs.GetCappedInt32(arguments, "max_details_per_category", 200, 1, Options.MaxResults);
 
         if (!TryExecute(
-                action: () => PkiApi.GetPosture(forestName),
-                result: out PkiConfiguration posture,
+                action: () => AdPkiToolSupport.BuildAssessment(
+                    forestName,
+                    includeEnrollmentPolicyEntries: true,
+                    includeIssuedRequestSample: true),
+                result: out PkiAssessmentSnapshot snapshot,
                 errorResponse: out var errorResponse,
                 defaultErrorMessage: "PKI posture query failed.",
                 invalidOperationErrorCode: "query_failed")) {
             return Task.FromResult(errorResponse!);
         }
 
-        var forest = posture.RocaConfirmed.ForestName;
-        if (string.IsNullOrWhiteSpace(forest)) {
-            forest = posture.RocaSuspected.ForestName;
-        }
-        if (string.IsNullOrWhiteSpace(forest)) {
-            forest = posture.WeakRsaComponents.ForestName;
-        }
-        if (string.IsNullOrWhiteSpace(forest)) {
-            forest = posture.EnrollmentEndpoints.ForestName;
-        }
-        forest ??= forestName ?? string.Empty;
+        var forest = AdPkiToolSupport.ResolveScopeName(snapshot, forestName);
+        var findings = AdPkiToolSupport.BuildFindings(snapshot);
+        var weakCryptoFindings = findings
+            .Where(AdPkiToolSupport.IsWeakRsaOrCryptoFinding)
+            .ToArray();
+        var endpointRows = AdPkiToolSupport.EnumerateEndpointRows(snapshot);
+        var insecureEndpointRows = endpointRows
+            .Where(endpoint => endpoint.Insecure)
+            .ToArray();
+        var httpEndpointFindings = findings
+            .Where(finding => string.Equals(finding.Id, PkiFindingIds.EnrollmentPolicyEndpointUsesHttp, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
 
         var summaryRows = new List<PkiPostureSummaryRow> {
             new(
                 Category: "roca_confirmed",
-                Count: posture.RocaConfirmed.Confirmed.Count,
-                Severity: posture.RocaConfirmed.Confirmed.Count > 0 ? "critical" : "info",
-                Notes: posture.RocaConfirmed.DatasetAvailable
-                    ? "Dataset-based ROCA confirmation."
-                    : "ROCA dataset unavailable; confirmed list may be empty."),
+                Count: 0,
+                Severity: "info",
+                Notes: RocaDetector.IsAvailable
+                    ? "ROCA dataset is available, but CertNoob now exposes PKI assessment findings rather than legacy confirmed-item rows."
+                    : "ROCA dataset unavailable; set TESTIMOX_ROCA_DATASET, CERTNOOB_ROCA_DATASET, or ADP_ROCA_DATASET to enable checks where supported."),
             new(
                 Category: "roca_suspected",
-                Count: posture.RocaSuspected.Items.Count,
-                Severity: posture.RocaSuspected.Items.Count > 0 ? "high" : "info",
-                Notes: "Heuristic ROCA indicators."),
+                Count: 0,
+                Severity: "info",
+                Notes: "Legacy suspected-item rows are no longer produced by the CertNoob assessment surface."),
             new(
                 Category: "weak_rsa_components",
-                Count: posture.WeakRsaComponents.Items.Count,
-                Severity: posture.WeakRsaComponents.Items.Count > 0 ? "medium" : "info",
-                Notes: "Weak RSA exponent/parameter indicators."),
+                Count: weakCryptoFindings.Sum(finding => Math.Max(finding.AffectedCount, 1)),
+                Severity: ResolveHighestSeverity(weakCryptoFindings),
+                Notes: "Weak RSA and related weak-crypto indicators from CertNoob findings."),
             new(
                 Category: "enrollment_endpoints_insecure",
-                Count: posture.EnrollmentEndpoints.Insecure.Count,
-                Severity: posture.EnrollmentEndpoints.Insecure.Count > 0 ? "high" : "info",
+                Count: insecureEndpointRows.Length,
+                Severity: httpEndpointFindings.Length > 0 ? ResolveHighestSeverity(httpEndpointFindings) : "info",
                 Notes: "HTTP enrollment endpoints should be remediated to HTTPS.")
         };
 
-        var insecureEndpointDetails = posture.EnrollmentEndpoints.Insecure
+        var insecureEndpointDetails = insecureEndpointRows
             .Take(maxDetailsPerCategory)
             .ToArray();
         var endpointDetails = insecureEndpointsOnly
             ? insecureEndpointDetails
-            : posture.EnrollmentEndpoints.Endpoints.Take(maxDetailsPerCategory).ToArray();
+            : endpointRows.Take(maxDetailsPerCategory).ToArray();
 
         var result = new AdPkiPostureResult(
             ForestName: forest,
@@ -120,20 +124,20 @@ public sealed class AdPkiPostureTool : ActiveDirectoryToolBase, ITool {
             InsecureEndpointsOnly: insecureEndpointsOnly,
             Summary: summaryRows,
             RocaConfirmed: includeDetails
-                ? posture.RocaConfirmed.Confirmed.Take(maxDetailsPerCategory).ToArray()
-                : Array.Empty<RocaConfirmedEvaluator.Item>(),
+                ? Array.Empty<AdPkiToolSupport.PkiFindingRow>()
+                : Array.Empty<AdPkiToolSupport.PkiFindingRow>(),
             RocaSuspected: includeDetails
-                ? posture.RocaSuspected.Items.Take(maxDetailsPerCategory).ToArray()
-                : Array.Empty<RocaSuspectedEvaluator.Item>(),
+                ? Array.Empty<AdPkiToolSupport.PkiFindingRow>()
+                : Array.Empty<AdPkiToolSupport.PkiFindingRow>(),
             WeakRsaComponents: includeDetails
-                ? posture.WeakRsaComponents.Items.Take(maxDetailsPerCategory).ToArray()
-                : Array.Empty<WeakRsaComponentEvaluator.Item>(),
+                ? AdPkiToolSupport.ToFindingRows(weakCryptoFindings, maxDetailsPerCategory)
+                : Array.Empty<AdPkiToolSupport.PkiFindingRow>(),
             InsecureEnrollmentEndpoints: includeDetails
                 ? insecureEndpointDetails
-                : Array.Empty<EnrollmentHttpsRequiredEvaluator.Endpoint>(),
+                : Array.Empty<AdPkiToolSupport.PkiEndpointRow>(),
             EnrollmentEndpoints: includeDetails
                 ? endpointDetails
-                : Array.Empty<EnrollmentHttpsRequiredEvaluator.Endpoint>());
+                : Array.Empty<AdPkiToolSupport.PkiEndpointRow>());
 
         return Task.FromResult(BuildAutoTableResponse(
             arguments: arguments,
@@ -151,6 +155,18 @@ public sealed class AdPkiPostureTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("max_details_per_category", maxDetailsPerCategory);
             }));
     }
-}
 
+    private static string ResolveHighestSeverity(IReadOnlyList<PkiFinding> findings) {
+        if (findings.Count == 0) {
+            return "info";
+        }
+
+        return findings
+            .OrderByDescending(finding => finding.Severity)
+            .First()
+            .Severity
+            .ToString()
+            .ToLowerInvariant();
+    }
+}
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiTemplatesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiTemplatesTool.cs
@@ -129,7 +129,7 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
             Scanned: scanned,
             Truncated: truncated,
             TotalTemplates: templates.Count,
-            TakeoverCount: takeoverFindings.Length,
+            TakeoverCount: takeoverFindings.Sum(finding => Math.Max(finding.AffectedCount, 1)),
             Templates: projectedRows,
             TakeoverRows: projectedTakeoverRows);
 

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiTemplatesTool.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiTemplatesTool.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using ADPlayground.Pki;
+using CertNoob.Dashboard;
+using CertNoob.Pki;
 using IntelligenceX.Json;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
@@ -37,8 +38,33 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
         bool Truncated,
         int TotalTemplates,
         int TakeoverCount,
-        IReadOnlyList<PkiTemplatesEvaluator.TemplateRow> Templates,
-        IReadOnlyList<PkiTemplatesEvaluator.TakeoverRow> TakeoverRows);
+        IReadOnlyList<AdPkiTemplateRow> Templates,
+        IReadOnlyList<AdPkiToolSupport.PkiFindingRow> TakeoverRows);
+
+    private sealed record AdPkiTemplateRow(
+        string Name,
+        string? DisplayName,
+        string DistinguishedName,
+        int? MinimalKeySize,
+        int PublishedOnCount,
+        IReadOnlyList<string> PublishedOn,
+        bool WeakKey,
+        bool TakeoverRisk,
+        bool CodeSigningRisk,
+        bool ClientAuthRisk,
+        bool ExportableKey,
+        bool AutoEnrollmentEnabled,
+        bool EnrolleeSuppliesSubject,
+        bool EnrolleeSuppliesSubjectAltName,
+        bool PendAllRequests,
+        bool RequireKeyArchival,
+        string? MaxSeverity,
+        int VulnerabilityCount,
+        IReadOnlyList<string> VulnerabilityTypes,
+        IReadOnlyList<string> ExtendedKeyUsages,
+        int EnrollPrincipalCount,
+        int AutoEnrollPrincipalCount,
+        int FullControlPrincipalCount);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AdPkiTemplatesTool"/> class.
@@ -62,15 +88,24 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
         var maxTakeoverRows = ResolveMaxResults(arguments, "max_takeover_rows");
 
         if (!TryExecute(
-                action: () => PkiApi.GetTemplates(forestName),
-                result: out PkiTemplatesEvaluator.View view,
+                action: () => AdPkiToolSupport.BuildAssessment(
+                    forestName,
+                    includeEnrollmentPolicyEntries: false),
+                result: out PkiAssessmentSnapshot snapshot,
                 errorResponse: out var errorResponse,
                 defaultErrorMessage: "PKI template query failed.",
                 invalidOperationErrorCode: "query_failed")) {
             return Task.FromResult(errorResponse!);
         }
 
-        var filtered = view.Items
+        var templates = snapshot.Dashboard?.Templates ?? new List<TemplateRiskView>();
+        var findings = AdPkiToolSupport.BuildFindings(snapshot);
+        var takeoverFindings = findings
+            .Where(IsTemplateTakeoverFinding)
+            .ToArray();
+
+        var filtered = templates
+            .Select(ToTemplateRow)
             .Where(item => !weakKeyOnly || item.WeakKey)
             .Where(item => !takeoverRiskOnly || item.TakeoverRisk)
             .Where(item => !codeSigningRiskOnly || item.CodeSigningRisk)
@@ -78,21 +113,23 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
             .ToArray();
 
         var scanned = filtered.Length;
-        IReadOnlyList<PkiTemplatesEvaluator.TemplateRow> projectedRows = scanned > maxResults
+        IReadOnlyList<AdPkiTemplateRow> projectedRows = scanned > maxResults
             ? filtered.Take(maxResults).ToArray()
             : filtered;
         var truncated = scanned > projectedRows.Count;
 
-        IReadOnlyList<PkiTemplatesEvaluator.TakeoverRow> projectedTakeoverRows = includeTakeoverRows
-            ? view.Takeover.Take(maxTakeoverRows).ToArray()
-            : Array.Empty<PkiTemplatesEvaluator.TakeoverRow>();
+        IReadOnlyList<AdPkiToolSupport.PkiFindingRow> projectedTakeoverRows = includeTakeoverRows
+            ? AdPkiToolSupport.ToFindingRows(takeoverFindings, maxTakeoverRows)
+            : Array.Empty<AdPkiToolSupport.PkiFindingRow>();
+
+        var forest = AdPkiToolSupport.ResolveScopeName(snapshot, forestName);
 
         var result = new AdPkiTemplatesResult(
-            ForestName: view.ForestName,
+            ForestName: forest,
             Scanned: scanned,
             Truncated: truncated,
-            TotalTemplates: view.Items.Count,
-            TakeoverCount: view.Takeover.Count,
+            TotalTemplates: templates.Count,
+            TakeoverCount: takeoverFindings.Length,
             Templates: projectedRows,
             TakeoverRows: projectedTakeoverRows);
 
@@ -106,7 +143,7 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
             baseTruncated: truncated,
             scanned: scanned,
             metaMutate: meta => {
-                meta.Add("forest_name", view.ForestName);
+                meta.Add("forest_name", forest);
                 AddMaxResultsMeta(meta, maxResults);
                 meta.Add("max_takeover_rows", maxTakeoverRows);
                 meta.Add("weak_key_only", weakKeyOnly);
@@ -116,5 +153,43 @@ public sealed class AdPkiTemplatesTool : ActiveDirectoryToolBase, ITool {
                 meta.Add("include_takeover_rows", includeTakeoverRows);
             }));
     }
-}
 
+    private static AdPkiTemplateRow ToTemplateRow(TemplateRiskView template) {
+        var weakKey = AdPkiToolSupport.IsWeakKeyTemplate(template);
+        var takeoverRisk = AdPkiToolSupport.IsTakeoverRiskTemplate(template);
+        var codeSigningRisk = AdPkiToolSupport.IsCodeSigningTemplate(template);
+        var clientAuthRisk = AdPkiToolSupport.IsAuthenticationCapableTemplate(template);
+
+        return new AdPkiTemplateRow(
+            Name: template.Name,
+            DisplayName: template.DisplayName,
+            DistinguishedName: template.DistinguishedName,
+            MinimalKeySize: template.MinimalKeySize,
+            PublishedOnCount: template.PublishedOnCount,
+            PublishedOn: template.PublishedOn.ToArray(),
+            WeakKey: weakKey,
+            TakeoverRisk: takeoverRisk,
+            CodeSigningRisk: codeSigningRisk,
+            ClientAuthRisk: clientAuthRisk,
+            ExportableKey: template.ExportableKey,
+            AutoEnrollmentEnabled: template.AutoEnrollmentEnabled,
+            EnrolleeSuppliesSubject: template.EnrolleeSuppliesSubject,
+            EnrolleeSuppliesSubjectAltName: template.EnrolleeSuppliesSubjectAltName,
+            PendAllRequests: template.PendAllRequests,
+            RequireKeyArchival: template.RequireKeyArchival,
+            MaxSeverity: template.MaxSeverity?.ToString(),
+            VulnerabilityCount: template.VulnerabilityCount,
+            VulnerabilityTypes: template.VulnerabilityTypes.Select(t => t.ToString()).ToArray(),
+            ExtendedKeyUsages: template.ExtendedKeyUsages.ToArray(),
+            EnrollPrincipalCount: template.EnrollPrincipalCount,
+            AutoEnrollPrincipalCount: template.AutoEnrollPrincipalCount,
+            FullControlPrincipalCount: template.FullControlPrincipalCount);
+    }
+
+    private static bool IsTemplateTakeoverFinding(PkiFinding finding) =>
+        finding.Tags.Any(tag => string.Equals(tag, "Template", StringComparison.OrdinalIgnoreCase)) &&
+        (finding.Severity >= PkiFindingSeverity.Medium ||
+         string.Equals(finding.Id, PkiFindingIds.TemplateBroadEnrollmentRights, StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(finding.Id, PkiFindingIds.TemplateModifiableByNonPrivileged, StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(finding.Id, PkiFindingIds.TemplateOwnedByNonPrivileged, StringComparison.OrdinalIgnoreCase));
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiToolSupport.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiToolSupport.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CertNoob.Dashboard;
+using CertNoob.Pki;
+
+namespace IntelligenceX.Tools.ADPlayground;
+
+internal static class AdPkiToolSupport {
+    private const string AnyPurposeEku = "2.5.29.37.0";
+    private const string ClientAuthenticationEku = "1.3.6.1.5.5.7.3.2";
+    private const string CodeSigningEku = "1.3.6.1.5.5.7.3.3";
+    private const string SmartCardLogonEku = "1.3.6.1.4.1.311.20.2.2";
+
+    internal sealed record PkiFindingRow(
+        string Id,
+        string Category,
+        string Severity,
+        string Title,
+        string Statement,
+        int AffectedCount);
+
+    internal sealed record PkiEndpointRow(
+        string Policy,
+        string Type,
+        string Endpoint,
+        bool Insecure);
+
+    internal static PkiAssessmentSnapshot BuildAssessment(
+        string? forestName,
+        bool includeEnrollmentPolicyEntries,
+        bool includeAcls = true,
+        bool includeIssuedRequestSample = false) {
+        var options = new PkiAssessmentOptions {
+            IncludeDashboard = true,
+            IncludeEsc = true,
+            IncludeTemplateRisk = true,
+            IncludeAcls = includeAcls,
+            IncludeGpoAutoEnrollment = false,
+            IncludeAutoEnrollmentBaseline = false,
+            IncludeHostAnalysis = false,
+            IncludeEnrollmentPolicyEntries = includeEnrollmentPolicyEntries,
+            IncludeDirectoryPrincipals = false,
+            IncludeTrustStores = false,
+            IncludeKraEntries = false,
+            IncludePendingRequestBacklog = false,
+            IncludeFailedRequestBacklog = false,
+            IncludeIssuedRequestSample = includeIssuedRequestSample,
+            IncludeExpiringCertificateSample = false,
+            IncludeRevokedRequestSample = false,
+            IncludeAclPrincipalPosture = false
+        };
+
+        var domains = string.IsNullOrWhiteSpace(forestName)
+            ? null
+            : new[] { forestName.Trim() };
+
+        return PkiAssessmentService.Build(options, domains: domains);
+    }
+
+    internal static string ResolveScopeName(PkiAssessmentSnapshot snapshot, string? fallback) {
+        var domain = snapshot.Domains.FirstOrDefault(s => !string.IsNullOrWhiteSpace(s));
+        if (!string.IsNullOrWhiteSpace(domain)) {
+            return domain!;
+        }
+
+        var dashboardDomain = snapshot.Dashboard?.Domain;
+        if (!string.IsNullOrWhiteSpace(dashboardDomain)) {
+            return dashboardDomain!;
+        }
+
+        return fallback ?? string.Empty;
+    }
+
+    internal static IReadOnlyList<PkiFinding> BuildFindings(PkiAssessmentSnapshot snapshot) =>
+        PkiFindingsService.Build(snapshot).Findings;
+
+    internal static IReadOnlyList<PkiFindingRow> ToFindingRows(IEnumerable<PkiFinding> findings, int maxRows) =>
+        findings
+            .Take(maxRows)
+            .Select(f => new PkiFindingRow(
+                Id: f.Id,
+                Category: f.Category.ToString(),
+                Severity: f.Severity.ToString(),
+                Title: f.Title,
+                Statement: f.Statement,
+                AffectedCount: f.AffectedCount))
+            .ToArray();
+
+    internal static bool IsWeakKeyTemplate(TemplateRiskView template) =>
+        template.MinimalKeySize.HasValue &&
+        template.MinimalKeySize.Value >= 1024 &&
+        template.MinimalKeySize.Value < 2048;
+
+    internal static bool IsTakeoverRiskTemplate(TemplateRiskView template) =>
+        template.VulnerabilityCount > 0 ||
+        template.FullControlPrincipalCount > 0 ||
+        template.EnrolleeSuppliesSubject ||
+        template.EnrolleeSuppliesSubjectAltName;
+
+    internal static bool IsCodeSigningTemplate(TemplateRiskView template) =>
+        ContainsEku(template.ExtendedKeyUsages, CodeSigningEku);
+
+    internal static bool IsAuthenticationCapableTemplate(TemplateRiskView template) =>
+        template.ExtendedKeyUsages.Count == 0 ||
+        ContainsEku(template.ExtendedKeyUsages, AnyPurposeEku) ||
+        ContainsEku(template.ExtendedKeyUsages, ClientAuthenticationEku) ||
+        ContainsEku(template.ExtendedKeyUsages, SmartCardLogonEku);
+
+    internal static IReadOnlyList<PkiEndpointRow> EnumerateEndpointRows(PkiAssessmentSnapshot snapshot) {
+        if (snapshot.EnrollmentPolicyEntries == null || snapshot.EnrollmentPolicyEntries.Count == 0) {
+            return Array.Empty<PkiEndpointRow>();
+        }
+
+        return snapshot.EnrollmentPolicyEntries
+            .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+            .SelectMany(e => EnumerateEndpointRows(e))
+            .ToArray();
+    }
+
+    internal static bool IsWeakRsaOrCryptoFinding(PkiFinding finding) =>
+        string.Equals(finding.Id, PkiFindingIds.TemplateWeakMinimalKeySize, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(finding.Id, PkiFindingIds.IssuedWeakAlgorithms, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(finding.Id, PkiFindingIds.PendingRequestsWeakKeys, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(finding.Id, PkiFindingIds.FailedRequestsWeakKeys, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(finding.Category.ToString(), nameof(PkiFindingCategory.Crypto), StringComparison.OrdinalIgnoreCase);
+
+    private static IEnumerable<PkiEndpointRow> EnumerateEndpointRows(EnrollmentPolicyEntry entry) {
+        foreach (var endpoint in EnumerateEndpointValues(entry)) {
+            if (string.IsNullOrWhiteSpace(endpoint.Value)) {
+                continue;
+            }
+
+            var value = endpoint.Value.Trim();
+            yield return new PkiEndpointRow(
+                Policy: !string.IsNullOrWhiteSpace(entry.Name) ? entry.Name : entry.DistinguishedName,
+                Type: endpoint.Type,
+                Endpoint: value,
+                Insecure: value.StartsWith("http://", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    private static IEnumerable<(string Type, string Value)> EnumerateEndpointValues(EnrollmentPolicyEntry entry) {
+        foreach (var value in entry.ServerEndpoints) {
+            yield return ("ServerEndpoint", value);
+        }
+
+        foreach (var value in entry.EnrollmentServers) {
+            yield return ("EnrollmentServer", value);
+        }
+    }
+
+    private static bool ContainsEku(IReadOnlyCollection<string> ekus, string oid) =>
+        ekus.Any(eku => string.Equals(eku?.Trim(), oid, StringComparison.OrdinalIgnoreCase));
+}

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiToolSupport.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/AdPkiToolSupport.cs
@@ -89,7 +89,6 @@ internal static class AdPkiToolSupport {
 
     internal static bool IsWeakKeyTemplate(TemplateRiskView template) =>
         template.MinimalKeySize.HasValue &&
-        template.MinimalKeySize.Value >= 1024 &&
         template.MinimalKeySize.Value < 2048;
 
     internal static bool IsTakeoverRiskTemplate(TemplateRiskView template) =>

--- a/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/IntelligenceX.Tools.ADPlayground.csproj
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.ADPlayground/IntelligenceX.Tools.ADPlayground.csproj
@@ -17,9 +17,10 @@
     <ProjectReference Include="..\\IntelligenceX.Tools.Common\\IntelligenceX.Tools.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <!-- Local engine dependency (TestimoX monorepo). Kept as a project reference because the engine isn't public on nuget.org. -->
+    <!-- Local engine dependencies (TestimoX monorepo). Kept as project references because these engines aren't public on nuget.org. -->
     <ProjectReference Include="$(TestimoXRoot)ADPlayground\\ADPlayground.csproj" Condition="Exists('$(TestimoXRoot)ADPlayground\\ADPlayground.csproj')" />
     <ProjectReference Include="$(TestimoXRoot)ADPlayground.Monitoring\\ADPlayground.Monitoring.csproj" Condition="Exists('$(TestimoXRoot)ADPlayground.Monitoring\\ADPlayground.Monitoring.csproj')" />
+    <ProjectReference Include="$(TestimoXRoot)CertNoob\\CertNoob.csproj" Condition="Exists('$(TestimoXRoot)CertNoob\\CertNoob.csproj')" />
   </ItemGroup>
   <ItemGroup>
     <!-- Shared core contract reference; path resolved in IntelligenceX.Tools/Directory.Build.props. -->

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -20,7 +20,7 @@ public class OfficeImoReadToolTests {
         var propsPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Directory.Build.props"));
         var props = LoadMsBuildProperties(propsPath);
 
-        Assert.Equal("0.1.16", props["OfficeImoReaderNuGetVersion"]);
+        Assert.Equal("0.1.36", props["OfficeImoReaderNuGetVersion"]);
     }
 
     [Fact]

--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSchemaSnapshotTests.ActiveDirectory.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/ToolSchemaSnapshotTests.ActiveDirectory.cs
@@ -72,6 +72,12 @@ public partial class ToolSchemaSnapshotTests {
         };
 
         yield return new object[] {
+            "ad_forest_replication_summary",
+            new[] { "domain_controller", "domain_name", "forest_name", "outbound", "by_source", "stale_threshold_hours", "bucket_hours", "include_details", "max_details", "max_domain_controllers", "max_errors", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
             "ad_ds_heuristics",
             new[] { "forest_name", "include_positions", "non_default_only", "max_position_rows", "columns", "sort_by", "sort_direction", "top" },
             Array.Empty<string>()
@@ -389,6 +395,24 @@ public partial class ToolSchemaSnapshotTests {
         };
 
         yield return new object[] {
+            "ad_replication_probe_run",
+            new[] { "bind_identity", "bind_secret", "columns", "degraded_above_ms", "directory_allow_authenticated_fallback", "directory_allowed_shares", "directory_attribute", "directory_dns_servers", "directory_exclude_sites", "directory_filter", "directory_ignore_drive_shares", "directory_include_forest_roles", "directory_optional_shares", "directory_probe_kind", "directory_query_name", "directory_query_timeout_ms", "directory_require_global_catalog_ready", "directory_require_synchronized", "directory_required_shares", "directory_search_base", "directory_share_name", "directory_sites", "directory_use_all_dns_servers", "directory_use_anonymous_bind", "directory_use_ldaps", "directory_use_start_tls", "directory_zones", "discovery_fallback", "dns_queries", "dns_service_query_name", "dns_service_record_type", "dns_service_require_answers", "domain_controller", "domain_name", "exclude_domain_controllers", "exclude_domains", "forest_name", "identity", "include_children", "include_domain_controllers", "include_domains", "include_facts", "include_global_catalog", "include_sysvol", "include_trusts", "include_udp", "latency_threshold_ms", "loss_threshold_percent", "max_concurrency", "name", "p95_latency_threshold_ms", "path", "port", "probe_kind", "protocol", "query_mode", "request_timeout_ms", "require_wsus", "retries", "retry_delay_ms", "skip_rodc", "sort_by", "sort_direction", "split_protocol_results", "stale_threshold_hours", "targets", "tcp_ports", "test_ping", "test_ports", "test_sysvol_shares", "timeout_ms", "top", "total_budget_ms", "udp_ports", "url", "use_ad_core_profile", "verify_certificate" },
+            new[] { "probe_kind" }
+        };
+
+        yield return new object[] {
+            "ad_replikacja_probe",
+            new[] { "bind_identity", "bind_secret", "columns", "degraded_above_ms", "directory_allow_authenticated_fallback", "directory_allowed_shares", "directory_attribute", "directory_dns_servers", "directory_exclude_sites", "directory_filter", "directory_ignore_drive_shares", "directory_include_forest_roles", "directory_optional_shares", "directory_probe_kind", "directory_query_name", "directory_query_timeout_ms", "directory_require_global_catalog_ready", "directory_require_synchronized", "directory_required_shares", "directory_search_base", "directory_share_name", "directory_sites", "directory_use_all_dns_servers", "directory_use_anonymous_bind", "directory_use_ldaps", "directory_use_start_tls", "directory_zones", "discovery_fallback", "dns_queries", "dns_service_query_name", "dns_service_record_type", "dns_service_require_answers", "domain_controller", "domain_name", "exclude_domain_controllers", "exclude_domains", "forest_name", "identity", "include_children", "include_domain_controllers", "include_domains", "include_facts", "include_global_catalog", "include_sysvol", "include_trusts", "include_udp", "latency_threshold_ms", "loss_threshold_percent", "max_concurrency", "name", "p95_latency_threshold_ms", "path", "port", "probe_kind", "protocol", "query_mode", "request_timeout_ms", "require_wsus", "retries", "retry_delay_ms", "skip_rodc", "sort_by", "sort_direction", "split_protocol_results", "stale_threshold_hours", "targets", "tcp_ports", "test_ping", "test_ports", "test_sysvol_shares", "timeout_ms", "top", "total_budget_ms", "udp_ports", "url", "use_ad_core_profile", "verify_certificate" },
+            new[] { "probe_kind" }
+        };
+
+        yield return new object[] {
+            "ad_replikacja_diagnostyka",
+            new[] { "bind_identity", "bind_secret", "columns", "degraded_above_ms", "directory_allow_authenticated_fallback", "directory_allowed_shares", "directory_attribute", "directory_dns_servers", "directory_exclude_sites", "directory_filter", "directory_ignore_drive_shares", "directory_include_forest_roles", "directory_optional_shares", "directory_probe_kind", "directory_query_name", "directory_query_timeout_ms", "directory_require_global_catalog_ready", "directory_require_synchronized", "directory_required_shares", "directory_search_base", "directory_share_name", "directory_sites", "directory_use_all_dns_servers", "directory_use_anonymous_bind", "directory_use_ldaps", "directory_use_start_tls", "directory_zones", "discovery_fallback", "dns_queries", "dns_service_query_name", "dns_service_record_type", "dns_service_require_answers", "domain_controller", "domain_name", "exclude_domain_controllers", "exclude_domains", "forest_name", "identity", "include_children", "include_domain_controllers", "include_domains", "include_facts", "include_global_catalog", "include_sysvol", "include_trusts", "include_udp", "latency_threshold_ms", "loss_threshold_percent", "max_concurrency", "name", "p95_latency_threshold_ms", "path", "port", "probe_kind", "protocol", "query_mode", "request_timeout_ms", "require_wsus", "retries", "retry_delay_ms", "skip_rodc", "sort_by", "sort_direction", "split_protocol_results", "stale_threshold_hours", "targets", "tcp_ports", "test_ping", "test_ports", "test_sysvol_shares", "timeout_ms", "top", "total_budget_ms", "udp_ports", "url", "use_ad_core_profile", "verify_certificate" },
+            new[] { "probe_kind" }
+        };
+
+        yield return new object[] {
             "ad_krbtgt_health",
             new[] { "domain_name", "forest_name", "age_threshold_days", "max_results", "columns", "sort_by", "sort_direction", "top" },
             Array.Empty<string>()
@@ -635,13 +659,73 @@ public partial class ToolSchemaSnapshotTests {
         };
 
         yield return new object[] {
+            "ad_replication_health_summary",
+            new[] { "domain_controller", "domain_name", "forest_name", "outbound", "by_source", "stale_threshold_hours", "bucket_hours", "include_details", "max_details", "max_domain_controllers", "max_errors", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "ad_replikacja_podsumowanie",
+            new[] { "domain_controller", "domain_name", "forest_name", "outbound", "by_source", "stale_threshold_hours", "bucket_hours", "include_details", "max_details", "max_domain_controllers", "max_errors", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "ad_replikacja_forestu",
+            new[] { "domain_controller", "domain_name", "forest_name", "outbound", "by_source", "stale_threshold_hours", "bucket_hours", "include_details", "max_details", "max_domain_controllers", "max_errors", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "ad_replikacja_utc",
+            new[] { "domain_controller", "domain_name", "forest_name", "outbound", "by_source", "stale_threshold_hours", "bucket_hours", "include_details", "max_details", "max_domain_controllers", "max_errors", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
             "ad_replication_connections",
             new[] { "server", "server_match", "site", "site_match", "source_server", "source_server_match", "transport", "state", "origin", "summary", "summary_by", "max_results", "columns", "sort_by", "sort_direction", "top" },
             Array.Empty<string>()
         };
 
         yield return new object[] {
+            "ad_replication_topology",
+            new[] { "server", "server_match", "site", "site_match", "source_server", "source_server_match", "transport", "state", "origin", "summary", "summary_by", "max_results", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "ad_replikacja_topologia",
+            new[] { "server", "server_match", "site", "site_match", "source_server", "source_server_match", "transport", "state", "origin", "summary", "summary_by", "max_results", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "ad_replikacja_wykres",
+            new[] { "server", "server_match", "site", "site_match", "source_server", "source_server_match", "transport", "state", "origin", "summary", "summary_by", "max_results", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
             "ad_replication_status",
+            new[] { "computer_names", "health_only", "max_results", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "ad_replication_health",
+            new[] { "computer_names", "health_only", "max_results", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "ad_replikacja_status",
+            new[] { "computer_names", "health_only", "max_results", "columns", "sort_by", "sort_direction", "top" },
+            Array.Empty<string>()
+        };
+
+        yield return new object[] {
+            "ad_replikacja_kontrolery",
             new[] { "computer_names", "health_only", "max_results", "columns", "sort_by", "sort_direction", "top" },
             Array.Empty<string>()
         };


### PR DESCRIPTION
## Summary
- make OpenAI auth-bundle reviewer failures fail the required reviewer action instead of passing open
- move AD PKI tools to the current TestimoX CertNoob assessment surface
- bump OfficeIMO package references and update the affected snapshot/runtime contract tests

## Validation
- dotnet build IntelligenceX.sln -c Release
- dotnet test IntelligenceX.Tools\IntelligenceX.Tools.Tests\IntelligenceX.Tools.Tests.csproj -c Release -f net8.0-windows
- dotnet test IntelligenceX.Chat\IntelligenceX.Chat.App.Tests\IntelligenceX.Chat.App.Tests.csproj -c Release
- dotnet .\IntelligenceX.Tests\bin\Release\net8.0\IntelligenceX.Tests.dll
- dotnet .\IntelligenceX.Tests\bin\Release\net10.0\IntelligenceX.Tests.dll
- git diff --check
- pwsh -NoLogo -NoProfile -File .agents\skills\intelligencex-analysis-gate\scripts\run-analysis-suite.ps1 -Mode fast