### PR TITLE
Centralize desktop chat turn coordination

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ChatServiceTurnRunnerTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ChatServiceTurnRunnerTests.cs
@@ -1,0 +1,270 @@
+using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Client;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Protects the shared request-scoped turn delivery and cancellation contracts.
+/// </summary>
+public sealed class ChatServiceTurnRunnerTests {
+    /// <summary>
+    /// Ensures every correlated update is delivered once, in order, without losing request options or result metadata.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_ForwardsCompleteOrderedTurnAndPreservesRequestOptions() {
+        var client = new FakeChatServiceClient();
+        var runner = new ChatServiceTurnRunner(client);
+        var request = new ChatRequest {
+            RequestId = "turn-1",
+            ThreadId = "thread-1",
+            Text = "inspect the directory",
+            Options = new ChatRequestOptions {
+                Model = "gpt-test",
+                MaxToolRounds = 7,
+                ParallelTools = false,
+                ToolTimeoutSeconds = 42
+            }
+        };
+        var startedAt = DateTime.UtcNow;
+        var metrics = new ChatMetricsMessage {
+            Kind = ChatServiceMessageKind.Event,
+            RequestId = request.RequestId,
+            ThreadId = request.ThreadId!,
+            StartedAtUtc = startedAt,
+            CompletedAtUtc = startedAt.AddSeconds(1),
+            DurationMs = 1000,
+            ToolCallsCount = 2,
+            ToolRounds = 1,
+            Outcome = "ok"
+        };
+        var response = new ChatResultMessage {
+            Kind = ChatServiceMessageKind.Response,
+            RequestId = request.RequestId,
+            ThreadId = request.ThreadId!,
+            Text = "done",
+            Tools = new ToolRunDto {
+                Calls = new[] {
+                    new ToolCallDto {
+                        CallId = "call-1",
+                        Name = "directory_list",
+                        ArgumentsJson = "{}"
+                    }
+                }
+            },
+            TurnTimelineEvents = new[] {
+                new TurnTimelineEventDto {
+                    Status = ChatStatusCodes.ToolCompleted,
+                    ToolName = "directory_list",
+                    AtUtc = startedAt
+                }
+            }
+        };
+        client.RequestHandler = (sent, _) => {
+            Assert.Same(request, sent);
+            var sentChat = Assert.IsType<ChatRequest>(sent);
+            Assert.Equal("gpt-test", sentChat.Options?.Model);
+            Assert.Equal(7, sentChat.Options?.MaxToolRounds);
+            Assert.False(sentChat.Options?.ParallelTools);
+            Assert.Equal(42, sentChat.Options?.ToolTimeoutSeconds);
+
+            client.Raise(new ChatDeltaMessage {
+                Kind = ChatServiceMessageKind.Event,
+                RequestId = "another-turn",
+                ThreadId = "thread-other",
+                Text = "ignore"
+            });
+            client.Raise(new ChatStatusMessage {
+                Kind = ChatServiceMessageKind.Event,
+                RequestId = request.RequestId,
+                ThreadId = request.ThreadId!,
+                Status = ChatStatusCodes.Thinking
+            });
+            client.Raise(new ChatAssistantProvisionalMessage {
+                Kind = ChatServiceMessageKind.Event,
+                RequestId = request.RequestId,
+                ThreadId = request.ThreadId!,
+                Text = "draft"
+            });
+            client.Raise(new ChatInterimResultMessage {
+                Kind = ChatServiceMessageKind.Event,
+                RequestId = request.RequestId,
+                ThreadId = request.ThreadId!,
+                Text = "reviewed draft",
+                ToolCallsCount = 2,
+                ToolOutputsCount = 2
+            });
+            client.Raise(metrics);
+            client.Raise(response);
+            return Task.FromResult<ChatServiceMessage>(response);
+        };
+
+        var updates = new List<ChatTurnUpdate>();
+        var activeCallbacks = 0;
+        var maximumConcurrentCallbacks = 0;
+        var result = await runner.RunAsync(
+            request,
+            async (update, cancellationToken) => {
+                _ = cancellationToken;
+                var concurrent = Interlocked.Increment(ref activeCallbacks);
+                maximumConcurrentCallbacks = Math.Max(maximumConcurrentCallbacks, concurrent);
+                await Task.Yield();
+                updates.Add(update);
+                _ = Interlocked.Decrement(ref activeCallbacks);
+            });
+
+        Assert.Same(response, result.Response);
+        Assert.Same(metrics, result.Metrics);
+        Assert.Equal(1, maximumConcurrentCallbacks);
+        Assert.Collection(
+            updates,
+            update => Assert.IsType<ChatTurnStatusUpdate>(update),
+            update => Assert.IsType<ChatTurnProvisionalUpdate>(update),
+            update => Assert.IsType<ChatTurnInterimUpdate>(update),
+            update => Assert.IsType<ChatTurnMetricsUpdate>(update),
+            update => Assert.IsType<ChatTurnCompletedUpdate>(update));
+    }
+
+    /// <summary>
+    /// Ensures a correlated error update reaches the consumer before the request exception is observed.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_ForwardsCorrelatedErrorBeforeRequestFailure() {
+        var client = new FakeChatServiceClient();
+        var runner = new ChatServiceTurnRunner(client);
+        var request = new ChatRequest {
+            RequestId = "turn-error",
+            Text = "fail"
+        };
+        var error = new ErrorMessage {
+            Kind = ChatServiceMessageKind.Response,
+            RequestId = request.RequestId,
+            Error = "provider unavailable",
+            Code = "chat_failed"
+        };
+        client.RequestHandler = (_, _) => {
+            client.Raise(error);
+            return Task.FromException<ChatServiceMessage>(
+                new ChatServiceRequestException(error.Error, error.Code));
+        };
+        var updates = new List<ChatTurnUpdate>();
+
+        var exception = await Assert.ThrowsAsync<ChatServiceRequestException>(() =>
+            runner.RunAsync(
+                request,
+                (update, _) => {
+                    updates.Add(update);
+                    return ValueTask.CompletedTask;
+                }));
+
+        Assert.Equal("chat_failed", exception.Code);
+        var forwarded = Assert.Single(updates);
+        Assert.Same(error, Assert.IsType<ChatTurnErrorUpdate>(forwarded).Error);
+    }
+
+    /// <summary>
+    /// Ensures all desktop consumers use the same cancel request shape.
+    /// </summary>
+    [Fact]
+    public async Task CancelAsync_UsesSharedCancelContract() {
+        var client = new FakeChatServiceClient();
+        var runner = new ChatServiceTurnRunner(client);
+        CancelChatRequest? captured = null;
+        client.RequestHandler = (request, _) => {
+            captured = Assert.IsType<CancelChatRequest>(request);
+            return Task.FromResult<ChatServiceMessage>(new AckMessage {
+                Kind = ChatServiceMessageKind.Response,
+                RequestId = request.RequestId,
+                Ok = true
+            });
+        };
+
+        await runner.CancelAsync("  turn-9  ");
+
+        Assert.NotNull(captured);
+        Assert.Equal("turn-9", captured.ChatRequestId);
+        Assert.StartsWith("turn-cancel-", captured.RequestId, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Ensures requesting cancellation does not detach the active turn before its terminal frames arrive.
+    /// </summary>
+    [Fact]
+    public async Task CancelAsync_KeepsRunAttachedThroughMetricsAndTerminalError() {
+        var client = new FakeChatServiceClient();
+        var runner = new ChatServiceTurnRunner(client);
+        var chatResponse = new TaskCompletionSource<ChatServiceMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var chatStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var request = new ChatRequest {
+            RequestId = "turn-cancel-target",
+            Text = "long running task"
+        };
+        var now = DateTime.UtcNow;
+        var metrics = new ChatMetricsMessage {
+            Kind = ChatServiceMessageKind.Event,
+            RequestId = request.RequestId,
+            ThreadId = "thread-1",
+            StartedAtUtc = now,
+            CompletedAtUtc = now.AddSeconds(1),
+            Outcome = "canceled",
+            ErrorCode = "chat_canceled"
+        };
+        var error = new ErrorMessage {
+            Kind = ChatServiceMessageKind.Response,
+            RequestId = request.RequestId,
+            Error = "Chat canceled by client.",
+            Code = "chat_canceled"
+        };
+        client.RequestHandler = (sent, _) => {
+            if (sent is ChatRequest) {
+                chatStarted.TrySetResult(null);
+                return chatResponse.Task;
+            }
+
+            var cancel = Assert.IsType<CancelChatRequest>(sent);
+            Assert.Equal(request.RequestId, cancel.ChatRequestId);
+            client.Raise(metrics);
+            client.Raise(error);
+            chatResponse.TrySetException(new ChatServiceRequestException(error.Error, error.Code));
+            return Task.FromResult<ChatServiceMessage>(new AckMessage {
+                Kind = ChatServiceMessageKind.Response,
+                RequestId = cancel.RequestId,
+                Ok = true
+            });
+        };
+        var updates = new List<ChatTurnUpdate>();
+        var runTask = runner.RunAsync(
+            request,
+            (update, _) => {
+                updates.Add(update);
+                return ValueTask.CompletedTask;
+            });
+        await chatStarted.Task;
+
+        await runner.CancelAsync(request.RequestId);
+        var exception = await Assert.ThrowsAsync<ChatServiceRequestException>(() => runTask);
+
+        Assert.Equal("chat_canceled", exception.Code);
+        Assert.Collection(
+            updates,
+            update => Assert.Same(metrics, Assert.IsType<ChatTurnMetricsUpdate>(update).Metrics),
+            update => Assert.Same(error, Assert.IsType<ChatTurnErrorUpdate>(update).Error));
+    }
+
+    private sealed class FakeChatServiceClient : IChatServiceClient {
+        public event Action<ChatServiceMessage>? MessageReceived;
+
+        public Func<ChatServiceRequest, CancellationToken, Task<ChatServiceMessage>> RequestHandler { get; set; } =
+            static (_, _) => Task.FromException<ChatServiceMessage>(new InvalidOperationException("No request handler configured."));
+
+        public async Task<TResponse> RequestAsync<TResponse>(ChatServiceRequest request, CancellationToken cancellationToken)
+            where TResponse : ChatServiceMessage {
+            var response = await RequestHandler(request, cancellationToken);
+            return Assert.IsType<TResponse>(response);
+        }
+
+        public void Raise(ChatServiceMessage message) {
+            MessageReceived?.Invoke(message);
+        }
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/AssistantStreamingState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/AssistantStreamingState.cs
@@ -1,203 +1,65 @@
 using System;
-using System.Text;
 using IntelligenceX.Chat.App.Markdown;
-using IntelligenceX.Chat.App.Rendering;
+using IntelligenceX.Chat.Client;
 
 namespace IntelligenceX.Chat.App;
 
 internal sealed class AssistantStreamingState {
-    private const int MaxBufferedChars = 64 * 1024;
-    private const int TrimmedBufferChars = 48 * 1024;
-    private const int SnapshotOverlapCandidateThresholdChars = 6;
-
     private readonly object _sync = new();
-    private readonly StringBuilder _buffer = new();
-    private bool _receivedDelta;
-    private bool _receivedProvisionalDelta;
-    private bool _deltaFragmentsLookLikeSnapshots;
-    private bool _provisionalFragmentsLookLikeSnapshots;
+    private readonly ChatTurnTextAccumulator _accumulator = new();
+    private string _rawPreviewCache = string.Empty;
     private string _normalizedPreviewCache = string.Empty;
-    private bool _normalizedPreviewDirty;
 
     public void Reset() {
         lock (_sync) {
-            _buffer.Clear();
-            _receivedDelta = false;
-            _receivedProvisionalDelta = false;
-            _deltaFragmentsLookLikeSnapshots = false;
-            _provisionalFragmentsLookLikeSnapshots = false;
+            _accumulator.Reset();
+            _rawPreviewCache = string.Empty;
             _normalizedPreviewCache = string.Empty;
-            _normalizedPreviewDirty = false;
         }
     }
 
     public string AppendDeltaAndNormalizePreview(string delta, bool fromProvisionalEvent = false) {
         ArgumentNullException.ThrowIfNull(delta);
 
-        if (string.IsNullOrEmpty(delta)) {
-            lock (_sync) {
-                return GetNormalizedPreviewLocked();
-            }
-        }
-
         lock (_sync) {
-            if (!TryMergeStreamingFragmentLocked(delta, fromProvisionalEvent)) {
-                _buffer.Append(delta);
-            }
-            TrimBufferIfNeeded();
-            _receivedDelta = true;
-            if (fromProvisionalEvent) {
-                _receivedProvisionalDelta = true;
-            }
-            _normalizedPreviewDirty = true;
-            return GetNormalizedPreviewLocked();
+            var rawPreview = _accumulator.Append(delta, fromProvisionalEvent);
+            return NormalizePreviewLocked(rawPreview);
         }
-    }
-
-    private bool TryMergeStreamingFragmentLocked(string delta, bool fromProvisionalEvent) {
-        if (_buffer.Length == 0) {
-            return false;
-        }
-
-        if (string.IsNullOrEmpty(delta)) {
-            return true;
-        }
-
-        var current = _buffer.ToString();
-        if (string.Equals(current, delta, StringComparison.Ordinal)) {
-            return true;
-        }
-
-        var shouldTrySnapshotMerge = fromProvisionalEvent
-            ? _provisionalFragmentsLookLikeSnapshots || !_receivedProvisionalDelta || delta.Length >= current.Length
-            : _deltaFragmentsLookLikeSnapshots || !_receivedDelta || delta.Length >= current.Length;
-        if (shouldTrySnapshotMerge
-            && TryMergeAsSnapshotFragmentLocked(current, delta, out var snapshotDetected)) {
-            if (snapshotDetected) {
-                if (fromProvisionalEvent) {
-                    _provisionalFragmentsLookLikeSnapshots = true;
-                } else {
-                    _deltaFragmentsLookLikeSnapshots = true;
-                }
-            }
-            return true;
-        }
-
-        if (current.EndsWith(delta, StringComparison.Ordinal)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    private bool TryMergeAsSnapshotFragmentLocked(string current, string delta, out bool snapshotDetected) {
-        snapshotDetected = false;
-        if (delta.Length == 0) {
-            return true;
-        }
-
-        if (delta.StartsWith(current, StringComparison.Ordinal)) {
-            _buffer.Append(delta.AsSpan(current.Length));
-            snapshotDetected = true;
-            return true;
-        }
-
-        if (current.StartsWith(delta, StringComparison.Ordinal)) {
-            // Keep the richer/larger current draft.
-            snapshotDetected = true;
-            return true;
-        }
-
-        var overlap = FindLongestSuffixPrefixOverlap(current, delta);
-        if (overlap < 1) {
-            return false;
-        }
-
-        var looksLikeSnapshotOverlap = overlap >= SnapshotOverlapCandidateThresholdChars
-                                       || overlap == current.Length
-                                       || overlap == delta.Length;
-        if (!looksLikeSnapshotOverlap) {
-            return false;
-        }
-
-        if (overlap < delta.Length) {
-            _buffer.Append(delta.AsSpan(overlap));
-        }
-        snapshotDetected = true;
-        return true;
-    }
-
-    private static int FindLongestSuffixPrefixOverlap(string left, string right) {
-        if (left.Length == 0 || right.Length == 0) {
-            return 0;
-        }
-
-        var max = Math.Min(left.Length, right.Length);
-        for (var len = max; len >= 1; len--) {
-            if (left.AsSpan(left.Length - len).SequenceEqual(right.AsSpan(0, len))) {
-                return len;
-            }
-        }
-
-        return 0;
     }
 
     public bool HasBufferedContent() {
-        lock (_sync) {
-            return _buffer.Length > 0;
-        }
+        return _accumulator.BufferedLength > 0;
     }
 
     public bool HasReceivedDelta() {
-        lock (_sync) {
-            return _receivedDelta;
-        }
+        return _accumulator.HasReceivedFragment;
     }
 
     public bool HasReceivedProvisionalDelta() {
-        lock (_sync) {
-            return _receivedProvisionalDelta;
-        }
+        return _accumulator.HasReceivedProvisionalFragment;
     }
 
     public void ClearReceivedDelta() {
-        lock (_sync) {
-            _receivedDelta = false;
-        }
+        _accumulator.ClearReceivedFragment();
     }
 
     public string SnapshotNormalizedPreview() {
         lock (_sync) {
-            return GetNormalizedPreviewLocked();
+            return NormalizePreviewLocked(_accumulator.Snapshot());
         }
     }
 
     internal int BufferedLengthForTesting() {
-        lock (_sync) {
-            return _buffer.Length;
-        }
+        return _accumulator.BufferedLength;
     }
 
-    private void TrimBufferIfNeeded() {
-        if (_buffer.Length <= MaxBufferedChars) {
-            return;
-        }
-
-        var removeCount = _buffer.Length - TrimmedBufferChars;
-        if (removeCount <= 0) {
-            return;
-        }
-
-        _buffer.Remove(0, removeCount);
-    }
-
-    private string GetNormalizedPreviewLocked() {
-        if (!_normalizedPreviewDirty) {
+    private string NormalizePreviewLocked(string rawPreview) {
+        if (string.Equals(_rawPreviewCache, rawPreview, StringComparison.Ordinal)) {
             return _normalizedPreviewCache;
         }
 
-        _normalizedPreviewCache = TranscriptMarkdownPreparation.PrepareStreamingPreview(_buffer.ToString());
-        _normalizedPreviewDirty = false;
+        _rawPreviewCache = rawPreview;
+        _normalizedPreviewCache = TranscriptMarkdownPreparation.PrepareStreamingPreview(rawPreview);
         return _normalizedPreviewCache;
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ChatTurns.cs
@@ -277,8 +277,19 @@ public sealed partial class MainWindow : Window {
             Options = BuildChatRequestOptions(turn.Conversation)
         };
 
-        var result = await client.RequestAsync<ChatResultMessage>(req, cancellationToken).ConfigureAwait(false);
-        await ApplyChatResultAsync(turn, result).ConfigureAwait(false);
+        var runner = ResolveTurnRunner(client);
+        var result = await runner
+            .RunAsync(req, ApplyChatTurnUpdateAsync, cancellationToken)
+            .ConfigureAwait(false);
+        await ApplyChatResultAsync(turn, result.Response).ConfigureAwait(false);
+    }
+
+    private ChatServiceTurnRunner ResolveTurnRunner(ChatServiceClient client) {
+        if (!ReferenceEquals(client, _client)) {
+            return new ChatServiceTurnRunner(client);
+        }
+
+        return _turnRunner ??= new ChatServiceTurnRunner(client);
     }
 
     private async Task ApplyChatResultAsync(ChatTurnContext turn, ChatResultMessage result) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Conversations.OnboardingAndKickoff.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Conversations.OnboardingAndKickoff.cs
@@ -128,7 +128,9 @@ public sealed partial class MainWindow : Window {
             };
             _activeKickoffRequestId = request.RequestId;
 
-            var result = await client.RequestAsync<ChatResultMessage>(request, CancellationToken.None).ConfigureAwait(false);
+            var runner = ResolveTurnRunner(client);
+            var run = await runner.RunAsync(request, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            var result = run.Response;
             conversation.ThreadId = result.ThreadId;
             if (string.Equals(conversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
                 _threadId = result.ThreadId;
@@ -184,18 +186,14 @@ public sealed partial class MainWindow : Window {
         _activeKickoffRequestId = null;
         _activeRequestConversationId = null;
 
-        var client = _client;
-        if (kickoffRequestId.Length == 0 || client is null) {
+        var runner = _turnRunner;
+        if (kickoffRequestId.Length == 0 || _client is null || runner is null) {
             return;
         }
 
         try {
             using var cts = new CancellationTokenSource(KickoffCancelAckTimeout);
-            var cancelRequest = new CancelChatRequest {
-                RequestId = NextId(),
-                ChatRequestId = kickoffRequestId
-            };
-            _ = await client.RequestAsync<AckMessage>(cancelRequest, cts.Token).ConfigureAwait(false);
+            await runner.CancelAsync(kickoffRequestId, cts.Token).ConfigureAwait(false);
         } catch (Exception ex) {
             if (VerboseServiceLogs || _debugMode) {
                 AppendSystem("Kickoff cancel best-effort: " + ex.Message);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.Connection.cs
@@ -771,6 +771,7 @@ public sealed partial class MainWindow : Window {
             }
 
             _client = client;
+            _turnRunner = new ChatServiceTurnRunner(client);
             _isConnected = true;
             ResetStartupMetadataFailureRecoveryDiagnostics();
             BeginStartupMetadataSyncTracking("preparing runtime metadata sync");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.ServiceMessages.cs
@@ -30,122 +30,22 @@ namespace IntelligenceX.Chat.App;
 public sealed partial class MainWindow : Window {
 
     private void OnServiceMessage(ChatServiceMessage msg) {
-        _ = _dispatcher.TryEnqueue(() => {
-            var requestConversation = ResolveRequestConversation();
-            switch (msg) {
-                case ChatDeltaMessage delta:
-                    if (!ShouldProcessLiveRequestMessage(delta.RequestId)) {
-                        break;
-                    }
-                    if (!IsActiveTurnRequest(delta.RequestId)) {
-                        // Kickoff/background deltas must not overwrite an existing assistant bubble.
-                        break;
-                    }
-                    if (ShouldUseProvisionalEventsForActiveTurn(requestConversation)) {
-                        // Once at least one provisional fragment has been observed for this turn,
-                        // prefer provisional events to avoid double-appending duplicate content.
-                        break;
-                    }
+        // Active turns are consumed by ChatServiceTurnRunner. Keep this listener for
+        // connection, login, kickoff, and other session-scoped protocol messages.
+        if (IsActiveTurnRequest(msg.RequestId) && ChatTurnUpdate.IsTurnMessage(msg)) {
+            return;
+        }
 
-                    MarkTurnDeltaStage(delta);
-                    ApplyAssistantStreamingFragment(
-                        requestConversation,
-                        delta.Text,
-                        preferProvisionalEvents: false,
-                        renderReason: "chat_delta");
-                    break;
-                case ChatAssistantProvisionalMessage provisional:
-                    if (!ShouldProcessLiveRequestMessage(provisional.RequestId)) {
-                        break;
-                    }
-                    if (!IsActiveTurnRequest(provisional.RequestId)) {
-                        break;
-                    }
+        _ = _dispatcher.TryEnqueue(() => ProcessServiceMessage(msg));
+    }
 
-                    MarkTurnDeltaStage(new ChatDeltaMessage {
-                        Kind = provisional.Kind,
-                        RequestId = provisional.RequestId,
-                        ThreadId = provisional.ThreadId,
-                        Text = provisional.Text
-                    });
-                    ApplyAssistantStreamingFragment(
-                        requestConversation,
-                        provisional.Text,
-                        preferProvisionalEvents: true,
-                        renderReason: "assistant_provisional");
-                    break;
-                case ChatInterimResultMessage interim:
-                    if (!ShouldProcessLiveRequestMessage(interim.RequestId)) {
-                        break;
-                    }
-                    if (!IsActiveTurnRequest(interim.RequestId)) {
-                        break;
-                    }
+    private void ProcessServiceMessage(ChatServiceMessage msg) {
+        var requestConversation = ResolveRequestConversation();
+        if (TryProcessChatTurnMessage(msg, requestConversation)) {
+            return;
+        }
 
-                    ApplyInterimAssistantResult(requestConversation, interim.Text);
-                    break;
-                case ChatStatusMessage status:
-                    if (!ShouldProcessLiveRequestMessage(status.RequestId)) {
-                        break;
-                    }
-
-                    MarkTurnStatusStage(status);
-                    var assistantStatusSignalChanged = ApplyActiveTurnStatusSignal(requestConversation, status.Status);
-                    var routingInsightUpdated = ApplyToolRoutingInsight(status);
-                    var routingPromptExposureUpdated = ApplyRoutingMetaPromptExposure(status);
-                    var activityText = IsTerminalChatStatus(status.Status) ? null : FormatActivityText(status);
-                    var timelineChanged = AppendActivityTimeline(status, activityText ?? string.Empty);
-                    var normalizedActivityText = activityText ?? string.Empty;
-                    var activityChanged = !string.Equals(_latestServiceActivityText, normalizedActivityText, StringComparison.Ordinal);
-                    _latestServiceActivityText = normalizedActivityText;
-                    var timelineLabelSource = activityText ?? FormatActivityText(status);
-                    var assistantTimelineChanged = AppendActiveTurnAssistantTimelineLabel(
-                        requestConversation,
-                        BuildActivityTimelineLabel(status, timelineLabelSource));
-                    if (activityChanged || timelineChanged) {
-                        _ = SetActivityAsync(activityText, SnapshotActivityTimeline());
-                    }
-                    if (timelineChanged) {
-                        RequestServiceDrivenSessionPublish();
-                    }
-                    if (routingPromptExposureUpdated) {
-                        RequestServiceDrivenSessionPublish();
-                    }
-                    if ((assistantTimelineChanged || assistantStatusSignalChanged)
-                        && string.Equals(requestConversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
-                        QueueTranscriptRender("chat_status_timeline");
-                    }
-                    if (routingInsightUpdated || routingPromptExposureUpdated) {
-                        _ = PublishOptionsStateSafeAsync();
-                    }
-                    if (VerboseServiceLogs || _debugMode) {
-                        AppendSystem(FormatStatusTrace(status));
-                    }
-                    break;
-                case ChatMetricsMessage metrics:
-                    if (!ShouldProcessLiveRequestMessage(metrics.RequestId) && !IsLatestTurnRequest(metrics.RequestId)) {
-                        break;
-                    }
-
-                    ApplyTurnMetrics(metrics);
-                    StartupLog.Write(
-                        "TurnMetrics request_id="
-                        + (metrics.RequestId ?? string.Empty).Trim()
-                        + " duration_ms="
-                        + metrics.DurationMs.ToString(CultureInfo.InvariantCulture)
-                        + " ttft_ms="
-                        + (metrics.TtftMs?.ToString(CultureInfo.InvariantCulture) ?? "null")
-                        + " outcome="
-                        + ((metrics.Outcome ?? string.Empty).Trim().Length == 0 ? "unknown" : metrics.Outcome!.Trim())
-                        + " tool_calls="
-                        + metrics.ToolCallsCount.ToString(CultureInfo.InvariantCulture)
-                        + " tool_rounds="
-                        + metrics.ToolRounds.ToString(CultureInfo.InvariantCulture));
-                    RequestServiceDrivenSessionPublish();
-                    if (VerboseServiceLogs || _debugMode) {
-                        AppendSystem(FormatMetricsTrace(metrics));
-                    }
-                    break;
+        switch (msg) {
                 case ChatGptLoginUrlMessage url:
                     _loginInProgress = true;
                     Interlocked.Exchange(ref _startupLoginSuccessMetadataSyncQueued, 0);
@@ -214,100 +114,7 @@ public sealed partial class MainWindow : Window {
                         AppendSystem(SystemNotice.ServiceError(err.Error, err.Code));
                     }
                     break;
-            }
-        });
-    }
-
-    private void ApplyAssistantStreamingFragment(ConversationRuntime conversation, string? fragment, bool preferProvisionalEvents, string renderReason) {
-        var delta = fragment ?? string.Empty;
-        if (delta.Length == 0) {
-            return;
         }
-        if (!TryAcceptActiveTurnDraftMutation(conversation)) {
-            return;
-        }
-
-        var normalizedPreview = _assistantStreamingState.AppendDeltaAndNormalizePreview(
-            delta,
-            fromProvisionalEvent: preferProvisionalEvents);
-        ReplaceLastAssistantText(
-            conversation,
-            normalizedPreview);
-        conversation.UpdatedUtc = DateTime.UtcNow;
-        BindActiveTurnAssistantMessage(conversation);
-        SetActiveTurnAssistantChannel(conversation, AssistantBubbleChannelKind.DraftThinking);
-        SetActiveTurnAssistantProvisional(conversation, provisional: true, preferProvisionalEvents);
-        if (string.Equals(conversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
-            QueueTranscriptRender(renderReason);
-        }
-    }
-
-    private void ApplyInterimAssistantResult(ConversationRuntime conversation, string? text) {
-        var interimText = (text ?? string.Empty).Trim();
-        if (interimText.Length == 0 || !TryAcceptActiveTurnDraftMutation(conversation) || !TryMarkActiveTurnInterimResult(interimText)) {
-            return;
-        }
-
-        _ = TryGetLastAssistantText(conversation, out var latestAssistantText);
-        var appendInterimBubble = ShouldAppendInterimAssistantResult(
-            activeTurnReceivedDelta: _assistantStreamingState.HasReceivedDelta(),
-            activeTurnBoundToConversation: IsActiveTurnBoundToConversation(conversation),
-            interimAssistantText: interimText,
-            latestAssistantText: latestAssistantText);
-        if (appendInterimBubble) {
-            AppendAssistantText(conversation, interimText);
-        } else {
-            ReplaceLastAssistantText(conversation, interimText);
-        }
-        conversation.UpdatedUtc = DateTime.UtcNow;
-        BindActiveTurnAssistantMessage(conversation);
-        SetActiveTurnAssistantChannel(conversation, AssistantBubbleChannelKind.DraftThinking);
-        // Interim snapshots are draft-by-definition and should stay visually distinct
-        // from the finalized assistant response.
-        SetActiveTurnAssistantProvisional(conversation, provisional: true, preferProvisionalEvents: false);
-        if (string.Equals(conversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
-            QueueTranscriptRender("assistant_interim_result");
-        }
-    }
-
-    internal static bool ShouldAppendInterimAssistantResult(bool activeTurnReceivedDelta, bool activeTurnBoundToConversation) {
-        // Interim snapshots should replace the active provisional draft when this turn has already streamed
-        // assistant content; appending in that case creates duplicate assistant bubbles.
-        if (activeTurnReceivedDelta && activeTurnBoundToConversation) {
-            return false;
-        }
-
-        return true;
-    }
-
-    internal static bool ShouldAppendInterimAssistantResult(
-        bool activeTurnReceivedDelta,
-        bool activeTurnBoundToConversation,
-        string? interimAssistantText,
-        string? latestAssistantText) {
-        if (!ShouldAppendInterimAssistantResult(activeTurnReceivedDelta, activeTurnBoundToConversation)) {
-            return false;
-        }
-
-        var interimText = NormalizeAssistantSnapshotForAppendDecision(interimAssistantText);
-        if (interimText.Length == 0) {
-            return false;
-        }
-
-        var latestText = NormalizeAssistantSnapshotForAppendDecision(latestAssistantText);
-        if (latestText.Length == 0) {
-            return true;
-        }
-
-        if (string.Equals(interimText, latestText, StringComparison.OrdinalIgnoreCase)) {
-            return false;
-        }
-
-        if (AreNearDuplicateAssistantSnapshots(interimText, latestText)) {
-            return false;
-        }
-
-        return true;
     }
 
     private void QueuePostLoginCompletion() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnQueue.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnQueue.cs
@@ -157,9 +157,7 @@ public sealed partial class MainWindow : Window {
             _activeTurnQueueWaitMs = queueWaitMs;
             ResetActivityTimeline();
             StartTurnWatchdog();
-            CancellationTokenSource? turnRequestCts = null;
             try {
-                turnRequestCts = new CancellationTokenSource();
                 var activeTurnFromQueuedAfterLogin = queuedAtUtc.HasValue && skipUserBubble;
                 var activeTurnPromptText = NormalizeQueuedPromptTextForDispatch(turn.UserText);
                 var activeTurnPromptConversationId = NormalizeQueuedPromptConversationId(turn.ConversationId);
@@ -167,7 +165,6 @@ public sealed partial class MainWindow : Window {
                     _activeTurnRequestId = requestId;
                     _latestTurnRequestId = requestId;
                     _cancelRequestedTurnRequestId = null;
-                    _activeTurnRequestCts = turnRequestCts;
                     _activeRequestConversationId = turn.ConversationId;
                     _activeTurnFromQueuedAfterLogin = activeTurnFromQueuedAfterLogin;
                     _activeTurnNormalizedPromptText = activeTurnPromptText;
@@ -178,7 +175,7 @@ public sealed partial class MainWindow : Window {
                 // Keep dispatch path hot: publish state asynchronously while request starts.
                 _ = PublishTurnStartUiStateBestEffortAsync();
 
-                await ExecuteChatTurnWithReconnectAsync(turn, turnRequestCts.Token).ConfigureAwait(false);
+                await ExecuteChatTurnWithReconnectAsync(turn, CancellationToken.None).ConfigureAwait(false);
             } finally {
                 StopTurnWatchdog();
                 CompleteActiveTurnDispatchSend();
@@ -198,17 +195,6 @@ public sealed partial class MainWindow : Window {
                         _cancelRequestedTurnRequestId = null;
                     }
 
-                    if (ReferenceEquals(_activeTurnRequestCts, turnRequestCts)) {
-                        _activeTurnRequestCts = null;
-                    }
-
-                    if (turnRequestCts is not null) {
-                        try {
-                            turnRequestCts.Dispose();
-                        } catch (ObjectDisposedException) {
-                            // Cancellation may race with completion; disposed CTS is safe to ignore.
-                        }
-                    }
                 }
                 _assistantStreamingState.ClearReceivedDelta();
                 _activeTurnQueueWaitMs = null;
@@ -972,11 +958,6 @@ public sealed partial class MainWindow : Window {
             } else {
                 chatRequestId = _activeTurnRequestId!;
                 _cancelRequestedTurnRequestId = chatRequestId;
-                try {
-                    _activeTurnRequestCts?.Cancel();
-                } catch (ObjectDisposedException) {
-                    // Turn completion may dispose the CTS before cancellation request arrives.
-                }
             }
         }
 
@@ -985,8 +966,8 @@ public sealed partial class MainWindow : Window {
             return;
         }
 
-        var client = _client;
-        if (client is null) {
+        var runner = _turnRunner;
+        if (_client is null || runner is null) {
             await SetStatusAsync(SessionStatus.Disconnected()).ConfigureAwait(false);
             return;
         }
@@ -994,13 +975,8 @@ public sealed partial class MainWindow : Window {
         await SetStatusAsync(SessionStatus.Canceling()).ConfigureAwait(false);
 
         try {
-            var cancelRequest = new CancelChatRequest {
-                RequestId = NextId(),
-                ChatRequestId = chatRequestId
-            };
-
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            _ = await client.RequestAsync<AckMessage>(cancelRequest, cts.Token).ConfigureAwait(false);
+            await runner.CancelAsync(chatRequestId, cts.Token).ConfigureAwait(false);
         } catch (Exception ex) {
             if (VerboseServiceLogs || _debugMode) {
                 AppendSystem(SystemNotice.CancelRequestFailed(ex.Message));

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnUpdates.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.Messaging.TurnUpdates.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.App.Conversation;
+using IntelligenceX.Chat.App.Rendering;
+using IntelligenceX.Chat.Client;
+using Microsoft.UI.Xaml;
+
+namespace IntelligenceX.Chat.App;
+
+public sealed partial class MainWindow : Window {
+    private ValueTask ApplyChatTurnUpdateAsync(ChatTurnUpdate update, CancellationToken _) {
+        return new ValueTask(RunOnUiThreadAsync(() => {
+            ProcessServiceMessage(update.Message);
+            return Task.CompletedTask;
+        }));
+    }
+
+    private bool TryProcessChatTurnMessage(ChatServiceMessage message, ConversationRuntime requestConversation) {
+        switch (message) {
+            case ChatDeltaMessage delta:
+                if (!ShouldProcessLiveRequestMessage(delta.RequestId)
+                    || !IsActiveTurnRequest(delta.RequestId)
+                    || ShouldUseProvisionalEventsForActiveTurn(requestConversation)) {
+                    return true;
+                }
+
+                MarkTurnDeltaStage(delta);
+                ApplyAssistantStreamingFragment(
+                    requestConversation,
+                    delta.Text,
+                    preferProvisionalEvents: false,
+                    renderReason: "chat_delta");
+                return true;
+            case ChatAssistantProvisionalMessage provisional:
+                if (!ShouldProcessLiveRequestMessage(provisional.RequestId)
+                    || !IsActiveTurnRequest(provisional.RequestId)) {
+                    return true;
+                }
+
+                MarkTurnDeltaStage(new ChatDeltaMessage {
+                    Kind = provisional.Kind,
+                    RequestId = provisional.RequestId,
+                    ThreadId = provisional.ThreadId,
+                    Text = provisional.Text
+                });
+                ApplyAssistantStreamingFragment(
+                    requestConversation,
+                    provisional.Text,
+                    preferProvisionalEvents: true,
+                    renderReason: "assistant_provisional");
+                return true;
+            case ChatInterimResultMessage interim:
+                if (ShouldProcessLiveRequestMessage(interim.RequestId)
+                    && IsActiveTurnRequest(interim.RequestId)) {
+                    ApplyInterimAssistantResult(requestConversation, interim.Text);
+                }
+                return true;
+            case ChatStatusMessage status:
+                if (!ShouldProcessLiveRequestMessage(status.RequestId)) {
+                    return true;
+                }
+
+                MarkTurnStatusStage(status);
+                var assistantStatusSignalChanged = ApplyActiveTurnStatusSignal(requestConversation, status.Status);
+                var routingInsightUpdated = ApplyToolRoutingInsight(status);
+                var routingPromptExposureUpdated = ApplyRoutingMetaPromptExposure(status);
+                var activityText = IsTerminalChatStatus(status.Status) ? null : FormatActivityText(status);
+                var timelineChanged = AppendActivityTimeline(status, activityText ?? string.Empty);
+                var normalizedActivityText = activityText ?? string.Empty;
+                var activityChanged = !string.Equals(_latestServiceActivityText, normalizedActivityText, StringComparison.Ordinal);
+                _latestServiceActivityText = normalizedActivityText;
+                var timelineLabelSource = activityText ?? FormatActivityText(status);
+                var assistantTimelineChanged = AppendActiveTurnAssistantTimelineLabel(
+                    requestConversation,
+                    BuildActivityTimelineLabel(status, timelineLabelSource));
+                if (activityChanged || timelineChanged) {
+                    _ = SetActivityAsync(activityText, SnapshotActivityTimeline());
+                }
+                if (timelineChanged || routingPromptExposureUpdated) {
+                    RequestServiceDrivenSessionPublish();
+                }
+                if ((assistantTimelineChanged || assistantStatusSignalChanged)
+                    && string.Equals(requestConversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
+                    QueueTranscriptRender("chat_status_timeline");
+                }
+                if (routingInsightUpdated || routingPromptExposureUpdated) {
+                    _ = PublishOptionsStateSafeAsync();
+                }
+                if (VerboseServiceLogs || _debugMode) {
+                    AppendSystem(FormatStatusTrace(status));
+                }
+                return true;
+            case ChatMetricsMessage metrics:
+                if (!ShouldProcessLiveRequestMessage(metrics.RequestId) && !IsLatestTurnRequest(metrics.RequestId)) {
+                    return true;
+                }
+
+                ApplyTurnMetrics(metrics);
+                StartupLog.Write(
+                    "TurnMetrics request_id="
+                    + (metrics.RequestId ?? string.Empty).Trim()
+                    + " duration_ms="
+                    + metrics.DurationMs.ToString(CultureInfo.InvariantCulture)
+                    + " ttft_ms="
+                    + (metrics.TtftMs?.ToString(CultureInfo.InvariantCulture) ?? "null")
+                    + " outcome="
+                    + ((metrics.Outcome ?? string.Empty).Trim().Length == 0 ? "unknown" : metrics.Outcome!.Trim())
+                    + " tool_calls="
+                    + metrics.ToolCallsCount.ToString(CultureInfo.InvariantCulture)
+                    + " tool_rounds="
+                    + metrics.ToolRounds.ToString(CultureInfo.InvariantCulture));
+                RequestServiceDrivenSessionPublish();
+                if (VerboseServiceLogs || _debugMode) {
+                    AppendSystem(FormatMetricsTrace(metrics));
+                }
+                return true;
+            case ChatResultMessage:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void ApplyAssistantStreamingFragment(
+        ConversationRuntime conversation,
+        string? fragment,
+        bool preferProvisionalEvents,
+        string renderReason) {
+        var delta = fragment ?? string.Empty;
+        if (delta.Length == 0 || !TryAcceptActiveTurnDraftMutation(conversation)) {
+            return;
+        }
+
+        var normalizedPreview = _assistantStreamingState.AppendDeltaAndNormalizePreview(
+            delta,
+            fromProvisionalEvent: preferProvisionalEvents);
+        ReplaceLastAssistantText(conversation, normalizedPreview);
+        conversation.UpdatedUtc = DateTime.UtcNow;
+        BindActiveTurnAssistantMessage(conversation);
+        SetActiveTurnAssistantChannel(conversation, AssistantBubbleChannelKind.DraftThinking);
+        SetActiveTurnAssistantProvisional(conversation, provisional: true, preferProvisionalEvents);
+        if (string.Equals(conversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
+            QueueTranscriptRender(renderReason);
+        }
+    }
+
+    private void ApplyInterimAssistantResult(ConversationRuntime conversation, string? text) {
+        var interimText = (text ?? string.Empty).Trim();
+        if (interimText.Length == 0 || !TryAcceptActiveTurnDraftMutation(conversation) || !TryMarkActiveTurnInterimResult(interimText)) {
+            return;
+        }
+
+        _ = TryGetLastAssistantText(conversation, out var latestAssistantText);
+        var appendInterimBubble = ShouldAppendInterimAssistantResult(
+            activeTurnReceivedDelta: _assistantStreamingState.HasReceivedDelta(),
+            activeTurnBoundToConversation: IsActiveTurnBoundToConversation(conversation),
+            interimAssistantText: interimText,
+            latestAssistantText: latestAssistantText);
+        if (appendInterimBubble) {
+            AppendAssistantText(conversation, interimText);
+        } else {
+            ReplaceLastAssistantText(conversation, interimText);
+        }
+        conversation.UpdatedUtc = DateTime.UtcNow;
+        BindActiveTurnAssistantMessage(conversation);
+        SetActiveTurnAssistantChannel(conversation, AssistantBubbleChannelKind.DraftThinking);
+        SetActiveTurnAssistantProvisional(conversation, provisional: true, preferProvisionalEvents: false);
+        if (string.Equals(conversation.Id, _activeConversationId, StringComparison.OrdinalIgnoreCase)) {
+            QueueTranscriptRender("assistant_interim_result");
+        }
+    }
+
+    internal static bool ShouldAppendInterimAssistantResult(bool activeTurnReceivedDelta, bool activeTurnBoundToConversation) {
+        return !activeTurnReceivedDelta || !activeTurnBoundToConversation;
+    }
+
+    internal static bool ShouldAppendInterimAssistantResult(
+        bool activeTurnReceivedDelta,
+        bool activeTurnBoundToConversation,
+        string? interimAssistantText,
+        string? latestAssistantText) {
+        if (!ShouldAppendInterimAssistantResult(activeTurnReceivedDelta, activeTurnBoundToConversation)) {
+            return false;
+        }
+
+        var interimText = NormalizeAssistantSnapshotForAppendDecision(interimAssistantText);
+        if (interimText.Length == 0) {
+            return false;
+        }
+
+        var latestText = NormalizeAssistantSnapshotForAppendDecision(latestAssistantText);
+        return latestText.Length == 0
+               || (!string.Equals(interimText, latestText, StringComparison.OrdinalIgnoreCase)
+                   && !AreNearDuplicateAssistantSnapshots(interimText, latestText));
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.ServiceLifecycle.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.ServiceAuth.ServiceLifecycle.cs
@@ -313,6 +313,7 @@ public sealed partial class MainWindow {
     private async Task DisposeClientAsync() {
         var client = _client;
         _client = null;
+        _turnRunner = null;
         _isConnected = false;
         _activeKickoffRequestId = null;
         lock (_aliveProbeSync) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -283,6 +283,7 @@ public sealed partial class MainWindow : Window {
     private int _startupBenchAutoSendQueued;
 
     private ChatServiceClient? _client;
+    private ChatServiceTurnRunner? _turnRunner;
     private string? _threadId;
     private int _nextRequestId = 1;
     private (string LoginId, string PromptId, string PromptText)? _pendingLoginPrompt;
@@ -406,11 +407,10 @@ public sealed partial class MainWindow : Window {
     private string? _latestTurnRequestId;
     private string? _activeKickoffRequestId;
     private string? _cancelRequestedTurnRequestId;
-    private CancellationTokenSource? _activeTurnRequestCts;
     private bool _activeTurnFromQueuedAfterLogin;
     private string _activeTurnNormalizedPromptText = string.Empty;
     private string _activeTurnPromptConversationId = string.Empty;
-    // Serializes active-turn request id/CTS handoff, cancel, and teardown.
+    // Serializes active-turn request id, cancel, and teardown.
     private readonly object _activeTurnLifecycleSync = new();
     private readonly object _turnDiagnosticsSync = new();
     private readonly List<string> _activityTimeline = new();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatServiceClient.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatServiceClient.cs
@@ -16,7 +16,7 @@ namespace IntelligenceX.Chat.Client;
 /// <summary>
 /// Minimal named-pipe client for <c>IntelligenceX.Chat.Service</c>.
 /// </summary>
-public sealed class ChatServiceClient : IAsyncDisposable {
+public sealed class ChatServiceClient : IChatServiceClient, IAsyncDisposable {
     private readonly ConcurrentDictionary<string, TaskCompletionSource<ChatServiceMessage>> _pending = new(StringComparer.Ordinal);
     private readonly SemaphoreSlim _writeLock = new(1, 1);
     private int _disconnectSignaled;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatServiceTurnRunner.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatServiceTurnRunner.cs
@@ -1,0 +1,109 @@
+using System.Threading.Channels;
+using IntelligenceX.Chat.Abstractions.Protocol;
+
+namespace IntelligenceX.Chat.Client;
+
+/// <summary>
+/// Runs request-scoped chat turns over a connected service client and preserves the full
+/// ordered status, stream, interim, metrics, tool, timeline, and final-result contract.
+/// </summary>
+public sealed class ChatServiceTurnRunner {
+    private readonly IChatServiceClient _client;
+
+    /// <summary>
+    /// Creates a turn runner over an already connected service client.
+    /// </summary>
+    public ChatServiceTurnRunner(IChatServiceClient client) {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <summary>
+    /// Runs a chat request and serially forwards every correlated turn update before returning.
+    /// </summary>
+    public async Task<ChatTurnRunResult> RunAsync(
+        ChatRequest request,
+        Func<ChatTurnUpdate, CancellationToken, ValueTask>? onUpdate = null,
+        CancellationToken cancellationToken = default) {
+        ArgumentNullException.ThrowIfNull(request);
+        if (string.IsNullOrWhiteSpace(request.RequestId)) {
+            throw new ArgumentException("RequestId is required.", nameof(request));
+        }
+
+        var requestId = request.RequestId;
+        var updates = Channel.CreateUnbounded<ChatTurnUpdate>(new UnboundedChannelOptions {
+            SingleReader = true,
+            SingleWriter = false,
+            AllowSynchronousContinuations = false
+        });
+        ChatMetricsMessage? metrics = null;
+
+        void OnMessage(ChatServiceMessage message) {
+            if (!string.Equals(message.RequestId, requestId, StringComparison.Ordinal)) {
+                return;
+            }
+
+            var update = ChatTurnUpdate.FromMessage(message);
+            if (update is not null) {
+                _ = updates.Writer.TryWrite(update);
+            }
+        }
+
+        async Task PumpUpdatesAsync() {
+            await foreach (var update in updates.Reader.ReadAllAsync(CancellationToken.None).ConfigureAwait(false)) {
+                if (update is ChatTurnMetricsUpdate metricsUpdate) {
+                    metrics = metricsUpdate.Metrics;
+                }
+
+                if (onUpdate is not null) {
+                    await onUpdate(update, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        _client.MessageReceived += OnMessage;
+        var updatePump = PumpUpdatesAsync();
+        try {
+            var response = await _client.RequestAsync<ChatResultMessage>(request, cancellationToken).ConfigureAwait(false);
+            updates.Writer.TryComplete();
+            await updatePump.ConfigureAwait(false);
+            return new ChatTurnRunResult(response, metrics);
+        } catch {
+            updates.Writer.TryComplete();
+            try {
+                await updatePump.ConfigureAwait(false);
+            } catch {
+                // Preserve the exception already being handled. When the pump itself was the
+                // original failure, the rethrow below still preserves that callback exception.
+            }
+            throw;
+        } finally {
+            _client.MessageReceived -= OnMessage;
+            updates.Writer.TryComplete();
+        }
+    }
+
+    /// <summary>
+    /// Requests cancellation of an active service turn.
+    /// </summary>
+    public async Task CancelAsync(string chatRequestId, CancellationToken cancellationToken = default) {
+        var normalizedRequestId = (chatRequestId ?? string.Empty).Trim();
+        if (normalizedRequestId.Length == 0) {
+            throw new ArgumentException("Chat request id is required.", nameof(chatRequestId));
+        }
+
+        var acknowledgement = await _client.RequestAsync<AckMessage>(
+                new CancelChatRequest {
+                    RequestId = "turn-cancel-" + Guid.NewGuid().ToString("N"),
+                    ChatRequestId = normalizedRequestId
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (!acknowledgement.Ok) {
+            throw new ChatServiceRequestException(
+                string.IsNullOrWhiteSpace(acknowledgement.Message)
+                    ? "The service did not accept the chat cancellation request."
+                    : acknowledgement.Message!,
+                acknowledgement.Code);
+        }
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatTurnTextAccumulator.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatTurnTextAccumulator.cs
@@ -1,0 +1,181 @@
+using System.Text;
+
+namespace IntelligenceX.Chat.Client;
+
+/// <summary>
+/// Builds one assistant draft from incremental or snapshot-style stream fragments.
+/// </summary>
+public sealed class ChatTurnTextAccumulator {
+    private const int MaxBufferedChars = 64 * 1024;
+    private const int TrimmedBufferChars = 48 * 1024;
+    private const int SnapshotOverlapCandidateThresholdChars = 6;
+
+    private readonly object _sync = new();
+    private readonly StringBuilder _buffer = new();
+    private bool _receivedFragment;
+    private bool _receivedProvisionalFragment;
+    private bool _deltaFragmentsLookLikeSnapshots;
+    private bool _provisionalFragmentsLookLikeSnapshots;
+
+    /// <summary>
+    /// Gets whether any assistant stream fragment has been observed since the last reset.
+    /// </summary>
+    public bool HasReceivedFragment {
+        get {
+            lock (_sync) {
+                return _receivedFragment;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets whether any provisional assistant fragment has been observed since the last reset.
+    /// </summary>
+    public bool HasReceivedProvisionalFragment {
+        get {
+            lock (_sync) {
+                return _receivedProvisionalFragment;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the current buffered character count.
+    /// </summary>
+    public int BufferedLength {
+        get {
+            lock (_sync) {
+                return _buffer.Length;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Clears all buffered text and stream-shape observations.
+    /// </summary>
+    public void Reset() {
+        lock (_sync) {
+            _buffer.Clear();
+            _receivedFragment = false;
+            _receivedProvisionalFragment = false;
+            _deltaFragmentsLookLikeSnapshots = false;
+            _provisionalFragmentsLookLikeSnapshots = false;
+        }
+    }
+
+    /// <summary>
+    /// Merges a stream fragment and returns the complete current draft.
+    /// </summary>
+    public string Append(string fragment, bool fromProvisionalEvent = false) {
+        ArgumentNullException.ThrowIfNull(fragment);
+
+        lock (_sync) {
+            if (fragment.Length > 0) {
+                if (!TryMergeStreamingFragmentLocked(fragment, fromProvisionalEvent)) {
+                    _buffer.Append(fragment);
+                }
+
+                TrimBufferIfNeededLocked();
+                _receivedFragment = true;
+                if (fromProvisionalEvent) {
+                    _receivedProvisionalFragment = true;
+                }
+            }
+
+            return _buffer.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Returns the complete current draft without mutating it.
+    /// </summary>
+    public string Snapshot() {
+        lock (_sync) {
+            return _buffer.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Clears only the general received-fragment signal while preserving the buffered draft.
+    /// </summary>
+    public void ClearReceivedFragment() {
+        lock (_sync) {
+            _receivedFragment = false;
+        }
+    }
+
+    private bool TryMergeStreamingFragmentLocked(string fragment, bool fromProvisionalEvent) {
+        if (_buffer.Length == 0) {
+            return false;
+        }
+
+        var current = _buffer.ToString();
+        if (string.Equals(current, fragment, StringComparison.Ordinal)) {
+            return true;
+        }
+
+        var shouldTrySnapshotMerge = fromProvisionalEvent
+            ? _provisionalFragmentsLookLikeSnapshots || !_receivedProvisionalFragment || fragment.Length >= current.Length
+            : _deltaFragmentsLookLikeSnapshots || !_receivedFragment || fragment.Length >= current.Length;
+        if (shouldTrySnapshotMerge
+            && TryMergeAsSnapshotFragmentLocked(current, fragment, out var snapshotDetected)) {
+            if (snapshotDetected) {
+                if (fromProvisionalEvent) {
+                    _provisionalFragmentsLookLikeSnapshots = true;
+                } else {
+                    _deltaFragmentsLookLikeSnapshots = true;
+                }
+            }
+            return true;
+        }
+
+        return current.EndsWith(fragment, StringComparison.Ordinal);
+    }
+
+    private bool TryMergeAsSnapshotFragmentLocked(string current, string fragment, out bool snapshotDetected) {
+        snapshotDetected = false;
+        if (fragment.StartsWith(current, StringComparison.Ordinal)) {
+            _buffer.Append(fragment.AsSpan(current.Length));
+            snapshotDetected = true;
+            return true;
+        }
+
+        if (current.StartsWith(fragment, StringComparison.Ordinal)) {
+            snapshotDetected = true;
+            return true;
+        }
+
+        var overlap = FindLongestSuffixPrefixOverlap(current, fragment);
+        var looksLikeSnapshotOverlap = overlap >= SnapshotOverlapCandidateThresholdChars
+                                       || overlap == current.Length
+                                       || overlap == fragment.Length;
+        if (overlap < 1 || !looksLikeSnapshotOverlap) {
+            return false;
+        }
+
+        if (overlap < fragment.Length) {
+            _buffer.Append(fragment.AsSpan(overlap));
+        }
+        snapshotDetected = true;
+        return true;
+    }
+
+    private static int FindLongestSuffixPrefixOverlap(string left, string right) {
+        var max = Math.Min(left.Length, right.Length);
+        for (var length = max; length >= 1; length--) {
+            if (left.AsSpan(left.Length - length).SequenceEqual(right.AsSpan(0, length))) {
+                return length;
+            }
+        }
+
+        return 0;
+    }
+
+    private void TrimBufferIfNeededLocked() {
+        if (_buffer.Length <= MaxBufferedChars) {
+            return;
+        }
+
+        _buffer.Remove(0, _buffer.Length - TrimmedBufferChars);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatTurnUpdate.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Client/ChatTurnUpdate.cs
@@ -1,0 +1,66 @@
+using IntelligenceX.Chat.Abstractions.Protocol;
+
+namespace IntelligenceX.Chat.Client;
+
+/// <summary>
+/// A request-scoped update emitted while a chat turn is running.
+/// </summary>
+public abstract record ChatTurnUpdate(ChatServiceMessage Message) {
+    /// <summary>
+    /// Creates the typed turn update represented by a protocol message.
+    /// </summary>
+    public static ChatTurnUpdate? FromMessage(ChatServiceMessage message) {
+        ArgumentNullException.ThrowIfNull(message);
+
+        return message switch {
+            ChatStatusMessage status => new ChatTurnStatusUpdate(status),
+            ChatDeltaMessage delta => new ChatTurnDeltaUpdate(delta),
+            ChatAssistantProvisionalMessage provisional => new ChatTurnProvisionalUpdate(provisional),
+            ChatInterimResultMessage interim => new ChatTurnInterimUpdate(interim),
+            ChatMetricsMessage metrics => new ChatTurnMetricsUpdate(metrics),
+            ChatResultMessage result => new ChatTurnCompletedUpdate(result),
+            ErrorMessage error => new ChatTurnErrorUpdate(error),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Returns whether a protocol message belongs to the shared turn update contract.
+    /// </summary>
+    public static bool IsTurnMessage(ChatServiceMessage message) {
+        ArgumentNullException.ThrowIfNull(message);
+        return message is ChatStatusMessage
+            or ChatDeltaMessage
+            or ChatAssistantProvisionalMessage
+            or ChatInterimResultMessage
+            or ChatMetricsMessage
+            or ChatResultMessage
+            or ErrorMessage;
+    }
+}
+
+/// <summary>Progress or tool status emitted by the service.</summary>
+public sealed record ChatTurnStatusUpdate(ChatStatusMessage Status) : ChatTurnUpdate(Status);
+
+/// <summary>Incremental assistant text emitted by the service.</summary>
+public sealed record ChatTurnDeltaUpdate(ChatDeltaMessage Delta) : ChatTurnUpdate(Delta);
+
+/// <summary>Provisional assistant text emitted during reviewed turns.</summary>
+public sealed record ChatTurnProvisionalUpdate(ChatAssistantProvisionalMessage Provisional) : ChatTurnUpdate(Provisional);
+
+/// <summary>Interim assistant snapshot emitted before final synthesis.</summary>
+public sealed record ChatTurnInterimUpdate(ChatInterimResultMessage Interim) : ChatTurnUpdate(Interim);
+
+/// <summary>Metrics and autonomy telemetry for the completed turn.</summary>
+public sealed record ChatTurnMetricsUpdate(ChatMetricsMessage Metrics) : ChatTurnUpdate(Metrics);
+
+/// <summary>Final assistant response, including tools and timeline metadata.</summary>
+public sealed record ChatTurnCompletedUpdate(ChatResultMessage Result) : ChatTurnUpdate(Result);
+
+/// <summary>Terminal error returned for the turn.</summary>
+public sealed record ChatTurnErrorUpdate(ErrorMessage Error) : ChatTurnUpdate(Error);
+
+/// <summary>
+/// Complete request result with the metrics event observed before the terminal response.
+/// </summary>
+public sealed record ChatTurnRunResult(ChatResultMessage Response, ChatMetricsMessage? Metrics);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Client/IChatServiceClient.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Client/IChatServiceClient.cs
@@ -1,0 +1,19 @@
+using IntelligenceX.Chat.Abstractions.Protocol;
+
+namespace IntelligenceX.Chat.Client;
+
+/// <summary>
+/// Request and event surface used by higher-level chat client coordinators.
+/// </summary>
+public interface IChatServiceClient {
+    /// <summary>
+    /// Raised for every protocol message received from the service.
+    /// </summary>
+    event Action<ChatServiceMessage>? MessageReceived;
+
+    /// <summary>
+    /// Sends a request and waits for its correlated response.
+    /// </summary>
+    Task<TResponse> RequestAsync<TResponse>(ChatServiceRequest request, CancellationToken cancellationToken)
+        where TResponse : ChatServiceMessage;
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
@@ -1727,6 +1727,12 @@ internal sealed partial class ChatServiceSession {
         active.Cancel();
         if (removedQueuedRun) {
             active.MarkCompleted();
+            await WriteAsync(writer, new ErrorMessage {
+                Kind = ChatServiceMessageKind.Response,
+                RequestId = chatRequestId,
+                Error = "Chat canceled before execution by client.",
+                Code = "chat_canceled"
+            }, cancellationToken).ConfigureAwait(false);
         }
         await WriteAsync(writer, new AckMessage {
             Kind = ChatServiceMessageKind.Response,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
@@ -1099,6 +1099,8 @@ internal sealed partial class ChatServiceSession {
                 requestedModel,
                 runtimeDefaultModel);
             var bufferDraftDeltasForSmartReview = ShouldBufferDraftDeltasForSmartReview(request);
+            ChatMetricsMessage? turnMetrics = null;
+            ChatServiceMessage? turnResponse = null;
             BeginTurnTimelineCapture(request.RequestId);
             try {
                 if (bufferDraftDeltasForSmartReview) {
@@ -1143,7 +1145,7 @@ internal sealed partial class ChatServiceSession {
                         status: ChatStatusCodes.Done,
                         message: "Turn completed.")
                     .ConfigureAwait(false);
-                await WriteAsync(writer, result.Result, CancellationToken.None).ConfigureAwait(false);
+                turnResponse = result.Result;
 
                 await TryRecordRecentModelAsync(telemetryModel, CancellationToken.None).ConfigureAwait(false);
             } catch (OpenAIAuthenticationRequiredException) {
@@ -1156,12 +1158,12 @@ internal sealed partial class ChatServiceSession {
                         status: ChatStatusCodes.Error,
                         message: "Authentication required.")
                     .ConfigureAwait(false);
-                await WriteAsync(writer, new ErrorMessage {
+                turnResponse = new ErrorMessage {
                     Kind = ChatServiceMessageKind.Response,
                     RequestId = request.RequestId,
                     Error = "Not authenticated. Run ChatGPT login in a client that can persist ~/.intelligencex/auth.json, then reconnect.",
                     Code = "not_authenticated"
-                }, CancellationToken.None).ConfigureAwait(false);
+                };
             } catch (OperationCanceledException) when (run.Cts.IsCancellationRequested && !sessionCancellationToken.IsCancellationRequested) {
                 outcome = "canceled";
                 outcomeCode = "chat_canceled";
@@ -1172,12 +1174,12 @@ internal sealed partial class ChatServiceSession {
                         status: ChatStatusCodes.Error,
                         message: "Chat canceled by client.")
                     .ConfigureAwait(false);
-                await WriteAsync(writer, new ErrorMessage {
+                turnResponse = new ErrorMessage {
                     Kind = ChatServiceMessageKind.Response,
                     RequestId = request.RequestId,
                     Error = "Chat canceled by client.",
                     Code = "chat_canceled"
-                }, CancellationToken.None).ConfigureAwait(false);
+                };
             } catch (OperationCanceledException ex) when (IsTurnTimeoutCancellation(request, run, sessionCancellationToken, ex.CancellationToken)) {
                 outcome = "timeout";
                 outcomeCode = "chat_timeout";
@@ -1192,12 +1194,12 @@ internal sealed partial class ChatServiceSession {
                         status: ChatStatusCodes.Timeout,
                         message: timeoutMessage)
                     .ConfigureAwait(false);
-                await WriteAsync(writer, new ErrorMessage {
+                turnResponse = new ErrorMessage {
                     Kind = ChatServiceMessageKind.Response,
                     RequestId = request.RequestId,
                     Error = timeoutMessage,
                     Code = "chat_timeout"
-                }, CancellationToken.None).ConfigureAwait(false);
+                };
             } catch (OperationCanceledException) when (sessionCancellationToken.IsCancellationRequested) {
                 // Session shutting down.
                 outcome = "canceled";
@@ -1212,12 +1214,12 @@ internal sealed partial class ChatServiceSession {
                         status: ChatStatusCodes.Error,
                         message: "Chat failed: " + ex.Message)
                     .ConfigureAwait(false);
-                await WriteAsync(writer, new ErrorMessage {
+                turnResponse = new ErrorMessage {
                     Kind = ChatServiceMessageKind.Response,
                     RequestId = request.RequestId,
                     Error = $"Chat failed: {ex.Message}",
                     Code = "chat_failed"
-                }, CancellationToken.None).ConfigureAwait(false);
+                };
             } finally {
                 var completedAtUtc = DateTime.UtcNow;
                 var durationMs = (long)Math.Max(0, (completedAtUtc - startedAtUtc).TotalMilliseconds);
@@ -1239,7 +1241,7 @@ internal sealed partial class ChatServiceSession {
                         toolErrors: toolErrors,
                         autonomyCounters: autonomyCounters,
                         completed: string.Equals(outcome, "ok", StringComparison.OrdinalIgnoreCase));
-                    await WriteAsync(writer, new ChatMetricsMessage {
+                    turnMetrics = new ChatMetricsMessage {
                         Kind = ChatServiceMessageKind.Event,
                         RequestId = request.RequestId,
                         ThreadId = threadIdForDelta,
@@ -1265,13 +1267,30 @@ internal sealed partial class ChatServiceSession {
                         EndpointHost = metricsEndpointHost,
                         Outcome = outcome,
                         ErrorCode = outcomeCode
-                    }, CancellationToken.None).ConfigureAwait(false);
+                    };
                 } catch {
-                    // Best-effort; ignore pipe failures.
+                    // Metrics are best-effort; keep the terminal response deliverable.
+                    turnMetrics = null;
                 }
 
                 deltaSubscription?.Dispose();
                 EndTurnTimelineCapture(request.RequestId);
+            }
+
+            // The response is the terminal frame for a request. Keeping metrics and every
+            // other event before it lets clients drain a complete ordered turn without a
+            // timing grace period or a second UI-specific event listener.
+            foreach (var frame in OrderTurnCompletionFrames(turnMetrics, turnResponse)) {
+                if (frame is ChatMetricsMessage) {
+                    try {
+                        await WriteAsync(writer, frame, CancellationToken.None).ConfigureAwait(false);
+                    } catch {
+                        // Metrics remain best-effort; a metrics write must not suppress the response.
+                    }
+                    continue;
+                }
+
+                await WriteAsync(writer, frame, CancellationToken.None).ConfigureAwait(false);
             }
         } catch (OperationCanceledException) when (run.Cts.IsCancellationRequested && !sessionCancellationToken.IsCancellationRequested) {
             await TryWriteStatusAsync(
@@ -1316,6 +1335,18 @@ internal sealed partial class ChatServiceSession {
                 }
             }
         }
+    }
+
+    internal static ChatServiceMessage[] OrderTurnCompletionFrames(
+        ChatMetricsMessage? metrics,
+        ChatServiceMessage? response) {
+        if (metrics is null) {
+            return response is null ? Array.Empty<ChatServiceMessage>() : new[] { response };
+        }
+
+        return response is null
+            ? new ChatServiceMessage[] { metrics }
+            : new ChatServiceMessage[] { metrics, response };
     }
 
     private int GetQueuedChatRunCountNoLock() {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RequestFlowLifecycle.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.RequestFlowLifecycle.cs
@@ -302,7 +302,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
-    public async Task HandleCancelChatAsync_CancelQueuedRun_KeepsRemainingQueueProgressing() {
+    public async Task HandleCancelChatAsync_CancelQueuedRun_EmitsTerminalCancellationAndKeepsRemainingQueueProgressing() {
         using var server = new DeterministicCompatibleHttpServer(responseIndex => {
             if (responseIndex == 1) {
                 Thread.Sleep(TimeSpan.FromSeconds(7));
@@ -353,18 +353,19 @@ public sealed partial class ChatServiceRoutingTrimTests {
         await InvokeHandleCancelChatAsync(session, writer, cancelRequest, CancellationToken.None);
 
         await WaitForAckAsync(capture, cancelRequest.RequestId, TimeSpan.FromSeconds(5));
+        await WaitForRequestErrorCodeAsync(capture, canceledQueuedRequest.RequestId!, "chat_canceled", TimeSpan.FromSeconds(5));
         await WaitForRequestStatusAsync(capture, activeRequest.RequestId!, ChatStatusCodes.Done, TimeSpan.FromSeconds(20));
         await WaitForRequestStatusAsync(capture, trailingQueuedRequest.RequestId!, ChatStatusCodes.Done, TimeSpan.FromSeconds(20));
 
         Assert.False(
             HasRequestStatus(capture.Snapshot(), canceledQueuedRequest.RequestId!, ChatStatusCodes.Done),
             "Canceled queued request unexpectedly reached done status.");
-        Assert.False(
+        Assert.True(
             HasRequestErrorCode(capture.Snapshot(), canceledQueuedRequest.RequestId!, "chat_canceled"),
-            "Queued cancellation should remove the queued run without emitting a terminal chat_canceled frame.");
-        Assert.False(
+            "Queued cancellation should emit a terminal chat_canceled response for the original request.");
+        Assert.True(
             HasTerminalFrame(capture.Snapshot(), canceledQueuedRequest.RequestId!),
-            "Canceled queued request unexpectedly emitted a terminal frame.");
+            "Canceled queued request should complete its original client wait with a terminal frame.");
     }
 
     private static async Task InvokeHandleChatRequestAsync(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatTurnCompletionFrameOrderingTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatTurnCompletionFrameOrderingTests.cs
@@ -1,0 +1,47 @@
+using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Service;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class ChatTurnCompletionFrameOrderingTests {
+    [Fact]
+    public void OrderTurnCompletionFrames_PutsMetricsBeforeTerminalResponse() {
+        var now = DateTime.UtcNow;
+        var metrics = new ChatMetricsMessage {
+            Kind = ChatServiceMessageKind.Event,
+            RequestId = "turn-1",
+            ThreadId = "thread-1",
+            StartedAtUtc = now,
+            CompletedAtUtc = now,
+            Outcome = "ok"
+        };
+        var response = new ChatResultMessage {
+            Kind = ChatServiceMessageKind.Response,
+            RequestId = "turn-1",
+            ThreadId = "thread-1",
+            Text = "done"
+        };
+
+        var frames = ChatServiceSession.OrderTurnCompletionFrames(metrics, response);
+
+        Assert.Collection(
+            frames,
+            frame => Assert.Same(metrics, frame),
+            frame => Assert.Same(response, frame));
+    }
+
+    [Fact]
+    public void OrderTurnCompletionFrames_KeepsResponseWhenMetricsUnavailable() {
+        var response = new ErrorMessage {
+            Kind = ChatServiceMessageKind.Response,
+            RequestId = "turn-1",
+            Error = "failed",
+            Code = "chat_failed"
+        };
+
+        var frames = ChatServiceSession.OrderTurnCompletionFrames(metrics: null, response);
+
+        Assert.Same(response, Assert.Single(frames));
+    }
+}


### PR DESCRIPTION
## Summary

- add a UI-neutral `ChatServiceTurnRunner` that preserves correlated status, delta, provisional, interim, metrics, final result, tools, timeline, and error frames
- add one shared stream accumulator for incremental and snapshot-style assistant fragments, with the current shell retaining only markdown preview normalization
- migrate user turns and onboarding kickoff turns to the shared runner and shared cancellation contract
- split turn projection out of the mixed service/login message partial
- make the service response the terminal request frame, so metrics are delivered before a runner detaches

## Compatibility

This intentionally changes internal desktop coordination APIs. `ChatServiceClient` now implements the small `IChatServiceClient` contract, and desktop consumers should use `ChatServiceTurnRunner` rather than subscribing to turn frames independently.

The wire payload shapes are unchanged, but completion ordering is now explicit: `chat_metrics` is emitted before the terminal `chat_result` or `error` response. Canceling an accepted queued turn now also completes its original request with a terminal `chat_canceled` error before the cancel acknowledgment, so clients cannot remain stuck waiting for a removed queue item.

## Validation

- `IntelligenceX.Chat.App.Tests`: 1,366 passed
- Release app and service sidecar builds: succeeded
- packaged desktop startup smoke: runtime connect, hello, and model sync completed

The full local solution restore is blocked by the configured sibling TestimoX graph missing `Licensing.Verification`; clean GitHub CI remains the full-solution check.