### PR TITLE
CI: repin PowerForge after crypto audit fix

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@455ae22ec1b1405e6b719e377f1cd8258891fc93
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@4d4cc085cfadd4a17f56e2de019f9b1958d45a96
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -27,7 +27,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 455ae22ec1b1405e6b719e377f1cd8258891fc93
+      powerforge_ref: 4d4cc085cfadd4a17f56e2de019f9b1958d45a96
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/github-housekeeping.yml
+++ b/.github/workflows/github-housekeeping.yml
@@ -20,11 +20,11 @@ concurrency:
 
 jobs:
   housekeeping:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-housekeeping.yml@455ae22ec1b1405e6b719e377f1cd8258891fc93
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-housekeeping.yml@4d4cc085cfadd4a17f56e2de019f9b1958d45a96
     with:
       config-path: ./.powerforge/github-housekeeping.json
       apply: ${{ (github.event_name == 'workflow_dispatch' && inputs.apply == 'true') || (github.event_name != 'workflow_dispatch' && vars.POWERFORGE_GITHUB_HOUSEKEEPING_APPLY == 'true') }}
-      powerforge-ref: 455ae22ec1b1405e6b719e377f1cd8258891fc93
+      powerforge-ref: 4d4cc085cfadd4a17f56e2de019f9b1958d45a96
       report-artifact-name: github-housekeeping-reports
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -10,11 +10,11 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@455ae22ec1b1405e6b719e377f1cd8258891fc93
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@4d4cc085cfadd4a17f56e2de019f9b1958d45a96
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 455ae22ec1b1405e6b719e377f1cd8258891fc93
+      powerforge_ref: 4d4cc085cfadd4a17f56e2de019f9b1958d45a96


### PR DESCRIPTION
Updates the reusable PowerForge workflow and runtime references to the current audited shared commit. This removes the scheduled housekeeping restore failure caused by System.Security.Cryptography.Xml 10.0.7.