### PR TITLE
Keep capability summaries side-effect free

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.cs
@@ -170,7 +170,7 @@ internal sealed partial class ChatServiceSession {
             completedItemCount += Math.Max(0, snapshot.CompletedCount);
             pendingReadOnlyItemCount += Math.Max(0, snapshot.PendingReadOnlyCount);
             pendingUnknownItemCount += Math.Max(0, snapshot.PendingUnknownCount);
-            var summaryToolDefinitions = EnsureDeferredBackgroundWorkToolDefinitionsLoaded(
+            var summaryToolDefinitions = MergeDeferredBackgroundWorkToolDefinitions(
                 snapshot.Items,
                 activeToolDefinitions,
                 includeReadyTargets: true,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundWork.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundWork.cs
@@ -383,13 +383,18 @@ internal sealed partial class ChatServiceSession {
         IReadOnlyDictionary<string, bool>? mutatingToolHintsByName,
         out BackgroundWorkReplayCandidate candidate,
         out string reason) {
-        toolDefinitions = EnsureDeferredBackgroundWorkToolDefinitionsLoaded(
-            threadId,
-            toolDefinitions,
-            includeReadyTargets: true,
-            includeBlockedDependencies: false);
+        var normalizedThreadId = (threadId ?? string.Empty).Trim();
+        if (normalizedThreadId.Length > 0
+            && TryGetRememberedThreadBackgroundWorkSnapshot(normalizedThreadId, out var snapshot)) {
+            toolDefinitions = MergeDeferredBackgroundWorkToolDefinitions(
+                snapshot.Items,
+                toolDefinitions,
+                includeReadyTargets: true,
+                includeBlockedDependencies: false);
+        }
+
         return TryBuildReadyBackgroundWorkReplayCandidateCore(
-            threadId,
+            normalizedThreadId,
             userRequest,
             toolDefinitions,
             mutatingToolHintsByName,
@@ -599,33 +604,16 @@ internal sealed partial class ChatServiceSession {
         bool includeBlockedDependencies) {
         ArgumentNullException.ThrowIfNull(toolDefinitions);
 
+        var mergedDefinitions = MergeDeferredBackgroundWorkToolDefinitions(
+            items,
+            toolDefinitions,
+            includeReadyTargets,
+            includeBlockedDependencies);
         if (items is null
             || items.Count == 0
             || (!includeReadyTargets && !includeBlockedDependencies)) {
-            return toolDefinitions;
+            return mergedDefinitions;
         }
-
-        var requestedToolNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        for (var i = 0; i < items.Count; i++) {
-            var item = items[i];
-            if (includeReadyTargets
-                && string.Equals(item.State, BackgroundWorkStateReady, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(item.Kind, BackgroundWorkKindToolHandoff, StringComparison.OrdinalIgnoreCase)) {
-                var readyToolName = NormalizeToolNameForAnswerPlan(item.TargetToolName);
-                if (readyToolName.Length > 0) {
-                    requestedToolNames.Add(readyToolName);
-                }
-            }
-
-            if (includeBlockedDependencies && IsBackgroundWorkDependencyBlocked(item)) {
-                var blockedToolName = NormalizeToolNameForAnswerPlan(item.TargetToolName);
-                if (blockedToolName.Length > 0) {
-                    requestedToolNames.Add(blockedToolName);
-                }
-            }
-        }
-
-        var mergedDefinitions = MergeMissingToolDefinitionsFromDeferredDescriptors(toolDefinitions, requestedToolNames);
 
         var activationPackIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var itemsById = includeBlockedDependencies
@@ -633,34 +621,6 @@ internal sealed partial class ChatServiceSession {
                 .Where(static item => !string.IsNullOrWhiteSpace(item.Id))
                 .ToDictionary(static item => item.Id, static item => item, StringComparer.OrdinalIgnoreCase)
             : null;
-        if (itemsById is not null) {
-            for (var i = 0; i < items.Count; i++) {
-                var item = items[i];
-                if (!IsBackgroundWorkDependencyBlocked(item) || item.DependencyItemIds.Length == 0) {
-                    continue;
-                }
-
-                for (var dependencyIndex = 0; dependencyIndex < item.DependencyItemIds.Length; dependencyIndex++) {
-                    var dependencyId = (item.DependencyItemIds[dependencyIndex] ?? string.Empty).Trim();
-                    if (dependencyId.Length == 0
-                        || !itemsById.TryGetValue(dependencyId, out var dependencyItem)
-                        || string.Equals(
-                            NormalizeBackgroundWorkState(dependencyItem.State),
-                            BackgroundWorkStateCompleted,
-                            StringComparison.OrdinalIgnoreCase)) {
-                        continue;
-                    }
-
-                    var dependencyToolName = NormalizeToolNameForAnswerPlan(dependencyItem.TargetToolName);
-                    if (dependencyToolName.Length > 0) {
-                        requestedToolNames.Add(dependencyToolName);
-                    }
-                }
-            }
-
-            mergedDefinitions = MergeMissingToolDefinitionsFromDeferredDescriptors(toolDefinitions, requestedToolNames);
-        }
-
         for (var i = 0; i < items.Count; i++) {
             var item = items[i];
             if (includeReadyTargets
@@ -720,6 +680,75 @@ internal sealed partial class ChatServiceSession {
         return activatedAny || sawActivePack
             ? _registry.GetDefinitions()
             : mergedDefinitions;
+    }
+
+    private IReadOnlyList<ToolDefinition> MergeDeferredBackgroundWorkToolDefinitions(
+        IReadOnlyList<ThreadBackgroundWorkItem>? items,
+        IReadOnlyList<ToolDefinition> toolDefinitions,
+        bool includeReadyTargets,
+        bool includeBlockedDependencies) {
+        ArgumentNullException.ThrowIfNull(toolDefinitions);
+
+        if (items is null
+            || items.Count == 0
+            || (!includeReadyTargets && !includeBlockedDependencies)) {
+            return toolDefinitions;
+        }
+
+        var requestedToolNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < items.Count; i++) {
+            var item = items[i];
+            if (includeReadyTargets
+                && string.Equals(item.State, BackgroundWorkStateReady, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(item.Kind, BackgroundWorkKindToolHandoff, StringComparison.OrdinalIgnoreCase)) {
+                var readyToolName = NormalizeToolNameForAnswerPlan(item.TargetToolName);
+                if (readyToolName.Length > 0) {
+                    requestedToolNames.Add(readyToolName);
+                }
+            }
+
+            if (includeBlockedDependencies && IsBackgroundWorkDependencyBlocked(item)) {
+                var blockedToolName = NormalizeToolNameForAnswerPlan(item.TargetToolName);
+                if (blockedToolName.Length > 0) {
+                    requestedToolNames.Add(blockedToolName);
+                }
+            }
+        }
+
+        var mergedDefinitions = MergeMissingToolDefinitionsFromDeferredDescriptors(toolDefinitions, requestedToolNames);
+        var itemsById = includeBlockedDependencies
+            ? items
+                .Where(static item => !string.IsNullOrWhiteSpace(item.Id))
+                .ToDictionary(static item => item.Id, static item => item, StringComparer.OrdinalIgnoreCase)
+            : null;
+        if (itemsById is not null) {
+            for (var i = 0; i < items.Count; i++) {
+                var item = items[i];
+                if (!IsBackgroundWorkDependencyBlocked(item) || item.DependencyItemIds.Length == 0) {
+                    continue;
+                }
+
+                for (var dependencyIndex = 0; dependencyIndex < item.DependencyItemIds.Length; dependencyIndex++) {
+                    var dependencyId = (item.DependencyItemIds[dependencyIndex] ?? string.Empty).Trim();
+                    if (dependencyId.Length == 0
+                        || !itemsById.TryGetValue(dependencyId, out var dependencyItem)
+                        || string.Equals(
+                            NormalizeBackgroundWorkState(dependencyItem.State),
+                            BackgroundWorkStateCompleted,
+                            StringComparison.OrdinalIgnoreCase)) {
+                        continue;
+                    }
+
+                    var dependencyToolName = NormalizeToolNameForAnswerPlan(dependencyItem.TargetToolName);
+                    if (dependencyToolName.Length > 0) {
+                        requestedToolNames.Add(dependencyToolName);
+                    }
+                }
+            }
+
+            mergedDefinitions = MergeMissingToolDefinitionsFromDeferredDescriptors(toolDefinitions, requestedToolNames);
+        }
+        return mergedDefinitions;
     }
 
     private bool TryCollectDeferredBackgroundWorkActivationPackId(
@@ -2904,7 +2933,7 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        toolDefinitions = EnsureDeferredBackgroundWorkToolDefinitionsLoaded(
+        toolDefinitions = MergeDeferredBackgroundWorkToolDefinitions(
             snapshot.Items,
             toolDefinitions,
             includeReadyTargets: false,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.PlannerContext.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.PlannerContext.cs
@@ -864,15 +864,15 @@ internal sealed partial class ChatServiceSession {
     private static bool HasPlannerContextSignals(PlannerContextMetadata context) {
         return context.RequiresLiveExecution
                || !string.IsNullOrEmpty(context.MissingLiveEvidence)
-               || context.PreferredPackIds?.Length > 0
-               || context.PreferredToolNames?.Length > 0
-               || context.PreferredDeferredWorkCapabilityIds?.Length > 0
-               || context.StructuredNextActionSourceToolNames?.Length > 0
+               || context.PreferredPackIds?.Length is > 0
+               || context.PreferredToolNames?.Length is > 0
+               || context.PreferredDeferredWorkCapabilityIds?.Length is > 0
+               || context.StructuredNextActionSourceToolNames?.Length is > 0
                || !string.IsNullOrEmpty(context.StructuredNextActionReason)
                || context.StructuredNextActionConfidence.HasValue
-               || context.PreferredExecutionBackends?.Length > 0
-               || context.HandoffTargetPackIds?.Length > 0
-               || context.HandoffTargetToolNames?.Length > 0
+               || context.PreferredExecutionBackends?.Length is > 0
+               || context.HandoffTargetPackIds?.Length is > 0
+               || context.HandoffTargetToolNames?.Length is > 0
                || !string.IsNullOrEmpty(context.ContinuationSourceTool)
                || !string.IsNullOrEmpty(context.ContinuationReason)
                || !string.IsNullOrEmpty(context.ContinuationConfidence)

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.PlannerContext.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.PlannerContext.cs
@@ -863,27 +863,27 @@ internal sealed partial class ChatServiceSession {
 
     private static bool HasPlannerContextSignals(PlannerContextMetadata context) {
         return context.RequiresLiveExecution
-               || context.MissingLiveEvidence.Length > 0
-               || context.PreferredPackIds.Length > 0
-               || context.PreferredToolNames.Length > 0
-               || context.PreferredDeferredWorkCapabilityIds.Length > 0
-               || context.StructuredNextActionSourceToolNames.Length > 0
-               || context.StructuredNextActionReason.Length > 0
+               || !string.IsNullOrEmpty(context.MissingLiveEvidence)
+               || context.PreferredPackIds?.Length > 0
+               || context.PreferredToolNames?.Length > 0
+               || context.PreferredDeferredWorkCapabilityIds?.Length > 0
+               || context.StructuredNextActionSourceToolNames?.Length > 0
+               || !string.IsNullOrEmpty(context.StructuredNextActionReason)
                || context.StructuredNextActionConfidence.HasValue
-               || context.PreferredExecutionBackends.Length > 0
-               || context.HandoffTargetPackIds.Length > 0
-               || context.HandoffTargetToolNames.Length > 0
-               || context.ContinuationSourceTool.Length > 0
-               || context.ContinuationReason.Length > 0
-               || context.ContinuationConfidence.Length > 0
+               || context.PreferredExecutionBackends?.Length > 0
+               || context.HandoffTargetPackIds?.Length > 0
+               || context.HandoffTargetToolNames?.Length > 0
+               || !string.IsNullOrEmpty(context.ContinuationSourceTool)
+               || !string.IsNullOrEmpty(context.ContinuationReason)
+               || !string.IsNullOrEmpty(context.ContinuationConfidence)
                || context.BackgroundPreparationAllowed
                || context.BackgroundPendingReadOnlyActions > 0
                || context.BackgroundPendingUnknownActions > 0
-               || context.BackgroundFollowUpClasses.Length > 0
-               || context.BackgroundPriorityFocus.Length > 0
-               || context.BackgroundFollowUpFocus.Length > 0
-               || context.BackgroundRecentEvidenceTools.Length > 0
-               || context.MatchingSkills.Length > 0
+               || context.BackgroundFollowUpClasses?.Length > 0
+               || !string.IsNullOrEmpty(context.BackgroundPriorityFocus)
+               || !string.IsNullOrEmpty(context.BackgroundFollowUpFocus)
+               || context.BackgroundRecentEvidenceTools?.Length > 0
+               || context.MatchingSkills?.Length > 0
                || context.AllowCachedEvidenceReuse;
     }
 


### PR DESCRIPTION
## Summary

- keep runtime capability and background-work preview paths read-only
- separate deferred definition projection from pack activation
- keep pack activation in execution paths only
- tolerate the default planner-context value without null dereferences

## Why

Building the runtime capability prompt could reactivate a persisted background-work pack and replace the live tool registry during a chat turn. The model could receive one tool schema and then execute against a different registry. Empty replay rounds could also dereference null fields from a default record value.

## Validation

- six focused chat routing regressions pass on .NET 10, including per-turn and cross-thread pack isolation
- restore/build uses the same local dependency feed only for unavailable validation dependencies; no package was published