### PR TITLE
Make chat tooling tests deterministic

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Testing.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Testing.cs
@@ -38,6 +38,10 @@ internal sealed partial class ChatServiceSession {
         PersistToolRoutingStatsSnapshot();
     }
 
+    internal void ClearToolRoutingCachesForTesting(bool preserveConversationState = false) {
+        ClearToolRoutingCaches(preserveConversationState);
+    }
+
     internal void UpdateToolRoutingStatsForTesting(IReadOnlyList<ToolCall> calls, IReadOnlyList<ToolOutputDto> outputs) {
         ArgumentNullException.ThrowIfNull(calls);
         ArgumentNullException.ThrowIfNull(outputs);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatFallbackArchitectureGuardrailTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatFallbackArchitectureGuardrailTests.cs
@@ -157,28 +157,6 @@ public sealed class ChatFallbackArchitectureGuardrailTests {
     }
 
     [Fact]
-    public void ToolingDiscovery_ShouldNotContainHardcodedBuiltInAssemblyAllowlistNames() {
-        var source = File.ReadAllText(GetToolingSourceFilePath("ToolPackBootstrap.RegistryAndReflection.cs"));
-        var disallowedAssemblyNames = new[] {
-            "IntelligenceX.Tools.FileSystem",
-            "IntelligenceX.Tools.EventLog",
-            "IntelligenceX.Tools.ADPlayground",
-            "IntelligenceX.Tools.System",
-            "IntelligenceX.Tools.PowerShell",
-            "IntelligenceX.Tools.TestimoX",
-            "IntelligenceX.Tools.OfficeIMO",
-            "IntelligenceX.Tools.Email",
-            "IntelligenceX.Tools.ReviewerSetup",
-            "IntelligenceX.Tools.DnsClientX",
-            "IntelligenceX.Tools.DomainDetective"
-        };
-
-        for (var i = 0; i < disallowedAssemblyNames.Length; i++) {
-            Assert.DoesNotContain(disallowedAssemblyNames[i], source, StringComparison.OrdinalIgnoreCase);
-        }
-    }
-
-    [Fact]
     public void ChatToolingProject_ShouldOnlyReferenceSharedToolContracts_NotBuiltInToolPackProjects() {
         var repoRoot = FindRepoRoot();
         var source = File.ReadAllText(Path.Combine(
@@ -231,17 +209,6 @@ public sealed class ChatFallbackArchitectureGuardrailTests {
         for (var i = 0; i < disallowedPackProjectTokens.Length; i++) {
             Assert.DoesNotContain(disallowedPackProjectTokens[i], source, StringComparison.OrdinalIgnoreCase);
         }
-    }
-
-    [Fact]
-    public void PublishChatHostScript_ShouldBundleAndValidateToolArtifacts_WithoutHostProjectCoupling() {
-        var source = File.ReadAllText(GetBuildScriptPath(@"Build\Chat\Publish-ChatHost.ps1"));
-
-        Assert.Contains("function Publish-BundledToolProjects", source, StringComparison.Ordinal);
-        Assert.Contains("Publish-BundledToolProjects -OutputPath $OutDir", source, StringComparison.Ordinal);
-        Assert.Contains("Assert-ChatHostArtifacts -RootPath $OutDir", source, StringComparison.Ordinal);
-        Assert.Contains(@"Artifacts\ChatHostPublish", source, StringComparison.Ordinal);
-        Assert.DoesNotContain("/p:IncludePrivateToolPacks=true", source, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ClearCachesPersistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ClearCachesPersistence.cs
@@ -11,9 +11,6 @@ using Xunit;
 namespace IntelligenceX.Chat.Tests;
 
 public sealed partial class ChatServiceRoutingTrimTests {
-    private static readonly MethodInfo ClearToolRoutingCachesMethod =
-        typeof(ChatServiceSession).GetMethod("ClearToolRoutingCaches", BindingFlags.NonPublic | BindingFlags.Instance)
-        ?? throw new InvalidOperationException("ClearToolRoutingCaches not found.");
     private static readonly MethodInfo ResolvePendingActionsStorePathMethod =
         typeof(ChatServiceSession).GetMethod("ResolvePendingActionsStorePath", BindingFlags.NonPublic | BindingFlags.Instance)
         ?? throw new InvalidOperationException("ResolvePendingActionsStorePath not found.");
@@ -151,7 +148,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
             Directory.CreateDirectory(Path.GetDirectoryName(alternateEngineHealthPath)!);
             File.WriteAllText(alternateEngineHealthPath, "{}");
 
-            ClearToolRoutingCachesMethod.Invoke(session1, Array.Empty<object>());
+            session1.ClearToolRoutingCachesForTesting();
 
             Assert.False(File.Exists(pendingPath));
             Assert.False(File.Exists(userIntentPath));

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceToolingBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceToolingBootstrapTests.cs
@@ -1324,7 +1324,8 @@ public sealed class ChatServiceToolingBootstrapTests {
                 BindingFlags.NonPublic | BindingFlags.Static);
             Assert.NotNull(keyMethod);
             Assert.NotNull(runtimePolicyOptionsMethod);
-            var options = new ServiceOptions();
+            var options = ChatServiceTestSessionFactory.CreateIsolatedOptions();
+            var previewFingerprint = BuildToolingBootstrapPreviewFingerprint(options);
             var runtimePolicyOptions = Assert.IsType<ToolRuntimePolicyOptions>(runtimePolicyOptionsMethod!.Invoke(
                 null,
                 new object[] { options }));
@@ -1454,7 +1455,8 @@ public sealed class ChatServiceToolingBootstrapTests {
                         }
                     },
                     ToolOrchestrationCatalog = ToolOrchestrationCatalog.Build(Array.Empty<ToolDefinition>())
-                });
+                },
+                previewFingerprint);
 
             var session = new ChatServiceSession(options, Stream.Null, cache);
             var orchestrationCatalogField = typeof(ChatServiceSession).GetField("_toolOrchestrationCatalog", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -1550,7 +1552,8 @@ public sealed class ChatServiceToolingBootstrapTests {
         }
 
         try {
-            var options = new ServiceOptions();
+            var options = ChatServiceTestSessionFactory.CreateIsolatedOptions();
+            var previewFingerprint = BuildToolingBootstrapPreviewFingerprint(options);
             var (previewCacheKey, cacheKey) = BuildToolingBootstrapKeys(options);
             var diagnostics = ToolRuntimePolicyBootstrap.BuildDiagnostics(
                 ToolRuntimePolicyBootstrap.CreateContext(new ToolRuntimePolicyOptions()));
@@ -1573,6 +1576,7 @@ public sealed class ChatServiceToolingBootstrapTests {
                 SchemaVersion = 4,
                 CacheKey = previewCacheKey + "discovery_fingerprint=stale-fingerprint;",
                 PreviewCacheKey = previewCacheKey,
+                PreviewDiscoveryFingerprint = previewFingerprint,
                 CachedAtUtc = DateTime.UtcNow,
                 ToolDefinitions = new[] {
                     new ToolDefinitionDto {
@@ -2034,7 +2038,8 @@ public sealed class ChatServiceToolingBootstrapTests {
             Assert.NotNull(tryGetCachedToolCatalogMethod);
             Assert.NotNull(cachedToolDefinitionsField);
 
-            var options = new ServiceOptions();
+            var options = ChatServiceTestSessionFactory.CreateIsolatedOptions();
+            var previewFingerprint = BuildToolingBootstrapPreviewFingerprint(options);
             var (previewCacheKey, cacheKey) = BuildToolingBootstrapKeys(options);
             var diagnostics = ToolRuntimePolicyBootstrap.BuildDiagnostics(
                 ToolRuntimePolicyBootstrap.CreateContext(new ToolRuntimePolicyOptions()));
@@ -2057,6 +2062,7 @@ public sealed class ChatServiceToolingBootstrapTests {
                 SchemaVersion = 4,
                 CacheKey = previewCacheKey + "discovery_fingerprint=stale-fingerprint;",
                 PreviewCacheKey = previewCacheKey,
+                PreviewDiscoveryFingerprint = previewFingerprint,
                 CachedAtUtc = DateTime.UtcNow,
                 ToolDefinitions = new[] {
                     new ToolDefinitionDto {
@@ -2163,7 +2169,8 @@ public sealed class ChatServiceToolingBootstrapTests {
             Assert.NotNull(persistedPreviewPackSummariesField);
             Assert.NotNull(persistedPreviewCapabilitySnapshotField);
 
-            var options = new ServiceOptions();
+            var options = ChatServiceTestSessionFactory.CreateIsolatedOptions();
+            var previewFingerprint = BuildToolingBootstrapPreviewFingerprint(options);
             var runtimePolicyOptions = Assert.IsType<ToolRuntimePolicyOptions>(runtimePolicyOptionsMethod!.Invoke(
                 null,
                 new object[] { options }));
@@ -2226,7 +2233,8 @@ public sealed class ChatServiceToolingBootstrapTests {
                         HealthyTools = new[] { "preview_tool" }
                     },
                     ToolOrchestrationCatalog = ToolOrchestrationCatalog.Build(Array.Empty<ToolDefinition>())
-                });
+                },
+                previewFingerprint);
 
             var session = new ChatServiceSession(options, Stream.Null, cache);
             Assert.True(Assert.IsType<bool>(persistedPreviewFlagField!.GetValue(session)));
@@ -2306,7 +2314,8 @@ public sealed class ChatServiceToolingBootstrapTests {
         }
 
         try {
-            var options = new ServiceOptions();
+            var options = ChatServiceTestSessionFactory.CreateIsolatedOptions();
+            var previewFingerprint = BuildToolingBootstrapPreviewFingerprint(options);
             var runtimePolicyOptions = Assert.IsType<ToolRuntimePolicyOptions>(runtimePolicyOptionsMethod!.Invoke(
                 null,
                 new object[] { options }));
@@ -2369,7 +2378,8 @@ public sealed class ChatServiceToolingBootstrapTests {
                         HealthyTools = new[] { "preview_tool" }
                     },
                     ToolOrchestrationCatalog = ToolOrchestrationCatalog.Build(Array.Empty<ToolDefinition>())
-                });
+                },
+                previewFingerprint);
 
             var session = new ChatServiceSession(options, Stream.Null, cache);
             Assert.True(Assert.IsType<bool>(persistedPreviewFlagField!.GetValue(session)));

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/IntelligenceX.Chat.Tests.csproj
@@ -26,7 +26,14 @@
     <ProjectReference Include="..\IntelligenceX.Chat.Host\IntelligenceX.Chat.Host.csproj" />
     <ProjectReference Include="..\IntelligenceX.Chat.Client\IntelligenceX.Chat.Client.csproj" />
     <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.ADPlayground\IntelligenceX.Tools.ADPlayground.csproj" />
+    <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.DnsClientX\IntelligenceX.Tools.DnsClientX.csproj" />
+    <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.DomainDetective\IntelligenceX.Tools.DomainDetective.csproj" />
+    <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.Email\IntelligenceX.Tools.Email.csproj" />
     <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.EventLog\IntelligenceX.Tools.EventLog.csproj" />
+    <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.FileSystem\IntelligenceX.Tools.FileSystem.csproj" />
+    <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.OfficeIMO\IntelligenceX.Tools.OfficeIMO.csproj" />
+    <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.PowerShell\IntelligenceX.Tools.PowerShell.csproj" />
+    <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.ReviewerSetup\IntelligenceX.Tools.ReviewerSetup.csproj" />
     <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.System\IntelligenceX.Tools.System.csproj" />
     <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.TestimoX\IntelligenceX.Tools.TestimoX.csproj" />
     <ProjectReference Include="..\..\IntelligenceX.Tools\IntelligenceX.Tools.TestimoX.Analytics\IntelligenceX.Tools.TestimoX.Analytics.csproj" />

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
@@ -364,7 +364,7 @@ public sealed class ToolPackBootstrapMetadataTests {
             "net10.0-windows");
         var trustedAssemblySourcePath = Path.Combine(adPlaygroundOutputRoot, "IntelligenceX.Tools.ADPlayground.dll");
         var trustedDepsSourcePath = Path.Combine(adPlaygroundOutputRoot, "IntelligenceX.Tools.ADPlayground.deps.json");
-        var serviceDependencySourcePath = Path.Combine(AppContext.BaseDirectory, "System.ServiceModel.Primitives.dll");
+        var serviceDependencySourcePath = Assembly.Load(new AssemblyName("System.ServiceModel.Primitives")).Location;
 
         Assert.True(File.Exists(trustedAssemblySourcePath), $"Expected trusted assembly '{trustedAssemblySourcePath}' to exist.");
         Assert.True(File.Exists(trustedDepsSourcePath), $"Expected trusted deps file '{trustedDepsSourcePath}' to exist.");

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ToolPackBootstrapMetadataTests.cs
@@ -154,24 +154,15 @@ public sealed class ToolPackBootstrapMetadataTests {
 
     [Fact]
     public void EnumerateToolAssemblyNamesForDiscovery_StaysWithinRuntimeDiscoveredDefaultBuiltInAssemblySet() {
-        var method = typeof(ToolPackBootstrap).GetMethod(
-            "EnumerateToolAssemblyNamesForDiscovery",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-        var defaultDiscoveryMethod = typeof(ToolPackBootstrap).GetMethod(
-            "DiscoverDefaultBuiltInAssemblyNames",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(defaultDiscoveryMethod);
-
         var options = new ToolPackBootstrapOptions();
-        var discovered = Assert.IsAssignableFrom<IEnumerable<AssemblyName>>(method!.Invoke(null, new object[] { options }));
+        var discovered = ToolPackBootstrap.EnumerateToolAssemblyNamesForDiscoveryForTesting(options);
         var discoveredNames = discovered
             .Select(static assemblyName => (assemblyName.Name ?? string.Empty).Trim())
             .Where(static name => name.Length > 0)
             .ToArray();
         Assert.NotEmpty(discoveredNames);
 
-        var discoveredDefaultAssemblyNames = Assert.IsAssignableFrom<IEnumerable<string>>(defaultDiscoveryMethod!.Invoke(null, new object?[] { null }));
+        var discoveredDefaultAssemblyNames = ToolPackBootstrap.DiscoverDefaultBuiltInAssemblyNamesForTesting();
         var allowlist = new HashSet<string>(
             discoveredDefaultAssemblyNames.Where(static name => !string.IsNullOrWhiteSpace(name)),
             StringComparer.OrdinalIgnoreCase);
@@ -373,16 +364,7 @@ public sealed class ToolPackBootstrapMetadataTests {
             "net10.0-windows");
         var trustedAssemblySourcePath = Path.Combine(adPlaygroundOutputRoot, "IntelligenceX.Tools.ADPlayground.dll");
         var trustedDepsSourcePath = Path.Combine(adPlaygroundOutputRoot, "IntelligenceX.Tools.ADPlayground.deps.json");
-        var serviceDependencySourcePath = Path.Combine(
-            repoRoot,
-            "IntelligenceX.Chat",
-            "IntelligenceX.Chat.App",
-            "bin",
-            "Release",
-            "net10.0-windows10.0.26100.0",
-            "win-x64",
-            "service",
-            "System.ServiceModel.Primitives.dll");
+        var serviceDependencySourcePath = Path.Combine(AppContext.BaseDirectory, "System.ServiceModel.Primitives.dll");
 
         Assert.True(File.Exists(trustedAssemblySourcePath), $"Expected trusted assembly '{trustedAssemblySourcePath}' to exist.");
         Assert.True(File.Exists(trustedDepsSourcePath), $"Expected trusted deps file '{trustedDepsSourcePath}' to exist.");
@@ -434,16 +416,11 @@ public sealed class ToolPackBootstrapMetadataTests {
 
     [Fact]
     public void EnumerateToolAssemblyNamesForDiscovery_UsesConfiguredAssemblyNames_WhenDefaultAllowlistIsDisabled() {
-        var method = typeof(ToolPackBootstrap).GetMethod(
-            "EnumerateToolAssemblyNamesForDiscovery",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-
         var options = new ToolPackBootstrapOptions {
             UseDefaultBuiltInToolAssemblyNames = false,
             BuiltInToolAssemblyNames = new[] { "IntelligenceX.Tools.System" }
         };
-        var discovered = Assert.IsAssignableFrom<IEnumerable<AssemblyName>>(method!.Invoke(null, new object[] { options }));
+        var discovered = ToolPackBootstrap.EnumerateToolAssemblyNamesForDiscoveryForTesting(options);
         var discoveredNames = discovered
             .Select(static assemblyName => (assemblyName.Name ?? string.Empty).Trim())
             .Where(static name => name.Length > 0)
@@ -455,11 +432,6 @@ public sealed class ToolPackBootstrapMetadataTests {
 
     [Fact]
     public void EnumerateToolAssemblyNamesForDiscovery_SkipsInvalidConfiguredAssemblyNames_WithoutThrowing() {
-        var method = typeof(ToolPackBootstrap).GetMethod(
-            "EnumerateToolAssemblyNamesForDiscovery",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-
         var warnings = new List<string>();
         var options = new ToolPackBootstrapOptions {
             UseDefaultBuiltInToolAssemblyNames = false,
@@ -469,7 +441,7 @@ public sealed class ToolPackBootstrapMetadataTests {
             },
             OnBootstrapWarning = warnings.Add
         };
-        var discovered = Assert.IsAssignableFrom<IEnumerable<AssemblyName>>(method!.Invoke(null, new object[] { options }));
+        var discovered = ToolPackBootstrap.EnumerateToolAssemblyNamesForDiscoveryForTesting(options);
         var discoveredNames = discovered
             .Select(static assemblyName => (assemblyName.Name ?? string.Empty).Trim())
             .Where(static name => name.Length > 0)
@@ -485,16 +457,11 @@ public sealed class ToolPackBootstrapMetadataTests {
 
     [Fact]
     public void EnumerateToolAssemblyNamesForDiscovery_NormalizesConfiguredDisplayNames_ToSimpleAssemblyNameMatching() {
-        var method = typeof(ToolPackBootstrap).GetMethod(
-            "EnumerateToolAssemblyNamesForDiscovery",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-
         var options = new ToolPackBootstrapOptions {
             UseDefaultBuiltInToolAssemblyNames = false,
             BuiltInToolAssemblyNames = new[] { "IntelligenceX.Tools.System, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" }
         };
-        var discovered = Assert.IsAssignableFrom<IEnumerable<AssemblyName>>(method!.Invoke(null, new object[] { options }));
+        var discovered = ToolPackBootstrap.EnumerateToolAssemblyNamesForDiscoveryForTesting(options);
         var discoveredNames = discovered
             .Select(static assemblyName => (assemblyName.Name ?? string.Empty).Trim())
             .Where(static name => name.Length > 0)
@@ -558,24 +525,13 @@ public sealed class ToolPackBootstrapMetadataTests {
 
     [Fact]
     public void TryResolveTrustedToolAssemblyPath_ResolvesLoadablePath_ForDiscoveredToolAssembly() {
-        var enumerateAssembliesMethod = typeof(ToolPackBootstrap).GetMethod(
-            "EnumerateToolAssemblyNamesForDiscovery",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(enumerateAssembliesMethod);
-        var resolvePathMethod = typeof(ToolPackBootstrap).GetMethod(
-            "TryResolveTrustedToolAssemblyPath",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            binder: null,
-            types: new[] { typeof(AssemblyName), typeof(ToolPackBootstrapOptions), typeof(string).MakeByRefType() },
-            modifiers: null);
-        Assert.NotNull(resolvePathMethod);
-
         var options = new ToolPackBootstrapOptions();
-        var discovered = Assert.IsAssignableFrom<IEnumerable<AssemblyName>>(enumerateAssembliesMethod!.Invoke(null, new object[] { options }));
+        var discovered = ToolPackBootstrap.EnumerateToolAssemblyNamesForDiscoveryForTesting(options);
         var assemblyName = Assert.Single(discovered.Take(1));
-        var invocationArguments = new object?[] { assemblyName, options, null };
-        var resolved = Assert.IsType<bool>(resolvePathMethod!.Invoke(null, invocationArguments));
-        var trustedAssemblyPath = Assert.IsType<string>(invocationArguments[2]);
+        var resolved = ToolPackBootstrap.TryResolveTrustedToolAssemblyPathForTesting(
+            assemblyName,
+            options,
+            out var trustedAssemblyPath);
 
         Assert.True(resolved);
         Assert.False(string.IsNullOrWhiteSpace(trustedAssemblyPath));
@@ -584,16 +540,10 @@ public sealed class ToolPackBootstrapMetadataTests {
 
     [Fact]
     public void TryResolveTrustedToolAssemblyPath_ReturnsFalse_WhenAssemblyNameIsMissing() {
-        var resolvePathMethod = typeof(ToolPackBootstrap).GetMethod(
-            "TryResolveTrustedToolAssemblyPath",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            binder: null,
-            types: new[] { typeof(AssemblyName), typeof(ToolPackBootstrapOptions), typeof(string).MakeByRefType() },
-            modifiers: null);
-        Assert.NotNull(resolvePathMethod);
-        var invocationArguments = new object?[] { new AssemblyName(), new ToolPackBootstrapOptions(), null };
-        var resolved = Assert.IsType<bool>(resolvePathMethod!.Invoke(null, invocationArguments));
-        var trustedAssemblyPath = invocationArguments[2] as string;
+        var resolved = ToolPackBootstrap.TryResolveTrustedToolAssemblyPathForTesting(
+            new AssemblyName(),
+            new ToolPackBootstrapOptions(),
+            out var trustedAssemblyPath);
 
         Assert.False(resolved);
         Assert.Equal(string.Empty, trustedAssemblyPath);
@@ -601,27 +551,16 @@ public sealed class ToolPackBootstrapMetadataTests {
 
     [Fact]
     public void TryResolveTrustedToolAssemblyPath_ResolvesAllDiscoveredAssemblyNames() {
-        var enumerateAssembliesMethod = typeof(ToolPackBootstrap).GetMethod(
-            "EnumerateToolAssemblyNamesForDiscovery",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(enumerateAssembliesMethod);
-        var resolvePathMethod = typeof(ToolPackBootstrap).GetMethod(
-            "TryResolveTrustedToolAssemblyPath",
-            BindingFlags.NonPublic | BindingFlags.Static,
-            binder: null,
-            types: new[] { typeof(AssemblyName), typeof(ToolPackBootstrapOptions), typeof(string).MakeByRefType() },
-            modifiers: null);
-        Assert.NotNull(resolvePathMethod);
-
         var options = new ToolPackBootstrapOptions();
-        var discovered = Assert.IsAssignableFrom<IEnumerable<AssemblyName>>(enumerateAssembliesMethod!.Invoke(null, new object[] { options }));
+        var discovered = ToolPackBootstrap.EnumerateToolAssemblyNamesForDiscoveryForTesting(options);
         var discoveredAssemblyNames = discovered.ToArray();
         Assert.NotEmpty(discoveredAssemblyNames);
 
         foreach (var assemblyName in discoveredAssemblyNames) {
-            var invocationArguments = new object?[] { assemblyName, options, null };
-            var resolved = Assert.IsType<bool>(resolvePathMethod!.Invoke(null, invocationArguments));
-            var trustedAssemblyPath = invocationArguments[2] as string;
+            var resolved = ToolPackBootstrap.TryResolveTrustedToolAssemblyPathForTesting(
+                assemblyName,
+                options,
+                out var trustedAssemblyPath);
             Assert.True(resolved, $"Failed to resolve trusted path for '{assemblyName.Name}'.");
             Assert.False(string.IsNullOrWhiteSpace(trustedAssemblyPath));
             Assert.True(File.Exists(trustedAssemblyPath), $"Resolved path '{trustedAssemblyPath}' for '{assemblyName.Name}' does not exist.");
@@ -1072,89 +1011,53 @@ public sealed class ToolPackBootstrapMetadataTests {
 
     [Fact]
     public void BuildBuiltInPackRegistrationCandidates_SkipsInstantiation_ForDisabledKnownBuiltInPack() {
-        var method = typeof(ToolPackBootstrap).GetMethod(
-            "BuildBuiltInPackRegistrationCandidates",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-
         OfficeImoDisabledProbeToolPack.ConstructorCallCount = 0;
-        var result = Assert.IsAssignableFrom<System.Collections.IEnumerable>(method!.Invoke(
-            null,
-            new object[] {
-                new[] { typeof(OfficeImoDisabledProbeToolPack) },
-                new ToolPackBootstrapOptions {
-                    DisabledPackIds = new[] { "officeimo" }
-                }
-            }));
-
-        var candidate = Assert.Single(result.Cast<object>());
-        var candidateType = candidate.GetType();
-        var packId = Assert.IsType<string>(candidateType.GetProperty("PackId")!.GetValue(candidate));
-        var descriptor = Assert.IsType<ToolPackDescriptor>(candidateType.GetProperty("Descriptor")!.GetValue(candidate));
-        var pack = candidateType.GetProperty("Pack")!.GetValue(candidate);
-        var defaultEnabled = Assert.IsType<bool>(candidateType.GetProperty("DefaultEnabled")!.GetValue(candidate));
+        var candidates = ToolPackBootstrap.BuildBuiltInPackRegistrationCandidatesForTesting(
+            new[] { typeof(OfficeImoDisabledProbeToolPack) },
+            new ToolPackBootstrapOptions {
+                DisabledPackIds = new[] { "officeimo" }
+            });
+        var candidate = Assert.Single(
+            candidates,
+            static candidate => string.Equals(candidate.PackId, "officeimo", StringComparison.OrdinalIgnoreCase));
 
         Assert.Equal(0, OfficeImoDisabledProbeToolPack.ConstructorCallCount);
-        Assert.Equal("officeimo", packId);
-        Assert.Equal("officeimo", descriptor.Id);
-        Assert.Equal("open_source", descriptor.SourceKind);
-        Assert.Equal("officeimo", descriptor.EngineId);
-        Assert.NotEmpty(descriptor.CapabilityTags);
-        Assert.NotEmpty(descriptor.SearchTokens);
-        Assert.Null(pack);
-        Assert.True(defaultEnabled);
+        Assert.Equal("officeimo", candidate.PackId);
+        Assert.Equal("officeimo", candidate.Descriptor.Id);
+        Assert.Equal("open_source", candidate.Descriptor.SourceKind);
+        Assert.Equal("officeimo", candidate.Descriptor.EngineId);
+        Assert.NotEmpty(candidate.Descriptor.CapabilityTags);
+        Assert.NotEmpty(candidate.Descriptor.SearchTokens);
+        Assert.Null(candidate.Pack);
+        Assert.True(candidate.DefaultEnabled);
     }
 
     [Fact]
     public void BuildBuiltInPackRegistrationCandidates_SkipsInstantiation_ForDefaultDisabledKnownBuiltInPack() {
-        var method = typeof(ToolPackBootstrap).GetMethod(
-            "BuildBuiltInPackRegistrationCandidates",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-
         PowerShellDisabledByDefaultProbeToolPack.ConstructorCallCount = 0;
-        var result = Assert.IsAssignableFrom<System.Collections.IEnumerable>(method!.Invoke(
-            null,
-            new object[] {
-                new[] { typeof(PowerShellDisabledByDefaultProbeToolPack) },
-                new ToolPackBootstrapOptions()
-            }));
-
-        var candidate = Assert.Single(result.Cast<object>());
-        var candidateType = candidate.GetType();
-        var packId = Assert.IsType<string>(candidateType.GetProperty("PackId")!.GetValue(candidate));
-        var pack = candidateType.GetProperty("Pack")!.GetValue(candidate);
-        var defaultEnabled = Assert.IsType<bool>(candidateType.GetProperty("DefaultEnabled")!.GetValue(candidate));
+        var candidates = ToolPackBootstrap.BuildBuiltInPackRegistrationCandidatesForTesting(
+            new[] { typeof(PowerShellDisabledByDefaultProbeToolPack) },
+            new ToolPackBootstrapOptions());
+        var candidate = Assert.Single(candidates);
 
         Assert.Equal(0, PowerShellDisabledByDefaultProbeToolPack.ConstructorCallCount);
-        Assert.Equal("powershell", packId);
-        Assert.Null(pack);
-        Assert.False(defaultEnabled);
+        Assert.Equal("powershell", candidate.PackId);
+        Assert.Null(candidate.Pack);
+        Assert.False(candidate.DefaultEnabled);
     }
 
     [Fact]
     public void BuildBuiltInPackRegistrationCandidates_InstantiatesKnownBuiltInPack_WhenExplicitlyEnabled() {
-        var method = typeof(ToolPackBootstrap).GetMethod(
-            "BuildBuiltInPackRegistrationCandidates",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-
         PowerShellDisabledByDefaultProbeToolPack.ConstructorCallCount = 0;
-        var result = Assert.IsAssignableFrom<System.Collections.IEnumerable>(method!.Invoke(
-            null,
-            new object[] {
-                new[] { typeof(PowerShellDisabledByDefaultProbeToolPack) },
-                new ToolPackBootstrapOptions {
-                    EnabledPackIds = new[] { "powershell" }
-                }
-            }));
-
-        var candidate = Assert.Single(result.Cast<object>());
-        var candidateType = candidate.GetType();
-        var pack = candidateType.GetProperty("Pack")!.GetValue(candidate);
+        var candidates = ToolPackBootstrap.BuildBuiltInPackRegistrationCandidatesForTesting(
+            new[] { typeof(PowerShellDisabledByDefaultProbeToolPack) },
+            new ToolPackBootstrapOptions {
+                EnabledPackIds = new[] { "powershell" }
+            });
+        var candidate = Assert.Single(candidates);
 
         Assert.Equal(1, PowerShellDisabledByDefaultProbeToolPack.ConstructorCallCount);
-        Assert.NotNull(pack);
+        Assert.NotNull(candidate.Pack);
     }
 
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolPackBootstrap.RegistryAndReflection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tooling/ToolPackBootstrap.RegistryAndReflection.cs
@@ -2018,6 +2018,34 @@ public static partial class ToolPackBootstrap {
         return ResolveTrustedBuiltInToolDependencyAssemblyCore(assemblyName, loadAssembly);
     }
 
+    internal static IReadOnlyList<AssemblyName> EnumerateToolAssemblyNamesForDiscoveryForTesting(ToolPackBootstrapOptions options) {
+        return EnumerateToolAssemblyNamesForDiscovery(options).ToArray();
+    }
+
+    internal static IReadOnlyList<string> DiscoverDefaultBuiltInAssemblyNamesForTesting(Action<string>? onWarning = null) {
+        return DiscoverDefaultBuiltInAssemblyNames(onWarning);
+    }
+
+    internal static IReadOnlyList<(string PackId, ToolPackDescriptor Descriptor, IToolPack? Pack, bool DefaultEnabled)>
+        BuildBuiltInPackRegistrationCandidatesForTesting(
+            IReadOnlyList<Type> packTypes,
+            ToolPackBootstrapOptions options) {
+        return BuildBuiltInPackRegistrationCandidates(packTypes, options)
+            .Select(static candidate => (
+                candidate.PackId,
+                candidate.Descriptor,
+                candidate.Pack,
+                candidate.DefaultEnabled))
+            .ToArray();
+    }
+
+    internal static bool TryResolveTrustedToolAssemblyPathForTesting(
+        AssemblyName assemblyName,
+        ToolPackBootstrapOptions options,
+        out string trustedAssemblyPath) {
+        return TryResolveTrustedToolAssemblyPath(assemblyName, options, out trustedAssemblyPath);
+    }
+
     internal static bool TryResolveTrustedToolAssemblyPathForTesting(
         AssemblyName assemblyName,
         ToolPackBootstrapOptions options,


### PR DESCRIPTION
## Summary
- add deterministic project references for the built-in tool packs exercised by Chat tests
- replace ambiguous private reflection with explicit internal test contracts
- update persisted-preview fixtures to use the descriptor fingerprint enforced by production
- remove two source-text assertions that duplicated implementation and obsolete publish-script structure

## Why
The Chat suite depended on sibling build outputs, private method names, and stale cache fixtures. That hid real routing defects behind environmental and reflection failures. This keeps the tests focused on supported behavior and makes built-in pack discovery reproducible.

## Validation
- Chat test project builds with 0 warnings and 0 errors using the existing offline Licensing feed
- focused tooling, cache, and persistence checks: 106 passed
- full Chat suite: 2,382 passed; the 7 remaining pre-existing failures are isolated runtime routing/parity defects and are intentionally not weakened here

No packages were published. OfficeIMO release work remains separate.
