### PR TITLE
Stop duplicate chat recovery passes

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedFinalizeDecision.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedFinalizeDecision.cs
@@ -382,7 +382,7 @@ internal sealed partial class ChatServiceSession {
             hasSuccessfulToolOutput: hasSuccessfulToolOutput,
             toolCalls: toolCalls,
             toolOutputs: toolOutputs,
-            assistantDraft: assistantDraft,
+            assistantDraft: recoveredAssistantDraft,
             localNoTextDirectRetryUsed: localNoTextDirectRetryUsed,
             isLocalCompatibleLoopback: isLocalCompatibleLoopback,
             availableToolCount: availableToolCount,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedFinalizeDecision.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedFinalizeDecision.cs
@@ -371,10 +371,16 @@ internal sealed partial class ChatServiceSession {
         int availableToolCount,
         int priorToolCalls,
         string userRequest) {
-        var recoveredAssistantDraft = ResolveAssistantTextFromToolOutputsFallback(
-            assistantDraft: assistantDraft,
-            toolCalls: toolCalls,
-            toolOutputs: toolOutputs);
+        var requestedArtifactIntent = ResolveRequestedArtifactIntent(userRequest);
+        var recoveredAssistantDraft = requestedArtifactIntent.RequiresArtifact
+            ? ResolveAssistantTextFromRequestedArtifactToolOutputsFallback(
+                userRequest: userRequest,
+                assistantDraft: assistantDraft,
+                toolOutputs: toolOutputs)
+            : ResolveAssistantTextFromToolOutputsFallback(
+                assistantDraft: assistantDraft,
+                toolCalls: toolCalls,
+                toolOutputs: toolOutputs);
         var decision = ResolveNoExtractedFinalizeNoTextDecision(
             noTextToolOutputDirectRetryUsed: noTextToolOutputDirectRetryUsed,
             planExecuteReviewLoop: planExecuteReviewLoop,
@@ -568,7 +574,8 @@ internal sealed partial class ChatServiceSession {
         bool isLocalCompatibleLoopback,
         int availableToolCount,
         int priorToolCalls,
-        string userRequest) {
+        string userRequest,
+        string? toolOutputSummaryMarkdown = null) {
         var toolCalls = new List<ToolCallDto> {
             new() {
                 CallId = "call_1",
@@ -579,7 +586,8 @@ internal sealed partial class ChatServiceSession {
             new() {
                 CallId = "call_1",
                 Ok = hasSuccessfulToolOutput,
-                Output = "Found 3 relevant results."
+                Output = "Found 3 relevant results.",
+                SummaryMarkdown = toolOutputSummaryMarkdown
             }
         };
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedRecovery.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedRecovery.cs
@@ -66,8 +66,6 @@ internal sealed partial class ChatServiceSession {
         var visibleUserRequest = string.IsNullOrWhiteSpace(userRequest) ? routedUserRequest : userRequest;
         var bootstrapOnlyToolActivity = hostDomainIntentBootstrapReplayUsed
             && HasOnlyHostGeneratedPackPreflightToolActivity(toolCalls, toolOutputs);
-        var priorToolCallsForRecoveryRetry = bootstrapOnlyToolActivity ? 0 : toolCalls.Count;
-        var priorToolOutputsForRecoveryRetry = bootstrapOnlyToolActivity ? 0 : toolOutputs.Count;
 
                 var text = EasyChatResult.FromTurn(turn).Text ?? string.Empty;
                 var controlPayloadDetected = isLocalCompatibleLoopback && LooksLikeRuntimeControlPayloadArtifact(text);
@@ -145,28 +143,22 @@ internal sealed partial class ChatServiceSession {
                     executionContractApplies: executionContractApplies,
                     compactFollowUpTurn: compactFollowUpTurn,
                     toolsAvailable: toolDefs.Count > 0 || fullToolDefs.Length > 0,
-                    priorToolCalls: priorToolCallsForRecoveryRetry,
-                    priorToolOutputs: priorToolOutputsForRecoveryRetry,
+                    priorToolCalls: toolCalls.Count,
+                    priorToolOutputs: toolOutputs.Count,
                     userRequest: visibleUserRequest,
                     assistantDraft: text);
                 if (suppressLocalToolRecoveryRetries) {
                     executionNudgeReason = "local_runtime_recovery_disabled";
                 } else if (!executionNudgeUsed) {
-                    if (LooksLikeExecutionAcknowledgeDraft(text)
-                        && AssistantDraftReferencesUserRequest(visibleUserRequest, text)) {
-                        shouldAttemptExecutionNudge = true;
-                        executionNudgeReason = "execution_ack_draft_direct_retry";
-                    } else {
-                        shouldAttemptExecutionNudge = EvaluateToolExecutionNudgeDecision(
-                            userRequest: visibleUserRequest,
-                            assistantDraft: text,
-                            toolsAvailable: toolDefs.Count > 0,
-                            priorToolCalls: priorToolCallsForRecoveryRetry,
-                            assistantDraftToolCalls: extracted.Count,
-                            usedContinuationSubset: usedContinuationSubset,
-                            compactFollowUpHint: compactFollowUpTurn,
-                            out executionNudgeReason);
-                    }
+                    shouldAttemptExecutionNudge = EvaluateToolExecutionNudgeDecision(
+                        userRequest: visibleUserRequest,
+                        assistantDraft: text,
+                        toolsAvailable: toolDefs.Count > 0,
+                        priorToolCalls: toolCalls.Count,
+                        assistantDraftToolCalls: extracted.Count,
+                        usedContinuationSubset: usedContinuationSubset,
+                        compactFollowUpHint: compactFollowUpTurn,
+                        out executionNudgeReason);
                 }
                 if (string.Equals(Environment.GetEnvironmentVariable("IX_CHAT_TRACE_TOOL_NUDGE"), "1", StringComparison.Ordinal)) {
                     Console.Error.WriteLine(
@@ -183,7 +175,7 @@ internal sealed partial class ChatServiceSession {
                         userRequest: visibleUserRequest,
                         usedContinuationSubset: usedContinuationSubset,
                         toolsAvailable: toolDefs.Count > 0,
-                        priorToolCalls: priorToolCallsForRecoveryRetry,
+                        priorToolCalls: toolCalls.Count,
                         assistantDraftToolCalls: extracted.Count,
                         executionNudgeAlreadyUsed: executionNudgeUsed,
                         shouldAttemptNudge: shouldAttemptExecutionNudge,
@@ -219,7 +211,7 @@ internal sealed partial class ChatServiceSession {
                     userRequest: visibleUserRequest,
                     usedContinuationSubset: usedContinuationSubset,
                     toolsAvailable: toolDefs.Count > 0,
-                    priorToolCalls: priorToolCallsForRecoveryRetry,
+                    priorToolCalls: toolCalls.Count,
                     assistantDraftToolCalls: extracted.Count,
                     executionNudgeAlreadyUsed: executionNudgeUsed,
                     shouldAttemptNudge: false,
@@ -231,8 +223,8 @@ internal sealed partial class ChatServiceSession {
                                                             userRequest: visibleUserRequest,
                                                             assistantDraft: text,
                                                             tools: toolDefs,
-                                                            priorToolCalls: priorToolCallsForRecoveryRetry,
-                                                            priorToolOutputs: priorToolOutputsForRecoveryRetry,
+                                                            priorToolCalls: toolCalls.Count,
+                                                            priorToolOutputs: toolOutputs.Count,
                                                             assistantDraftToolCalls: extracted.Count);
 
                 var shouldAttemptWatchdog = false;
@@ -244,8 +236,8 @@ internal sealed partial class ChatServiceSession {
                         userRequest: visibleUserRequest,
                         assistantDraft: text,
                         toolsAvailable: toolDefs.Count > 0,
-                        priorToolCalls: priorToolCallsForRecoveryRetry,
-                        priorToolOutputs: priorToolOutputsForRecoveryRetry,
+                        priorToolCalls: toolCalls.Count,
+                        priorToolOutputs: toolOutputs.Count,
                         assistantDraftToolCalls: extracted.Count,
                         continuationFollowUpTurn: continuationFollowUpTurn,
                         compactFollowUpTurn: compactFollowUpTurn,
@@ -258,8 +250,8 @@ internal sealed partial class ChatServiceSession {
                     userRequest: visibleUserRequest,
                     executionContractApplies: executionContractApplies,
                     toolsAvailable: toolDefs.Count > 0,
-                    priorToolCalls: priorToolCallsForRecoveryRetry,
-                    priorToolOutputs: priorToolOutputsForRecoveryRetry,
+                    priorToolCalls: toolCalls.Count,
+                    priorToolOutputs: toolOutputs.Count,
                     assistantDraftToolCalls: extracted.Count,
                     continuationFollowUpTurn: continuationFollowUpTurn,
                     compactFollowUpTurn: compactFollowUpTurn,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.ActionSelection.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.ActionSelection.cs
@@ -438,8 +438,17 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static bool TryReadActionSelectionIntent(string text, out string actionId, out ActionMutability mutability) {
+        return TryReadActionSelectionIntent(text, out actionId, out mutability, out _);
+    }
+
+    private static bool TryReadActionSelectionIntent(
+        string text,
+        out string actionId,
+        out ActionMutability mutability,
+        out string selectedRequest) {
         actionId = string.Empty;
         mutability = ActionMutability.Unknown;
+        selectedRequest = string.Empty;
 
         var normalized = (text ?? string.Empty).Trim();
         if (normalized.Length == 0 || normalized.Length > MaxActionSelectionPayloadChars) {
@@ -494,6 +503,13 @@ internal sealed partial class ChatServiceSession {
             }
 
             mutability = ResolveActionSelectionMutability(selection);
+            if (TryGetObjectPropertyCaseInsensitive(selection, out var request, "request")) {
+                selectedRequest = request.ValueKind == JsonValueKind.String
+                    ? (request.GetString() ?? string.Empty).Trim()
+                    : request.ValueKind is JsonValueKind.Object or JsonValueKind.Array
+                        ? request.GetRawText()
+                        : string.Empty;
+            }
             return true;
         } catch (JsonException) {
             return false;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
@@ -237,6 +237,11 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
+        if (HasUnknownActionSelection(userRequest)) {
+            reason = "action_selection_mutability_unknown";
+            return false;
+        }
+
         if (!executionContractApplies && HasArtifactRequestWithoutExplicitToolIntent(userRequest)) {
             reason = "artifact_only_follow_up_request";
             return false;
@@ -399,6 +404,11 @@ internal sealed partial class ChatServiceSession {
         var request = (userRequest ?? string.Empty).Trim();
         if (request.Length == 0) {
             reason = "empty_user_request";
+            return false;
+        }
+
+        if (HasUnknownActionSelection(request)) {
+            reason = "action_selection_mutability_unknown";
             return false;
         }
 
@@ -604,13 +614,31 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
+        var hasActionSelection = TryReadActionSelectionIntent(
+            text: request,
+            actionId: out _,
+            mutability: out var actionSelectionMutability,
+            selectedRequest: out var selectedActionRequest);
+        var hasExplicitReadOnlyActionSelection = hasActionSelection
+                                                 && actionSelectionMutability == ActionMutability.ReadOnly;
         if (ExtractExplicitRequestedToolNames(request).Length > 0
-            || LooksLikeActionSelectionPayload(request)
+            || hasExplicitReadOnlyActionSelection
             || ShouldEnforceExecuteOrExplainContract(request)) {
             return false;
         }
 
-        return ResolveRequestedArtifactIntent(request).RequiresArtifact;
+        var artifactRequest = hasActionSelection && !string.IsNullOrWhiteSpace(selectedActionRequest)
+            ? selectedActionRequest
+            : request;
+        return ResolveRequestedArtifactIntent(artifactRequest).RequiresArtifact;
+    }
+
+    private static bool HasUnknownActionSelection(string userRequest) {
+        return TryReadActionSelectionIntent(
+                   text: userRequest,
+                   actionId: out _,
+                   mutability: out var mutability)
+               && mutability == ActionMutability.Unknown;
     }
 
     private static bool LooksLikeStructuredExecutionDeferredDraft(string assistantDraft) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
@@ -237,7 +237,7 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (!executionContractApplies && IsArtifactOnlyFollowUpRequest(userRequest)) {
+        if (!executionContractApplies && HasArtifactRequestWithoutExplicitToolIntent(userRequest)) {
             reason = "artifact_only_follow_up_request";
             return false;
         }
@@ -402,14 +402,15 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (IsArtifactOnlyFollowUpRequest(request)) {
-            reason = "artifact_only_follow_up_request";
-            return false;
-        }
-
+        var hasArtifactRequestWithoutExplicitToolIntent = HasArtifactRequestWithoutExplicitToolIntent(request);
         var draft = (assistantDraft ?? string.Empty).Trim();
         if (draft.Length == 0 || draft.Length > 2400) {
             if (draft.Length == 0) {
+                if (hasArtifactRequestWithoutExplicitToolIntent) {
+                    reason = "artifact_only_follow_up_request";
+                    return false;
+                }
+
                 var requestTokenCount = CountLetterDigitTokens(request, maxTokens: 64);
                 if (requestTokenCount >= 4) {
                     reason = "empty_assistant_draft_retry";
@@ -430,6 +431,14 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
+        var hasSinglePendingActionEnvelope = TryGetSinglePendingActionEnvelopeMutability(draft, out var singlePendingActionMutability);
+        var hasSingleNonMutatingPendingActionEnvelope = hasSinglePendingActionEnvelope
+                                                        && singlePendingActionMutability != ActionMutability.Mutating;
+        if (hasArtifactRequestWithoutExplicitToolIntent && !hasSingleNonMutatingPendingActionEnvelope) {
+            reason = "artifact_only_follow_up_request";
+            return false;
+        }
+
         // If the user selected an explicit pending action (/act or ordinal selection), we should strongly prefer
         // tool execution over a "talky" draft. This is language-agnostic and works after app restarts.
         if (LooksLikeActionSelectionPayload(request)) {
@@ -443,9 +452,6 @@ internal sealed partial class ChatServiceSession {
         var compactFollowUp = compactFollowUpHint || LooksLikeCompactFollowUp(request);
         var contextualFollowUp = !compactFollowUp && LooksLikeContextualFollowUpForExecutionNudge(request, draft);
         var draftReferencesFollowUp = AssistantDraftReferencesUserRequest(request, draft);
-        var hasSinglePendingActionEnvelope = TryGetSinglePendingActionEnvelopeMutability(draft, out var singlePendingActionMutability);
-        var hasSingleNonMutatingPendingActionEnvelope = hasSinglePendingActionEnvelope
-                                                        && singlePendingActionMutability != ActionMutability.Mutating;
         var hasExecutionAckReference = LooksLikeExecutionAcknowledgeDraft(draft)
                                        && draft.IndexOf('"') < 0
                                        && draft.IndexOf('\'') < 0
@@ -590,7 +596,7 @@ internal sealed partial class ChatServiceSession {
         return false;
     }
 
-    private static bool IsArtifactOnlyFollowUpRequest(string userRequest) {
+    private static bool HasArtifactRequestWithoutExplicitToolIntent(string userRequest) {
         var request = (userRequest ?? string.Empty).Trim();
         if (request.Length == 0) {
             return false;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.ToolNudge.cs
@@ -432,9 +432,11 @@ internal sealed partial class ChatServiceSession {
         }
 
         var hasSinglePendingActionEnvelope = TryGetSinglePendingActionEnvelopeMutability(draft, out var singlePendingActionMutability);
-        var hasSingleNonMutatingPendingActionEnvelope = hasSinglePendingActionEnvelope
-                                                        && singlePendingActionMutability != ActionMutability.Mutating;
-        if (hasArtifactRequestWithoutExplicitToolIntent && !hasSingleNonMutatingPendingActionEnvelope) {
+        var hasSingleReadOnlyPendingActionEnvelope = hasSinglePendingActionEnvelope
+                                                     && singlePendingActionMutability == ActionMutability.ReadOnly;
+        var hasSingleExecutionEligiblePendingActionEnvelope = hasSinglePendingActionEnvelope
+                                                              && singlePendingActionMutability != ActionMutability.Mutating;
+        if (hasArtifactRequestWithoutExplicitToolIntent && !hasSingleReadOnlyPendingActionEnvelope) {
             reason = "artifact_only_follow_up_request";
             return false;
         }
@@ -483,7 +485,7 @@ internal sealed partial class ChatServiceSession {
         }
 
         if (!usedContinuationSubset && !echoedCallToAction && !contextualFollowUp) {
-            if (hasSingleNonMutatingPendingActionEnvelope && !ContainsQuestionSignal(draft)) {
+            if (hasSingleExecutionEligiblePendingActionEnvelope && !ContainsQuestionSignal(draft)) {
                 reason = singlePendingActionMutability == ActionMutability.Unknown
                     ? "single_unknown_pending_action_envelope"
                     : "single_readonly_pending_action_envelope";
@@ -535,7 +537,7 @@ internal sealed partial class ChatServiceSession {
                                   || draft.Contains('{', StringComparison.Ordinal)
                                   || draft.Contains('[', StringComparison.Ordinal);
         if (hasStructuredOutput) {
-            if (hasSingleNonMutatingPendingActionEnvelope && !asksAnotherQuestion) {
+            if (hasSingleExecutionEligiblePendingActionEnvelope && !asksAnotherQuestion) {
                 reason = singlePendingActionMutability == ActionMutability.Unknown
                     ? "structured_draft_single_unknown_pending_action_envelope"
                     : "structured_draft_single_readonly_pending_action_envelope";
@@ -602,7 +604,9 @@ internal sealed partial class ChatServiceSession {
             return false;
         }
 
-        if (ExtractExplicitRequestedToolNames(request).Length > 0 || ShouldEnforceExecuteOrExplainContract(request)) {
+        if (ExtractExplicitRequestedToolNames(request).Length > 0
+            || LooksLikeActionSelectionPayload(request)
+            || ShouldEnforceExecuteOrExplainContract(request)) {
             return false;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.IntelligenceLoop.EndToEnd.cs
@@ -1598,7 +1598,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
         Assert.Equal(5, statuses.Count(static s => string.Equals(s, "tool_round_completed", StringComparison.OrdinalIgnoreCase)));
         Assert.DoesNotContain(statuses, static s => string.Equals(s, "tool_round_limit_reached", StringComparison.OrdinalIgnoreCase));
 
-        Assert.Equal(7, server.ChatCompletionRequestCount);
+        Assert.Equal(6, server.ChatCompletionRequestCount);
         Assert.Equal(1, CountRoleMessages(server.GetChatRequestBody(0), "user"));
         for (var round = 1; round <= 5; round++) {
             Assert.True(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.NoExtractedFinalizeDecision.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.NoExtractedFinalizeDecision.cs
@@ -382,7 +382,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
-    public void ResolveNoExtractedFinalizeNoTextOutcomeForTesting_PreservesFallbackTextButStillSelectsSynthesisRetry() {
+    public void ResolveNoExtractedFinalizeNoTextOutcomeForTesting_PrefersRecoveredToolOutputOverSynthesisRetry() {
         var result = ChatServiceSession.ResolveNoExtractedFinalizeNoTextOutcomeForTesting(
             noTextToolOutputDirectRetryUsed: false,
             planExecuteReviewLoop: true,
@@ -396,8 +396,8 @@ public sealed partial class ChatServiceRoutingTrimTests {
             userRequest: "Summarize the tool result.");
 
         Assert.Contains("Recovered findings from executed tools", result.AssistantDraft, StringComparison.Ordinal);
-        Assert.Equal("ToolOutputSynthesisRetry", result.Kind);
-        Assert.Equal("tool_output_synthesis_retry", result.Reason);
+        Assert.Equal("None", result.Kind);
+        Assert.Equal("no_no_text_recovery_selected", result.Reason);
     }
 
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.NoExtractedFinalizeDecision.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.NoExtractedFinalizeDecision.cs
@@ -401,6 +401,53 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ResolveNoExtractedFinalizeNoTextOutcomeForTesting_PreservesCompleteRequestedArtifactSummary() {
+        var mermaid = """
+            ```mermaid
+            graph TD
+                A[AD1] --> B[AD2]
+                B --> C[AD3]
+            ```
+            """;
+        var result = ChatServiceSession.ResolveNoExtractedFinalizeNoTextOutcomeForTesting(
+            noTextToolOutputDirectRetryUsed: false,
+            planExecuteReviewLoop: true,
+            redactEnabled: false,
+            hasSuccessfulToolOutput: true,
+            assistantDraft: string.Empty,
+            localNoTextDirectRetryUsed: false,
+            isLocalCompatibleLoopback: true,
+            availableToolCount: 2,
+            priorToolCalls: 1,
+            userRequest: "Show the replication topology as a Mermaid diagram.",
+            toolOutputSummaryMarkdown: mermaid);
+
+        Assert.Equal(mermaid, result.AssistantDraft);
+        Assert.Equal("None", result.Kind);
+        Assert.Equal("no_no_text_recovery_selected", result.Reason);
+    }
+
+    [Fact]
+    public void ResolveNoExtractedFinalizeNoTextOutcomeForTesting_RetriesSynthesisWhenToolSummaryMissesRequestedArtifact() {
+        var result = ChatServiceSession.ResolveNoExtractedFinalizeNoTextOutcomeForTesting(
+            noTextToolOutputDirectRetryUsed: false,
+            planExecuteReviewLoop: true,
+            redactEnabled: false,
+            hasSuccessfulToolOutput: true,
+            assistantDraft: string.Empty,
+            localNoTextDirectRetryUsed: false,
+            isLocalCompatibleLoopback: true,
+            availableToolCount: 2,
+            priorToolCalls: 1,
+            userRequest: "Show the replication topology as a Mermaid diagram.",
+            toolOutputSummaryMarkdown: "Replication data was collected successfully.");
+
+        Assert.Equal(string.Empty, result.AssistantDraft);
+        Assert.Equal("ToolOutputSynthesisRetry", result.Kind);
+        Assert.Equal("tool_output_synthesis_retry", result.Reason);
+    }
+
+    [Fact]
     public void BuildNoTextToolOutputSynthesisPrompt_CarriesRequestedArtifactGuidanceIntoRetryPrompt() {
         var prompt = ChatServiceSession.BuildNoTextToolOutputSynthesisPrompt(
             userRequest: "Pokaz to na wykresie topologii replikacji.",

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.NoExtractedRecoveryDecision.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.NoExtractedRecoveryDecision.cs
@@ -8,7 +8,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     [Fact]
     public void ResolveNoExtractedPromptRecoveryDecisionForTesting_PrefersExecutionNudge() {
         var result = ChatServiceSession.ResolveNoExtractedPromptRecoveryDecisionForTesting(
-            userRequest: "{\"ix_action_selection\":{\"id\":\"act_001\",\"title\":\"Run forest probe\",\"request\":\"Run it.\"}}",
+            userRequest: "{\"ix_action_selection\":{\"id\":\"act_001\",\"title\":\"Run forest probe\",\"request\":\"Run it.\",\"mutating\":false}}",
             assistantDraft: "Ok, doing it now.",
             executionContractApplies: false,
             usedContinuationSubset: false,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ExecutionContract.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ExecutionContract.cs
@@ -494,6 +494,18 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ShouldAttemptToolExecutionNudge_DoesNotTreatUnknownActionSelectionAsSafeArtifactBypass() {
+        var userRequest = "{\"ix_action_selection\":{\"id\":\"act_001\",\"title\":\"Show topology\",\"request\":\"Run replication diagnostics and return a network diagram.\"}}";
+        var assistantDraft = "I will run the replication diagnostics and return the network diagram now.";
+        var args = new object?[] { userRequest, assistantDraft, true, 0, 0, false, false, null };
+
+        var result = EvaluateToolExecutionNudgeDecisionMethod.Invoke(null, args);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Equal("action_selection_mutability_unknown", Assert.IsType<string>(args[7]));
+    }
+
+    [Fact]
     public void ShouldAttemptToolExecutionNudge_DoesNotTreatUnknownPendingActionAsSafeArtifactBypass() {
         var userRequest = "Show the replication topology as a network diagram.";
         var assistantDraft = """

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ExecutionContract.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.ExecutionContract.cs
@@ -482,6 +482,37 @@ public sealed partial class ChatServiceRoutingTrimTests {
     }
 
     [Fact]
+    public void ShouldAttemptToolExecutionNudge_TriggersForReadOnlyActionSelectionThatRequestsDiagram() {
+        var userRequest = "{\"ix_action_selection\":{\"id\":\"act_001\",\"title\":\"Show topology\",\"request\":\"Run replication diagnostics and return a network diagram.\",\"mutating\":false}}";
+        var assistantDraft = "I will run the replication diagnostics and return the network diagram now.";
+        var args = new object?[] { userRequest, assistantDraft, true, 0, 0, false, false, null };
+
+        var result = EvaluateToolExecutionNudgeDecisionMethod.Invoke(null, args);
+
+        Assert.True(Assert.IsType<bool>(result));
+        Assert.Equal("explicit_action_selection_payload", Assert.IsType<string>(args[7]));
+    }
+
+    [Fact]
+    public void ShouldAttemptToolExecutionNudge_DoesNotTreatUnknownPendingActionAsSafeArtifactBypass() {
+        var userRequest = "Show the replication topology as a network diagram.";
+        var assistantDraft = """
+            [Action]
+            ix:action:v1
+            id: act_unknown
+            title: Continue with topology analysis
+            request: Run replication diagnostics and return a network diagram.
+            reply: /act act_unknown
+            """;
+        var args = new object?[] { userRequest, assistantDraft, true, 0, 0, false, false, null };
+
+        var result = EvaluateToolExecutionNudgeDecisionMethod.Invoke(null, args);
+
+        Assert.False(Assert.IsType<bool>(result));
+        Assert.Equal("artifact_only_follow_up_request", Assert.IsType<string>(args[7]));
+    }
+
+    [Fact]
     public void ShouldAttemptToolExecutionNudge_DoesNotTriggerForSingleMutatingPendingActionEnvelopeWithoutContinuationSubset() {
         var userRequest = "Disable stale account evotec\\john and then verify.";
         var assistantDraft = """

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceRoutingTrimTests.ToolNudge.cs
@@ -18,7 +18,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ShouldAttemptToolExecutionNudge_TriggersForActionSelectionJsonEvenWithoutContinuationSubset() {
-        var userRequest = "{\"ix_action_selection\":{\"id\":\"act_001\",\"title\":\"Run forest probe\",\"request\":\"Run it.\"}}";
+        var userRequest = "{\"ix_action_selection\":{\"id\":\"act_001\",\"title\":\"Run forest probe\",\"request\":\"Run it.\",\"mutating\":false}}";
         var assistantDraft = "Ok, doing it now.";
 
         var result = ShouldAttemptToolExecutionNudgeMethod.Invoke(
@@ -31,7 +31,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ShouldAttemptToolExecutionNudge_TriggersForActionSelectionJsonWithCaseVariantKeys() {
-        var userRequest = "{\"IX_Action_Selection\":{\"ActionId\":\"act_001\",\"Title\":\"Run forest probe\",\"Request\":\"Run it.\"}}";
+        var userRequest = "{\"IX_Action_Selection\":{\"ActionId\":\"act_001\",\"Title\":\"Run forest probe\",\"Request\":\"Run it.\",\"Mutating\":false}}";
         var assistantDraft = "Ok, doing it now.";
 
         var result = ShouldAttemptToolExecutionNudgeMethod.Invoke(
@@ -46,7 +46,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
     public void ShouldAttemptToolExecutionNudge_TriggersForFencedActionSelectionJsonPayload() {
         var userRequest = """
                           ```ix_action_selection
-                          {"ix_action_selection":{"id":"act_001","title":"Run forest probe","request":"Run it."}}
+                          {"ix_action_selection":{"id":"act_001","title":"Run forest probe","request":"Run it.","mutating":false}}
                           ```
                           """;
         var assistantDraft = "Ok, doing it now.";
@@ -92,7 +92,7 @@ public sealed partial class ChatServiceRoutingTrimTests {
 
     [Fact]
     public void ShouldAttemptToolExecutionNudge_TriggersForNumericActionSelectionId() {
-        var userRequest = "{\"ix_action_selection\":{\"id\":1,\"title\":\"Run\",\"request\":\"Run it.\"}}";
+        var userRequest = "{\"ix_action_selection\":{\"id\":1,\"title\":\"Run\",\"request\":\"Run it.\",\"mutating\":false}}";
         var assistantDraft = "Ok, doing it now.";
 
         var result = ShouldAttemptToolExecutionNudgeMethod.Invoke(


### PR DESCRIPTION
## Summary
- route execution acknowledgements through the shared recovery eligibility decision so completed tool activity cannot trigger another execution-correction pass
- keep visual-only follow-ups non-executing while allowing explicitly read-only pending actions to continue
- fail closed when a structured action selection omits mutability instead of treating it as safe to execute
- preserve complete requested table and visual artifacts from successful tool output
- leave post-bootstrap operational continuation to the dedicated host continuation decision

## User impact
This removes redundant model calls after successful tools, prevents valid turns from exhausting MaxToolRounds, and closes an unsafe recovery path where an untyped action selection could reach write-capable tools without explicit mutability.

## Validation
- Release solution build passed in package-mode OfficeIMO.Reader configuration
- 2,393 applicable IntelligenceX Chat tests passed
- focused recovery, structured mutability, five-round autonomy, bootstrap, artifact-only, and queue lifecycle contracts passed
- executable harnesses passed on net8.0 and net10.0

The one local Chat test excluded from this count is the separate live TestimoX capability-parity gap being fixed through the shared TestimoX owner PR. No OfficeIMO package is changed or published here.
