### PR TITLE
Consolidate chat persistence and state paths

### DIFF
--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Properties/AssemblyInfo.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("IntelligenceX.Chat.Tests")]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatJsonFileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatJsonFileStore.cs
@@ -1,0 +1,122 @@
+using System.Text;
+
+namespace IntelligenceX.Chat.Abstractions.Storage;
+
+/// <summary>
+/// Provides bounded reads and crash-safe atomic replacement for small JSON state files.
+/// </summary>
+public static class ChatJsonFileStore {
+    /// <summary>
+    /// Reads a bounded JSON snapshot and distinguishes missing from malformed storage.
+    /// </summary>
+    public static ChatJsonFileReadResult Read(string path, long maximumBytes) {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
+            return ChatJsonFileReadResult.Empty();
+        }
+
+        var info = new FileInfo(path);
+        if (info.Length <= 0 || info.Length > maximumBytes) {
+            return ChatJsonFileReadResult.Invalid();
+        }
+
+        var json = File.ReadAllText(path, Encoding.UTF8);
+        return string.IsNullOrWhiteSpace(json)
+            ? ChatJsonFileReadResult.Invalid()
+            : ChatJsonFileReadResult.Loaded(json);
+    }
+
+    /// <summary>
+    /// Atomically replaces a JSON snapshot and applies owner-only Unix permissions.
+    /// </summary>
+    public static void Write(string path, string json) {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(json);
+
+        string? temporaryPath = null;
+        try {
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
+                Directory.CreateDirectory(directory);
+            }
+
+            if (!string.IsNullOrWhiteSpace(directory)) {
+                TryHardenUnixDirectory(directory);
+            }
+
+            var fileName = Path.GetFileName(path);
+            var temporaryName = $"{fileName}.{Guid.NewGuid():N}.tmp";
+            temporaryPath = string.IsNullOrWhiteSpace(directory)
+                ? temporaryName
+                : Path.Combine(directory, temporaryName);
+
+            using (var stream = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
+                TryHardenUnixFile(temporaryPath);
+                using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                writer.Write(json);
+                writer.Flush();
+                stream.Flush(flushToDisk: true);
+            }
+
+            if (File.Exists(path)) {
+                File.Replace(temporaryPath, path, destinationBackupFileName: null, ignoreMetadataErrors: true);
+            } else {
+                File.Move(temporaryPath, path);
+            }
+
+            temporaryPath = null;
+            TryHardenUnixFile(path);
+        } finally {
+            if (!string.IsNullOrWhiteSpace(temporaryPath) && File.Exists(temporaryPath)) {
+                try {
+                    File.Delete(temporaryPath);
+                } catch {
+                    // Preserve the original write failure.
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deletes a JSON snapshot when it exists.
+    /// </summary>
+    public static void Delete(string path) {
+        if (!string.IsNullOrWhiteSpace(path) && File.Exists(path)) {
+            File.Delete(path);
+        }
+    }
+
+    private static void TryHardenUnixDirectory(string path) {
+        if (!OperatingSystem.IsWindows()) {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    private static void TryHardenUnixFile(string path) {
+        if (!OperatingSystem.IsWindows()) {
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+    }
+}
+
+/// <summary>
+/// Describes the outcome of a bounded JSON file read.
+/// </summary>
+public enum ChatJsonFileReadState {
+    /// <summary>The snapshot does not exist.</summary>
+    Empty,
+    /// <summary>The snapshot exists but is empty, oversized, or whitespace-only.</summary>
+    Invalid,
+    /// <summary>The snapshot contains bounded non-whitespace JSON text.</summary>
+    Loaded
+}
+
+/// <summary>
+/// Contains a bounded JSON file read result.
+/// </summary>
+public readonly record struct ChatJsonFileReadResult(ChatJsonFileReadState State, string? Json) {
+    internal static ChatJsonFileReadResult Empty() => new(ChatJsonFileReadState.Empty, null);
+    internal static ChatJsonFileReadResult Invalid() => new(ChatJsonFileReadState.Invalid, null);
+    internal static ChatJsonFileReadResult Loaded(string json) => new(ChatJsonFileReadState.Loaded, json);
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatJsonFileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatJsonFileStore.cs
@@ -1,3 +1,7 @@
+using System.Buffers;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Text;
 
 namespace IntelligenceX.Chat.Abstractions.Storage;
@@ -10,36 +14,91 @@ public static class ChatJsonFileStore {
     /// Reads a bounded JSON snapshot and distinguishes missing from malformed storage.
     /// </summary>
     public static ChatJsonFileReadResult Read(string path, long maximumBytes) {
-        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
+        if (maximumBytes <= 0 || maximumBytes > int.MaxValue) {
+            throw new ArgumentOutOfRangeException(nameof(maximumBytes), maximumBytes, "The JSON read limit must be between 1 byte and 2 GB.");
+        }
+
+        if (string.IsNullOrWhiteSpace(path)) {
             return ChatJsonFileReadResult.Empty();
         }
 
-        var info = new FileInfo(path);
-        if (info.Length <= 0 || info.Length > maximumBytes) {
-            return ChatJsonFileReadResult.Invalid();
+        FileStream stream;
+        try {
+            stream = new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read | FileShare.Delete,
+                bufferSize: 4096,
+                FileOptions.SequentialScan);
+        } catch (FileNotFoundException) {
+            return ChatJsonFileReadResult.Empty();
+        } catch (DirectoryNotFoundException) {
+            return ChatJsonFileReadResult.Empty();
         }
 
-        var json = File.ReadAllText(path, Encoding.UTF8);
-        return string.IsNullOrWhiteSpace(json)
-            ? ChatJsonFileReadResult.Invalid()
-            : ChatJsonFileReadResult.Loaded(json);
+        using (stream) {
+            if (stream.Length <= 0 || stream.Length > maximumBytes) {
+                return ChatJsonFileReadResult.Invalid();
+            }
+
+            using var content = new MemoryStream(capacity: (int)stream.Length);
+            var buffer = ArrayPool<byte>.Shared.Rent(81920);
+            try {
+                long totalBytes = 0;
+                while (true) {
+                    var remainingWithOverflowProbe = maximumBytes - totalBytes + 1;
+                    var requestedBytes = (int)Math.Min(buffer.Length, remainingWithOverflowProbe);
+                    var bytesRead = stream.Read(buffer, 0, requestedBytes);
+                    if (bytesRead == 0) {
+                        break;
+                    }
+
+                    totalBytes += bytesRead;
+                    if (totalBytes > maximumBytes) {
+                        return ChatJsonFileReadResult.Invalid();
+                    }
+
+                    content.Write(buffer, 0, bytesRead);
+                }
+            } finally {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+
+            if (content.Length == 0) {
+                return ChatJsonFileReadResult.Invalid();
+            }
+
+            var json = Encoding.UTF8.GetString(content.GetBuffer(), 0, (int)content.Length);
+            return string.IsNullOrWhiteSpace(json)
+                ? ChatJsonFileReadResult.Invalid()
+                : ChatJsonFileReadResult.Loaded(json);
+        }
     }
 
     /// <summary>
-    /// Atomically replaces a JSON snapshot and applies owner-only Unix permissions.
+    /// Atomically replaces a JSON snapshot and applies owner-only file permissions.
     /// </summary>
-    public static void Write(string path, string json) {
+    /// <param name="path">Destination JSON file path.</param>
+    /// <param name="json">Serialized JSON content.</param>
+    /// <param name="hardenExistingDirectory">
+    /// Whether an existing Unix parent directory is dedicated to private chat state and may be restricted to the current user.
+    /// Newly created directories are always restricted.
+    /// </param>
+    public static void Write(string path, string json, bool hardenExistingDirectory = false) {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
         ArgumentNullException.ThrowIfNull(json);
 
         string? temporaryPath = null;
         try {
             var directory = Path.GetDirectoryName(path);
+            var directoryCreated = false;
             if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
                 Directory.CreateDirectory(directory);
+                directoryCreated = true;
             }
 
-            if (!string.IsNullOrWhiteSpace(directory)) {
+            if (!string.IsNullOrWhiteSpace(directory) && (directoryCreated || hardenExistingDirectory)) {
                 TryHardenUnixDirectory(directory);
             }
 
@@ -50,7 +109,7 @@ public static class ChatJsonFileStore {
                 : Path.Combine(directory, temporaryName);
 
             using (var stream = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenUnixFile(temporaryPath);
+                HardenTemporaryFile(temporaryPath);
                 using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
                 writer.Write(json);
                 writer.Flush();
@@ -58,13 +117,14 @@ public static class ChatJsonFileStore {
             }
 
             if (File.Exists(path)) {
+                HardenFile(path);
                 File.Replace(temporaryPath, path, destinationBackupFileName: null, ignoreMetadataErrors: true);
             } else {
                 File.Move(temporaryPath, path);
             }
 
             temporaryPath = null;
-            TryHardenUnixFile(path);
+            HardenFile(path);
         } finally {
             if (!string.IsNullOrWhiteSpace(temporaryPath) && File.Exists(temporaryPath)) {
                 try {
@@ -97,6 +157,41 @@ public static class ChatJsonFileStore {
         if (!OperatingSystem.IsWindows()) {
             File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
         }
+    }
+
+    private static void HardenTemporaryFile(string path) {
+        HardenFile(path);
+    }
+
+    private static void HardenFile(string path) {
+        if (OperatingSystem.IsWindows()) {
+            HardenWindowsFile(path);
+            return;
+        }
+
+        TryHardenUnixFile(path);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void HardenWindowsFile(string path) {
+        var currentSid = WindowsIdentity.GetCurrent().User
+            ?? throw new InvalidOperationException("The current Windows identity does not expose a security identifier.");
+        var fileInfo = new FileInfo(path);
+        var security = fileInfo.GetAccessControl();
+        security.SetOwner(currentSid);
+        security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+        foreach (FileSystemAccessRule rule in security.GetAccessRules(
+                     includeExplicit: true,
+                     includeInherited: false,
+                     typeof(SecurityIdentifier))) {
+            security.RemoveAccessRuleSpecific(rule);
+        }
+
+        security.AddAccessRule(new FileSystemAccessRule(
+            currentSid,
+            FileSystemRights.FullControl,
+            AccessControlType.Allow));
+        fileInfo.SetAccessControl(security);
     }
 }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatJsonFileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatJsonFileStore.cs
@@ -10,6 +10,10 @@ namespace IntelligenceX.Chat.Abstractions.Storage;
 /// Provides bounded reads and crash-safe atomic replacement for small JSON state files.
 /// </summary>
 public static class ChatJsonFileStore {
+    private const UnixFileMode PrivateDirectoryMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+    private const UnixFileMode PrivateFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
     /// <summary>
     /// Reads a bounded JSON snapshot and distinguishes missing from malformed storage.
     /// </summary>
@@ -92,14 +96,8 @@ public static class ChatJsonFileStore {
         string? temporaryPath = null;
         try {
             var directory = Path.GetDirectoryName(path);
-            var directoryCreated = false;
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-                directoryCreated = true;
-            }
-
-            if (!string.IsNullOrWhiteSpace(directory) && (directoryCreated || hardenExistingDirectory)) {
-                TryHardenUnixDirectory(directory);
+            if (!string.IsNullOrWhiteSpace(directory)) {
+                EnsureDirectory(directory, hardenExistingDirectory);
             }
 
             var fileName = Path.GetFileName(path);
@@ -108,7 +106,7 @@ public static class ChatJsonFileStore {
                 ? temporaryName
                 : Path.Combine(directory, temporaryName);
 
-            using (var stream = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
+            using (var stream = CreatePrivateTemporaryFile(temporaryPath)) {
                 HardenTemporaryFile(temporaryPath);
                 using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
                 writer.Write(json);
@@ -147,16 +145,39 @@ public static class ChatJsonFileStore {
 
     private static void TryHardenUnixDirectory(string path) {
         if (!OperatingSystem.IsWindows()) {
-            File.SetUnixFileMode(
-                path,
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            File.SetUnixFileMode(path, PrivateDirectoryMode);
         }
     }
 
     private static void TryHardenUnixFile(string path) {
         if (!OperatingSystem.IsWindows()) {
-            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            File.SetUnixFileMode(path, PrivateFileMode);
         }
+    }
+
+    private static void EnsureDirectory(string path, bool hardenExistingDirectory) {
+        if (OperatingSystem.IsWindows()) {
+            Directory.CreateDirectory(path);
+            return;
+        }
+
+        Directory.CreateDirectory(path, PrivateDirectoryMode);
+        if (hardenExistingDirectory) {
+            TryHardenUnixDirectory(path);
+        }
+    }
+
+    private static FileStream CreatePrivateTemporaryFile(string path) {
+        var options = new FileStreamOptions {
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.Write,
+            Share = FileShare.None
+        };
+        if (!OperatingSystem.IsWindows()) {
+            options.UnixCreateMode = PrivateFileMode;
+        }
+
+        return new FileStream(path, options);
     }
 
     private static void HardenTemporaryFile(string path) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatStatePaths.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatStatePaths.cs
@@ -37,7 +37,9 @@ public static class ChatStatePaths {
         }
 
         try {
-            return IsPathWithinDirectory(GetDefaultDirectory(), path);
+            var directory = GetDefaultDirectory();
+            return IsPathWithinDirectory(directory, path)
+                   && HasNoReparsePointsBelowDirectory(directory, path);
         } catch {
             return false;
         }
@@ -59,6 +61,9 @@ public static class ChatStatePaths {
         var parent = Path.GetDirectoryName(path);
         if (!string.Equals(parent, directory, PathComparison)) {
             throw new ArgumentException("The state file must resolve directly beneath the shared state directory.", nameof(fileName));
+        }
+        if (!HasNoReparsePointsBelowDirectory(directory, path)) {
+            throw new InvalidOperationException("The state file path cannot traverse a symbolic link or reparse point.");
         }
 
         return path;
@@ -89,10 +94,44 @@ public static class ChatStatePaths {
         return fullPath.StartsWith(fullDirectory, PathComparison);
     }
 
+    internal static bool HasNoReparsePointsBelowDirectory(string directory, string path) {
+        var fullDirectory = Path.GetFullPath(directory);
+        var directoryPrefix = fullDirectory
+                                  .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                              + Path.DirectorySeparatorChar;
+        var fullPath = Path.GetFullPath(path);
+        if (!fullPath.StartsWith(directoryPrefix, PathComparison)) {
+            return false;
+        }
+
+        var relativePath = fullPath[directoryPrefix.Length..];
+        var segments = relativePath.Split(
+            new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+            StringSplitOptions.RemoveEmptyEntries);
+        var currentPath = fullDirectory;
+        foreach (var segment in segments) {
+            currentPath = Path.Combine(currentPath, segment);
+            FileAttributes attributes;
+            try {
+                attributes = File.GetAttributes(currentPath);
+            } catch (FileNotFoundException) {
+                break;
+            } catch (DirectoryNotFoundException) {
+                break;
+            }
+
+            if ((attributes & FileAttributes.ReparsePoint) != 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private static bool TryNormalizeAbsoluteRoot(string? candidate, out string root) {
         root = string.Empty;
         var normalized = (candidate ?? string.Empty).Trim();
-        if (normalized.Length == 0 || !Path.IsPathRooted(normalized)) {
+        if (normalized.Length == 0 || !Path.IsPathFullyQualified(normalized)) {
             return false;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatStatePaths.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatStatePaths.cs
@@ -1,0 +1,78 @@
+namespace IntelligenceX.Chat.Abstractions.Storage;
+
+/// <summary>
+/// Resolves the single per-user directory used by IntelligenceX Chat state across desktop and service surfaces.
+/// </summary>
+public static class ChatStatePaths {
+    private const string ApplicationDirectoryName = "IntelligenceX.Chat";
+
+    /// <summary>
+    /// Resolves the durable per-user state directory.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No secure per-user data root is available.</exception>
+    public static string GetDefaultDirectory() {
+        return ResolveDefaultDirectory(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Environment.GetEnvironmentVariable("XDG_DATA_HOME"),
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+    }
+
+    /// <summary>
+    /// Resolves a file beneath the durable per-user state directory.
+    /// </summary>
+    public static string GetDefaultPath(string fileName) {
+        return ResolveDefaultPath(
+            fileName,
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Environment.GetEnvironmentVariable("XDG_DATA_HOME"),
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+    }
+
+    internal static string ResolveDefaultPath(
+        string fileName,
+        string? localApplicationData,
+        string? xdgDataHome,
+        string? userProfile) {
+        var normalizedFileName = Path.GetFileName((fileName ?? string.Empty).Trim());
+        if (normalizedFileName.Length == 0) {
+            throw new ArgumentException("A state file name is required.", nameof(fileName));
+        }
+
+        return Path.Combine(
+            ResolveDefaultDirectory(localApplicationData, xdgDataHome, userProfile),
+            normalizedFileName);
+    }
+
+    internal static string ResolveDefaultDirectory(
+        string? localApplicationData,
+        string? xdgDataHome,
+        string? userProfile) {
+        if (TryNormalizeAbsoluteRoot(localApplicationData, out var root)
+            || TryNormalizeAbsoluteRoot(xdgDataHome, out root)) {
+            return Path.Combine(root, ApplicationDirectoryName);
+        }
+
+        if (TryNormalizeAbsoluteRoot(userProfile, out root)) {
+            return Path.Combine(root, ".local", "share", ApplicationDirectoryName);
+        }
+
+        throw new InvalidOperationException(
+            "IntelligenceX Chat cannot resolve a durable per-user state directory. Configure a user profile or an absolute XDG_DATA_HOME path.");
+    }
+
+    private static bool TryNormalizeAbsoluteRoot(string? candidate, out string root) {
+        root = string.Empty;
+        var normalized = (candidate ?? string.Empty).Trim();
+        if (normalized.Length == 0 || !Path.IsPathRooted(normalized)) {
+            return false;
+        }
+
+        try {
+            root = Path.GetFullPath(normalized);
+            return root.Length > 0;
+        } catch {
+            root = string.Empty;
+            return false;
+        }
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatStatePaths.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatStatePaths.cs
@@ -28,6 +28,21 @@ public static class ChatStatePaths {
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
     }
 
+    /// <summary>
+    /// Determines whether a file resolves inside the durable per-user state directory.
+    /// </summary>
+    public static bool IsPathInDefaultDirectory(string path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return false;
+        }
+
+        try {
+            return IsPathWithinDirectory(GetDefaultDirectory(), path);
+        } catch {
+            return false;
+        }
+    }
+
     internal static string ResolveDefaultPath(
         string fileName,
         string? localApplicationData,
@@ -64,6 +79,14 @@ public static class ChatStatePaths {
 
         throw new InvalidOperationException(
             "IntelligenceX Chat cannot resolve a durable per-user state directory. Configure a user profile or an absolute XDG_DATA_HOME path.");
+    }
+
+    internal static bool IsPathWithinDirectory(string directory, string path) {
+        var fullDirectory = Path.GetFullPath(directory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        var fullPath = Path.GetFullPath(path);
+        return fullPath.StartsWith(fullDirectory, PathComparison);
     }
 
     private static bool TryNormalizeAbsoluteRoot(string? candidate, out string root) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatStatePaths.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatStatePaths.cs
@@ -34,13 +34,19 @@ public static class ChatStatePaths {
         string? xdgDataHome,
         string? userProfile) {
         var normalizedFileName = Path.GetFileName((fileName ?? string.Empty).Trim());
-        if (normalizedFileName.Length == 0) {
+        if (normalizedFileName.Length == 0
+            || normalizedFileName is "." or "..") {
             throw new ArgumentException("A state file name is required.", nameof(fileName));
         }
 
-        return Path.Combine(
-            ResolveDefaultDirectory(localApplicationData, xdgDataHome, userProfile),
-            normalizedFileName);
+        var directory = ResolveDefaultDirectory(localApplicationData, xdgDataHome, userProfile);
+        var path = Path.GetFullPath(Path.Combine(directory, normalizedFileName));
+        var parent = Path.GetDirectoryName(path);
+        if (!string.Equals(parent, directory, PathComparison)) {
+            throw new ArgumentException("The state file must resolve directly beneath the shared state directory.", nameof(fileName));
+        }
+
+        return path;
     }
 
     internal static string ResolveDefaultDirectory(
@@ -75,4 +81,7 @@ public static class ChatStatePaths {
             return false;
         }
     }
+
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatStatePaths.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Storage/ChatStatePaths.cs
@@ -45,6 +45,25 @@ public static class ChatStatePaths {
         }
     }
 
+    /// <summary>
+    /// Determines whether a file is a direct child of a directory without traversing an existing symbolic link or reparse point.
+    /// </summary>
+    public static bool IsDirectChildPath(string directory, string path) {
+        if (string.IsNullOrWhiteSpace(directory) || string.IsNullOrWhiteSpace(path)) {
+            return false;
+        }
+
+        try {
+            var fullDirectory = Path.GetFullPath(directory);
+            var fullPath = Path.GetFullPath(path);
+            var parent = Path.GetDirectoryName(fullPath);
+            return string.Equals(parent, fullDirectory, PathComparison)
+                   && HasNoReparsePointsBelowDirectory(fullDirectory, fullPath);
+        } catch {
+            return false;
+        }
+    }
+
     internal static string ResolveDefaultPath(
         string fileName,
         string? localApplicationData,
@@ -75,11 +94,11 @@ public static class ChatStatePaths {
         string? userProfile) {
         if (TryNormalizeAbsoluteRoot(localApplicationData, out var root)
             || TryNormalizeAbsoluteRoot(xdgDataHome, out root)) {
-            return Path.Combine(root, ApplicationDirectoryName);
+            return ValidateDefaultDirectory(Path.Combine(root, ApplicationDirectoryName));
         }
 
         if (TryNormalizeAbsoluteRoot(userProfile, out root)) {
-            return Path.Combine(root, ".local", "share", ApplicationDirectoryName);
+            return ValidateDefaultDirectory(Path.Combine(root, ".local", "share", ApplicationDirectoryName));
         }
 
         throw new InvalidOperationException(
@@ -101,6 +120,10 @@ public static class ChatStatePaths {
                               + Path.DirectorySeparatorChar;
         var fullPath = Path.GetFullPath(path);
         if (!fullPath.StartsWith(directoryPrefix, PathComparison)) {
+            return false;
+        }
+
+        if (IsExistingReparsePoint(fullDirectory)) {
             return false;
         }
 
@@ -126,6 +149,25 @@ public static class ChatStatePaths {
         }
 
         return true;
+    }
+
+    private static string ValidateDefaultDirectory(string path) {
+        var fullPath = Path.GetFullPath(path);
+        if (IsExistingReparsePoint(fullPath)) {
+            throw new InvalidOperationException("The shared state directory cannot be a symbolic link or reparse point.");
+        }
+
+        return fullPath;
+    }
+
+    private static bool IsExistingReparsePoint(string path) {
+        try {
+            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0;
+        } catch (FileNotFoundException) {
+            return false;
+        } catch (DirectoryNotFoundException) {
+            return false;
+        }
     }
 
     private static bool TryNormalizeAbsoluteRoot(string? candidate, out string root) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ChatStatePathParityTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App.Tests/ChatStatePathParityTests.cs
@@ -1,0 +1,20 @@
+using IntelligenceX.Chat.Abstractions.Storage;
+using Xunit;
+
+namespace IntelligenceX.Chat.App.Tests;
+
+/// <summary>
+/// Verifies that desktop persistence surfaces consume the shared state-path owner.
+/// </summary>
+public sealed class ChatStatePathParityTests {
+    /// <summary>
+    /// Ensures app state and startup cache defaults cannot drift into separate location policies.
+    /// </summary>
+    [Fact]
+    public void DesktopStateStores_UseTheSharedStatePathOwner() {
+        Assert.Equal(ChatStatePaths.GetDefaultPath("app-state.db"), ChatAppStateStore.GetDefaultDbPath());
+        Assert.Equal(
+            ChatStatePaths.GetDefaultPath("startup-webview-budget-cache-v1.json"),
+            MainWindow.ResolveStartupWebViewBudgetCachePath());
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/ChatAppStateStore.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX;
 using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Abstractions.Storage;
 using IntelligenceX.OpenAI;
 
 namespace IntelligenceX.Chat.App;
@@ -46,12 +47,7 @@ internal sealed class ChatAppStateStore : IDisposable {
     }
 
     public static string GetDefaultDbPath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
-
-        return Path.Combine(root, "IntelligenceX.Chat", "app-state.db");
+        return ChatStatePaths.GetDefaultPath("app-state.db");
     }
 
     internal string DatabasePath => _dbPath;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.WebViewBudget.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.WebViewBudget.cs
@@ -273,13 +273,13 @@ public sealed partial class MainWindow : Window {
 
     private static StartupWebViewBudgetCacheEntry LoadStartupWebViewBudgetCache() {
         var path = ResolveStartupWebViewBudgetCachePath();
-        if (!File.Exists(path)) {
-            return StartupWebViewBudgetCacheEntry.Default;
-        }
-
         try {
-            var json = File.ReadAllText(path);
-            var payload = JsonSerializer.Deserialize<StartupWebViewBudgetCachePayload>(json);
+            var snapshot = ChatJsonFileStore.Read(path, StartupWebViewBudgetCacheMaximumBytes);
+            if (snapshot.State != ChatJsonFileReadState.Loaded || snapshot.Json is null) {
+                return StartupWebViewBudgetCacheEntry.Default;
+            }
+
+            var payload = JsonSerializer.Deserialize<StartupWebViewBudgetCachePayload>(snapshot.Json);
             if (payload is null) {
                 return StartupWebViewBudgetCacheEntry.Default;
             }
@@ -329,11 +329,6 @@ public sealed partial class MainWindow : Window {
     private static void SaveStartupWebViewBudgetCache(StartupWebViewBudgetCacheEntry cache) {
         try {
             var path = ResolveStartupWebViewBudgetCachePath();
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
             var payload = new StartupWebViewBudgetCachePayload {
                 LastEnsureWebViewMs = cache.LastEnsureWebViewMs,
                 ConsecutiveBudgetExhaustions = Math.Max(0, cache.ConsecutiveBudgetExhaustions),
@@ -344,7 +339,7 @@ public sealed partial class MainWindow : Window {
             };
 
             var json = JsonSerializer.Serialize(payload);
-            File.WriteAllText(path, json);
+            ChatJsonFileStore.Write(path, json);
         } catch {
             // Startup budget cache is best-effort only.
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.WebViewBudget.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.WebViewBudget.cs
@@ -339,7 +339,7 @@ public sealed partial class MainWindow : Window {
             };
 
             var json = JsonSerializer.Serialize(payload);
-            ChatJsonFileStore.Write(path, json);
+            ChatJsonFileStore.Write(path, json, hardenExistingDirectory: true);
         } catch {
             // Startup budget cache is best-effort only.
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.WebViewBudget.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.WebViewBudget.cs
@@ -272,8 +272,8 @@ public sealed partial class MainWindow : Window {
     }
 
     private static StartupWebViewBudgetCacheEntry LoadStartupWebViewBudgetCache() {
-        var path = ResolveStartupWebViewBudgetCachePath();
         try {
+            var path = ResolveStartupWebViewBudgetCachePath();
             var snapshot = ChatJsonFileStore.Read(path, StartupWebViewBudgetCacheMaximumBytes);
             if (snapshot.State != ChatJsonFileReadState.Loaded || snapshot.Json is null) {
                 return StartupWebViewBudgetCacheEntry.Default;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.WebViewBudget.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.StartupFlow.WebViewBudget.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Chat.Abstractions.Policy;
 using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Abstractions.Storage;
 using IntelligenceX.Chat.App.Conversation;
 using IntelligenceX.Chat.App.Theming;
 using IntelligenceX.Chat.Client;
@@ -349,13 +350,8 @@ public sealed partial class MainWindow : Window {
         }
     }
 
-    private static string ResolveStartupWebViewBudgetCachePath() {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(localAppData)) {
-            return Path.Combine(Path.GetTempPath(), "IntelligenceX.Chat", StartupWebViewBudgetCacheFileName);
-        }
-
-        return Path.Combine(localAppData, "IntelligenceX.Chat", StartupWebViewBudgetCacheFileName);
+    internal static string ResolveStartupWebViewBudgetCachePath() {
+        return ChatStatePaths.GetDefaultPath(StartupWebViewBudgetCacheFileName);
     }
 
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.App/MainWindow.cs
@@ -142,6 +142,7 @@ public sealed partial class MainWindow : Window {
     private const long FirstTurnLatencySystemNoticeThresholdMs = 1200;
     private const long SlowTurnSystemNoticeThresholdMs = 4500;
     private const string StartupWebViewBudgetCacheFileName = "startup-webview-budget-cache-v1.json";
+    private const int StartupWebViewBudgetCacheMaximumBytes = 64 * 1024;
     private const string StartupWebViewBudgetReasonCooldownConservative = "cooldown_conservative";
     private const string StartupWebViewBudgetReasonExhaustionConservative = "exhaustion_conservative";
     private const string StartupWebViewBudgetReasonInsufficientStability = "insufficient_stability";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Compare.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Compare.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using IntelligenceX.Chat.Abstractions.Storage;
 using IntelligenceX.Chat.Profiles;
 using IntelligenceX.Chat.Tooling;
 using IntelligenceX.OpenAI;
@@ -292,12 +293,7 @@ internal static partial class Program {
     }
 
     private static string WriteCompareArtifact(string prompt, IReadOnlyList<CompareProfileRun> runs, ReplOptions options) {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
-
-        var folder = Path.Combine(root, "IntelligenceX.Chat", "benchmarks");
+        var folder = Path.Combine(ChatStatePaths.GetDefaultDirectory(), "benchmarks");
         Directory.CreateDirectory(folder);
 
         var timestamp = DateTime.UtcNow;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Host/Program.Options.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Abstractions.Storage;
 using IntelligenceX.Chat.Profiles;
 using IntelligenceX.Chat.Tooling;
 using IntelligenceX.Json;
@@ -516,11 +517,7 @@ internal static partial class Program {
         }
 
         internal static string GetDefaultStateDbPath() {
-            var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            if (string.IsNullOrWhiteSpace(root)) {
-                root = ".";
-            }
-            return Path.Combine(root, "IntelligenceX.Chat", "state.db");
+            return ChatStatePaths.GetDefaultPath("state.db");
         }
 
         private static void PreScanProfileFlags(string[] args, ReplOptions options, out string? error) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/BackgroundSchedulerRuntimeStoreJsonContext.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/BackgroundSchedulerRuntimeStoreJsonContext.cs
@@ -8,6 +8,7 @@ namespace IntelligenceX.Chat.Service;
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(BackgroundSchedulerRuntimeStoreDto))]
+[JsonSerializable(typeof(BackgroundSchedulerFailureEventDto[]))]
 [JsonSerializable(typeof(SessionCapabilityBackgroundSchedulerActivityDto[]))]
 internal sealed partial class BackgroundSchedulerRuntimeStoreJsonContext : JsonSerializerContext;
 
@@ -32,6 +33,8 @@ internal sealed class BackgroundSchedulerRuntimeStoreDto {
     public int ReleasedExecutionCount { get; set; }
     [JsonPropertyName("consecutiveFailureCount")]
     public int ConsecutiveFailureCount { get; set; }
+    [JsonPropertyName("failureStreakEvents")]
+    public BackgroundSchedulerFailureEventDto[] FailureStreakEvents { get; set; } = Array.Empty<BackgroundSchedulerFailureEventDto>();
     [JsonPropertyName("pausedUntilUtcTicks")]
     public long PausedUntilUtcTicks { get; set; }
     [JsonPropertyName("pauseReason")]
@@ -44,4 +47,11 @@ internal sealed class BackgroundSchedulerRuntimeStoreDto {
     public string LastAdaptiveIdleReason { get; set; } = string.Empty;
     [JsonPropertyName("recentActivity")]
     public SessionCapabilityBackgroundSchedulerActivityDto[] RecentActivity { get; set; } = Array.Empty<SessionCapabilityBackgroundSchedulerActivityDto>();
+}
+
+internal sealed class BackgroundSchedulerFailureEventDto {
+    [JsonPropertyName("eventId")]
+    public string EventId { get; set; } = string.Empty;
+    [JsonPropertyName("recordedUtcTicks")]
+    public long RecordedUtcTicks { get; set; }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceBackgroundSchedulerControlState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceBackgroundSchedulerControlState.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Security.AccessControl;
-using System.Security.Principal;
-using System.Text;
 using System.Text.Json;
 using IntelligenceX.Chat.Abstractions.Policy;
 using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Service.Persistence;
 using IntelligenceX.Chat.Tooling;
 
 namespace IntelligenceX.Chat.Service;
@@ -18,6 +15,8 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
     private const int MaxPauseReasonLength = 120;
     private const int MaxMaintenanceWindowSpecLength = 160;
     private const int MaxMaintenanceWindowThreadScopeLength = 120;
+    private const int MaximumStoreBytes = 64 * 1024;
+    private const string StoreName = "Background scheduler control state";
     private static readonly object StoreLock = new();
     private static readonly JsonSerializerOptions StoreJsonOptions = new() {
         WriteIndented = false,
@@ -1418,13 +1417,9 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
     }
 
     private string ResolveStorePath() {
-        var pendingActionsPath = ResolvePendingActionsStorePath();
-        var directory = Path.GetDirectoryName(pendingActionsPath);
-        if (!string.IsNullOrWhiteSpace(directory)) {
-            return Path.Combine(directory, "background-scheduler-control.json");
-        }
-
-        return Path.Combine(Environment.CurrentDirectory, "background-scheduler-control.json");
+        return ChatServiceJsonFileStore.ResolveSiblingPath(
+            ResolvePendingActionsStorePath(),
+            "background-scheduler-control.json");
     }
 
     private string ResolvePendingActionsStorePath() {
@@ -1469,96 +1464,94 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
     }
 
     private static string ResolveDefaultPendingActionsStorePath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
-
-        return Path.Combine(root, "IntelligenceX.Chat", "pending-actions.json");
+        return ChatServiceJsonFileStore.ResolveDefaultPath("pending-actions.json");
     }
 
     private StoreDto ReadStoreStateNoThrow() {
         var path = ResolveStorePath();
         lock (StoreLock) {
-            try {
-                if (!File.Exists(path)) {
-                    return new StoreDto();
-                }
-
-                var info = new FileInfo(path);
-                if (info.Length <= 0 || info.Length > 64 * 1024) {
-                    return new StoreDto();
-                }
-
-                var json = File.ReadAllText(path, Encoding.UTF8);
-                if (string.IsNullOrWhiteSpace(json)) {
-                    return new StoreDto();
-                }
-
-                var store = JsonSerializer.Deserialize<StoreDto>(json, StoreJsonOptions);
-                if (store is null || store.Version <= 0 || store.Version > StoreVersion) {
-                    return new StoreDto();
-                }
-
-                var normalized = new StoreDto {
-                    ManualPauseActive = store.ManualPauseActive,
-                    PausedUntilUtcTicks = Math.Max(0, store.PausedUntilUtcTicks),
-                    PauseReason = NormalizeActivityText(store.PauseReason, MaxPauseReasonLength + 32),
-                    BlockedPackIdsCustomized = store.BlockedPackIdsCustomized,
-                    BlockedPackIds = NormalizeBlockedPackIds(store.BlockedPackIds),
-                    TemporaryBlockedPacks = NormalizeTemporarySuppressions(
-                            store.TemporaryBlockedPacks,
-                            maxIdLength: ChatRequestOptionLimits.MaxToolSelectorLength,
-                            normalizeId: ToolPackBootstrap.NormalizePackId,
-                            StringComparer.OrdinalIgnoreCase,
-                            DateTime.UtcNow.Ticks)
-                        .Select(static item => new TemporarySuppressionStoreDto {
-                            Id = item.Id,
-                            ExpiresUtcTicks = item.ExpiresUtcTicks
-                        })
-                        .ToArray(),
-                    BlockedThreadIdsCustomized = store.BlockedThreadIdsCustomized,
-                    BlockedThreadIds = NormalizeBlockedThreadIds(store.BlockedThreadIds),
-                    TemporaryBlockedThreads = NormalizeTemporarySuppressions(
-                            store.TemporaryBlockedThreads,
-                            maxIdLength: ChatRequestOptionLimits.MaxToolSelectorLength,
-                            normalizeId: NormalizeMaintenanceWindowThreadId,
-                            StringComparer.Ordinal,
-                            DateTime.UtcNow.Ticks)
-                        .Select(static item => new TemporarySuppressionStoreDto {
-                            Id = item.Id,
-                            ExpiresUtcTicks = item.ExpiresUtcTicks
-                        })
-                        .ToArray(),
-                    MaintenanceWindowsCustomized = store.MaintenanceWindowsCustomized,
-                    MaintenanceWindowSpecs = NormalizeMaintenanceWindowSpecs(store.MaintenanceWindowSpecs)
-                };
-
-                if (!normalized.ManualPauseActive) {
-                    normalized.PausedUntilUtcTicks = 0;
-                    normalized.PauseReason = string.Empty;
-                }
-
-                if (normalized.PausedUntilUtcTicks > 0 && (!TryGetUtcDateTimeFromTicks(normalized.PausedUntilUtcTicks, out var pausedUntilUtc) || pausedUntilUtc <= DateTime.UtcNow)) {
-                    TryDeleteStoreNoThrow(path);
-                    return new StoreDto {
-                        BlockedPackIdsCustomized = normalized.BlockedPackIdsCustomized,
-                        BlockedPackIds = normalized.BlockedPackIds,
-                        TemporaryBlockedPacks = normalized.TemporaryBlockedPacks,
-                        BlockedThreadIdsCustomized = normalized.BlockedThreadIdsCustomized,
-                        BlockedThreadIds = normalized.BlockedThreadIds,
-                        TemporaryBlockedThreads = normalized.TemporaryBlockedThreads,
-                        MaintenanceWindowsCustomized = normalized.MaintenanceWindowsCustomized,
-                        MaintenanceWindowSpecs = normalized.MaintenanceWindowSpecs
-                    };
-                }
-
-                return normalized;
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Background scheduler control state read failed: {ex.GetType().Name}: {ex.Message}");
+            var expiredPauseRemoved = false;
+            var result = ChatServiceJsonFileStore.Read<StoreDto>(
+                path,
+                MaximumStoreBytes,
+                static json => JsonSerializer.Deserialize<StoreDto>(json, StoreJsonOptions),
+                static store => store.Version > 0 && store.Version <= StoreVersion,
+                store => expiredPauseRemoved = NormalizeStoreState(store, DateTime.UtcNow),
+                StoreName);
+            if (result.State != ChatServiceJsonFileReadState.Loaded || result.Value is null) {
                 return new StoreDto();
             }
+
+            if (expiredPauseRemoved) {
+                PersistNormalizedStore(path, result.Value);
+            }
+
+            return result.Value;
         }
+    }
+
+    private static bool NormalizeStoreState(StoreDto store, DateTime nowUtc) {
+        var normalized = new StoreDto {
+            ManualPauseActive = store.ManualPauseActive,
+            PausedUntilUtcTicks = Math.Max(0, store.PausedUntilUtcTicks),
+            PauseReason = NormalizeActivityText(store.PauseReason, MaxPauseReasonLength + 32),
+            BlockedPackIdsCustomized = store.BlockedPackIdsCustomized,
+            BlockedPackIds = NormalizeBlockedPackIds(store.BlockedPackIds),
+            TemporaryBlockedPacks = NormalizeTemporarySuppressions(
+                    store.TemporaryBlockedPacks,
+                    maxIdLength: ChatRequestOptionLimits.MaxToolSelectorLength,
+                    normalizeId: ToolPackBootstrap.NormalizePackId,
+                    StringComparer.OrdinalIgnoreCase,
+                    nowUtc.Ticks)
+                .Select(static item => new TemporarySuppressionStoreDto {
+                    Id = item.Id,
+                    ExpiresUtcTicks = item.ExpiresUtcTicks
+                })
+                .ToArray(),
+            BlockedThreadIdsCustomized = store.BlockedThreadIdsCustomized,
+            BlockedThreadIds = NormalizeBlockedThreadIds(store.BlockedThreadIds),
+            TemporaryBlockedThreads = NormalizeTemporarySuppressions(
+                    store.TemporaryBlockedThreads,
+                    maxIdLength: ChatRequestOptionLimits.MaxToolSelectorLength,
+                    normalizeId: NormalizeMaintenanceWindowThreadId,
+                    StringComparer.Ordinal,
+                    nowUtc.Ticks)
+                .Select(static item => new TemporarySuppressionStoreDto {
+                    Id = item.Id,
+                    ExpiresUtcTicks = item.ExpiresUtcTicks
+                })
+                .ToArray(),
+            MaintenanceWindowsCustomized = store.MaintenanceWindowsCustomized,
+            MaintenanceWindowSpecs = NormalizeMaintenanceWindowSpecs(store.MaintenanceWindowSpecs)
+        };
+
+        if (!normalized.ManualPauseActive) {
+            normalized.PausedUntilUtcTicks = 0;
+            normalized.PauseReason = string.Empty;
+        }
+
+        var expiredPauseRemoved = normalized.PausedUntilUtcTicks > 0
+            && (!TryGetUtcDateTimeFromTicks(normalized.PausedUntilUtcTicks, out var pausedUntilUtc)
+                || pausedUntilUtc <= nowUtc);
+        if (expiredPauseRemoved) {
+            normalized.ManualPauseActive = false;
+            normalized.PausedUntilUtcTicks = 0;
+            normalized.PauseReason = string.Empty;
+        }
+
+        store.Version = StoreVersion;
+        store.ManualPauseActive = normalized.ManualPauseActive;
+        store.PausedUntilUtcTicks = normalized.PausedUntilUtcTicks;
+        store.PauseReason = normalized.PauseReason;
+        store.BlockedPackIdsCustomized = normalized.BlockedPackIdsCustomized;
+        store.BlockedPackIds = normalized.BlockedPackIds;
+        store.TemporaryBlockedPacks = normalized.TemporaryBlockedPacks;
+        store.BlockedThreadIdsCustomized = normalized.BlockedThreadIdsCustomized;
+        store.BlockedThreadIds = normalized.BlockedThreadIds;
+        store.TemporaryBlockedThreads = normalized.TemporaryBlockedThreads;
+        store.MaintenanceWindowsCustomized = normalized.MaintenanceWindowsCustomized;
+        store.MaintenanceWindowSpecs = normalized.MaintenanceWindowSpecs;
+        return expiredPauseRemoved;
     }
 
     private void PersistStateNoThrow() {
@@ -1603,80 +1596,43 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
 
         var path = ResolveStorePath();
         lock (StoreLock) {
-            try {
-                if (!manualPauseActive
-                    && !blockedPackIdsCustomized
-                    && temporaryBlockedPacks.Length == 0
-                    && !blockedThreadIdsCustomized
-                    && temporaryBlockedThreads.Length == 0
-                    && !maintenanceWindowsCustomized) {
-                    TryDeleteStoreNoThrow(path);
-                    return;
-                }
-
-                var directory = Path.GetDirectoryName(path);
-                if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                    Directory.CreateDirectory(directory);
-                }
-
-                var store = new StoreDto {
-                    ManualPauseActive = manualPauseActive,
-                    PausedUntilUtcTicks = manualPauseActive ? Math.Max(0, pausedUntilUtcTicks) : 0,
-                    PauseReason = manualPauseActive ? NormalizeActivityText(pauseReason, MaxPauseReasonLength + 32) : string.Empty,
-                    BlockedPackIdsCustomized = blockedPackIdsCustomized,
-                    BlockedPackIds = blockedPackIdsCustomized ? blockedPackIds : Array.Empty<string>(),
-                    TemporaryBlockedPacks = temporaryBlockedPacks,
-                    BlockedThreadIdsCustomized = blockedThreadIdsCustomized,
-                    BlockedThreadIds = blockedThreadIdsCustomized ? blockedThreadIds : Array.Empty<string>(),
-                    TemporaryBlockedThreads = temporaryBlockedThreads,
-                    MaintenanceWindowsCustomized = maintenanceWindowsCustomized,
-                    MaintenanceWindowSpecs = maintenanceWindowsCustomized ? maintenanceWindowSpecs : Array.Empty<string>()
-                };
-                var json = JsonSerializer.Serialize(store, StoreJsonOptions);
-                string? tmp = null;
-                try {
-                    var fileName = Path.GetFileName(path);
-                    var tmpName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-                    tmp = string.IsNullOrWhiteSpace(directory) ? tmpName : Path.Combine(directory!, tmpName);
-
-                    using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                        TryHardenStoreAclNoThrow(tmp);
-                        using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                        writer.Write(json);
-                        writer.Flush();
-                        fs.Flush(true);
-                    }
-
-                    if (File.Exists(path)) {
-                        File.Replace(tmp, path, null, ignoreMetadataErrors: true);
-                    } else {
-                        File.Move(tmp, path);
-                    }
-
-                    TryHardenStoreAclNoThrow(path);
-                } finally {
-                    if (!string.IsNullOrWhiteSpace(tmp) && File.Exists(tmp)) {
-                        try {
-                            File.Delete(tmp);
-                        } catch {
-                            // Best effort only.
-                        }
-                    }
-                }
-            } catch (Exception ex) {
-                Trace.TraceWarning($"Background scheduler control state write failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            var store = new StoreDto {
+                ManualPauseActive = manualPauseActive,
+                PausedUntilUtcTicks = manualPauseActive ? Math.Max(0, pausedUntilUtcTicks) : 0,
+                PauseReason = manualPauseActive ? NormalizeActivityText(pauseReason, MaxPauseReasonLength + 32) : string.Empty,
+                BlockedPackIdsCustomized = blockedPackIdsCustomized,
+                BlockedPackIds = blockedPackIdsCustomized ? blockedPackIds : Array.Empty<string>(),
+                TemporaryBlockedPacks = temporaryBlockedPacks,
+                BlockedThreadIdsCustomized = blockedThreadIdsCustomized,
+                BlockedThreadIds = blockedThreadIdsCustomized ? blockedThreadIds : Array.Empty<string>(),
+                TemporaryBlockedThreads = temporaryBlockedThreads,
+                MaintenanceWindowsCustomized = maintenanceWindowsCustomized,
+                MaintenanceWindowSpecs = maintenanceWindowsCustomized ? maintenanceWindowSpecs : Array.Empty<string>()
+            };
+            PersistNormalizedStore(path, store);
         }
     }
 
-    private static void TryDeleteStoreNoThrow(string path) {
-        try {
-            if (File.Exists(path)) {
-                File.Delete(path);
-            }
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Background scheduler control state clear failed: {ex.GetType().Name}: {ex.Message}");
+    private static void PersistNormalizedStore(string path, StoreDto store) {
+        if (!HasPersistableState(store)) {
+            ChatServiceJsonFileStore.Delete(path, StoreName);
+            return;
         }
+
+        ChatServiceJsonFileStore.Write(
+            path,
+            store,
+            static value => JsonSerializer.Serialize(value, StoreJsonOptions),
+            StoreName);
+    }
+
+    private static bool HasPersistableState(StoreDto store) {
+        return store.ManualPauseActive
+            || store.BlockedPackIdsCustomized
+            || store.TemporaryBlockedPacks.Length > 0
+            || store.BlockedThreadIdsCustomized
+            || store.TemporaryBlockedThreads.Length > 0
+            || store.MaintenanceWindowsCustomized;
     }
 
     private static bool TryGetUtcDateTimeFromTicks(long utcTicks, out DateTime value) {
@@ -1690,37 +1646,6 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
             return true;
         } catch (ArgumentOutOfRangeException) {
             return false;
-        }
-    }
-
-    private static void TryHardenStoreAclNoThrow(string path) {
-        if (string.IsNullOrWhiteSpace(path) || !OperatingSystem.IsWindows()) {
-            return;
-        }
-
-        try {
-            if (!File.Exists(path)) {
-                return;
-            }
-
-            var attrs = File.GetAttributes(path);
-            if ((attrs & FileAttributes.Directory) != 0) {
-                return;
-            }
-
-            var currentSid = WindowsIdentity.GetCurrent().User;
-            if (currentSid is null) {
-                return;
-            }
-
-            var fileInfo = new FileInfo(path);
-            var security = fileInfo.GetAccessControl();
-            security.SetOwner(currentSid);
-            security.SetAccessRuleProtection(isProtected: true, preserveInheritance: true);
-            security.SetAccessRule(new FileSystemAccessRule(currentSid, FileSystemRights.FullControl, AccessControlType.Allow));
-            fileInfo.SetAccessControl(security);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Background scheduler control state ACL hardening failed: {ex.GetType().Name}: {ex.Message}");
         }
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceBackgroundSchedulerControlState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceBackgroundSchedulerControlState.cs
@@ -1422,45 +1422,10 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
             "background-scheduler-control.json");
     }
 
-    private string ResolvePendingActionsStorePath() {
-        var candidate = (_options.PendingActionsStorePath ?? string.Empty).Trim();
-        if (candidate.Length == 0) {
-            return ResolveDefaultPendingActionsStorePath();
-        }
-
-        var baseDir = ChatServiceJsonFileStore.ResolveDefaultDirectory();
-        var defaultPath = ResolveDefaultPendingActionsStorePath();
-
-        try {
-            if (candidate.StartsWith(@"\\", StringComparison.Ordinal)) {
-                return defaultPath;
-            }
-
-            if (!Path.IsPathFullyQualified(candidate)) {
-                if (candidate.Contains("..", StringComparison.Ordinal)
-                    || candidate.IndexOfAny(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }) >= 0) {
-                    return defaultPath;
-                }
-
-                return Path.Combine(baseDir, candidate);
-            }
-
-            var fullCandidate = Path.GetFullPath(candidate);
-            var fullBaseDir = Path.GetFullPath(baseDir)
-                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                + Path.DirectorySeparatorChar;
-
-            return fullCandidate.StartsWith(fullBaseDir, StringComparison.OrdinalIgnoreCase)
-                ? fullCandidate
-                : defaultPath;
-        } catch {
-            return defaultPath;
-        }
-    }
-
-    private static string ResolveDefaultPendingActionsStorePath() {
-        return ChatServiceJsonFileStore.ResolveDefaultPath("pending-actions.json");
-    }
+    private string ResolvePendingActionsStorePath() =>
+        ChatServiceJsonFileStore.ResolvePathOverrideWithinDefaultDirectory(
+            _options.PendingActionsStorePath,
+            "pending-actions.json");
 
     private StoreDto ReadStoreStateNoThrow() {
         var path = ResolveStorePath();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceBackgroundSchedulerControlState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceBackgroundSchedulerControlState.cs
@@ -71,6 +71,10 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
         string Id,
         long ExpiresUtcTicks);
 
+    private readonly record struct StoreMutationResult(
+        bool Persisted,
+        StoreDto Store);
+
     internal ChatServiceBackgroundSchedulerControlState(ServiceOptions options) {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _defaultBlockedPackIds = NormalizeBlockedPackIds(_options.BackgroundSchedulerBlockedPackIds);
@@ -81,76 +85,52 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
         _maintenanceWindows = _defaultMaintenanceWindows;
 
         var persisted = ReadStoreStateNoThrow();
-        if (persisted.ManualPauseActive) {
-            _manualPauseActive = true;
-            _pausedUntilUtcTicks = persisted.PausedUntilUtcTicks;
-            _pauseReason = persisted.PauseReason;
-        }
-        if (persisted.BlockedPackIdsCustomized) {
-            _blockedPackIdsCustomized = true;
-            _blockedPackIds = NormalizeBlockedPackIds(persisted.BlockedPackIds);
-        }
-        _temporaryBlockedPackSuppressions = NormalizeTemporarySuppressions(
-            persisted.TemporaryBlockedPacks,
-            maxIdLength: ChatRequestOptionLimits.MaxToolSelectorLength,
-            normalizeId: ToolPackBootstrap.NormalizePackId,
-            StringComparer.OrdinalIgnoreCase,
-            DateTime.UtcNow.Ticks);
-        if (persisted.BlockedThreadIdsCustomized) {
-            _blockedThreadIdsCustomized = true;
-            _blockedThreadIds = NormalizeBlockedThreadIds(persisted.BlockedThreadIds);
-        }
-        _temporaryBlockedThreadSuppressions = NormalizeTemporarySuppressions(
-            persisted.TemporaryBlockedThreads,
-            maxIdLength: ChatRequestOptionLimits.MaxToolSelectorLength,
-            normalizeId: NormalizeMaintenanceWindowThreadId,
-            StringComparer.Ordinal,
-            DateTime.UtcNow.Ticks);
-        if (persisted.MaintenanceWindowsCustomized) {
-            _maintenanceWindowsCustomized = true;
-            _maintenanceWindows = BuildMaintenanceWindows(persisted.MaintenanceWindowSpecs);
-        }
+        ApplyStoreStateNoLock(persisted, DateTime.UtcNow.Ticks);
 
         var snapshot = GetSnapshot(DateTime.UtcNow.Ticks);
         if (!snapshot.ManualPauseActive && _options.BackgroundSchedulerStartPaused) {
             int? pauseSeconds = _options.BackgroundSchedulerStartupPauseSeconds > 0
                 ? _options.BackgroundSchedulerStartupPauseSeconds
                 : null;
-            SetManualPause(
+            if (!SetManualPause(
                 paused: true,
                 pauseSeconds,
-                "startup");
+                "startup")) {
+                lock (_lock) {
+                    ApplyManualPauseNoLock(paused: true, pauseSeconds, "startup", DateTime.UtcNow.Ticks);
+                }
+            }
         }
     }
 
     internal BackgroundSchedulerPauseStateSnapshot GetSnapshot(long nowTicks) {
         lock (_lock) {
             var expired = NormalizeExpiredManualPauseNoLock(nowTicks);
-            var snapshot = BuildSnapshotNoLock(nowTicks);
             if (expired) {
-                PersistStateNoThrow();
+                TrySynchronizeNormalizedStoreNoLock(nowTicks);
             }
 
-            return snapshot;
+            return BuildSnapshotNoLock(nowTicks);
         }
     }
 
     internal bool SetManualPause(bool paused, int? pauseSeconds, string pauseReason) {
-        var nowTicks = DateTime.UtcNow.Ticks;
         lock (_lock) {
-            if (!paused) {
-                _manualPauseActive = false;
-                _pausedUntilUtcTicks = 0;
-                _pauseReason = string.Empty;
-            } else {
-                _manualPauseActive = true;
-                _pausedUntilUtcTicks = pauseSeconds is > 0
+            return TryMutatePersistedStoreNoLock(store => {
+                if (!paused) {
+                    store.ManualPauseActive = false;
+                    store.PausedUntilUtcTicks = 0;
+                    store.PauseReason = string.Empty;
+                    return;
+                }
+
+                store.ManualPauseActive = true;
+                var nowTicks = DateTime.UtcNow.Ticks;
+                store.PausedUntilUtcTicks = pauseSeconds is > 0
                     ? nowTicks + TimeSpan.FromSeconds(pauseSeconds.Value).Ticks
                     : 0;
-                _pauseReason = NormalizeManualPauseReason(pauseReason, pauseSeconds);
-            }
-
-            return PersistStateNoThrow();
+                store.PauseReason = NormalizeManualPauseReason(pauseReason, pauseSeconds);
+            });
         }
     }
 
@@ -173,7 +153,7 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
     internal string[] GetBlockedPackIds(long nowTicks) {
         lock (_lock) {
             if (NormalizeExpiredTemporarySuppressionsNoLock(nowTicks)) {
-                PersistStateNoThrow();
+                TrySynchronizeNormalizedStoreNoLock(nowTicks);
             }
 
             return BuildCombinedSuppressionIdsNoLock(_blockedPackIds, _temporaryBlockedPackSuppressions, StringComparer.OrdinalIgnoreCase);
@@ -183,7 +163,7 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
     internal SessionCapabilityBackgroundSchedulerSuppressionDto[] GetBlockedPackSuppressions(long nowTicks) {
         lock (_lock) {
             if (NormalizeExpiredTemporarySuppressionsNoLock(nowTicks)) {
-                PersistStateNoThrow();
+                TrySynchronizeNormalizedStoreNoLock(nowTicks);
             }
 
             return BuildSuppressionDtosNoLock(
@@ -197,7 +177,7 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
     internal string[] GetBlockedThreadIds(long nowTicks) {
         lock (_lock) {
             if (NormalizeExpiredTemporarySuppressionsNoLock(nowTicks)) {
-                PersistStateNoThrow();
+                TrySynchronizeNormalizedStoreNoLock(nowTicks);
             }
 
             return BuildCombinedSuppressionIdsNoLock(_blockedThreadIds, _temporaryBlockedThreadSuppressions, StringComparer.Ordinal);
@@ -207,7 +187,7 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
     internal SessionCapabilityBackgroundSchedulerSuppressionDto[] GetBlockedThreadSuppressions(long nowTicks) {
         lock (_lock) {
             if (NormalizeExpiredTemporarySuppressionsNoLock(nowTicks)) {
-                PersistStateNoThrow();
+                TrySynchronizeNormalizedStoreNoLock(nowTicks);
             }
 
             return BuildSuppressionDtosNoLock(
@@ -260,124 +240,169 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
         var normalizedOperation = NormalizeMaintenanceWindowOperation(operation);
         var normalizedSpecs = NormalizeMaintenanceWindowSpecs(rawSpecs);
         lock (_lock) {
-            switch (normalizedOperation) {
-                case "add":
-                    _maintenanceWindowsCustomized = true;
-                    _maintenanceWindows = MergeMaintenanceWindows(_maintenanceWindows, normalizedSpecs);
-                    break;
-                case "remove":
-                    _maintenanceWindowsCustomized = true;
-                    _maintenanceWindows = RemoveMaintenanceWindows(_maintenanceWindows, normalizedSpecs);
-                    break;
-                case "replace":
-                    _maintenanceWindowsCustomized = true;
-                    _maintenanceWindows = BuildMaintenanceWindows(normalizedSpecs);
-                    break;
-                case "clear":
-                    _maintenanceWindowsCustomized = true;
-                    _maintenanceWindows = Array.Empty<MaintenanceWindow>();
-                    break;
-                case "reset":
-                    _maintenanceWindowsCustomized = false;
-                    _maintenanceWindows = _defaultMaintenanceWindows;
-                    break;
-            }
+            return TryMutatePersistedStoreNoLock(store => {
+                var customized = store.MaintenanceWindowsCustomized;
+                var windows = customized
+                    ? BuildMaintenanceWindows(store.MaintenanceWindowSpecs)
+                    : _defaultMaintenanceWindows;
+                switch (normalizedOperation) {
+                    case "add":
+                        customized = true;
+                        windows = MergeMaintenanceWindows(windows, normalizedSpecs);
+                        break;
+                    case "remove":
+                        customized = true;
+                        windows = RemoveMaintenanceWindows(windows, normalizedSpecs);
+                        break;
+                    case "replace":
+                        customized = true;
+                        windows = BuildMaintenanceWindows(normalizedSpecs);
+                        break;
+                    case "clear":
+                        customized = true;
+                        windows = Array.Empty<MaintenanceWindow>();
+                        break;
+                    case "reset":
+                        customized = false;
+                        windows = _defaultMaintenanceWindows;
+                        break;
+                }
 
-            return PersistStateNoThrow();
+                store.MaintenanceWindowsCustomized = customized;
+                store.MaintenanceWindowSpecs = customized
+                    ? windows.Select(static window => window.NormalizedSpec).ToArray()
+                    : Array.Empty<string>();
+            });
         }
     }
 
     internal bool UpdateBlockedPacks(string operation, IReadOnlyList<string>? rawPackIds, int? durationSeconds = null) {
         var normalizedOperation = NormalizeMaintenanceWindowOperation(operation);
         var normalizedPackIds = NormalizeBlockedPackIds(rawPackIds);
-        var nowTicks = DateTime.UtcNow.Ticks;
         lock (_lock) {
-            NormalizeExpiredTemporarySuppressionsNoLock(nowTicks);
-            switch (normalizedOperation) {
-                case "add":
-                    if (durationSeconds is > 0) {
-                        _temporaryBlockedPackSuppressions = UpsertTemporarySuppressions(
-                            _temporaryBlockedPackSuppressions,
-                            normalizedPackIds,
-                            nowTicks + TimeSpan.FromSeconds(durationSeconds.Value).Ticks,
-                            _blockedPackIds,
-                            StringComparer.OrdinalIgnoreCase);
-                    } else {
-                        _blockedPackIdsCustomized = true;
-                        _blockedPackIds = MergeBlockedPackIds(_blockedPackIds, normalizedPackIds);
-                        _temporaryBlockedPackSuppressions = RemoveTemporarySuppressions(_temporaryBlockedPackSuppressions, normalizedPackIds, StringComparer.OrdinalIgnoreCase);
-                    }
-                    break;
-                case "remove":
-                    _blockedPackIdsCustomized = true;
-                    _blockedPackIds = RemoveBlockedPackIds(_blockedPackIds, normalizedPackIds);
-                    _temporaryBlockedPackSuppressions = RemoveTemporarySuppressions(_temporaryBlockedPackSuppressions, normalizedPackIds, StringComparer.OrdinalIgnoreCase);
-                    break;
-                case "replace":
-                    _blockedPackIdsCustomized = true;
-                    _blockedPackIds = normalizedPackIds;
-                    _temporaryBlockedPackSuppressions = Array.Empty<TemporarySuppression>();
-                    break;
-                case "clear":
-                    _blockedPackIdsCustomized = true;
-                    _blockedPackIds = Array.Empty<string>();
-                    _temporaryBlockedPackSuppressions = Array.Empty<TemporarySuppression>();
-                    break;
-                case "reset":
-                    _blockedPackIdsCustomized = false;
-                    _blockedPackIds = _defaultBlockedPackIds;
-                    _temporaryBlockedPackSuppressions = Array.Empty<TemporarySuppression>();
-                    break;
-            }
+            return TryMutatePersistedStoreNoLock(store => {
+                var nowTicks = DateTime.UtcNow.Ticks;
+                var customized = store.BlockedPackIdsCustomized;
+                var blockedPackIds = customized
+                    ? NormalizeBlockedPackIds(store.BlockedPackIds)
+                    : _defaultBlockedPackIds;
+                var temporarySuppressions = NormalizeTemporarySuppressions(
+                    store.TemporaryBlockedPacks,
+                    maxIdLength: ChatRequestOptionLimits.MaxToolSelectorLength,
+                    normalizeId: ToolPackBootstrap.NormalizePackId,
+                    StringComparer.OrdinalIgnoreCase,
+                    nowTicks);
+                switch (normalizedOperation) {
+                    case "add":
+                        if (durationSeconds is > 0) {
+                            temporarySuppressions = UpsertTemporarySuppressions(
+                                temporarySuppressions,
+                                normalizedPackIds,
+                                nowTicks + TimeSpan.FromSeconds(durationSeconds.Value).Ticks,
+                                blockedPackIds,
+                                StringComparer.OrdinalIgnoreCase);
+                        } else {
+                            customized = true;
+                            blockedPackIds = MergeBlockedPackIds(blockedPackIds, normalizedPackIds);
+                            temporarySuppressions = RemoveTemporarySuppressions(temporarySuppressions, normalizedPackIds, StringComparer.OrdinalIgnoreCase);
+                        }
+                        break;
+                    case "remove":
+                        customized = true;
+                        blockedPackIds = RemoveBlockedPackIds(blockedPackIds, normalizedPackIds);
+                        temporarySuppressions = RemoveTemporarySuppressions(temporarySuppressions, normalizedPackIds, StringComparer.OrdinalIgnoreCase);
+                        break;
+                    case "replace":
+                        customized = true;
+                        blockedPackIds = normalizedPackIds;
+                        temporarySuppressions = Array.Empty<TemporarySuppression>();
+                        break;
+                    case "clear":
+                        customized = true;
+                        blockedPackIds = Array.Empty<string>();
+                        temporarySuppressions = Array.Empty<TemporarySuppression>();
+                        break;
+                    case "reset":
+                        customized = false;
+                        blockedPackIds = _defaultBlockedPackIds;
+                        temporarySuppressions = Array.Empty<TemporarySuppression>();
+                        break;
+                }
 
-            return PersistStateNoThrow();
+                store.BlockedPackIdsCustomized = customized;
+                store.BlockedPackIds = customized ? blockedPackIds : Array.Empty<string>();
+                store.TemporaryBlockedPacks = temporarySuppressions
+                    .Select(static item => new TemporarySuppressionStoreDto {
+                        Id = item.Id,
+                        ExpiresUtcTicks = item.ExpiresUtcTicks
+                    })
+                    .ToArray();
+            });
         }
     }
 
     internal bool UpdateBlockedThreads(string operation, IReadOnlyList<string>? rawThreadIds, int? durationSeconds = null) {
         var normalizedOperation = NormalizeMaintenanceWindowOperation(operation);
         var normalizedThreadIds = NormalizeBlockedThreadIds(rawThreadIds);
-        var nowTicks = DateTime.UtcNow.Ticks;
         lock (_lock) {
-            NormalizeExpiredTemporarySuppressionsNoLock(nowTicks);
-            switch (normalizedOperation) {
-                case "add":
-                    if (durationSeconds is > 0) {
-                        _temporaryBlockedThreadSuppressions = UpsertTemporarySuppressions(
-                            _temporaryBlockedThreadSuppressions,
-                            normalizedThreadIds,
-                            nowTicks + TimeSpan.FromSeconds(durationSeconds.Value).Ticks,
-                            _blockedThreadIds,
-                            StringComparer.Ordinal);
-                    } else {
-                        _blockedThreadIdsCustomized = true;
-                        _blockedThreadIds = MergeBlockedThreadIds(_blockedThreadIds, normalizedThreadIds);
-                        _temporaryBlockedThreadSuppressions = RemoveTemporarySuppressions(_temporaryBlockedThreadSuppressions, normalizedThreadIds, StringComparer.Ordinal);
-                    }
-                    break;
-                case "remove":
-                    _blockedThreadIdsCustomized = true;
-                    _blockedThreadIds = RemoveBlockedThreadIds(_blockedThreadIds, normalizedThreadIds);
-                    _temporaryBlockedThreadSuppressions = RemoveTemporarySuppressions(_temporaryBlockedThreadSuppressions, normalizedThreadIds, StringComparer.Ordinal);
-                    break;
-                case "replace":
-                    _blockedThreadIdsCustomized = true;
-                    _blockedThreadIds = normalizedThreadIds;
-                    _temporaryBlockedThreadSuppressions = Array.Empty<TemporarySuppression>();
-                    break;
-                case "clear":
-                    _blockedThreadIdsCustomized = true;
-                    _blockedThreadIds = Array.Empty<string>();
-                    _temporaryBlockedThreadSuppressions = Array.Empty<TemporarySuppression>();
-                    break;
-                case "reset":
-                    _blockedThreadIdsCustomized = false;
-                    _blockedThreadIds = _defaultBlockedThreadIds;
-                    _temporaryBlockedThreadSuppressions = Array.Empty<TemporarySuppression>();
-                    break;
-            }
+            return TryMutatePersistedStoreNoLock(store => {
+                var nowTicks = DateTime.UtcNow.Ticks;
+                var customized = store.BlockedThreadIdsCustomized;
+                var blockedThreadIds = customized
+                    ? NormalizeBlockedThreadIds(store.BlockedThreadIds)
+                    : _defaultBlockedThreadIds;
+                var temporarySuppressions = NormalizeTemporarySuppressions(
+                    store.TemporaryBlockedThreads,
+                    maxIdLength: ChatRequestOptionLimits.MaxToolSelectorLength,
+                    normalizeId: NormalizeMaintenanceWindowThreadId,
+                    StringComparer.Ordinal,
+                    nowTicks);
+                switch (normalizedOperation) {
+                    case "add":
+                        if (durationSeconds is > 0) {
+                            temporarySuppressions = UpsertTemporarySuppressions(
+                                temporarySuppressions,
+                                normalizedThreadIds,
+                                nowTicks + TimeSpan.FromSeconds(durationSeconds.Value).Ticks,
+                                blockedThreadIds,
+                                StringComparer.Ordinal);
+                        } else {
+                            customized = true;
+                            blockedThreadIds = MergeBlockedThreadIds(blockedThreadIds, normalizedThreadIds);
+                            temporarySuppressions = RemoveTemporarySuppressions(temporarySuppressions, normalizedThreadIds, StringComparer.Ordinal);
+                        }
+                        break;
+                    case "remove":
+                        customized = true;
+                        blockedThreadIds = RemoveBlockedThreadIds(blockedThreadIds, normalizedThreadIds);
+                        temporarySuppressions = RemoveTemporarySuppressions(temporarySuppressions, normalizedThreadIds, StringComparer.Ordinal);
+                        break;
+                    case "replace":
+                        customized = true;
+                        blockedThreadIds = normalizedThreadIds;
+                        temporarySuppressions = Array.Empty<TemporarySuppression>();
+                        break;
+                    case "clear":
+                        customized = true;
+                        blockedThreadIds = Array.Empty<string>();
+                        temporarySuppressions = Array.Empty<TemporarySuppression>();
+                        break;
+                    case "reset":
+                        customized = false;
+                        blockedThreadIds = _defaultBlockedThreadIds;
+                        temporarySuppressions = Array.Empty<TemporarySuppression>();
+                        break;
+                }
 
-            return PersistStateNoThrow();
+                store.BlockedThreadIdsCustomized = customized;
+                store.BlockedThreadIds = customized ? blockedThreadIds : Array.Empty<string>();
+                store.TemporaryBlockedThreads = temporarySuppressions
+                    .Select(static item => new TemporarySuppressionStoreDto {
+                        Id = item.Id,
+                        ExpiresUtcTicks = item.ExpiresUtcTicks
+                    })
+                    .ToArray();
+            });
         }
     }
 
@@ -1431,20 +1456,29 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
     }
 
     private static StoreDto ReadStoreStateWithCleanup(string path) {
-        var expiredPauseRemoved = false;
+        var store = ReadNormalizedStoreState(path, DateTime.UtcNow, out var expiredPauseRemoved);
+        if (expiredPauseRemoved) {
+            PersistNormalizedStore(path, store);
+        }
+
+        return store;
+    }
+
+    private static StoreDto ReadNormalizedStoreState(
+        string path,
+        DateTime nowUtc,
+        out bool expiredPauseRemoved) {
+        var pauseRemoved = false;
         var result = ChatServiceJsonFileStore.Read<StoreDto>(
             path,
             MaximumStoreBytes,
             static json => JsonSerializer.Deserialize<StoreDto>(json, StoreJsonOptions),
             static store => store.Version > 0 && store.Version <= StoreVersion,
-            store => expiredPauseRemoved = NormalizeStoreState(store, DateTime.UtcNow),
+            store => pauseRemoved = NormalizeStoreState(store, nowUtc),
             StoreName);
+        expiredPauseRemoved = pauseRemoved;
         if (result.State != ChatServiceJsonFileReadState.Loaded || result.Value is null) {
             return new StoreDto();
-        }
-
-        if (expiredPauseRemoved) {
-            PersistNormalizedStore(path, result.Value);
         }
 
         return result.Value;
@@ -1514,67 +1548,95 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
         return expiredPauseRemoved;
     }
 
-    private bool PersistStateNoThrow() {
-        bool manualPauseActive;
-        long pausedUntilUtcTicks;
-        string pauseReason;
-        bool blockedPackIdsCustomized;
-        string[] blockedPackIds;
-        TemporarySuppressionStoreDto[] temporaryBlockedPacks;
-        bool blockedThreadIdsCustomized;
-        string[] blockedThreadIds;
-        TemporarySuppressionStoreDto[] temporaryBlockedThreads;
-        bool maintenanceWindowsCustomized;
-        string[] maintenanceWindowSpecs;
-        lock (_lock) {
-            var nowTicks = DateTime.UtcNow.Ticks;
-            NormalizeExpiredTemporarySuppressionsNoLock(nowTicks);
-            manualPauseActive = _manualPauseActive;
-            pausedUntilUtcTicks = _pausedUntilUtcTicks;
-            pauseReason = _pauseReason;
-            blockedPackIdsCustomized = _blockedPackIdsCustomized;
-            blockedPackIds = _blockedPackIds.ToArray();
-            temporaryBlockedPacks = _temporaryBlockedPackSuppressions
-                .Select(static item => new TemporarySuppressionStoreDto {
-                    Id = item.Id,
-                    ExpiresUtcTicks = item.ExpiresUtcTicks
-                })
-                .ToArray();
-            blockedThreadIdsCustomized = _blockedThreadIdsCustomized;
-            blockedThreadIds = _blockedThreadIds.ToArray();
-            temporaryBlockedThreads = _temporaryBlockedThreadSuppressions
-                .Select(static item => new TemporarySuppressionStoreDto {
-                    Id = item.Id,
-                    ExpiresUtcTicks = item.ExpiresUtcTicks
-                })
-                .ToArray();
-            maintenanceWindowsCustomized = _maintenanceWindowsCustomized;
-            maintenanceWindowSpecs = _maintenanceWindows
-                .Select(static window => window.NormalizedSpec)
-                .ToArray();
-            var store = new StoreDto {
-                ManualPauseActive = manualPauseActive,
-                PausedUntilUtcTicks = manualPauseActive ? Math.Max(0, pausedUntilUtcTicks) : 0,
-                PauseReason = manualPauseActive ? NormalizeActivityText(pauseReason, MaxPauseReasonLength + 32) : string.Empty,
-                BlockedPackIdsCustomized = blockedPackIdsCustomized,
-                BlockedPackIds = blockedPackIdsCustomized ? blockedPackIds : Array.Empty<string>(),
-                TemporaryBlockedPacks = temporaryBlockedPacks,
-                BlockedThreadIdsCustomized = blockedThreadIdsCustomized,
-                BlockedThreadIds = blockedThreadIdsCustomized ? blockedThreadIds : Array.Empty<string>(),
-                TemporaryBlockedThreads = temporaryBlockedThreads,
-                MaintenanceWindowsCustomized = maintenanceWindowsCustomized,
-                MaintenanceWindowSpecs = maintenanceWindowsCustomized ? maintenanceWindowSpecs : Array.Empty<string>()
-            };
+    private bool TrySynchronizeNormalizedStoreNoLock(long nowTicks) {
+        var nowUtc = TryGetUtcDateTimeFromTicks(nowTicks, out var suppliedNowUtc)
+            ? suppliedNowUtc
+            : DateTime.UtcNow;
+        return TryMutatePersistedStoreNoLock(static _ => { }, nowUtc);
+    }
 
-            var path = ResolveStorePath();
-            var lockAcquired = ChatServiceJsonFileStore.TryWithExclusiveAccess(
-                path,
-                static state => PersistNormalizedStore(state.Path, state.Store),
-                (Path: path, Store: store),
-                out var persisted,
-                StoreName);
-            return lockAcquired && persisted;
+    private bool TryMutatePersistedStoreNoLock(Action<StoreDto> mutation, DateTime? normalizationUtc = null) {
+        ArgumentNullException.ThrowIfNull(mutation);
+        var path = ResolveStorePath();
+        var lockAcquired = ChatServiceJsonFileStore.TryWithExclusiveAccess(
+            path,
+            static state => {
+                var nowUtc = state.NormalizationUtc ?? DateTime.UtcNow;
+                var store = ReadNormalizedStoreState(state.Path, nowUtc, out _);
+                state.Mutation(store);
+                NormalizeStoreState(store, nowUtc);
+                return new StoreMutationResult(
+                    PersistNormalizedStore(state.Path, store),
+                    store);
+            },
+            (Path: path, Mutation: mutation, NormalizationUtc: normalizationUtc),
+            out var result,
+            StoreName);
+        if (!lockAcquired || !result.Persisted) {
+            return false;
         }
+
+        ApplyStoreStateNoLock(result.Store, DateTime.UtcNow.Ticks);
+        return true;
+    }
+
+    private void ApplyStoreStateNoLock(StoreDto store, long nowTicks) {
+        ArgumentNullException.ThrowIfNull(store);
+        ApplyManualPauseNoLock(
+            store.ManualPauseActive,
+            store.PausedUntilUtcTicks,
+            store.PauseReason);
+
+        _blockedPackIdsCustomized = store.BlockedPackIdsCustomized;
+        _blockedPackIds = _blockedPackIdsCustomized
+            ? NormalizeBlockedPackIds(store.BlockedPackIds)
+            : _defaultBlockedPackIds;
+        _temporaryBlockedPackSuppressions = NormalizeTemporarySuppressions(
+            store.TemporaryBlockedPacks,
+            maxIdLength: ChatRequestOptionLimits.MaxToolSelectorLength,
+            normalizeId: ToolPackBootstrap.NormalizePackId,
+            StringComparer.OrdinalIgnoreCase,
+            nowTicks);
+
+        _blockedThreadIdsCustomized = store.BlockedThreadIdsCustomized;
+        _blockedThreadIds = _blockedThreadIdsCustomized
+            ? NormalizeBlockedThreadIds(store.BlockedThreadIds)
+            : _defaultBlockedThreadIds;
+        _temporaryBlockedThreadSuppressions = NormalizeTemporarySuppressions(
+            store.TemporaryBlockedThreads,
+            maxIdLength: ChatRequestOptionLimits.MaxToolSelectorLength,
+            normalizeId: NormalizeMaintenanceWindowThreadId,
+            StringComparer.Ordinal,
+            nowTicks);
+
+        _maintenanceWindowsCustomized = store.MaintenanceWindowsCustomized;
+        _maintenanceWindows = _maintenanceWindowsCustomized
+            ? BuildMaintenanceWindows(store.MaintenanceWindowSpecs)
+            : _defaultMaintenanceWindows;
+    }
+
+    private void ApplyManualPauseNoLock(
+        bool paused,
+        int? pauseSeconds,
+        string pauseReason,
+        long nowTicks) {
+        ApplyManualPauseNoLock(
+            paused,
+            paused && pauseSeconds is > 0
+                ? nowTicks + TimeSpan.FromSeconds(pauseSeconds.Value).Ticks
+                : 0,
+            paused ? NormalizeManualPauseReason(pauseReason, pauseSeconds) : string.Empty);
+    }
+
+    private void ApplyManualPauseNoLock(
+        bool paused,
+        long pausedUntilUtcTicks,
+        string pauseReason) {
+        _manualPauseActive = paused;
+        _pausedUntilUtcTicks = paused ? Math.Max(0, pausedUntilUtcTicks) : 0;
+        _pauseReason = paused
+            ? NormalizeActivityText(pauseReason, MaxPauseReasonLength + 32)
+            : string.Empty;
     }
 
     private static bool PersistNormalizedStore(string path, StoreDto store) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceBackgroundSchedulerControlState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceBackgroundSchedulerControlState.cs
@@ -1428,12 +1428,7 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
             return ResolveDefaultPendingActionsStorePath();
         }
 
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
-
-        var baseDir = Path.Combine(root, "IntelligenceX.Chat");
+        var baseDir = ChatServiceJsonFileStore.ResolveDefaultDirectory();
         var defaultPath = ResolveDefaultPendingActionsStorePath();
 
         try {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceBackgroundSchedulerControlState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceBackgroundSchedulerControlState.cs
@@ -17,7 +17,6 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
     private const int MaxMaintenanceWindowThreadScopeLength = 120;
     private const int MaximumStoreBytes = 64 * 1024;
     private const string StoreName = "Background scheduler control state";
-    private static readonly object StoreLock = new();
     private static readonly JsonSerializerOptions StoreJsonOptions = new() {
         WriteIndented = false,
         PropertyNameCaseInsensitive = false
@@ -136,9 +135,8 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
         }
     }
 
-    internal BackgroundSchedulerPauseStateSnapshot SetManualPause(bool paused, int? pauseSeconds, string pauseReason) {
+    internal bool SetManualPause(bool paused, int? pauseSeconds, string pauseReason) {
         var nowTicks = DateTime.UtcNow.Ticks;
-        BackgroundSchedulerPauseStateSnapshot snapshot;
         lock (_lock) {
             if (!paused) {
                 _manualPauseActive = false;
@@ -152,15 +150,8 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
                 _pauseReason = NormalizeManualPauseReason(pauseReason, pauseSeconds);
             }
 
-            snapshot = new BackgroundSchedulerPauseStateSnapshot(
-                ManualPauseActive: _manualPauseActive,
-                ScheduledPauseActive: false,
-                PausedUntilUtcTicks: _pausedUntilUtcTicks,
-                PauseReason: _pauseReason);
+            return PersistStateNoThrow();
         }
-
-        PersistStateNoThrow();
-        return snapshot;
     }
 
     internal static string NormalizeManualPauseReason(string? reason, int? pauseSeconds) {
@@ -265,7 +256,7 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
         }
     }
 
-    internal void UpdateMaintenanceWindows(string operation, IReadOnlyList<string>? rawSpecs) {
+    internal bool UpdateMaintenanceWindows(string operation, IReadOnlyList<string>? rawSpecs) {
         var normalizedOperation = NormalizeMaintenanceWindowOperation(operation);
         var normalizedSpecs = NormalizeMaintenanceWindowSpecs(rawSpecs);
         lock (_lock) {
@@ -291,12 +282,12 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
                     _maintenanceWindows = _defaultMaintenanceWindows;
                     break;
             }
-        }
 
-        PersistStateNoThrow();
+            return PersistStateNoThrow();
+        }
     }
 
-    internal void UpdateBlockedPacks(string operation, IReadOnlyList<string>? rawPackIds, int? durationSeconds = null) {
+    internal bool UpdateBlockedPacks(string operation, IReadOnlyList<string>? rawPackIds, int? durationSeconds = null) {
         var normalizedOperation = NormalizeMaintenanceWindowOperation(operation);
         var normalizedPackIds = NormalizeBlockedPackIds(rawPackIds);
         var nowTicks = DateTime.UtcNow.Ticks;
@@ -338,12 +329,12 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
                     _temporaryBlockedPackSuppressions = Array.Empty<TemporarySuppression>();
                     break;
             }
-        }
 
-        PersistStateNoThrow();
+            return PersistStateNoThrow();
+        }
     }
 
-    internal void UpdateBlockedThreads(string operation, IReadOnlyList<string>? rawThreadIds, int? durationSeconds = null) {
+    internal bool UpdateBlockedThreads(string operation, IReadOnlyList<string>? rawThreadIds, int? durationSeconds = null) {
         var normalizedOperation = NormalizeMaintenanceWindowOperation(operation);
         var normalizedThreadIds = NormalizeBlockedThreadIds(rawThreadIds);
         var nowTicks = DateTime.UtcNow.Ticks;
@@ -385,9 +376,9 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
                     _temporaryBlockedThreadSuppressions = Array.Empty<TemporarySuppression>();
                     break;
             }
-        }
 
-        PersistStateNoThrow();
+            return PersistStateNoThrow();
+        }
     }
 
     internal bool TryResolveBlockedPackDurationUntilNextMaintenanceWindow(
@@ -1429,25 +1420,34 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
 
     private StoreDto ReadStoreStateNoThrow() {
         var path = ResolveStorePath();
-        lock (StoreLock) {
-            var expiredPauseRemoved = false;
-            var result = ChatServiceJsonFileStore.Read<StoreDto>(
-                path,
-                MaximumStoreBytes,
-                static json => JsonSerializer.Deserialize<StoreDto>(json, StoreJsonOptions),
-                static store => store.Version > 0 && store.Version <= StoreVersion,
-                store => expiredPauseRemoved = NormalizeStoreState(store, DateTime.UtcNow),
-                StoreName);
-            if (result.State != ChatServiceJsonFileReadState.Loaded || result.Value is null) {
-                return new StoreDto();
-            }
+        return ChatServiceJsonFileStore.TryWithExclusiveAccess(
+                   path,
+                   ReadStoreStateWithCleanup,
+                   path,
+                   out var store,
+                   StoreName)
+            ? store
+            : new StoreDto();
+    }
 
-            if (expiredPauseRemoved) {
-                PersistNormalizedStore(path, result.Value);
-            }
-
-            return result.Value;
+    private static StoreDto ReadStoreStateWithCleanup(string path) {
+        var expiredPauseRemoved = false;
+        var result = ChatServiceJsonFileStore.Read<StoreDto>(
+            path,
+            MaximumStoreBytes,
+            static json => JsonSerializer.Deserialize<StoreDto>(json, StoreJsonOptions),
+            static store => store.Version > 0 && store.Version <= StoreVersion,
+            store => expiredPauseRemoved = NormalizeStoreState(store, DateTime.UtcNow),
+            StoreName);
+        if (result.State != ChatServiceJsonFileReadState.Loaded || result.Value is null) {
+            return new StoreDto();
         }
+
+        if (expiredPauseRemoved) {
+            PersistNormalizedStore(path, result.Value);
+        }
+
+        return result.Value;
     }
 
     private static bool NormalizeStoreState(StoreDto store, DateTime nowUtc) {
@@ -1514,7 +1514,7 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
         return expiredPauseRemoved;
     }
 
-    private void PersistStateNoThrow() {
+    private bool PersistStateNoThrow() {
         bool manualPauseActive;
         long pausedUntilUtcTicks;
         string pauseReason;
@@ -1552,10 +1552,6 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
             maintenanceWindowSpecs = _maintenanceWindows
                 .Select(static window => window.NormalizedSpec)
                 .ToArray();
-        }
-
-        var path = ResolveStorePath();
-        lock (StoreLock) {
             var store = new StoreDto {
                 ManualPauseActive = manualPauseActive,
                 PausedUntilUtcTicks = manualPauseActive ? Math.Max(0, pausedUntilUtcTicks) : 0,
@@ -1569,17 +1565,24 @@ internal sealed class ChatServiceBackgroundSchedulerControlState {
                 MaintenanceWindowsCustomized = maintenanceWindowsCustomized,
                 MaintenanceWindowSpecs = maintenanceWindowsCustomized ? maintenanceWindowSpecs : Array.Empty<string>()
             };
-            PersistNormalizedStore(path, store);
+
+            var path = ResolveStorePath();
+            var lockAcquired = ChatServiceJsonFileStore.TryWithExclusiveAccess(
+                path,
+                static state => PersistNormalizedStore(state.Path, state.Store),
+                (Path: path, Store: store),
+                out var persisted,
+                StoreName);
+            return lockAcquired && persisted;
         }
     }
 
-    private static void PersistNormalizedStore(string path, StoreDto store) {
+    private static bool PersistNormalizedStore(string path, StoreDto store) {
         if (!HasPersistableState(store)) {
-            ChatServiceJsonFileStore.Delete(path, StoreName);
-            return;
+            return ChatServiceJsonFileStore.Delete(path, StoreName);
         }
 
-        ChatServiceJsonFileStore.Write(
+        return ChatServiceJsonFileStore.Write(
             path,
             store,
             static value => JsonSerializer.Serialize(value, StoreJsonOptions),

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.FailureStreak.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.FailureStreak.cs
@@ -6,9 +6,9 @@ using System.Linq;
 namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
-    // The runtime store is capped at 512 KiB. This retains far more events than the
-    // maximum configured auto-pause threshold while keeping malformed or abandoned
-    // stores bounded.
+    // The event window is the failure-streak authority and intentionally saturates.
+    // It is far above the maximum auto-pause threshold while keeping the runtime
+    // store below its 512 KiB read limit. Lifetime outcome counters remain separate.
     internal const int MaxBackgroundSchedulerFailureStreakEvents = 4096;
     private const int MaxBackgroundSchedulerFailureEventIdLength = 40;
 
@@ -22,6 +22,7 @@ internal sealed partial class ChatServiceSession {
                 0,
                 _backgroundSchedulerFailureStreakEvents.Count - MaxBackgroundSchedulerFailureStreakEvents);
         }
+        _backgroundSchedulerConsecutiveFailureCount = _backgroundSchedulerFailureStreakEvents.Count;
     }
 
     private static void MergeBackgroundSchedulerConsecutiveFailureState(
@@ -41,27 +42,8 @@ internal sealed partial class ChatServiceSession {
             merged.LastSuccessUtcTicks);
 
         merged.FailureStreakEvents = mergedEvents;
-        var successResetChanged = desired.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks
-            || persisted.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks;
-        if (successResetChanged
-            || (BackgroundSchedulerFailureEventsAreComplete(persisted)
-                && BackgroundSchedulerFailureEventsAreComplete(baseline)
-                && BackgroundSchedulerFailureEventsAreComplete(desired))) {
-            // An overflowed scalar has no event ordering. Once either writer records
-            // a success, only the bounded events after that success are safe to keep.
-            merged.ConsecutiveFailureCount = mergedEvents.Length;
-            return;
-        }
-
-        merged.ConsecutiveFailureCount = AddBackgroundSchedulerCounterDelta(
-            persisted.ConsecutiveFailureCount,
-            baseline.ConsecutiveFailureCount,
-            desired.ConsecutiveFailureCount);
+        merged.ConsecutiveFailureCount = mergedEvents.Length;
     }
-
-    private static bool BackgroundSchedulerFailureEventsAreComplete(BackgroundSchedulerRuntimeStoreDto store) =>
-        Math.Max(0, store.ConsecutiveFailureCount) <= MaxBackgroundSchedulerFailureStreakEvents
-        && Math.Max(0, store.ConsecutiveFailureCount) == store.FailureStreakEvents.Length;
 
     private static BackgroundSchedulerFailureEventDto[] NormalizeBackgroundSchedulerFailureEvents(
         IEnumerable<BackgroundSchedulerFailureEventDto>? failureEvents,
@@ -121,12 +103,8 @@ internal sealed partial class ChatServiceSession {
             })
             .ToArray();
 
-    private static int ResolveBackgroundSchedulerConsecutiveFailureCount(
-        int consecutiveFailureCount,
-        int failureEventCount) =>
-        Math.Max(0, consecutiveFailureCount) <= MaxBackgroundSchedulerFailureStreakEvents
-            ? Math.Max(0, failureEventCount)
-            : Math.Max(Math.Max(0, consecutiveFailureCount), Math.Max(0, failureEventCount));
+    private static int ResolveBackgroundSchedulerConsecutiveFailureCount(int failureEventCount) =>
+        Math.Clamp(failureEventCount, 0, MaxBackgroundSchedulerFailureStreakEvents);
 
     private static string NormalizeBackgroundSchedulerFailureEventId(string? eventId) {
         var normalized = eventId?.Trim() ?? string.Empty;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.FailureStreak.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.FailureStreak.cs
@@ -9,7 +9,7 @@ internal sealed partial class ChatServiceSession {
     // The runtime store is capped at 512 KiB. This retains far more events than the
     // maximum configured auto-pause threshold while keeping malformed or abandoned
     // stores bounded.
-    private const int MaxBackgroundSchedulerFailureStreakEvents = 4096;
+    internal const int MaxBackgroundSchedulerFailureStreakEvents = 4096;
     private const int MaxBackgroundSchedulerFailureEventIdLength = 40;
 
     private void RememberBackgroundSchedulerFailureEventNoLock(long recordedUtcTicks) {
@@ -41,53 +41,27 @@ internal sealed partial class ChatServiceSession {
             merged.LastSuccessUtcTicks);
 
         merged.FailureStreakEvents = mergedEvents;
-        if (BackgroundSchedulerFailureEventsAreComplete(persisted)
-            && BackgroundSchedulerFailureEventsAreComplete(baseline)
-            && BackgroundSchedulerFailureEventsAreComplete(desired)) {
+        var successResetChanged = desired.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks
+            || persisted.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks;
+        if (successResetChanged
+            || (BackgroundSchedulerFailureEventsAreComplete(persisted)
+                && BackgroundSchedulerFailureEventsAreComplete(baseline)
+                && BackgroundSchedulerFailureEventsAreComplete(desired))) {
+            // An overflowed scalar has no event ordering. Once either writer records
+            // a success, only the bounded events after that success are safe to keep.
             merged.ConsecutiveFailureCount = mergedEvents.Length;
             return;
         }
 
-        MergeOverflowedBackgroundSchedulerConsecutiveFailureState(
-            merged,
-            persisted,
-            baseline,
-            desired);
+        merged.ConsecutiveFailureCount = AddBackgroundSchedulerCounterDelta(
+            persisted.ConsecutiveFailureCount,
+            baseline.ConsecutiveFailureCount,
+            desired.ConsecutiveFailureCount);
     }
 
     private static bool BackgroundSchedulerFailureEventsAreComplete(BackgroundSchedulerRuntimeStoreDto store) =>
         Math.Max(0, store.ConsecutiveFailureCount) <= MaxBackgroundSchedulerFailureStreakEvents
         && Math.Max(0, store.ConsecutiveFailureCount) == store.FailureStreakEvents.Length;
-
-    private static void MergeOverflowedBackgroundSchedulerConsecutiveFailureState(
-        BackgroundSchedulerRuntimeStoreDto merged,
-        BackgroundSchedulerRuntimeStoreDto persisted,
-        BackgroundSchedulerRuntimeStoreDto baseline,
-        BackgroundSchedulerRuntimeStoreDto desired) {
-        var localSuccessChanged = desired.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks;
-        var persistedSuccessChanged = persisted.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks;
-        if (!localSuccessChanged && !persistedSuccessChanged) {
-            merged.ConsecutiveFailureCount = AddBackgroundSchedulerCounterDelta(
-                persisted.ConsecutiveFailureCount,
-                baseline.ConsecutiveFailureCount,
-                desired.ConsecutiveFailureCount);
-            return;
-        }
-
-        var latestSuccessIsLocal = localSuccessChanged
-            && (!persistedSuccessChanged || desired.LastSuccessUtcTicks >= persisted.LastSuccessUtcTicks);
-        var resetWriter = latestSuccessIsLocal ? desired : persisted;
-        var otherWriter = latestSuccessIsLocal ? persisted : desired;
-        var postResetCount = Math.Max(0, resetWriter.ConsecutiveFailureCount);
-        if (otherWriter.LastFailureUtcTicks > resetWriter.LastSuccessUtcTicks) {
-            postResetCount = AddBackgroundSchedulerCounterDelta(
-                postResetCount,
-                0,
-                Math.Max(0, otherWriter.ConsecutiveFailureCount - baseline.ConsecutiveFailureCount));
-        }
-
-        merged.ConsecutiveFailureCount = Math.Max(postResetCount, merged.FailureStreakEvents.Length);
-    }
 
     private static BackgroundSchedulerFailureEventDto[] NormalizeBackgroundSchedulerFailureEvents(
         IEnumerable<BackgroundSchedulerFailureEventDto>? failureEvents,
@@ -156,8 +130,16 @@ internal sealed partial class ChatServiceSession {
 
     private static string NormalizeBackgroundSchedulerFailureEventId(string? eventId) {
         var normalized = eventId?.Trim() ?? string.Empty;
-        return normalized.Length <= MaxBackgroundSchedulerFailureEventIdLength
+        if (normalized.Length == 0 || normalized.Length > MaxBackgroundSchedulerFailureEventIdLength) {
+            return string.Empty;
+        }
+
+        return normalized.All(static character =>
+            character is >= 'a' and <= 'z'
+            or >= 'A' and <= 'Z'
+            or >= '0' and <= '9'
+            or '-' or '_' or '.' or ':')
             ? normalized
-            : normalized[..MaxBackgroundSchedulerFailureEventIdLength];
+            : string.Empty;
     }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.FailureStreak.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.FailureStreak.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace IntelligenceX.Chat.Service;
+
+internal sealed partial class ChatServiceSession {
+    // The runtime store is capped at 512 KiB. This retains far more events than the
+    // maximum configured auto-pause threshold while keeping malformed or abandoned
+    // stores bounded.
+    private const int MaxBackgroundSchedulerFailureStreakEvents = 4096;
+    private const int MaxBackgroundSchedulerFailureEventIdLength = 40;
+
+    private void RememberBackgroundSchedulerFailureEventNoLock(long recordedUtcTicks) {
+        _backgroundSchedulerFailureStreakEvents.Add(new BackgroundSchedulerFailureEventDto {
+            EventId = Guid.NewGuid().ToString("N"),
+            RecordedUtcTicks = Math.Max(1, recordedUtcTicks)
+        });
+        if (_backgroundSchedulerFailureStreakEvents.Count > MaxBackgroundSchedulerFailureStreakEvents) {
+            _backgroundSchedulerFailureStreakEvents.RemoveRange(
+                0,
+                _backgroundSchedulerFailureStreakEvents.Count - MaxBackgroundSchedulerFailureStreakEvents);
+        }
+    }
+
+    private static void MergeBackgroundSchedulerConsecutiveFailureState(
+        BackgroundSchedulerRuntimeStoreDto merged,
+        BackgroundSchedulerRuntimeStoreDto persisted,
+        BackgroundSchedulerRuntimeStoreDto baseline,
+        BackgroundSchedulerRuntimeStoreDto desired) {
+        var baselineIds = baseline.FailureStreakEvents
+            .Select(static failureEvent => failureEvent.EventId)
+            .ToHashSet(StringComparer.Ordinal);
+        var desiredDelta = desired.FailureStreakEvents
+            .Where(failureEvent => !baselineIds.Contains(failureEvent.EventId));
+        var mergedEvents = NormalizeBackgroundSchedulerFailureEvents(
+            persisted.FailureStreakEvents.Concat(desiredDelta),
+            consecutiveFailureCount: 0,
+            Math.Max(persisted.LastFailureUtcTicks, desired.LastFailureUtcTicks),
+            merged.LastSuccessUtcTicks);
+
+        merged.FailureStreakEvents = mergedEvents;
+        if (BackgroundSchedulerFailureEventsAreComplete(persisted)
+            && BackgroundSchedulerFailureEventsAreComplete(baseline)
+            && BackgroundSchedulerFailureEventsAreComplete(desired)) {
+            merged.ConsecutiveFailureCount = mergedEvents.Length;
+            return;
+        }
+
+        MergeOverflowedBackgroundSchedulerConsecutiveFailureState(
+            merged,
+            persisted,
+            baseline,
+            desired);
+    }
+
+    private static bool BackgroundSchedulerFailureEventsAreComplete(BackgroundSchedulerRuntimeStoreDto store) =>
+        Math.Max(0, store.ConsecutiveFailureCount) <= MaxBackgroundSchedulerFailureStreakEvents
+        && Math.Max(0, store.ConsecutiveFailureCount) == store.FailureStreakEvents.Length;
+
+    private static void MergeOverflowedBackgroundSchedulerConsecutiveFailureState(
+        BackgroundSchedulerRuntimeStoreDto merged,
+        BackgroundSchedulerRuntimeStoreDto persisted,
+        BackgroundSchedulerRuntimeStoreDto baseline,
+        BackgroundSchedulerRuntimeStoreDto desired) {
+        var localSuccessChanged = desired.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks;
+        var persistedSuccessChanged = persisted.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks;
+        if (!localSuccessChanged && !persistedSuccessChanged) {
+            merged.ConsecutiveFailureCount = AddBackgroundSchedulerCounterDelta(
+                persisted.ConsecutiveFailureCount,
+                baseline.ConsecutiveFailureCount,
+                desired.ConsecutiveFailureCount);
+            return;
+        }
+
+        var latestSuccessIsLocal = localSuccessChanged
+            && (!persistedSuccessChanged || desired.LastSuccessUtcTicks >= persisted.LastSuccessUtcTicks);
+        var resetWriter = latestSuccessIsLocal ? desired : persisted;
+        var otherWriter = latestSuccessIsLocal ? persisted : desired;
+        var postResetCount = Math.Max(0, resetWriter.ConsecutiveFailureCount);
+        if (otherWriter.LastFailureUtcTicks > resetWriter.LastSuccessUtcTicks) {
+            postResetCount = AddBackgroundSchedulerCounterDelta(
+                postResetCount,
+                0,
+                Math.Max(0, otherWriter.ConsecutiveFailureCount - baseline.ConsecutiveFailureCount));
+        }
+
+        merged.ConsecutiveFailureCount = Math.Max(postResetCount, merged.FailureStreakEvents.Length);
+    }
+
+    private static BackgroundSchedulerFailureEventDto[] NormalizeBackgroundSchedulerFailureEvents(
+        IEnumerable<BackgroundSchedulerFailureEventDto>? failureEvents,
+        int consecutiveFailureCount,
+        long lastFailureUtcTicks,
+        long lastSuccessUtcTicks) {
+        var normalized = (failureEvents ?? Array.Empty<BackgroundSchedulerFailureEventDto>())
+            .Where(static failureEvent => failureEvent is not null)
+            .Select(static failureEvent => new BackgroundSchedulerFailureEventDto {
+                EventId = NormalizeBackgroundSchedulerFailureEventId(failureEvent.EventId),
+                RecordedUtcTicks = Math.Max(0, failureEvent.RecordedUtcTicks)
+            })
+            .Where(failureEvent => failureEvent.EventId.Length > 0
+                && failureEvent.RecordedUtcTicks > Math.Max(0, lastSuccessUtcTicks))
+            .GroupBy(static failureEvent => failureEvent.EventId, StringComparer.Ordinal)
+            .Select(static group => group.OrderByDescending(static failureEvent => failureEvent.RecordedUtcTicks).First())
+            .OrderBy(static failureEvent => failureEvent.RecordedUtcTicks)
+            .ThenBy(static failureEvent => failureEvent.EventId, StringComparer.Ordinal)
+            .TakeLast(MaxBackgroundSchedulerFailureStreakEvents)
+            .ToList();
+
+        var targetCount = lastFailureUtcTicks > lastSuccessUtcTicks
+            ? Math.Min(MaxBackgroundSchedulerFailureStreakEvents, Math.Max(0, consecutiveFailureCount))
+            : 0;
+        if (normalized.Count >= targetCount) {
+            return normalized.ToArray();
+        }
+
+        var existingIds = normalized
+            .Select(static failureEvent => failureEvent.EventId)
+            .ToHashSet(StringComparer.Ordinal);
+        var legacyRecordedUtcTicks = Math.Max(1, lastFailureUtcTicks);
+        for (var index = 0; normalized.Count < targetCount; index++) {
+            var eventId = "legacy-" + index.ToString("D4", CultureInfo.InvariantCulture);
+            if (!existingIds.Add(eventId)) {
+                continue;
+            }
+
+            normalized.Add(new BackgroundSchedulerFailureEventDto {
+                EventId = eventId,
+                RecordedUtcTicks = legacyRecordedUtcTicks
+            });
+        }
+
+        return normalized
+            .OrderBy(static failureEvent => failureEvent.RecordedUtcTicks)
+            .ThenBy(static failureEvent => failureEvent.EventId, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static BackgroundSchedulerFailureEventDto[] CloneBackgroundSchedulerFailureEvents(
+        IEnumerable<BackgroundSchedulerFailureEventDto> failureEvents) =>
+        failureEvents
+            .Select(static failureEvent => new BackgroundSchedulerFailureEventDto {
+                EventId = failureEvent.EventId,
+                RecordedUtcTicks = failureEvent.RecordedUtcTicks
+            })
+            .ToArray();
+
+    private static int ResolveBackgroundSchedulerConsecutiveFailureCount(
+        int consecutiveFailureCount,
+        int failureEventCount) =>
+        Math.Max(0, consecutiveFailureCount) <= MaxBackgroundSchedulerFailureStreakEvents
+            ? Math.Max(0, failureEventCount)
+            : Math.Max(Math.Max(0, consecutiveFailureCount), Math.Max(0, failureEventCount));
+
+    private static string NormalizeBackgroundSchedulerFailureEventId(string? eventId) {
+        var normalized = eventId?.Trim() ?? string.Empty;
+        return normalized.Length <= MaxBackgroundSchedulerFailureEventIdLength
+            ? normalized
+            : normalized[..MaxBackgroundSchedulerFailureEventIdLength];
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
@@ -49,10 +49,6 @@ internal sealed partial class ChatServiceSession {
             _backgroundSchedulerRuntimeStoreLoadState = readResult.LoadState;
         }
 
-        if (readResult.Store is null) {
-            return;
-        }
-
         var nowTicks = DateTime.UtcNow.Ticks;
         var store = readResult.Store;
         BackgroundSchedulerRuntimeStoreDto? deferredPersistStore;
@@ -115,17 +111,27 @@ internal sealed partial class ChatServiceSession {
         }
 
         if (TryPersistBackgroundSchedulerRuntimeStoreSnapshot(path, store)) {
+            var retryPending = false;
             lock (_backgroundSchedulerTelemetryLock) {
                 if (_backgroundSchedulerRuntimeStoreDeferredPersistStore is not null
                     && BackgroundSchedulerRuntimeStoreEquals(_backgroundSchedulerRuntimeStoreDeferredPersistStore, deferredPersistStore)) {
                     _backgroundSchedulerRuntimeStoreDeferredPersistStore = null;
                 }
+                retryPending = _backgroundSchedulerRuntimeStoreDeferredPersistStore is not null;
+                _backgroundSchedulerRuntimeStoreLoadState = retryPending
+                    ? BackgroundSchedulerRuntimeStoreLoadStateDeferred
+                    : BackgroundSchedulerRuntimeStoreLoadStateLoaded;
+            }
+            if (retryPending) {
+                Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 1);
             }
             return;
         }
 
+        Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 1);
         lock (_backgroundSchedulerTelemetryLock) {
             _backgroundSchedulerRuntimeStoreDeferredPersistStore = store;
+            _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateDeferred;
         }
     }
 
@@ -147,9 +153,36 @@ internal sealed partial class ChatServiceSession {
             return;
         }
 
-        _ = TryPersistBackgroundSchedulerRuntimeStoreSnapshot(
+        BackgroundSchedulerRuntimeStoreDto? deferredBeforePersist;
+        lock (_backgroundSchedulerTelemetryLock) {
+            deferredBeforePersist = _backgroundSchedulerRuntimeStoreDeferredPersistStore;
+        }
+
+        var persisted = TryPersistBackgroundSchedulerRuntimeStoreSnapshot(
             ResolveBackgroundSchedulerRuntimeStorePath(),
             store);
+        if (!persisted) {
+            Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 1);
+        }
+        var retryPending = false;
+        lock (_backgroundSchedulerTelemetryLock) {
+            if (!persisted) {
+                _backgroundSchedulerRuntimeStoreDeferredPersistStore = store;
+                _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateDeferred;
+            } else if (deferredBeforePersist is not null
+                && _backgroundSchedulerRuntimeStoreDeferredPersistStore is not null
+                && BackgroundSchedulerRuntimeStoreEquals(_backgroundSchedulerRuntimeStoreDeferredPersistStore, deferredBeforePersist)) {
+                _backgroundSchedulerRuntimeStoreDeferredPersistStore = null;
+            }
+
+            if (persisted && _backgroundSchedulerRuntimeStoreDeferredPersistStore is not null) {
+                retryPending = true;
+                _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateDeferred;
+            }
+        }
+        if (retryPending) {
+            Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 1);
+        }
     }
 
     private BackgroundSchedulerRuntimeStoreDto CaptureBackgroundSchedulerRuntimeStoreSnapshot() {
@@ -185,14 +218,12 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static bool TryPersistBackgroundSchedulerRuntimeStoreSnapshot(string path, BackgroundSchedulerRuntimeStoreDto store) {
-        return TryWithBackgroundSchedulerRuntimeStoreLock(
+        var lockAcquired = TryWithBackgroundSchedulerRuntimeStoreLock(
             path,
-            static state => {
-                WriteBackgroundSchedulerRuntimeStoreNoThrow(state.Path, state.Store);
-                return true;
-            },
+            static state => WriteBackgroundSchedulerRuntimeStoreNoThrow(state.Path, state.Store),
             (Path: path, Store: store),
-            out _);
+            out var persisted);
+        return lockAcquired && persisted;
     }
 
     private static BackgroundSchedulerRuntimeStoreDto MergeBackgroundSchedulerRuntimeStore(
@@ -356,8 +387,8 @@ internal sealed partial class ChatServiceSession {
         };
     }
 
-    private static void WriteBackgroundSchedulerRuntimeStoreNoThrow(string path, BackgroundSchedulerRuntimeStoreDto store) {
-        ChatServiceJsonFileStore.Write(
+    private static bool WriteBackgroundSchedulerRuntimeStoreNoThrow(string path, BackgroundSchedulerRuntimeStoreDto store) {
+        return ChatServiceJsonFileStore.Write(
             path,
             store,
             static value => JsonSerializer.Serialize(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
@@ -23,6 +23,7 @@ internal sealed partial class ChatServiceSession {
     private int _backgroundSchedulerRuntimeStoreRehydratePending;
     private string _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateEmpty;
     private BackgroundSchedulerRuntimeStoreDto? _backgroundSchedulerRuntimeStoreDeferredPersistStore;
+    private bool _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute;
 
     private static string ResolveDefaultBackgroundSchedulerRuntimeStorePath() =>
         ChatServiceJsonFileStore.ResolveDefaultPath("background-scheduler-runtime.json");
@@ -52,12 +53,16 @@ internal sealed partial class ChatServiceSession {
         var nowTicks = DateTime.UtcNow.Ticks;
         var store = readResult.Store;
         BackgroundSchedulerRuntimeStoreDto? deferredPersistStore;
+        bool deferredPersistIsAbsolute;
         lock (_backgroundSchedulerTelemetryLock) {
             deferredPersistStore = _backgroundSchedulerRuntimeStoreDeferredPersistStore;
+            deferredPersistIsAbsolute = _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute;
         }
 
         if (deferredPersistStore is not null) {
-            store = MergeBackgroundSchedulerRuntimeStore(store, deferredPersistStore);
+            store = deferredPersistIsAbsolute
+                ? CloneBackgroundSchedulerRuntimeStore(deferredPersistStore)
+                : MergeBackgroundSchedulerRuntimeStore(store, deferredPersistStore);
         }
 
         if (store is null) {
@@ -114,8 +119,10 @@ internal sealed partial class ChatServiceSession {
             var retryPending = false;
             lock (_backgroundSchedulerTelemetryLock) {
                 if (_backgroundSchedulerRuntimeStoreDeferredPersistStore is not null
+                    && _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute == deferredPersistIsAbsolute
                     && BackgroundSchedulerRuntimeStoreEquals(_backgroundSchedulerRuntimeStoreDeferredPersistStore, deferredPersistStore)) {
                     _backgroundSchedulerRuntimeStoreDeferredPersistStore = null;
+                    _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute = false;
                 }
                 retryPending = _backgroundSchedulerRuntimeStoreDeferredPersistStore is not null;
                 _backgroundSchedulerRuntimeStoreLoadState = retryPending
@@ -131,6 +138,7 @@ internal sealed partial class ChatServiceSession {
         Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 1);
         lock (_backgroundSchedulerTelemetryLock) {
             _backgroundSchedulerRuntimeStoreDeferredPersistStore = store;
+            _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute = true;
             _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateDeferred;
         }
     }
@@ -148,14 +156,19 @@ internal sealed partial class ChatServiceSession {
         var store = CaptureBackgroundSchedulerRuntimeStoreSnapshot();
         if (Volatile.Read(ref _backgroundSchedulerRuntimeStoreRehydratePending) != 0) {
             lock (_backgroundSchedulerTelemetryLock) {
+                var preserveAbsoluteSemantics = _backgroundSchedulerRuntimeStoreDeferredPersistStore is not null
+                    && _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute;
                 _backgroundSchedulerRuntimeStoreDeferredPersistStore = store;
+                _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute = preserveAbsoluteSemantics;
             }
             return;
         }
 
         BackgroundSchedulerRuntimeStoreDto? deferredBeforePersist;
+        bool deferredBeforePersistIsAbsolute;
         lock (_backgroundSchedulerTelemetryLock) {
             deferredBeforePersist = _backgroundSchedulerRuntimeStoreDeferredPersistStore;
+            deferredBeforePersistIsAbsolute = _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute;
         }
 
         var persisted = TryPersistBackgroundSchedulerRuntimeStoreSnapshot(
@@ -168,11 +181,14 @@ internal sealed partial class ChatServiceSession {
         lock (_backgroundSchedulerTelemetryLock) {
             if (!persisted) {
                 _backgroundSchedulerRuntimeStoreDeferredPersistStore = store;
+                _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute = true;
                 _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateDeferred;
             } else if (deferredBeforePersist is not null
                 && _backgroundSchedulerRuntimeStoreDeferredPersistStore is not null
+                && _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute == deferredBeforePersistIsAbsolute
                 && BackgroundSchedulerRuntimeStoreEquals(_backgroundSchedulerRuntimeStoreDeferredPersistStore, deferredBeforePersist)) {
                 _backgroundSchedulerRuntimeStoreDeferredPersistStore = null;
+                _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute = false;
             }
 
             if (persisted && _backgroundSchedulerRuntimeStoreDeferredPersistStore is not null) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
@@ -20,10 +20,12 @@ internal sealed partial class ChatServiceSession {
         WriteIndented = false
     };
     private static Func<string, bool?>? BackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting;
+    private readonly object _backgroundSchedulerRuntimeStorePersistenceLock = new();
     private int _backgroundSchedulerRuntimeStoreRehydratePending;
     private string _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateEmpty;
+    private BackgroundSchedulerRuntimeStoreDto _backgroundSchedulerRuntimeStoreLocalBaseline = new();
     private BackgroundSchedulerRuntimeStoreDto? _backgroundSchedulerRuntimeStoreDeferredPersistStore;
-    private bool _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute;
+    private BackgroundSchedulerRuntimeStoreDto? _backgroundSchedulerRuntimeStoreDeferredPersistBaseline;
 
     private static string ResolveDefaultBackgroundSchedulerRuntimeStorePath() =>
         ChatServiceJsonFileStore.ResolveDefaultPath("background-scheduler-runtime.json");
@@ -32,7 +34,33 @@ internal sealed partial class ChatServiceSession {
         ChatServiceJsonFileStore.ResolveSiblingPath(ResolvePendingActionsStorePath(), "background-scheduler-runtime.json");
 
     private void TryRehydrateBackgroundSchedulerRuntimeState() {
+        lock (_backgroundSchedulerRuntimeStorePersistenceLock) {
+            TryRehydrateBackgroundSchedulerRuntimeStateCore();
+        }
+    }
+
+    private void TryRehydrateBackgroundSchedulerRuntimeStateCore() {
         var path = ResolveBackgroundSchedulerRuntimeStorePath();
+        BackgroundSchedulerRuntimeStoreDto? deferredPersistStore;
+        BackgroundSchedulerRuntimeStoreDto? deferredPersistBaseline;
+        lock (_backgroundSchedulerTelemetryLock) {
+            deferredPersistStore = _backgroundSchedulerRuntimeStoreDeferredPersistStore is null
+                ? null
+                : CloneBackgroundSchedulerRuntimeStore(_backgroundSchedulerRuntimeStoreDeferredPersistStore);
+            deferredPersistBaseline = _backgroundSchedulerRuntimeStoreDeferredPersistBaseline is null
+                ? null
+                : CloneBackgroundSchedulerRuntimeStore(_backgroundSchedulerRuntimeStoreDeferredPersistBaseline);
+        }
+
+        if (deferredPersistStore is not null) {
+            TryPersistDeferredBackgroundSchedulerRuntimeState(
+                path,
+                deferredPersistBaseline ?? new BackgroundSchedulerRuntimeStoreDto(),
+                deferredPersistStore);
+            return;
+        }
+
+        var localBeforeRead = CaptureBackgroundSchedulerRuntimeStoreSnapshot();
         if (!TryWithBackgroundSchedulerRuntimeStoreLock(
                 path,
                 static runtimeStorePath => ReadBackgroundSchedulerRuntimeStoreNoThrow(runtimeStorePath),
@@ -45,50 +73,61 @@ internal sealed partial class ChatServiceSession {
             return;
         }
 
-        Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 0);
-        lock (_backgroundSchedulerTelemetryLock) {
-            _backgroundSchedulerRuntimeStoreLoadState = readResult.LoadState;
-        }
-
-        var nowTicks = DateTime.UtcNow.Ticks;
-        var store = readResult.Store;
-        BackgroundSchedulerRuntimeStoreDto? deferredPersistStore;
-        bool deferredPersistIsAbsolute;
-        lock (_backgroundSchedulerTelemetryLock) {
-            deferredPersistStore = _backgroundSchedulerRuntimeStoreDeferredPersistStore;
-            deferredPersistIsAbsolute = _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute;
-        }
-
-        if (deferredPersistStore is not null) {
-            store = deferredPersistIsAbsolute
-                ? CloneBackgroundSchedulerRuntimeStore(deferredPersistStore)
-                : MergeBackgroundSchedulerRuntimeStore(store, deferredPersistStore);
-        }
-
-        if (store is null) {
+        var store = readResult.Store is null
+            ? new BackgroundSchedulerRuntimeStoreDto()
+            : CloneBackgroundSchedulerRuntimeStore(readResult.Store);
+        NormalizeBackgroundSchedulerRuntimeStoreForPersistence(store, DateTime.UtcNow.Ticks);
+        if (!TryApplyBackgroundSchedulerRuntimeStoreIfUnchanged(localBeforeRead, store)) {
+            DeferBackgroundSchedulerRuntimeStoreSnapshot(
+                CaptureBackgroundSchedulerRuntimeStoreSnapshot(),
+                localBeforeRead);
             return;
         }
 
+        Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 0);
+        lock (_backgroundSchedulerTelemetryLock) {
+            _backgroundSchedulerRuntimeStoreLocalBaseline = CloneBackgroundSchedulerRuntimeStore(store);
+            _backgroundSchedulerRuntimeStoreLoadState = readResult.LoadState;
+        }
+    }
+
+    private void TryPersistDeferredBackgroundSchedulerRuntimeState(
+        string path,
+        BackgroundSchedulerRuntimeStoreDto baseline,
+        BackgroundSchedulerRuntimeStoreDto deferredStore) {
+        if (!TryPersistBackgroundSchedulerRuntimeStoreSnapshot(path, baseline, deferredStore, out var result)) {
+            DeferBackgroundSchedulerRuntimeStoreSnapshot(
+                CaptureBackgroundSchedulerRuntimeStoreSnapshot(),
+                baseline);
+            return;
+        }
+
+        CompleteBackgroundSchedulerRuntimeStorePersistence(baseline, deferredStore, result);
+    }
+
+    private bool TryApplyBackgroundSchedulerRuntimeStoreIfUnchanged(
+        BackgroundSchedulerRuntimeStoreDto expectedStore,
+        BackgroundSchedulerRuntimeStoreDto store) {
+        lock (_backgroundSchedulerTelemetryLock) {
+            var currentStore = CaptureBackgroundSchedulerRuntimeStoreSnapshot();
+            if (!BackgroundSchedulerRuntimeStoreEquals(currentStore, expectedStore)) {
+                return false;
+            }
+
+            ApplyBackgroundSchedulerRuntimeStore(store);
+            return true;
+        }
+    }
+
+    private void ApplyBackgroundSchedulerRuntimeStore(BackgroundSchedulerRuntimeStoreDto store) {
+        ArgumentNullException.ThrowIfNull(store);
+        var nowTicks = DateTime.UtcNow.Ticks;
         (store.LastAdaptiveIdleUtcTicks, store.LastAdaptiveIdleDelaySeconds, store.LastAdaptiveIdleReason) =
             NormalizeBackgroundSchedulerAdaptiveIdleState(
                 store.LastAdaptiveIdleUtcTicks,
                 store.LastAdaptiveIdleDelaySeconds,
                 store.LastAdaptiveIdleReason,
                 nowTicks);
-
-        if (string.IsNullOrWhiteSpace(store.LastOutcome)
-            && store.LastOutcomeUtcTicks <= 0
-            && store.LastSuccessUtcTicks <= 0
-            && store.LastFailureUtcTicks <= 0
-            && store.CompletedExecutionCount <= 0
-            && store.RequeuedExecutionCount <= 0
-            && store.ReleasedExecutionCount <= 0
-            && store.ConsecutiveFailureCount <= 0
-            && store.PausedUntilUtcTicks <= 0
-            && store.LastAdaptiveIdleUtcTicks <= 0
-            && (store.RecentActivity?.Length ?? 0) == 0) {
-            return;
-        }
 
         var normalizedRecentActivity = NormalizeBackgroundSchedulerActivities(store.RecentActivity);
         lock (_backgroundSchedulerTelemetryLock) {
@@ -110,37 +149,6 @@ internal sealed partial class ChatServiceSession {
             _backgroundSchedulerRecentActivity.AddRange(normalizedRecentActivity);
             NormalizeBackgroundSchedulerPauseStateNoLock(DateTime.UtcNow.Ticks);
         }
-
-        if (deferredPersistStore is null) {
-            return;
-        }
-
-        if (TryPersistBackgroundSchedulerRuntimeStoreSnapshot(path, store)) {
-            var retryPending = false;
-            lock (_backgroundSchedulerTelemetryLock) {
-                if (_backgroundSchedulerRuntimeStoreDeferredPersistStore is not null
-                    && _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute == deferredPersistIsAbsolute
-                    && BackgroundSchedulerRuntimeStoreEquals(_backgroundSchedulerRuntimeStoreDeferredPersistStore, deferredPersistStore)) {
-                    _backgroundSchedulerRuntimeStoreDeferredPersistStore = null;
-                    _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute = false;
-                }
-                retryPending = _backgroundSchedulerRuntimeStoreDeferredPersistStore is not null;
-                _backgroundSchedulerRuntimeStoreLoadState = retryPending
-                    ? BackgroundSchedulerRuntimeStoreLoadStateDeferred
-                    : BackgroundSchedulerRuntimeStoreLoadStateLoaded;
-            }
-            if (retryPending) {
-                Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 1);
-            }
-            return;
-        }
-
-        Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 1);
-        lock (_backgroundSchedulerTelemetryLock) {
-            _backgroundSchedulerRuntimeStoreDeferredPersistStore = store;
-            _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute = true;
-            _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateDeferred;
-        }
     }
 
     private void EnsureBackgroundSchedulerRuntimeStateRehydratedIfPending() {
@@ -152,52 +160,85 @@ internal sealed partial class ChatServiceSession {
     }
 
     private void PersistBackgroundSchedulerRuntimeStateNoThrow() {
-        EnsureBackgroundSchedulerRuntimeStateRehydratedIfPending();
-        var store = CaptureBackgroundSchedulerRuntimeStoreSnapshot();
-        if (Volatile.Read(ref _backgroundSchedulerRuntimeStoreRehydratePending) != 0) {
+        lock (_backgroundSchedulerRuntimeStorePersistenceLock) {
+            var store = CaptureBackgroundSchedulerRuntimeStoreSnapshot();
+            if (Volatile.Read(ref _backgroundSchedulerRuntimeStoreRehydratePending) != 0) {
+                BackgroundSchedulerRuntimeStoreDto baseline;
+                lock (_backgroundSchedulerTelemetryLock) {
+                    baseline = CloneBackgroundSchedulerRuntimeStore(
+                        _backgroundSchedulerRuntimeStoreDeferredPersistBaseline
+                        ?? _backgroundSchedulerRuntimeStoreLocalBaseline);
+                    _backgroundSchedulerRuntimeStoreDeferredPersistStore = CloneBackgroundSchedulerRuntimeStore(store);
+                    _backgroundSchedulerRuntimeStoreDeferredPersistBaseline ??= CloneBackgroundSchedulerRuntimeStore(baseline);
+                }
+                TryRehydrateBackgroundSchedulerRuntimeStateCore();
+                return;
+            }
+
+            BackgroundSchedulerRuntimeStoreDto localBaseline;
             lock (_backgroundSchedulerTelemetryLock) {
-                var preserveAbsoluteSemantics = _backgroundSchedulerRuntimeStoreDeferredPersistStore is not null
-                    && _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute;
-                _backgroundSchedulerRuntimeStoreDeferredPersistStore = store;
-                _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute = preserveAbsoluteSemantics;
+                localBaseline = CloneBackgroundSchedulerRuntimeStore(_backgroundSchedulerRuntimeStoreLocalBaseline);
+            }
+
+            if (!TryPersistBackgroundSchedulerRuntimeStoreSnapshot(
+                    ResolveBackgroundSchedulerRuntimeStorePath(),
+                    localBaseline,
+                    store,
+                    out var result)) {
+                DeferBackgroundSchedulerRuntimeStoreSnapshot(
+                    CaptureBackgroundSchedulerRuntimeStoreSnapshot(),
+                    localBaseline);
+                return;
+            }
+
+            CompleteBackgroundSchedulerRuntimeStorePersistence(localBaseline, store, result);
+        }
+    }
+
+    private void CompleteBackgroundSchedulerRuntimeStorePersistence(
+        BackgroundSchedulerRuntimeStoreDto baseline,
+        BackgroundSchedulerRuntimeStoreDto attemptedStore,
+        BackgroundSchedulerRuntimeStorePersistResult result) {
+        var appliedMergedStore = TryApplyBackgroundSchedulerRuntimeStoreIfUnchanged(
+            attemptedStore,
+            result.MergedStore);
+        if (result.Persisted && appliedMergedStore) {
+            Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 0);
+            lock (_backgroundSchedulerTelemetryLock) {
+                _backgroundSchedulerRuntimeStoreLocalBaseline = CloneBackgroundSchedulerRuntimeStore(result.MergedStore);
+                _backgroundSchedulerRuntimeStoreDeferredPersistStore = null;
+                _backgroundSchedulerRuntimeStoreDeferredPersistBaseline = null;
+                _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateLoaded;
             }
             return;
         }
 
-        BackgroundSchedulerRuntimeStoreDto? deferredBeforePersist;
-        bool deferredBeforePersistIsAbsolute;
-        lock (_backgroundSchedulerTelemetryLock) {
-            deferredBeforePersist = _backgroundSchedulerRuntimeStoreDeferredPersistStore;
-            deferredBeforePersistIsAbsolute = _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute;
+        if (result.Persisted) {
+            DeferBackgroundSchedulerRuntimeStoreSnapshot(
+                CaptureBackgroundSchedulerRuntimeStoreSnapshot(),
+                attemptedStore);
+            return;
         }
 
-        var persisted = TryPersistBackgroundSchedulerRuntimeStoreSnapshot(
-            ResolveBackgroundSchedulerRuntimeStorePath(),
-            store);
-        if (!persisted) {
-            Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 1);
+        if (appliedMergedStore) {
+            DeferBackgroundSchedulerRuntimeStoreSnapshot(result.MergedStore, result.PersistedStore);
+            return;
         }
-        var retryPending = false;
-        lock (_backgroundSchedulerTelemetryLock) {
-            if (!persisted) {
-                _backgroundSchedulerRuntimeStoreDeferredPersistStore = store;
-                _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute = true;
-                _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateDeferred;
-            } else if (deferredBeforePersist is not null
-                && _backgroundSchedulerRuntimeStoreDeferredPersistStore is not null
-                && _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute == deferredBeforePersistIsAbsolute
-                && BackgroundSchedulerRuntimeStoreEquals(_backgroundSchedulerRuntimeStoreDeferredPersistStore, deferredBeforePersist)) {
-                _backgroundSchedulerRuntimeStoreDeferredPersistStore = null;
-                _backgroundSchedulerRuntimeStoreDeferredPersistIsAbsolute = false;
-            }
 
-            if (persisted && _backgroundSchedulerRuntimeStoreDeferredPersistStore is not null) {
-                retryPending = true;
-                _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateDeferred;
-            }
-        }
-        if (retryPending) {
-            Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 1);
+        DeferBackgroundSchedulerRuntimeStoreSnapshot(
+            CaptureBackgroundSchedulerRuntimeStoreSnapshot(),
+            baseline);
+    }
+
+    private void DeferBackgroundSchedulerRuntimeStoreSnapshot(
+        BackgroundSchedulerRuntimeStoreDto store,
+        BackgroundSchedulerRuntimeStoreDto baseline) {
+        Interlocked.Exchange(ref _backgroundSchedulerRuntimeStoreRehydratePending, 1);
+        lock (_backgroundSchedulerTelemetryLock) {
+            _backgroundSchedulerRuntimeStoreLocalBaseline = CloneBackgroundSchedulerRuntimeStore(baseline);
+            _backgroundSchedulerRuntimeStoreDeferredPersistStore = CloneBackgroundSchedulerRuntimeStore(store);
+            _backgroundSchedulerRuntimeStoreDeferredPersistBaseline = CloneBackgroundSchedulerRuntimeStore(baseline);
+            _backgroundSchedulerRuntimeStoreLoadState = BackgroundSchedulerRuntimeStoreLoadStateDeferred;
         }
     }
 
@@ -233,71 +274,203 @@ internal sealed partial class ChatServiceSession {
         }
     }
 
-    private static bool TryPersistBackgroundSchedulerRuntimeStoreSnapshot(string path, BackgroundSchedulerRuntimeStoreDto store) {
-        var lockAcquired = TryWithBackgroundSchedulerRuntimeStoreLock(
+    private static bool TryPersistBackgroundSchedulerRuntimeStoreSnapshot(
+        string path,
+        BackgroundSchedulerRuntimeStoreDto baseline,
+        BackgroundSchedulerRuntimeStoreDto store,
+        out BackgroundSchedulerRuntimeStorePersistResult result) {
+        return TryWithBackgroundSchedulerRuntimeStoreLock(
             path,
-            static state => WriteBackgroundSchedulerRuntimeStoreNoThrow(state.Path, state.Store),
-            (Path: path, Store: store),
-            out var persisted);
-        return lockAcquired && persisted;
+            static state => {
+                var readResult = ReadBackgroundSchedulerRuntimeStoreNoThrow(state.Path);
+                var persistedStore = readResult.Store is null
+                    ? new BackgroundSchedulerRuntimeStoreDto()
+                    : CloneBackgroundSchedulerRuntimeStore(readResult.Store);
+                var mergedStore = MergeBackgroundSchedulerRuntimeStore(
+                    persistedStore,
+                    state.Baseline,
+                    state.Store);
+                NormalizeBackgroundSchedulerRuntimeStoreForPersistence(mergedStore, DateTime.UtcNow.Ticks);
+                var persisted = WriteBackgroundSchedulerRuntimeStoreNoThrow(state.Path, mergedStore);
+                if (!persisted) {
+                    var verification = ReadBackgroundSchedulerRuntimeStoreNoThrow(state.Path);
+                    persisted = verification.Store is not null
+                        && BackgroundSchedulerRuntimeStoreEquals(verification.Store, mergedStore);
+                }
+                return new BackgroundSchedulerRuntimeStorePersistResult(
+                    persisted,
+                    persistedStore,
+                    mergedStore);
+            },
+            (Path: path, Baseline: baseline, Store: store),
+            out result);
     }
 
     private static BackgroundSchedulerRuntimeStoreDto MergeBackgroundSchedulerRuntimeStore(
         BackgroundSchedulerRuntimeStoreDto? persistedStore,
-        BackgroundSchedulerRuntimeStoreDto deferredStore) {
-        ArgumentNullException.ThrowIfNull(deferredStore);
+        BackgroundSchedulerRuntimeStoreDto? baselineStore,
+        BackgroundSchedulerRuntimeStoreDto desiredStore) {
+        ArgumentNullException.ThrowIfNull(desiredStore);
 
-        if (persistedStore is null) {
-            return CloneBackgroundSchedulerRuntimeStore(deferredStore);
+        var persisted = persistedStore is null
+            ? new BackgroundSchedulerRuntimeStoreDto()
+            : CloneBackgroundSchedulerRuntimeStore(persistedStore);
+        var baseline = baselineStore is null
+            ? new BackgroundSchedulerRuntimeStoreDto()
+            : CloneBackgroundSchedulerRuntimeStore(baselineStore);
+        var desired = CloneBackgroundSchedulerRuntimeStore(desiredStore);
+        var merged = CloneBackgroundSchedulerRuntimeStore(persisted);
+
+        if (desired.LastSchedulerTickUtcTicks != baseline.LastSchedulerTickUtcTicks) {
+            merged.LastSchedulerTickUtcTicks = Math.Max(merged.LastSchedulerTickUtcTicks, desired.LastSchedulerTickUtcTicks);
         }
 
-        var merged = CloneBackgroundSchedulerRuntimeStore(persistedStore);
-        merged.LastSchedulerTickUtcTicks = Math.Max(merged.LastSchedulerTickUtcTicks, deferredStore.LastSchedulerTickUtcTicks);
-        if (deferredStore.LastOutcomeUtcTicks >= merged.LastOutcomeUtcTicks && deferredStore.LastOutcomeUtcTicks > 0) {
-            merged.LastOutcomeUtcTicks = deferredStore.LastOutcomeUtcTicks;
-            merged.LastOutcome = NormalizeBackgroundSchedulerActivityText(deferredStore.LastOutcome, maxLength: 80);
+        if (BackgroundSchedulerOutcomeStateChanged(baseline, desired)
+            && (BackgroundSchedulerOutcomeStateEquals(persisted, baseline)
+                || desired.LastOutcomeUtcTicks >= persisted.LastOutcomeUtcTicks)) {
+            merged.LastOutcomeUtcTicks = Math.Max(0, desired.LastOutcomeUtcTicks);
+            merged.LastOutcome = NormalizeBackgroundSchedulerActivityText(desired.LastOutcome, maxLength: 80);
         }
 
-        merged.LastSuccessUtcTicks = Math.Max(merged.LastSuccessUtcTicks, deferredStore.LastSuccessUtcTicks);
-        merged.LastFailureUtcTicks = Math.Max(merged.LastFailureUtcTicks, deferredStore.LastFailureUtcTicks);
-        merged.CompletedExecutionCount = Math.Max(0, merged.CompletedExecutionCount) + Math.Max(0, deferredStore.CompletedExecutionCount);
-        merged.RequeuedExecutionCount = Math.Max(0, merged.RequeuedExecutionCount) + Math.Max(0, deferredStore.RequeuedExecutionCount);
-        merged.ReleasedExecutionCount = Math.Max(0, merged.ReleasedExecutionCount) + Math.Max(0, deferredStore.ReleasedExecutionCount);
-
-        if (deferredStore.LastSuccessUtcTicks > persistedStore.LastSuccessUtcTicks) {
-            merged.ConsecutiveFailureCount = Math.Max(0, deferredStore.ConsecutiveFailureCount);
-        } else if (deferredStore.LastFailureUtcTicks > persistedStore.LastFailureUtcTicks
-            && deferredStore.ConsecutiveFailureCount > 0) {
-            merged.ConsecutiveFailureCount = Math.Max(0, merged.ConsecutiveFailureCount) + Math.Max(0, deferredStore.ConsecutiveFailureCount);
+        if (desired.LastSuccessUtcTicks != baseline.LastSuccessUtcTicks) {
+            merged.LastSuccessUtcTicks = Math.Max(merged.LastSuccessUtcTicks, desired.LastSuccessUtcTicks);
+        }
+        if (desired.LastFailureUtcTicks != baseline.LastFailureUtcTicks) {
+            merged.LastFailureUtcTicks = Math.Max(merged.LastFailureUtcTicks, desired.LastFailureUtcTicks);
         }
 
-        if (deferredStore.LastOutcomeUtcTicks > 0
-            && deferredStore.PausedUntilUtcTicks <= 0
-            && string.IsNullOrWhiteSpace(deferredStore.PauseReason)) {
-            merged.PausedUntilUtcTicks = 0;
-            merged.PauseReason = string.Empty;
-        } else if (deferredStore.PausedUntilUtcTicks > 0 || !string.IsNullOrWhiteSpace(deferredStore.PauseReason)) {
-            merged.PausedUntilUtcTicks = Math.Max(0, deferredStore.PausedUntilUtcTicks);
-            merged.PauseReason = NormalizeBackgroundSchedulerActivityText(deferredStore.PauseReason, maxLength: 120);
+        merged.CompletedExecutionCount = AddBackgroundSchedulerCounterDelta(
+            persisted.CompletedExecutionCount,
+            baseline.CompletedExecutionCount,
+            desired.CompletedExecutionCount);
+        merged.RequeuedExecutionCount = AddBackgroundSchedulerCounterDelta(
+            persisted.RequeuedExecutionCount,
+            baseline.RequeuedExecutionCount,
+            desired.RequeuedExecutionCount);
+        merged.ReleasedExecutionCount = AddBackgroundSchedulerCounterDelta(
+            persisted.ReleasedExecutionCount,
+            baseline.ReleasedExecutionCount,
+            desired.ReleasedExecutionCount);
+
+        MergeBackgroundSchedulerConsecutiveFailureState(merged, persisted, baseline, desired);
+
+        if (BackgroundSchedulerPauseStateChanged(baseline, desired)
+            && (BackgroundSchedulerPauseStateEquals(persisted, baseline)
+                || desired.LastOutcomeUtcTicks >= persisted.LastOutcomeUtcTicks)) {
+            merged.PausedUntilUtcTicks = Math.Max(0, desired.PausedUntilUtcTicks);
+            merged.PauseReason = NormalizeBackgroundSchedulerActivityText(desired.PauseReason, maxLength: 120);
         }
 
-        if (deferredStore.LastOutcomeUtcTicks > 0
-            && deferredStore.LastAdaptiveIdleUtcTicks <= 0
-            && deferredStore.LastAdaptiveIdleDelaySeconds <= 0
-            && string.IsNullOrWhiteSpace(deferredStore.LastAdaptiveIdleReason)) {
-            merged.LastAdaptiveIdleUtcTicks = 0;
-            merged.LastAdaptiveIdleDelaySeconds = 0;
-            merged.LastAdaptiveIdleReason = string.Empty;
-        } else if (deferredStore.LastAdaptiveIdleUtcTicks > 0
-            || deferredStore.LastAdaptiveIdleDelaySeconds > 0
-            || !string.IsNullOrWhiteSpace(deferredStore.LastAdaptiveIdleReason)) {
-            merged.LastAdaptiveIdleUtcTicks = Math.Max(0, deferredStore.LastAdaptiveIdleUtcTicks);
-            merged.LastAdaptiveIdleDelaySeconds = Math.Max(0, deferredStore.LastAdaptiveIdleDelaySeconds);
-            merged.LastAdaptiveIdleReason = NormalizeBackgroundSchedulerActivityText(deferredStore.LastAdaptiveIdleReason, maxLength: 160);
+        if (BackgroundSchedulerAdaptiveIdleStateChanged(baseline, desired)
+            && (BackgroundSchedulerAdaptiveIdleStateEquals(persisted, baseline)
+                || desired.LastAdaptiveIdleUtcTicks >= persisted.LastAdaptiveIdleUtcTicks)) {
+            merged.LastAdaptiveIdleUtcTicks = Math.Max(0, desired.LastAdaptiveIdleUtcTicks);
+            merged.LastAdaptiveIdleDelaySeconds = Math.Max(0, desired.LastAdaptiveIdleDelaySeconds);
+            merged.LastAdaptiveIdleReason = NormalizeBackgroundSchedulerActivityText(desired.LastAdaptiveIdleReason, maxLength: 160);
         }
 
-        merged.RecentActivity = MergeBackgroundSchedulerActivities(merged.RecentActivity, deferredStore.RecentActivity);
+        merged.RecentActivity = MergeBackgroundSchedulerActivities(
+            persisted.RecentActivity,
+            GetBackgroundSchedulerActivityDelta(baseline.RecentActivity, desired.RecentActivity));
         return merged;
+    }
+
+    private static int AddBackgroundSchedulerCounterDelta(int persisted, int baseline, int desired) {
+        var delta = Math.Max(0L, (long)Math.Max(0, desired) - Math.Max(0, baseline));
+        return (int)Math.Min(int.MaxValue, Math.Max(0L, persisted) + delta);
+    }
+
+    private static void MergeBackgroundSchedulerConsecutiveFailureState(
+        BackgroundSchedulerRuntimeStoreDto merged,
+        BackgroundSchedulerRuntimeStoreDto persisted,
+        BackgroundSchedulerRuntimeStoreDto baseline,
+        BackgroundSchedulerRuntimeStoreDto desired) {
+        var localSuccessChanged = desired.LastSuccessUtcTicks != baseline.LastSuccessUtcTicks;
+        var localFailureChanged = desired.LastFailureUtcTicks != baseline.LastFailureUtcTicks;
+        if (!localSuccessChanged && !localFailureChanged
+            && desired.ConsecutiveFailureCount == baseline.ConsecutiveFailureCount) {
+            return;
+        }
+
+        var localLatestEvent = Math.Max(desired.LastSuccessUtcTicks, desired.LastFailureUtcTicks);
+        var persistedLatestEvent = Math.Max(persisted.LastSuccessUtcTicks, persisted.LastFailureUtcTicks);
+        if (localLatestEvent < persistedLatestEvent) {
+            return;
+        }
+
+        if (desired.LastSuccessUtcTicks >= desired.LastFailureUtcTicks
+            || desired.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks) {
+            merged.ConsecutiveFailureCount = Math.Max(0, desired.ConsecutiveFailureCount);
+            return;
+        }
+
+        var failureDelta = Math.Max(
+            0,
+            Math.Max(0, desired.ConsecutiveFailureCount) - Math.Max(0, baseline.ConsecutiveFailureCount));
+        merged.ConsecutiveFailureCount = (int)Math.Min(
+            int.MaxValue,
+            (long)Math.Max(0, persisted.ConsecutiveFailureCount) + failureDelta);
+    }
+
+    private static bool BackgroundSchedulerOutcomeStateChanged(
+        BackgroundSchedulerRuntimeStoreDto baseline,
+        BackgroundSchedulerRuntimeStoreDto desired) =>
+        !BackgroundSchedulerOutcomeStateEquals(baseline, desired);
+
+    private static bool BackgroundSchedulerOutcomeStateEquals(
+        BackgroundSchedulerRuntimeStoreDto left,
+        BackgroundSchedulerRuntimeStoreDto right) =>
+        left.LastOutcomeUtcTicks == right.LastOutcomeUtcTicks
+        && string.Equals(left.LastOutcome, right.LastOutcome, StringComparison.Ordinal);
+
+    private static bool BackgroundSchedulerPauseStateChanged(
+        BackgroundSchedulerRuntimeStoreDto baseline,
+        BackgroundSchedulerRuntimeStoreDto desired) =>
+        !BackgroundSchedulerPauseStateEquals(baseline, desired);
+
+    private static bool BackgroundSchedulerPauseStateEquals(
+        BackgroundSchedulerRuntimeStoreDto left,
+        BackgroundSchedulerRuntimeStoreDto right) =>
+        left.PausedUntilUtcTicks == right.PausedUntilUtcTicks
+        && string.Equals(left.PauseReason, right.PauseReason, StringComparison.Ordinal);
+
+    private static bool BackgroundSchedulerAdaptiveIdleStateChanged(
+        BackgroundSchedulerRuntimeStoreDto baseline,
+        BackgroundSchedulerRuntimeStoreDto desired) =>
+        !BackgroundSchedulerAdaptiveIdleStateEquals(baseline, desired);
+
+    private static bool BackgroundSchedulerAdaptiveIdleStateEquals(
+        BackgroundSchedulerRuntimeStoreDto left,
+        BackgroundSchedulerRuntimeStoreDto right) =>
+        left.LastAdaptiveIdleUtcTicks == right.LastAdaptiveIdleUtcTicks
+        && left.LastAdaptiveIdleDelaySeconds == right.LastAdaptiveIdleDelaySeconds
+        && string.Equals(left.LastAdaptiveIdleReason, right.LastAdaptiveIdleReason, StringComparison.Ordinal);
+
+    private static SessionCapabilityBackgroundSchedulerActivityDto[] GetBackgroundSchedulerActivityDelta(
+        IReadOnlyList<SessionCapabilityBackgroundSchedulerActivityDto>? baselineActivities,
+        IReadOnlyList<SessionCapabilityBackgroundSchedulerActivityDto>? desiredActivities) {
+        var baselineKeys = (baselineActivities ?? Array.Empty<SessionCapabilityBackgroundSchedulerActivityDto>())
+            .Select(static activity => (
+                activity.RecordedUtcTicks,
+                activity.Outcome,
+                activity.ThreadId,
+                activity.ItemId,
+                activity.ToolName,
+                activity.Reason,
+                activity.OutputCount,
+                activity.FailureDetail))
+            .ToHashSet();
+        return NormalizeBackgroundSchedulerActivities(
+            (desiredActivities ?? Array.Empty<SessionCapabilityBackgroundSchedulerActivityDto>())
+            .Where(activity => !baselineKeys.Contains((
+                activity.RecordedUtcTicks,
+                activity.Outcome,
+                activity.ThreadId,
+                activity.ItemId,
+                activity.ToolName,
+                activity.Reason,
+                activity.OutputCount,
+                activity.FailureDetail))));
     }
 
     private static SessionCapabilityBackgroundSchedulerActivityDto[] MergeBackgroundSchedulerActivities(
@@ -316,7 +489,26 @@ internal sealed partial class ChatServiceSession {
                     activity.Reason,
                     activity.OutputCount,
                     activity.FailureDetail))
-            .Select(static group => group.First()));
+            .Select(static group => group.First())
+            .OrderByDescending(static activity => activity.RecordedUtcTicks));
+    }
+
+    private static void NormalizeBackgroundSchedulerRuntimeStoreForPersistence(
+        BackgroundSchedulerRuntimeStoreDto store,
+        long nowTicks) {
+        ArgumentNullException.ThrowIfNull(store);
+        if (store.PausedUntilUtcTicks > 0 && nowTicks > 0 && store.PausedUntilUtcTicks <= nowTicks) {
+            store.PausedUntilUtcTicks = 0;
+            store.PauseReason = string.Empty;
+        }
+
+        (store.LastAdaptiveIdleUtcTicks, store.LastAdaptiveIdleDelaySeconds, store.LastAdaptiveIdleReason) =
+            NormalizeBackgroundSchedulerAdaptiveIdleState(
+                store.LastAdaptiveIdleUtcTicks,
+                store.LastAdaptiveIdleDelaySeconds,
+                store.LastAdaptiveIdleReason,
+                nowTicks);
+        store.RecentActivity = NormalizeBackgroundSchedulerActivities(store.RecentActivity);
     }
 
     private static BackgroundSchedulerRuntimeStoreDto CloneBackgroundSchedulerRuntimeStore(BackgroundSchedulerRuntimeStoreDto source) {
@@ -457,4 +649,9 @@ internal sealed partial class ChatServiceSession {
             return new(BackgroundSchedulerRuntimeStoreLoadStateLoaded, store);
         }
     }
+
+    private readonly record struct BackgroundSchedulerRuntimeStorePersistResult(
+        bool Persisted,
+        BackgroundSchedulerRuntimeStoreDto PersistedStore,
+        BackgroundSchedulerRuntimeStoreDto MergedStore);
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
@@ -130,6 +130,11 @@ internal sealed partial class ChatServiceSession {
                 nowTicks);
 
         var normalizedRecentActivity = NormalizeBackgroundSchedulerActivities(store.RecentActivity);
+        var normalizedFailureEvents = NormalizeBackgroundSchedulerFailureEvents(
+            store.FailureStreakEvents,
+            store.ConsecutiveFailureCount,
+            store.LastFailureUtcTicks,
+            store.LastSuccessUtcTicks);
         lock (_backgroundSchedulerTelemetryLock) {
             Interlocked.Exchange(ref _backgroundSchedulerLastTickUtcTicks, Math.Max(0, store.LastSchedulerTickUtcTicks));
             _backgroundSchedulerLastOutcome = NormalizeBackgroundSchedulerActivityText(store.LastOutcome, maxLength: 80);
@@ -139,7 +144,11 @@ internal sealed partial class ChatServiceSession {
             _backgroundSchedulerCompletedExecutionCount = Math.Max(0, store.CompletedExecutionCount);
             _backgroundSchedulerRequeuedExecutionCount = Math.Max(0, store.RequeuedExecutionCount);
             _backgroundSchedulerReleasedExecutionCount = Math.Max(0, store.ReleasedExecutionCount);
-            _backgroundSchedulerConsecutiveFailureCount = Math.Max(0, store.ConsecutiveFailureCount);
+            _backgroundSchedulerConsecutiveFailureCount = ResolveBackgroundSchedulerConsecutiveFailureCount(
+                store.ConsecutiveFailureCount,
+                normalizedFailureEvents.Length);
+            _backgroundSchedulerFailureStreakEvents.Clear();
+            _backgroundSchedulerFailureStreakEvents.AddRange(normalizedFailureEvents);
             _backgroundSchedulerPausedUntilUtcTicks = Math.Max(0, store.PausedUntilUtcTicks);
             _backgroundSchedulerPauseReason = NormalizeBackgroundSchedulerActivityText(store.PauseReason, maxLength: 120);
             _backgroundSchedulerLastAdaptiveIdleUtcTicks = Math.Max(0, store.LastAdaptiveIdleUtcTicks);
@@ -257,6 +266,7 @@ internal sealed partial class ChatServiceSession {
                 RequeuedExecutionCount = Math.Max(0, _backgroundSchedulerRequeuedExecutionCount),
                 ReleasedExecutionCount = Math.Max(0, _backgroundSchedulerReleasedExecutionCount),
                 ConsecutiveFailureCount = Math.Max(0, _backgroundSchedulerConsecutiveFailureCount),
+                FailureStreakEvents = CloneBackgroundSchedulerFailureEvents(_backgroundSchedulerFailureStreakEvents),
                 PausedUntilUtcTicks = Math.Max(0, _backgroundSchedulerPausedUntilUtcTicks),
                 PauseReason = NormalizeBackgroundSchedulerActivityText(_backgroundSchedulerPauseReason, maxLength: 120),
                 LastAdaptiveIdleUtcTicks = Math.Max(0, _backgroundSchedulerLastAdaptiveIdleUtcTicks),
@@ -380,62 +390,6 @@ internal sealed partial class ChatServiceSession {
         return (int)Math.Min(int.MaxValue, Math.Max(0L, persisted) + delta);
     }
 
-    private static void MergeBackgroundSchedulerConsecutiveFailureState(
-        BackgroundSchedulerRuntimeStoreDto merged,
-        BackgroundSchedulerRuntimeStoreDto persisted,
-        BackgroundSchedulerRuntimeStoreDto baseline,
-        BackgroundSchedulerRuntimeStoreDto desired) {
-        var localSuccessChanged = desired.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks;
-        var localFailureChanged = desired.LastFailureUtcTicks > baseline.LastFailureUtcTicks;
-        if (!localSuccessChanged && !localFailureChanged
-            && desired.ConsecutiveFailureCount == baseline.ConsecutiveFailureCount) {
-            return;
-        }
-
-        var persistedSuccessChanged = persisted.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks;
-        if (!localSuccessChanged && !persistedSuccessChanged) {
-            merged.ConsecutiveFailureCount = AddBackgroundSchedulerCounterDelta(
-                persisted.ConsecutiveFailureCount,
-                baseline.ConsecutiveFailureCount,
-                desired.ConsecutiveFailureCount);
-            return;
-        }
-
-        if (localSuccessChanged
-            && (!persistedSuccessChanged || desired.LastSuccessUtcTicks >= persisted.LastSuccessUtcTicks)) {
-            var localPostResetCount = Math.Max(0, desired.ConsecutiveFailureCount);
-            if (persisted.LastFailureUtcTicks > desired.LastSuccessUtcTicks) {
-                var persistedFailureDelta = persistedSuccessChanged
-                    ? Math.Max(0, persisted.ConsecutiveFailureCount)
-                    : Math.Max(
-                        0,
-                        Math.Max(0, persisted.ConsecutiveFailureCount) - Math.Max(0, baseline.ConsecutiveFailureCount));
-                localPostResetCount = AddBackgroundSchedulerCounterDelta(
-                    localPostResetCount,
-                    0,
-                    persistedFailureDelta);
-            }
-
-            merged.ConsecutiveFailureCount = localPostResetCount;
-            return;
-        }
-
-        var persistedPostResetCount = Math.Max(0, persisted.ConsecutiveFailureCount);
-        if (desired.LastFailureUtcTicks > persisted.LastSuccessUtcTicks) {
-            var localFailureDelta = localSuccessChanged
-                ? Math.Max(0, desired.ConsecutiveFailureCount)
-                : Math.Max(
-                    0,
-                    Math.Max(0, desired.ConsecutiveFailureCount) - Math.Max(0, baseline.ConsecutiveFailureCount));
-            persistedPostResetCount = AddBackgroundSchedulerCounterDelta(
-                persistedPostResetCount,
-                0,
-                localFailureDelta);
-        }
-
-        merged.ConsecutiveFailureCount = persistedPostResetCount;
-    }
-
     private static bool BackgroundSchedulerOutcomeStateChanged(
         BackgroundSchedulerRuntimeStoreDto baseline,
         BackgroundSchedulerRuntimeStoreDto desired) =>
@@ -532,11 +486,24 @@ internal sealed partial class ChatServiceSession {
                 store.LastAdaptiveIdleDelaySeconds,
                 store.LastAdaptiveIdleReason,
                 nowTicks);
+        store.FailureStreakEvents = NormalizeBackgroundSchedulerFailureEvents(
+            store.FailureStreakEvents,
+            store.ConsecutiveFailureCount,
+            store.LastFailureUtcTicks,
+            store.LastSuccessUtcTicks);
+        store.ConsecutiveFailureCount = ResolveBackgroundSchedulerConsecutiveFailureCount(
+            store.ConsecutiveFailureCount,
+            store.FailureStreakEvents.Length);
         store.RecentActivity = NormalizeBackgroundSchedulerActivities(store.RecentActivity);
     }
 
     private static BackgroundSchedulerRuntimeStoreDto CloneBackgroundSchedulerRuntimeStore(BackgroundSchedulerRuntimeStoreDto source) {
         ArgumentNullException.ThrowIfNull(source);
+        var failureEvents = NormalizeBackgroundSchedulerFailureEvents(
+            source.FailureStreakEvents,
+            source.ConsecutiveFailureCount,
+            source.LastFailureUtcTicks,
+            source.LastSuccessUtcTicks);
         return new BackgroundSchedulerRuntimeStoreDto {
             Version = BackgroundSchedulerRuntimeStoreVersion,
             LastSchedulerTickUtcTicks = Math.Max(0, source.LastSchedulerTickUtcTicks),
@@ -547,7 +514,10 @@ internal sealed partial class ChatServiceSession {
             CompletedExecutionCount = Math.Max(0, source.CompletedExecutionCount),
             RequeuedExecutionCount = Math.Max(0, source.RequeuedExecutionCount),
             ReleasedExecutionCount = Math.Max(0, source.ReleasedExecutionCount),
-            ConsecutiveFailureCount = Math.Max(0, source.ConsecutiveFailureCount),
+            ConsecutiveFailureCount = ResolveBackgroundSchedulerConsecutiveFailureCount(
+                source.ConsecutiveFailureCount,
+                failureEvents.Length),
+            FailureStreakEvents = failureEvents,
             PausedUntilUtcTicks = Math.Max(0, source.PausedUntilUtcTicks),
             PauseReason = NormalizeBackgroundSchedulerActivityText(source.PauseReason, maxLength: 120),
             LastAdaptiveIdleUtcTicks = Math.Max(0, source.LastAdaptiveIdleUtcTicks),

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using System.Threading;
 using IntelligenceX.Chat.Abstractions.Policy;
@@ -374,75 +371,13 @@ internal sealed partial class ChatServiceSession {
         Func<TState, TStateResult> action,
         TState state,
         out TStateResult result) {
-        ArgumentNullException.ThrowIfNull(action);
-        result = default!;
-
-        var mutexName = BuildBackgroundSchedulerRuntimeStoreMutexName(path);
-        var acquisitionOverride = BackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting;
-        if (acquisitionOverride is not null) {
-            var overrideResult = acquisitionOverride(path);
-            if (overrideResult.HasValue) {
-                if (!overrideResult.Value) {
-                    Trace.TraceWarning($"Background scheduler runtime store lock timeout for '{mutexName}'.");
-                    return false;
-                }
-
-                result = action(state);
-                return true;
-            }
-        }
-
-        Mutex? mutex = null;
-        var acquired = false;
-        try {
-            mutex = new Mutex(initiallyOwned: false, mutexName);
-            try {
-                acquired = mutex.WaitOne(TimeSpan.FromSeconds(15));
-            } catch (AbandonedMutexException) {
-                acquired = true;
-            }
-
-            if (!acquired) {
-                Trace.TraceWarning($"Background scheduler runtime store lock timeout for '{mutexName}'.");
-                return false;
-            }
-
-            result = action(state);
-            return true;
-        } catch (Exception ex) {
-            Trace.TraceWarning($"Background scheduler runtime store lock failed: {ex.GetType().Name}: {ex.Message}");
-            return false;
-        } finally {
-            if (acquired && mutex is not null) {
-                try {
-                    mutex.ReleaseMutex();
-                } catch {
-                    // Best effort only.
-                }
-            }
-
-            mutex?.Dispose();
-        }
-    }
-
-    private static string BuildBackgroundSchedulerRuntimeStoreMutexName(string path) {
-        var normalizedPath = NormalizeBackgroundSchedulerRuntimeStoreMutexPath(path);
-        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalizedPath));
-        return $"IntelligenceX.Chat.BackgroundSchedulerRuntimeStore.{Convert.ToHexString(hash)}";
-    }
-
-    private static string NormalizeBackgroundSchedulerRuntimeStoreMutexPath(string path) {
-        var candidate = string.IsNullOrWhiteSpace(path)
-            ? ResolveDefaultBackgroundSchedulerRuntimeStorePath()
-            : path.Trim();
-
-        try {
-            candidate = Path.GetFullPath(candidate);
-        } catch {
-            // Keep the original candidate when full path resolution fails.
-        }
-
-        return OperatingSystem.IsWindows() ? candidate.ToUpperInvariant() : candidate;
+        return ChatServiceJsonFileStore.TryWithExclusiveAccess(
+            path,
+            action,
+            state,
+            out result,
+            "Background scheduler runtime store",
+            BackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting);
     }
 
     private static (long LastAdaptiveIdleUtcTicks, int LastAdaptiveIdleDelaySeconds, string LastAdaptiveIdleReason) NormalizeBackgroundSchedulerAdaptiveIdleState(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
@@ -385,31 +385,55 @@ internal sealed partial class ChatServiceSession {
         BackgroundSchedulerRuntimeStoreDto persisted,
         BackgroundSchedulerRuntimeStoreDto baseline,
         BackgroundSchedulerRuntimeStoreDto desired) {
-        var localSuccessChanged = desired.LastSuccessUtcTicks != baseline.LastSuccessUtcTicks;
-        var localFailureChanged = desired.LastFailureUtcTicks != baseline.LastFailureUtcTicks;
+        var localSuccessChanged = desired.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks;
+        var localFailureChanged = desired.LastFailureUtcTicks > baseline.LastFailureUtcTicks;
         if (!localSuccessChanged && !localFailureChanged
             && desired.ConsecutiveFailureCount == baseline.ConsecutiveFailureCount) {
             return;
         }
 
-        var localLatestEvent = Math.Max(desired.LastSuccessUtcTicks, desired.LastFailureUtcTicks);
-        var persistedLatestEvent = Math.Max(persisted.LastSuccessUtcTicks, persisted.LastFailureUtcTicks);
-        if (localLatestEvent < persistedLatestEvent) {
+        var persistedSuccessChanged = persisted.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks;
+        if (!localSuccessChanged && !persistedSuccessChanged) {
+            merged.ConsecutiveFailureCount = AddBackgroundSchedulerCounterDelta(
+                persisted.ConsecutiveFailureCount,
+                baseline.ConsecutiveFailureCount,
+                desired.ConsecutiveFailureCount);
             return;
         }
 
-        if (desired.LastSuccessUtcTicks >= desired.LastFailureUtcTicks
-            || desired.LastSuccessUtcTicks > baseline.LastSuccessUtcTicks) {
-            merged.ConsecutiveFailureCount = Math.Max(0, desired.ConsecutiveFailureCount);
+        if (localSuccessChanged
+            && (!persistedSuccessChanged || desired.LastSuccessUtcTicks >= persisted.LastSuccessUtcTicks)) {
+            var localPostResetCount = Math.Max(0, desired.ConsecutiveFailureCount);
+            if (persisted.LastFailureUtcTicks > desired.LastSuccessUtcTicks) {
+                var persistedFailureDelta = persistedSuccessChanged
+                    ? Math.Max(0, persisted.ConsecutiveFailureCount)
+                    : Math.Max(
+                        0,
+                        Math.Max(0, persisted.ConsecutiveFailureCount) - Math.Max(0, baseline.ConsecutiveFailureCount));
+                localPostResetCount = AddBackgroundSchedulerCounterDelta(
+                    localPostResetCount,
+                    0,
+                    persistedFailureDelta);
+            }
+
+            merged.ConsecutiveFailureCount = localPostResetCount;
             return;
         }
 
-        var failureDelta = Math.Max(
-            0,
-            Math.Max(0, desired.ConsecutiveFailureCount) - Math.Max(0, baseline.ConsecutiveFailureCount));
-        merged.ConsecutiveFailureCount = (int)Math.Min(
-            int.MaxValue,
-            (long)Math.Max(0, persisted.ConsecutiveFailureCount) + failureDelta);
+        var persistedPostResetCount = Math.Max(0, persisted.ConsecutiveFailureCount);
+        if (desired.LastFailureUtcTicks > persisted.LastSuccessUtcTicks) {
+            var localFailureDelta = localSuccessChanged
+                ? Math.Max(0, desired.ConsecutiveFailureCount)
+                : Math.Max(
+                    0,
+                    Math.Max(0, desired.ConsecutiveFailureCount) - Math.Max(0, baseline.ConsecutiveFailureCount));
+            persistedPostResetCount = AddBackgroundSchedulerCounterDelta(
+                persistedPostResetCount,
+                0,
+                localFailureDelta);
+        }
+
+        merged.ConsecutiveFailureCount = persistedPostResetCount;
     }
 
     private static bool BackgroundSchedulerOutcomeStateChanged(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
@@ -146,7 +146,6 @@ internal sealed partial class ChatServiceSession {
             _backgroundSchedulerRequeuedExecutionCount = Math.Max(0, store.RequeuedExecutionCount);
             _backgroundSchedulerReleasedExecutionCount = Math.Max(0, store.ReleasedExecutionCount);
             _backgroundSchedulerConsecutiveFailureCount = ResolveBackgroundSchedulerConsecutiveFailureCount(
-                store.ConsecutiveFailureCount,
                 normalizedFailureEvents.Length);
             _backgroundSchedulerFailureStreakEvents.Clear();
             _backgroundSchedulerFailureStreakEvents.AddRange(normalizedFailureEvents);
@@ -266,7 +265,7 @@ internal sealed partial class ChatServiceSession {
                 CompletedExecutionCount = Math.Max(0, _backgroundSchedulerCompletedExecutionCount),
                 RequeuedExecutionCount = Math.Max(0, _backgroundSchedulerRequeuedExecutionCount),
                 ReleasedExecutionCount = Math.Max(0, _backgroundSchedulerReleasedExecutionCount),
-                ConsecutiveFailureCount = Math.Max(0, _backgroundSchedulerConsecutiveFailureCount),
+                ConsecutiveFailureCount = _backgroundSchedulerFailureStreakEvents.Count,
                 FailureStreakEvents = CloneBackgroundSchedulerFailureEvents(_backgroundSchedulerFailureStreakEvents),
                 PausedUntilUtcTicks = Math.Max(0, _backgroundSchedulerPausedUntilUtcTicks),
                 PauseReason = NormalizeBackgroundSchedulerActivityText(_backgroundSchedulerPauseReason, maxLength: 120),
@@ -493,7 +492,6 @@ internal sealed partial class ChatServiceSession {
             store.LastFailureUtcTicks,
             store.LastSuccessUtcTicks);
         store.ConsecutiveFailureCount = ResolveBackgroundSchedulerConsecutiveFailureCount(
-            store.ConsecutiveFailureCount,
             store.FailureStreakEvents.Length);
         store.RecentActivity = NormalizeBackgroundSchedulerActivities(store.RecentActivity);
     }
@@ -516,7 +514,6 @@ internal sealed partial class ChatServiceSession {
             RequeuedExecutionCount = Math.Max(0, source.RequeuedExecutionCount),
             ReleasedExecutionCount = Math.Max(0, source.ReleasedExecutionCount),
             ConsecutiveFailureCount = ResolveBackgroundSchedulerConsecutiveFailureCount(
-                source.ConsecutiveFailureCount,
                 failureEvents.Length),
             FailureStreakEvents = failureEvents,
             PausedUntilUtcTicks = Math.Max(0, source.PausedUntilUtcTicks),

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.Persistence.cs
@@ -15,6 +15,7 @@ internal sealed partial class ChatServiceSession {
     private const string BackgroundSchedulerRuntimeStoreLoadStateInvalid = "invalid";
     private const string BackgroundSchedulerRuntimeStoreLoadStateDeferred = "deferred";
     private const int BackgroundSchedulerRuntimeStoreVersion = 1;
+    internal const int BackgroundSchedulerRuntimeStoreMaximumBytes = 512 * 1024;
     private static readonly JsonSerializerOptions BackgroundSchedulerRuntimeStoreReadJsonOptions = new() {
         PropertyNameCaseInsensitive = true,
         WriteIndented = false
@@ -573,7 +574,7 @@ internal sealed partial class ChatServiceSession {
     private static BackgroundSchedulerRuntimeStoreReadResult ReadBackgroundSchedulerRuntimeStoreNoThrow(string path) {
         var result = ChatServiceJsonFileStore.Read(
             path,
-            maximumBytes: 512 * 1024,
+            maximumBytes: BackgroundSchedulerRuntimeStoreMaximumBytes,
             static json => JsonSerializer.Deserialize<BackgroundSchedulerRuntimeStoreDto>(
                 json,
                 BackgroundSchedulerRuntimeStoreReadJsonOptions),

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.cs
@@ -797,13 +797,11 @@ internal sealed partial class ChatServiceSession {
         return true;
     }
 
-    private SessionCapabilityBackgroundSchedulerDto SetBackgroundSchedulerManualPause(bool paused, int? pauseSeconds, string? reason) {
-        _backgroundSchedulerControlState.SetManualPause(
+    private bool SetBackgroundSchedulerManualPause(bool paused, int? pauseSeconds, string? reason) {
+        return _backgroundSchedulerControlState.SetManualPause(
             paused,
             pauseSeconds,
             reason ?? string.Empty);
-
-        return BuildBackgroundSchedulerSummary();
     }
 
     private static string NormalizeBackgroundSchedulerOutcome(BackgroundSchedulerIterationOutcomeKind outcome) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.cs
@@ -625,6 +625,7 @@ internal sealed partial class ChatServiceSession {
                     _backgroundSchedulerLastSuccessUtcTicks = recordedTicks;
                     _backgroundSchedulerCompletedExecutionCount++;
                     _backgroundSchedulerConsecutiveFailureCount = 0;
+                    _backgroundSchedulerFailureStreakEvents.Clear();
                     _backgroundSchedulerPausedUntilUtcTicks = 0;
                     _backgroundSchedulerPauseReason = string.Empty;
                     break;
@@ -632,12 +633,14 @@ internal sealed partial class ChatServiceSession {
                     _backgroundSchedulerLastFailureUtcTicks = recordedTicks;
                     _backgroundSchedulerRequeuedExecutionCount++;
                     _backgroundSchedulerConsecutiveFailureCount++;
+                    RememberBackgroundSchedulerFailureEventNoLock(recordedTicks);
                     break;
                 case BackgroundSchedulerIterationOutcomeKind.ReleasedAfterEmptyOutput:
                 case BackgroundSchedulerIterationOutcomeKind.ReleasedAfterException:
                     _backgroundSchedulerLastFailureUtcTicks = recordedTicks;
                     _backgroundSchedulerReleasedExecutionCount++;
                     _backgroundSchedulerConsecutiveFailureCount++;
+                    RememberBackgroundSchedulerFailureEventNoLock(recordedTicks);
                     break;
             }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.cs
@@ -632,14 +632,12 @@ internal sealed partial class ChatServiceSession {
                 case BackgroundSchedulerIterationOutcomeKind.RequeuedAfterToolFailure:
                     _backgroundSchedulerLastFailureUtcTicks = recordedTicks;
                     _backgroundSchedulerRequeuedExecutionCount++;
-                    _backgroundSchedulerConsecutiveFailureCount++;
                     RememberBackgroundSchedulerFailureEventNoLock(recordedTicks);
                     break;
                 case BackgroundSchedulerIterationOutcomeKind.ReleasedAfterEmptyOutput:
                 case BackgroundSchedulerIterationOutcomeKind.ReleasedAfterException:
                     _backgroundSchedulerLastFailureUtcTicks = recordedTicks;
                     _backgroundSchedulerReleasedExecutionCount++;
-                    _backgroundSchedulerConsecutiveFailureCount++;
                     RememberBackgroundSchedulerFailureEventNoLock(recordedTicks);
                     break;
             }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.BackgroundScheduler.cs
@@ -830,7 +830,10 @@ internal sealed partial class ChatServiceSession {
         }
 
         var threshold = Math.Max(1, _options.BackgroundSchedulerFailureThreshold);
-        if (_backgroundSchedulerConsecutiveFailureCount <= 0 || _backgroundSchedulerConsecutiveFailureCount % threshold != 0) {
+        var saturatedFailureStreak = _backgroundSchedulerConsecutiveFailureCount
+            >= MaxBackgroundSchedulerFailureStreakEvents;
+        if (_backgroundSchedulerConsecutiveFailureCount <= 0
+            || (!saturatedFailureStreak && _backgroundSchedulerConsecutiveFailureCount % threshold != 0)) {
             return;
         }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.Persistence.cs
@@ -59,14 +59,9 @@ internal sealed partial class ChatServiceSession {
             return ResolveDefaultPendingActionsStorePath();
         }
 
-        // Treat overrides as trusted *file names* under LocalAppData by default to avoid arbitrary-path writes.
-        // If a fully-qualified path is provided, only honor it when it still resolves under LocalAppData\IntelligenceX.Chat.
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
-
-        var baseDir = Path.Combine(root, "IntelligenceX.Chat");
+        // Treat overrides as trusted file names beneath the shared per-user state directory.
+        // Fully-qualified paths are honored only when they remain inside that directory.
+        var baseDir = ChatServiceJsonFileStore.ResolveDefaultDirectory();
         var defaultPath = ResolveDefaultPendingActionsStorePath();
 
         try {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.Persistence.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.PendingActions.Persistence.cs
@@ -50,46 +50,10 @@ internal sealed partial class ChatServiceSession {
         public bool? Mutating { get; set; }
     }
 
-    private static string ResolveDefaultPendingActionsStorePath() =>
-        ChatServiceJsonFileStore.ResolveDefaultPath("pending-actions.json");
-
-    private string ResolvePendingActionsStorePath() {
-        var candidate = (_options.PendingActionsStorePath ?? string.Empty).Trim();
-        if (candidate.Length == 0) {
-            return ResolveDefaultPendingActionsStorePath();
-        }
-
-        // Treat overrides as trusted file names beneath the shared per-user state directory.
-        // Fully-qualified paths are honored only when they remain inside that directory.
-        var baseDir = ChatServiceJsonFileStore.ResolveDefaultDirectory();
-        var defaultPath = ResolveDefaultPendingActionsStorePath();
-
-        try {
-            if (candidate.StartsWith(@"\\", StringComparison.Ordinal)) {
-                return defaultPath;
-            }
-
-            if (!Path.IsPathFullyQualified(candidate)) {
-                // Only allow simple file names (no traversal / no separators) for overrides.
-                if (candidate.Contains("..", StringComparison.Ordinal) ||
-                    candidate.IndexOfAny(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }) >= 0) {
-                    return defaultPath;
-                }
-                return Path.Combine(baseDir, candidate);
-            }
-
-            var fullCandidate = Path.GetFullPath(candidate);
-            var fullBaseDir = Path.GetFullPath(baseDir)
-                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                + Path.DirectorySeparatorChar;
-
-            return fullCandidate.StartsWith(fullBaseDir, StringComparison.OrdinalIgnoreCase)
-                ? fullCandidate
-                : defaultPath;
-        } catch {
-            return defaultPath;
-        }
-    }
+    private string ResolvePendingActionsStorePath() =>
+        ChatServiceJsonFileStore.ResolvePathOverrideWithinDefaultDirectory(
+            _options.PendingActionsStorePath,
+            "pending-actions.json");
 
     private void PersistPendingActionsSnapshot(string threadId, long seenUtcTicks, PendingAction[] actions, string[] callToActionTokens) {
         if (string.IsNullOrWhiteSpace(threadId) || actions is null || actions.Length == 0 || seenUtcTicks <= 0) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ProfilesAndModels.cs
@@ -930,25 +930,30 @@ internal sealed partial class ChatServiceSession {
             routingCatalogDiagnostics,
             toolOrchestrationCatalog);
 
-        _toolingBootstrapCache?.StoreSnapshot(
-            bootstrapCacheKey,
-            new ChatServiceToolingBootstrapSnapshot {
-                Registry = registry,
-                ToolDefinitions = toolDefinitions,
-                PackSummaries = BuildPackPolicyList(packAvailability, toolOrchestrationCatalog),
-                Packs = packs,
-                PackAvailability = packAvailability,
-                PluginAvailability = bootstrapResult.PluginAvailability.ToArray(),
-                PluginCatalog = bootstrapResult.PluginCatalog.ToArray(),
-                StartupWarnings = warnings,
-                StartupBootstrap = startupBootstrap,
-                PluginSearchPaths = pluginSearchPaths,
-                RuntimePolicyDiagnostics = runtimePolicyDiagnostics,
-                RoutingCatalogDiagnostics = routingCatalogDiagnostics,
-                CapabilitySnapshot = BuildRuntimeCapabilitySnapshot(),
-                ToolOrchestrationCatalog = toolOrchestrationCatalog
-            },
-            previewDiscoveryFingerprint: previewDiscoveryFingerprint);
+        if (_toolingBootstrapCache is not null) {
+            var persisted = _toolingBootstrapCache.StoreSnapshot(
+                bootstrapCacheKey,
+                new ChatServiceToolingBootstrapSnapshot {
+                    Registry = registry,
+                    ToolDefinitions = toolDefinitions,
+                    PackSummaries = BuildPackPolicyList(packAvailability, toolOrchestrationCatalog),
+                    Packs = packs,
+                    PackAvailability = packAvailability,
+                    PluginAvailability = bootstrapResult.PluginAvailability.ToArray(),
+                    PluginCatalog = bootstrapResult.PluginCatalog.ToArray(),
+                    StartupWarnings = warnings,
+                    StartupBootstrap = startupBootstrap,
+                    PluginSearchPaths = pluginSearchPaths,
+                    RuntimePolicyDiagnostics = runtimePolicyDiagnostics,
+                    RoutingCatalogDiagnostics = routingCatalogDiagnostics,
+                    CapabilitySnapshot = BuildRuntimeCapabilitySnapshot(),
+                    ToolOrchestrationCatalog = toolOrchestrationCatalog
+                },
+                previewDiscoveryFingerprint: previewDiscoveryFingerprint);
+            if (!persisted && _toolingBootstrapCache.TryGetPersistedSnapshotWarning(out var persistenceWarning)) {
+                RecordStartupWarning(persistenceWarning);
+            }
+        }
 
         if (clearRoutingCaches) {
             ClearToolRoutingCaches();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
@@ -127,10 +127,15 @@ internal sealed partial class ChatServiceSession {
             return;
         }
 
+        if (!SetBackgroundSchedulerManualPause(request.Paused, normalizedPauseSeconds, request.Reason)) {
+            await WriteAsync(writer, BuildBackgroundSchedulerPersistenceError(request.RequestId), cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
         await WriteAsync(writer, new BackgroundSchedulerStatusMessage {
             Kind = ChatServiceMessageKind.Response,
             RequestId = request.RequestId,
-            Scheduler = SetBackgroundSchedulerManualPause(request.Paused, normalizedPauseSeconds, request.Reason)
+            Scheduler = BuildBackgroundSchedulerSummary()
         }, cancellationToken).ConfigureAwait(false);
     }
 
@@ -148,7 +153,10 @@ internal sealed partial class ChatServiceSession {
             return;
         }
 
-        _backgroundSchedulerControlState.UpdateMaintenanceWindows(normalizedOperation, normalizedWindows);
+        if (!_backgroundSchedulerControlState.UpdateMaintenanceWindows(normalizedOperation, normalizedWindows)) {
+            await WriteAsync(writer, BuildBackgroundSchedulerPersistenceError(request.RequestId), cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
         await WriteAsync(writer, new BackgroundSchedulerStatusMessage {
             Kind = ChatServiceMessageKind.Response,
@@ -205,7 +213,10 @@ internal sealed partial class ChatServiceSession {
             durationSeconds = resolvedDurationSeconds;
         }
 
-        _backgroundSchedulerControlState.UpdateBlockedPacks(normalizedOperation, normalizedPackIds, durationSeconds);
+        if (!_backgroundSchedulerControlState.UpdateBlockedPacks(normalizedOperation, normalizedPackIds, durationSeconds)) {
+            await WriteAsync(writer, BuildBackgroundSchedulerPersistenceError(request.RequestId), cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
         await WriteAsync(writer, new BackgroundSchedulerStatusMessage {
             Kind = ChatServiceMessageKind.Response,
@@ -262,13 +273,25 @@ internal sealed partial class ChatServiceSession {
             durationSeconds = resolvedDurationSeconds;
         }
 
-        _backgroundSchedulerControlState.UpdateBlockedThreads(normalizedOperation, normalizedThreadIds, durationSeconds);
+        if (!_backgroundSchedulerControlState.UpdateBlockedThreads(normalizedOperation, normalizedThreadIds, durationSeconds)) {
+            await WriteAsync(writer, BuildBackgroundSchedulerPersistenceError(request.RequestId), cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
         await WriteAsync(writer, new BackgroundSchedulerStatusMessage {
             Kind = ChatServiceMessageKind.Response,
             RequestId = request.RequestId,
             Scheduler = BuildBackgroundSchedulerSummary()
         }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static ErrorMessage BuildBackgroundSchedulerPersistenceError(string requestId) {
+        return new ErrorMessage {
+            Kind = ChatServiceMessageKind.Response,
+            RequestId = requestId,
+            Error = "The background scheduler state changed in memory but could not be persisted. Retry after restoring access to the state directory.",
+            Code = "persistence_failed"
+        };
     }
 
     internal static bool ShouldUseCachedToolCatalogFallbackForListTools(bool startupToolingBootstrapInProgress) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.RequestFlow.cs
@@ -289,7 +289,7 @@ internal sealed partial class ChatServiceSession {
         return new ErrorMessage {
             Kind = ChatServiceMessageKind.Response,
             RequestId = requestId,
-            Error = "The background scheduler state changed in memory but could not be persisted. Retry after restoring access to the state directory.",
+            Error = "The background scheduler state was not changed because it could not be persisted. Retry after restoring access to the state directory.",
             Code = "persistence_failed"
         };
     }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
@@ -17,15 +17,13 @@ namespace IntelligenceX.Chat.Service;
 internal sealed partial class ChatServiceSession {
     private const int StartupToolHealthBackoffMaxExponent = 6;
     private const int MaximumStartupToolHealthCacheBytes = 1024 * 1024;
+    private const int MaximumStartupToolHealthObservationCount = 4096;
     private const string StartupToolHealthCacheFileName = "startup-tool-health-cache-v1.json";
     private const string StartupToolHealthCacheStoreName = "Startup tool health cache";
     private static readonly JsonSerializerOptions StartupToolHealthCacheJson = new() {
         PropertyNameCaseInsensitive = true,
         WriteIndented = false
     };
-    private static readonly object StartupToolHealthCacheStoreLock = new();
-    private static readonly Dictionary<string, Dictionary<string, DateTime>> StartupToolHealthLatestObservationsByPath = new(
-        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
     internal readonly record struct ToolHealthProbeCatalogEntry(
         string ToolName,
         string PackId,
@@ -171,7 +169,14 @@ internal sealed partial class ChatServiceSession {
             // Startup priming is best-effort and bounded by the startup budget.
         } finally {
             if (mutations.Count > 0) {
-                ApplyStartupToolHealthCacheMutations(ResolveStartupToolHealthCachePath(), mutations);
+                try {
+                    if (!ApplyStartupToolHealthCacheMutations(ResolveStartupToolHealthCachePath(), mutations)) {
+                        RecordStartupWarning("[tool health] Startup tool-health cache updates could not be persisted.");
+                    }
+                } catch (Exception ex) {
+                    RecordStartupWarning("[tool health] Startup tool-health cache updates could not be persisted.");
+                    Trace.TraceWarning($"{StartupToolHealthCacheStoreName} update failed: {ex.GetType().Name}: {ex.Message}");
+                }
             }
         }
 
@@ -373,99 +378,135 @@ internal sealed partial class ChatServiceSession {
     }
 
     internal static Dictionary<string, StartupToolHealthCacheEntry> LoadStartupToolHealthCache(string path) {
-        var result = ChatServiceJsonFileStore.Read<Dictionary<string, StartupToolHealthCacheEntry>>(
+        return LoadStartupToolHealthCacheState(path).Entries;
+    }
+
+    private static StartupToolHealthCacheState LoadStartupToolHealthCacheState(string path) {
+        var result = ChatServiceJsonFileStore.Read<StartupToolHealthCacheState>(
             path,
             MaximumStartupToolHealthCacheBytes,
-            DeserializeStartupToolHealthCache,
+            DeserializeStartupToolHealthCacheState,
             static _ => true,
             normalize: null,
             StartupToolHealthCacheStoreName);
         return result.State == ChatServiceJsonFileReadState.Loaded && result.Value is not null
             ? result.Value
-            : new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
+            : StartupToolHealthCacheState.Empty();
     }
 
     internal static Dictionary<string, StartupToolHealthCacheEntry> DeserializeStartupToolHealthCache(string json) {
+        return DeserializeStartupToolHealthCacheState(json).Entries;
+    }
+
+    private static StartupToolHealthCacheState DeserializeStartupToolHealthCacheState(string json) {
         var payload = JsonSerializer.Deserialize<StartupToolHealthCachePayload>(json, StartupToolHealthCacheJson);
         var entries = payload?.Entries;
 
-        var map = new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
-        if (entries is null) {
-            return map;
-        }
+        var state = StartupToolHealthCacheState.Empty();
+        if (entries is not null) {
+            for (var i = 0; i < entries.Count; i++) {
+                var entry = entries[i];
+                var key = (entry?.Key ?? string.Empty).Trim();
+                if (key.Length == 0) {
+                    continue;
+                }
 
-        for (var i = 0; i < entries.Count; i++) {
-            var entry = entries[i];
-            if (entry is null || string.IsNullOrWhiteSpace(entry.Key)) {
-                continue;
+                var cacheEntry = new StartupToolHealthCacheEntry(
+                    ErrorCode: NormalizeHealthErrorCode(entry!.ErrorCode),
+                    Error: NormalizeHealthError(entry.Error),
+                    LastFailedUtc: entry.LastFailedUtc,
+                    NextProbeUtc: entry.NextProbeUtc,
+                    ConsecutiveFailures: Math.Clamp(entry.ConsecutiveFailures, 1, 64));
+                state.Entries[key] = cacheEntry;
+                RememberLatestStartupToolHealthObservation(
+                    state.LatestObservations,
+                    key,
+                    new StartupToolHealthObservation(
+                        NormalizeStartupToolHealthObservationUtc(cacheEntry.LastFailedUtc),
+                        Successful: false));
             }
-
-            map[entry.Key] = new StartupToolHealthCacheEntry(
-                ErrorCode: NormalizeHealthErrorCode(entry.ErrorCode),
-                Error: NormalizeHealthError(entry.Error),
-                LastFailedUtc: entry.LastFailedUtc,
-                NextProbeUtc: entry.NextProbeUtc,
-                ConsecutiveFailures: Math.Clamp(entry.ConsecutiveFailures, 1, 64));
         }
 
-        return map;
+        var observations = payload?.LatestObservations;
+        if (observations is not null) {
+            for (var i = 0; i < observations.Count; i++) {
+                var observation = observations[i];
+                var key = (observation?.Key ?? string.Empty).Trim();
+                if (key.Length == 0) {
+                    continue;
+                }
+
+                RememberLatestStartupToolHealthObservation(
+                    state.LatestObservations,
+                    key,
+                    new StartupToolHealthObservation(
+                        NormalizeStartupToolHealthObservationUtc(observation!.ObservedUtc),
+                        observation.Successful));
+            }
+        }
+
+        return state;
     }
 
-    internal static void ApplyStartupToolHealthCacheMutations(
+    internal static bool ApplyStartupToolHealthCacheMutations(
         string path,
         IReadOnlyList<StartupToolHealthCacheMutation> mutations) {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
         ArgumentNullException.ThrowIfNull(mutations);
         if (mutations.Count == 0) {
-            return;
+            return true;
         }
 
         var normalizedPath = Path.GetFullPath(path);
-        lock (StartupToolHealthCacheStoreLock) {
-            var cache = LoadStartupToolHealthCache(normalizedPath);
-            if (!StartupToolHealthLatestObservationsByPath.TryGetValue(normalizedPath, out var latestObservations)) {
-                latestObservations = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
-                StartupToolHealthLatestObservationsByPath[normalizedPath] = latestObservations;
+        var lockAcquired = ChatServiceJsonFileStore.TryWithExclusiveAccess(
+            normalizedPath,
+            static state => ApplyStartupToolHealthCacheMutationsNoLock(state.Path, state.Mutations),
+            (Path: normalizedPath, Mutations: mutations),
+            out var applied,
+            StartupToolHealthCacheStoreName);
+        return lockAcquired && applied;
+    }
+
+    private static bool ApplyStartupToolHealthCacheMutationsNoLock(
+        string path,
+        IReadOnlyList<StartupToolHealthCacheMutation> mutations) {
+        var state = LoadStartupToolHealthCacheState(path);
+        var changed = false;
+        foreach (var mutation in mutations) {
+            var key = (mutation.Key ?? string.Empty).Trim();
+            if (key.Length == 0) {
+                continue;
             }
 
-            var changed = false;
-            foreach (var mutation in mutations) {
-                var key = (mutation.Key ?? string.Empty).Trim();
-                if (key.Length == 0) {
-                    continue;
-                }
-
-                var observedUtc = NormalizeStartupToolHealthObservationUtc(mutation.ObservedUtc);
-                var latestUtc = latestObservations.TryGetValue(key, out var knownObservation)
-                    ? NormalizeStartupToolHealthObservationUtc(knownObservation)
-                    : DateTime.MinValue;
-                if (cache.TryGetValue(key, out var currentEntry)) {
-                    var storedUtc = NormalizeStartupToolHealthObservationUtc(currentEntry.LastFailedUtc);
-                    if (storedUtc > latestUtc) {
-                        latestUtc = storedUtc;
-                    }
-                }
-
-                if (observedUtc < latestUtc) {
-                    continue;
-                }
-
-                latestObservations[key] = observedUtc;
-                if (mutation.Entry is null) {
-                    changed |= cache.Remove(key);
-                    continue;
-                }
-
-                if (!cache.TryGetValue(key, out var existing) || existing != mutation.Entry) {
-                    cache[key] = mutation.Entry;
-                    changed = true;
-                }
+            var nextObservation = new StartupToolHealthObservation(
+                NormalizeStartupToolHealthObservationUtc(mutation.ObservedUtc),
+                Successful: mutation.Entry is null);
+            if (state.LatestObservations.TryGetValue(key, out var latestObservation)
+                && (nextObservation.ObservedUtc < latestObservation.ObservedUtc
+                    || (nextObservation.ObservedUtc == latestObservation.ObservedUtc
+                        && latestObservation.Successful
+                        && !nextObservation.Successful))) {
+                continue;
             }
 
-            if (changed) {
-                SaveStartupToolHealthCache(normalizedPath, cache);
+            if (!state.LatestObservations.TryGetValue(key, out latestObservation)
+                || latestObservation != nextObservation) {
+                state.LatestObservations[key] = nextObservation;
+                changed = true;
+            }
+
+            if (mutation.Entry is null) {
+                changed |= state.Entries.Remove(key);
+                continue;
+            }
+
+            if (!state.Entries.TryGetValue(key, out var existing) || existing != mutation.Entry) {
+                state.Entries[key] = mutation.Entry;
+                changed = true;
             }
         }
+
+        return !changed || SaveStartupToolHealthCache(path, state);
     }
 
     private static DateTime NormalizeStartupToolHealthObservationUtc(DateTime value) {
@@ -476,11 +517,12 @@ internal sealed partial class ChatServiceSession {
         };
     }
 
-    private static void SaveStartupToolHealthCache(
+    private static bool SaveStartupToolHealthCache(
         string path,
-        Dictionary<string, StartupToolHealthCacheEntry> cache) {
+        StartupToolHealthCacheState state) {
         var payload = new StartupToolHealthCachePayload {
-            Entries = cache
+            Entries = state.Entries
+                .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)
                 .Select(static pair => new StartupToolHealthCachePayloadEntry {
                     Key = pair.Key,
                     ErrorCode = pair.Value.ErrorCode,
@@ -489,14 +531,35 @@ internal sealed partial class ChatServiceSession {
                     NextProbeUtc = pair.Value.NextProbeUtc,
                     ConsecutiveFailures = pair.Value.ConsecutiveFailures
                 })
+                .ToList(),
+            LatestObservations = state.LatestObservations
+                .OrderByDescending(static pair => pair.Value.ObservedUtc)
+                .Take(MaximumStartupToolHealthObservationCount)
+                .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(static pair => new StartupToolHealthCachePayloadObservation {
+                    Key = pair.Key,
+                    ObservedUtc = pair.Value.ObservedUtc,
+                    Successful = pair.Value.Successful
+                })
                 .ToList()
         };
 
-        ChatServiceJsonFileStore.Write(
+        return ChatServiceJsonFileStore.Write(
             path,
             payload,
             static value => JsonSerializer.Serialize(value, StartupToolHealthCacheJson),
             StartupToolHealthCacheStoreName);
+    }
+
+    private static void RememberLatestStartupToolHealthObservation(
+        Dictionary<string, StartupToolHealthObservation> observations,
+        string key,
+        StartupToolHealthObservation candidate) {
+        if (!observations.TryGetValue(key, out var current)
+            || candidate.ObservedUtc > current.ObservedUtc
+            || (candidate.ObservedUtc == current.ObservedUtc && candidate.Successful && !current.Successful)) {
+            observations[key] = candidate;
+        }
     }
 
     private static string ResolveStartupToolHealthCachePath() {
@@ -517,6 +580,7 @@ internal sealed partial class ChatServiceSession {
 
     private sealed class StartupToolHealthCachePayload {
         public List<StartupToolHealthCachePayloadEntry> Entries { get; set; } = new();
+        public List<StartupToolHealthCachePayloadObservation> LatestObservations { get; set; } = new();
     }
 
     private sealed class StartupToolHealthCachePayloadEntry {
@@ -527,6 +591,22 @@ internal sealed partial class ChatServiceSession {
         public DateTime NextProbeUtc { get; set; }
         public int ConsecutiveFailures { get; set; } = 1;
     }
+
+    private sealed class StartupToolHealthCachePayloadObservation {
+        public string Key { get; set; } = string.Empty;
+        public DateTime ObservedUtc { get; set; }
+        public bool Successful { get; set; }
+    }
+
+    private sealed record StartupToolHealthCacheState(
+        Dictionary<string, StartupToolHealthCacheEntry> Entries,
+        Dictionary<string, StartupToolHealthObservation> LatestObservations) {
+        internal static StartupToolHealthCacheState Empty() => new(
+            new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase),
+            new Dictionary<string, StartupToolHealthObservation>(StringComparer.OrdinalIgnoreCase));
+    }
+
+    private readonly record struct StartupToolHealthObservation(DateTime ObservedUtc, bool Successful);
 
     private void RecordStartupWarning(string? warning) {
         var normalized = (warning ?? string.Empty).Trim();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.Chat.Abstractions.Policy;
 using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Service.Persistence;
 using IntelligenceX.Chat.Tooling;
 using IntelligenceX.Tools;
 
@@ -15,7 +15,9 @@ namespace IntelligenceX.Chat.Service;
 
 internal sealed partial class ChatServiceSession {
     private const int StartupToolHealthBackoffMaxExponent = 6;
+    private const int MaximumStartupToolHealthCacheBytes = 1024 * 1024;
     private const string StartupToolHealthCacheFileName = "startup-tool-health-cache-v1.json";
+    private const string StartupToolHealthCacheStoreName = "Startup tool health cache";
     private static readonly JsonSerializerOptions StartupToolHealthCacheJson = new() {
         PropertyNameCaseInsensitive = true,
         WriteIndented = false
@@ -362,77 +364,60 @@ internal sealed partial class ChatServiceSession {
 
     private static Dictionary<string, StartupToolHealthCacheEntry> LoadStartupToolHealthCache() {
         var path = ResolveStartupToolHealthCachePath();
-        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
+        var result = ChatServiceJsonFileStore.Read<StartupToolHealthCachePayload>(
+            path,
+            MaximumStartupToolHealthCacheBytes,
+            static json => JsonSerializer.Deserialize<StartupToolHealthCachePayload>(json, StartupToolHealthCacheJson),
+            static payload => payload.Entries is not null,
+            normalize: null,
+            StartupToolHealthCacheStoreName);
+        if (result.State != ChatServiceJsonFileReadState.Loaded
+            || result.Value?.Entries is not { Count: > 0 } entries) {
             return new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
         }
 
-        try {
-            var json = File.ReadAllText(path);
-            var payload = JsonSerializer.Deserialize<StartupToolHealthCachePayload>(json, StartupToolHealthCacheJson);
-            if (payload?.Entries is null || payload.Entries.Count == 0) {
-                return new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        var map = new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < entries.Count; i++) {
+            var entry = entries[i];
+            if (string.IsNullOrWhiteSpace(entry.Key)) {
+                continue;
             }
 
-            var map = new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
-            for (var i = 0; i < payload.Entries.Count; i++) {
-                var entry = payload.Entries[i];
-                if (string.IsNullOrWhiteSpace(entry.Key)) {
-                    continue;
-                }
-
-                map[entry.Key] = new StartupToolHealthCacheEntry(
-                    ErrorCode: NormalizeHealthErrorCode(entry.ErrorCode),
-                    Error: NormalizeHealthError(entry.Error),
-                    LastFailedUtc: entry.LastFailedUtc,
-                    NextProbeUtc: entry.NextProbeUtc,
-                    ConsecutiveFailures: Math.Clamp(entry.ConsecutiveFailures, 1, 64));
-            }
-
-            return map;
-        } catch {
-            return new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
+            map[entry.Key] = new StartupToolHealthCacheEntry(
+                ErrorCode: NormalizeHealthErrorCode(entry.ErrorCode),
+                Error: NormalizeHealthError(entry.Error),
+                LastFailedUtc: entry.LastFailedUtc,
+                NextProbeUtc: entry.NextProbeUtc,
+                ConsecutiveFailures: Math.Clamp(entry.ConsecutiveFailures, 1, 64));
         }
+
+        return map;
     }
 
     private static void SaveStartupToolHealthCache(Dictionary<string, StartupToolHealthCacheEntry> cache) {
         var path = ResolveStartupToolHealthCachePath();
-        if (string.IsNullOrWhiteSpace(path)) {
-            return;
-        }
+        var payload = new StartupToolHealthCachePayload {
+            Entries = cache
+                .Select(static pair => new StartupToolHealthCachePayloadEntry {
+                    Key = pair.Key,
+                    ErrorCode = pair.Value.ErrorCode,
+                    Error = pair.Value.Error,
+                    LastFailedUtc = pair.Value.LastFailedUtc,
+                    NextProbeUtc = pair.Value.NextProbeUtc,
+                    ConsecutiveFailures = pair.Value.ConsecutiveFailures
+                })
+                .ToList()
+        };
 
-        try {
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var payload = new StartupToolHealthCachePayload {
-                Entries = cache
-                    .Select(static pair => new StartupToolHealthCachePayloadEntry {
-                        Key = pair.Key,
-                        ErrorCode = pair.Value.ErrorCode,
-                        Error = pair.Value.Error,
-                        LastFailedUtc = pair.Value.LastFailedUtc,
-                        NextProbeUtc = pair.Value.NextProbeUtc,
-                        ConsecutiveFailures = pair.Value.ConsecutiveFailures
-                    })
-                    .ToList()
-            };
-
-            var json = JsonSerializer.Serialize(payload, StartupToolHealthCacheJson);
-            File.WriteAllText(path, json);
-        } catch {
-            // Ignore cache write failures.
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            payload,
+            static value => JsonSerializer.Serialize(value, StartupToolHealthCacheJson),
+            StartupToolHealthCacheStoreName);
     }
 
     private static string ResolveStartupToolHealthCachePath() {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(localAppData)) {
-            return Path.Combine(Path.GetTempPath(), "IntelligenceX.Chat", StartupToolHealthCacheFileName);
-        }
-
-        return Path.Combine(localAppData, "IntelligenceX.Chat", StartupToolHealthCacheFileName);
+        return ChatServiceJsonFileStore.ResolveDefaultPath(StartupToolHealthCacheFileName);
     }
 
     private sealed record StartupToolHealthCacheEntry(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -22,6 +23,9 @@ internal sealed partial class ChatServiceSession {
         PropertyNameCaseInsensitive = true,
         WriteIndented = false
     };
+    private static readonly object StartupToolHealthCacheStoreLock = new();
+    private static readonly Dictionary<string, Dictionary<string, DateTime>> StartupToolHealthLatestObservationsByPath = new(
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
     internal readonly record struct ToolHealthProbeCatalogEntry(
         string ToolName,
         string PackId,
@@ -96,7 +100,7 @@ internal sealed partial class ChatServiceSession {
         }
 
         var cache = LoadStartupToolHealthCache();
-        var cacheUpdated = false;
+        var mutations = new List<StartupToolHealthCacheMutation>();
 
         try {
             foreach (var entry in probeCatalog) {
@@ -131,12 +135,13 @@ internal sealed partial class ChatServiceSession {
                 }
 
                 if (probe.Ok) {
-                    if (cache.Remove(cacheKey)) {
-                        cacheUpdated = true;
-                    }
+                    var observedUtc = DateTime.UtcNow;
+                    cache.Remove(cacheKey);
+                    mutations.Add(new StartupToolHealthCacheMutation(cacheKey, Entry: null, ObservedUtc: observedUtc));
                     continue;
                 }
 
+                var failedUtc = DateTime.UtcNow;
                 var sourceLabel = ToSourceLabel(entry.SourceKind);
                 var packLabel = entry.PackId.Length == 0 ? "unknown" : entry.PackId;
                 var prefix = ShouldDowngradeStartupToolHealthFailure(entry.SourceKind, probe.ErrorCode)
@@ -148,24 +153,25 @@ internal sealed partial class ChatServiceSession {
                 var errorCode = NormalizeHealthErrorCode(probe.ErrorCode);
                 var nextFailureCount = ResolveNextFailureCount(cachedFailure, errorCode);
                 var nextProbeUtc = ComputeNextStartupToolHealthProbeUtc(
-                    nowUtc,
+                    failedUtc,
                     entry.SourceKind,
                     entry.PackId,
                     errorCode,
                     nextFailureCount);
-                cache[cacheKey] = new StartupToolHealthCacheEntry(
+                var cacheEntry = new StartupToolHealthCacheEntry(
                     ErrorCode: errorCode,
                     Error: NormalizeHealthError(probe.Error),
-                    LastFailedUtc: nowUtc,
+                    LastFailedUtc: failedUtc,
                     NextProbeUtc: nextProbeUtc,
                     ConsecutiveFailures: nextFailureCount);
-                cacheUpdated = true;
+                cache[cacheKey] = cacheEntry;
+                mutations.Add(new StartupToolHealthCacheMutation(cacheKey, cacheEntry, failedUtc));
             }
         } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
             // Startup priming is best-effort and bounded by the startup budget.
         } finally {
-            if (cacheUpdated) {
-                SaveStartupToolHealthCache(cache);
+            if (mutations.Count > 0) {
+                ApplyStartupToolHealthCacheMutations(ResolveStartupToolHealthCachePath(), mutations);
             }
         }
 
@@ -363,7 +369,10 @@ internal sealed partial class ChatServiceSession {
     }
 
     private static Dictionary<string, StartupToolHealthCacheEntry> LoadStartupToolHealthCache() {
-        var path = ResolveStartupToolHealthCachePath();
+        return LoadStartupToolHealthCache(ResolveStartupToolHealthCachePath());
+    }
+
+    internal static Dictionary<string, StartupToolHealthCacheEntry> LoadStartupToolHealthCache(string path) {
         var result = ChatServiceJsonFileStore.Read<Dictionary<string, StartupToolHealthCacheEntry>>(
             path,
             MaximumStartupToolHealthCacheBytes,
@@ -402,8 +411,74 @@ internal sealed partial class ChatServiceSession {
         return map;
     }
 
-    private static void SaveStartupToolHealthCache(Dictionary<string, StartupToolHealthCacheEntry> cache) {
-        var path = ResolveStartupToolHealthCachePath();
+    internal static void ApplyStartupToolHealthCacheMutations(
+        string path,
+        IReadOnlyList<StartupToolHealthCacheMutation> mutations) {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(mutations);
+        if (mutations.Count == 0) {
+            return;
+        }
+
+        var normalizedPath = Path.GetFullPath(path);
+        lock (StartupToolHealthCacheStoreLock) {
+            var cache = LoadStartupToolHealthCache(normalizedPath);
+            if (!StartupToolHealthLatestObservationsByPath.TryGetValue(normalizedPath, out var latestObservations)) {
+                latestObservations = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+                StartupToolHealthLatestObservationsByPath[normalizedPath] = latestObservations;
+            }
+
+            var changed = false;
+            foreach (var mutation in mutations) {
+                var key = (mutation.Key ?? string.Empty).Trim();
+                if (key.Length == 0) {
+                    continue;
+                }
+
+                var observedUtc = NormalizeStartupToolHealthObservationUtc(mutation.ObservedUtc);
+                var latestUtc = latestObservations.TryGetValue(key, out var knownObservation)
+                    ? NormalizeStartupToolHealthObservationUtc(knownObservation)
+                    : DateTime.MinValue;
+                if (cache.TryGetValue(key, out var currentEntry)) {
+                    var storedUtc = NormalizeStartupToolHealthObservationUtc(currentEntry.LastFailedUtc);
+                    if (storedUtc > latestUtc) {
+                        latestUtc = storedUtc;
+                    }
+                }
+
+                if (observedUtc < latestUtc) {
+                    continue;
+                }
+
+                latestObservations[key] = observedUtc;
+                if (mutation.Entry is null) {
+                    changed |= cache.Remove(key);
+                    continue;
+                }
+
+                if (!cache.TryGetValue(key, out var existing) || existing != mutation.Entry) {
+                    cache[key] = mutation.Entry;
+                    changed = true;
+                }
+            }
+
+            if (changed) {
+                SaveStartupToolHealthCache(normalizedPath, cache);
+            }
+        }
+    }
+
+    private static DateTime NormalizeStartupToolHealthObservationUtc(DateTime value) {
+        return value.Kind switch {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+    }
+
+    private static void SaveStartupToolHealthCache(
+        string path,
+        Dictionary<string, StartupToolHealthCacheEntry> cache) {
         var payload = new StartupToolHealthCachePayload {
             Entries = cache
                 .Select(static pair => new StartupToolHealthCachePayloadEntry {
@@ -434,6 +509,11 @@ internal sealed partial class ChatServiceSession {
         DateTime LastFailedUtc,
         DateTime NextProbeUtc,
         int ConsecutiveFailures);
+
+    internal sealed record StartupToolHealthCacheMutation(
+        string Key,
+        StartupToolHealthCacheEntry? Entry,
+        DateTime ObservedUtc);
 
     private sealed class StartupToolHealthCachePayload {
         public List<StartupToolHealthCachePayloadEntry> Entries { get; set; } = new();

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolHealth.cs
@@ -364,22 +364,30 @@ internal sealed partial class ChatServiceSession {
 
     private static Dictionary<string, StartupToolHealthCacheEntry> LoadStartupToolHealthCache() {
         var path = ResolveStartupToolHealthCachePath();
-        var result = ChatServiceJsonFileStore.Read<StartupToolHealthCachePayload>(
+        var result = ChatServiceJsonFileStore.Read<Dictionary<string, StartupToolHealthCacheEntry>>(
             path,
             MaximumStartupToolHealthCacheBytes,
-            static json => JsonSerializer.Deserialize<StartupToolHealthCachePayload>(json, StartupToolHealthCacheJson),
-            static payload => payload.Entries is not null,
+            DeserializeStartupToolHealthCache,
+            static _ => true,
             normalize: null,
             StartupToolHealthCacheStoreName);
-        if (result.State != ChatServiceJsonFileReadState.Loaded
-            || result.Value?.Entries is not { Count: > 0 } entries) {
-            return new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
-        }
+        return result.State == ChatServiceJsonFileReadState.Loaded && result.Value is not null
+            ? result.Value
+            : new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal static Dictionary<string, StartupToolHealthCacheEntry> DeserializeStartupToolHealthCache(string json) {
+        var payload = JsonSerializer.Deserialize<StartupToolHealthCachePayload>(json, StartupToolHealthCacheJson);
+        var entries = payload?.Entries;
 
         var map = new Dictionary<string, StartupToolHealthCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        if (entries is null) {
+            return map;
+        }
+
         for (var i = 0; i < entries.Count; i++) {
             var entry = entries[i];
-            if (string.IsNullOrWhiteSpace(entry.Key)) {
+            if (entry is null || string.IsNullOrWhiteSpace(entry.Key)) {
                 continue;
             }
 
@@ -420,7 +428,7 @@ internal sealed partial class ChatServiceSession {
         return ChatServiceJsonFileStore.ResolveDefaultPath(StartupToolHealthCacheFileName);
     }
 
-    private sealed record StartupToolHealthCacheEntry(
+    internal sealed record StartupToolHealthCacheEntry(
         string ErrorCode,
         string Error,
         DateTime LastFailedUtc,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Testing.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ToolRouting.Testing.cs
@@ -654,6 +654,12 @@ internal sealed partial class ChatServiceSession {
         RememberBackgroundSchedulerAdaptiveIdleDecision(delay, reason, utcTicks);
     }
 
+    internal void RememberBackgroundSchedulerIterationResultForTesting(
+        BackgroundSchedulerIterationResult result,
+        long? utcTicks = null) {
+        RememberBackgroundSchedulerIterationResult(result, utcTicks);
+    }
+
     internal bool TryReleaseScheduledBackgroundWorkReplayCandidateForTesting(string threadId, string itemId) {
         ArgumentNullException.ThrowIfNull(threadId);
         ArgumentNullException.ThrowIfNull(itemId);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
@@ -183,8 +183,8 @@ internal sealed partial class ChatServiceSession {
         TryApplyPersistedToolingBootstrapPreview();
         if (_startupWarnings.Length == 0
             && _toolingBootstrapCache is not null
-            && _toolingBootstrapCache.TryGetPersistedSnapshotLoadWarning(out var persistedSnapshotLoadWarning)) {
-            _startupWarnings = NormalizeDistinctStrings(new[] { persistedSnapshotLoadWarning }, maxItems: 64);
+            && _toolingBootstrapCache.TryGetPersistedSnapshotWarning(out var persistedSnapshotWarning)) {
+            _startupWarnings = NormalizeDistinctStrings(new[] { persistedSnapshotWarning }, maxItems: 64);
         }
 
         _json = new JsonSerializerOptions {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.cs
@@ -120,6 +120,7 @@ internal sealed partial class ChatServiceSession {
     private int _backgroundSchedulerRequeuedExecutionCount;
     private int _backgroundSchedulerReleasedExecutionCount;
     private int _backgroundSchedulerConsecutiveFailureCount;
+    private readonly List<BackgroundSchedulerFailureEventDto> _backgroundSchedulerFailureStreakEvents = new();
     private long _backgroundSchedulerPausedUntilUtcTicks;
     private string _backgroundSchedulerPauseReason = string.Empty;
     private long _backgroundSchedulerLastAdaptiveIdleUtcTicks;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceToolingBootstrapCache.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceToolingBootstrapCache.cs
@@ -26,11 +26,11 @@ internal sealed class ChatServiceToolingBootstrapCache {
     private string _cacheKey = string.Empty;
     private ChatServiceToolingBootstrapSnapshot? _snapshot;
     private ChatServiceToolingBootstrapPersistedSnapshot? _persistedSnapshot;
-    private string? _persistedSnapshotLoadWarning;
+    private string? _persistedSnapshotWarning;
 
     public ChatServiceToolingBootstrapCache(string? persistedSnapshotPath = null) {
         _persistedSnapshotPath = ResolvePersistedSnapshotPath(persistedSnapshotPath);
-        _persistedSnapshot = LoadPersistedSnapshot(_persistedSnapshotPath, out _persistedSnapshotLoadWarning);
+        _persistedSnapshot = LoadPersistedSnapshot(_persistedSnapshotPath, out _persistedSnapshotWarning);
     }
 
     public bool TryGetSnapshot(string cacheKey, out ChatServiceToolingBootstrapSnapshot snapshot) {
@@ -101,30 +101,30 @@ internal sealed class ChatServiceToolingBootstrapCache {
                     normalizedPersistedPreviewDiscoveryFingerprint,
                     normalizedExpectedPreviewDiscoveryFingerprint,
                     StringComparison.Ordinal)) {
-                _persistedSnapshotLoadWarning = StartupBootstrapWarningBuilder.BuildPersistedPreviewIgnoredSummary("preview_fingerprint_mismatch");
+                _persistedSnapshotWarning = StartupBootstrapWarningBuilder.BuildPersistedPreviewIgnoredSummary("preview_fingerprint_mismatch");
                 snapshot = null!;
                 return false;
             }
 
-            _persistedSnapshotLoadWarning = null;
+            _persistedSnapshotWarning = null;
             snapshot = _persistedSnapshot;
             return true;
         }
     }
 
-    public bool TryGetPersistedSnapshotLoadWarning(out string warning) {
+    public bool TryGetPersistedSnapshotWarning(out string warning) {
         lock (_sync) {
-            if (string.IsNullOrWhiteSpace(_persistedSnapshotLoadWarning)) {
+            if (string.IsNullOrWhiteSpace(_persistedSnapshotWarning)) {
                 warning = string.Empty;
                 return false;
             }
 
-            warning = _persistedSnapshotLoadWarning;
+            warning = _persistedSnapshotWarning;
             return true;
         }
     }
 
-    public void StoreSnapshot(
+    public bool StoreSnapshot(
         string cacheKey,
         ChatServiceToolingBootstrapSnapshot snapshot,
         string? previewDiscoveryFingerprint = null) {
@@ -141,8 +141,12 @@ internal sealed class ChatServiceToolingBootstrapCache {
             _cacheKey = normalizedCacheKey;
             _snapshot = snapshot;
             _persistedSnapshot = BuildPersistedSnapshot(normalizedCacheKey, snapshot, previewDiscoveryFingerprint);
-            _persistedSnapshotLoadWarning = null;
-            SavePersistedSnapshot(_persistedSnapshotPath, _persistedSnapshot);
+            _persistedSnapshotWarning = null;
+            var persisted = SavePersistedSnapshot(_persistedSnapshotPath, _persistedSnapshot);
+            if (!persisted) {
+                _persistedSnapshotWarning = StartupBootstrapWarningBuilder.BuildPersistedPreviewIgnoredSummary("write_failed");
+            }
+            return persisted;
         }
     }
 
@@ -151,7 +155,7 @@ internal sealed class ChatServiceToolingBootstrapCache {
             _cacheKey = string.Empty;
             _snapshot = null;
             _persistedSnapshot = null;
-            _persistedSnapshotLoadWarning = null;
+            _persistedSnapshotWarning = null;
             TryDeletePersistedSnapshot(_persistedSnapshotPath);
         }
     }
@@ -360,8 +364,8 @@ internal sealed class ChatServiceToolingBootstrapCache {
         return true;
     }
 
-    private static void SavePersistedSnapshot(string path, ChatServiceToolingBootstrapPersistedSnapshot snapshot) {
-        ChatServiceJsonFileStore.Write(
+    private static bool SavePersistedSnapshot(string path, ChatServiceToolingBootstrapPersistedSnapshot snapshot) {
+        return ChatServiceJsonFileStore.Write(
             path,
             snapshot,
             static value => JsonSerializer.Serialize(value, PersistedSnapshotJson),

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceToolingBootstrapCache.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceToolingBootstrapCache.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text.Json;
 using IntelligenceX.Chat.Abstractions.Policy;
 using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Service.Persistence;
 using IntelligenceX.Chat.Tooling;
 using IntelligenceX.Tools;
 using IntelligenceX.Tools.Common;
@@ -12,7 +13,9 @@ namespace IntelligenceX.Chat.Service;
 internal sealed class ChatServiceToolingBootstrapCache {
     private const int PersistedSnapshotSchemaVersion = 4;
     private const int PersistedDescriptorSnapshotSchemaVersion = 1;
+    private const int MaximumPersistedSnapshotBytes = 16 * 1024 * 1024;
     private const string DefaultPersistedSnapshotFileName = "tooling-bootstrap-cache-v1.json";
+    private const string PersistedSnapshotStoreName = "Tooling bootstrap cache";
     private static readonly JsonSerializerOptions PersistedSnapshotJson = new() {
         PropertyNameCaseInsensitive = true,
         WriteIndented = false
@@ -210,22 +213,36 @@ internal sealed class ChatServiceToolingBootstrapCache {
             }
         }
 
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
-
-        return Path.Combine(root, "IntelligenceX.Chat", DefaultPersistedSnapshotFileName);
+        return ChatServiceJsonFileStore.ResolveDefaultPath(DefaultPersistedSnapshotFileName);
     }
 
     private static ChatServiceToolingBootstrapPersistedSnapshot? LoadPersistedSnapshot(string path, out string? warning) {
         warning = null;
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return null;
-            }
+        string? validationWarning = null;
+        var result = ChatServiceJsonFileStore.Read<ChatServiceToolingBootstrapPersistedSnapshot>(
+            path,
+            MaximumPersistedSnapshotBytes,
+            json => DeserializeAndNormalizePersistedSnapshot(json, out validationWarning),
+            static _ => true,
+            normalize: null,
+            PersistedSnapshotStoreName);
+        if (result.State == ChatServiceJsonFileReadState.Loaded && result.Value is not null) {
+            return result.Value;
+        }
 
-            var json = File.ReadAllText(path);
+        if (result.State == ChatServiceJsonFileReadState.Invalid) {
+            warning = validationWarning
+                ?? StartupBootstrapWarningBuilder.BuildPersistedPreviewIgnoredSummary("read_failed");
+        }
+
+        return null;
+    }
+
+    private static ChatServiceToolingBootstrapPersistedSnapshot? DeserializeAndNormalizePersistedSnapshot(
+        string json,
+        out string? warning) {
+        warning = null;
+        try {
             var snapshot = JsonSerializer.Deserialize<ChatServiceToolingBootstrapPersistedSnapshot>(json, PersistedSnapshotJson);
             if (snapshot is null) {
                 warning = StartupBootstrapWarningBuilder.BuildPersistedPreviewIgnoredSummary("deserialize_failed");
@@ -344,34 +361,15 @@ internal sealed class ChatServiceToolingBootstrapCache {
     }
 
     private static void SavePersistedSnapshot(string path, ChatServiceToolingBootstrapPersistedSnapshot snapshot) {
-        try {
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            var tempPath = path + ".tmp-" + Guid.NewGuid().ToString("N");
-            var json = JsonSerializer.Serialize(snapshot, PersistedSnapshotJson);
-            File.WriteAllText(tempPath, json);
-            if (File.Exists(path)) {
-                File.Delete(path);
-            }
-            File.Move(tempPath, path);
-        } catch {
-            // Persisted startup metadata cache is best-effort.
-        }
+        ChatServiceJsonFileStore.Write(
+            path,
+            snapshot,
+            static value => JsonSerializer.Serialize(value, PersistedSnapshotJson),
+            PersistedSnapshotStoreName);
     }
 
     private static void TryDeletePersistedSnapshot(string path) {
-        try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
-                return;
-            }
-
-            File.Delete(path);
-        } catch {
-            // Best-effort cleanup.
-        }
+        ChatServiceJsonFileStore.Delete(path, PersistedSnapshotStoreName);
     }
 
     private static string NormalizePreviewCacheKey(string? previewCacheKey, string? cacheKey) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
 using IntelligenceX.Chat.Abstractions.Storage;
 
 namespace IntelligenceX.Chat.Service.Persistence;
@@ -23,13 +25,19 @@ internal static class ChatServiceJsonFileStore {
     /// Resolves an optional store override while keeping it inside the shared state directory.
     /// </summary>
     internal static string ResolvePathOverrideWithinDefaultDirectory(string? candidate, string defaultFileName) {
-        var defaultPath = ResolveDefaultPath(defaultFileName);
-        var normalizedCandidate = (candidate ?? string.Empty).Trim();
-        if (normalizedCandidate.Length == 0) {
-            return defaultPath;
+        string defaultPath;
+        try {
+            defaultPath = ResolveDefaultPath(defaultFileName);
+        } catch {
+            return string.Empty;
         }
 
         try {
+            var normalizedCandidate = (candidate ?? string.Empty).Trim();
+            if (normalizedCandidate.Length == 0) {
+                return defaultPath;
+            }
+
             if (normalizedCandidate.StartsWith(@"\\", StringComparison.Ordinal)) {
                 return defaultPath;
             }
@@ -42,7 +50,7 @@ internal static class ChatServiceJsonFileStore {
                     return defaultPath;
                 }
 
-                return Path.Combine(ResolveDefaultDirectory(), fileName);
+                return ResolveDefaultPath(fileName);
             }
 
             var fullCandidate = Path.GetFullPath(normalizedCandidate);
@@ -58,15 +66,27 @@ internal static class ChatServiceJsonFileStore {
     /// Resolves a state file beside an already validated anchor store path.
     /// </summary>
     internal static string ResolveSiblingPath(string anchorPath, string fileName) {
-        var normalizedFileName = Path.GetFileName((fileName ?? string.Empty).Trim());
-        if (normalizedFileName.Length == 0) {
+        if (string.IsNullOrWhiteSpace(anchorPath)) {
+            return string.Empty;
+        }
+
+        var normalizedCandidate = (fileName ?? string.Empty).Trim();
+        var normalizedFileName = Path.GetFileName(normalizedCandidate);
+        if (normalizedFileName.Length == 0
+            || normalizedFileName is "." or ".."
+            || !string.Equals(normalizedFileName, normalizedCandidate, StringComparison.Ordinal)) {
             throw new ArgumentException("A state file name is required.", nameof(fileName));
         }
 
         var directory = Path.GetDirectoryName(anchorPath);
-        return !string.IsNullOrWhiteSpace(directory)
-            ? Path.Combine(directory, normalizedFileName)
-            : ResolveDefaultPath(normalizedFileName);
+        if (string.IsNullOrWhiteSpace(directory)) {
+            return string.Empty;
+        }
+
+        var candidate = Path.GetFullPath(Path.Combine(directory, normalizedFileName));
+        return ChatStatePaths.IsDirectChildPath(directory, candidate)
+            ? candidate
+            : string.Empty;
     }
 
     /// <summary>
@@ -81,6 +101,12 @@ internal static class ChatServiceJsonFileStore {
         string storeName) where T : class {
         ArgumentNullException.ThrowIfNull(deserialize);
         ArgumentNullException.ThrowIfNull(validate);
+        if (string.IsNullOrWhiteSpace(path)) {
+            return ChatServiceJsonFileReadResult<T>.Empty();
+        }
+        if (!IsSafeDirectFilePath(path)) {
+            return ChatServiceJsonFileReadResult<T>.Invalid();
+        }
 
         try {
             var snapshot = ChatJsonFileStore.Read(path, maximumBytes);
@@ -137,6 +163,9 @@ internal static class ChatServiceJsonFileStore {
             if (string.IsNullOrWhiteSpace(path)) {
                 return false;
             }
+            if (!IsSafeDirectFilePath(path)) {
+                return false;
+            }
 
             var json = serialize(value);
             ChatJsonFileStore.Write(
@@ -153,11 +182,115 @@ internal static class ChatServiceJsonFileStore {
     /// <summary>
     /// Deletes a snapshot without allowing cleanup failures to escape into chat execution.
     /// </summary>
-    internal static void Delete(string path, string storeName) {
+    internal static bool Delete(string path, string storeName) {
         try {
+            if (string.IsNullOrWhiteSpace(path)) {
+                return false;
+            }
+            if (!IsSafeDirectFilePath(path)) {
+                return false;
+            }
+
             ChatJsonFileStore.Delete(path);
+            return true;
         } catch (Exception ex) {
             Trace.TraceWarning($"{NormalizeStoreName(storeName)} clear failed: {ex.GetType().Name}: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Serializes a read-modify-write operation across service sessions and processes for one store path.
+    /// </summary>
+    internal static bool TryWithExclusiveAccess<TState, TResult>(
+        string path,
+        Func<TState, TResult> action,
+        TState state,
+        out TResult result,
+        string storeName,
+        Func<string, bool?>? acquisitionOverride = null) {
+        ArgumentNullException.ThrowIfNull(action);
+        result = default!;
+        if (string.IsNullOrWhiteSpace(path)) {
+            return false;
+        }
+
+        var mutexName = BuildMutexName(path);
+        if (acquisitionOverride is not null) {
+            var overrideResult = acquisitionOverride(path);
+            if (overrideResult.HasValue) {
+                if (!overrideResult.Value) {
+                    Trace.TraceWarning($"{NormalizeStoreName(storeName)} lock timeout for '{mutexName}'.");
+                    return false;
+                }
+
+                try {
+                    result = action(state);
+                    return true;
+                } catch (Exception ex) {
+                    Trace.TraceWarning($"{NormalizeStoreName(storeName)} locked operation failed: {ex.GetType().Name}: {ex.Message}");
+                    return false;
+                }
+            }
+        }
+
+        Mutex? mutex = null;
+        var acquired = false;
+        try {
+            mutex = new Mutex(initiallyOwned: false, mutexName);
+            try {
+                acquired = mutex.WaitOne(TimeSpan.FromSeconds(15));
+            } catch (AbandonedMutexException) {
+                acquired = true;
+            }
+
+            if (!acquired) {
+                Trace.TraceWarning($"{NormalizeStoreName(storeName)} lock timeout for '{mutexName}'.");
+                return false;
+            }
+
+            result = action(state);
+            return true;
+        } catch (Exception ex) {
+            Trace.TraceWarning($"{NormalizeStoreName(storeName)} lock failed: {ex.GetType().Name}: {ex.Message}");
+            return false;
+        } finally {
+            if (acquired && mutex is not null) {
+                try {
+                    mutex.ReleaseMutex();
+                } catch {
+                    // Preserve the operation result when lock cleanup fails.
+                }
+            }
+
+            mutex?.Dispose();
+        }
+    }
+
+    private static string BuildMutexName(string path) {
+        var normalizedPath = path.Trim();
+        try {
+            normalizedPath = Path.GetFullPath(normalizedPath);
+        } catch {
+            // Hash the original path when full path resolution is unavailable.
+        }
+
+        if (OperatingSystem.IsWindows()) {
+            normalizedPath = normalizedPath.ToUpperInvariant();
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalizedPath));
+        return $"IntelligenceX.Chat.JsonStore.{Convert.ToHexString(hash)}";
+    }
+
+    private static bool IsSafeDirectFilePath(string path) {
+        try {
+            var fullPath = Path.GetFullPath(path);
+            var directory = Path.GetDirectoryName(fullPath);
+            return !string.IsNullOrWhiteSpace(directory)
+                   && ChatStatePaths.IsDirectChildPath(directory, fullPath);
+        } catch {
+            return false;
         }
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Security.AccessControl;
 using System.Security.Principal;
-using System.Text;
 using IntelligenceX.Chat.Abstractions.Storage;
 
 namespace IntelligenceX.Chat.Service.Persistence;
@@ -51,21 +50,15 @@ internal static class ChatServiceJsonFileStore {
         ArgumentNullException.ThrowIfNull(validate);
 
         try {
-            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
+            var snapshot = ChatJsonFileStore.Read(path, maximumBytes);
+            if (snapshot.State == ChatJsonFileReadState.Empty) {
                 return ChatServiceJsonFileReadResult<T>.Empty();
             }
-
-            var info = new FileInfo(path);
-            if (info.Length <= 0 || info.Length > maximumBytes) {
+            if (snapshot.State != ChatJsonFileReadState.Loaded || snapshot.Json is null) {
                 return ChatServiceJsonFileReadResult<T>.Invalid();
             }
 
-            var json = File.ReadAllText(path, Encoding.UTF8);
-            if (string.IsNullOrWhiteSpace(json)) {
-                return ChatServiceJsonFileReadResult<T>.Invalid();
-            }
-
-            var value = deserialize(json);
+            var value = deserialize(snapshot.Json);
             if (value is null || !validate(value)) {
                 return ChatServiceJsonFileReadResult<T>.Invalid();
             }
@@ -107,54 +100,16 @@ internal static class ChatServiceJsonFileStore {
         string storeName) {
         ArgumentNullException.ThrowIfNull(serialize);
 
-        string? temporaryPath = null;
         try {
             if (string.IsNullOrWhiteSpace(path)) {
                 return;
             }
 
-            var directory = Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory)) {
-                Directory.CreateDirectory(directory);
-            }
-
-            if (!string.IsNullOrWhiteSpace(directory)) {
-                TryHardenDirectoryNoThrow(directory, storeName);
-            }
-
             var json = serialize(value);
-            var fileName = Path.GetFileName(path);
-            var temporaryName = $"{fileName}.{Guid.NewGuid():N}.tmp";
-            temporaryPath = string.IsNullOrWhiteSpace(directory)
-                ? temporaryName
-                : Path.Combine(directory, temporaryName);
-
-            using (var stream = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenFileNoThrow(temporaryPath, storeName);
-                using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(json);
-                writer.Flush();
-                stream.Flush(flushToDisk: true);
-            }
-
-            if (File.Exists(path)) {
-                File.Replace(temporaryPath, path, destinationBackupFileName: null, ignoreMetadataErrors: true);
-            } else {
-                File.Move(temporaryPath, path);
-            }
-
-            temporaryPath = null;
-            TryHardenFileNoThrow(path, storeName);
+            ChatJsonFileStore.Write(path, json);
+            TryHardenWindowsFileNoThrow(path, storeName);
         } catch (Exception ex) {
             Trace.TraceWarning($"{NormalizeStoreName(storeName)} write failed: {ex.GetType().Name}: {ex.Message}");
-        } finally {
-            if (!string.IsNullOrWhiteSpace(temporaryPath) && File.Exists(temporaryPath)) {
-                try {
-                    File.Delete(temporaryPath);
-                } catch {
-                    // Best effort only.
-                }
-            }
         }
     }
 
@@ -163,44 +118,19 @@ internal static class ChatServiceJsonFileStore {
     /// </summary>
     internal static void Delete(string path, string storeName) {
         try {
-            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path)) {
-                File.Delete(path);
-            }
+            ChatJsonFileStore.Delete(path);
         } catch (Exception ex) {
             Trace.TraceWarning($"{NormalizeStoreName(storeName)} clear failed: {ex.GetType().Name}: {ex.Message}");
         }
     }
 
-    private static void TryHardenDirectoryNoThrow(string path, string storeName) {
-        if (string.IsNullOrWhiteSpace(path) || OperatingSystem.IsWindows()) {
-            return;
-        }
-
-        try {
-            if (!Directory.Exists(path)) {
-                return;
-            }
-
-            File.SetUnixFileMode(
-                path,
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"{NormalizeStoreName(storeName)} directory permission hardening failed: {ex.GetType().Name}: {ex.Message}");
-        }
-    }
-
-    private static void TryHardenFileNoThrow(string path, string storeName) {
-        if (string.IsNullOrWhiteSpace(path)) {
+    private static void TryHardenWindowsFileNoThrow(string path, string storeName) {
+        if (string.IsNullOrWhiteSpace(path) || !OperatingSystem.IsWindows()) {
             return;
         }
 
         try {
             if (!File.Exists(path)) {
-                return;
-            }
-
-            if (!OperatingSystem.IsWindows()) {
-                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
                 return;
             }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
@@ -11,20 +11,39 @@ namespace IntelligenceX.Chat.Service.Persistence;
 /// </summary>
 internal static class ChatServiceJsonFileStore {
     /// <summary>
-    /// Resolves a chat service state file beneath the current user's local application data folder.
+    /// Resolves a chat service state file beneath local application data, with the OS temporary directory as a safe fallback.
     /// </summary>
     internal static string ResolveDefaultPath(string fileName) {
+        return ResolveDefaultPath(
+            fileName,
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Path.GetTempPath());
+    }
+
+    internal static string ResolveDefaultPath(string fileName, string? localApplicationData, string temporaryPath) {
         var normalizedFileName = Path.GetFileName((fileName ?? string.Empty).Trim());
         if (normalizedFileName.Length == 0) {
             throw new ArgumentException("A state file name is required.", nameof(fileName));
         }
 
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(ResolveDefaultDirectory(localApplicationData, temporaryPath), normalizedFileName);
+    }
+
+    internal static string ResolveDefaultDirectory() {
+        return ResolveDefaultDirectory(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Path.GetTempPath());
+    }
+
+    internal static string ResolveDefaultDirectory(string? localApplicationData, string temporaryPath) {
+        var root = string.IsNullOrWhiteSpace(localApplicationData)
+            ? temporaryPath
+            : localApplicationData;
         if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
+            throw new ArgumentException("A temporary state directory is required when local application data is unavailable.", nameof(temporaryPath));
         }
 
-        return Path.Combine(root, "IntelligenceX.Chat", normalizedFileName);
+        return Path.Combine(root, "IntelligenceX.Chat");
     }
 
     /// <summary>

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
@@ -1,6 +1,4 @@
 using System.Diagnostics;
-using System.Security.AccessControl;
-using System.Security.Principal;
 using IntelligenceX.Chat.Abstractions.Storage;
 
 namespace IntelligenceX.Chat.Service.Persistence;
@@ -19,6 +17,41 @@ internal static class ChatServiceJsonFileStore {
 
     internal static string ResolveDefaultDirectory() {
         return ChatStatePaths.GetDefaultDirectory();
+    }
+
+    /// <summary>
+    /// Resolves an optional store override while keeping it inside the shared state directory.
+    /// </summary>
+    internal static string ResolvePathOverrideWithinDefaultDirectory(string? candidate, string defaultFileName) {
+        var defaultPath = ResolveDefaultPath(defaultFileName);
+        var normalizedCandidate = (candidate ?? string.Empty).Trim();
+        if (normalizedCandidate.Length == 0) {
+            return defaultPath;
+        }
+
+        try {
+            if (normalizedCandidate.StartsWith(@"\\", StringComparison.Ordinal)) {
+                return defaultPath;
+            }
+
+            if (!Path.IsPathFullyQualified(normalizedCandidate)) {
+                var fileName = Path.GetFileName(normalizedCandidate);
+                if (fileName.Length == 0
+                    || fileName is "." or ".."
+                    || !string.Equals(fileName, normalizedCandidate, StringComparison.Ordinal)) {
+                    return defaultPath;
+                }
+
+                return Path.Combine(ResolveDefaultDirectory(), fileName);
+            }
+
+            var fullCandidate = Path.GetFullPath(normalizedCandidate);
+            return ChatStatePaths.IsPathInDefaultDirectory(fullCandidate)
+                ? fullCandidate
+                : defaultPath;
+        } catch {
+            return defaultPath;
+        }
     }
 
     /// <summary>
@@ -106,8 +139,10 @@ internal static class ChatServiceJsonFileStore {
             }
 
             var json = serialize(value);
-            ChatJsonFileStore.Write(path, json);
-            TryHardenWindowsFileNoThrow(path, storeName);
+            ChatJsonFileStore.Write(
+                path,
+                json,
+                hardenExistingDirectory: ChatStatePaths.IsPathInDefaultDirectory(path));
         } catch (Exception ex) {
             Trace.TraceWarning($"{NormalizeStoreName(storeName)} write failed: {ex.GetType().Name}: {ex.Message}");
         }
@@ -121,40 +156,6 @@ internal static class ChatServiceJsonFileStore {
             ChatJsonFileStore.Delete(path);
         } catch (Exception ex) {
             Trace.TraceWarning($"{NormalizeStoreName(storeName)} clear failed: {ex.GetType().Name}: {ex.Message}");
-        }
-    }
-
-    private static void TryHardenWindowsFileNoThrow(string path, string storeName) {
-        if (string.IsNullOrWhiteSpace(path) || !OperatingSystem.IsWindows()) {
-            return;
-        }
-
-        try {
-            if (!File.Exists(path)) {
-                return;
-            }
-
-            var attributes = File.GetAttributes(path);
-            if ((attributes & FileAttributes.Directory) != 0) {
-                return;
-            }
-
-            var currentSid = WindowsIdentity.GetCurrent().User;
-            if (currentSid is null) {
-                return;
-            }
-
-            var fileInfo = new FileInfo(path);
-            var security = fileInfo.GetAccessControl();
-            security.SetOwner(currentSid);
-            security.SetAccessRuleProtection(isProtected: true, preserveInheritance: true);
-            security.SetAccessRule(new FileSystemAccessRule(
-                currentSid,
-                FileSystemRights.FullControl,
-                AccessControlType.Allow));
-            fileInfo.SetAccessControl(security);
-        } catch (Exception ex) {
-            Trace.TraceWarning($"{NormalizeStoreName(storeName)} ACL hardening failed: {ex.GetType().Name}: {ex.Message}");
         }
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text;
+using IntelligenceX.Chat.Abstractions.Storage;
 
 namespace IntelligenceX.Chat.Service.Persistence;
 
@@ -11,39 +12,14 @@ namespace IntelligenceX.Chat.Service.Persistence;
 /// </summary>
 internal static class ChatServiceJsonFileStore {
     /// <summary>
-    /// Resolves a chat service state file beneath local application data, with the OS temporary directory as a safe fallback.
+    /// Resolves a chat service state file beneath the shared durable per-user state directory.
     /// </summary>
     internal static string ResolveDefaultPath(string fileName) {
-        return ResolveDefaultPath(
-            fileName,
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            Path.GetTempPath());
-    }
-
-    internal static string ResolveDefaultPath(string fileName, string? localApplicationData, string temporaryPath) {
-        var normalizedFileName = Path.GetFileName((fileName ?? string.Empty).Trim());
-        if (normalizedFileName.Length == 0) {
-            throw new ArgumentException("A state file name is required.", nameof(fileName));
-        }
-
-        return Path.Combine(ResolveDefaultDirectory(localApplicationData, temporaryPath), normalizedFileName);
+        return ChatStatePaths.GetDefaultPath(fileName);
     }
 
     internal static string ResolveDefaultDirectory() {
-        return ResolveDefaultDirectory(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            Path.GetTempPath());
-    }
-
-    internal static string ResolveDefaultDirectory(string? localApplicationData, string temporaryPath) {
-        var root = string.IsNullOrWhiteSpace(localApplicationData)
-            ? temporaryPath
-            : localApplicationData;
-        if (string.IsNullOrWhiteSpace(root)) {
-            throw new ArgumentException("A temporary state directory is required when local application data is unavailable.", nameof(temporaryPath));
-        }
-
-        return Path.Combine(root, "IntelligenceX.Chat");
+        return ChatStatePaths.GetDefaultDirectory();
     }
 
     /// <summary>
@@ -86,7 +62,7 @@ internal static class ChatServiceJsonFileStore {
 
             var json = File.ReadAllText(path, Encoding.UTF8);
             if (string.IsNullOrWhiteSpace(json)) {
-                return ChatServiceJsonFileReadResult<T>.Empty();
+                return ChatServiceJsonFileReadResult<T>.Invalid();
             }
 
             var value = deserialize(json);
@@ -122,7 +98,7 @@ internal static class ChatServiceJsonFileStore {
     }
 
     /// <summary>
-    /// Atomically replaces a JSON snapshot and applies best-effort per-user ACL hardening.
+    /// Atomically replaces a JSON snapshot and applies best-effort owner-only permissions.
     /// </summary>
     internal static void Write<T>(
         string path,
@@ -142,6 +118,10 @@ internal static class ChatServiceJsonFileStore {
                 Directory.CreateDirectory(directory);
             }
 
+            if (!string.IsNullOrWhiteSpace(directory)) {
+                TryHardenDirectoryNoThrow(directory, storeName);
+            }
+
             var json = serialize(value);
             var fileName = Path.GetFileName(path);
             var temporaryName = $"{fileName}.{Guid.NewGuid():N}.tmp";
@@ -150,7 +130,7 @@ internal static class ChatServiceJsonFileStore {
                 : Path.Combine(directory, temporaryName);
 
             using (var stream = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
-                TryHardenAclNoThrow(temporaryPath, storeName);
+                TryHardenFileNoThrow(temporaryPath, storeName);
                 using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
                 writer.Write(json);
                 writer.Flush();
@@ -164,7 +144,7 @@ internal static class ChatServiceJsonFileStore {
             }
 
             temporaryPath = null;
-            TryHardenAclNoThrow(path, storeName);
+            TryHardenFileNoThrow(path, storeName);
         } catch (Exception ex) {
             Trace.TraceWarning($"{NormalizeStoreName(storeName)} write failed: {ex.GetType().Name}: {ex.Message}");
         } finally {
@@ -191,13 +171,36 @@ internal static class ChatServiceJsonFileStore {
         }
     }
 
-    private static void TryHardenAclNoThrow(string path, string storeName) {
-        if (string.IsNullOrWhiteSpace(path) || !OperatingSystem.IsWindows()) {
+    private static void TryHardenDirectoryNoThrow(string path, string storeName) {
+        if (string.IsNullOrWhiteSpace(path) || OperatingSystem.IsWindows()) {
+            return;
+        }
+
+        try {
+            if (!Directory.Exists(path)) {
+                return;
+            }
+
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        } catch (Exception ex) {
+            Trace.TraceWarning($"{NormalizeStoreName(storeName)} directory permission hardening failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static void TryHardenFileNoThrow(string path, string storeName) {
+        if (string.IsNullOrWhiteSpace(path)) {
             return;
         }
 
         try {
             if (!File.Exists(path)) {
+                return;
+            }
+
+            if (!OperatingSystem.IsWindows()) {
+                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
                 return;
             }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/Persistence/ChatServiceJsonFileStore.cs
@@ -124,9 +124,9 @@ internal static class ChatServiceJsonFileStore {
     }
 
     /// <summary>
-    /// Atomically replaces a JSON snapshot and applies best-effort owner-only permissions.
+    /// Atomically replaces a JSON snapshot and reports whether owner-only persistence succeeded.
     /// </summary>
-    internal static void Write<T>(
+    internal static bool Write<T>(
         string path,
         T value,
         Func<T, string> serialize,
@@ -135,7 +135,7 @@ internal static class ChatServiceJsonFileStore {
 
         try {
             if (string.IsNullOrWhiteSpace(path)) {
-                return;
+                return false;
             }
 
             var json = serialize(value);
@@ -143,8 +143,10 @@ internal static class ChatServiceJsonFileStore {
                 path,
                 json,
                 hardenExistingDirectory: ChatStatePaths.IsPathInDefaultDirectory(path));
+            return true;
         } catch (Exception ex) {
             Trace.TraceWarning($"{NormalizeStoreName(storeName)} write failed: {ex.GetType().Name}: {ex.Message}");
+            return false;
         }
     }
 

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ServiceOptions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Chat.Abstractions.Storage;
 using IntelligenceX.Chat.Profiles;
 using IntelligenceX.Chat.Tooling;
 using IntelligenceX.OpenAI;
@@ -999,11 +1000,7 @@ internal sealed partial class ServiceOptions : IToolRuntimePolicySettings, ITool
     }
 
     internal static string GetDefaultStateDbPath() {
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
-        return Path.Combine(root, "IntelligenceX.Chat", "state.db");
+        return ChatStatePaths.GetDefaultPath("state.db");
     }
 
     internal static string GetDefaultToolingBootstrapCachePath(string? stateDbPath = null) {
@@ -1020,12 +1017,7 @@ internal sealed partial class ServiceOptions : IToolRuntimePolicySettings, ITool
             }
         }
 
-        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(root)) {
-            root = ".";
-        }
-
-        return Path.Combine(root, "IntelligenceX.Chat", "tooling-bootstrap-cache-v1.json");
+        return ChatStatePaths.GetDefaultPath("tooling-bootstrap-cache-v1.json");
     }
 
     internal static bool TryApplyPackEnablement(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
@@ -3065,7 +3065,7 @@ public sealed class ChatServiceBackgroundWorkTests {
     }
 
     [Fact]
-    public void BackgroundSchedulerControlState_ReportsDurableWriteFailure() {
+    public void BackgroundSchedulerControlState_ReportsDurableWriteFailure_WithoutChangingLiveState() {
         var (options, _, persistenceDirectory) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         var storePath = Path.Combine(persistenceDirectory, "background-scheduler-control.json");
         Directory.CreateDirectory(storePath);
@@ -3074,12 +3074,26 @@ public sealed class ChatServiceBackgroundWorkTests {
             var state = new ChatServiceBackgroundSchedulerControlState(options);
 
             Assert.False(state.SetManualPause(paused: true, pauseSeconds: 300, pauseReason: "must-persist"));
-            Assert.True(state.GetSnapshot(DateTime.UtcNow.Ticks).ManualPauseActive);
+            Assert.False(state.GetSnapshot(DateTime.UtcNow.Ticks).ManualPauseActive);
         } finally {
             if (Directory.Exists(persistenceDirectory)) {
                 Directory.Delete(persistenceDirectory, recursive: true);
             }
         }
+    }
+
+    [Fact]
+    public void BackgroundSchedulerControlState_MergesIndependentUpdatesFromStaleInstances() {
+        var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
+        var packWriter = new ChatServiceBackgroundSchedulerControlState(options);
+        var threadWriter = new ChatServiceBackgroundSchedulerControlState(options);
+
+        Assert.True(packWriter.UpdateBlockedPacks("replace", new[] { "system" }));
+        Assert.True(threadWriter.UpdateBlockedThreads("replace", new[] { "thread-muted" }));
+
+        var reader = new ChatServiceBackgroundSchedulerControlState(options);
+        Assert.Equal(new[] { "system" }, reader.GetBlockedPackIds(DateTime.UtcNow.Ticks));
+        Assert.Equal(new[] { "thread-muted" }, reader.GetBlockedThreadIds(DateTime.UtcNow.Ticks));
     }
 
     [Fact]
@@ -3817,6 +3831,47 @@ public sealed class ChatServiceBackgroundWorkTests {
         }
 
         Assert.False(File.Exists(runtimeStorePath));
+    }
+
+    [Fact]
+    public void BackgroundSchedulerRuntimeState_RetriesSnapshotAfterDurableWriteFailure() {
+        var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
+        var session = new ChatServiceSession(options, Stream.Null);
+        var runtimeStorePath = session.ResolveBackgroundSchedulerRuntimeStorePathForTesting();
+        Directory.CreateDirectory(runtimeStorePath);
+
+        try {
+            session.RememberBackgroundSchedulerAdaptiveIdleDecisionForTesting(
+                TimeSpan.FromSeconds(45),
+                "policy=write_retry");
+
+            var deferred = session.BuildBackgroundSchedulerSummaryForTesting();
+            Assert.True(deferred.RuntimeStoreRehydratePending);
+            Assert.Equal("deferred", deferred.RuntimeStoreLoadState);
+            Assert.True(deferred.AdaptiveIdleActive);
+            Assert.Equal(45, deferred.LastAdaptiveIdleDelaySeconds);
+
+            Directory.Delete(runtimeStorePath);
+
+            var recovered = session.BuildBackgroundSchedulerSummaryForTesting();
+            Assert.False(recovered.RuntimeStoreRehydratePending);
+            Assert.Equal("loaded", recovered.RuntimeStoreLoadState);
+            Assert.True(recovered.AdaptiveIdleActive);
+            Assert.Equal(45, recovered.LastAdaptiveIdleDelaySeconds);
+            Assert.Contains("policy=write_retry", recovered.LastAdaptiveIdleReason, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(runtimeStorePath));
+
+            var restarted = new ChatServiceSession(options, Stream.Null).BuildBackgroundSchedulerSummaryForTesting();
+            Assert.False(restarted.RuntimeStoreRehydratePending);
+            Assert.Equal("loaded", restarted.RuntimeStoreLoadState);
+            Assert.True(restarted.AdaptiveIdleActive);
+            Assert.Equal(45, restarted.LastAdaptiveIdleDelaySeconds);
+            Assert.Contains("policy=write_retry", restarted.LastAdaptiveIdleReason, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            if (Directory.Exists(runtimeStorePath)) {
+                Directory.Delete(runtimeStorePath, recursive: true);
+            }
+        }
     }
 
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
@@ -3916,6 +3916,56 @@ public sealed class ChatServiceBackgroundWorkTests {
     }
 
     [Fact]
+    public void BackgroundSchedulerRuntimeState_PreservesConcurrentPersistedUpdatesDuringRetry() {
+        var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
+        var seedSession = new ChatServiceSession(options, Stream.Null);
+        var runtimeStorePath = seedSession.ResolveBackgroundSchedulerRuntimeStorePathForTesting();
+        var runtimeDirectory = Path.GetDirectoryName(runtimeStorePath);
+        Assert.False(string.IsNullOrWhiteSpace(runtimeDirectory));
+        Directory.CreateDirectory(runtimeDirectory!);
+        var initialTicks = DateTime.UtcNow.AddMinutes(-3).Ticks;
+        File.WriteAllText(
+            runtimeStorePath,
+            $$"""
+            {"version":1,"lastOutcome":"completed","lastOutcomeUtcTicks":{{initialTicks}},"lastSuccessUtcTicks":{{initialTicks}},"completedExecutionCount":10,"recentActivity":[]}
+            """);
+
+        var session = new ChatServiceSession(options, Stream.Null);
+        Assert.Equal(10, session.BuildBackgroundSchedulerSummaryForTesting().CompletedExecutionCount);
+
+        ChatServiceSession.SetBackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting(
+            path => string.Equals(path, runtimeStorePath, StringComparison.OrdinalIgnoreCase) ? false : null);
+        try {
+            session.RememberBackgroundSchedulerAdaptiveIdleDecisionForTesting(
+                TimeSpan.FromSeconds(45),
+                "policy=concurrent_retry");
+        } finally {
+            ChatServiceSession.SetBackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting(null);
+        }
+
+        var concurrentTicks = DateTime.UtcNow.AddMinutes(-1).Ticks;
+        File.WriteAllText(
+            runtimeStorePath,
+            $$"""
+            {"version":1,"lastOutcome":"completed","lastOutcomeUtcTicks":{{concurrentTicks}},"lastSuccessUtcTicks":{{concurrentTicks}},"completedExecutionCount":12,"recentActivity":[{"recordedUtcTicks":{{concurrentTicks}},"outcome":"completed","threadId":"thread-concurrent","itemId":"item-concurrent","toolName":"system_info","reason":"concurrent_writer","outputCount":1,"failureDetail":""}]}
+            """);
+
+        var recovered = session.BuildBackgroundSchedulerSummaryForTesting();
+        Assert.False(recovered.RuntimeStoreRehydratePending);
+        Assert.Equal("loaded", recovered.RuntimeStoreLoadState);
+        Assert.Equal(12, recovered.CompletedExecutionCount);
+        Assert.True(recovered.AdaptiveIdleActive);
+        Assert.Contains("policy=concurrent_retry", recovered.LastAdaptiveIdleReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(recovered.RecentActivity, activity => string.Equals(activity.Reason, "concurrent_writer", StringComparison.Ordinal));
+
+        var restarted = new ChatServiceSession(options, Stream.Null).BuildBackgroundSchedulerSummaryForTesting();
+        Assert.Equal(12, restarted.CompletedExecutionCount);
+        Assert.True(restarted.AdaptiveIdleActive);
+        Assert.Contains("policy=concurrent_retry", restarted.LastAdaptiveIdleReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(restarted.RecentActivity, activity => string.Equals(activity.Reason, "concurrent_writer", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task BackgroundSchedulerRuntimeState_ClearsAdaptiveIdleMetadataAfterWorkResumesAcrossRestart() {
         var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         const string threadId = "thread-background-scheduler-adaptive-idle-clear-after-work";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
@@ -3966,6 +3966,66 @@ public sealed class ChatServiceBackgroundWorkTests {
     }
 
     [Fact]
+    public void BackgroundSchedulerRuntimeState_PreservesConcurrentFailureStreakIncrementsDuringRetry() {
+        var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
+        var seedSession = new ChatServiceSession(options, Stream.Null);
+        var runtimeStorePath = seedSession.ResolveBackgroundSchedulerRuntimeStorePathForTesting();
+        var runtimeDirectory = Path.GetDirectoryName(runtimeStorePath);
+        Assert.False(string.IsNullOrWhiteSpace(runtimeDirectory));
+        Directory.CreateDirectory(runtimeDirectory!);
+        var initialTicks = DateTime.UtcNow.AddMinutes(-3).Ticks;
+        File.WriteAllText(
+            runtimeStorePath,
+            $$"""
+            {"version":1,"lastOutcome":"requeued_after_tool_failure","lastOutcomeUtcTicks":{{initialTicks}},"lastFailureUtcTicks":{{initialTicks}},"requeuedExecutionCount":3,"consecutiveFailureCount":3,"recentActivity":[]}
+            """);
+
+        var session = new ChatServiceSession(options, Stream.Null);
+        var initial = session.BuildBackgroundSchedulerSummaryForTesting();
+        Assert.Equal(3, initial.RequeuedExecutionCount);
+        Assert.Equal(3, initial.ConsecutiveFailureCount);
+
+        var localFailureTicks = DateTime.UtcNow.AddMinutes(-2).Ticks;
+        ChatServiceSession.SetBackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting(
+            path => string.Equals(path, runtimeStorePath, StringComparison.OrdinalIgnoreCase) ? false : null);
+        try {
+            session.RememberBackgroundSchedulerIterationResultForTesting(
+                new ChatServiceSession.BackgroundSchedulerIterationResult(
+                    ChatServiceSession.BackgroundSchedulerIterationOutcomeKind.RequeuedAfterToolFailure,
+                    "thread-local-failure",
+                    "item-local-failure",
+                    "system_info",
+                    "local_failure",
+                    0,
+                    "local_probe_failed"),
+                localFailureTicks);
+        } finally {
+            ChatServiceSession.SetBackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting(null);
+        }
+
+        var concurrentFailureTicks = DateTime.UtcNow.AddMinutes(-1).Ticks;
+        File.WriteAllText(
+            runtimeStorePath,
+            $$"""
+            {"version":1,"lastOutcome":"requeued_after_tool_failure","lastOutcomeUtcTicks":{{concurrentFailureTicks}},"lastFailureUtcTicks":{{concurrentFailureTicks}},"requeuedExecutionCount":4,"consecutiveFailureCount":4,"recentActivity":[{"recordedUtcTicks":{{concurrentFailureTicks}},"outcome":"requeued_after_tool_failure","threadId":"thread-concurrent-failure","itemId":"item-concurrent-failure","toolName":"system_info","reason":"concurrent_failure","outputCount":0,"failureDetail":"concurrent_probe_failed"}]}
+            """);
+
+        var recovered = session.BuildBackgroundSchedulerSummaryForTesting();
+        Assert.False(recovered.RuntimeStoreRehydratePending);
+        Assert.Equal("loaded", recovered.RuntimeStoreLoadState);
+        Assert.Equal(5, recovered.RequeuedExecutionCount);
+        Assert.Equal(5, recovered.ConsecutiveFailureCount);
+        Assert.Contains(recovered.RecentActivity, activity => string.Equals(activity.Reason, "local_failure", StringComparison.Ordinal));
+        Assert.Contains(recovered.RecentActivity, activity => string.Equals(activity.Reason, "concurrent_failure", StringComparison.Ordinal));
+
+        var restarted = new ChatServiceSession(options, Stream.Null).BuildBackgroundSchedulerSummaryForTesting();
+        Assert.Equal(5, restarted.RequeuedExecutionCount);
+        Assert.Equal(5, restarted.ConsecutiveFailureCount);
+        Assert.Contains(restarted.RecentActivity, activity => string.Equals(activity.Reason, "local_failure", StringComparison.Ordinal));
+        Assert.Contains(restarted.RecentActivity, activity => string.Equals(activity.Reason, "concurrent_failure", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task BackgroundSchedulerRuntimeState_ClearsAdaptiveIdleMetadataAfterWorkResumesAcrossRestart() {
         var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         const string threadId = "thread-background-scheduler-adaptive-idle-clear-after-work";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
@@ -4105,6 +4105,117 @@ public sealed class ChatServiceBackgroundWorkTests {
     }
 
     [Fact]
+    public void BackgroundSchedulerRuntimeState_ResetsOverflowedFailuresBeforeConcurrentSuccess() {
+        const int initialConsecutiveFailureCount = 5000;
+        var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
+        var seedSession = new ChatServiceSession(options, Stream.Null);
+        var runtimeStorePath = seedSession.ResolveBackgroundSchedulerRuntimeStorePathForTesting();
+        var runtimeDirectory = Path.GetDirectoryName(runtimeStorePath);
+        Assert.False(string.IsNullOrWhiteSpace(runtimeDirectory));
+        Directory.CreateDirectory(runtimeDirectory!);
+        var initialFailureTicks = DateTime.UtcNow.AddMinutes(-5).Ticks;
+        var seedStore = new BackgroundSchedulerRuntimeStoreDto {
+            LastOutcome = "requeued_after_tool_failure",
+            LastOutcomeUtcTicks = initialFailureTicks,
+            LastFailureUtcTicks = initialFailureTicks,
+            RequeuedExecutionCount = initialConsecutiveFailureCount,
+            ConsecutiveFailureCount = initialConsecutiveFailureCount,
+            FailureStreakEvents = Enumerable.Range(0, ChatServiceSession.MaxBackgroundSchedulerFailureStreakEvents)
+                .Select(index => new BackgroundSchedulerFailureEventDto {
+                    EventId = $"seed-{index:D4}",
+                    RecordedUtcTicks = initialFailureTicks
+                })
+                .ToArray()
+        };
+        File.WriteAllText(
+            runtimeStorePath,
+            JsonSerializer.Serialize(
+                seedStore,
+                BackgroundSchedulerRuntimeStoreJsonContext.Default.BackgroundSchedulerRuntimeStoreDto));
+
+        var localSession = new ChatServiceSession(options, Stream.Null);
+        var concurrentSession = new ChatServiceSession(options, Stream.Null);
+        Assert.Equal(initialConsecutiveFailureCount, localSession.BuildBackgroundSchedulerSummaryForTesting().ConsecutiveFailureCount);
+        var firstFailureTicks = DateTime.UtcNow.AddMinutes(-3).Ticks;
+        var resetSuccessTicks = DateTime.UtcNow.AddMinutes(-2).Ticks;
+        var secondFailureTicks = DateTime.UtcNow.AddMinutes(-1).Ticks;
+
+        ChatServiceSession.SetBackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting(
+            path => string.Equals(path, runtimeStorePath, StringComparison.OrdinalIgnoreCase) ? false : null);
+        try {
+            localSession.RememberBackgroundSchedulerIterationResultForTesting(
+                new ChatServiceSession.BackgroundSchedulerIterationResult(
+                    ChatServiceSession.BackgroundSchedulerIterationOutcomeKind.Completed,
+                    "thread-overflow-reset",
+                    "item-overflow-reset",
+                    "system_info",
+                    "overflow_reset",
+                    1,
+                    string.Empty),
+                resetSuccessTicks);
+        } finally {
+            ChatServiceSession.SetBackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting(null);
+        }
+
+        concurrentSession.RememberBackgroundSchedulerIterationResultForTesting(
+            new ChatServiceSession.BackgroundSchedulerIterationResult(
+                ChatServiceSession.BackgroundSchedulerIterationOutcomeKind.RequeuedAfterToolFailure,
+                "thread-overflow-first-failure",
+                "item-overflow-first-failure",
+                "system_info",
+                "overflow_failure_before_reset",
+                0,
+                "first_overflow_probe_failed"),
+            firstFailureTicks);
+        concurrentSession.RememberBackgroundSchedulerIterationResultForTesting(
+            new ChatServiceSession.BackgroundSchedulerIterationResult(
+                ChatServiceSession.BackgroundSchedulerIterationOutcomeKind.RequeuedAfterToolFailure,
+                "thread-overflow-second-failure",
+                "item-overflow-second-failure",
+                "system_info",
+                "overflow_failure_after_reset",
+                0,
+                "second_overflow_probe_failed"),
+            secondFailureTicks);
+
+        var recovered = localSession.BuildBackgroundSchedulerSummaryForTesting();
+        Assert.Equal(initialConsecutiveFailureCount + 2, recovered.RequeuedExecutionCount);
+        Assert.Equal(1, recovered.ConsecutiveFailureCount);
+        var restarted = new ChatServiceSession(options, Stream.Null).BuildBackgroundSchedulerSummaryForTesting();
+        Assert.Equal(1, restarted.ConsecutiveFailureCount);
+    }
+
+    [Fact]
+    public void BackgroundSchedulerRuntimeState_RewritesUnsafeFailureEventIds() {
+        var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
+        var seedSession = new ChatServiceSession(options, Stream.Null);
+        var runtimeStorePath = seedSession.ResolveBackgroundSchedulerRuntimeStorePathForTesting();
+        var runtimeDirectory = Path.GetDirectoryName(runtimeStorePath);
+        Assert.False(string.IsNullOrWhiteSpace(runtimeDirectory));
+        Directory.CreateDirectory(runtimeDirectory!);
+        var failureTicks = DateTime.UtcNow.AddMinutes(-2).Ticks;
+        File.WriteAllText(
+            runtimeStorePath,
+            $$"""
+            {"version":1,"lastOutcome":"requeued_after_tool_failure","lastOutcomeUtcTicks":{{failureTicks}},"lastFailureUtcTicks":{{failureTicks}},"requeuedExecutionCount":1,"consecutiveFailureCount":1,"failureStreakEvents":[{"eventId":"\\\\\\\\\\\\\\\\","recordedUtcTicks":{{failureTicks}}}],"recentActivity":[]}
+            """);
+
+        var session = new ChatServiceSession(options, Stream.Null);
+        Assert.Equal(1, session.BuildBackgroundSchedulerSummaryForTesting().ConsecutiveFailureCount);
+        session.RememberBackgroundSchedulerAdaptiveIdleDecisionForTesting(
+            TimeSpan.FromSeconds(45),
+            "policy=rewrite_unsafe_failure_id");
+
+        using var persistedStore = JsonDocument.Parse(File.ReadAllText(runtimeStorePath));
+        var eventId = persistedStore.RootElement
+            .GetProperty("failureStreakEvents")[0]
+            .GetProperty("eventId")
+            .GetString();
+        Assert.Equal("legacy-0000", eventId);
+        Assert.True(new FileInfo(runtimeStorePath).Length < ChatServiceSession.BackgroundSchedulerRuntimeStoreMaximumBytes);
+    }
+
+    [Fact]
     public async Task BackgroundSchedulerRuntimeState_ClearsAdaptiveIdleMetadataAfterWorkResumesAcrossRestart() {
         var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         const string threadId = "thread-background-scheduler-adaptive-idle-clear-after-work";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
@@ -3039,7 +3039,8 @@ public sealed class ChatServiceBackgroundWorkTests {
         var (options, _, persistenceDirectory) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
 
         var writerState = new ChatServiceBackgroundSchedulerControlState(options);
-        var paused = writerState.SetManualPause(paused: true, pauseSeconds: 300, pauseReason: "maintenance-window");
+        Assert.True(writerState.SetManualPause(paused: true, pauseSeconds: 300, pauseReason: "maintenance-window"));
+        var paused = writerState.GetSnapshot(DateTime.UtcNow.Ticks);
         var storePath = writerState.ResolveStorePathForTesting();
 
         Assert.True(paused.ManualPauseActive);
@@ -3061,6 +3062,24 @@ public sealed class ChatServiceBackgroundWorkTests {
         Assert.Equal(0, resumed.PausedUntilUtcTicks);
         Assert.Equal(string.Empty, resumed.PauseReason);
         Assert.False(File.Exists(storePath));
+    }
+
+    [Fact]
+    public void BackgroundSchedulerControlState_ReportsDurableWriteFailure() {
+        var (options, _, persistenceDirectory) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
+        var storePath = Path.Combine(persistenceDirectory, "background-scheduler-control.json");
+        Directory.CreateDirectory(storePath);
+
+        try {
+            var state = new ChatServiceBackgroundSchedulerControlState(options);
+
+            Assert.False(state.SetManualPause(paused: true, pauseSeconds: 300, pauseReason: "must-persist"));
+            Assert.True(state.GetSnapshot(DateTime.UtcNow.Ticks).ManualPauseActive);
+        } finally {
+            if (Directory.Exists(persistenceDirectory)) {
+                Directory.Delete(persistenceDirectory, recursive: true);
+            }
+        }
     }
 
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
@@ -4023,6 +4023,85 @@ public sealed class ChatServiceBackgroundWorkTests {
         Assert.Equal(5, restarted.ConsecutiveFailureCount);
         Assert.Contains(restarted.RecentActivity, activity => string.Equals(activity.Reason, "local_failure", StringComparison.Ordinal));
         Assert.Contains(restarted.RecentActivity, activity => string.Equals(activity.Reason, "concurrent_failure", StringComparison.Ordinal));
+        using var migratedStore = JsonDocument.Parse(File.ReadAllText(runtimeStorePath));
+        Assert.Equal(5, migratedStore.RootElement.GetProperty("failureStreakEvents").GetArrayLength());
+    }
+
+    [Fact]
+    public void BackgroundSchedulerRuntimeState_ResetsOnlyFailuresBeforeConcurrentSuccess() {
+        var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
+        var localSession = new ChatServiceSession(options, Stream.Null);
+        var concurrentSession = new ChatServiceSession(options, Stream.Null);
+        var runtimeStorePath = localSession.ResolveBackgroundSchedulerRuntimeStorePathForTesting();
+        var firstSuccessTicks = DateTime.UtcNow.AddMinutes(-4).Ticks;
+        var firstFailureTicks = DateTime.UtcNow.AddMinutes(-3).Ticks;
+        var resetSuccessTicks = DateTime.UtcNow.AddMinutes(-2).Ticks;
+        var secondFailureTicks = DateTime.UtcNow.AddMinutes(-1).Ticks;
+
+        ChatServiceSession.SetBackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting(
+            path => string.Equals(path, runtimeStorePath, StringComparison.OrdinalIgnoreCase) ? false : null);
+        try {
+            localSession.RememberBackgroundSchedulerIterationResultForTesting(
+                new ChatServiceSession.BackgroundSchedulerIterationResult(
+                    ChatServiceSession.BackgroundSchedulerIterationOutcomeKind.Completed,
+                    "thread-local-success",
+                    "item-local-success",
+                    "system_info",
+                    "local_success",
+                    1,
+                    string.Empty),
+                resetSuccessTicks);
+        } finally {
+            ChatServiceSession.SetBackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting(null);
+        }
+
+        concurrentSession.RememberBackgroundSchedulerIterationResultForTesting(
+            new ChatServiceSession.BackgroundSchedulerIterationResult(
+                ChatServiceSession.BackgroundSchedulerIterationOutcomeKind.Completed,
+                "thread-concurrent-success",
+                "item-concurrent-success",
+                "system_info",
+                "concurrent_success",
+                1,
+                string.Empty),
+            firstSuccessTicks);
+        concurrentSession.RememberBackgroundSchedulerIterationResultForTesting(
+            new ChatServiceSession.BackgroundSchedulerIterationResult(
+                ChatServiceSession.BackgroundSchedulerIterationOutcomeKind.RequeuedAfterToolFailure,
+                "thread-concurrent-first-failure",
+                "item-concurrent-first-failure",
+                "system_info",
+                "concurrent_failure_before_reset",
+                0,
+                "first_probe_failed"),
+            firstFailureTicks);
+        concurrentSession.RememberBackgroundSchedulerIterationResultForTesting(
+            new ChatServiceSession.BackgroundSchedulerIterationResult(
+                ChatServiceSession.BackgroundSchedulerIterationOutcomeKind.RequeuedAfterToolFailure,
+                "thread-concurrent-second-failure",
+                "item-concurrent-second-failure",
+                "system_info",
+                "concurrent_failure_after_reset",
+                0,
+                "second_probe_failed"),
+            secondFailureTicks);
+
+        var recovered = localSession.BuildBackgroundSchedulerSummaryForTesting();
+        Assert.False(recovered.RuntimeStoreRehydratePending);
+        Assert.Equal("loaded", recovered.RuntimeStoreLoadState);
+        Assert.Equal(2, recovered.CompletedExecutionCount);
+        Assert.Equal(2, recovered.RequeuedExecutionCount);
+        Assert.Equal(1, recovered.ConsecutiveFailureCount);
+        Assert.Contains(recovered.RecentActivity, activity => string.Equals(activity.Reason, "local_success", StringComparison.Ordinal));
+        Assert.Contains(recovered.RecentActivity, activity => string.Equals(activity.Reason, "concurrent_failure_before_reset", StringComparison.Ordinal));
+        Assert.Contains(recovered.RecentActivity, activity => string.Equals(activity.Reason, "concurrent_failure_after_reset", StringComparison.Ordinal));
+
+        var restarted = new ChatServiceSession(options, Stream.Null).BuildBackgroundSchedulerSummaryForTesting();
+        Assert.Equal(2, restarted.CompletedExecutionCount);
+        Assert.Equal(2, restarted.RequeuedExecutionCount);
+        Assert.Equal(1, restarted.ConsecutiveFailureCount);
+        using var persistedStore = JsonDocument.Parse(File.ReadAllText(runtimeStorePath));
+        Assert.Equal(1, persistedStore.RootElement.GetProperty("failureStreakEvents").GetArrayLength());
     }
 
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
@@ -3064,6 +3064,45 @@ public sealed class ChatServiceBackgroundWorkTests {
     }
 
     [Fact]
+    public void BackgroundSchedulerControlState_ExpiredPauseCleanupPreservesOtherPersistedOverrides() {
+        var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
+        var seedState = new ChatServiceBackgroundSchedulerControlState(options);
+        var storePath = seedState.ResolveStorePathForTesting();
+        var expiredPauseTicks = DateTime.UtcNow.AddMinutes(-5).Ticks;
+        File.WriteAllText(
+            storePath,
+            $$"""
+            {
+              "Version": 4,
+              "ManualPauseActive": true,
+              "PausedUntilUtcTicks": {{expiredPauseTicks}},
+              "PauseReason": "manual_pause:60s:expired",
+              "BlockedPackIdsCustomized": true,
+              "BlockedPackIds": ["system"],
+              "TemporaryBlockedPacks": [],
+              "BlockedThreadIdsCustomized": false,
+              "BlockedThreadIds": [],
+              "TemporaryBlockedThreads": [],
+              "MaintenanceWindowsCustomized": false,
+              "MaintenanceWindowSpecs": []
+            }
+            """);
+
+        var firstRestart = new ChatServiceBackgroundSchedulerControlState(options);
+        var firstSnapshot = firstRestart.GetSnapshot(DateTime.UtcNow.Ticks);
+
+        Assert.False(firstSnapshot.ManualPauseActive);
+        Assert.Equal(new[] { "system" }, firstRestart.GetBlockedPackIds(DateTime.UtcNow.Ticks));
+        Assert.True(File.Exists(storePath));
+
+        var secondRestart = new ChatServiceBackgroundSchedulerControlState(options);
+        var secondSnapshot = secondRestart.GetSnapshot(DateTime.UtcNow.Ticks);
+
+        Assert.False(secondSnapshot.ManualPauseActive);
+        Assert.Equal(new[] { "system" }, secondRestart.GetBlockedPackIds(DateTime.UtcNow.Ticks));
+    }
+
+    [Fact]
     public void BuildBackgroundSchedulerSummary_RehydratesPersistedManualPauseFromFreshControlState() {
         var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         var writerState = new ChatServiceBackgroundSchedulerControlState(options);

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
@@ -4110,28 +4110,11 @@ public sealed class ChatServiceBackgroundWorkTests {
         var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         var seedSession = new ChatServiceSession(options, Stream.Null);
         var runtimeStorePath = seedSession.ResolveBackgroundSchedulerRuntimeStorePathForTesting();
-        var runtimeDirectory = Path.GetDirectoryName(runtimeStorePath);
-        Assert.False(string.IsNullOrWhiteSpace(runtimeDirectory));
-        Directory.CreateDirectory(runtimeDirectory!);
         var initialFailureTicks = DateTime.UtcNow.AddMinutes(-5).Ticks;
-        var seedStore = new BackgroundSchedulerRuntimeStoreDto {
-            LastOutcome = "requeued_after_tool_failure",
-            LastOutcomeUtcTicks = initialFailureTicks,
-            LastFailureUtcTicks = initialFailureTicks,
-            RequeuedExecutionCount = initialConsecutiveFailureCount,
-            ConsecutiveFailureCount = initialConsecutiveFailureCount,
-            FailureStreakEvents = Enumerable.Range(0, ChatServiceSession.MaxBackgroundSchedulerFailureStreakEvents)
-                .Select(index => new BackgroundSchedulerFailureEventDto {
-                    EventId = $"seed-{index:D4}",
-                    RecordedUtcTicks = initialFailureTicks
-                })
-                .ToArray()
-        };
-        File.WriteAllText(
+        WriteBackgroundSchedulerFailureStreakStore(
             runtimeStorePath,
-            JsonSerializer.Serialize(
-                seedStore,
-                BackgroundSchedulerRuntimeStoreJsonContext.Default.BackgroundSchedulerRuntimeStoreDto));
+            initialConsecutiveFailureCount,
+            initialFailureTicks);
 
         var localSession = new ChatServiceSession(options, Stream.Null);
         var concurrentSession = new ChatServiceSession(options, Stream.Null);
@@ -4185,6 +4168,43 @@ public sealed class ChatServiceBackgroundWorkTests {
         Assert.Equal(1, recovered.ConsecutiveFailureCount);
         var restarted = new ChatServiceSession(options, Stream.Null).BuildBackgroundSchedulerSummaryForTesting();
         Assert.Equal(1, restarted.ConsecutiveFailureCount);
+    }
+
+    [Fact]
+    public void BackgroundSchedulerRuntimeState_AutoPausesAfterSaturatedFailure() {
+        const int initialConsecutiveFailureCount = 5000;
+        var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
+        options.EnableBackgroundSchedulerDaemon = true;
+        options.BackgroundSchedulerFailureThreshold = 5;
+        options.BackgroundSchedulerFailurePauseSeconds = 120;
+        var seedSession = new ChatServiceSession(options, Stream.Null);
+        var runtimeStorePath = seedSession.ResolveBackgroundSchedulerRuntimeStorePathForTesting();
+        var initialFailureTicks = DateTime.UtcNow.AddMinutes(-2).Ticks;
+        WriteBackgroundSchedulerFailureStreakStore(
+            runtimeStorePath,
+            initialConsecutiveFailureCount,
+            initialFailureTicks);
+
+        var session = new ChatServiceSession(options, Stream.Null);
+        Assert.Equal(
+            ChatServiceSession.MaxBackgroundSchedulerFailureStreakEvents,
+            session.BuildBackgroundSchedulerSummaryForTesting().ConsecutiveFailureCount);
+        session.RememberBackgroundSchedulerIterationResultForTesting(
+            new ChatServiceSession.BackgroundSchedulerIterationResult(
+                ChatServiceSession.BackgroundSchedulerIterationOutcomeKind.RequeuedAfterToolFailure,
+                "thread-saturated-failure",
+                "item-saturated-failure",
+                "system_info",
+                "saturated_failure",
+                0,
+                "saturated_probe_failed"),
+            DateTime.UtcNow.AddMinutes(-1).Ticks);
+
+        var summary = session.BuildBackgroundSchedulerSummaryForTesting();
+        Assert.Equal(initialConsecutiveFailureCount + 1, summary.RequeuedExecutionCount);
+        Assert.Equal(ChatServiceSession.MaxBackgroundSchedulerFailureStreakEvents, summary.ConsecutiveFailureCount);
+        Assert.True(summary.Paused);
+        Assert.Contains("consecutive_failure_threshold_reached", summary.PauseReason, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -7353,6 +7373,37 @@ public sealed class ChatServiceBackgroundWorkTests {
             description: "test tool",
             handoff: handoff,
             writeGovernance: writeGovernance);
+    }
+
+    private static void WriteBackgroundSchedulerFailureStreakStore(
+        string runtimeStorePath,
+        int consecutiveFailureCount,
+        long recordedUtcTicks) {
+        var runtimeDirectory = Path.GetDirectoryName(runtimeStorePath);
+        Assert.False(string.IsNullOrWhiteSpace(runtimeDirectory));
+        Directory.CreateDirectory(runtimeDirectory!);
+        var seedStore = new BackgroundSchedulerRuntimeStoreDto {
+            LastOutcome = "requeued_after_tool_failure",
+            LastOutcomeUtcTicks = recordedUtcTicks,
+            LastFailureUtcTicks = recordedUtcTicks,
+            RequeuedExecutionCount = Math.Max(0, consecutiveFailureCount),
+            ConsecutiveFailureCount = Math.Max(0, consecutiveFailureCount),
+            FailureStreakEvents = Enumerable.Range(
+                    0,
+                    Math.Min(
+                        Math.Max(0, consecutiveFailureCount),
+                        ChatServiceSession.MaxBackgroundSchedulerFailureStreakEvents))
+                .Select(index => new BackgroundSchedulerFailureEventDto {
+                    EventId = $"seed-{index:D4}",
+                    RecordedUtcTicks = recordedUtcTicks
+                })
+                .ToArray()
+        };
+        File.WriteAllText(
+            runtimeStorePath,
+            JsonSerializer.Serialize(
+                seedStore,
+                BackgroundSchedulerRuntimeStoreJsonContext.Default.BackgroundSchedulerRuntimeStoreDto));
     }
 
     private static ChatServiceSession.ThreadBackgroundWorkItem CreateBackgroundWorkItem(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
@@ -3875,6 +3875,47 @@ public sealed class ChatServiceBackgroundWorkTests {
     }
 
     [Fact]
+    public void BackgroundSchedulerRuntimeState_DoesNotDoubleCountAbsoluteSnapshotDuringRetry() {
+        var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
+        var seedSession = new ChatServiceSession(options, Stream.Null);
+        var runtimeStorePath = seedSession.ResolveBackgroundSchedulerRuntimeStorePathForTesting();
+        var runtimeDirectory = Path.GetDirectoryName(runtimeStorePath);
+        Assert.False(string.IsNullOrWhiteSpace(runtimeDirectory));
+        Directory.CreateDirectory(runtimeDirectory!);
+        var recordedTicks = DateTime.UtcNow.AddMinutes(-2).Ticks;
+        File.WriteAllText(
+            runtimeStorePath,
+            $$"""
+            {"version":1,"lastOutcome":"completed","lastOutcomeUtcTicks":{{recordedTicks}},"lastSuccessUtcTicks":{{recordedTicks}},"completedExecutionCount":10,"recentActivity":[]}
+            """);
+
+        var session = new ChatServiceSession(options, Stream.Null);
+        Assert.Equal(10, session.BuildBackgroundSchedulerSummaryForTesting().CompletedExecutionCount);
+
+        ChatServiceSession.SetBackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting(
+            path => string.Equals(path, runtimeStorePath, StringComparison.OrdinalIgnoreCase) ? false : null);
+        try {
+            session.RememberBackgroundSchedulerAdaptiveIdleDecisionForTesting(
+                TimeSpan.FromSeconds(45),
+                "policy=absolute_retry");
+        } finally {
+            ChatServiceSession.SetBackgroundSchedulerRuntimeStoreLockAcquisitionOverrideForTesting(null);
+        }
+
+        var recovered = session.BuildBackgroundSchedulerSummaryForTesting();
+        Assert.False(recovered.RuntimeStoreRehydratePending);
+        Assert.Equal("loaded", recovered.RuntimeStoreLoadState);
+        Assert.Equal(10, recovered.CompletedExecutionCount);
+        Assert.True(recovered.AdaptiveIdleActive);
+        Assert.Contains("policy=absolute_retry", recovered.LastAdaptiveIdleReason, StringComparison.OrdinalIgnoreCase);
+
+        var restarted = new ChatServiceSession(options, Stream.Null).BuildBackgroundSchedulerSummaryForTesting();
+        Assert.Equal(10, restarted.CompletedExecutionCount);
+        Assert.True(restarted.AdaptiveIdleActive);
+        Assert.Contains("policy=absolute_retry", restarted.LastAdaptiveIdleReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task BackgroundSchedulerRuntimeState_ClearsAdaptiveIdleMetadataAfterWorkResumesAcrossRestart() {
         var (options, _, _) = ChatServiceTestSessionFactory.CreateIsolatedPersistenceOptions();
         const string threadId = "thread-background-scheduler-adaptive-idle-clear-after-work";

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceBackgroundWorkTests.cs
@@ -4135,7 +4135,9 @@ public sealed class ChatServiceBackgroundWorkTests {
 
         var localSession = new ChatServiceSession(options, Stream.Null);
         var concurrentSession = new ChatServiceSession(options, Stream.Null);
-        Assert.Equal(initialConsecutiveFailureCount, localSession.BuildBackgroundSchedulerSummaryForTesting().ConsecutiveFailureCount);
+        Assert.Equal(
+            ChatServiceSession.MaxBackgroundSchedulerFailureStreakEvents,
+            localSession.BuildBackgroundSchedulerSummaryForTesting().ConsecutiveFailureCount);
         var firstFailureTicks = DateTime.UtcNow.AddMinutes(-3).Ticks;
         var resetSuccessTicks = DateTime.UtcNow.AddMinutes(-2).Ticks;
         var secondFailureTicks = DateTime.UtcNow.AddMinutes(-1).Ticks;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
@@ -44,6 +44,34 @@ public sealed class ChatServiceJsonFileStoreTests {
     }
 
     [Fact]
+    public void ResolveDefaultPath_RejectsSharedStateDirectoryReparsePoint() {
+        var root = CreateRoot();
+        var outside = CreateRoot();
+        var sharedDirectory = Path.Combine(root, "IntelligenceX.Chat");
+        try {
+            try {
+                Directory.CreateSymbolicLink(sharedDirectory, outside);
+            } catch (Exception ex) when (ex is UnauthorizedAccessException or PlatformNotSupportedException or IOException) {
+                return;
+            }
+
+            Assert.Throws<InvalidOperationException>(() => ChatStatePaths.ResolveDefaultPath(
+                "state.json",
+                localApplicationData: root,
+                xdgDataHome: " ",
+                userProfile: " "));
+        } finally {
+            DeleteDirectoryLink(sharedDirectory);
+            if (Directory.Exists(root)) {
+                Directory.Delete(root, recursive: true);
+            }
+            if (Directory.Exists(outside)) {
+                Directory.Delete(outside, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void ServiceDefaults_UseTheSharedStatePathOwner() {
         Assert.Equal(ChatStatePaths.GetDefaultPath("state.db"), ServiceOptions.GetDefaultStateDbPath());
         Assert.Equal(
@@ -289,6 +317,101 @@ public sealed class ChatServiceJsonFileStoreTests {
     }
 
     [Fact]
+    public void ResolvePathOverrideWithinDefaultDirectory_RejectsRelativeFileReparsePoint() {
+        var directory = ChatStatePaths.GetDefaultDirectory();
+        var outside = Path.Combine(CreateRoot(), "outside.json");
+        var fileName = "reparse-" + Guid.NewGuid().ToString("N") + ".json";
+        var link = Path.Combine(directory, fileName);
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(outside, "{}");
+
+        try {
+            try {
+                File.CreateSymbolicLink(link, outside);
+            } catch (Exception ex) when (ex is UnauthorizedAccessException or PlatformNotSupportedException or IOException) {
+                return;
+            }
+
+            Assert.Equal(
+                ChatStatePaths.GetDefaultPath("pending-actions.json"),
+                ChatServiceJsonFileStore.ResolvePathOverrideWithinDefaultDirectory(fileName, "pending-actions.json"));
+        } finally {
+            if (File.Exists(link)) {
+                File.Delete(link);
+            }
+            var outsideDirectory = Path.GetDirectoryName(outside);
+            if (!string.IsNullOrWhiteSpace(outsideDirectory) && Directory.Exists(outsideDirectory)) {
+                Directory.Delete(outsideDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ResolveSiblingPath_RejectsExistingFileReparsePoint() {
+        var root = CreateRoot();
+        var outside = Path.Combine(CreateRoot(), "outside.json");
+        var anchor = Path.Combine(root, "anchor.json");
+        var link = Path.Combine(root, "sibling.json");
+        File.WriteAllText(outside, "{}");
+
+        try {
+            try {
+                File.CreateSymbolicLink(link, outside);
+            } catch (Exception ex) when (ex is UnauthorizedAccessException or PlatformNotSupportedException or IOException) {
+                return;
+            }
+
+            Assert.Equal(string.Empty, ChatServiceJsonFileStore.ResolveSiblingPath(anchor, "sibling.json"));
+        } finally {
+            if (File.Exists(link)) {
+                File.Delete(link);
+            }
+            if (Directory.Exists(root)) {
+                Directory.Delete(root, recursive: true);
+            }
+            var outsideDirectory = Path.GetDirectoryName(outside);
+            if (!string.IsNullOrWhiteSpace(outsideDirectory) && Directory.Exists(outsideDirectory)) {
+                Directory.Delete(outsideDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ReadAndWrite_RejectExistingFileReparsePoint() {
+        var root = CreateRoot();
+        var outsideDirectory = CreateRoot();
+        var outside = Path.Combine(outsideDirectory, "outside.json");
+        var link = Path.Combine(root, "state.json");
+        File.WriteAllText(outside, "{\"Version\":2,\"Value\":\"outside\"}");
+
+        try {
+            try {
+                File.CreateSymbolicLink(link, outside);
+            } catch (Exception ex) when (ex is UnauthorizedAccessException or PlatformNotSupportedException or IOException) {
+                return;
+            }
+
+            Assert.Equal(ChatServiceJsonFileReadState.Invalid, Read(link).State);
+            Assert.False(ChatServiceJsonFileStore.Write(
+                link,
+                new TestStore { Version = 2, Value = "overwritten" },
+                static value => JsonSerializer.Serialize(value),
+                "Test store"));
+            Assert.Contains("outside", File.ReadAllText(outside), StringComparison.Ordinal);
+        } finally {
+            if (File.Exists(link)) {
+                File.Delete(link);
+            }
+            if (Directory.Exists(root)) {
+                Directory.Delete(root, recursive: true);
+            }
+            if (Directory.Exists(outsideDirectory)) {
+                Directory.Delete(outsideDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void ResolvePathOverrideWithinDefaultDirectory_RejectsReparsePointEscape() {
         var root = Path.Combine(
             ChatStatePaths.GetDefaultDirectory(),
@@ -355,6 +478,16 @@ public sealed class ChatServiceJsonFileStoreTests {
         var root = Path.Combine(Path.GetTempPath(), "IntelligenceX.Chat.Tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         return root;
+    }
+
+    private static void DeleteDirectoryLink(string path) {
+        try {
+            if (Directory.Exists(path)) {
+                Directory.Delete(path);
+            }
+        } catch {
+            // Best-effort cleanup for platforms with unusual link deletion semantics.
+        }
     }
 
     private sealed class TestStore {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
@@ -148,6 +148,30 @@ public sealed class ChatServiceJsonFileStoreTests {
     }
 
     [Fact]
+    public void Write_CreatesPrivateUnixDirectoryAtomically() {
+        if (OperatingSystem.IsWindows()) {
+            return;
+        }
+
+        var root = CreateRoot();
+        try {
+            var stateDirectory = Path.Combine(root, "private-state");
+            var path = Path.Combine(stateDirectory, "state.json");
+
+            ChatJsonFileStore.Write(path, "{}");
+
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+                File.GetUnixFileMode(stateDirectory));
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                File.GetUnixFileMode(path));
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Read_RejectsSnapshotsAboveTheDomainLimit() {
         var root = CreateRoot();
         try {
@@ -262,6 +286,48 @@ public sealed class ChatServiceJsonFileStoreTests {
             "pending-actions.json");
 
         Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ResolvePathOverrideWithinDefaultDirectory_RejectsReparsePointEscape() {
+        var root = Path.Combine(
+            ChatStatePaths.GetDefaultDirectory(),
+            "tests",
+            "reparse-" + Guid.NewGuid().ToString("N"));
+        var outside = CreateRoot();
+        var link = Path.Combine(root, "redirect");
+        Directory.CreateDirectory(root);
+
+        try {
+            try {
+                Directory.CreateSymbolicLink(link, outside);
+            } catch (Exception ex) when (ex is UnauthorizedAccessException or PlatformNotSupportedException or IOException) {
+                return;
+            }
+
+            var candidate = Path.Combine(link, "pending-actions.json");
+            var expected = ChatStatePaths.GetDefaultPath("pending-actions.json");
+
+            Assert.False(ChatStatePaths.IsPathInDefaultDirectory(candidate));
+            Assert.Equal(
+                expected,
+                ChatServiceJsonFileStore.ResolvePathOverrideWithinDefaultDirectory(candidate, "pending-actions.json"));
+        } finally {
+            try {
+                if (Directory.Exists(link)) {
+                    Directory.Delete(link);
+                }
+            } catch {
+                // Best-effort cleanup for platforms with unusual link deletion semantics.
+            }
+
+            if (Directory.Exists(root)) {
+                Directory.Delete(root, recursive: true);
+            }
+            if (Directory.Exists(outside)) {
+                Directory.Delete(outside, recursive: true);
+            }
+        }
     }
 
     [Fact]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
@@ -6,6 +6,18 @@ namespace IntelligenceX.Chat.Tests;
 
 public sealed class ChatServiceJsonFileStoreTests {
     [Fact]
+    public void ResolveDefaultPath_UsesTemporaryDirectoryWhenLocalApplicationDataIsUnavailable() {
+        var temporaryRoot = Path.Combine(Path.GetTempPath(), "IntelligenceX.Chat.Tests", Guid.NewGuid().ToString("N"));
+
+        var path = ChatServiceJsonFileStore.ResolveDefaultPath(
+            "state.json",
+            localApplicationData: " ",
+            temporaryPath: temporaryRoot);
+
+        Assert.Equal(Path.Combine(temporaryRoot, "IntelligenceX.Chat", "state.json"), path);
+    }
+
+    [Fact]
     public void WriteAndRead_RoundTripsThroughAtomicSnapshot() {
         var root = CreateRoot();
         try {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
@@ -29,6 +29,20 @@ public sealed class ChatServiceJsonFileStoreTests {
             userProfile: " "));
     }
 
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("nested/..")]
+    public void ResolveDefaultPath_RejectsDotSegments(string fileName) {
+        var userProfile = Path.Combine(Path.GetTempPath(), "IntelligenceX.Chat.Tests", Guid.NewGuid().ToString("N"));
+
+        Assert.Throws<ArgumentException>(() => ChatStatePaths.ResolveDefaultPath(
+            fileName,
+            localApplicationData: " ",
+            xdgDataHome: " ",
+            userProfile: userProfile));
+    }
+
     [Fact]
     public void ServiceDefaults_UseTheSharedStatePathOwner() {
         Assert.Equal(ChatStatePaths.GetDefaultPath("state.db"), ServiceOptions.GetDefaultStateDbPath());

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
@@ -87,7 +87,7 @@ public sealed class ChatServiceJsonFileStoreTests {
     }
 
     [Fact]
-    public void Write_HardensUnixDirectoryAndFilePermissions() {
+    public void Write_DoesNotChangeArbitraryUnixDirectoryPermissions() {
         if (OperatingSystem.IsWindows()) {
             return;
         }
@@ -95,12 +95,46 @@ public sealed class ChatServiceJsonFileStoreTests {
         var root = CreateRoot();
         try {
             var path = Path.Combine(root, "state.json");
+            var originalMode = UnixFileMode.UserRead
+                               | UnixFileMode.UserWrite
+                               | UnixFileMode.UserExecute
+                               | UnixFileMode.GroupRead
+                               | UnixFileMode.GroupExecute
+                               | UnixFileMode.OtherRead
+                               | UnixFileMode.OtherExecute;
+            File.SetUnixFileMode(root, originalMode);
 
             ChatServiceJsonFileStore.Write(
                 path,
                 new TestStore { Version = 2, Value = "private" },
                 static value => JsonSerializer.Serialize(value),
                 "Test store");
+
+            Assert.Equal(originalMode, File.GetUnixFileMode(root));
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                File.GetUnixFileMode(path));
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Write_HardensExplicitDedicatedUnixDirectory() {
+        if (OperatingSystem.IsWindows()) {
+            return;
+        }
+
+        var root = CreateRoot();
+        try {
+            var path = Path.Combine(root, "state.json");
+            File.SetUnixFileMode(
+                root,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+            ChatJsonFileStore.Write(path, "{}", hardenExistingDirectory: true);
 
             Assert.Equal(
                 UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
@@ -202,6 +236,43 @@ public sealed class ChatServiceJsonFileStoreTests {
         } finally {
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    [Theory]
+    [InlineData("../escape.json")]
+    [InlineData("nested/escape.json")]
+    [InlineData(".")]
+    [InlineData("..")]
+    public void ResolvePathOverrideWithinDefaultDirectory_RejectsUnsafeRelativePaths(string candidate) {
+        var expected = ChatStatePaths.GetDefaultPath("pending-actions.json");
+
+        var actual = ChatServiceJsonFileStore.ResolvePathOverrideWithinDefaultDirectory(
+            candidate,
+            "pending-actions.json");
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ResolvePathOverrideWithinDefaultDirectory_AllowsAbsoluteDescendant() {
+        var expected = Path.Combine(ChatStatePaths.GetDefaultDirectory(), "tests", "pending-actions.json");
+
+        var actual = ChatServiceJsonFileStore.ResolvePathOverrideWithinDefaultDirectory(
+            expected,
+            "pending-actions.json");
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void IsPathWithinDirectory_UsesPlatformCaseRules() {
+        var parent = Path.Combine(Path.GetTempPath(), "ix-path-case-" + Guid.NewGuid().ToString("N"));
+        var caseChangedParent = parent.ToUpperInvariant();
+        var candidate = Path.Combine(caseChangedParent, "state.json");
+
+        Assert.Equal(
+            OperatingSystem.IsWindows(),
+            ChatStatePaths.IsPathWithinDirectory(parent, candidate));
     }
 
     private static ChatServiceJsonFileReadResult<TestStore> Read(string path) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceJsonFileStoreTests.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using IntelligenceX.Chat.Abstractions.Storage;
+using IntelligenceX.Chat.Service;
 using IntelligenceX.Chat.Service.Persistence;
 using Xunit;
 
@@ -6,15 +8,33 @@ namespace IntelligenceX.Chat.Tests;
 
 public sealed class ChatServiceJsonFileStoreTests {
     [Fact]
-    public void ResolveDefaultPath_UsesTemporaryDirectoryWhenLocalApplicationDataIsUnavailable() {
-        var temporaryRoot = Path.Combine(Path.GetTempPath(), "IntelligenceX.Chat.Tests", Guid.NewGuid().ToString("N"));
+    public void ResolveDefaultPath_UsesDurableUserProfileWhenPlatformDataRootsAreUnavailable() {
+        var userProfile = Path.Combine(Path.GetTempPath(), "IntelligenceX.Chat.Tests", Guid.NewGuid().ToString("N"));
 
-        var path = ChatServiceJsonFileStore.ResolveDefaultPath(
+        var path = ChatStatePaths.ResolveDefaultPath(
             "state.json",
             localApplicationData: " ",
-            temporaryPath: temporaryRoot);
+            xdgDataHome: " ",
+            userProfile: userProfile);
 
-        Assert.Equal(Path.Combine(temporaryRoot, "IntelligenceX.Chat", "state.json"), path);
+        Assert.Equal(Path.Combine(userProfile, ".local", "share", "IntelligenceX.Chat", "state.json"), path);
+    }
+
+    [Fact]
+    public void ResolveDefaultPath_RejectsMissingPerUserRoots() {
+        Assert.Throws<InvalidOperationException>(() => ChatStatePaths.ResolveDefaultPath(
+            "state.json",
+            localApplicationData: " ",
+            xdgDataHome: "relative/path",
+            userProfile: " "));
+    }
+
+    [Fact]
+    public void ServiceDefaults_UseTheSharedStatePathOwner() {
+        Assert.Equal(ChatStatePaths.GetDefaultPath("state.db"), ServiceOptions.GetDefaultStateDbPath());
+        Assert.Equal(
+            ChatStatePaths.GetDefaultPath("tooling-bootstrap-cache-v1.json"),
+            ServiceOptions.GetDefaultToolingBootstrapCachePath());
     }
 
     [Fact]
@@ -53,6 +73,33 @@ public sealed class ChatServiceJsonFileStoreTests {
     }
 
     [Fact]
+    public void Write_HardensUnixDirectoryAndFilePermissions() {
+        if (OperatingSystem.IsWindows()) {
+            return;
+        }
+
+        var root = CreateRoot();
+        try {
+            var path = Path.Combine(root, "state.json");
+
+            ChatServiceJsonFileStore.Write(
+                path,
+                new TestStore { Version = 2, Value = "private" },
+                static value => JsonSerializer.Serialize(value),
+                "Test store");
+
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+                File.GetUnixFileMode(root));
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                File.GetUnixFileMode(path));
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Read_RejectsSnapshotsAboveTheDomainLimit() {
         var root = CreateRoot();
         try {
@@ -85,6 +132,21 @@ public sealed class ChatServiceJsonFileStoreTests {
 
             Assert.Equal(ChatServiceJsonFileReadState.Empty, missing.State);
             Assert.Equal(ChatServiceJsonFileReadState.Invalid, invalid.State);
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Read_TreatsWhitespaceOnlySnapshotAsInvalid() {
+        var root = CreateRoot();
+        try {
+            var path = Path.Combine(root, "state.json");
+            File.WriteAllText(path, "   \r\n\t");
+
+            var result = Read(path);
+
+            Assert.Equal(ChatServiceJsonFileReadState.Invalid, result.State);
         } finally {
             Directory.Delete(root, recursive: true);
         }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceToolingBootstrapTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceToolingBootstrapTests.cs
@@ -21,6 +21,49 @@ public sealed class ChatServiceToolingBootstrapTests {
         return TempPathTestHelper.CreateTempFilePath("ix-chat-" + namePrefix, ".json");
     }
 
+    [Fact]
+    public void ToolingBootstrapCache_ReportsPersistedSnapshotWriteFailure() {
+        var cachePath = CreateToolingBootstrapCachePath("tooling-cache-write-failure");
+        Directory.CreateDirectory(cachePath);
+        try {
+            var diagnostics = ToolRuntimePolicyBootstrap.BuildDiagnostics(
+                ToolRuntimePolicyBootstrap.CreateContext(new ToolRuntimePolicyOptions()));
+            var routingDiagnostics = ToolRoutingCatalogDiagnosticsBuilder.Build(Array.Empty<ToolDefinition>());
+            var cache = new ChatServiceToolingBootstrapCache(cachePath);
+
+            var persisted = cache.StoreSnapshot(
+                "write-failure-cache-key",
+                new ChatServiceToolingBootstrapSnapshot {
+                    Registry = new ToolRegistry(),
+                    ToolDefinitions = Array.Empty<ToolDefinitionDto>(),
+                    PackSummaries = Array.Empty<ToolPackInfoDto>(),
+                    Packs = Array.Empty<IToolPack>(),
+                    PackAvailability = Array.Empty<ToolPackAvailabilityInfo>(),
+                    PluginAvailability = Array.Empty<ToolPluginAvailabilityInfo>(),
+                    StartupWarnings = Array.Empty<string>(),
+                    StartupBootstrap = new SessionStartupBootstrapTelemetryDto(),
+                    PluginSearchPaths = Array.Empty<string>(),
+                    RuntimePolicyDiagnostics = diagnostics,
+                    RoutingCatalogDiagnostics = routingDiagnostics,
+                    CapabilitySnapshot = new SessionCapabilitySnapshotDto {
+                        RegisteredTools = 0,
+                        EnabledPackCount = 0,
+                        PluginCount = 0,
+                        EnabledPluginCount = 0,
+                        ToolingAvailable = false,
+                        AllowedRootCount = 0
+                    },
+                    ToolOrchestrationCatalog = ToolOrchestrationCatalog.Build(Array.Empty<ToolDefinition>())
+                });
+
+            Assert.False(persisted);
+            Assert.True(cache.TryGetPersistedSnapshotWarning(out var warning));
+            Assert.Contains("write_failed", warning, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            Directory.Delete(cachePath, recursive: true);
+        }
+    }
+
     private static (string PreviewCacheKey, string CacheKey) BuildToolingBootstrapKeys(ServiceOptions options) {
         var runtimePolicyOptionsMethod = typeof(ChatServiceSession).GetMethod(
             "BuildRuntimePolicyOptions",
@@ -1721,7 +1764,7 @@ public sealed class ChatServiceToolingBootstrapTests {
 
             cache = new ChatServiceToolingBootstrapCache(cachePath);
             Assert.False(cache.TryGetPersistedPreviewSnapshot(previewCacheKey, currentPreviewFingerprint, out _));
-            Assert.True(cache.TryGetPersistedSnapshotLoadWarning(out var warning));
+            Assert.True(cache.TryGetPersistedSnapshotWarning(out var warning));
             Assert.Contains("preview_fingerprint_mismatch", warning, StringComparison.OrdinalIgnoreCase);
         } finally {
             try {
@@ -1884,7 +1927,7 @@ public sealed class ChatServiceToolingBootstrapTests {
             File.WriteAllText(cachePath, JsonSerializer.Serialize(persistedSnapshot));
 
             var cache = new ChatServiceToolingBootstrapCache(cachePath);
-            Assert.True(cache.TryGetPersistedSnapshotLoadWarning(out var cacheLoadWarning));
+            Assert.True(cache.TryGetPersistedSnapshotWarning(out var cacheLoadWarning));
             Assert.Contains("descriptor_snapshot_schema_mismatch", cacheLoadWarning, StringComparison.OrdinalIgnoreCase);
 
             var startupWarningsField = typeof(ChatServiceSession).GetField(
@@ -1978,7 +2021,7 @@ public sealed class ChatServiceToolingBootstrapTests {
             File.WriteAllText(cachePath, JsonSerializer.Serialize(persistedSnapshot));
 
             var cache = new ChatServiceToolingBootstrapCache(cachePath);
-            Assert.True(cache.TryGetPersistedSnapshotLoadWarning(out var cacheLoadWarning));
+            Assert.True(cache.TryGetPersistedSnapshotWarning(out var cacheLoadWarning));
             Assert.Contains("schema_mismatch", cacheLoadWarning, StringComparison.OrdinalIgnoreCase);
 
             var startupWarningsField = typeof(ChatServiceSession).GetField(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthCacheTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthCacheTests.cs
@@ -1,0 +1,33 @@
+using IntelligenceX.Chat.Service;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+public sealed class StartupToolHealthCacheTests {
+    [Fact]
+    public void DeserializeStartupToolHealthCache_SkipsMalformedEntriesWithoutDiscardingValidBackoff() {
+        const string Json = """
+                            {
+                              "Entries": [
+                                null,
+                                { "Key": " " },
+                                {
+                                  "Key": "open_source|system|system_pack_info",
+                                  "ErrorCode": " tool_timeout ",
+                                  "Error": " timed out ",
+                                  "LastFailedUtc": "2026-07-16T18:00:00Z",
+                                  "NextProbeUtc": "2026-07-16T18:10:00Z",
+                                  "ConsecutiveFailures": 100
+                                }
+                              ]
+                            }
+                            """;
+
+        var entries = ChatServiceSession.DeserializeStartupToolHealthCache(Json);
+
+        var entry = Assert.Single(entries).Value;
+        Assert.Equal("tool_timeout", entry.ErrorCode);
+        Assert.Equal("timed out", entry.Error);
+        Assert.Equal(64, entry.ConsecutiveFailures);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthCacheTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthCacheTests.cs
@@ -30,4 +30,73 @@ public sealed class StartupToolHealthCacheTests {
         Assert.Equal("timed out", entry.Error);
         Assert.Equal(64, entry.ConsecutiveFailures);
     }
+
+    [Fact]
+    public void ApplyStartupToolHealthCacheMutations_PreservesUpdatesFromSeparateSessions() {
+        var root = CreateRoot();
+        try {
+            var path = Path.Combine(root, "startup-tool-health-cache.json");
+            var firstObservedUtc = new DateTime(2026, 7, 16, 18, 0, 0, DateTimeKind.Utc);
+            var secondObservedUtc = firstObservedUtc.AddSeconds(1);
+
+            ChatServiceSession.ApplyStartupToolHealthCacheMutations(path, [
+                CreateFailureMutation("open_source|first|pack_info", firstObservedUtc)
+            ]);
+            ChatServiceSession.ApplyStartupToolHealthCacheMutations(path, [
+                CreateFailureMutation("open_source|second|pack_info", secondObservedUtc)
+            ]);
+
+            var entries = ChatServiceSession.LoadStartupToolHealthCache(path);
+
+            Assert.Equal(2, entries.Count);
+            Assert.Contains("open_source|first|pack_info", entries.Keys);
+            Assert.Contains("open_source|second|pack_info", entries.Keys);
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ApplyStartupToolHealthCacheMutations_DoesNotRestoreFailureOlderThanSuccess() {
+        var root = CreateRoot();
+        try {
+            var path = Path.Combine(root, "startup-tool-health-cache.json");
+            const string CacheKey = "open_source|system|system_pack_info";
+            var initialFailureUtc = new DateTime(2026, 7, 16, 18, 0, 0, DateTimeKind.Utc);
+            var staleFailureUtc = initialFailureUtc.AddMinutes(1);
+            var successfulProbeUtc = staleFailureUtc.AddMinutes(1);
+
+            ChatServiceSession.ApplyStartupToolHealthCacheMutations(path, [
+                CreateFailureMutation(CacheKey, initialFailureUtc)
+            ]);
+            ChatServiceSession.ApplyStartupToolHealthCacheMutations(path, [
+                new ChatServiceSession.StartupToolHealthCacheMutation(CacheKey, Entry: null, successfulProbeUtc)
+            ]);
+            ChatServiceSession.ApplyStartupToolHealthCacheMutations(path, [
+                CreateFailureMutation(CacheKey, staleFailureUtc)
+            ]);
+
+            Assert.Empty(ChatServiceSession.LoadStartupToolHealthCache(path));
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static ChatServiceSession.StartupToolHealthCacheMutation CreateFailureMutation(
+        string key,
+        DateTime observedUtc) {
+        var entry = new ChatServiceSession.StartupToolHealthCacheEntry(
+            ErrorCode: "tool_timeout",
+            Error: "timed out",
+            LastFailedUtc: observedUtc,
+            NextProbeUtc: observedUtc.AddMinutes(5),
+            ConsecutiveFailures: 1);
+        return new ChatServiceSession.StartupToolHealthCacheMutation(key, entry, observedUtc);
+    }
+
+    private static string CreateRoot() {
+        var root = Path.Combine(Path.GetTempPath(), "IntelligenceX.Chat.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthCacheTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/StartupToolHealthCacheTests.cs
@@ -77,6 +77,7 @@ public sealed class StartupToolHealthCacheTests {
             ]);
 
             Assert.Empty(ChatServiceSession.LoadStartupToolHealthCache(path));
+            Assert.Contains("\"Successful\":true", File.ReadAllText(path), StringComparison.Ordinal);
         } finally {
             Directory.Delete(root, recursive: true);
         }


### PR DESCRIPTION
## Summary

- route scheduler control state, tooling bootstrap cache, startup tool-health state, and the desktop WebView budget cache through one bounded atomic JSON file owner
- centralize Service, Host, and desktop state locations in `ChatStatePaths`
- preserve scheduler schemas while replacing duplicate file, ACL, temporary-replacement, desktop write, path-containment, and cross-process lock implementations
- serialize shared JSON mutations across sessions and processes through one path-keyed lock owner
- apply scheduler control updates as persisted read-modify-write transactions: re-read the latest shared state under the mutex, commit live state only after durable success, and retain unrelated fields from other processes
- persist scheduler runtime telemetry as a locked read-merge-write transaction, retaining a local baseline so retries apply only local deltas, preserve concurrent counters, and merge failure events by stable identity across retries and processes
- make the bounded failure-event window the sole streak authority, migrate legacy scalar stores, saturate at 4,096, and keep circuit-breaker backoff active after saturation
- verify ambiguous write failures against the durable snapshot before retrying so a completed atomic replacement cannot be counted twice
- persist successful tool-health observations as bounded tombstones so a stale failure from another process cannot overwrite newer success
- retain unrelated scheduler overrides during expiry cleanup and return `persistence_failed` without claiming a failed request changed live state
- use LocalApplicationData or XDG data roots with a durable per-user profile fallback, never a shared temp or working directory
- enforce read limits on one open file handle, protect temporary files before JSON is written, and create Unix private files/directories with owner-only modes
- reject state-path escapes through traversal, casing differences, unsafe direct-child targets, symlinks, and reparse points, including the shared state directory itself
- keep optional WebView cache resolution and malformed tool-health data inside their best-effort/no-throw boundaries
- surface tooling-cache persistence failures in startup warnings instead of silently losing snapshots

## Why this matters

The chat surfaces had multiple persistence, locking, and default-path brains with different crash, corruption, fallback, containment, and security behavior. Expiry cleanup could remove unrelated scheduler state, stale instances could overwrite another process's controls, failed writes could still change live scheduler behavior, and runtime telemetry could be silently discarded, double-counted, or overwrite another process during recovery. The shared owners now provide consistent physical-path policy, same-handle size bounds, atomic replacement, secure creation, observable failures, transactional control updates, and baseline-aware runtime merges.

## Validation

- scheduler runtime persistence and retry tests on Windows: 20 passed
- the same scheduler runtime tests on a Linux runtime through WSL: 20 passed
- complete `IntelligenceX.Chat.Tests` suite in three non-overlapping runs: 2,430 passed (976 routing, 122 background-work, 1,332 remaining)
- complete `IntelligenceX.Chat.App.Tests` suite: 1,367 passed
- complete solution build: 0 warnings, 0 errors
- solution test projects: 208 net8 unit, 208 net10 unit, and 998 tools passed
- standalone `IntelligenceX.Tests` harnesses on net8 and net10: all tests passed

Validation used the existing OfficeIMO.Reader package and merged TestimoX source. No package publication or release is part of this PR.

## CI infrastructure

The PR babysit monitor rejects GitHub's Actions token before monitoring begins; the same authentication failure repeated on rerun and is tracked in #1362. The build, test, website, and reviewer jobs are independent of that monitor failure.
