### PR TITLE
Align the OfficeIMO.Reader pin contract

### DIFF
--- a/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
+++ b/IntelligenceX.Tools/IntelligenceX.Tools.Tests/OfficeImoReadToolTests.cs
@@ -20,7 +20,7 @@ public class OfficeImoReadToolTests {
         var propsPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Directory.Build.props"));
         var props = LoadMsBuildProperties(propsPath);
 
-        Assert.Equal("0.1.36", props["OfficeImoReaderNuGetVersion"]);
+        Assert.Equal("0.1.50", props["OfficeImoReaderNuGetVersion"]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- update the OfficeIMO.Reader package-pin contract to match the existing 0.1.50 fallback
- restore the full IntelligenceX.Tools test suite after the Dependabot pin update

## Validation
- confirmed OfficeIMO.Reader 0.1.50 is available on nuget.org
- targeted package-pin contract test passed in Release package mode

This does not change or publish any OfficeIMO package.
