### PR TITLE
Repin PowerForge deploy workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@efd54edb2b67f62531b883d4db5c2e7983c5a506
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@105a24cf399ce8c7a3a7a269427ef2bfbc3b5d64
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -27,7 +27,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7c122532aae02d8690e2d2fb5013076157748080
+      powerforge_ref: 105a24cf399ce8c7a3a7a269427ef2bfbc3b5d64
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@105a24cf399ce8c7a3a7a269427ef2bfbc3b5d64
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@8357ab905522ef2aa708d2493734e995e6a5a447
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -27,7 +27,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 105a24cf399ce8c7a3a7a269427ef2bfbc3b5d64
+      powerforge_ref: 8357ab905522ef2aa708d2493734e995e6a5a447
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -10,11 +10,11 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@105a24cf399ce8c7a3a7a269427ef2bfbc3b5d64
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@8357ab905522ef2aa708d2493734e995e6a5a447
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 105a24cf399ce8c7a3a7a269427ef2bfbc3b5d64
+      powerforge_ref: 8357ab905522ef2aa708d2493734e995e6a5a447


### PR DESCRIPTION
## Summary
- Repin `Deploy Website` and `Website Build (PR)` reusable PowerForge workflows to merged PSPublishModule `8357ab905522ef2aa708d2493734e995e6a5a447`.
- This consumes the shared Scriban audit fix from PSPublishModule PR #479.

## Evidence
- Original failed default-branch run: https://github.com/EvotecIT/IntelligenceX/actions/runs/28261333451
- Initial branch proof removed the stale Magick.NET 14.13.1 issue but exposed Scriban 7.2.0 NU1902 advisories: https://github.com/EvotecIT/IntelligenceX/actions/runs/28281127770
- PSPublishModule shared fix merged: https://github.com/EvotecIT/PSPublishModule/pull/479

## Validation
- `git diff --check`
- PSPublishModule PR #479 checks passed and was merged.
- Follow-up IntelligenceX PR checks and branch deploy dispatch are being rechecked after the latest push.