### PR TITLE
Add Codex thread recovery detection to tray

### DIFF
--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.BrokenThreads.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.BrokenThreads.cs
@@ -58,8 +58,10 @@ public sealed partial class CodexLocalStateDiagnosticsService {
                     found ? state.Title : string.Empty,
                     item.FailureCount,
                     DateTimeOffset.FromUnixTimeSeconds(item.LastSeen),
+                    found && state.LastActivity > 0 ? DateTimeOffset.FromUnixTimeSeconds(state.LastActivity) : null,
                     found,
-                    found && state.IsArchived);
+                    found && state.IsArchived,
+                    !found || state.LastActivity <= 0 || item.LastSeen >= state.LastActivity);
             })
             .OrderByDescending(static item => item.LastSeenUtc)
             .ThenByDescending(static item => item.FailureCount)
@@ -140,25 +142,27 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         }
     }
 
-    private static IReadOnlyDictionary<string, (string Title, bool IsArchived)> ReadThreadArchiveStates(
+    private static IReadOnlyDictionary<string, (string Title, bool IsArchived, long LastActivity)> ReadThreadArchiveStates(
         string stateDb,
         IEnumerable<string> threadIds,
         CancellationToken cancellationToken) {
         var ids = threadIds.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
         if (ids.Length == 0 || !File.Exists(stateDb)) {
-            return new Dictionary<string, (string Title, bool IsArchived)>(StringComparer.OrdinalIgnoreCase);
+            return new Dictionary<string, (string Title, bool IsArchived, long LastActivity)>(StringComparer.OrdinalIgnoreCase);
         }
 
         var columns = GetTableColumns(stateDb, "threads")
             .Select(static column => column.Name)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         if (!columns.Contains("id")) {
-            return new Dictionary<string, (string Title, bool IsArchived)>(StringComparer.OrdinalIgnoreCase);
+            return new Dictionary<string, (string Title, bool IsArchived, long LastActivity)>(StringComparer.OrdinalIgnoreCase);
         }
 
         var titleExpr = columns.Contains("title") ? QuoteIdentifier("title") : "''";
         var archivedExpr = columns.Contains("archived") ? QuoteIdentifier("archived") : "NULL";
         var archivedAtExpr = columns.Contains("archived_at") ? QuoteIdentifier("archived_at") : "NULL";
+        var updatedAtExpr = columns.Contains("updated_at") ? QuoteIdentifier("updated_at") : "NULL";
+        var recencyAtExpr = columns.Contains("recency_at") ? QuoteIdentifier("recency_at") : "NULL";
         var builder = new SqliteConnectionStringBuilder {
             DataSource = stateDb,
             Mode = SqliteOpenMode.ReadOnly
@@ -167,11 +171,11 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         connection.Open();
         SetBusyTimeout(connection, 1000);
 
-        var result = new Dictionary<string, (string Title, bool IsArchived)>(StringComparer.OrdinalIgnoreCase);
+        var result = new Dictionary<string, (string Title, bool IsArchived, long LastActivity)>(StringComparer.OrdinalIgnoreCase);
         foreach (var threadId in ids) {
             cancellationToken.ThrowIfCancellationRequested();
             using var command = connection.CreateCommand();
-            command.CommandText = $"SELECT {titleExpr}, {archivedExpr}, {archivedAtExpr} FROM threads WHERE {QuoteIdentifier("id")} = @threadId LIMIT 1;";
+            command.CommandText = $"SELECT {titleExpr}, {archivedExpr}, {archivedAtExpr}, {updatedAtExpr}, {recencyAtExpr} FROM threads WHERE {QuoteIdentifier("id")} = @threadId LIMIT 1;";
             command.Parameters.AddWithValue("@threadId", threadId);
             using var reader = command.ExecuteReader();
             if (!reader.Read()) {
@@ -181,7 +185,9 @@ public sealed partial class CodexLocalStateDiagnosticsService {
             var title = reader.IsDBNull(0) ? string.Empty : reader.GetString(0);
             var archived = reader.IsDBNull(1) ? null : reader.GetValue(1);
             var archivedAt = reader.IsDBNull(2) ? null : reader.GetValue(2);
-            result[threadId] = (title, IsTruthySqliteValue(archived) || HasSqliteValue(archivedAt));
+            var updatedAt = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3), CultureInfo.InvariantCulture);
+            var recencyAt = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4), CultureInfo.InvariantCulture);
+            result[threadId] = (title, IsTruthySqliteValue(archived) || HasSqliteValue(archivedAt), Math.Max(updatedAt, recencyAt));
         }
 
         return result;

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.BrokenThreads.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.BrokenThreads.cs
@@ -12,12 +12,13 @@ namespace IntelligenceX.Codex;
 
 public sealed partial class CodexLocalStateDiagnosticsService {
     private const int BrokenThreadLogLookbackHours = 48;
-    private static readonly string[] BrokenThreadLogPatterns = [
-        "agent loop died",
+    private static readonly string[] BrokenThreadLogPrefixes = [
+        "failed to queue mcp refresh for thread ",
         "failed to start turn",
         "failed to update thread settings",
         "error creating task",
-        "error submitting message"
+        "error submitting message",
+        "failed to submit message"
     ];
 
     private static readonly Regex ThreadReferenceRegex = new(
@@ -79,7 +80,7 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         using var command = connection.CreateCommand();
         var filters = string.Join(
             " OR ",
-            BrokenThreadLogPatterns.Select((_, index) => $"lower(coalesce(feedback_log_body,'')) LIKE @pattern{index.ToString(CultureInfo.InvariantCulture)}"));
+            BrokenThreadLogPrefixes.Select((_, index) => $"lower(coalesce(feedback_log_body,'')) LIKE @pattern{index.ToString(CultureInfo.InvariantCulture)}"));
         command.CommandText = $"""
                               SELECT ts, thread_id, feedback_log_body
                               FROM logs
@@ -88,8 +89,8 @@ public sealed partial class CodexLocalStateDiagnosticsService {
                               ORDER BY ts DESC;
                               """;
         command.Parameters.AddWithValue("@since", since);
-        for (var i = 0; i < BrokenThreadLogPatterns.Length; i++) {
-            command.Parameters.AddWithValue("@pattern" + i.ToString(CultureInfo.InvariantCulture), "%" + BrokenThreadLogPatterns[i] + "%");
+        for (var i = 0; i < BrokenThreadLogPrefixes.Length; i++) {
+            command.Parameters.AddWithValue("@pattern" + i.ToString(CultureInfo.InvariantCulture), BrokenThreadLogPrefixes[i] + "%");
         }
 
         var candidates = new Dictionary<string, (int Count, long LastSeen)>(StringComparer.OrdinalIgnoreCase);
@@ -99,6 +100,10 @@ public sealed partial class CodexLocalStateDiagnosticsService {
             var ts = reader.IsDBNull(0) ? 0L : Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture);
             var explicitThreadId = reader.IsDBNull(1) ? string.Empty : reader.GetString(1);
             var body = reader.IsDBNull(2) ? string.Empty : reader.GetString(2);
+            if (!IsBrokenThreadFailureLog(body)) {
+                continue;
+            }
+
             foreach (var threadId in ExtractThreadIds(explicitThreadId, body)) {
                 if (!candidates.TryGetValue(threadId, out var current)) {
                     candidates[threadId] = (1, ts);
@@ -114,6 +119,11 @@ public sealed partial class CodexLocalStateDiagnosticsService {
             .OrderByDescending(static item => item.LastSeen)
             .ThenByDescending(static item => item.Count)
             .ToArray();
+    }
+
+    private static bool IsBrokenThreadFailureLog(string body) {
+        var text = body.TrimStart().ToLowerInvariant();
+        return BrokenThreadLogPrefixes.Any(prefix => text.StartsWith(prefix, StringComparison.Ordinal));
     }
 
     private static IEnumerable<string> ExtractThreadIds(string explicitThreadId, string body) {

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.BrokenThreads.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.BrokenThreads.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
-using Microsoft.Data.Sqlite;
+using DBAClientX;
 
 namespace IntelligenceX.Codex;
 
@@ -37,7 +37,9 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         IReadOnlyList<(string ThreadId, int FailureCount, long LastSeen)> loggedCandidates;
         try {
             loggedCandidates = ReadBrokenThreadLogCandidates(logsDb, cancellationToken);
-        } catch (SqliteException) {
+        } catch (DbaClientXException) {
+            return [];
+        } catch (Exception ex) when (IsSqliteProviderException(ex)) {
             return [];
         } catch (IOException) {
             return [];
@@ -72,48 +74,49 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         string logsDb,
         CancellationToken cancellationToken) {
         var since = DateTimeOffset.UtcNow.AddHours(-BrokenThreadLogLookbackHours).ToUnixTimeSeconds();
-        var builder = new SqliteConnectionStringBuilder {
-            DataSource = logsDb,
-            Mode = SqliteOpenMode.ReadOnly
-        };
-        using var connection = new SqliteConnection(builder.ConnectionString);
-        connection.Open();
-        SetBusyTimeout(connection, 1000);
-        using var command = connection.CreateCommand();
         var filters = string.Join(
             " OR ",
             BrokenThreadLogPrefixes.Select((_, index) => $"lower(ltrim(coalesce(feedback_log_body,''), @trimCharacters)) LIKE @pattern{index.ToString(CultureInfo.InvariantCulture)}"));
-        command.CommandText = $"""
-                              SELECT ts, thread_id, feedback_log_body
-                              FROM logs
-                              WHERE ts >= @since
-                                AND ({filters})
-                              ORDER BY ts DESC;
-                              """;
-        command.Parameters.AddWithValue("@since", since);
-        command.Parameters.AddWithValue("@trimCharacters", " \t\r\n");
+        var parameters = new Dictionary<string, object?> {
+            ["@since"] = since,
+            ["@trimCharacters"] = " \t\r\n"
+        };
         for (var i = 0; i < BrokenThreadLogPrefixes.Length; i++) {
-            command.Parameters.AddWithValue("@pattern" + i.ToString(CultureInfo.InvariantCulture), BrokenThreadLogPrefixes[i] + "%");
+            parameters["@pattern" + i.ToString(CultureInfo.InvariantCulture)] = BrokenThreadLogPrefixes[i] + "%";
         }
 
+        using var sqlite = new SQLite {
+            CommandTimeout = 10
+        };
+        using var session = sqlite.OpenSession(logsDb);
+        var rows = session.QueryAsList(
+            $"""
+             SELECT ts, thread_id, feedback_log_body
+             FROM logs
+             WHERE ts >= @since
+               AND ({filters})
+             ORDER BY ts DESC;
+             """,
+            static row => (
+                Ts: row.IsDBNull(0) ? 0L : Convert.ToInt64(row.GetValue(0), CultureInfo.InvariantCulture),
+                ThreadId: row.IsDBNull(1) ? string.Empty : Convert.ToString(row.GetValue(1), CultureInfo.InvariantCulture) ?? string.Empty,
+                Body: row.IsDBNull(2) ? string.Empty : Convert.ToString(row.GetValue(2), CultureInfo.InvariantCulture) ?? string.Empty),
+            parameters);
+
         var candidates = new Dictionary<string, (int Count, long LastSeen)>(StringComparer.OrdinalIgnoreCase);
-        using var reader = command.ExecuteReader();
-        while (reader.Read()) {
+        foreach (var row in rows) {
             cancellationToken.ThrowIfCancellationRequested();
-            var ts = reader.IsDBNull(0) ? 0L : Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture);
-            var explicitThreadId = reader.IsDBNull(1) ? string.Empty : reader.GetString(1);
-            var body = reader.IsDBNull(2) ? string.Empty : reader.GetString(2);
-            if (!IsBrokenThreadFailureLog(body)) {
+            if (!IsBrokenThreadFailureLog(row.Body)) {
                 continue;
             }
 
-            foreach (var threadId in ExtractThreadIds(explicitThreadId, body)) {
+            foreach (var threadId in ExtractThreadIds(row.ThreadId, row.Body)) {
                 if (!candidates.TryGetValue(threadId, out var current)) {
-                    candidates[threadId] = (1, ts);
+                    candidates[threadId] = (1, row.Ts);
                     continue;
                 }
 
-                candidates[threadId] = (current.Count + 1, Math.Max(current.LastSeen, ts));
+                candidates[threadId] = (current.Count + 1, Math.Max(current.LastSeen, row.Ts));
             }
         }
 
@@ -163,31 +166,31 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         var archivedAtExpr = columns.Contains("archived_at") ? QuoteIdentifier("archived_at") : "NULL";
         var updatedAtExpr = columns.Contains("updated_at") ? QuoteIdentifier("updated_at") : "NULL";
         var recencyAtExpr = columns.Contains("recency_at") ? QuoteIdentifier("recency_at") : "NULL";
-        var builder = new SqliteConnectionStringBuilder {
-            DataSource = stateDb,
-            Mode = SqliteOpenMode.ReadOnly
+        using var sqlite = new SQLite {
+            CommandTimeout = 10
         };
-        using var connection = new SqliteConnection(builder.ConnectionString);
-        connection.Open();
-        SetBusyTimeout(connection, 1000);
+        using var session = sqlite.OpenSession(stateDb);
 
         var result = new Dictionary<string, (string Title, bool IsArchived, long LastActivity)>(StringComparer.OrdinalIgnoreCase);
         foreach (var threadId in ids) {
             cancellationToken.ThrowIfCancellationRequested();
-            using var command = connection.CreateCommand();
-            command.CommandText = $"SELECT {titleExpr}, {archivedExpr}, {archivedAtExpr}, {updatedAtExpr}, {recencyAtExpr} FROM threads WHERE {QuoteIdentifier("id")} = @threadId LIMIT 1;";
-            command.Parameters.AddWithValue("@threadId", threadId);
-            using var reader = command.ExecuteReader();
-            if (!reader.Read()) {
+            var rows = session.QueryAsList(
+                $"SELECT {titleExpr}, {archivedExpr}, {archivedAtExpr}, {updatedAtExpr}, {recencyAtExpr} FROM threads WHERE {QuoteIdentifier("id")} = @threadId LIMIT 1;",
+                static row => (
+                    Title: row.IsDBNull(0) ? string.Empty : Convert.ToString(row.GetValue(0), CultureInfo.InvariantCulture) ?? string.Empty,
+                    Archived: row.IsDBNull(1) ? null : row.GetValue(1),
+                    ArchivedAt: row.IsDBNull(2) ? null : row.GetValue(2),
+                    UpdatedAt: row.IsDBNull(3) ? 0L : Convert.ToInt64(row.GetValue(3), CultureInfo.InvariantCulture),
+                    RecencyAt: row.IsDBNull(4) ? 0L : Convert.ToInt64(row.GetValue(4), CultureInfo.InvariantCulture)),
+                new Dictionary<string, object?> {
+                    ["@threadId"] = threadId
+                });
+            if (rows.Count == 0) {
                 continue;
             }
 
-            var title = reader.IsDBNull(0) ? string.Empty : reader.GetString(0);
-            var archived = reader.IsDBNull(1) ? null : reader.GetValue(1);
-            var archivedAt = reader.IsDBNull(2) ? null : reader.GetValue(2);
-            var updatedAt = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3), CultureInfo.InvariantCulture);
-            var recencyAt = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4), CultureInfo.InvariantCulture);
-            result[threadId] = (title, IsTruthySqliteValue(archived) || HasSqliteValue(archivedAt), Math.Max(updatedAt, recencyAt));
+            var row = rows[0];
+            result[threadId] = (row.Title, IsTruthySqliteValue(row.Archived) || HasSqliteValue(row.ArchivedAt), Math.Max(row.UpdatedAt, row.RecencyAt));
         }
 
         return result;

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.BrokenThreads.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.BrokenThreads.cs
@@ -1,0 +1,179 @@
+#if !NETSTANDARD2_0
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Microsoft.Data.Sqlite;
+
+namespace IntelligenceX.Codex;
+
+public sealed partial class CodexLocalStateDiagnosticsService {
+    private const int BrokenThreadLogLookbackHours = 48;
+    private static readonly string[] BrokenThreadLogPatterns = [
+        "agent loop died",
+        "failed to start turn",
+        "failed to update thread settings",
+        "error creating task",
+        "error submitting message"
+    ];
+
+    private static readonly Regex ThreadReferenceRegex = new(
+        @"(?:thread|conversation)(?:\s+id)?\s*[:=]?\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static IReadOnlyList<CodexLocalStateBrokenThreadCandidate> CollectBrokenThreadCandidates(
+        string codexHome,
+        string stateDb,
+        CancellationToken cancellationToken) {
+        var logsDb = Path.Combine(codexHome, "logs_2.sqlite");
+        if (!File.Exists(logsDb)) {
+            return [];
+        }
+
+        IReadOnlyList<(string ThreadId, int FailureCount, long LastSeen)> loggedCandidates;
+        try {
+            loggedCandidates = ReadBrokenThreadLogCandidates(logsDb, cancellationToken);
+        } catch (SqliteException) {
+            return [];
+        } catch (IOException) {
+            return [];
+        } catch (UnauthorizedAccessException) {
+            return [];
+        }
+
+        if (loggedCandidates.Count == 0) {
+            return [];
+        }
+
+        var threadStateById = ReadThreadArchiveStates(stateDb, loggedCandidates.Select(static item => item.ThreadId), cancellationToken);
+        return loggedCandidates
+            .Select(item => {
+                var found = threadStateById.TryGetValue(item.ThreadId, out var state);
+                return new CodexLocalStateBrokenThreadCandidate(
+                    item.ThreadId,
+                    found ? state.Title : string.Empty,
+                    item.FailureCount,
+                    DateTimeOffset.FromUnixTimeSeconds(item.LastSeen),
+                    found,
+                    found && state.IsArchived);
+            })
+            .OrderByDescending(static item => item.LastSeenUtc)
+            .ThenByDescending(static item => item.FailureCount)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<(string ThreadId, int FailureCount, long LastSeen)> ReadBrokenThreadLogCandidates(
+        string logsDb,
+        CancellationToken cancellationToken) {
+        var since = DateTimeOffset.UtcNow.AddHours(-BrokenThreadLogLookbackHours).ToUnixTimeSeconds();
+        var builder = new SqliteConnectionStringBuilder {
+            DataSource = logsDb,
+            Mode = SqliteOpenMode.ReadOnly
+        };
+        using var connection = new SqliteConnection(builder.ConnectionString);
+        connection.Open();
+        SetBusyTimeout(connection, 1000);
+        using var command = connection.CreateCommand();
+        var filters = string.Join(
+            " OR ",
+            BrokenThreadLogPatterns.Select((_, index) => $"lower(coalesce(feedback_log_body,'')) LIKE @pattern{index.ToString(CultureInfo.InvariantCulture)}"));
+        command.CommandText = $"""
+                              SELECT ts, thread_id, feedback_log_body
+                              FROM logs
+                              WHERE ts >= @since
+                                AND ({filters})
+                              ORDER BY ts DESC;
+                              """;
+        command.Parameters.AddWithValue("@since", since);
+        for (var i = 0; i < BrokenThreadLogPatterns.Length; i++) {
+            command.Parameters.AddWithValue("@pattern" + i.ToString(CultureInfo.InvariantCulture), "%" + BrokenThreadLogPatterns[i] + "%");
+        }
+
+        var candidates = new Dictionary<string, (int Count, long LastSeen)>(StringComparer.OrdinalIgnoreCase);
+        using var reader = command.ExecuteReader();
+        while (reader.Read()) {
+            cancellationToken.ThrowIfCancellationRequested();
+            var ts = reader.IsDBNull(0) ? 0L : Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture);
+            var explicitThreadId = reader.IsDBNull(1) ? string.Empty : reader.GetString(1);
+            var body = reader.IsDBNull(2) ? string.Empty : reader.GetString(2);
+            foreach (var threadId in ExtractThreadIds(explicitThreadId, body)) {
+                if (!candidates.TryGetValue(threadId, out var current)) {
+                    candidates[threadId] = (1, ts);
+                    continue;
+                }
+
+                candidates[threadId] = (current.Count + 1, Math.Max(current.LastSeen, ts));
+            }
+        }
+
+        return candidates
+            .Select(static pair => (pair.Key, pair.Value.Count, pair.Value.LastSeen))
+            .OrderByDescending(static item => item.LastSeen)
+            .ThenByDescending(static item => item.Count)
+            .ToArray();
+    }
+
+    private static IEnumerable<string> ExtractThreadIds(string explicitThreadId, string body) {
+        if (Guid.TryParse(explicitThreadId, out _)) {
+            yield return explicitThreadId;
+        }
+
+        foreach (Match match in ThreadReferenceRegex.Matches(body)) {
+            var value = match.Groups[1].Value;
+            if (Guid.TryParse(value, out _)) {
+                yield return value;
+            }
+        }
+    }
+
+    private static IReadOnlyDictionary<string, (string Title, bool IsArchived)> ReadThreadArchiveStates(
+        string stateDb,
+        IEnumerable<string> threadIds,
+        CancellationToken cancellationToken) {
+        var ids = threadIds.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        if (ids.Length == 0 || !File.Exists(stateDb)) {
+            return new Dictionary<string, (string Title, bool IsArchived)>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var columns = GetTableColumns(stateDb, "threads")
+            .Select(static column => column.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (!columns.Contains("id")) {
+            return new Dictionary<string, (string Title, bool IsArchived)>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var titleExpr = columns.Contains("title") ? QuoteIdentifier("title") : "''";
+        var archivedExpr = columns.Contains("archived") ? QuoteIdentifier("archived") : "NULL";
+        var archivedAtExpr = columns.Contains("archived_at") ? QuoteIdentifier("archived_at") : "NULL";
+        var builder = new SqliteConnectionStringBuilder {
+            DataSource = stateDb,
+            Mode = SqliteOpenMode.ReadOnly
+        };
+        using var connection = new SqliteConnection(builder.ConnectionString);
+        connection.Open();
+        SetBusyTimeout(connection, 1000);
+
+        var result = new Dictionary<string, (string Title, bool IsArchived)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var threadId in ids) {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var command = connection.CreateCommand();
+            command.CommandText = $"SELECT {titleExpr}, {archivedExpr}, {archivedAtExpr} FROM threads WHERE {QuoteIdentifier("id")} = @threadId LIMIT 1;";
+            command.Parameters.AddWithValue("@threadId", threadId);
+            using var reader = command.ExecuteReader();
+            if (!reader.Read()) {
+                continue;
+            }
+
+            var title = reader.IsDBNull(0) ? string.Empty : reader.GetString(0);
+            var archived = reader.IsDBNull(1) ? null : reader.GetValue(1);
+            var archivedAt = reader.IsDBNull(2) ? null : reader.GetValue(2);
+            result[threadId] = (title, IsTruthySqliteValue(archived) || HasSqliteValue(archivedAt));
+        }
+
+        return result;
+    }
+}
+#endif

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.BrokenThreads.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.BrokenThreads.cs
@@ -80,7 +80,7 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         using var command = connection.CreateCommand();
         var filters = string.Join(
             " OR ",
-            BrokenThreadLogPrefixes.Select((_, index) => $"lower(coalesce(feedback_log_body,'')) LIKE @pattern{index.ToString(CultureInfo.InvariantCulture)}"));
+            BrokenThreadLogPrefixes.Select((_, index) => $"lower(ltrim(coalesce(feedback_log_body,''), @trimCharacters)) LIKE @pattern{index.ToString(CultureInfo.InvariantCulture)}"));
         command.CommandText = $"""
                               SELECT ts, thread_id, feedback_log_body
                               FROM logs
@@ -89,6 +89,7 @@ public sealed partial class CodexLocalStateDiagnosticsService {
                               ORDER BY ts DESC;
                               """;
         command.Parameters.AddWithValue("@since", since);
+        command.Parameters.AddWithValue("@trimCharacters", " \t\r\n");
         for (var i = 0; i < BrokenThreadLogPrefixes.Length; i++) {
             command.Parameters.AddWithValue("@pattern" + i.ToString(CultureInfo.InvariantCulture), BrokenThreadLogPrefixes[i] + "%");
         }

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.ThreadRecovery.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.ThreadRecovery.cs
@@ -1,0 +1,223 @@
+#if !NETSTANDARD2_0
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+
+namespace IntelligenceX.Codex;
+
+/// <summary>
+/// Result of a backup-first Codex thread archive-state refresh.
+/// </summary>
+public sealed class CodexLocalStateThreadRecoveryResult {
+    /// <summary>Resolved Codex home directory.</summary>
+    public string CodexHome { get; init; } = string.Empty;
+    /// <summary>Resolved Codex SQLite state database path.</summary>
+    public string StateDatabasePath { get; init; } = string.Empty;
+    /// <summary>Thread id requested for recovery.</summary>
+    public string ThreadId { get; init; } = string.Empty;
+    /// <summary>Whether the state database existed when recovery was requested.</summary>
+    public bool DatabaseExists { get; init; }
+    /// <summary>Whether the threads table has archive-state columns IX can refresh.</summary>
+    public bool ArchiveColumnsAvailable { get; init; }
+    /// <summary>Whether the requested thread row was found.</summary>
+    public bool ThreadFound { get; init; }
+    /// <summary>Whether the thread was archived before the refresh.</summary>
+    public bool WasArchived { get; init; }
+    /// <summary>Whether the thread was archived after the refresh.</summary>
+    public bool FinalArchived { get; init; }
+    /// <summary>Directory containing the SQLite backup created before mutation.</summary>
+    public string BackupDirectory { get; init; } = string.Empty;
+    /// <summary>Path to the SQLite backup created before mutation.</summary>
+    public string BackupDatabasePath { get; init; } = string.Empty;
+}
+
+public sealed partial class CodexLocalStateDiagnosticsService {
+    /// <summary>
+    /// Backs up the Codex SQLite state database, toggles one thread through an
+    /// archived state, then restores its original final active/archived state.
+    /// </summary>
+    /// <param name="threadId">Codex thread id to refresh.</param>
+    /// <param name="codexHome">Optional Codex home override. Defaults to CODEX_HOME or ~/.codex.</param>
+    /// <param name="backupRoot">Optional backup root override. Defaults to Documents\Codex\codex-backups.</param>
+    /// <param name="cancellationToken">Cancellation token for the recovery operation.</param>
+    /// <returns>A summary of the backed-up thread refresh.</returns>
+    public Task<CodexLocalStateThreadRecoveryResult> RecoverThreadArchiveStateAsync(
+        string threadId,
+        string? codexHome = null,
+        string? backupRoot = null,
+        CancellationToken cancellationToken = default) {
+        return Task.Run(
+            () => RecoverThreadArchiveState(threadId, codexHome, backupRoot, cancellationToken),
+            cancellationToken);
+    }
+
+    private CodexLocalStateThreadRecoveryResult RecoverThreadArchiveState(
+        string threadId,
+        string? codexHome,
+        string? backupRoot,
+        CancellationToken cancellationToken) {
+        var normalizedThreadId = threadId?.Trim() ?? string.Empty;
+        if (!Guid.TryParse(normalizedThreadId, out _)) {
+            throw new ArgumentException("Thread id must be a UUID.", nameof(threadId));
+        }
+
+        var requestedHome = string.IsNullOrWhiteSpace(codexHome) ? ResolveDefaultCodexHome() : codexHome!.Trim();
+        var home = Path.GetFullPath(requestedHome);
+        var stateDb = Path.Combine(home, "state_5.sqlite");
+        if (!File.Exists(stateDb)) {
+            return new CodexLocalStateThreadRecoveryResult {
+                CodexHome = home,
+                StateDatabasePath = stateDb,
+                ThreadId = normalizedThreadId,
+                DatabaseExists = false
+            };
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var backupDirectory = CreateBackupDirectory(backupRoot);
+        var backupDb = Path.Combine(backupDirectory, "state_5.sqlite");
+
+        var builder = new SqliteConnectionStringBuilder {
+            DataSource = stateDb,
+            Mode = SqliteOpenMode.ReadWrite
+        };
+        using var connection = new SqliteConnection(builder.ConnectionString);
+        connection.Open();
+        SetBusyTimeout(connection, 10000);
+        BackupDatabase(connection, backupDb);
+
+        var columnNames = GetTableColumns(stateDb, "threads")
+            .Select(static column => column.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var hasArchiveColumns = columnNames.Contains("archived") || columnNames.Contains("archived_at");
+        if (!columnNames.Contains("id") || !hasArchiveColumns) {
+            return new CodexLocalStateThreadRecoveryResult {
+                CodexHome = home,
+                StateDatabasePath = stateDb,
+                ThreadId = normalizedThreadId,
+                DatabaseExists = true,
+                ArchiveColumnsAvailable = false,
+                BackupDirectory = backupDirectory,
+                BackupDatabasePath = backupDb
+            };
+        }
+
+        var wasArchived = ReadThreadArchivedState(connection, normalizedThreadId, columnNames, cancellationToken);
+        if (wasArchived is null) {
+            return new CodexLocalStateThreadRecoveryResult {
+                CodexHome = home,
+                StateDatabasePath = stateDb,
+                ThreadId = normalizedThreadId,
+                DatabaseExists = true,
+                ArchiveColumnsAvailable = true,
+                ThreadFound = false,
+                BackupDirectory = backupDirectory,
+                BackupDatabasePath = backupDb
+            };
+        }
+
+        using var transaction = connection.BeginTransaction();
+        SetThreadArchivedState(connection, transaction, normalizedThreadId, columnNames, archived: true);
+        SetThreadArchivedState(connection, transaction, normalizedThreadId, columnNames, archived: wasArchived.Value);
+        transaction.Commit();
+
+        return new CodexLocalStateThreadRecoveryResult {
+            CodexHome = home,
+            StateDatabasePath = stateDb,
+            ThreadId = normalizedThreadId,
+            DatabaseExists = true,
+            ArchiveColumnsAvailable = true,
+            ThreadFound = true,
+            WasArchived = wasArchived.Value,
+            FinalArchived = wasArchived.Value,
+            BackupDirectory = backupDirectory,
+            BackupDatabasePath = backupDb
+        };
+    }
+
+    private static bool? ReadThreadArchivedState(
+        SqliteConnection connection,
+        string threadId,
+        ISet<string> columns,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        using var command = connection.CreateCommand();
+        var archivedExpression = columns.Contains("archived")
+            ? QuoteIdentifier("archived")
+            : "NULL";
+        var archivedAtExpression = columns.Contains("archived_at")
+            ? QuoteIdentifier("archived_at")
+            : "NULL";
+        command.CommandText = $"SELECT {archivedExpression} AS archived, {archivedAtExpression} AS archived_at FROM threads WHERE {QuoteIdentifier("id")} = @threadId LIMIT 1;";
+        command.Parameters.AddWithValue("@threadId", threadId);
+        using var reader = command.ExecuteReader();
+        if (!reader.Read()) {
+            return null;
+        }
+
+        var archivedValue = reader.IsDBNull(0) ? null : reader.GetValue(0);
+        var archivedAtValue = reader.IsDBNull(1) ? null : reader.GetValue(1);
+        return IsTruthySqliteValue(archivedValue) || HasSqliteValue(archivedAtValue);
+    }
+
+    private static void SetThreadArchivedState(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string threadId,
+        ISet<string> columns,
+        bool archived) {
+        var assignments = new List<string>();
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        if (columns.Contains("archived")) {
+            assignments.Add($"{QuoteIdentifier("archived")} = @archived");
+            command.Parameters.AddWithValue("@archived", archived ? 1 : 0);
+        }
+
+        if (columns.Contains("archived_at")) {
+            assignments.Add($"{QuoteIdentifier("archived_at")} = @archivedAt");
+            command.Parameters.AddWithValue("@archivedAt", archived ? DateTimeOffset.UtcNow.ToUnixTimeSeconds() : DBNull.Value);
+        }
+
+        command.CommandText = "UPDATE threads SET "
+                              + string.Join(", ", assignments)
+                              + $" WHERE {QuoteIdentifier("id")} = @threadId;";
+        command.Parameters.AddWithValue("@threadId", threadId);
+        command.ExecuteNonQuery();
+    }
+
+    private static bool IsTruthySqliteValue(object? value) {
+        if (!HasSqliteValue(value)) {
+            return false;
+        }
+
+        return value switch {
+            bool boolean => boolean,
+            byte number => number != 0,
+            short number => number != 0,
+            int number => number != 0,
+            long number => number != 0,
+            string text => IsTruthyString(text),
+            _ => false
+        };
+    }
+
+    private static bool HasSqliteValue(object? value) {
+        return value is not null
+               && value is not DBNull
+               && !string.IsNullOrWhiteSpace(Convert.ToString(value, CultureInfo.InvariantCulture));
+    }
+
+    private static bool IsTruthyString(string value) {
+        var text = value.Trim();
+        return string.Equals(text, "1", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(text, "true", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(text, "yes", StringComparison.OrdinalIgnoreCase);
+    }
+}
+#endif

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.ThreadRecovery.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.ThreadRecovery.cs
@@ -138,10 +138,16 @@ public sealed partial class CodexLocalStateDiagnosticsService {
                 automationBackups: automationBackups);
         }
 
-        using var transaction = connection.BeginTransaction();
-        SetThreadArchivedState(connection, transaction, normalizedThreadId, columnNames, archived: true);
-        SetThreadArchivedState(connection, transaction, normalizedThreadId, columnNames, archived: wasArchived.Value);
-        transaction.Commit();
+        using (var transition = connection.BeginTransaction()) {
+            SetThreadArchivedState(connection, transition, normalizedThreadId, columnNames, archived: !wasArchived.Value);
+            transition.Commit();
+        }
+
+        using (var restore = connection.BeginTransaction()) {
+            SetThreadArchivedState(connection, restore, normalizedThreadId, columnNames, archived: wasArchived.Value);
+            restore.Commit();
+        }
+
         var restoredAutomations = RestoreMissingThreadAutomations(automationBackups);
 
         return CreateThreadRecoveryResult(

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.ThreadRecovery.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.ThreadRecovery.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Data.Sqlite;
+using DBAClientX;
 
 namespace IntelligenceX.Codex;
 
@@ -99,14 +99,7 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         var backupDb = Path.Combine(backupDirectory, "state_5.sqlite");
         var automationBackups = BackupThreadAutomations(home, normalizedThreadId, backupDirectory);
 
-        var builder = new SqliteConnectionStringBuilder {
-            DataSource = stateDb,
-            Mode = SqliteOpenMode.ReadWrite
-        };
-        using var connection = new SqliteConnection(builder.ConnectionString);
-        connection.Open();
-        SetBusyTimeout(connection, 10000);
-        BackupDatabase(connection, backupDb);
+        _sqlite.BackupDatabase(stateDb, backupDb, busyTimeoutMs: 10000);
 
         var columnNames = GetTableColumns(stateDb, "threads")
             .Select(static column => column.Name)
@@ -124,7 +117,8 @@ public sealed partial class CodexLocalStateDiagnosticsService {
                 automationBackups: automationBackups);
         }
 
-        var wasArchived = ReadThreadArchivedState(connection, normalizedThreadId, columnNames, cancellationToken);
+        using var session = _sqlite.OpenSession(stateDb);
+        var wasArchived = ReadThreadArchivedState(session, normalizedThreadId, columnNames, cancellationToken);
         if (wasArchived is null) {
             return CreateThreadRecoveryResult(
                 home,
@@ -138,15 +132,11 @@ public sealed partial class CodexLocalStateDiagnosticsService {
                 automationBackups: automationBackups);
         }
 
-        using (var transition = connection.BeginTransaction()) {
-            SetThreadArchivedState(connection, transition, normalizedThreadId, columnNames, archived: !wasArchived.Value);
-            transition.Commit();
-        }
+        session.RunInTransaction(transition =>
+            SetThreadArchivedState(transition, normalizedThreadId, columnNames, archived: !wasArchived.Value));
 
-        using (var restore = connection.BeginTransaction()) {
-            SetThreadArchivedState(connection, restore, normalizedThreadId, columnNames, archived: wasArchived.Value);
-            restore.Commit();
-        }
+        session.RunInTransaction(restore =>
+            SetThreadArchivedState(restore, normalizedThreadId, columnNames, archived: wasArchived.Value));
 
         var restoredAutomations = RestoreMissingThreadAutomations(automationBackups);
 
@@ -291,54 +281,57 @@ public sealed partial class CodexLocalStateDiagnosticsService {
     }
 
     private static bool? ReadThreadArchivedState(
-        SqliteConnection connection,
+        SQLiteSession session,
         string threadId,
         ISet<string> columns,
         CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
-        using var command = connection.CreateCommand();
         var archivedExpression = columns.Contains("archived")
             ? QuoteIdentifier("archived")
             : "NULL";
         var archivedAtExpression = columns.Contains("archived_at")
             ? QuoteIdentifier("archived_at")
             : "NULL";
-        command.CommandText = $"SELECT {archivedExpression} AS archived, {archivedAtExpression} AS archived_at FROM threads WHERE {QuoteIdentifier("id")} = @threadId LIMIT 1;";
-        command.Parameters.AddWithValue("@threadId", threadId);
-        using var reader = command.ExecuteReader();
-        if (!reader.Read()) {
+        var rows = session.QueryAsList(
+            $"SELECT {archivedExpression} AS archived, {archivedAtExpression} AS archived_at FROM threads WHERE {QuoteIdentifier("id")} = @threadId LIMIT 1;",
+            static row => (
+                Archived: row.IsDBNull(row.GetOrdinal("archived")) ? null : row.GetValue(row.GetOrdinal("archived")),
+                ArchivedAt: row.IsDBNull(row.GetOrdinal("archived_at")) ? null : row.GetValue(row.GetOrdinal("archived_at"))),
+            new Dictionary<string, object?> {
+                ["@threadId"] = threadId
+            });
+        if (rows.Count == 0) {
             return null;
         }
 
-        var archivedValue = reader.IsDBNull(0) ? null : reader.GetValue(0);
-        var archivedAtValue = reader.IsDBNull(1) ? null : reader.GetValue(1);
-        return IsTruthySqliteValue(archivedValue) || HasSqliteValue(archivedAtValue);
+        var row = rows[0];
+        return IsTruthySqliteValue(row.Archived) || HasSqliteValue(row.ArchivedAt);
     }
 
     private static void SetThreadArchivedState(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
+        SQLiteSession session,
         string threadId,
         ISet<string> columns,
         bool archived) {
         var assignments = new List<string>();
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
+        var parameters = new Dictionary<string, object?> {
+            ["@threadId"] = threadId
+        };
         if (columns.Contains("archived")) {
             assignments.Add($"{QuoteIdentifier("archived")} = @archived");
-            command.Parameters.AddWithValue("@archived", archived ? 1 : 0);
+            parameters["@archived"] = archived ? 1 : 0;
         }
 
         if (columns.Contains("archived_at")) {
             assignments.Add($"{QuoteIdentifier("archived_at")} = @archivedAt");
-            command.Parameters.AddWithValue("@archivedAt", archived ? DateTimeOffset.UtcNow.ToUnixTimeSeconds() : DBNull.Value);
+            parameters["@archivedAt"] = archived ? DateTimeOffset.UtcNow.ToUnixTimeSeconds() : DBNull.Value;
         }
 
-        command.CommandText = "UPDATE threads SET "
-                              + string.Join(", ", assignments)
-                              + $" WHERE {QuoteIdentifier("id")} = @threadId;";
-        command.Parameters.AddWithValue("@threadId", threadId);
-        command.ExecuteNonQuery();
+        session.ExecuteNonQuery(
+            "UPDATE threads SET "
+            + string.Join(", ", assignments)
+            + $" WHERE {QuoteIdentifier("id")} = @threadId;",
+            parameters);
     }
 
     private static bool IsTruthySqliteValue(object? value) {

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.ThreadRecovery.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.ThreadRecovery.cs
@@ -34,9 +34,25 @@ public sealed class CodexLocalStateThreadRecoveryResult {
     public string BackupDirectory { get; init; } = string.Empty;
     /// <summary>Path to the SQLite backup created before mutation.</summary>
     public string BackupDatabasePath { get; init; } = string.Empty;
+    /// <summary>Directory containing automation backups for this thread, when any were found.</summary>
+    public string AutomationBackupDirectory { get; init; } = string.Empty;
+    /// <summary>Automation ids that targeted this thread before recovery.</summary>
+    public IReadOnlyList<string> AutomationIds { get; init; } = [];
+    /// <summary>Number of automations targeting this thread before recovery.</summary>
+    public int AutomationCountBefore { get; init; }
+    /// <summary>Number of automations targeting this thread after recovery and restore checks.</summary>
+    public int AutomationCountAfter { get; init; }
+    /// <summary>Number of automation definitions restored from backup after recovery.</summary>
+    public int AutomationRestoredCount { get; init; }
 }
 
 public sealed partial class CodexLocalStateDiagnosticsService {
+    private sealed class ThreadAutomationBackup {
+        public string AutomationId { get; init; } = string.Empty;
+        public string SourceDirectory { get; init; } = string.Empty;
+        public string BackupDirectory { get; init; } = string.Empty;
+    }
+
     /// <summary>
     /// Backs up the Codex SQLite state database, toggles one thread through an
     /// archived state, then restores its original final active/archived state.
@@ -81,6 +97,7 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         cancellationToken.ThrowIfCancellationRequested();
         var backupDirectory = CreateBackupDirectory(backupRoot);
         var backupDb = Path.Combine(backupDirectory, "state_5.sqlite");
+        var automationBackups = BackupThreadAutomations(home, normalizedThreadId, backupDirectory);
 
         var builder = new SqliteConnectionStringBuilder {
             DataSource = stateDb,
@@ -96,48 +113,175 @@ public sealed partial class CodexLocalStateDiagnosticsService {
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         var hasArchiveColumns = columnNames.Contains("archived") || columnNames.Contains("archived_at");
         if (!columnNames.Contains("id") || !hasArchiveColumns) {
-            return new CodexLocalStateThreadRecoveryResult {
-                CodexHome = home,
-                StateDatabasePath = stateDb,
-                ThreadId = normalizedThreadId,
-                DatabaseExists = true,
-                ArchiveColumnsAvailable = false,
-                BackupDirectory = backupDirectory,
-                BackupDatabasePath = backupDb
-            };
+            return CreateThreadRecoveryResult(
+                home,
+                stateDb,
+                normalizedThreadId,
+                databaseExists: true,
+                archiveColumnsAvailable: false,
+                backupDirectory: backupDirectory,
+                backupDb: backupDb,
+                automationBackups: automationBackups);
         }
 
         var wasArchived = ReadThreadArchivedState(connection, normalizedThreadId, columnNames, cancellationToken);
         if (wasArchived is null) {
-            return new CodexLocalStateThreadRecoveryResult {
-                CodexHome = home,
-                StateDatabasePath = stateDb,
-                ThreadId = normalizedThreadId,
-                DatabaseExists = true,
-                ArchiveColumnsAvailable = true,
-                ThreadFound = false,
-                BackupDirectory = backupDirectory,
-                BackupDatabasePath = backupDb
-            };
+            return CreateThreadRecoveryResult(
+                home,
+                stateDb,
+                normalizedThreadId,
+                databaseExists: true,
+                archiveColumnsAvailable: true,
+                threadFound: false,
+                backupDirectory: backupDirectory,
+                backupDb: backupDb,
+                automationBackups: automationBackups);
         }
 
         using var transaction = connection.BeginTransaction();
         SetThreadArchivedState(connection, transaction, normalizedThreadId, columnNames, archived: true);
         SetThreadArchivedState(connection, transaction, normalizedThreadId, columnNames, archived: wasArchived.Value);
         transaction.Commit();
+        var restoredAutomations = RestoreMissingThreadAutomations(automationBackups);
 
+        return CreateThreadRecoveryResult(
+            home,
+            stateDb,
+            normalizedThreadId,
+            databaseExists: true,
+            archiveColumnsAvailable: true,
+            threadFound: true,
+            wasArchived: wasArchived.Value,
+            finalArchived: wasArchived.Value,
+            backupDirectory: backupDirectory,
+            backupDb: backupDb,
+            automationBackups: automationBackups,
+            automationRestoredCount: restoredAutomations);
+    }
+
+    private static CodexLocalStateThreadRecoveryResult CreateThreadRecoveryResult(
+        string home,
+        string stateDb,
+        string threadId,
+        bool databaseExists,
+        bool archiveColumnsAvailable = false,
+        bool threadFound = false,
+        bool wasArchived = false,
+        bool finalArchived = false,
+        string backupDirectory = "",
+        string backupDb = "",
+        IReadOnlyList<ThreadAutomationBackup>? automationBackups = null,
+        int automationRestoredCount = 0) {
+        var backups = automationBackups ?? [];
         return new CodexLocalStateThreadRecoveryResult {
             CodexHome = home,
             StateDatabasePath = stateDb,
-            ThreadId = normalizedThreadId,
-            DatabaseExists = true,
-            ArchiveColumnsAvailable = true,
-            ThreadFound = true,
-            WasArchived = wasArchived.Value,
-            FinalArchived = wasArchived.Value,
+            ThreadId = threadId,
+            DatabaseExists = databaseExists,
+            ArchiveColumnsAvailable = archiveColumnsAvailable,
+            ThreadFound = threadFound,
+            WasArchived = wasArchived,
+            FinalArchived = finalArchived,
             BackupDirectory = backupDirectory,
-            BackupDatabasePath = backupDb
+            BackupDatabasePath = backupDb,
+            AutomationBackupDirectory = backups.Count > 0
+                ? Path.Combine(backupDirectory, "automations")
+                : string.Empty,
+            AutomationIds = backups.Select(static item => item.AutomationId).ToArray(),
+            AutomationCountBefore = backups.Count,
+            AutomationCountAfter = CountThreadAutomations(home, threadId),
+            AutomationRestoredCount = automationRestoredCount
         };
+    }
+
+    private static IReadOnlyList<ThreadAutomationBackup> BackupThreadAutomations(
+        string codexHome,
+        string threadId,
+        string backupDirectory) {
+        var automationsRoot = Path.Combine(codexHome, "automations");
+        if (!Directory.Exists(automationsRoot)) {
+            return [];
+        }
+
+        var backupRoot = Path.Combine(backupDirectory, "automations");
+        var backups = new List<ThreadAutomationBackup>();
+        foreach (var automationDirectory in Directory.EnumerateDirectories(automationsRoot)) {
+            var definitionPath = Path.Combine(automationDirectory, "automation.toml");
+            if (!File.Exists(definitionPath) || !AutomationTargetsThread(definitionPath, threadId)) {
+                continue;
+            }
+
+            var automationId = Path.GetFileName(automationDirectory);
+            var destination = Path.Combine(backupRoot, automationId);
+            CopyDirectory(automationDirectory, destination, overwrite: true);
+            backups.Add(new ThreadAutomationBackup {
+                AutomationId = automationId,
+                SourceDirectory = automationDirectory,
+                BackupDirectory = destination
+            });
+        }
+
+        return backups;
+    }
+
+    private static int RestoreMissingThreadAutomations(IReadOnlyList<ThreadAutomationBackup> backups) {
+        var restored = 0;
+        foreach (var backup in backups) {
+            var sourceDefinition = Path.Combine(backup.SourceDirectory, "automation.toml");
+            if (File.Exists(sourceDefinition)) {
+                continue;
+            }
+
+            CopyDirectory(backup.BackupDirectory, backup.SourceDirectory, overwrite: true);
+            restored++;
+        }
+
+        return restored;
+    }
+
+    private static int CountThreadAutomations(string codexHome, string threadId) {
+        var automationsRoot = Path.Combine(codexHome, "automations");
+        if (!Directory.Exists(automationsRoot)) {
+            return 0;
+        }
+
+        return Directory.EnumerateDirectories(automationsRoot)
+            .Select(static directory => Path.Combine(directory, "automation.toml"))
+            .Count(path => File.Exists(path) && AutomationTargetsThread(path, threadId));
+    }
+
+    private static bool AutomationTargetsThread(string definitionPath, string threadId) {
+        foreach (var line in File.ReadLines(definitionPath)) {
+            var trimmed = line.Trim();
+            if (!trimmed.StartsWith("target_thread_id", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            var separator = trimmed.IndexOf('=');
+            if (separator < 0) {
+                continue;
+            }
+
+            var value = trimmed.Substring(separator + 1).Trim().Trim('"');
+            if (string.Equals(value, threadId, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void CopyDirectory(string sourceDirectory, string destinationDirectory, bool overwrite) {
+        Directory.CreateDirectory(destinationDirectory);
+        foreach (var file in Directory.EnumerateFiles(sourceDirectory)) {
+            var destination = Path.Combine(destinationDirectory, Path.GetFileName(file));
+            File.Copy(file, destination, overwrite);
+        }
+
+        foreach (var directory in Directory.EnumerateDirectories(sourceDirectory)) {
+            var childDestination = Path.Combine(destinationDirectory, Path.GetFileName(directory));
+            CopyDirectory(directory, childDestination, overwrite);
+        }
     }
 
     private static bool? ReadThreadArchivedState(

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX;
-using Microsoft.Data.Sqlite;
 
 namespace IntelligenceX.Codex;
 
@@ -405,14 +404,7 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         var backupDirectory = CreateBackupDirectory(backupRoot);
         var backupDb = Path.Combine(backupDirectory, "state_5.sqlite");
 
-        var builder = new SqliteConnectionStringBuilder {
-            DataSource = stateDb,
-            Mode = SqliteOpenMode.ReadWrite
-        };
-        using var connection = new SqliteConnection(builder.ConnectionString);
-        connection.Open();
-        SetBusyTimeout(connection, 10000);
-        BackupDatabase(connection, backupDb);
+        _sqlite.BackupDatabase(stateDb, backupDb, busyTimeoutMs: 10000);
 
         var columns = GetTableColumns(stateDb, "threads");
         var columnNames = columns
@@ -433,39 +425,39 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         }
 
         var activeExpr = BuildActiveThreadExpression(columnNames);
-        var rows = ReadActiveThreadPathRows(connection, pathColumns, activeExpr, cancellationToken);
+        using var session = _sqlite.OpenSession(stateDb);
+        var rows = ReadActiveThreadPathRows(session, pathColumns, activeExpr, cancellationToken);
         var scannedValues = 0;
         var changedValues = 0;
         var changedRows = 0;
 
-        using var transaction = connection.BeginTransaction();
-        foreach (var row in rows) {
-            cancellationToken.ThrowIfCancellationRequested();
-            var updates = new List<(string Column, string OriginalValue, string NormalizedValue)>();
-            foreach (var (column, value) in row.Values) {
-                if (string.IsNullOrWhiteSpace(value)) {
+        session.RunInTransaction(transaction => {
+            foreach (var row in rows) {
+                cancellationToken.ThrowIfCancellationRequested();
+                var updates = new List<(string Column, string OriginalValue, string NormalizedValue)>();
+                foreach (var (column, value) in row.Values) {
+                    if (string.IsNullOrWhiteSpace(value)) {
+                        continue;
+                    }
+
+                    scannedValues++;
+                    if (!TryNormalizeExtendedWindowsPath(value!, out var normalized)) {
+                        continue;
+                    }
+
+                    updates.Add((column, value!, normalized));
+                }
+
+                if (updates.Count == 0) {
                     continue;
                 }
 
-                scannedValues++;
-                if (!TryNormalizeExtendedWindowsPath(value!, out var normalized)) {
-                    continue;
+                if (UpdateThreadPathRow(transaction, row.RowId, updates, activeExpr)) {
+                    changedValues += updates.Count;
+                    changedRows++;
                 }
-
-                updates.Add((column, value!, normalized));
             }
-
-            if (updates.Count == 0) {
-                continue;
-            }
-
-            if (UpdateThreadPathRow(connection, transaction, row.RowId, updates, activeExpr)) {
-                changedValues += updates.Count;
-                changedRows++;
-            }
-        }
-
-        transaction.Commit();
+        });
         return new CodexLocalStatePathRepairResult {
             CodexHome = home,
             StateDatabasePath = stateDb,
@@ -605,20 +597,17 @@ public sealed partial class CodexLocalStateDiagnosticsService {
             var activeExpr = BuildActiveThreadExpression(columnNames);
             var selectedColumns = string.Join(", ", pathColumns.Select(QuoteIdentifier));
             var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var builder = new SqliteConnectionStringBuilder {
-                DataSource = stateDb,
-                Mode = SqliteOpenMode.ReadOnly
+            using var sqlite = new SQLite {
+                CommandTimeout = 10
             };
-            using var connection = new SqliteConnection(builder.ConnectionString);
-            connection.Open();
-            using var command = connection.CreateCommand();
-            command.CommandText = $"SELECT {selectedColumns} FROM threads WHERE {activeExpr};";
-            using var reader = command.ExecuteReader();
-            var ordinals = pathColumns.Select(reader.GetOrdinal).ToArray();
-            while (reader.Read()) {
-                foreach (var ordinal in ordinals) {
-                    if (!reader.IsDBNull(ordinal)
-                        && TryResolveActiveSessionPath(reader.GetString(ordinal), out var activePath)) {
+            using var session = sqlite.OpenSession(stateDb);
+            var rows = session.QueryAsList(
+                $"SELECT {selectedColumns} FROM threads WHERE {activeExpr};",
+                row => pathColumns.Select(column => GetNullableString(row, column)).ToArray());
+            foreach (var row in rows) {
+                foreach (var value in row) {
+                    if (!string.IsNullOrWhiteSpace(value)
+                        && TryResolveActiveSessionPath(value!, out var activePath)) {
                         result.Add(activePath);
                     }
                 }
@@ -914,103 +903,62 @@ public sealed partial class CodexLocalStateDiagnosticsService {
     }
 
     private static IReadOnlyList<(string Name, string Type)> GetTableColumns(string stateDb, string table) {
-        var columns = new List<(string Name, string Type)>();
-        var builder = new SqliteConnectionStringBuilder {
-            DataSource = stateDb,
-            Mode = SqliteOpenMode.ReadOnly
+        using var sqlite = new SQLite {
+            ReturnType = ReturnType.DataTable,
+            CommandTimeout = 10
         };
-        using var connection = new SqliteConnection(builder.ConnectionString);
-        connection.Open();
-        using var command = connection.CreateCommand();
-        command.CommandText = $"PRAGMA table_info({QuoteString(table)});";
-        using var reader = command.ExecuteReader();
-        var nameOrdinal = reader.GetOrdinal("name");
-        var typeOrdinal = reader.GetOrdinal("type");
-        while (reader.Read()) {
-            var name = reader.IsDBNull(nameOrdinal) ? string.Empty : reader.GetString(nameOrdinal);
-            if (string.IsNullOrWhiteSpace(name)) {
-                continue;
-            }
-
-            var type = reader.IsDBNull(typeOrdinal) ? string.Empty : reader.GetString(typeOrdinal);
-            columns.Add((name, type));
-        }
-
-        return columns;
+        using var session = sqlite.OpenSession(stateDb);
+        return session.QueryAsList(
+                $"PRAGMA table_info({QuoteString(table)});",
+                static row => (
+                    Name: GetString(row, "name"),
+                    Type: GetString(row, "type")))
+            .Where(static column => !string.IsNullOrWhiteSpace(column.Name))
+            .ToArray();
     }
 
     private static IReadOnlyList<(long RowId, IReadOnlyList<(string Column, string? Value)> Values)> ReadActiveThreadPathRows(
-        SqliteConnection connection,
+        SQLiteSession session,
         IReadOnlyList<string> pathColumns,
         string activeExpr,
         CancellationToken cancellationToken) {
         var selectedColumns = string.Join(", ", pathColumns.Select(QuoteIdentifier));
-        using var command = connection.CreateCommand();
-        command.CommandText = $"SELECT rowid AS __ix_rowid, {selectedColumns} FROM threads WHERE {activeExpr};";
-        using var reader = command.ExecuteReader();
-        var rowIdOrdinal = reader.GetOrdinal("__ix_rowid");
-        var columnOrdinals = pathColumns
-            .Select(column => (Column: column, Ordinal: reader.GetOrdinal(column)))
-            .ToArray();
-        var rows = new List<(long RowId, IReadOnlyList<(string Column, string? Value)> Values)>();
-        while (reader.Read()) {
-            cancellationToken.ThrowIfCancellationRequested();
-            var values = new List<(string Column, string? Value)>(columnOrdinals.Length);
-            foreach (var (column, ordinal) in columnOrdinals) {
-                values.Add((column, reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal)));
-            }
+        return session.QueryAsList(
+            $"SELECT rowid AS __ix_rowid, {selectedColumns} FROM threads WHERE {activeExpr};",
+            row => {
+                cancellationToken.ThrowIfCancellationRequested();
+                var values = new List<(string Column, string? Value)>(pathColumns.Count);
+                foreach (var column in pathColumns) {
+                    values.Add((column, GetNullableString(row, column)));
+                }
 
-            rows.Add((reader.GetInt64(rowIdOrdinal), values));
-        }
-
-        return rows;
+                return (RowId: Convert.ToInt64(row.GetValue(row.GetOrdinal("__ix_rowid")), CultureInfo.InvariantCulture), Values: (IReadOnlyList<(string Column, string? Value)>)values);
+            });
     }
 
     private static bool UpdateThreadPathRow(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
+        SQLiteSession session,
         long rowId,
         IReadOnlyList<(string Column, string OriginalValue, string NormalizedValue)> updates,
         string activeExpr) {
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = "UPDATE threads SET "
-                              + string.Join(", ", updates.Select((item, index) => $"{QuoteIdentifier(item.Column)} = @p{index.ToString(CultureInfo.InvariantCulture)}"))
-                              + " WHERE rowid = @rowid AND "
-                              + activeExpr
-                              + " AND "
-                              + string.Join(" AND ", updates.Select((item, index) => $"{QuoteIdentifier(item.Column)} = @old{index.ToString(CultureInfo.InvariantCulture)}"))
-                              + ";";
+        var parameters = new Dictionary<string, object?> {
+            ["@rowid"] = rowId
+        };
         var parameterIndex = 0;
         foreach (var item in updates) {
-            command.Parameters.AddWithValue("@p" + parameterIndex.ToString(CultureInfo.InvariantCulture), item.NormalizedValue);
-            command.Parameters.AddWithValue("@old" + parameterIndex.ToString(CultureInfo.InvariantCulture), item.OriginalValue);
+            parameters["@p" + parameterIndex.ToString(CultureInfo.InvariantCulture)] = item.NormalizedValue;
+            parameters["@old" + parameterIndex.ToString(CultureInfo.InvariantCulture)] = item.OriginalValue;
             parameterIndex++;
         }
 
-        command.Parameters.AddWithValue("@rowid", rowId);
-        return command.ExecuteNonQuery() == 1;
-    }
-
-    private static void BackupDatabase(SqliteConnection sourceConnection, string backupDb) {
-        var directory = Path.GetDirectoryName(backupDb);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            Directory.CreateDirectory(directory);
-        }
-
-        var builder = new SqliteConnectionStringBuilder {
-            DataSource = backupDb,
-            Mode = SqliteOpenMode.ReadWriteCreate
-        };
-        using var destination = new SqliteConnection(builder.ConnectionString);
-        destination.Open();
-        sourceConnection.BackupDatabase(destination);
-    }
-
-    private static void SetBusyTimeout(SqliteConnection connection, int milliseconds) {
-        using var command = connection.CreateCommand();
-        command.CommandText = "PRAGMA busy_timeout = " + milliseconds.ToString(CultureInfo.InvariantCulture) + ";";
-        command.ExecuteNonQuery();
+        var command = "UPDATE threads SET "
+                      + string.Join(", ", updates.Select((item, index) => $"{QuoteIdentifier(item.Column)} = @p{index.ToString(CultureInfo.InvariantCulture)}"))
+                      + " WHERE rowid = @rowid AND "
+                      + activeExpr
+                      + " AND "
+                      + string.Join(" AND ", updates.Select((item, index) => $"{QuoteIdentifier(item.Column)} = @old{index.ToString(CultureInfo.InvariantCulture)}"))
+                      + ";";
+        return session.ExecuteNonQuery(command, parameters) == 1;
     }
 
     private static int CountConfigExtendedPaths(string codexHome) {
@@ -1034,6 +982,21 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         return value is DataTable table
             ? table.Rows.Cast<DataRow>().ToArray()
             : [];
+    }
+
+    private static string GetString(IDataRecord row, string column) {
+        var ordinal = row.GetOrdinal(column);
+        return row.IsDBNull(ordinal) ? string.Empty : Convert.ToString(row.GetValue(ordinal), CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+
+    private static string? GetNullableString(IDataRecord row, string column) {
+        var ordinal = row.GetOrdinal(column);
+        return row.IsDBNull(ordinal) ? null : Convert.ToString(row.GetValue(ordinal), CultureInfo.InvariantCulture);
+    }
+
+    private static bool IsSqliteProviderException(Exception exception) {
+        return string.Equals(exception.GetType().FullName, "Microsoft.Data.Sqlite.SqliteException", StringComparison.Ordinal)
+               || exception.InnerException is not null && IsSqliteProviderException(exception.InnerException);
     }
 
     private static CodexLocalStateHealthStatus BuildStatus(

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
@@ -1069,7 +1069,7 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         int recoverableBrokenThreadCandidateCount) {
         return string.Format(
             CultureInfo.InvariantCulture,
-            "{0} active threads • {1} SQLite path findings • {2} config paths • {3} metadata warnings • {4} broken candidates ({5} recoverable)",
+            "{0} active threads • {1} SQLite path findings • {2} config paths • {3} metadata warnings • {4} failure-log candidates ({5} active recoverable)",
             activeThreadCount,
             extendedPathCount,
             configExtendedPathCount,

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
@@ -100,6 +100,8 @@ public sealed class CodexLocalStateDiagnostics {
     public int ActiveThreadCount { get; init; }
     /// <summary>Number of recent broken-thread candidates found in local Codex logs.</summary>
     public int BrokenThreadCandidateCount { get; init; }
+    /// <summary>Number of recent broken-thread candidates that are active and can be refreshed automatically.</summary>
+    public int RecoverableBrokenThreadCandidateCount { get; init; }
     /// <summary>Main SQLite state database file size in bytes.</summary>
     public long StateDatabaseBytes { get; init; }
     /// <summary>Total SQLite state size including WAL and shared-memory files.</summary>
@@ -265,6 +267,8 @@ public sealed partial class CodexLocalStateDiagnosticsService {
                 oversizedMetadataCount));
         }
 
+        var recoverableBrokenThreadCandidateCount = brokenThreadCandidates.Count(static item => item.ThreadFound && !item.IsArchived);
+
         if (brokenThreadCandidates.Count > 0) {
             findings.Add(new CodexLocalStateFinding(
                 "broken-thread-candidates",
@@ -280,12 +284,13 @@ public sealed partial class CodexLocalStateDiagnosticsService {
             ScannedAtUtc = DateTimeOffset.UtcNow,
             Status = status,
             StatusText = BuildStatusText(status, findings),
-            DetailText = BuildDetailText(activeThreadCount, extendedPathCount, configExtendedPathCount, oversizedMetadataCount, brokenThreadCandidates.Count),
+            DetailText = BuildDetailText(activeThreadCount, extendedPathCount, configExtendedPathCount, oversizedMetadataCount, brokenThreadCandidates.Count, recoverableBrokenThreadCandidateCount),
             ExtendedPathCount = extendedPathCount,
             ConfigExtendedPathCount = configExtendedPathCount,
             OversizedThreadMetadataCount = oversizedMetadataCount,
             ActiveThreadCount = activeThreadCount,
             BrokenThreadCandidateCount = brokenThreadCandidates.Count,
+            RecoverableBrokenThreadCandidateCount = recoverableBrokenThreadCandidateCount,
             StateDatabaseBytes = sqliteDiagnostics.DatabaseFileSizeBytes,
             StateDatabaseTotalBytes = sqliteDiagnostics.TotalFileSizeBytes,
             SQLiteVersion = sqliteDiagnostics.SQLiteVersion,
@@ -1060,15 +1065,17 @@ public sealed partial class CodexLocalStateDiagnosticsService {
         int extendedPathCount,
         int configExtendedPathCount,
         int oversizedMetadataCount,
-        int brokenThreadCandidateCount) {
+        int brokenThreadCandidateCount,
+        int recoverableBrokenThreadCandidateCount) {
         return string.Format(
             CultureInfo.InvariantCulture,
-            "{0} active threads • {1} SQLite path findings • {2} config paths • {3} metadata warnings • {4} broken candidates",
+            "{0} active threads • {1} SQLite path findings • {2} config paths • {3} metadata warnings • {4} broken candidates ({5} recoverable)",
             activeThreadCount,
             extendedPathCount,
             configExtendedPathCount,
             oversizedMetadataCount,
-            brokenThreadCandidateCount);
+            brokenThreadCandidateCount,
+            recoverableBrokenThreadCandidateCount);
     }
 
     private static bool IsTextColumn(string? columnType) {

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
@@ -58,6 +58,23 @@ public sealed record CodexLocalStateArea(
     string Recommendation);
 
 /// <summary>
+/// A Codex thread id observed in recent local failure logs that may benefit from archive-state refresh.
+/// </summary>
+/// <param name="ThreadId">Codex thread id found in a failure log entry.</param>
+/// <param name="Title">Current local thread title, when available.</param>
+/// <param name="FailureCount">Number of matching recent failure log entries.</param>
+/// <param name="LastSeenUtc">Most recent matching failure timestamp.</param>
+/// <param name="ThreadFound">Whether the thread id exists in local state.</param>
+/// <param name="IsArchived">Whether the local thread is currently archived, when found.</param>
+public sealed record CodexLocalStateBrokenThreadCandidate(
+    string ThreadId,
+    string Title,
+    int FailureCount,
+    DateTimeOffset LastSeenUtc,
+    bool ThreadFound,
+    bool IsArchived);
+
+/// <summary>
 /// Snapshot of local Codex state health.
 /// </summary>
 public sealed class CodexLocalStateDiagnostics {
@@ -81,6 +98,8 @@ public sealed class CodexLocalStateDiagnostics {
     public int OversizedThreadMetadataCount { get; init; }
     /// <summary>Number of active threads found in the Codex state database.</summary>
     public int ActiveThreadCount { get; init; }
+    /// <summary>Number of recent broken-thread candidates found in local Codex logs.</summary>
+    public int BrokenThreadCandidateCount { get; init; }
     /// <summary>Main SQLite state database file size in bytes.</summary>
     public long StateDatabaseBytes { get; init; }
     /// <summary>Total SQLite state size including WAL and shared-memory files.</summary>
@@ -97,6 +116,8 @@ public sealed class CodexLocalStateDiagnostics {
     public bool CanConnect { get; init; }
     /// <summary>Detailed local Codex storage areas.</summary>
     public IReadOnlyList<CodexLocalStateArea> Areas { get; init; } = [];
+    /// <summary>Recent thread ids found in Codex failure logs.</summary>
+    public IReadOnlyList<CodexLocalStateBrokenThreadCandidate> BrokenThreadCandidates { get; init; } = [];
     /// <summary>Detailed local state findings.</summary>
     public IReadOnlyList<CodexLocalStateFinding> Findings { get; init; } = [];
 }
@@ -147,7 +168,7 @@ public sealed class CodexLocalStateCleanupResult {
 /// Reads local Codex Desktop/CLI state in a read-only way and summarizes issues
 /// that can make resume/navigation brittle.
 /// </summary>
-public sealed class CodexLocalStateDiagnosticsService {
+public sealed partial class CodexLocalStateDiagnosticsService {
     private const int DefaultTitleLimit = 120;
     private const int DefaultPreviewLimit = 240;
     private const long LargeLogsWarningBytes = 256L * 1024L * 1024L;
@@ -196,11 +217,13 @@ public sealed class CodexLocalStateDiagnosticsService {
         var extendedPathCount = 0;
         var activeThreadCount = 0;
         var oversizedMetadataCount = 0;
+        IReadOnlyList<CodexLocalStateBrokenThreadCandidate> brokenThreadCandidates = [];
         if (sqliteDiagnostics.CanConnect) {
             extendedPathCount = CountExtendedPathRows(stateDb, findings);
             var metadata = CountThreadMetadata(stateDb);
             activeThreadCount = metadata.ActiveThreads;
             oversizedMetadataCount = metadata.OversizedRows;
+            brokenThreadCandidates = CollectBrokenThreadCandidates(home, stateDb, cancellationToken);
         }
 
         var areas = CollectAreas(home, stateDb, sqliteDiagnostics.TotalFileSizeBytes);
@@ -242,6 +265,14 @@ public sealed class CodexLocalStateDiagnosticsService {
                 oversizedMetadataCount));
         }
 
+        if (brokenThreadCandidates.Count > 0) {
+            findings.Add(new CodexLocalStateFinding(
+                "broken-thread-candidates",
+                CodexLocalStateHealthStatus.Warning,
+                $"{brokenThreadCandidates.Count.ToString(CultureInfo.InvariantCulture)} recent Codex thread(s) have agent-loop/start-turn failure logs.",
+                brokenThreadCandidates.Count));
+        }
+
         var status = BuildStatus(findings, sqliteDiagnostics.Exists, sqliteDiagnostics.CanConnect);
         return new CodexLocalStateDiagnostics {
             CodexHome = home,
@@ -249,11 +280,12 @@ public sealed class CodexLocalStateDiagnosticsService {
             ScannedAtUtc = DateTimeOffset.UtcNow,
             Status = status,
             StatusText = BuildStatusText(status, findings),
-            DetailText = BuildDetailText(activeThreadCount, extendedPathCount, configExtendedPathCount, oversizedMetadataCount),
+            DetailText = BuildDetailText(activeThreadCount, extendedPathCount, configExtendedPathCount, oversizedMetadataCount, brokenThreadCandidates.Count),
             ExtendedPathCount = extendedPathCount,
             ConfigExtendedPathCount = configExtendedPathCount,
             OversizedThreadMetadataCount = oversizedMetadataCount,
             ActiveThreadCount = activeThreadCount,
+            BrokenThreadCandidateCount = brokenThreadCandidates.Count,
             StateDatabaseBytes = sqliteDiagnostics.DatabaseFileSizeBytes,
             StateDatabaseTotalBytes = sqliteDiagnostics.TotalFileSizeBytes,
             SQLiteVersion = sqliteDiagnostics.SQLiteVersion,
@@ -262,6 +294,7 @@ public sealed class CodexLocalStateDiagnosticsService {
             DatabaseExists = sqliteDiagnostics.Exists,
             CanConnect = sqliteDiagnostics.CanConnect,
             Areas = areas,
+            BrokenThreadCandidates = brokenThreadCandidates,
             Findings = findings
         };
     }
@@ -1026,14 +1059,16 @@ public sealed class CodexLocalStateDiagnosticsService {
         int activeThreadCount,
         int extendedPathCount,
         int configExtendedPathCount,
-        int oversizedMetadataCount) {
+        int oversizedMetadataCount,
+        int brokenThreadCandidateCount) {
         return string.Format(
             CultureInfo.InvariantCulture,
-            "{0} active threads • {1} SQLite path findings • {2} config paths • {3} metadata warnings",
+            "{0} active threads • {1} SQLite path findings • {2} config paths • {3} metadata warnings • {4} broken candidates",
             activeThreadCount,
             extendedPathCount,
             configExtendedPathCount,
-            oversizedMetadataCount);
+            oversizedMetadataCount,
+            brokenThreadCandidateCount);
     }
 
     private static bool IsTextColumn(string? columnType) {

--- a/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Storage.SQLite/Codex/CodexLocalStateDiagnostics.cs
@@ -64,15 +64,19 @@ public sealed record CodexLocalStateArea(
 /// <param name="Title">Current local thread title, when available.</param>
 /// <param name="FailureCount">Number of matching recent failure log entries.</param>
 /// <param name="LastSeenUtc">Most recent matching failure timestamp.</param>
+/// <param name="LastActivityUtc">Most recent local thread activity timestamp, when available.</param>
 /// <param name="ThreadFound">Whether the thread id exists in local state.</param>
 /// <param name="IsArchived">Whether the local thread is currently archived, when found.</param>
+/// <param name="IsCurrent">Whether the failure is newer than the last known local thread activity.</param>
 public sealed record CodexLocalStateBrokenThreadCandidate(
     string ThreadId,
     string Title,
     int FailureCount,
     DateTimeOffset LastSeenUtc,
+    DateTimeOffset? LastActivityUtc,
     bool ThreadFound,
-    bool IsArchived);
+    bool IsArchived,
+    bool IsCurrent);
 
 /// <summary>
 /// Snapshot of local Codex state health.
@@ -267,13 +271,13 @@ public sealed partial class CodexLocalStateDiagnosticsService {
                 oversizedMetadataCount));
         }
 
-        var recoverableBrokenThreadCandidateCount = brokenThreadCandidates.Count(static item => item.ThreadFound && !item.IsArchived);
+        var recoverableBrokenThreadCandidateCount = brokenThreadCandidates.Count(static item => item.ThreadFound && !item.IsArchived && item.IsCurrent);
 
         if (brokenThreadCandidates.Count > 0) {
             findings.Add(new CodexLocalStateFinding(
                 "broken-thread-candidates",
                 CodexLocalStateHealthStatus.Warning,
-                $"{brokenThreadCandidates.Count.ToString(CultureInfo.InvariantCulture)} recent Codex thread(s) have agent-loop/start-turn failure logs.",
+                $"{brokenThreadCandidates.Count.ToString(CultureInfo.InvariantCulture)} recent Codex thread failure-log candidate(s) were found.",
                 brokenThreadCandidates.Count));
         }
 

--- a/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
@@ -343,29 +343,45 @@ internal static partial class Program {
                     id TEXT PRIMARY KEY,
                     title TEXT,
                     archived INTEGER,
-                    archived_at INTEGER
+                    archived_at INTEGER,
+                    updated_at INTEGER,
+                    recency_at INTEGER
                 );
                 """);
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
             sqlite.ExecuteNonQuery(
                 dbPath,
                 """
-                INSERT INTO threads (id, title, archived, archived_at)
-                VALUES (@id, @title, 0, NULL);
+                INSERT INTO threads (id, title, archived, archived_at, updated_at, recency_at)
+                VALUES (@id, @title, 0, NULL, @updatedAt, NULL);
                 """,
                 new Dictionary<string, object?> {
                     ["@id"] = "12121212-1212-1212-1212-121212121212",
-                    ["@title"] = "recoverable candidate"
+                    ["@title"] = "recoverable candidate",
+                    ["@updatedAt"] = now - 100
                 });
             sqlite.ExecuteNonQuery(
                 dbPath,
                 """
-                INSERT INTO threads (id, title, archived, archived_at)
-                VALUES (@id, @title, 1, @archivedAt);
+                INSERT INTO threads (id, title, archived, archived_at, updated_at, recency_at)
+                VALUES (@id, @title, 1, @archivedAt, @updatedAt, NULL);
                 """,
                 new Dictionary<string, object?> {
                     ["@id"] = "34343434-3434-3434-3434-343434343434",
                     ["@title"] = "archived candidate",
-                    ["@archivedAt"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+                    ["@archivedAt"] = now,
+                    ["@updatedAt"] = now - 100
+                });
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                INSERT INTO threads (id, title, archived, archived_at, updated_at, recency_at)
+                VALUES (@id, @title, 0, NULL, @updatedAt, NULL);
+                """,
+                new Dictionary<string, object?> {
+                    ["@id"] = "56565656-5656-5656-5656-565656565656",
+                    ["@title"] = "stale active candidate",
+                    ["@updatedAt"] = now
                 });
             sqlite.ExecuteNonQuery(
                 logsDbPath,
@@ -416,6 +432,16 @@ internal static partial class Program {
                 VALUES (@ts, 'WARN', 'codex_app_server::mcp_refresh', @body, NULL);
                 """,
                 new Dictionary<string, object?> {
+                    ["@ts"] = now - 50,
+                    ["@body"] = "failed to queue MCP refresh for thread 56565656-5656-5656-5656-565656565656: internal error; agent loop died unexpectedly"
+                });
+            sqlite.ExecuteNonQuery(
+                logsDbPath,
+                """
+                INSERT INTO logs (ts, level, target, feedback_log_body, thread_id)
+                VALUES (@ts, 'WARN', 'codex_app_server::mcp_refresh', @body, NULL);
+                """,
+                new Dictionary<string, object?> {
                     ["@ts"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
                     ["@body"] = "user pasted unrelated id aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa while discussing agent loop died"
                 });
@@ -435,16 +461,20 @@ internal static partial class Program {
             var diagnostics = service.CollectAsync(codexHome).GetAwaiter().GetResult();
             var candidate = diagnostics.BrokenThreadCandidates.Single(item => item.ThreadId == "12121212-1212-1212-1212-121212121212");
             var archivedCandidate = diagnostics.BrokenThreadCandidates.Single(item => item.ThreadId == "34343434-3434-3434-3434-343434343434");
+            var staleCandidate = diagnostics.BrokenThreadCandidates.Single(item => item.ThreadId == "56565656-5656-5656-5656-565656565656");
 
             AssertEqual(CodexLocalStateHealthStatus.Warning, diagnostics.Status, "codex broken thread status");
-            AssertEqual(2, diagnostics.BrokenThreadCandidateCount, "codex broken thread candidate count");
+            AssertEqual(3, diagnostics.BrokenThreadCandidateCount, "codex broken thread candidate count");
             AssertEqual(1, diagnostics.RecoverableBrokenThreadCandidateCount, "codex recoverable broken thread candidate count");
             AssertEqual("12121212-1212-1212-1212-121212121212", candidate.ThreadId, "codex broken thread candidate id");
             AssertEqual(true, candidate.ThreadFound, "codex broken thread candidate found");
             AssertEqual(false, candidate.IsArchived, "codex broken thread candidate active");
+            AssertEqual(true, candidate.IsCurrent, "codex broken thread candidate current");
             AssertEqual(2, candidate.FailureCount, "codex broken thread candidate failures");
             AssertEqual(true, archivedCandidate.ThreadFound, "codex archived broken thread candidate found");
             AssertEqual(true, archivedCandidate.IsArchived, "codex archived broken thread candidate archived");
+            AssertEqual(false, staleCandidate.IsArchived, "codex stale broken thread candidate active");
+            AssertEqual(false, staleCandidate.IsCurrent, "codex stale broken thread candidate not current");
             AssertEqual(true, diagnostics.Findings.Any(f => f.Key == "broken-thread-candidates"), "codex broken thread finding");
         } finally {
             TryDeleteCodexDiagnosticsDirectory(root);

--- a/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
@@ -248,6 +248,143 @@ internal static partial class Program {
         }
     }
 
+    private static void TestCodexLocalStateDiagnosticsRecoversThreadArchiveState() {
+        var root = CreateCodexDiagnosticsTempDirectory();
+        try {
+            var codexHome = Path.Combine(root, ".codex");
+            var backupRoot = Path.Combine(root, "backups");
+            Directory.CreateDirectory(codexHome);
+            var dbPath = Path.Combine(codexHome, "state_5.sqlite");
+            var sqlite = new SQLite();
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    title TEXT,
+                    archived INTEGER,
+                    archived_at INTEGER
+                );
+                """);
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                INSERT INTO threads (id, title, archived, archived_at)
+                VALUES (@id, @title, 0, NULL);
+                """,
+                new Dictionary<string, object?> {
+                    ["@id"] = "abababab-abab-abab-abab-abababababab",
+                    ["@title"] = "active thread"
+                });
+
+            var service = new CodexLocalStateDiagnosticsService();
+            var result = service
+                .RecoverThreadArchiveStateAsync("abababab-abab-abab-abab-abababababab", codexHome, backupRoot)
+                .GetAwaiter()
+                .GetResult();
+            var archived = Convert.ToInt32(sqlite.ExecuteScalar(
+                dbPath,
+                "SELECT archived FROM threads WHERE id = @id;",
+                new Dictionary<string, object?> {
+                    ["@id"] = "abababab-abab-abab-abab-abababababab"
+                }), CultureInfo.InvariantCulture);
+            var archivedAt = sqlite.ExecuteScalar(
+                dbPath,
+                "SELECT archived_at FROM threads WHERE id = @id;",
+                new Dictionary<string, object?> {
+                    ["@id"] = "abababab-abab-abab-abab-abababababab"
+                });
+
+            AssertEqual(true, result.DatabaseExists, "codex thread recovery database exists");
+            AssertEqual(true, result.ArchiveColumnsAvailable, "codex thread recovery archive columns");
+            AssertEqual(true, result.ThreadFound, "codex thread recovery found target");
+            AssertEqual(false, result.WasArchived, "codex thread recovery original active");
+            AssertEqual(false, result.FinalArchived, "codex thread recovery final active");
+            AssertEqual(true, File.Exists(result.BackupDatabasePath), "codex thread recovery backup exists");
+            AssertEqual(0, archived, "codex thread recovery active archived flag");
+            AssertEqual(true, archivedAt is null || archivedAt is DBNull, "codex thread recovery active archived_at");
+        } finally {
+            TryDeleteCodexDiagnosticsDirectory(root);
+        }
+    }
+
+    private static void TestCodexLocalStateDiagnosticsDetectsBrokenThreadCandidates() {
+        var root = CreateCodexDiagnosticsTempDirectory();
+        try {
+            var codexHome = Path.Combine(root, ".codex");
+            Directory.CreateDirectory(codexHome);
+            var dbPath = Path.Combine(codexHome, "state_5.sqlite");
+            var logsDbPath = Path.Combine(codexHome, "logs_2.sqlite");
+            var sqlite = new SQLite();
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    title TEXT,
+                    archived INTEGER,
+                    archived_at INTEGER
+                );
+                """);
+            sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                INSERT INTO threads (id, title, archived, archived_at)
+                VALUES (@id, @title, 0, NULL);
+                """,
+                new Dictionary<string, object?> {
+                    ["@id"] = "12121212-1212-1212-1212-121212121212",
+                    ["@title"] = "recoverable candidate"
+                });
+            sqlite.ExecuteNonQuery(
+                logsDbPath,
+                """
+                CREATE TABLE logs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts INTEGER NOT NULL,
+                    level TEXT NOT NULL,
+                    target TEXT NOT NULL,
+                    feedback_log_body TEXT,
+                    thread_id TEXT
+                );
+                """);
+            sqlite.ExecuteNonQuery(
+                logsDbPath,
+                """
+                INSERT INTO logs (ts, level, target, feedback_log_body, thread_id)
+                VALUES (@ts, 'WARN', 'codex_app_server::mcp_refresh', @body, NULL);
+                """,
+                new Dictionary<string, object?> {
+                    ["@ts"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                    ["@body"] = "failed to queue MCP refresh for thread 12121212-1212-1212-1212-121212121212: internal error; agent loop died unexpectedly"
+                });
+            sqlite.ExecuteNonQuery(
+                logsDbPath,
+                """
+                INSERT INTO logs (ts, level, target, feedback_log_body, thread_id)
+                VALUES (@ts, 'WARN', 'codex_app_server::mcp_refresh', @body, NULL);
+                """,
+                new Dictionary<string, object?> {
+                    ["@ts"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                    ["@body"] = "user pasted unrelated id aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa while discussing agent loop died"
+                });
+
+            var service = new CodexLocalStateDiagnosticsService();
+            var diagnostics = service.CollectAsync(codexHome).GetAwaiter().GetResult();
+            var candidate = diagnostics.BrokenThreadCandidates.Single();
+
+            AssertEqual(CodexLocalStateHealthStatus.Warning, diagnostics.Status, "codex broken thread status");
+            AssertEqual(1, diagnostics.BrokenThreadCandidateCount, "codex broken thread candidate count");
+            AssertEqual("12121212-1212-1212-1212-121212121212", candidate.ThreadId, "codex broken thread candidate id");
+            AssertEqual(true, candidate.ThreadFound, "codex broken thread candidate found");
+            AssertEqual(false, candidate.IsArchived, "codex broken thread candidate active");
+            AssertEqual(1, candidate.FailureCount, "codex broken thread candidate failures");
+            AssertEqual(true, diagnostics.Findings.Any(f => f.Key == "broken-thread-candidates"), "codex broken thread finding");
+        } finally {
+            TryDeleteCodexDiagnosticsDirectory(root);
+        }
+    }
+
     private static void TestCodexLocalStateDiagnosticsReportsStorageAreas() {
         var root = CreateCodexDiagnosticsTempDirectory();
         try {

--- a/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
@@ -388,6 +388,17 @@ internal static partial class Program {
                     ["@ts"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
                     ["@body"] = "user pasted unrelated id aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa while discussing agent loop died"
                 });
+            sqlite.ExecuteNonQuery(
+                logsDbPath,
+                """
+                INSERT INTO logs (ts, level, target, feedback_log_body, thread_id)
+                VALUES (@ts, 'INFO', 'codex_core::session', @body, @threadId);
+                """,
+                new Dictionary<string, object?> {
+                    ["@ts"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                    ["@body"] = "session_loop{thread_id=12121212-1212-1212-1212-121212121212}: diagnostic command text mentions agent loop died unexpectedly",
+                    ["@threadId"] = "12121212-1212-1212-1212-121212121212"
+                });
 
             var service = new CodexLocalStateDiagnosticsService();
             var diagnostics = service.CollectAsync(codexHome).GetAwaiter().GetResult();

--- a/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
@@ -357,6 +357,17 @@ internal static partial class Program {
                     ["@title"] = "recoverable candidate"
                 });
             sqlite.ExecuteNonQuery(
+                dbPath,
+                """
+                INSERT INTO threads (id, title, archived, archived_at)
+                VALUES (@id, @title, 1, @archivedAt);
+                """,
+                new Dictionary<string, object?> {
+                    ["@id"] = "34343434-3434-3434-3434-343434343434",
+                    ["@title"] = "archived candidate",
+                    ["@archivedAt"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+                });
+            sqlite.ExecuteNonQuery(
                 logsDbPath,
                 """
                 CREATE TABLE logs (
@@ -386,6 +397,16 @@ internal static partial class Program {
                 """,
                 new Dictionary<string, object?> {
                     ["@ts"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                    ["@body"] = "failed to queue MCP refresh for thread 34343434-3434-3434-3434-343434343434: internal error; agent loop died unexpectedly"
+                });
+            sqlite.ExecuteNonQuery(
+                logsDbPath,
+                """
+                INSERT INTO logs (ts, level, target, feedback_log_body, thread_id)
+                VALUES (@ts, 'WARN', 'codex_app_server::mcp_refresh', @body, NULL);
+                """,
+                new Dictionary<string, object?> {
+                    ["@ts"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
                     ["@body"] = "user pasted unrelated id aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa while discussing agent loop died"
                 });
             sqlite.ExecuteNonQuery(
@@ -402,14 +423,18 @@ internal static partial class Program {
 
             var service = new CodexLocalStateDiagnosticsService();
             var diagnostics = service.CollectAsync(codexHome).GetAwaiter().GetResult();
-            var candidate = diagnostics.BrokenThreadCandidates.Single();
+            var candidate = diagnostics.BrokenThreadCandidates.Single(item => item.ThreadId == "12121212-1212-1212-1212-121212121212");
+            var archivedCandidate = diagnostics.BrokenThreadCandidates.Single(item => item.ThreadId == "34343434-3434-3434-3434-343434343434");
 
             AssertEqual(CodexLocalStateHealthStatus.Warning, diagnostics.Status, "codex broken thread status");
-            AssertEqual(1, diagnostics.BrokenThreadCandidateCount, "codex broken thread candidate count");
+            AssertEqual(2, diagnostics.BrokenThreadCandidateCount, "codex broken thread candidate count");
+            AssertEqual(1, diagnostics.RecoverableBrokenThreadCandidateCount, "codex recoverable broken thread candidate count");
             AssertEqual("12121212-1212-1212-1212-121212121212", candidate.ThreadId, "codex broken thread candidate id");
             AssertEqual(true, candidate.ThreadFound, "codex broken thread candidate found");
             AssertEqual(false, candidate.IsArchived, "codex broken thread candidate active");
             AssertEqual(1, candidate.FailureCount, "codex broken thread candidate failures");
+            AssertEqual(true, archivedCandidate.ThreadFound, "codex archived broken thread candidate found");
+            AssertEqual(true, archivedCandidate.IsArchived, "codex archived broken thread candidate archived");
             AssertEqual(true, diagnostics.Findings.Any(f => f.Key == "broken-thread-candidates"), "codex broken thread finding");
         } finally {
             TryDeleteCodexDiagnosticsDirectory(root);

--- a/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
@@ -397,6 +397,16 @@ internal static partial class Program {
                 """,
                 new Dictionary<string, object?> {
                     ["@ts"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                    ["@body"] = " \t\r\nfailed to queue MCP refresh for thread 12121212-1212-1212-1212-121212121212: internal error; agent loop died unexpectedly"
+                });
+            sqlite.ExecuteNonQuery(
+                logsDbPath,
+                """
+                INSERT INTO logs (ts, level, target, feedback_log_body, thread_id)
+                VALUES (@ts, 'WARN', 'codex_app_server::mcp_refresh', @body, NULL);
+                """,
+                new Dictionary<string, object?> {
+                    ["@ts"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
                     ["@body"] = "failed to queue MCP refresh for thread 34343434-3434-3434-3434-343434343434: internal error; agent loop died unexpectedly"
                 });
             sqlite.ExecuteNonQuery(
@@ -432,7 +442,7 @@ internal static partial class Program {
             AssertEqual("12121212-1212-1212-1212-121212121212", candidate.ThreadId, "codex broken thread candidate id");
             AssertEqual(true, candidate.ThreadFound, "codex broken thread candidate found");
             AssertEqual(false, candidate.IsArchived, "codex broken thread candidate active");
-            AssertEqual(1, candidate.FailureCount, "codex broken thread candidate failures");
+            AssertEqual(2, candidate.FailureCount, "codex broken thread candidate failures");
             AssertEqual(true, archivedCandidate.ThreadFound, "codex archived broken thread candidate found");
             AssertEqual(true, archivedCandidate.IsArchived, "codex archived broken thread candidate archived");
             AssertEqual(true, diagnostics.Findings.Any(f => f.Key == "broken-thread-candidates"), "codex broken thread finding");

--- a/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
+++ b/IntelligenceX.Tests/Program.CodexLocalStateDiagnostics.cs
@@ -254,6 +254,20 @@ internal static partial class Program {
             var codexHome = Path.Combine(root, ".codex");
             var backupRoot = Path.Combine(root, "backups");
             Directory.CreateDirectory(codexHome);
+            var automationDirectory = Path.Combine(codexHome, "automations", "recheck-thread");
+            Directory.CreateDirectory(automationDirectory);
+            var automationPath = Path.Combine(automationDirectory, "automation.toml");
+            File.WriteAllText(
+                automationPath,
+                """
+                version = 1
+                id = "recheck-thread"
+                kind = "heartbeat"
+                name = "Recheck Thread"
+                status = "ACTIVE"
+                rrule = "FREQ=MINUTELY;INTERVAL=15"
+                target_thread_id = "abababab-abab-abab-abab-abababababab"
+                """);
             var dbPath = Path.Combine(codexHome, "state_5.sqlite");
             var sqlite = new SQLite();
             sqlite.ExecuteNonQuery(
@@ -301,6 +315,12 @@ internal static partial class Program {
             AssertEqual(false, result.WasArchived, "codex thread recovery original active");
             AssertEqual(false, result.FinalArchived, "codex thread recovery final active");
             AssertEqual(true, File.Exists(result.BackupDatabasePath), "codex thread recovery backup exists");
+            AssertEqual(1, result.AutomationCountBefore, "codex thread recovery automation count before");
+            AssertEqual(1, result.AutomationCountAfter, "codex thread recovery automation count after");
+            AssertEqual(0, result.AutomationRestoredCount, "codex thread recovery automation restored count");
+            AssertEqual("recheck-thread", result.AutomationIds.Single(), "codex thread recovery automation id");
+            AssertEqual(true, File.Exists(Path.Combine(result.AutomationBackupDirectory, "recheck-thread", "automation.toml")), "codex thread recovery automation backup exists");
+            AssertEqual(true, File.Exists(automationPath), "codex thread recovery automation preserved");
             AssertEqual(0, archived, "codex thread recovery active archived flag");
             AssertEqual(true, archivedAt is null || archivedAt is DBNull, "codex thread recovery active archived_at");
         } finally {

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -361,6 +361,10 @@ internal static partial class Program {
             TestCodexLocalStateDiagnosticsHandlesMigrationDefaultValues);
         failed += Run("Codex local state diagnostics normalizes active thread paths",
             TestCodexLocalStateDiagnosticsNormalizesActiveThreadPaths);
+        failed += Run("Codex local state diagnostics recovers thread archive state",
+            TestCodexLocalStateDiagnosticsRecoversThreadArchiveState);
+        failed += Run("Codex local state diagnostics detects broken thread candidates",
+            TestCodexLocalStateDiagnosticsDetectsBrokenThreadCandidates);
         failed += Run("Codex local state diagnostics reports storage areas",
             TestCodexLocalStateDiagnosticsReportsStorageAreas);
         failed += Run("Codex local state cleanup archives stale files",

--- a/IntelligenceX.Tray/ViewModels/MainViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/MainViewModel.cs
@@ -1460,7 +1460,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         }
 
         var candidate = diagnostics.BrokenThreadCandidates
-            .Where(static item => item.ThreadFound)
+            .Where(static item => item.ThreadFound && !item.IsArchived)
             .OrderByDescending(static item => item.LastSeenUtc)
             .ThenByDescending(static item => item.FailureCount)
             .FirstOrDefault();

--- a/IntelligenceX.Tray/ViewModels/MainViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/MainViewModel.cs
@@ -89,10 +89,12 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
     private bool _isCodexDiagnosticsLoading;
     private bool _isCodexPathRepairRunning;
     private bool _isCodexCleanupRunning;
+    private bool _isCodexThreadRecoveryRunning;
     private bool _isCodexDiagnosticsDetailsExpanded;
     private string _statusText = "Initializing...";
     private string _codexDiagnosticsStatusText = "Codex state not scanned";
     private string _codexDiagnosticsDetailText = "Waiting for first local state check.";
+    private string _codexThreadRecoveryId = string.Empty;
     private string _loadingDetailText = "Preparing tray refresh...";
     private double _loadingProgressValue;
     private double _loadingProgressMaximum = 1d;
@@ -166,6 +168,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         RefreshCodexDiagnosticsCommand = new RelayCommand(RefreshCodexDiagnosticsAsync, CanRunCodexMaintenance);
         RepairCodexPathsCommand = new RelayCommand(RepairCodexPathsAsync, CanRunCodexMaintenance);
         CleanUpCodexStateCommand = new RelayCommand(CleanUpCodexStateAsync, CanRunCodexMaintenance);
+        RecoverCodexThreadCommand = new RelayCommand(RecoverCodexThreadAsync, CanRecoverCodexThread);
         ToggleCodexDiagnosticsDetailsCommand = new RelayCommand(ToggleCodexDiagnosticsDetails);
         RefreshGitHubCommand = new RelayCommand(RefreshGitHubCurrentAsync);
         OpenOpenAiCacheCommand = new RelayCommand(OpenOpenAiCacheAsync);
@@ -305,6 +308,16 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         }
     }
 
+    public bool IsCodexThreadRecoveryRunning {
+        get => _isCodexThreadRecoveryRunning;
+        private set {
+            if (SetProperty(ref _isCodexThreadRecoveryRunning, value)) {
+                OnPropertyChanged(nameof(CodexDiagnosticsThreadRecoveryActionLabel));
+                RaiseCodexMaintenanceCanExecuteChanged();
+            }
+        }
+    }
+
     public bool IsCodexDiagnosticsDetailsExpanded {
         get => _isCodexDiagnosticsDetailsExpanded;
         private set {
@@ -365,6 +378,15 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         private set => SetProperty(ref _codexDiagnosticsDetailText, value);
     }
 
+    public string CodexThreadRecoveryId {
+        get => _codexThreadRecoveryId;
+        set {
+            if (SetProperty(ref _codexThreadRecoveryId, value)) {
+                RecoverCodexThreadCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
     public string CodexDiagnosticsIssueText {
         get {
             if (_latestCodexDiagnostics is null) {
@@ -395,6 +417,8 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
     public string CodexDiagnosticsRepairActionLabel => IsCodexPathRepairRunning ? "Repairing" : "Repair paths";
 
     public string CodexDiagnosticsCleanupActionLabel => IsCodexCleanupRunning ? "Cleaning" : "Clean up";
+
+    public string CodexDiagnosticsThreadRecoveryActionLabel => IsCodexThreadRecoveryRunning ? "Recovering" : "Recover thread";
 
     public string CodexDiagnosticsDetailsActionLabel => IsCodexDiagnosticsDetailsExpanded ? "Hide" : "Details";
 
@@ -574,6 +598,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
     public RelayCommand RefreshCodexDiagnosticsCommand { get; }
     public RelayCommand RepairCodexPathsCommand { get; }
     public RelayCommand CleanUpCodexStateCommand { get; }
+    public RelayCommand RecoverCodexThreadCommand { get; }
     public RelayCommand ToggleCodexDiagnosticsDetailsCommand { get; }
     public RelayCommand RefreshGitHubCommand { get; }
     public RelayCommand OpenOpenAiCacheCommand { get; }
@@ -1219,6 +1244,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
                 () => _codexDiagnosticsService.CollectAsync(),
                 CancellationToken.None).ConfigureAwait(true);
             _latestCodexDiagnostics = diagnostics;
+            ApplyDetectedCodexThreadCandidate(diagnostics);
             CodexDiagnosticsStatusText = diagnostics.StatusText;
             CodexDiagnosticsDetailText = diagnostics.DetailText;
             OnCodexDiagnosticsSnapshotChanged();
@@ -1323,6 +1349,67 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         }
     }
 
+    private async Task RecoverCodexThreadAsync() {
+        if (IsCodexThreadRecoveryRunning) {
+            return;
+        }
+
+        var threadId = CodexThreadRecoveryId.Trim();
+        if (!Guid.TryParse(threadId, out _)) {
+            CodexDiagnosticsStatusText = "Codex thread id invalid";
+            CodexDiagnosticsDetailText = "Paste a UUID thread id before recovery.";
+            return;
+        }
+
+        IsCodexThreadRecoveryRunning = true;
+        CodexDiagnosticsStatusText = "Recovering Codex thread...";
+        CodexDiagnosticsDetailText = "Creating a backup before refreshing the thread archive state.";
+        try {
+            var result = await _codexDiagnosticsService.RecoverThreadArchiveStateAsync(threadId).ConfigureAwait(true);
+            await RefreshCodexDiagnosticsAsync().ConfigureAwait(true);
+
+            if (!result.DatabaseExists) {
+                CodexDiagnosticsStatusText = "Codex state database missing";
+                CodexDiagnosticsDetailText = result.StateDatabasePath;
+                return;
+            }
+
+            if (!result.ArchiveColumnsAvailable) {
+                CodexDiagnosticsStatusText = "Codex thread recovery unavailable";
+                CodexDiagnosticsDetailText = "The local threads table does not expose archive-state columns IX can refresh.";
+                return;
+            }
+
+            if (!result.ThreadFound) {
+                CodexDiagnosticsStatusText = "Codex thread not found";
+                CodexDiagnosticsDetailText = "Thread " + ShortThreadId(result.ThreadId) + " was not found in local state. Backup: " + result.BackupDirectory;
+                return;
+            }
+
+            CodexDiagnosticsStatusText = "Codex thread refreshed";
+            CodexDiagnosticsDetailText = BuildCodexThreadRecoveryDetailText(result);
+            if (NotificationsEnabled) {
+                NotificationRequested?.Invoke(this, new TrayNotificationRequestedEventArgs(
+                    "Codex thread refreshed",
+                    CodexDiagnosticsDetailText,
+                    isCritical: false,
+                    providerId: "codex"));
+            }
+        } catch (Exception ex) {
+            CodexDiagnosticsStatusText = "Codex thread recovery failed";
+            CodexDiagnosticsDetailText = ex.Message;
+            if (NotificationsEnabled) {
+                NotificationRequested?.Invoke(this, new TrayNotificationRequestedEventArgs(
+                    "Codex thread recovery failed",
+                    ex.Message,
+                    isCritical: true,
+                    providerId: "codex"));
+            }
+        } finally {
+            IsCodexThreadRecoveryRunning = false;
+        }
+    }
+
     private Task ToggleCodexDiagnosticsDetails() {
         IsCodexDiagnosticsDetailsExpanded = !IsCodexDiagnosticsDetailsExpanded;
         if (IsCodexDiagnosticsDetailsExpanded && !IsCodexProviderSelected) {
@@ -1367,14 +1454,38 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         OnPropertyChanged(nameof(CodexDiagnosticsPrimaryFindingBrush));
     }
 
+    private void ApplyDetectedCodexThreadCandidate(CodexLocalStateDiagnostics diagnostics) {
+        if (!string.IsNullOrWhiteSpace(CodexThreadRecoveryId)) {
+            return;
+        }
+
+        var candidate = diagnostics.BrokenThreadCandidates
+            .Where(static item => item.ThreadFound)
+            .OrderByDescending(static item => item.LastSeenUtc)
+            .ThenByDescending(static item => item.FailureCount)
+            .FirstOrDefault();
+        if (candidate is not null) {
+            CodexThreadRecoveryId = candidate.ThreadId;
+        }
+    }
+
     private bool CanRunCodexMaintenance() {
-        return !IsCodexDiagnosticsLoading && !IsCodexPathRepairRunning && !IsCodexCleanupRunning;
+        return !IsCodexDiagnosticsLoading
+               && !IsCodexPathRepairRunning
+               && !IsCodexCleanupRunning
+               && !IsCodexThreadRecoveryRunning;
+    }
+
+    private bool CanRecoverCodexThread() {
+        return CanRunCodexMaintenance()
+               && Guid.TryParse(CodexThreadRecoveryId.Trim(), out _);
     }
 
     private void RaiseCodexMaintenanceCanExecuteChanged() {
         RefreshCodexDiagnosticsCommand.RaiseCanExecuteChanged();
         RepairCodexPathsCommand.RaiseCanExecuteChanged();
         CleanUpCodexStateCommand.RaiseCanExecuteChanged();
+        RecoverCodexThreadCommand.RaiseCanExecuteChanged();
     }
 
     private static string BuildCodexPathRepairDetailText(CodexLocalStatePathRepairResult result) {
@@ -1396,6 +1507,19 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
             result.ArchivedSessionFileCount,
             FormatBytes(result.ArchivedSessionBytes),
             result.ArchiveDirectory);
+    }
+
+    private static string BuildCodexThreadRecoveryDetailText(CodexLocalStateThreadRecoveryResult result) {
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "Thread {0} archive state refreshed. Final state: {1}. Backup: {2}",
+            ShortThreadId(result.ThreadId),
+            result.FinalArchived ? "archived" : "active",
+            result.BackupDirectory);
+    }
+
+    private static string ShortThreadId(string threadId) {
+        return threadId.Length > 8 ? threadId.Substring(0, 8) : threadId;
     }
 
     private static string BuildCodexFindingSeverityLabel(CodexLocalStateHealthStatus severity) {

--- a/IntelligenceX.Tray/ViewModels/MainViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/MainViewModel.cs
@@ -1510,11 +1510,20 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
     }
 
     private static string BuildCodexThreadRecoveryDetailText(CodexLocalStateThreadRecoveryResult result) {
+        var automationText = result.AutomationCountBefore == 0
+            ? "No thread automations found."
+            : string.Format(
+                CultureInfo.InvariantCulture,
+                "Automations: {0} backed up, {1} restored, {2} present after recovery.",
+                result.AutomationCountBefore,
+                result.AutomationRestoredCount,
+                result.AutomationCountAfter);
         return string.Format(
             CultureInfo.InvariantCulture,
-            "Thread {0} archive state refreshed. Final state: {1}. Backup: {2}",
+            "Thread {0} archive state refreshed. Final state: {1}. {2} Backup: {3}",
             ShortThreadId(result.ThreadId),
             result.FinalArchived ? "archived" : "active",
+            automationText,
             result.BackupDirectory);
     }
 

--- a/IntelligenceX.Tray/ViewModels/MainViewModel.cs
+++ b/IntelligenceX.Tray/ViewModels/MainViewModel.cs
@@ -1460,7 +1460,7 @@ public sealed class MainViewModel : ViewModelBase, IDisposable {
         }
 
         var candidate = diagnostics.BrokenThreadCandidates
-            .Where(static item => item.ThreadFound && !item.IsArchived)
+            .Where(static item => item.ThreadFound && !item.IsArchived && item.IsCurrent)
             .OrderByDescending(static item => item.LastSeenUtc)
             .ThenByDescending(static item => item.FailureCount)
             .FirstOrDefault();

--- a/IntelligenceX.Tray/Views/TrayPopupWindow.xaml
+++ b/IntelligenceX.Tray/Views/TrayPopupWindow.xaml
@@ -741,6 +741,39 @@
                                     </WrapPanel>
                                 </Grid>
 
+                                <Grid Margin="0,0,0,10">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               Text="Thread ID"
+                                               Style="{StaticResource LabelTextStyle}"
+                                               VerticalAlignment="Center"
+                                               Margin="0,0,8,0" />
+                                    <TextBox Grid.Column="1"
+                                             Text="{Binding DataContext.CodexThreadRecoveryId, RelativeSource={RelativeSource AncestorType={x:Type Window}}, UpdateSourceTrigger=PropertyChanged}"
+                                             FontFamily="{StaticResource AppFont}"
+                                             FontSize="11"
+                                             Background="{StaticResource SubtleSurfaceBrush}"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource BorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,5"
+                                             CaretBrush="{StaticResource PrimaryTextBrush}"
+                                             ToolTip="Codex thread id"
+                                             AutomationProperties.Name="Codex thread id" />
+                                    <Button Grid.Column="2"
+                                            Style="{StaticResource LinkButtonStyle}"
+                                            Command="{Binding DataContext.RecoverCodexThreadCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                            ToolTip="Back up and refresh this Codex thread archive state"
+                                            AutomationProperties.Name="Recover Codex thread"
+                                            Margin="6,0,0,0">
+                                        <TextBlock Text="{Binding DataContext.CodexDiagnosticsThreadRecoveryActionLabel, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" />
+                                    </Button>
+                                </Grid>
+
                                 <UniformGrid Columns="4" Margin="0,0,0,10">
                                     <Border CornerRadius="10"
                                             Background="{StaticResource SubtleSurfaceMutedBrush}"


### PR DESCRIPTION
## Summary
- add Codex logs_2.sqlite broken-thread candidate detection to local state diagnostics
- add backup-first targeted thread archive-state recovery in IX diagnostics/tray
- prefill the tray recovery field with the newest recoverable detected candidate after a scan
- cover detection, false-positive filtering, and recovery with diagnostics tests

## Validation
- python keep-codex-fast smoke tests passed separately for the shared skill
- dotnet build IntelligenceX.Storage.SQLite/IntelligenceX.Storage.SQLite.csproj -c Debug --no-restore -m:1 -p:UseSharedCompilation=false -p:MSBuildWarningsAsErrors= -p:WarningsAsErrors= -p:TreatWarningsAsErrors=false passed after restore with NuGetAudit=false
- dotnet test IntelligenceX.Tests/IntelligenceX.Tests.csproj -c Debug --no-restore -m:1 -p:UseSharedCompilation=false -p:MSBuildWarningsAsErrors= -p:WarningsAsErrors= -p:TreatWarningsAsErrors=false --filter FullyQualifiedName~CodexLocalStateDiagnostics exited 0 after restore with NuGetAudit=false
- dotnet build IntelligenceX.Tray/IntelligenceX.Tray.csproj -c Debug --no-restore -m:1 -p:UseSharedCompilation=false -p:MSBuildWarningsAsErrors= -p:WarningsAsErrors= -p:TreatWarningsAsErrors=false passed after restore with NuGetAudit=false

## Known blocker
- normal restore/build currently fails on existing NU1903 package audit for SQLitePCLRaw.lib.e_sqlite3 2.1.11 (GHSA-2m69-gcr7-jv3q); this PR does not hide or pin around that issue