### PR TITLE
Fix vulnerable AngleSharp CI dependencies

### DIFF
--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -17,4 +17,4 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 1fbe30fb0e12726b0e195a1072b37d875d7edf12
+      powerforge_ref: 4434a0c11e0b2f61209efaf3703566c338a2dcd3

--- a/IntelligenceX.Chat/Directory.Build.props
+++ b/IntelligenceX.Chat/Directory.Build.props
@@ -21,10 +21,11 @@
     <OfficeImoMarkdownRendererNuGetVersion Condition="'$(OfficeImoMarkdownRendererNuGetVersion)' == ''">0.2.28</OfficeImoMarkdownRendererNuGetVersion>
     <OfficeImoExcelNuGetVersion Condition="'$(OfficeImoExcelNuGetVersion)' == ''">0.6.41</OfficeImoExcelNuGetVersion>
     <OfficeImoWordMarkdownNuGetVersion Condition="'$(OfficeImoWordMarkdownNuGetVersion)' == ''">1.0.37</OfficeImoWordMarkdownNuGetVersion>
+    <AngleSharpNuGetVersion Condition="'$(AngleSharpNuGetVersion)' == ''">1.5.2</AngleSharpNuGetVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- OfficeIMO.Markdown.Html and OfficeIMO.Word.Html pin vulnerable AngleSharp 1.4.0 transitively. -->
-    <PackageReference Include="AngleSharp" Version="1.5.2" PrivateAssets="all" />
+    <PackageReference Include="AngleSharp" Version="$(AngleSharpNuGetVersion)" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/IntelligenceX.Chat/Directory.Build.props
+++ b/IntelligenceX.Chat/Directory.Build.props
@@ -22,4 +22,9 @@
     <OfficeImoExcelNuGetVersion Condition="'$(OfficeImoExcelNuGetVersion)' == ''">0.6.41</OfficeImoExcelNuGetVersion>
     <OfficeImoWordMarkdownNuGetVersion Condition="'$(OfficeImoWordMarkdownNuGetVersion)' == ''">1.0.37</OfficeImoWordMarkdownNuGetVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- OfficeIMO.Markdown.Html and OfficeIMO.Word.Html pin vulnerable AngleSharp 1.4.0 transitively. -->
+    <PackageReference Include="AngleSharp" Version="1.5.2" PrivateAssets="all" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Unblocks the current Dependabot CI queue without suppressing vulnerability warnings.

- Resolves the Chat package graph to AngleSharp 1.5.2, which is the first patched version for GHSA-pgww-w46g-26qg.
- Advances the website CI PowerForge source pin to the existing HtmlTinkerX security-fix commit, which resolves its separate AngleSharp chain to 1.5.2.

The change is intentionally centralized so the three Dependabot PRs can be rerun on a secure base.