### PR TITLE
Centralize chat JSON persistence

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.AlternateEngineHealth.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.AlternateEngineHealth.Persistence.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 using IntelligenceX.Chat.Tooling;
 using IntelligenceX.Chat.Abstractions.Protocol;
 
@@ -15,10 +16,6 @@ internal sealed partial class ChatServiceSession {
     private const int MaxRememberedAlternateEngineHealthEntriesPerThread = 24;
     private static readonly TimeSpan AlternateEngineHealthContextMaxAge = TimeSpan.FromMinutes(30);
     private static readonly object AlternateEngineHealthStoreLock = new();
-    private static readonly JsonSerializerOptions AlternateEngineHealthStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class AlternateEngineHealthStoreDto {
         public int Version { get; set; } = AlternateEngineHealthStoreVersion;
@@ -42,24 +39,11 @@ internal sealed partial class ChatServiceSession {
         long LastSuccessUtcTicks,
         long LastFailureUtcTicks);
 
-    private static string ResolveDefaultAlternateEngineHealthStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultAlternateEngineHealthStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("alternate-engine-health.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "alternate-engine-health.json");
-    }
-
-    private string ResolveAlternateEngineHealthStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "alternate-engine-health.json");
-        }
-
-        return ResolveDefaultAlternateEngineHealthStorePath();
-    }
+    private string ResolveAlternateEngineHealthStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "alternate-engine-health.json");
 
     private void RememberAlternateEngineOutcome(string threadId, string toolName, string engineId, ToolOutputDto output, long? seenUtcTicks = null) {
         var normalizedThreadId = (threadId ?? string.Empty).Trim();
@@ -262,13 +246,7 @@ internal sealed partial class ChatServiceSession {
     private void ClearAlternateEngineHealthSnapshots() {
         var path = ResolveAlternateEngineHealthStorePath();
         lock (AlternateEngineHealthStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Alternate engine health store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Alternate engine health store");
         }
     }
 
@@ -338,80 +316,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static AlternateEngineHealthStoreDto ReadAlternateEngineHealthStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new AlternateEngineHealthStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 512 * 1024) {
-                return new AlternateEngineHealthStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new AlternateEngineHealthStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<AlternateEngineHealthStoreDto>(json, AlternateEngineHealthStoreJsonOptions);
-            if (store is null || store.Version != AlternateEngineHealthStoreVersion || store.Threads is null) {
-                return new AlternateEngineHealthStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, AlternateEngineHealthStoreEntryDto[]>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Alternate engine health store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new AlternateEngineHealthStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 512 * 1024,
+            static json => JsonSerializer.Deserialize<AlternateEngineHealthStoreDto>(json),
+            static store => store.Version == AlternateEngineHealthStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, AlternateEngineHealthStoreEntryDto[]>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new AlternateEngineHealthStoreDto(),
+            "Alternate engine health store");
     }
 
     private static void WriteAlternateEngineHealthStoreNoThrow(string path, AlternateEngineHealthStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, AlternateEngineHealthStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Alternate engine health store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Alternate engine health store");
     }
 
     private static void PruneAlternateEngineHealthStore(AlternateEngineHealthStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using IntelligenceX.Chat.Abstractions.Policy;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
@@ -26,24 +27,11 @@ internal sealed partial class ChatServiceSession {
     private string _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateEmpty;
     private BackgroundSchedulerRuntimeStoreDto? _backgroundSchedulerRuntimeStoreDeferredPersistStore;
 
-    private static string ResolveDefaultBackgroundSchedulerRuntimeStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultBackgroundSchedulerRuntimeStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("background-scheduler-runtime.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "background-scheduler-runtime.json");
-    }
-
-    private string ResolveBackgroundSchedulerRuntimeStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "background-scheduler-runtime.json");
-        }
-
-        return ResolveDefaultBackgroundSchedulerRuntimeStorePath();
-    }
+    private string ResolveBackgroundSchedulerRuntimeStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "background-scheduler-runtime.json");
 
     private void TryRehydrateBackgroundSchedulerRuntimeState() {
         var path = ResolveBackgroundSchedulerRuntimeStorePath();
@@ -353,84 +341,32 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static BackgroundSchedulerRuntimeStoreReadResult ReadBackgroundSchedulerRuntimeStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return BackgroundSchedulerRuntimeStoreReadResult.Empty();
-            }
+        var result = ChatServiceJsonFileStore.Read(
+            path,
+            maximumBytes: 512 * 1024,
+            static json => JsonSerializer.Deserialize<BackgroundSchedulerRuntimeStoreDto>(
+                json,
+                BackgroundSchedulerRuntimeStoreReadJsonOptions),
+            static store => store.Version == BackgroundSchedulerRuntimeStoreVersion,
+            normalize: null,
+            "Background scheduler runtime store");
 
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 512 * 1024) {
-                return BackgroundSchedulerRuntimeStoreReadResult.Invalid();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return BackgroundSchedulerRuntimeStoreReadResult.Empty();
-            }
-
-            var store = JsonSerializer.Deserialize<BackgroundSchedulerRuntimeStoreDto>(json, BackgroundSchedulerRuntimeStoreReadJsonOptions);
-            if (store is null) {
-                return BackgroundSchedulerRuntimeStoreReadResult.Invalid();
-            }
-
-            if (store.Version != BackgroundSchedulerRuntimeStoreVersion) {
-                Trace.TraceWarning(
-                    $"Background scheduler runtime store version mismatch: expected {BackgroundSchedulerRuntimeStoreVersion}, found {store.Version}.");
-                return BackgroundSchedulerRuntimeStoreReadResult.Invalid();
-            }
-
-            return BackgroundSchedulerRuntimeStoreReadResult.Loaded(store);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Background scheduler runtime store read failed: {ex.GetType().Name}: {ex.Message}");
-            return BackgroundSchedulerRuntimeStoreReadResult.Invalid();
-        }
+        return result.State switch {
+            ChatServiceJsonFileReadState.Loaded when result.Value is not null =>
+                BackgroundSchedulerRuntimeStoreReadResult.Loaded(result.Value),
+            ChatServiceJsonFileReadState.Empty => BackgroundSchedulerRuntimeStoreReadResult.Empty(),
+            _ => BackgroundSchedulerRuntimeStoreReadResult.Invalid()
+        };
     }
 
     private static void WriteBackgroundSchedulerRuntimeStoreNoThrow(string path, BackgroundSchedulerRuntimeStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(
-                store,
-                BackgroundSchedulerRuntimeStoreJsonContext.Default.BackgroundSchedulerRuntimeStoreDto);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Background scheduler runtime store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(
+                value,
+                BackgroundSchedulerRuntimeStoreJsonContext.Default.BackgroundSchedulerRuntimeStoreDto),
+            "Background scheduler runtime store");
     }
 
     private static bool TryWithBackgroundSchedulerRuntimeStoreLock<TState, TStateResult>(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundWork.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundWork.Persistence.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 using IntelligenceX.Tools;
 
 namespace IntelligenceX.Chat.Service;
@@ -12,10 +13,6 @@ namespace IntelligenceX.Chat.Service;
 internal sealed partial class ChatServiceSession {
     private const int BackgroundWorkStoreVersion = 4;
     private static readonly object BackgroundWorkStoreLock = new();
-    private static readonly JsonSerializerOptions BackgroundWorkStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class BackgroundWorkStoreDto {
         public int Version { get; set; } = BackgroundWorkStoreVersion;
@@ -60,24 +57,11 @@ internal sealed partial class ChatServiceSession {
         public long UpdatedUtcTicks { get; set; }
     }
 
-    private static string ResolveDefaultBackgroundWorkStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultBackgroundWorkStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("background-work-cache.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "background-work-cache.json");
-    }
-
-    private string ResolveBackgroundWorkStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "background-work-cache.json");
-        }
-
-        return ResolveDefaultBackgroundWorkStorePath();
-    }
+    private string ResolveBackgroundWorkStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "background-work-cache.json");
 
     private void PersistThreadBackgroundWorkSnapshot(string threadId, ThreadBackgroundWorkSnapshot snapshot, long seenUtcTicks) {
         var normalizedThreadId = (threadId ?? string.Empty).Trim();
@@ -345,91 +329,31 @@ internal sealed partial class ChatServiceSession {
     private void ClearBackgroundWorkSnapshots() {
         var path = ResolveBackgroundWorkStorePath();
         lock (BackgroundWorkStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Background work store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Background work store");
         }
     }
 
     private static BackgroundWorkStoreDto ReadBackgroundWorkStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new BackgroundWorkStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 1024 * 1024) {
-                return new BackgroundWorkStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new BackgroundWorkStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<BackgroundWorkStoreDto>(json, BackgroundWorkStoreJsonOptions);
-            if (store is null || store.Version != BackgroundWorkStoreVersion || store.Threads is null) {
-                return new BackgroundWorkStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, BackgroundWorkStoreThreadEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Background work store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new BackgroundWorkStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 1024 * 1024,
+            static json => JsonSerializer.Deserialize<BackgroundWorkStoreDto>(json),
+            static store => store.Version == BackgroundWorkStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, BackgroundWorkStoreThreadEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new BackgroundWorkStoreDto(),
+            "Background work store");
     }
 
     private static void WriteBackgroundWorkStoreNoThrow(string path, BackgroundWorkStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, BackgroundWorkStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Background work store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Background work store");
     }
 
     private static void PruneBackgroundWorkStore(BackgroundWorkStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.DomainIntent.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.DomainIntent.Persistence.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int DomainIntentStoreVersion = 1;
     private static readonly object DomainIntentStoreLock = new();
-    private static readonly JsonSerializerOptions DomainIntentStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class DomainIntentStoreDto {
         public int Version { get; set; } = DomainIntentStoreVersion;
@@ -26,23 +23,11 @@ internal sealed partial class ChatServiceSession {
         public long SeenUtcTicks { get; set; }
     }
 
-    private static string ResolveDefaultDomainIntentStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
-        return Path.Combine(root, "IntelligenceX.Chat", "domain-intent-families.json");
-    }
+    private static string ResolveDefaultDomainIntentStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("domain-intent-families.json");
 
-    private string ResolveDomainIntentStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "domain-intent-families.json");
-        }
-
-        return ResolveDefaultDomainIntentStorePath();
-    }
+    private string ResolveDomainIntentStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "domain-intent-families.json");
 
     private void PersistDomainIntentFamilySnapshot(string threadId, string family, long seenUtcTicks) {
         var normalizedThreadId = (threadId ?? string.Empty).Trim();
@@ -85,13 +70,7 @@ internal sealed partial class ChatServiceSession {
     private void ClearDomainIntentFamilySnapshots() {
         var path = ResolveDomainIntentStorePath();
         lock (DomainIntentStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Domain intent store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Domain intent store");
         }
     }
 
@@ -142,80 +121,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static DomainIntentStoreDto ReadDomainIntentStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new DomainIntentStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 512 * 1024) {
-                return new DomainIntentStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new DomainIntentStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<DomainIntentStoreDto>(json, DomainIntentStoreJsonOptions);
-            if (store is null || store.Version != DomainIntentStoreVersion || store.Threads is null) {
-                return new DomainIntentStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, DomainIntentStoreEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Domain intent store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new DomainIntentStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 512 * 1024,
+            static json => JsonSerializer.Deserialize<DomainIntentStoreDto>(json),
+            static store => store.Version == DomainIntentStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, DomainIntentStoreEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new DomainIntentStoreDto(),
+            "Domain intent store");
     }
 
     private static void WriteDomainIntentStoreNoThrow(string path, DomainIntentStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, DomainIntentStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Domain intent store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Domain intent store");
     }
 
     private static void PruneDomainIntentStore(DomainIntentStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.DomainIntentClarification.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.DomainIntentClarification.Persistence.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int DomainIntentClarificationStoreVersion = 1;
     private static readonly object DomainIntentClarificationStoreLock = new();
-    private static readonly JsonSerializerOptions DomainIntentClarificationStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class DomainIntentClarificationStoreDto {
         public int Version { get; set; } = DomainIntentClarificationStoreVersion;
@@ -26,24 +23,11 @@ internal sealed partial class ChatServiceSession {
         public string[] Families { get; set; } = Array.Empty<string>();
     }
 
-    private static string ResolveDefaultDomainIntentClarificationStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultDomainIntentClarificationStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("domain-intent-clarifications.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "domain-intent-clarifications.json");
-    }
-
-    private string ResolveDomainIntentClarificationStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "domain-intent-clarifications.json");
-        }
-
-        return ResolveDefaultDomainIntentClarificationStorePath();
-    }
+    private string ResolveDomainIntentClarificationStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "domain-intent-clarifications.json");
 
     private void PersistPendingDomainIntentClarificationSnapshot(string threadId, long seenUtcTicks, IReadOnlyList<string>? families) {
         var normalizedThreadId = (threadId ?? string.Empty).Trim();
@@ -83,13 +67,7 @@ internal sealed partial class ChatServiceSession {
     private void ClearPendingDomainIntentClarificationSnapshots() {
         var path = ResolveDomainIntentClarificationStorePath();
         lock (DomainIntentClarificationStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Domain intent clarification store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Domain intent clarification store");
         }
     }
 
@@ -151,80 +129,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static DomainIntentClarificationStoreDto ReadDomainIntentClarificationStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new DomainIntentClarificationStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 256 * 1024) {
-                return new DomainIntentClarificationStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new DomainIntentClarificationStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<DomainIntentClarificationStoreDto>(json, DomainIntentClarificationStoreJsonOptions);
-            if (store is null || store.Version != DomainIntentClarificationStoreVersion || store.Threads is null) {
-                return new DomainIntentClarificationStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, DomainIntentClarificationStoreEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Domain intent clarification store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new DomainIntentClarificationStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 256 * 1024,
+            static json => JsonSerializer.Deserialize<DomainIntentClarificationStoreDto>(json),
+            static store => store.Version == DomainIntentClarificationStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, DomainIntentClarificationStoreEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new DomainIntentClarificationStoreDto(),
+            "Domain intent clarification store");
     }
 
     private static void WriteDomainIntentClarificationStoreNoThrow(string path, DomainIntentClarificationStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, DomainIntentClarificationStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Domain intent clarification store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Domain intent clarification store");
     }
 
     private static void PruneDomainIntentClarificationStore(DomainIntentClarificationStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.HostBootstrapFailures.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.HostBootstrapFailures.Persistence.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.Chat.Tooling;
 using IntelligenceX.OpenAI.ToolCalling;
@@ -19,10 +20,6 @@ internal sealed partial class ChatServiceSession {
     private const string HostBootstrapFailureKindPackPreflight = "pack_preflight";
     private const string HostBootstrapFailureKindRecoveryHelper = "recovery_helper";
     private static readonly object HostBootstrapFailureStoreLock = new();
-    private static readonly JsonSerializerOptions HostBootstrapFailureStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class HostBootstrapFailureStoreDto {
         public int Version { get; set; } = HostBootstrapFailureStoreVersion;
@@ -44,24 +41,11 @@ internal sealed partial class ChatServiceSession {
         string Error,
         long SeenUtcTicks);
 
-    private static string ResolveDefaultHostBootstrapFailureStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultHostBootstrapFailureStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("host-bootstrap-failures.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "host-bootstrap-failures.json");
-    }
-
-    private string ResolveHostBootstrapFailureStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "host-bootstrap-failures.json");
-        }
-
-        return ResolveDefaultHostBootstrapFailureStorePath();
-    }
+    private string ResolveHostBootstrapFailureStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "host-bootstrap-failures.json");
 
     private void RememberHostBootstrapFailure(string threadId, string toolName, string failureKind, ToolOutputDto output) {
         var normalizedThreadId = (threadId ?? string.Empty).Trim();
@@ -251,13 +235,7 @@ internal sealed partial class ChatServiceSession {
     private void ClearHostBootstrapFailureSnapshots() {
         var path = ResolveHostBootstrapFailureStorePath();
         lock (HostBootstrapFailureStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Host bootstrap failure store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Host bootstrap failure store");
         }
     }
 
@@ -343,80 +321,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static HostBootstrapFailureStoreDto ReadHostBootstrapFailureStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new HostBootstrapFailureStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 512 * 1024) {
-                return new HostBootstrapFailureStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new HostBootstrapFailureStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<HostBootstrapFailureStoreDto>(json, HostBootstrapFailureStoreJsonOptions);
-            if (store is null || store.Version != HostBootstrapFailureStoreVersion || store.Threads is null) {
-                return new HostBootstrapFailureStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, HostBootstrapFailureStoreEntryDto[]>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Host bootstrap failure store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new HostBootstrapFailureStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 512 * 1024,
+            static json => JsonSerializer.Deserialize<HostBootstrapFailureStoreDto>(json),
+            static store => store.Version == HostBootstrapFailureStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, HostBootstrapFailureStoreEntryDto[]>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new HostBootstrapFailureStoreDto(),
+            "Host bootstrap failure store");
     }
 
     private static void WriteHostBootstrapFailureStoreNoThrow(string path, HostBootstrapFailureStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, HostBootstrapFailureStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Host bootstrap failure store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Host bootstrap failure store");
     }
 
     private static void PruneHostBootstrapFailureStore(HostBootstrapFailureStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackPreflight.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PackPreflight.Persistence.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int PackPreflightStoreVersion = 1;
     private static readonly object PackPreflightStoreLock = new();
-    private static readonly JsonSerializerOptions PackPreflightStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class PackPreflightStoreDto {
         public int Version { get; set; } = PackPreflightStoreVersion;
@@ -26,24 +23,11 @@ internal sealed partial class ChatServiceSession {
         public long SeenUtcTicks { get; set; }
     }
 
-    private static string ResolveDefaultPackPreflightStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultPackPreflightStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("pack-preflight.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "pack-preflight.json");
-    }
-
-    private string ResolvePackPreflightStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "pack-preflight.json");
-        }
-
-        return ResolveDefaultPackPreflightStorePath();
-    }
+    private string ResolvePackPreflightStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "pack-preflight.json");
 
     private void PersistPackPreflightSnapshot(string threadId, IReadOnlyCollection<string> toolNames, long seenUtcTicks) {
         var normalizedThreadId = (threadId ?? string.Empty).Trim();
@@ -89,13 +73,7 @@ internal sealed partial class ChatServiceSession {
     private void ClearPackPreflightSnapshots() {
         var path = ResolvePackPreflightStorePath();
         lock (PackPreflightStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Pack preflight store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Pack preflight store");
         }
     }
 
@@ -150,80 +128,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static PackPreflightStoreDto ReadPackPreflightStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new PackPreflightStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 512 * 1024) {
-                return new PackPreflightStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new PackPreflightStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<PackPreflightStoreDto>(json, PackPreflightStoreJsonOptions);
-            if (store is null || store.Version != PackPreflightStoreVersion || store.Threads is null) {
-                return new PackPreflightStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, PackPreflightStoreEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Pack preflight store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new PackPreflightStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 512 * 1024,
+            static json => JsonSerializer.Deserialize<PackPreflightStoreDto>(json),
+            static store => store.Version == PackPreflightStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, PackPreflightStoreEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new PackPreflightStoreDto(),
+            "Pack preflight store");
     }
 
     private static void WritePackPreflightStoreNoThrow(string path, PackPreflightStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, PackPreflightStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Pack preflight store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Pack preflight store");
     }
 
     private static void PrunePackPreflightStore(PackPreflightStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.Persistence.cs
@@ -3,20 +3,15 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Security.AccessControl;
-using System.Security.Principal;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int PendingActionStoreVersion = 1;
     private static readonly object PendingActionStoreLock = new();
-    private static readonly JsonSerializerOptions PendingActionStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private static bool TryGetUtcDateTimeFromTicks(long utcTicks, out DateTime value) {
         value = default;
@@ -31,40 +26,6 @@ internal sealed partial class ChatServiceSession {
             return true;
         } catch (ArgumentOutOfRangeException) {
             return false;
-        }
-    }
-
-    private static void TryHardenPendingActionsStoreAclNoThrow(string path) {
-        if (string.IsNullOrWhiteSpace(path)) {
-            return;
-        }
-        if (!OperatingSystem.IsWindows()) {
-            return;
-        }
-
-        try {
-            if (!File.Exists(path)) {
-                return;
-            }
-            var attrs = File.GetAttributes(path);
-            if ((attrs & FileAttributes.Directory) != 0) {
-                return;
-            }
-
-            var currentSid = WindowsIdentity.GetCurrent().User;
-            if (currentSid is null) {
-                return;
-            }
-
-            var fileInfo = new FileInfo(path);
-            var security = fileInfo.GetAccessControl();
-            security.SetOwner(currentSid);
-            // Keep inherited rules to avoid breaking access; LocalAppData already provides per-user isolation.
-            security.SetAccessRuleProtection(isProtected: true, preserveInheritance: true);
-            security.SetAccessRule(new FileSystemAccessRule(currentSid, FileSystemRights.FullControl, AccessControlType.Allow));
-            fileInfo.SetAccessControl(security);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Pending action store ACL hardening failed: {ex.GetType().Name}: {ex.Message}");
         }
     }
 
@@ -89,13 +50,8 @@ internal sealed partial class ChatServiceSession {
         public bool? Mutating { get; set; }
     }
 
-    private static string ResolveDefaultPendingActionsStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
-        return Path.Combine(root, "IntelligenceX.Chat", "pending-actions.json");
-    }
+    private static string ResolveDefaultPendingActionsStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("pending-actions.json");
 
     private string ResolvePendingActionsStorePath() {
         var candidate = (_options.PendingActionsStorePath ?? string.Empty).Trim();
@@ -202,13 +158,7 @@ internal sealed partial class ChatServiceSession {
     private void ClearPendingActionsSnapshots() {
         var path = ResolvePendingActionsStorePath();
         lock (PendingActionStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Pending action store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Pending action store");
         }
     }
 
@@ -289,85 +239,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static PendingActionStoreDto ReadPendingActionsStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new PendingActionStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 1024 * 1024) {
-                // Cap read size to avoid local DoS via gigantic store files.
-                return new PendingActionStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new PendingActionStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<PendingActionStoreDto>(json, PendingActionStoreJsonOptions);
-            if (store is null || store.Version != PendingActionStoreVersion || store.Threads is null) {
-                return new PendingActionStoreDto();
-            }
-
-            // Ensure dictionary comparer matches expectations.
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, PendingActionStoreEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Pending action store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new PendingActionStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 1024 * 1024,
+            static json => JsonSerializer.Deserialize<PendingActionStoreDto>(json),
+            static store => store.Version == PendingActionStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, PendingActionStoreEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new PendingActionStoreDto(),
+            "Pending action store");
     }
 
     private static void WritePendingActionsStoreNoThrow(string path, PendingActionStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var dir = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir)) {
-                Directory.CreateDirectory(dir);
-            }
-
-            var json = JsonSerializer.Serialize(store, PendingActionStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(dir) ? tmpName : Path.Combine(dir!, tmpName);
-
-            // CreateNew avoids clobbering attacker-planted tmp files.
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                // Harden as early as possible; with FileShare.None other users can't open this file while we write.
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                // Atomic swap (best-effort) to avoid losing the store if we crash mid-write.
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Pending action store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Ignore cleanup failures; store writes are best-effort.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Pending action store");
     }
 
     private static void PrunePendingActionsStore(PendingActionStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PlannerThreadContext.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PlannerThreadContext.Persistence.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int PlannerThreadContextStoreVersion = 1;
     private static readonly object PlannerThreadContextStoreLock = new();
-    private static readonly JsonSerializerOptions PlannerThreadContextStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class PlannerThreadContextStoreDto {
         public int Version { get; set; } = PlannerThreadContextStoreVersion;
@@ -26,24 +23,11 @@ internal sealed partial class ChatServiceSession {
         public long SeenUtcTicks { get; set; }
     }
 
-    private static string ResolveDefaultPlannerThreadContextStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultPlannerThreadContextStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("planner-thread-contexts.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "planner-thread-contexts.json");
-    }
-
-    private string ResolvePlannerThreadContextStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "planner-thread-contexts.json");
-        }
-
-        return ResolveDefaultPlannerThreadContextStorePath();
-    }
+    private string ResolvePlannerThreadContextStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "planner-thread-contexts.json");
 
     private void PersistPlannerThreadContextSnapshot(string activeThreadId, string plannerThreadId, long seenUtcTicks) {
         var normalizedActiveThreadId = (activeThreadId ?? string.Empty).Trim();
@@ -86,13 +70,7 @@ internal sealed partial class ChatServiceSession {
     private void ClearPlannerThreadContextSnapshots() {
         var path = ResolvePlannerThreadContextStorePath();
         lock (PlannerThreadContextStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Planner thread-context store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Planner thread-context store");
         }
     }
 
@@ -139,80 +117,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static PlannerThreadContextStoreDto ReadPlannerThreadContextStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new PlannerThreadContextStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 1024 * 1024) {
-                return new PlannerThreadContextStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new PlannerThreadContextStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<PlannerThreadContextStoreDto>(json, PlannerThreadContextStoreJsonOptions);
-            if (store is null || store.Version != PlannerThreadContextStoreVersion || store.Threads is null) {
-                return new PlannerThreadContextStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, PlannerThreadContextStoreEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Planner thread-context store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new PlannerThreadContextStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 1024 * 1024,
+            static json => JsonSerializer.Deserialize<PlannerThreadContextStoreDto>(json),
+            static store => store.Version == PlannerThreadContextStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, PlannerThreadContextStoreEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new PlannerThreadContextStoreDto(),
+            "Planner thread-context store");
     }
 
     private static void WritePlannerThreadContextStoreNoThrow(string path, PlannerThreadContextStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, PlannerThreadContextStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Planner thread-context store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Planner thread-context store");
     }
 
     private static void PrunePlannerThreadContextStore(PlannerThreadContextStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.StructuredNextAction.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.StructuredNextAction.Persistence.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int StructuredNextActionStoreVersion = 2;
     private static readonly object StructuredNextActionStoreLock = new();
-    private static readonly JsonSerializerOptions StructuredNextActionStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class StructuredNextActionStoreDto {
         public int Version { get; set; } = StructuredNextActionStoreVersion;
@@ -31,24 +28,11 @@ internal sealed partial class ChatServiceSession {
         public long SeenUtcTicks { get; set; }
     }
 
-    private static string ResolveDefaultStructuredNextActionStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultStructuredNextActionStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("structured-next-actions.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "structured-next-actions.json");
-    }
-
-    private string ResolveStructuredNextActionStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "structured-next-actions.json");
-        }
-
-        return ResolveDefaultStructuredNextActionStorePath();
-    }
+    private string ResolveStructuredNextActionStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "structured-next-actions.json");
 
     private void PersistStructuredNextActionSnapshot(string threadId, StructuredNextActionSnapshot snapshot) {
         var normalizedThreadId = (threadId ?? string.Empty).Trim();
@@ -98,13 +82,7 @@ internal sealed partial class ChatServiceSession {
     private void ClearStructuredNextActionSnapshots() {
         var path = ResolveStructuredNextActionStorePath();
         lock (StructuredNextActionStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Structured next-action store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Structured next-action store");
         }
     }
 
@@ -156,80 +134,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static StructuredNextActionStoreDto ReadStructuredNextActionStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new StructuredNextActionStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 1024 * 1024) {
-                return new StructuredNextActionStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new StructuredNextActionStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<StructuredNextActionStoreDto>(json, StructuredNextActionStoreJsonOptions);
-            if (store is null || store.Version != StructuredNextActionStoreVersion || store.Threads is null) {
-                return new StructuredNextActionStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, StructuredNextActionStoreEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Structured next-action store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new StructuredNextActionStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 1024 * 1024,
+            static json => JsonSerializer.Deserialize<StructuredNextActionStoreDto>(json),
+            static store => store.Version == StructuredNextActionStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, StructuredNextActionStoreEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new StructuredNextActionStoreDto(),
+            "Structured next-action store");
     }
 
     private static void WriteStructuredNextActionStoreNoThrow(string path, StructuredNextActionStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, StructuredNextActionStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Structured next-action store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Structured next-action store");
     }
 
     private static void PruneStructuredNextActionStore(StructuredNextActionStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ThreadRecoveryAliases.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ThreadRecoveryAliases.Persistence.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int ThreadRecoveryAliasStoreVersion = 1;
     private static readonly object ThreadRecoveryAliasStoreLock = new();
-    private static readonly JsonSerializerOptions ThreadRecoveryAliasStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class ThreadRecoveryAliasStoreDto {
         public int Version { get; set; } = ThreadRecoveryAliasStoreVersion;
@@ -26,24 +23,11 @@ internal sealed partial class ChatServiceSession {
         public long SeenUtcTicks { get; set; }
     }
 
-    private static string ResolveDefaultThreadRecoveryAliasStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultThreadRecoveryAliasStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("thread-recovery-aliases.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "thread-recovery-aliases.json");
-    }
-
-    private string ResolveThreadRecoveryAliasStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "thread-recovery-aliases.json");
-        }
-
-        return ResolveDefaultThreadRecoveryAliasStorePath();
-    }
+    private string ResolveThreadRecoveryAliasStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "thread-recovery-aliases.json");
 
     private void PersistRecoveredThreadAliasSnapshot(string originalThreadId, string recoveredThreadId, long seenUtcTicks) {
         var normalizedOriginal = (originalThreadId ?? string.Empty).Trim();
@@ -87,13 +71,7 @@ internal sealed partial class ChatServiceSession {
     private void ClearRecoveredThreadAliasSnapshots() {
         var path = ResolveThreadRecoveryAliasStorePath();
         lock (ThreadRecoveryAliasStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Thread-recovery alias store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Thread-recovery alias store");
         }
     }
 
@@ -140,80 +118,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static ThreadRecoveryAliasStoreDto ReadThreadRecoveryAliasStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new ThreadRecoveryAliasStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 1024 * 1024) {
-                return new ThreadRecoveryAliasStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new ThreadRecoveryAliasStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<ThreadRecoveryAliasStoreDto>(json, ThreadRecoveryAliasStoreJsonOptions);
-            if (store is null || store.Version != ThreadRecoveryAliasStoreVersion || store.Threads is null) {
-                return new ThreadRecoveryAliasStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, ThreadRecoveryAliasStoreEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Thread-recovery alias store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new ThreadRecoveryAliasStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 1024 * 1024,
+            static json => JsonSerializer.Deserialize<ThreadRecoveryAliasStoreDto>(json),
+            static store => store.Version == ThreadRecoveryAliasStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, ThreadRecoveryAliasStoreEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new ThreadRecoveryAliasStoreDto(),
+            "Thread-recovery alias store");
     }
 
     private static void WriteThreadRecoveryAliasStoreNoThrow(string path, ThreadRecoveryAliasStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, ThreadRecoveryAliasStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Thread-recovery alias store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Thread-recovery alias store");
     }
 
     private static void PruneThreadRecoveryAliasStore(ThreadRecoveryAliasStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolEvidence.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolEvidence.Persistence.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int ToolEvidenceStoreVersion = 1;
     private static readonly object ToolEvidenceStoreLock = new();
-    private static readonly JsonSerializerOptions ToolEvidenceStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class ToolEvidenceStoreDto {
         public int Version { get; set; } = ToolEvidenceStoreVersion;
@@ -35,24 +32,11 @@ internal sealed partial class ChatServiceSession {
         public long SeenUtcTicks { get; set; }
     }
 
-    private static string ResolveDefaultToolEvidenceStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultToolEvidenceStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("tool-evidence-cache.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "tool-evidence-cache.json");
-    }
-
-    private string ResolveToolEvidenceStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "tool-evidence-cache.json");
-        }
-
-        return ResolveDefaultToolEvidenceStorePath();
-    }
+    private string ResolveToolEvidenceStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "tool-evidence-cache.json");
 
     private void PersistThreadToolEvidenceSnapshot(string threadId, IReadOnlyCollection<ThreadToolEvidenceEntry> entries) {
         var normalizedThreadId = (threadId ?? string.Empty).Trim();
@@ -155,95 +139,33 @@ internal sealed partial class ChatServiceSession {
     }
 
     private void ClearThreadToolEvidenceSnapshotsNoThrow() {
-        try {
-            var path = ResolveToolEvidenceStorePath();
-            lock (ToolEvidenceStoreLock) {
-                if (!File.Exists(path)) {
-                    return;
-                }
-
-                File.Delete(path);
-            }
-        } catch {
-            // Best effort only.
+        var path = ResolveToolEvidenceStorePath();
+        lock (ToolEvidenceStoreLock) {
+            ChatServiceJsonFileStore.Delete(path, "Tool evidence store");
         }
     }
 
     private static ToolEvidenceStoreDto ReadToolEvidenceStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new ToolEvidenceStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 1024 * 1024) {
-                return new ToolEvidenceStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new ToolEvidenceStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<ToolEvidenceStoreDto>(json, ToolEvidenceStoreJsonOptions);
-            if (store is null || store.Version != ToolEvidenceStoreVersion || store.Threads is null) {
-                return new ToolEvidenceStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, ToolEvidenceStoreThreadEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Tool evidence store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new ToolEvidenceStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 1024 * 1024,
+            static json => JsonSerializer.Deserialize<ToolEvidenceStoreDto>(json),
+            static store => store.Version == ToolEvidenceStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, ToolEvidenceStoreThreadEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new ToolEvidenceStoreDto(),
+            "Tool evidence store");
     }
 
     private static void WriteToolEvidenceStoreNoThrow(string path, ToolEvidenceStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, ToolEvidenceStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Tool evidence store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Tool evidence store");
     }
 
     private static void PruneToolEvidenceStore(ToolEvidenceStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRoutingStats.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRoutingStats.Persistence.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int ToolRoutingStatsStoreVersion = 1;
     private static readonly object ToolRoutingStatsStoreLock = new();
-    private static readonly JsonSerializerOptions ToolRoutingStatsStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class ToolRoutingStatsStoreDto {
         public int Version { get; set; } = ToolRoutingStatsStoreVersion;
@@ -29,24 +26,11 @@ internal sealed partial class ChatServiceSession {
         public long LastSuccessUtcTicks { get; set; }
     }
 
-    private static string ResolveDefaultToolRoutingStatsStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultToolRoutingStatsStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("tool-routing-stats.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "tool-routing-stats.json");
-    }
-
-    private string ResolveToolRoutingStatsStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "tool-routing-stats.json");
-        }
-
-        return ResolveDefaultToolRoutingStatsStorePath();
-    }
+    private string ResolveToolRoutingStatsStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "tool-routing-stats.json");
 
     private void TryRehydrateToolRoutingStats() {
         var path = ResolveToolRoutingStatsStorePath();
@@ -111,91 +95,31 @@ internal sealed partial class ChatServiceSession {
     private void ClearToolRoutingStatsSnapshots() {
         var path = ResolveToolRoutingStatsStorePath();
         lock (ToolRoutingStatsStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Tool routing stats store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Tool routing stats store");
         }
     }
 
     private static ToolRoutingStatsStoreDto ReadToolRoutingStatsStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new ToolRoutingStatsStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 1024 * 1024) {
-                return new ToolRoutingStatsStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new ToolRoutingStatsStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<ToolRoutingStatsStoreDto>(json, ToolRoutingStatsStoreJsonOptions);
-            if (store is null || store.Version != ToolRoutingStatsStoreVersion || store.Tools is null) {
-                return new ToolRoutingStatsStoreDto();
-            }
-
-            if (store.Tools.Comparer != StringComparer.OrdinalIgnoreCase) {
-                store.Tools = new Dictionary<string, ToolRoutingStatsStoreEntryDto>(store.Tools, StringComparer.OrdinalIgnoreCase);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Tool routing stats store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new ToolRoutingStatsStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 1024 * 1024,
+            static json => JsonSerializer.Deserialize<ToolRoutingStatsStoreDto>(json),
+            static store => store.Version == ToolRoutingStatsStoreVersion && store.Tools is not null,
+            static store => {
+                if (store.Tools.Comparer != StringComparer.OrdinalIgnoreCase) {
+                    store.Tools = new Dictionary<string, ToolRoutingStatsStoreEntryDto>(store.Tools, StringComparer.OrdinalIgnoreCase);
+                }
+            },
+            static () => new ToolRoutingStatsStoreDto(),
+            "Tool routing stats store");
     }
 
     private static void WriteToolRoutingStatsStoreNoThrow(string path, ToolRoutingStatsStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, ToolRoutingStatsStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Tool routing stats store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Tool routing stats store");
     }
 
     private static void PruneToolRoutingStatsStore(ToolRoutingStatsStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.UserIntent.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.UserIntent.Persistence.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int UserIntentStoreVersion = 1;
     private static readonly object UserIntentStoreLock = new();
-    private static readonly JsonSerializerOptions UserIntentStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class UserIntentStoreDto {
         public int Version { get; set; } = UserIntentStoreVersion;
@@ -26,24 +23,11 @@ internal sealed partial class ChatServiceSession {
         public long SeenUtcTicks { get; set; }
     }
 
-    private static string ResolveDefaultUserIntentStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultUserIntentStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("user-intents.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "user-intents.json");
-    }
-
-    private string ResolveUserIntentStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "user-intents.json");
-        }
-
-        return ResolveDefaultUserIntentStorePath();
-    }
+    private string ResolveUserIntentStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "user-intents.json");
 
     private void PersistUserIntentSnapshot(string threadId, string intent, long seenUtcTicks) {
         var normalizedThreadId = (threadId ?? string.Empty).Trim();
@@ -88,13 +72,7 @@ internal sealed partial class ChatServiceSession {
     private void ClearUserIntentSnapshots() {
         var path = ResolveUserIntentStorePath();
         lock (UserIntentStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"User intent store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "User intent store");
         }
     }
 
@@ -145,80 +123,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static UserIntentStoreDto ReadUserIntentStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new UserIntentStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 512 * 1024) {
-                return new UserIntentStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new UserIntentStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<UserIntentStoreDto>(json, UserIntentStoreJsonOptions);
-            if (store is null || store.Version != UserIntentStoreVersion || store.Threads is null) {
-                return new UserIntentStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, UserIntentStoreEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"User intent store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new UserIntentStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 512 * 1024,
+            static json => JsonSerializer.Deserialize<UserIntentStoreDto>(json),
+            static store => store.Version == UserIntentStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, UserIntentStoreEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new UserIntentStoreDto(),
+            "User intent store");
     }
 
     private static void WriteUserIntentStoreNoThrow(string path, UserIntentStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, UserIntentStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"User intent store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "User intent store");
     }
 
     private static void PruneUserIntentStore(UserIntentStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.WeightedSubset.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.WeightedSubset.Persistence.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int WeightedSubsetStoreVersion = 1;
     private static readonly object WeightedSubsetStoreLock = new();
-    private static readonly JsonSerializerOptions WeightedSubsetStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class WeightedSubsetStoreDto {
         public int Version { get; set; } = WeightedSubsetStoreVersion;
@@ -26,24 +23,11 @@ internal sealed partial class ChatServiceSession {
         public string[] ToolNames { get; set; } = Array.Empty<string>();
     }
 
-    private static string ResolveDefaultWeightedSubsetStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultWeightedSubsetStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("weighted-tool-subsets.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "weighted-tool-subsets.json");
-    }
-
-    private string ResolveWeightedSubsetStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "weighted-tool-subsets.json");
-        }
-
-        return ResolveDefaultWeightedSubsetStorePath();
-    }
+    private string ResolveWeightedSubsetStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "weighted-tool-subsets.json");
 
     private void PersistWeightedToolSubsetSnapshot(string threadId, long seenUtcTicks, IReadOnlyList<string> toolNames) {
         var normalizedThreadId = (threadId ?? string.Empty).Trim();
@@ -93,13 +77,7 @@ internal sealed partial class ChatServiceSession {
     private void ClearWeightedToolSubsetSnapshots() {
         var path = ResolveWeightedSubsetStorePath();
         lock (WeightedSubsetStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Weighted subset store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Weighted subset store");
         }
     }
 
@@ -151,80 +129,26 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static WeightedSubsetStoreDto ReadWeightedSubsetStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new WeightedSubsetStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 1024 * 1024) {
-                return new WeightedSubsetStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new WeightedSubsetStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<WeightedSubsetStoreDto>(json, WeightedSubsetStoreJsonOptions);
-            if (store is null || store.Version != WeightedSubsetStoreVersion || store.Threads is null) {
-                return new WeightedSubsetStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, WeightedSubsetStoreEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Weighted subset store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new WeightedSubsetStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 1024 * 1024,
+            static json => JsonSerializer.Deserialize<WeightedSubsetStoreDto>(json),
+            static store => store.Version == WeightedSubsetStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, WeightedSubsetStoreEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new WeightedSubsetStoreDto(),
+            "Weighted subset store");
     }
 
     private static void WriteWeightedSubsetStoreNoThrow(string path, WeightedSubsetStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, WeightedSubsetStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Weighted subset store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Weighted subset store");
     }
 
     private static void PruneWeightedSubsetStore(WeightedSubsetStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.WorkingMemoryCheckpoint.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.WorkingMemoryCheckpoint.Persistence.cs
@@ -5,16 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
 
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int WorkingMemoryCheckpointStoreVersion = 2;
     private static readonly object WorkingMemoryCheckpointStoreLock = new();
-    private static readonly JsonSerializerOptions WorkingMemoryCheckpointStoreJsonOptions = new() {
-        WriteIndented = false,
-        PropertyNameCaseInsensitive = false
-    };
 
     private sealed class WorkingMemoryCheckpointStoreDto {
         public int Version { get; set; } = WorkingMemoryCheckpointStoreVersion;
@@ -44,24 +41,11 @@ internal sealed partial class ChatServiceSession {
         public long SeenUtcTicks { get; set; }
     }
 
-    private static string ResolveDefaultWorkingMemoryCheckpointStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
+    private static string ResolveDefaultWorkingMemoryCheckpointStorePath() =>
+        ChatServiceJsonFileStore.ResolveDefaultPath("working-memory-checkpoints.json");
 
-        return Path.Combine(root, "IntelligenceX.Chat", "working-memory-checkpoints.json");
-    }
-
-    private string ResolveWorkingMemoryCheckpointStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "working-memory-checkpoints.json");
-        }
-
-        return ResolveDefaultWorkingMemoryCheckpointStorePath();
-    }
+    private string ResolveWorkingMemoryCheckpointStorePath() =>
+        ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "working-memory-checkpoints.json");
 
     private void PersistWorkingMemoryCheckpointSnapshot(string threadId, WorkingMemoryCheckpoint checkpoint) {
         var normalizedThreadId = (threadId ?? string.Empty).Trim();
@@ -252,91 +236,31 @@ internal sealed partial class ChatServiceSession {
     private void ClearPersistedWorkingMemoryCheckpointStore() {
         var path = ResolveWorkingMemoryCheckpointStorePath();
         lock (WorkingMemoryCheckpointStoreLock) {
-            try {
-                if (File.Exists(path)) {
-                    File.Delete(path);
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Working-memory checkpoint store clear failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            ChatServiceJsonFileStore.Delete(path, "Working-memory checkpoint store");
         }
     }
 
     private static WorkingMemoryCheckpointStoreDto ReadWorkingMemoryCheckpointStoreNoThrow(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return new WorkingMemoryCheckpointStoreDto();
-            }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > 1024 * 1024) {
-                return new WorkingMemoryCheckpointStoreDto();
-            }
-
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return new WorkingMemoryCheckpointStoreDto();
-            }
-
-            var store = JsonSerializer.Deserialize<WorkingMemoryCheckpointStoreDto>(json, WorkingMemoryCheckpointStoreJsonOptions);
-            if (store is null || store.Version != WorkingMemoryCheckpointStoreVersion || store.Threads is null) {
-                return new WorkingMemoryCheckpointStoreDto();
-            }
-
-            if (store.Threads.Comparer != StringComparer.Ordinal) {
-                store.Threads = new Dictionary<string, WorkingMemoryCheckpointStoreEntryDto>(store.Threads, StringComparer.Ordinal);
-            }
-
-            return store;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Working-memory checkpoint store read failed: {ex.GetType().Name}: {ex.Message}");
-            return new WorkingMemoryCheckpointStoreDto();
-        }
+        return ChatServiceJsonFileStore.ReadOrCreate(
+            path,
+            maximumBytes: 1024 * 1024,
+            static json => JsonSerializer.Deserialize<WorkingMemoryCheckpointStoreDto>(json),
+            static store => store.Version == WorkingMemoryCheckpointStoreVersion && store.Threads is not null,
+            static store => {
+                if (store.Threads.Comparer != StringComparer.Ordinal) {
+                    store.Threads = new Dictionary<string, WorkingMemoryCheckpointStoreEntryDto>(store.Threads, StringComparer.Ordinal);
+                }
+            },
+            static () => new WorkingMemoryCheckpointStoreDto(),
+            "Working-memory checkpoint store");
     }
 
     private static void WriteWorkingMemoryCheckpointStoreNoThrow(string path, WorkingMemoryCheckpointStoreDto store) {
-        string? tmp = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path)) {
-                return;
-            }
-
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var json = JsonSerializer.Serialize(store, WorkingMemoryCheckpointStoreJsonOptions);
-            var fileName = Path.GetFileName(path);
-            var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-            using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenPendingActionsStoreAclNoThrow(tmp);
-                using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                fs.Flush(true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(tmp, path);
-            }
-
-            TryHardenPendingActionsStoreAclNoThrow(path);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Working-memory checkpoint store write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                try {
-                    File.Delete(tmp);
-                } catch {
-                    // Best effort only.
-                }
-            }
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value),
+            "Working-memory checkpoint store");
     }
 
     private static void PruneWorkingMemoryCheckpointStore(WorkingMemoryCheckpointStoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
@@ -1,0 +1,232 @@
+using System.Diagnostics;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Text;
+
+namespace IntelligenceX.Chat.Service.Persistence;
+
+/// <summary>
+/// Provides the single durable-file implementation used by chat service JSON snapshot stores.
+/// Domain stores retain ownership of their schemas, validation, locking, and retention rules.
+/// </summary>
+internal static class ChatServiceJsonFileStore {
+    /// <summary>
+    /// Resolves a chat service state file beneath the current user's local application data folder.
+    /// </summary>
+    internal static string ResolveDefaultPath(string fileName) {
+        var normalizedFileName = Path.GetFileName((fileName ?? string.Empty).Trim());
+        if (normalizedFileName.Length == 0) {
+            throw new ArgumentException("A state file name is required.", nameof(fileName));
+        }
+
+        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(root)) {
+            root = ".";
+        }
+
+        return Path.Combine(root, "IntelligenceX.Chat", normalizedFileName);
+    }
+
+    /// <summary>
+    /// Resolves a state file beside an already validated anchor store path.
+    /// </summary>
+    internal static string ResolveSiblingPath(string anchorPath, string fileName) {
+        var normalizedFileName = Path.GetFileName((fileName ?? string.Empty).Trim());
+        if (normalizedFileName.Length == 0) {
+            throw new ArgumentException("A state file name is required.", nameof(fileName));
+        }
+
+        var directory = Path.GetDirectoryName(anchorPath);
+        return !string.IsNullOrWhiteSpace(directory)
+            ? Path.Combine(directory, normalizedFileName)
+            : ResolveDefaultPath(normalizedFileName);
+    }
+
+    /// <summary>
+    /// Reads and validates a JSON snapshot without allowing storage failures to escape into chat execution.
+    /// </summary>
+    internal static ChatServiceJsonFileReadResult<T> Read<T>(
+        string path,
+        long maximumBytes,
+        Func<string, T?> deserialize,
+        Func<T, bool> validate,
+        Action<T>? normalize,
+        string storeName) where T : class {
+        ArgumentNullException.ThrowIfNull(deserialize);
+        ArgumentNullException.ThrowIfNull(validate);
+
+        try {
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
+                return ChatServiceJsonFileReadResult<T>.Empty();
+            }
+
+            var info = new FileInfo(path);
+            if (info.Length <= 0 || info.Length > maximumBytes) {
+                return ChatServiceJsonFileReadResult<T>.Invalid();
+            }
+
+            var json = File.ReadAllText(path, Encoding.UTF8);
+            if (string.IsNullOrWhiteSpace(json)) {
+                return ChatServiceJsonFileReadResult<T>.Empty();
+            }
+
+            var value = deserialize(json);
+            if (value is null || !validate(value)) {
+                return ChatServiceJsonFileReadResult<T>.Invalid();
+            }
+
+            normalize?.Invoke(value);
+            return ChatServiceJsonFileReadResult<T>.Loaded(value);
+        } catch (Exception ex) {
+            Trace.TraceWarning($"{NormalizeStoreName(storeName)} read failed: {ex.GetType().Name}: {ex.Message}");
+            return ChatServiceJsonFileReadResult<T>.Invalid();
+        }
+    }
+
+    /// <summary>
+    /// Reads a valid JSON snapshot or creates an empty domain store when no usable snapshot exists.
+    /// </summary>
+    internal static T ReadOrCreate<T>(
+        string path,
+        long maximumBytes,
+        Func<string, T?> deserialize,
+        Func<T, bool> validate,
+        Action<T>? normalize,
+        Func<T> create,
+        string storeName) where T : class {
+        ArgumentNullException.ThrowIfNull(create);
+
+        var result = Read(path, maximumBytes, deserialize, validate, normalize, storeName);
+        return result.State == ChatServiceJsonFileReadState.Loaded && result.Value is not null
+            ? result.Value
+            : create();
+    }
+
+    /// <summary>
+    /// Atomically replaces a JSON snapshot and applies best-effort per-user ACL hardening.
+    /// </summary>
+    internal static void Write<T>(
+        string path,
+        T value,
+        Func<T, string> serialize,
+        string storeName) {
+        ArgumentNullException.ThrowIfNull(serialize);
+
+        string? temporaryPath = null;
+        try {
+            if (string.IsNullOrWhiteSpace(path)) {
+                return;
+            }
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
+                Directory.CreateDirectory(directory);
+            }
+
+            var json = serialize(value);
+            var fileName = Path.GetFileName(path);
+            var temporaryName = $"{fileName}.{Guid.NewGuid():N}.tmp";
+            temporaryPath = string.IsNullOrWhiteSpace(directory)
+                ? temporaryName
+                : Path.Combine(directory, temporaryName);
+
+            using (var stream = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
+                TryHardenAclNoThrow(temporaryPath, storeName);
+                using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                writer.Write(json);
+                writer.Flush();
+                stream.Flush(flushToDisk: true);
+            }
+
+            if (File.Exists(path)) {
+                File.Replace(temporaryPath, path, destinationBackupFileName: null, ignoreMetadataErrors: true);
+            } else {
+                File.Move(temporaryPath, path);
+            }
+
+            temporaryPath = null;
+            TryHardenAclNoThrow(path, storeName);
+        } catch (Exception ex) {
+            Trace.TraceWarning($"{NormalizeStoreName(storeName)} write failed: {ex.GetType().Name}: {ex.Message}");
+        } finally {
+            if (!string.IsNullOrWhiteSpace(temporaryPath) && File.Exists(temporaryPath)) {
+                try {
+                    File.Delete(temporaryPath);
+                } catch {
+                    // Best effort only.
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deletes a snapshot without allowing cleanup failures to escape into chat execution.
+    /// </summary>
+    internal static void Delete(string path, string storeName) {
+        try {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path)) {
+                File.Delete(path);
+            }
+        } catch (Exception ex) {
+            Trace.TraceWarning($"{NormalizeStoreName(storeName)} clear failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static void TryHardenAclNoThrow(string path, string storeName) {
+        if (string.IsNullOrWhiteSpace(path) || !OperatingSystem.IsWindows()) {
+            return;
+        }
+
+        try {
+            if (!File.Exists(path)) {
+                return;
+            }
+
+            var attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.Directory) != 0) {
+                return;
+            }
+
+            var currentSid = WindowsIdentity.GetCurrent().User;
+            if (currentSid is null) {
+                return;
+            }
+
+            var fileInfo = new FileInfo(path);
+            var security = fileInfo.GetAccessControl();
+            security.SetOwner(currentSid);
+            security.SetAccessRuleProtection(isProtected: true, preserveInheritance: true);
+            security.SetAccessRule(new FileSystemAccessRule(
+                currentSid,
+                FileSystemRights.FullControl,
+                AccessControlType.Allow));
+            fileInfo.SetAccessControl(security);
+        } catch (Exception ex) {
+            Trace.TraceWarning($"{NormalizeStoreName(storeName)} ACL hardening failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static string NormalizeStoreName(string storeName) {
+        var normalized = (storeName ?? string.Empty).Trim();
+        return normalized.Length == 0 ? "Chat service JSON store" : normalized;
+    }
+}
+
+internal enum ChatServiceJsonFileReadState {
+    Empty,
+    Invalid,
+    Loaded
+}
+
+internal readonly record struct ChatServiceJsonFileReadResult<T>(
+    ChatServiceJsonFileReadState State,
+    T? Value) where T : class {
+    internal static ChatServiceJsonFileReadResult<T> Empty() =>
+        new(ChatServiceJsonFileReadState.Empty, null);
+
+    internal static ChatServiceJsonFileReadResult<T> Invalid() =>
+        new(ChatServiceJsonFileReadState.Invalid, null);
+
+    internal static ChatServiceJsonFileReadResult<T> Loaded(T value) =>
+        new(ChatServiceJsonFileReadState.Loaded, value);
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+using IntelligenceX.Chat.Service.Persistence;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class ChatServiceJsonFileStoreTests {
+    [Fact]
+    public void WriteAndRead_RoundTripsThroughAtomicSnapshot() {
+        var root = CreateRoot();
+        try {
+            var path = Path.Combine(root, "state.json");
+            var expected = new TestStore { Version = 2, Value = "ready" };
+
+            ChatServiceJsonFileStore.Write(
+                path,
+                expected,
+                static value => JsonSerializer.Serialize(value),
+                "Test store");
+            ChatServiceJsonFileStore.Write(
+                path,
+                new TestStore { Version = 2, Value = "updated" },
+                static value => JsonSerializer.Serialize(value),
+                "Test store");
+
+            var result = ChatServiceJsonFileStore.Read<TestStore>(
+                path,
+                maximumBytes: 1024,
+                static json => JsonSerializer.Deserialize<TestStore>(json),
+                static value => value.Version == 2,
+                normalize: null,
+                "Test store");
+
+            Assert.Equal(ChatServiceJsonFileReadState.Loaded, result.State);
+            Assert.NotNull(result.Value);
+            Assert.Equal("updated", result.Value.Value);
+            Assert.Empty(Directory.GetFiles(root, "*.tmp"));
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Read_RejectsSnapshotsAboveTheDomainLimit() {
+        var root = CreateRoot();
+        try {
+            var path = Path.Combine(root, "state.json");
+            File.WriteAllText(path, JsonSerializer.Serialize(new TestStore { Version = 2, Value = "too-large" }));
+
+            var result = ChatServiceJsonFileStore.Read<TestStore>(
+                path,
+                maximumBytes: 4,
+                static _ => throw new InvalidOperationException("Oversized snapshots must not be deserialized."),
+                static _ => true,
+                normalize: null,
+                "Test store");
+
+            Assert.Equal(ChatServiceJsonFileReadState.Invalid, result.State);
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Read_DistinguishesMissingAndInvalidSnapshots() {
+        var root = CreateRoot();
+        try {
+            var path = Path.Combine(root, "state.json");
+            var missing = Read(path);
+
+            File.WriteAllText(path, "{not-json}");
+            var invalid = Read(path);
+
+            Assert.Equal(ChatServiceJsonFileReadState.Empty, missing.State);
+            Assert.Equal(ChatServiceJsonFileReadState.Invalid, invalid.State);
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReadOrCreate_RejectsUnsupportedVersions() {
+        var root = CreateRoot();
+        try {
+            var path = Path.Combine(root, "state.json");
+            File.WriteAllText(path, JsonSerializer.Serialize(new TestStore { Version = 1, Value = "stale" }));
+
+            var result = ChatServiceJsonFileStore.ReadOrCreate(
+                path,
+                maximumBytes: 1024,
+                static json => JsonSerializer.Deserialize<TestStore>(json),
+                static value => value.Version == 2,
+                normalize: null,
+                static () => new TestStore { Version = 2 },
+                "Test store");
+
+            Assert.Equal(2, result.Version);
+            Assert.Equal(string.Empty, result.Value);
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Delete_RemovesExistingSnapshot() {
+        var root = CreateRoot();
+        try {
+            var path = Path.Combine(root, "state.json");
+            File.WriteAllText(path, "{}");
+
+            ChatServiceJsonFileStore.Delete(path, "Test store");
+
+            Assert.False(File.Exists(path));
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static ChatServiceJsonFileReadResult<TestStore> Read(string path) {
+        return ChatServiceJsonFileStore.Read(
+            path,
+            maximumBytes: 1024,
+            static json => JsonSerializer.Deserialize<TestStore>(json),
+            static value => value.Version == 2,
+            normalize: null,
+            "Test store");
+    }
+
+    private static string CreateRoot() {
+        var root = Path.Combine(Path.GetTempPath(), "IntelligenceX.Chat.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private sealed class TestStore {
+        public int Version { get; set; }
+        public string Value { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary

- replace 16 independent JSON file implementations with one bounded, atomic chat-service persistence primitive
- centralize temp-file replacement, flush-to-disk, cleanup, per-user ACL hardening, deletion, and LocalAppData/sibling path resolution
- keep domain schemas, versions, retention, normalization, and locking in their owning partials
- preserve the background scheduler's distinct empty/invalid/loaded contract and source-generated serialization

## Compatibility

Existing file names, JSON shapes, version checks, size limits, dictionary comparers, path override rules, and domain retention behavior remain unchanged. This is an internal API cleanup: all chat snapshot stores now delegate durable-file mechanics to `ChatServiceJsonFileStore`.

## Validation

- Release chat service build: succeeded with zero warnings
- focused persistence contracts: 5 passed, covering atomic replacement, invalid/missing state, size limits, version rejection, and deletion
- duplicate atomic file implementations remaining in chat persistence partials: none

The full local Chat test graph is blocked by the configured sibling TestimoX checkout missing `Licensing.Verification`; clean GitHub CI remains the full-solution proof.