### PR TITLE
Add local-first ChatGPT Realtime and media support

### DIFF
--- a/IntelligenceX.Chat/Docs/index.md
+++ b/IntelligenceX.Chat/Docs/index.md
@@ -9,6 +9,7 @@ This repo is the Windows tray chat UI for the IntelligenceX ecosystem.
 - `Docs/markdown-contract.md` - canonical markdown ownership and pipeline contract
 - `Docs/markdown-package-readiness.md` - OfficeIMO markdown package adoption checklist
 - `Docs/service-protocol.md` - NDJSON contract for `IntelligenceX.Chat.Service`
+- `Docs/realtime-media.md` - ChatGPT subscription auth, Realtime voice/WebSocket, and image boundaries for apps
 - `Docs/ui.md` - UI/UX requirements (tables, tool traces, staging)
 - `Docs/security.md` - safety model for tool execution
 - `Docs/engine-catalog.md` - canonical engines (ADPlayground/ComputerX/EventViewerX) and “thin tool” rules

--- a/IntelligenceX.Chat/Docs/realtime-media.md
+++ b/IntelligenceX.Chat/Docs/realtime-media.md
@@ -91,9 +91,12 @@ Regular IX chat communicates directly with OpenAI's ChatGPT Responses endpoint. 
 
 The desktop chat service now carries generated-image URL/path references in `ChatResultMessage.Images`. Large base64 payloads remain in the provider/core layer instead of being copied into NDJSON frames.
 
-The ChatGPT OAuth Realtime mint path is currently accepted for ChatGPT/Codex sessions, but OpenAI's public API documentation still describes API-key authorization for this endpoint. Treat subscription-backed minting as a capability that may be account- or rollout-dependent, and keep the failure visible rather than silently switching credentials.
+ChatGPT/Codex OAuth is a user-owned subscription capability, not an API-key fallback or an unofficial
+entitlement. Voice uses its plan-specific allowance, while work started through Voice uses the user's existing
+Codex usage budget. Surface plan limits and rollout errors to the user instead of silently switching identities
+or credentials.
 
-OpenAI also does not currently document a general third-party native-app ChatGPT OAuth redirect contract.
-Before shipping the Apple sign-in adapter, validate the complete authorization, callback, token refresh,
-revocation, and reconnect flow on a physical device. This release boundary does not require or justify an
-Evotec relay.
+Because the Realtime voice capability and the Apple adapters are new, validate the complete authorization,
+callback, token refresh, revocation, reconnect, interruption, and quota-exhaustion flows on physical devices
+before release. This is client compatibility and release hardening; it does not require or justify an Evotec
+relay.

--- a/IntelligenceX.Chat/Docs/realtime-media.md
+++ b/IntelligenceX.Chat/Docs/realtime-media.md
@@ -2,22 +2,32 @@
 
 IntelligenceX can use an existing ChatGPT/Codex sign-in for chat, image generation, and short-lived Realtime credentials. The Realtime client connects to `gpt-realtime-2.1` over WebSocket and handles streamed text and audio events.
 
-The credential boundary matters for mobile apps:
+CasaRay, Tactra, and other user-owned apps should connect directly to OpenAI:
 
-1. A trusted backend loads or refreshes the ChatGPT OAuth session.
-2. The backend calls `CreateClientSecretAsync` and returns only the short-lived `ek_...` value, expiry, and model.
-3. The app opens the WebSocket with that credential.
-4. The app discards the credential when the connection closes or it expires.
+1. The user explicitly signs in to their own ChatGPT account.
+2. The app stores the OAuth session in device-protected storage, such as Apple Keychain.
+3. The app calls OpenAI directly to create its short-lived `ek_...` Realtime credential.
+4. The same app opens the Realtime connection directly to OpenAI.
+5. The app discards the short-lived credential when the connection closes or it expires.
 
-Do not put the persisted ChatGPT access token or refresh token in an iOS app, logs, app settings, or an app-to-service protocol.
+No Evotec account, relay, or hosted IntelligenceX service is required. Prompts, audio, images, tool results,
+and ChatGPT credentials do not pass through Evotec infrastructure. The app must never log credentials or
+store them in plain-text settings.
 
-## Mint a credential in a trusted backend
+## Connect directly from the user's device
 
 ```csharp
+using IntelligenceX.OpenAI.Native;
 using IntelligenceX.OpenAI.Realtime;
 
-using var realtime = new OpenAIRealtimeClient();
-var credential = await realtime.CreateClientSecretAsync(
+var chatGpt = new OpenAINativeOptions {
+    // CasaRay and Tactra should provide an IAuthBundleStore backed by Apple Keychain.
+    AuthStore = keychainAuthStore,
+    LoadCodexAuthJson = false
+};
+
+using var realtime = new OpenAIRealtimeClient(chatGptOptions: chatGpt);
+using var session = await realtime.ConnectAsync(
     new OpenAIRealtimeSessionOptions {
         Model = "gpt-realtime-2.1",
         OutputModalities = new[] { "audio" },
@@ -25,24 +35,6 @@ var credential = await realtime.CreateClientSecretAsync(
         ClientSecretLifetime = TimeSpan.FromMinutes(2)
     },
     cancellationToken);
-
-// Return only credential.Value, credential.ExpiresAt, and credential.Model.
-```
-
-`OpenAIRealtimeClient` uses `OpenAIRealtimeOptions.ApiKey` when one is supplied. Otherwise it uses the same ChatGPT OAuth store as the native IntelligenceX OpenAI transport.
-
-## Connect from a .NET or iOS client
-
-```csharp
-using IntelligenceX.OpenAI.Realtime;
-
-var credential = new OpenAIRealtimeClientSecret(
-    valueFromBackend,
-    expiresAtFromBackend,
-    modelFromBackend);
-
-using var realtime = new OpenAIRealtimeClient();
-using var session = await realtime.ConnectAsync(credential, cancellationToken);
 
 await session.SendTextAsync("Say hello in Polish.", cancellationToken: cancellationToken);
 
@@ -59,14 +51,49 @@ while (await session.ReceiveEventAsync(cancellationToken) is { } serverEvent) {
 }
 ```
 
+`OpenAIRealtimeClient` uses `OpenAIRealtimeOptions.ApiKey` only when the user explicitly configures one.
+Otherwise it uses the user's ChatGPT OAuth session from the configured `IAuthBundleStore`. Desktop Codex
+integrations can use the existing Codex auth store; Apple apps should use their own Keychain-backed adapter.
+
 The same session can accept microphone buffers through `AppendAudioAsync` and `CommitAudioAsync`. `SendImageAsync` sends a public URL or data URL as Realtime image input.
 
-WebSocket is a good fit for native .NET clients and server-to-server use. OpenAI recommends WebRTC for browser and mobile clients when its media handling and network recovery are a better fit. The short-lived credential flow is the same trust boundary for either transport.
+WebSocket is available for native .NET clients and lower-level integrations. OpenAI recommends WebRTC for
+mobile clients because it handles media and changing network conditions more robustly. CasaRay and Tactra
+should therefore reuse the same local ChatGPT auth and Realtime session configuration while using a thin
+Apple WebRTC transport adapter for production voice.
+
+## Apple integration boundary
+
+CasaRay and Tactra are native Swift applications, so they should not connect to the Windows-shaped
+IntelligenceX Chat service or an Evotec-hosted replacement. Their thin local adapter should use:
+
+- a user-initiated system-browser OAuth flow, using `ASWebAuthenticationSession` when the current
+  ChatGPT/Codex redirect contract supports the app callback and a local loopback callback otherwise;
+- Apple Keychain for the resulting access and refresh credentials;
+- `URLSession` for direct ChatGPT Responses, image-generation, and Realtime credential requests;
+- WebRTC for production voice, with `URLSessionWebSocketTask` available where the WebSocket transport is useful;
+- the shared IntelligenceX capability/action contracts for tool descriptions, confirmation, and result mapping.
+
+This keeps reusable AI behavior and safety contracts in IntelligenceX without putting Evotec in the network
+path. The Swift adapter owns only Apple authentication, secure storage, transport, microphone, and playback.
+
+## Privacy contract
+
+- The app communicates with OpenAI directly.
+- Evotec cannot see prompts, conversations, microphone audio, generated images, tool results, or credentials.
+- ChatGPT OAuth credentials remain in device-protected storage and can be removed by disconnecting the account.
+- IntelligenceX usage telemetry remains opt-in and is not required for ChatGPT, image, or Realtime features.
+- Integrations such as Home Assistant communicate only with destinations the user configures.
 
 ## Chat and image generation
 
-Regular IX chat continues to use the ChatGPT Responses backend. It supports text and image inputs, and the built-in image-generation tool uses OpenAI's current `gpt-image-2` capability. `EasyChatResult.Images` exposes URL, path, base64, and MIME information to library consumers.
+Regular IX chat communicates directly with OpenAI's ChatGPT Responses endpoint. It supports text and image inputs, and the built-in image-generation tool uses OpenAI's current `gpt-image-2` capability. `EasyChatResult.Images` exposes URL, path, base64, and MIME information to library consumers.
 
 The desktop chat service now carries generated-image URL/path references in `ChatResultMessage.Images`. Large base64 payloads remain in the provider/core layer instead of being copied into NDJSON frames.
 
 The ChatGPT OAuth Realtime mint path is currently accepted for ChatGPT/Codex sessions, but OpenAI's public API documentation still describes API-key authorization for this endpoint. Treat subscription-backed minting as a capability that may be account- or rollout-dependent, and keep the failure visible rather than silently switching credentials.
+
+OpenAI also does not currently document a general third-party native-app ChatGPT OAuth redirect contract.
+Before shipping the Apple sign-in adapter, validate the complete authorization, callback, token refresh,
+revocation, and reconnect flow on a physical device. This release boundary does not require or justify an
+Evotec relay.

--- a/IntelligenceX.Chat/Docs/realtime-media.md
+++ b/IntelligenceX.Chat/Docs/realtime-media.md
@@ -2,10 +2,10 @@
 
 IntelligenceX can use an existing ChatGPT/Codex sign-in for chat, image generation, and short-lived Realtime credentials. The Realtime client connects to `gpt-realtime-2.1` over WebSocket and handles streamed text and audio events.
 
-CasaRay, Tactra, and other user-owned apps should connect directly to OpenAI:
+Applications using a user's ChatGPT account should connect directly to OpenAI:
 
 1. The user explicitly signs in to their own ChatGPT account.
-2. The app stores the OAuth session in device-protected storage, such as Apple Keychain.
+2. The app stores the OAuth session in the operating system's protected credential storage.
 3. The app calls OpenAI directly to create its short-lived `ek_...` Realtime credential.
 4. The same app opens the Realtime connection directly to OpenAI.
 5. The app discards the short-lived credential when the connection closes or it expires.
@@ -21,8 +21,8 @@ using IntelligenceX.OpenAI.Native;
 using IntelligenceX.OpenAI.Realtime;
 
 var chatGpt = new OpenAINativeOptions {
-    // CasaRay and Tactra should provide an IAuthBundleStore backed by Apple Keychain.
-    AuthStore = keychainAuthStore,
+    // Hosts should provide an IAuthBundleStore backed by protected credential storage.
+    AuthStore = protectedAuthStore,
     LoadCodexAuthJson = false
 };
 
@@ -53,34 +53,36 @@ while (await session.ReceiveEventAsync(cancellationToken) is { } serverEvent) {
 
 `OpenAIRealtimeClient` uses `OpenAIRealtimeOptions.ApiKey` only when the user explicitly configures one.
 Otherwise it uses the user's ChatGPT OAuth session from the configured `IAuthBundleStore`. Desktop Codex
-integrations can use the existing Codex auth store; Apple apps should use their own Keychain-backed adapter.
+integrations can use the existing Codex auth store; other hosts should provide an adapter backed by their
+platform's protected credential storage.
 
 The same session can accept microphone buffers through `AppendAudioAsync` and `CommitAudioAsync`. `SendImageAsync` sends a public URL or data URL as Realtime image input.
 
 WebSocket is available for native .NET clients and lower-level integrations. OpenAI recommends WebRTC for
-mobile clients because it handles media and changing network conditions more robustly. CasaRay and Tactra
-should therefore reuse the same local ChatGPT auth and Realtime session configuration while using a thin
-Apple WebRTC transport adapter for production voice.
+mobile clients because it handles media and changing network conditions more robustly. Native mobile hosts
+should reuse the same ChatGPT authentication and Realtime session configuration behind a thin WebRTC
+transport adapter.
 
-## Apple integration boundary
+## Host integration boundary
 
-CasaRay and Tactra are native Swift applications, so they should not connect to the Windows-shaped
-IntelligenceX Chat service or an Evotec-hosted replacement. Their thin local adapter should use:
+Hosts should not depend on another product's UI service or a vendor-operated replacement. A thin local
+platform adapter should use:
 
-- a user-initiated system-browser OAuth flow, using `ASWebAuthenticationSession` when the current
-  ChatGPT/Codex redirect contract supports the app callback and a local loopback callback otherwise;
-- Apple Keychain for the resulting access and refresh credentials;
-- `URLSession` for direct ChatGPT Responses, image-generation, and Realtime credential requests;
-- WebRTC for production voice, with `URLSessionWebSocketTask` available where the WebSocket transport is useful;
+- a user-initiated system-browser OAuth flow appropriate for the host;
+- operating-system protected storage for access and refresh credentials;
+- a native HTTP client for direct ChatGPT Responses, image-generation, and Realtime credential requests;
+- WebRTC for production voice, with WebSocket available where the lower-level transport is useful;
 - the shared IntelligenceX capability/action contracts for tool descriptions, confirmation, and result mapping.
 
-This keeps reusable AI behavior and safety contracts in IntelligenceX without putting Evotec in the network
-path. The Swift adapter owns only Apple authentication, secure storage, transport, microphone, and playback.
+This keeps reusable AI behavior and safety contracts in IntelligenceX without adding an intermediary to the
+network path. Each host adapter owns only platform authentication, secure storage, transport, microphone,
+and playback.
 
 ## Privacy contract
 
 - The app communicates with OpenAI directly.
-- Evotec cannot see prompts, conversations, microphone audio, generated images, tool results, or credentials.
+- Prompts, conversations, microphone audio, generated images, tool results, and credentials do not pass
+  through an IntelligenceX or vendor-operated service.
 - ChatGPT OAuth credentials remain in device-protected storage and can be removed by disconnecting the account.
 - IntelligenceX usage telemetry remains opt-in and is not required for ChatGPT, image, or Realtime features.
 - Integrations such as Home Assistant communicate only with destinations the user configures.
@@ -96,7 +98,7 @@ entitlement. Voice uses its plan-specific allowance, while work started through 
 Codex usage budget. Surface plan limits and rollout errors to the user instead of silently switching identities
 or credentials.
 
-Because the Realtime voice capability and the Apple adapters are new, validate the complete authorization,
-callback, token refresh, revocation, reconnect, interruption, and quota-exhaustion flows on physical devices
-before release. This is client compatibility and release hardening; it does not require or justify an Evotec
-relay.
+Because the Realtime voice capability and platform adapters are new, validate the complete authorization,
+callback, token refresh, revocation, reconnect, interruption, and quota-exhaustion flows on each target
+platform before release. This is client compatibility and release hardening; it does not require or justify
+an intermediary relay.

--- a/IntelligenceX.Chat/Docs/realtime-media.md
+++ b/IntelligenceX.Chat/Docs/realtime-media.md
@@ -1,0 +1,72 @@
+# ChatGPT Realtime, voice, and images
+
+IntelligenceX can use an existing ChatGPT/Codex sign-in for chat, image generation, and short-lived Realtime credentials. The Realtime client connects to `gpt-realtime-2.1` over WebSocket and handles streamed text and audio events.
+
+The credential boundary matters for mobile apps:
+
+1. A trusted backend loads or refreshes the ChatGPT OAuth session.
+2. The backend calls `CreateClientSecretAsync` and returns only the short-lived `ek_...` value, expiry, and model.
+3. The app opens the WebSocket with that credential.
+4. The app discards the credential when the connection closes or it expires.
+
+Do not put the persisted ChatGPT access token or refresh token in an iOS app, logs, app settings, or an app-to-service protocol.
+
+## Mint a credential in a trusted backend
+
+```csharp
+using IntelligenceX.OpenAI.Realtime;
+
+using var realtime = new OpenAIRealtimeClient();
+var credential = await realtime.CreateClientSecretAsync(
+    new OpenAIRealtimeSessionOptions {
+        Model = "gpt-realtime-2.1",
+        OutputModalities = new[] { "audio" },
+        Voice = "marin",
+        ClientSecretLifetime = TimeSpan.FromMinutes(2)
+    },
+    cancellationToken);
+
+// Return only credential.Value, credential.ExpiresAt, and credential.Model.
+```
+
+`OpenAIRealtimeClient` uses `OpenAIRealtimeOptions.ApiKey` when one is supplied. Otherwise it uses the same ChatGPT OAuth store as the native IntelligenceX OpenAI transport.
+
+## Connect from a .NET or iOS client
+
+```csharp
+using IntelligenceX.OpenAI.Realtime;
+
+var credential = new OpenAIRealtimeClientSecret(
+    valueFromBackend,
+    expiresAtFromBackend,
+    modelFromBackend);
+
+using var realtime = new OpenAIRealtimeClient();
+using var session = await realtime.ConnectAsync(credential, cancellationToken);
+
+await session.SendTextAsync("Say hello in Polish.", cancellationToken: cancellationToken);
+
+while (await session.ReceiveEventAsync(cancellationToken) is { } serverEvent) {
+    if (serverEvent.TextDelta is { } text) {
+        RenderText(text);
+    }
+    if (serverEvent.AudioDelta is { } base64Audio) {
+        PlayAudio(Convert.FromBase64String(base64Audio));
+    }
+    if (serverEvent.ErrorMessage is { } error) {
+        ReportError(error);
+    }
+}
+```
+
+The same session can accept microphone buffers through `AppendAudioAsync` and `CommitAudioAsync`. `SendImageAsync` sends a public URL or data URL as Realtime image input.
+
+WebSocket is a good fit for native .NET clients and server-to-server use. OpenAI recommends WebRTC for browser and mobile clients when its media handling and network recovery are a better fit. The short-lived credential flow is the same trust boundary for either transport.
+
+## Chat and image generation
+
+Regular IX chat continues to use the ChatGPT Responses backend. It supports text and image inputs, and the built-in image-generation tool uses OpenAI's current `gpt-image-2` capability. `EasyChatResult.Images` exposes URL, path, base64, and MIME information to library consumers.
+
+The desktop chat service now carries generated-image URL/path references in `ChatResultMessage.Images`. Large base64 payloads remain in the provider/core layer instead of being copied into NDJSON frames.
+
+The ChatGPT OAuth Realtime mint path is currently accepted for ChatGPT/Codex sessions, but OpenAI's public API documentation still describes API-key authorization for this endpoint. Treat subscription-backed minting as a capability that may be account- or rollout-dependent, and keep the failure visible rather than silently switching credentials.

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Protocol/ChatServiceMessage.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Protocol/ChatServiceMessage.cs
@@ -478,6 +478,11 @@ public sealed record ChatResultMessage : ChatServiceMessage {
     /// </summary>
     public ToolRunDto? Tools { get; init; }
     /// <summary>
+    /// Optional generated image outputs. Payload bytes remain in the provider/core layer; this contract
+    /// carries stable file or URL references suitable for app surfaces.
+    /// </summary>
+    public ChatImageOutputDto[]? Images { get; init; }
+    /// <summary>
     /// Optional structured timeline captured for this completed turn.
     /// </summary>
     public TurnTimelineEventDto[]? TurnTimelineEvents { get; init; }
@@ -485,4 +490,22 @@ public sealed record ChatResultMessage : ChatServiceMessage {
     /// Optional normalized autonomy telemetry summary for this turn.
     /// </summary>
     public AutonomyTelemetryDto? AutonomyTelemetry { get; init; }
+}
+
+/// <summary>
+/// Describes a generated image returned by a completed chat turn.
+/// </summary>
+public sealed record ChatImageOutputDto {
+    /// <summary>
+    /// Optional provider-hosted image URL.
+    /// </summary>
+    public string? Url { get; init; }
+    /// <summary>
+    /// Optional local path where the service saved the generated image.
+    /// </summary>
+    public string? Path { get; init; }
+    /// <summary>
+    /// Optional image MIME type.
+    /// </summary>
+    public string? MimeType { get; init; }
 }

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Serialization/ChatServiceJsonContext.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Abstractions/Serialization/ChatServiceJsonContext.cs
@@ -59,6 +59,7 @@ namespace IntelligenceX.Chat.Abstractions.Serialization;
 [JsonSerializable(typeof(ChatInterimResultMessage))]
 [JsonSerializable(typeof(ChatMetricsMessage))]
 [JsonSerializable(typeof(ChatResultMessage))]
+[JsonSerializable(typeof(ChatImageOutputDto))]
 [JsonSerializable(typeof(ToolDefinitionDto))]
 [JsonSerializable(typeof(ToolParameterDto))]
 [JsonSerializable(typeof(ToolHealthProbeDto))]

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedFinalize.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedFinalize.cs
@@ -677,6 +677,7 @@ internal sealed partial class ChatServiceSession {
                     autonomyCounters: autonomyCounters,
                     completed: true);
 
+                CaptureChatImageOutputs(state.CapturedImages, turn);
                 var result = new ChatResultMessage {
                     Kind = ChatServiceMessageKind.Response,
                     RequestId = request.RequestId,
@@ -685,6 +686,7 @@ internal sealed partial class ChatServiceSession {
                     Tools = toolCalls.Count == 0 && toolOutputs.Count == 0
                         ? null
                         : new ToolRunDto { Calls = toolCalls.ToArray(), Outputs = toolOutputs.ToArray() },
+                    Images = SnapshotChatImageOutputs(state.CapturedImages),
                     TurnTimelineEvents = SnapshotTurnTimelineEvents(request.RequestId),
                     AutonomyTelemetry = autonomyTelemetry
                 };
@@ -705,6 +707,7 @@ internal sealed partial class ChatServiceSession {
         }
 
         void PersistState() {
+            CaptureChatImageOutputs(state.CapturedImages, turn);
             state.Turn = turn;
             state.AssistantDraft = text;
             state.ControlPayloadDetected = controlPayloadDetected;

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedState.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.NoExtractedState.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using IntelligenceX.Chat.Abstractions.Protocol;
 using IntelligenceX.OpenAI.AppServer.Models;
 using IntelligenceX.OpenAI.Chat;
 using IntelligenceX.Tools;
@@ -57,7 +58,8 @@ internal sealed partial class ChatServiceSession {
             int proactiveSkipMutatingCount,
             int proactiveSkipReadOnlyCount,
             int proactiveSkipUnknownCount,
-            bool interimResultSent) {
+            bool interimResultSent,
+            List<ChatImageOutputDto> capturedImages) {
             Turn = turn;
             AssistantDraft = assistantDraft;
             AnswerPlan = answerPlan;
@@ -94,6 +96,8 @@ internal sealed partial class ChatServiceSession {
             ProactiveSkipReadOnlyCount = proactiveSkipReadOnlyCount;
             ProactiveSkipUnknownCount = proactiveSkipUnknownCount;
             InterimResultSent = interimResultSent;
+            CapturedImages = capturedImages;
+            CaptureChatImageOutputs(CapturedImages, turn);
         }
 
         public TurnInfo Turn { get; set; }
@@ -167,6 +171,8 @@ internal sealed partial class ChatServiceSession {
         public int ProactiveSkipUnknownCount { get; set; }
 
         public bool InterimResultSent { get; set; }
+
+        public List<ChatImageOutputDto> CapturedImages { get; }
     }
 
     private static void RestoreNoExtractedToolRoundState(

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ChatRouting.cs
@@ -618,9 +618,11 @@ internal sealed partial class ChatServiceSession {
                                         && IsLoopbackEndpoint(_options.OpenAIBaseUrl);
         var supportsSyntheticHostReplayItems = SupportsSyntheticHostReplayItems(_options.OpenAITransport);
         var replayOutputCompactionBudget = ResolveReplayOutputCompactionBudgetForTurn(resolvedModel);
+        var capturedImages = new List<ChatImageOutputDto>();
 
         var mutatingToolHints = BuildMutatingToolHintsByName(toolDefs);
         for (var round = 0; round < maxRounds; round++) {
+            CaptureChatImageOutputs(capturedImages, turn);
             var extracted = ToolCallParser.Extract(turn);
             if (extracted.Count == 0) {
                 var rawAssistantDraft = EasyChatResult.FromTurn(turn).Text ?? string.Empty;
@@ -667,7 +669,8 @@ internal sealed partial class ChatServiceSession {
                     proactiveSkipMutatingCount: proactiveSkipMutatingCount,
                     proactiveSkipReadOnlyCount: proactiveSkipReadOnlyCount,
                     proactiveSkipUnknownCount: proactiveSkipUnknownCount,
-                    interimResultSent: interimResultSent);
+                    interimResultSent: interimResultSent,
+                    capturedImages: capturedImages);
 
                 var noExtractedRecoveryOutcome = await HandleNoExtractedToolCallsRecoveryAsync(
                         client: client,

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ImageOutputs.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ImageOutputs.cs
@@ -40,7 +40,15 @@ internal sealed partial class ChatServiceSession {
     }
 
     internal static ChatImageOutputDto[]? SnapshotChatImageOutputs(IReadOnlyList<ChatImageOutputDto> images) {
-        return images.Count == 0 ? null : images.ToArray();
+        if (images.Count == 0) {
+            return null;
+        }
+
+        var snapshot = new ChatImageOutputDto[images.Count];
+        for (var i = 0; i < images.Count; i++) {
+            snapshot[i] = images[i];
+        }
+        return snapshot;
     }
 
     private static string? NormalizeImageOutputValue(string? value) {

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ImageOutputs.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Service/ChatServiceSession.ImageOutputs.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.OpenAI.AppServer.Models;
+
+namespace IntelligenceX.Chat.Service;
+
+internal sealed partial class ChatServiceSession {
+    internal static ChatImageOutputDto[]? BuildChatImageOutputs(TurnInfo turn) {
+        var images = new List<ChatImageOutputDto>(turn.ImageOutputs.Count);
+        CaptureChatImageOutputs(images, turn);
+        return SnapshotChatImageOutputs(images);
+    }
+
+    internal static void CaptureChatImageOutputs(List<ChatImageOutputDto> images, TurnInfo turn) {
+        foreach (var output in turn.ImageOutputs) {
+            if (string.IsNullOrWhiteSpace(output.ImageUrl) &&
+                string.IsNullOrWhiteSpace(output.ImagePath)) {
+                continue;
+            }
+
+            var url = NormalizeImageOutputValue(output.ImageUrl);
+            var path = NormalizeImageOutputValue(output.ImagePath);
+            var duplicate = false;
+            for (var i = 0; i < images.Count; i++) {
+                if (string.Equals(images[i].Url, url, System.StringComparison.Ordinal) &&
+                    string.Equals(images[i].Path, path, System.StringComparison.Ordinal)) {
+                    duplicate = true;
+                    break;
+                }
+            }
+
+            if (!duplicate) {
+                images.Add(new ChatImageOutputDto {
+                    Url = url,
+                    Path = path,
+                    MimeType = NormalizeImageOutputValue(output.MimeType)
+                });
+            }
+        }
+    }
+
+    internal static ChatImageOutputDto[]? SnapshotChatImageOutputs(IReadOnlyList<ChatImageOutputDto> images) {
+        return images.Count == 0 ? null : images.ToArray();
+    }
+
+    private static string? NormalizeImageOutputValue(string? value) {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatImageOutputMappingTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatImageOutputMappingTests.cs
@@ -1,0 +1,82 @@
+using IntelligenceX.Chat.Service;
+using IntelligenceX.Chat.Abstractions.Protocol;
+using IntelligenceX.Json;
+using IntelligenceX.OpenAI.AppServer.Models;
+using Xunit;
+
+namespace IntelligenceX.Chat.Tests;
+
+/// <summary>
+/// Guards generated-image projection at the service protocol boundary.
+/// </summary>
+public sealed class ChatImageOutputMappingTests {
+    /// <summary>
+    /// Ensures the service exposes stable image references without copying large base64 payloads into NDJSON.
+    /// </summary>
+    [Fact]
+    public void BuildChatImageOutputs_ProjectsPathUrlAndMimeType() {
+        var output = new TurnOutput(
+            type: "image",
+            text: null,
+            imageUrl: " https://example.test/generated.png ",
+            imagePath: @" C:\artifacts\generated.png ",
+            base64: "large-payload-is-not-forwarded",
+            mimeType: " image/png ",
+            raw: new JsonObject(),
+            additional: null);
+        var turn = new TurnInfo(
+            id: "turn-image",
+            status: "completed",
+            outputs: new[] { output },
+            imageOutputs: new[] { output },
+            raw: new JsonObject(),
+            additional: null);
+
+        var images = ChatServiceSession.BuildChatImageOutputs(turn);
+
+        var image = Assert.Single(images!);
+        Assert.Equal("https://example.test/generated.png", image.Url);
+        Assert.Equal(@"C:\artifacts\generated.png", image.Path);
+        Assert.Equal("image/png", image.MimeType);
+    }
+
+    /// <summary>
+    /// Ensures a later text-review phase cannot discard media produced by an earlier phase.
+    /// </summary>
+    [Fact]
+    public void CaptureChatImageOutputs_AccumulatesAndDeduplicatesAcrossModelPhases() {
+        var output = new TurnOutput(
+            type: "image",
+            text: null,
+            imageUrl: "https://example.test/generated.png",
+            imagePath: null,
+            base64: null,
+            mimeType: "image/png",
+            raw: new JsonObject(),
+            additional: null);
+        var initialTurn = new TurnInfo(
+            id: "turn-image",
+            status: "completed",
+            outputs: new[] { output },
+            imageOutputs: new[] { output },
+            raw: new JsonObject(),
+            additional: null);
+        var reviewTurn = new TurnInfo(
+            id: "turn-review",
+            status: "completed",
+            outputs: Array.Empty<TurnOutput>(),
+            imageOutputs: Array.Empty<TurnOutput>(),
+            raw: new JsonObject(),
+            additional: null);
+        var images = new List<ChatImageOutputDto>();
+
+        ChatServiceSession.CaptureChatImageOutputs(images, initialTurn);
+        ChatServiceSession.CaptureChatImageOutputs(images, reviewTurn);
+        ChatServiceSession.CaptureChatImageOutputs(images, initialTurn);
+        var snapshot = ChatServiceSession.SnapshotChatImageOutputs(images);
+
+        var image = Assert.Single(snapshot!);
+        Assert.Equal("https://example.test/generated.png", image.Url);
+        Assert.Equal("image/png", image.MimeType);
+    }
+}

--- a/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceClientMessageParsingTests.cs
+++ b/IntelligenceX.Chat/IntelligenceX.Chat.Tests/ChatServiceClientMessageParsingTests.cs
@@ -94,6 +94,35 @@ public sealed class ChatServiceClientMessageParsingTests {
     }
 
     /// <summary>
+    /// Ensures generated image references survive the service/client protocol boundary.
+    /// </summary>
+    [Fact]
+    public void TryDeserializeMessageLine_PreservesGeneratedImageReferences() {
+        const string line = """
+            {
+              "type":"chat_result",
+              "kind":"response",
+              "requestId":"req_image",
+              "threadId":"thread_image",
+              "text":"Generated an image.",
+              "images":[
+                {
+                  "path":"C:\\artifacts\\generated.png",
+                  "mimeType":"image/png"
+                }
+              ]
+            }
+            """;
+
+        var parsed = ChatServiceClient.TryDeserializeMessageLine(line);
+
+        var result = Assert.IsType<ChatResultMessage>(parsed);
+        var image = Assert.Single(result.Images!);
+        Assert.Equal(@"C:\artifacts\generated.png", image.Path);
+        Assert.Equal("image/png", image.MimeType);
+    }
+
+    /// <summary>
     /// Ensures non-chat_result invalid payloads are rejected.
     /// </summary>
     [Fact]

--- a/IntelligenceX.Tests/IntelligenceX.Tests.csproj
+++ b/IntelligenceX.Tests/IntelligenceX.Tests.csproj
@@ -22,6 +22,10 @@
         <ProjectReference Include="..\IntelligenceX.Storage.SQLite\IntelligenceX.Storage.SQLite.csproj" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+        <Reference Include="System.Net.Http" />
+    </ItemGroup>
+
     <PropertyGroup Condition=" '$(TargetFramework)' != 'net472' ">
         <DefineConstants>$(DefineConstants);INTELLIGENCEX_REVIEWER</DefineConstants>
     </PropertyGroup>

--- a/IntelligenceX.Tests/Program.Core.cs
+++ b/IntelligenceX.Tests/Program.Core.cs
@@ -573,6 +573,37 @@ internal static partial class Program {
         AssertEqual("acct-123", result!.NativeOptions.AuthAccountId, "EasySession auth account id");
     }
 
+    private static void TestEasySessionBuildClientOptionsCarriesNativeMediaAndAuthSettings() {
+        var options = new EasySessionOptions();
+        options.NativeOptions.ChatGptApiBaseUrl = "https://chatgpt.example.test/backend-api";
+        options.NativeOptions.LoadCodexAuthJson = false;
+        options.NativeOptions.PreferCurrentCodexSession = false;
+        options.NativeOptions.EnableToolSchemaFallback = false;
+        options.NativeOptions.ImageGeneration = new ImageGenerationOptions {
+            Enabled = true,
+            Quality = "low",
+            Size = "1024x1024",
+            OutputFormat = "png",
+            OutputDirectory = @"C:\generated",
+            SaveOutputImages = true
+        };
+
+        var method = typeof(EasySession).GetMethod("BuildClientOptions", BindingFlags.NonPublic | BindingFlags.Static);
+        AssertNotNull(method, "EasySession.BuildClientOptions native media method");
+        var result = method!.Invoke(null, new object?[] { options }) as IntelligenceXClientOptions;
+        AssertNotNull(result, "EasySession native media client options");
+        AssertEqual("https://chatgpt.example.test/backend-api", result!.NativeOptions.ChatGptApiBaseUrl,
+            "EasySession ChatGPT API base URL");
+        AssertEqual(false, result.NativeOptions.LoadCodexAuthJson, "EasySession Codex auth loading");
+        AssertEqual(false, result.NativeOptions.PreferCurrentCodexSession, "EasySession current Codex session preference");
+        AssertEqual(false, result.NativeOptions.EnableToolSchemaFallback, "EasySession tool schema fallback");
+        AssertEqual(true, result.NativeOptions.ImageGeneration.Enabled, "EasySession image generation enabled");
+        AssertEqual("low", result.NativeOptions.ImageGeneration.Quality, "EasySession image generation quality");
+        AssertEqual(@"C:\generated", result.NativeOptions.ImageGeneration.OutputDirectory,
+            "EasySession image generation output directory");
+        AssertEqual(true, result.NativeOptions.ImageGeneration.SaveOutputImages, "EasySession image generation save outputs");
+    }
+
     private static void TestEasySessionBuildClientOptionsCarriesUsageTelemetrySettings() {
         var options = new EasySessionOptions {
             EnableUsageTelemetry = true,

--- a/IntelligenceX.Tests/Program.OpenAI.NativeRequestBody.cs
+++ b/IntelligenceX.Tests/Program.OpenAI.NativeRequestBody.cs
@@ -267,6 +267,58 @@ internal static partial class Program {
         }
     }
 
+    private static void TestNativeImageGenerationPreservesStreamedOutputItems() {
+        var ix = typeof(IntelligenceXClient).Assembly;
+        var optionsType = ix.GetType("IntelligenceX.OpenAI.Native.OpenAINativeOptions", throwOnError: true)!;
+        var transportType = ix.GetType("IntelligenceX.OpenAI.Native.OpenAINativeTransport", throwOnError: true)!;
+        var outputRoot = Path.Combine(Path.GetTempPath(), "ix-imagegen-stream-" + Guid.NewGuid().ToString("N"));
+        try {
+            var options = Activator.CreateInstance(optionsType);
+            AssertNotNull(options, "OpenAINativeOptions");
+            var transport = Activator.CreateInstance(transportType, options);
+            AssertNotNull(transport, "OpenAINativeTransport");
+
+            var appendMethod = transportType.GetMethod(
+                "AppendMissingStreamedImageOutputs",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            AssertNotNull(appendMethod, "AppendMissingStreamedImageOutputs method");
+
+            var outputs = new List<JsonObject> {
+                new JsonObject().Add("type", "text").Add("text", "Done.")
+            };
+            var streamedOutputs = new List<JsonObject> {
+                new JsonObject()
+                    .Add("type", "image_generation_call")
+                    .Add("id", "ig_stream")
+                    .Add("status", "completed")
+                    .Add("result", "Zm9v")
+            };
+
+            appendMethod!.Invoke(transport, new object?[] {
+                outputs,
+                streamedOutputs,
+                "session-stream",
+                new ChatOptions {
+                    ImageGeneration = new ImageGenerationOptions {
+                        Enabled = true,
+                        OutputFormat = "png",
+                        OutputDirectory = outputRoot
+                    }
+                }
+            });
+
+            AssertEqual(3, outputs.Count, "streamed image merged output count");
+            AssertEqual("image", outputs[1].GetString("type"), "streamed image output type");
+            AssertEqual("Zm9v", outputs[1].GetString("base64"), "streamed image base64");
+            AssertEqual(true, File.Exists(outputs[1].GetString("path")!), "streamed image saved");
+            AssertEqual("text", outputs[2].GetString("type"), "streamed image fallback text");
+        } finally {
+            if (Directory.Exists(outputRoot)) {
+                Directory.Delete(outputRoot, recursive: true);
+            }
+        }
+    }
+
     private static void TestNativeRequestBodyNormalizesToolReplayInputItems() {
         var ix = typeof(IntelligenceXClient).Assembly;
         var optionsType = ix.GetType("IntelligenceX.OpenAI.Native.OpenAINativeOptions", throwOnError: true)!;

--- a/IntelligenceX.Tests/Program.OpenAI.NativeRequestBody.cs
+++ b/IntelligenceX.Tests/Program.OpenAI.NativeRequestBody.cs
@@ -312,6 +312,43 @@ internal static partial class Program {
             AssertEqual("Zm9v", outputs[1].GetString("base64"), "streamed image base64");
             AssertEqual(true, File.Exists(outputs[1].GetString("path")!), "streamed image saved");
             AssertEqual("text", outputs[2].GetString("type"), "streamed image fallback text");
+
+            var partialOutputs = new List<JsonObject> {
+                new JsonObject()
+                    .Add("type", "image")
+                    .Add("id", "ig_existing")
+                    .Add("base64", "Zm9v")
+            };
+            var partialStreamedOutputs = new List<JsonObject> {
+                new JsonObject()
+                    .Add("type", "image_generation_call")
+                    .Add("id", "ig_existing")
+                    .Add("status", "completed")
+                    .Add("result", "Zm9v"),
+                new JsonObject()
+                    .Add("type", "image_generation_call")
+                    .Add("id", "ig_stream_only")
+                    .Add("status", "completed")
+                    .Add("result", "YmFy")
+            };
+
+            appendMethod.Invoke(transport, new object?[] {
+                partialOutputs,
+                partialStreamedOutputs,
+                "session-partial-stream",
+                new ChatOptions {
+                    ImageGeneration = new ImageGenerationOptions {
+                        Enabled = true,
+                        OutputFormat = "png",
+                        OutputDirectory = outputRoot
+                    }
+                }
+            });
+
+            AssertEqual(3, partialOutputs.Count, "partial streamed image output count");
+            AssertEqual("ig_existing", partialOutputs[0].GetString("id"), "existing streamed image retained once");
+            AssertEqual("ig_stream_only", partialOutputs[1].GetString("id"), "streamed-only image merged");
+            AssertEqual("text", partialOutputs[2].GetString("type"), "partial streamed image fallback text");
         } finally {
             if (Directory.Exists(outputRoot)) {
                 Directory.Delete(outputRoot, recursive: true);

--- a/IntelligenceX.Tests/Program.OpenAI.Realtime.cs
+++ b/IntelligenceX.Tests/Program.OpenAI.Realtime.cs
@@ -137,6 +137,11 @@ internal static partial class Program {
         AssertEqual("AQID", audioEvent.AudioDelta, "Realtime audio delta");
         AssertEqual<string?>(null, audioEvent.TextDelta, "Realtime audio text delta");
 
+        var transcriptEvent = OpenAIRealtimeEvent.Parse(
+            """{"type":"response.output_audio_transcript.delta","delta":"spoken text"}""");
+        AssertEqual("spoken text", transcriptEvent.TextDelta, "Realtime audio transcript text delta");
+        AssertEqual<string?>(null, transcriptEvent.AudioDelta, "Realtime audio transcript binary delta");
+
         var errorEvent = OpenAIRealtimeEvent.Parse("""{"type":"error","error":{"message":"bad request"}}""");
         AssertEqual("bad request", errorEvent.ErrorMessage, "Realtime error message");
     }
@@ -173,6 +178,24 @@ internal static partial class Program {
             codex,
             OpenAINativeAuthManager.SelectPreferredBundle(stored, codex, preferCodexSession: true),
             "Explicit current Codex session preference");
+
+        var codexWithoutRefresh = new AuthBundle(
+            OpenAICodexDefaults.Provider,
+            "codex-without-refresh",
+            string.Empty,
+            DateTimeOffset.UtcNow.AddMinutes(-5)) {
+            AccountId = stored.AccountId
+        };
+        AssertEqual(
+            stored,
+            OpenAINativeAuthManager.SelectRefreshCandidate(codexWithoutRefresh, stored),
+            "Stored same-account refresh fallback");
+
+        stored.AccountId = "other-account";
+        AssertEqual(
+            codexWithoutRefresh,
+            OpenAINativeAuthManager.SelectRefreshCandidate(codexWithoutRefresh, stored),
+            "Different-account refresh bundle rejected");
     }
 
     private static void TestChatGptOAuthRefreshIsSingleFlightForSharedBundles() {

--- a/IntelligenceX.Tests/Program.OpenAI.Realtime.cs
+++ b/IntelligenceX.Tests/Program.OpenAI.Realtime.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.OpenAI.Auth;
+using IntelligenceX.OpenAI.Native;
+using IntelligenceX.OpenAI.Realtime;
+
+namespace IntelligenceX.Tests;
+
+internal static partial class Program {
+    private static void TestCodexAuthStoreReadsCurrentOAuthBundle() {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "ix-codex-auth-" + Guid.NewGuid().ToString("N"));
+        var authPath = Path.Combine(tempRoot, "auth.json");
+        Directory.CreateDirectory(tempRoot);
+        try {
+            var payload = """
+                {"exp":2000000000,"https://api.openai.com/auth":{"chatgpt_account_id":"acct-current"}}
+                """;
+            var token = EncodeBase64Url("""{"alg":"none"}""") + "." + EncodeBase64Url(payload) + ".signature";
+            File.WriteAllText(
+                authPath,
+                "{\"tokens\":{\"access_token\":\"" + token +
+                "\",\"refresh_token\":\"refresh-current\",\"id_token\":\"id-current\"}}");
+
+            var bundle = CodexAuthStore.TryReadBundle(authPath);
+
+            AssertNotNull(bundle, "Codex auth bundle");
+            AssertEqual(token, bundle!.AccessToken, "Codex auth access token");
+            AssertEqual("refresh-current", bundle.RefreshToken, "Codex auth refresh token");
+            AssertEqual("acct-current", bundle.AccountId, "Codex auth account id");
+            AssertEqual(DateTimeOffset.FromUnixTimeSeconds(2000000000), bundle.ExpiresAt, "Codex auth expiry");
+        } finally {
+            if (Directory.Exists(tempRoot)) {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    private static void TestRealtimeClientSecretUsesChatGptOAuth() {
+        var store = new TestRealtimeAuthStore(new AuthBundle(
+            OpenAICodexDefaults.Provider,
+            "oauth-access-token",
+            "oauth-refresh-token",
+            DateTimeOffset.UtcNow.AddHours(1)) {
+            AccountId = "account-123"
+        });
+        var handler = new RecordingRealtimeHandler(
+            """{"value":"ek_test","expires_at":2000000000,"session":{"model":"gpt-realtime-2.1"}}""");
+        var chatGptOptions = new OpenAINativeOptions {
+            AuthStore = store,
+            PersistCodexAuthJson = false,
+            LoadCodexAuthJson = false
+        };
+        using var httpClient = new HttpClient(handler);
+        using var client = new OpenAIRealtimeClient(
+            new OpenAIRealtimeOptions(),
+            chatGptOptions,
+            httpClient,
+            ownsHttpClient: false);
+
+        var secret = client.CreateClientSecretAsync(new OpenAIRealtimeSessionOptions {
+            OutputModalities = new[] { "text" },
+            ClientSecretLifetime = TimeSpan.FromSeconds(90)
+        }).GetAwaiter().GetResult();
+
+        AssertEqual("ek_test", secret.Value, "Realtime client secret value");
+        AssertEqual(OpenAIModelCatalog.DefaultRealtimeModel, secret.Model, "Realtime client secret model");
+        AssertEqual("Bearer", handler.AuthorizationScheme, "Realtime OAuth authorization scheme");
+        AssertEqual("oauth-access-token", handler.AuthorizationParameter, "Realtime OAuth access token");
+        AssertEqual("account-123", handler.AccountId, "Realtime OAuth account header");
+        AssertContainsText(handler.Body ?? string.Empty, "\"seconds\":90", "Realtime client secret lifetime");
+        AssertContainsText(handler.Body ?? string.Empty, "\"output_modalities\":[\"text\"]", "Realtime output modality");
+    }
+
+    private static void TestRealtimeSessionPayloadCarriesVoiceContract() {
+        var options = new OpenAIRealtimeSessionOptions {
+            Model = "gpt-realtime-2.1",
+            Instructions = "Speak briefly.",
+            OutputModalities = new[] { "audio" },
+            Voice = "marin",
+            ClientSecretLifetime = TimeSpan.FromSeconds(75)
+        };
+        options.Validate();
+
+        var payload = OpenAIRealtimeClient.BuildClientSecretPayload(options);
+        using var document = JsonDocument.Parse(payload);
+        var root = document.RootElement;
+        AssertEqual(75, root.GetProperty("expires_after").GetProperty("seconds").GetInt32(), "Realtime expiry seconds");
+        var session = root.GetProperty("session");
+        AssertEqual("realtime", session.GetProperty("type").GetString(), "Realtime session type");
+        AssertEqual("gpt-realtime-2.1", session.GetProperty("model").GetString(), "Realtime model");
+        AssertEqual("Speak briefly.", session.GetProperty("instructions").GetString(), "Realtime instructions");
+        AssertEqual("audio", session.GetProperty("output_modalities")[0].GetString(), "Realtime voice modality");
+        AssertEqual("marin", session.GetProperty("audio").GetProperty("output").GetProperty("voice").GetString(),
+            "Realtime voice");
+    }
+
+    private static void TestRealtimeSessionValidatesServiceContract() {
+        AssertThrows<ArgumentException>(
+            () => new OpenAIRealtimeSessionOptions {
+                OutputModalities = new[] { "audio", "text" }
+            }.Validate(),
+            "Realtime rejects multiple output modalities");
+        AssertThrows<ArgumentOutOfRangeException>(
+            () => new OpenAIRealtimeSessionOptions {
+                ClientSecretLifetime = TimeSpan.FromSeconds(9)
+            }.Validate(),
+            "Realtime rejects too-short client secret lifetime");
+        AssertThrows<ArgumentOutOfRangeException>(
+            () => new OpenAIRealtimeSessionOptions {
+                ClientSecretLifetime = TimeSpan.FromSeconds(7201)
+            }.Validate(),
+            "Realtime rejects too-long client secret lifetime");
+
+        var minimum = new OpenAIRealtimeSessionOptions {
+            ClientSecretLifetime = TimeSpan.FromSeconds(10)
+        };
+        minimum.Validate();
+        var maximum = new OpenAIRealtimeSessionOptions {
+            ClientSecretLifetime = TimeSpan.FromSeconds(7200)
+        };
+        maximum.Validate();
+    }
+
+    private static void TestRealtimeEventsProjectTextAudioAndErrors() {
+        var textEvent = OpenAIRealtimeEvent.Parse("""{"type":"response.output_text.delta","delta":"hello"}""");
+        AssertEqual("response.output_text.delta", textEvent.Type, "Realtime text event type");
+        AssertEqual("hello", textEvent.TextDelta, "Realtime text delta");
+        AssertEqual<string?>(null, textEvent.AudioDelta, "Realtime text audio delta");
+
+        var audioEvent = OpenAIRealtimeEvent.Parse("""{"type":"response.output_audio.delta","delta":"AQID"}""");
+        AssertEqual("AQID", audioEvent.AudioDelta, "Realtime audio delta");
+        AssertEqual<string?>(null, audioEvent.TextDelta, "Realtime audio text delta");
+
+        var errorEvent = OpenAIRealtimeEvent.Parse("""{"type":"error","error":{"message":"bad request"}}""");
+        AssertEqual("bad request", errorEvent.ErrorMessage, "Realtime error message");
+    }
+
+    private static void TestStoredChatGptAuthTakesPrecedenceOverCodexFallback() {
+        var stored = new AuthBundle(
+            OpenAICodexDefaults.Provider,
+            "stored-token",
+            "stored-refresh",
+            DateTimeOffset.UtcNow.AddMinutes(5)) {
+            AccountId = "stored-account"
+        };
+        var codex = new AuthBundle(
+            OpenAICodexDefaults.Provider,
+            "codex-token",
+            "codex-refresh",
+            DateTimeOffset.UtcNow.AddHours(1)) {
+            AccountId = "different-account"
+        };
+
+        var selected = OpenAINativeAuthManager.SelectPreferredBundle(stored, codex);
+
+        AssertEqual(stored, selected, "Configured auth store bundle");
+        AssertEqual(codex, OpenAINativeAuthManager.SelectPreferredBundle(null, codex), "Codex auth fallback bundle");
+
+        codex.AccountId = stored.AccountId;
+        AssertEqual(
+            codex,
+            OpenAINativeAuthManager.SelectPreferredBundle(stored, codex),
+            "Fresher Codex bundle for same account");
+
+        codex.AccountId = "different-account";
+        AssertEqual(
+            codex,
+            OpenAINativeAuthManager.SelectPreferredBundle(stored, codex, preferCodexSession: true),
+            "Explicit current Codex session preference");
+    }
+
+    private static void TestChatGptOAuthRefreshIsSingleFlightForSharedBundles() {
+        var sharedBundle = new AuthBundle(
+            OpenAICodexDefaults.Provider,
+            "old-access-token",
+            "old-refresh-token",
+            DateTimeOffset.UtcNow.AddMinutes(-5)) {
+            AccountId = "shared-refresh-account"
+        };
+        var store = new TestRealtimeAuthStore(sharedBundle);
+        var options = new OpenAINativeOptions {
+            AuthStore = store,
+            LoadCodexAuthJson = false,
+            PersistCodexAuthJson = false
+        };
+        var refreshCount = 0;
+        var manager = new OpenAINativeAuthManager(
+            options,
+            async (_, bundle, cancellationToken) => {
+                Interlocked.Increment(ref refreshCount);
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+                bundle.AccessToken = "new-access-token";
+                bundle.RefreshToken = "new-refresh-token";
+                bundle.ExpiresAt = DateTimeOffset.UtcNow.AddHours(1);
+                return new OAuthLoginResult(bundle, new Dictionary<string, string>());
+            });
+
+        var first = manager.RefreshAsync(sharedBundle, CancellationToken.None);
+        var second = manager.RefreshAsync(sharedBundle, CancellationToken.None);
+        Task.WhenAll(first, second).GetAwaiter().GetResult();
+
+        AssertEqual(1, refreshCount, "OAuth refresh call count");
+        AssertEqual("new-access-token", first.Result.AccessToken, "First refreshed access token");
+        AssertEqual("new-access-token", second.Result.AccessToken, "Second refreshed access token");
+    }
+
+    private sealed class RecordingRealtimeHandler : HttpMessageHandler {
+        private readonly string _responseJson;
+
+        internal RecordingRealtimeHandler(string responseJson) {
+            _responseJson = responseJson;
+        }
+
+        internal string? AuthorizationScheme { get; private set; }
+        internal string? AuthorizationParameter { get; private set; }
+        internal string? AccountId { get; private set; }
+        internal string? Body { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) {
+            AuthorizationScheme = request.Headers.Authorization?.Scheme;
+            AuthorizationParameter = request.Headers.Authorization?.Parameter;
+            AccountId = request.Headers.TryGetValues("ChatGPT-Account-ID", out var values)
+                ? string.Join(",", values)
+                : null;
+            Body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+            };
+        }
+    }
+
+    private sealed class TestRealtimeAuthStore : IAuthBundleStore {
+        private readonly AuthBundle _bundle;
+
+        internal TestRealtimeAuthStore(AuthBundle bundle) {
+            _bundle = bundle;
+        }
+
+        public Task<AuthBundle?> GetAsync(
+            string provider,
+            string? accountId = null,
+            CancellationToken cancellationToken = default) {
+            return Task.FromResult<AuthBundle?>(_bundle);
+        }
+
+        public Task<IReadOnlyList<AuthBundle>> ListAsync(
+            string provider,
+            CancellationToken cancellationToken = default) {
+            return Task.FromResult<IReadOnlyList<AuthBundle>>(new[] { _bundle });
+        }
+
+        public Task SaveAsync(AuthBundle bundle, CancellationToken cancellationToken = default) {
+            return Task.CompletedTask;
+        }
+    }
+
+    private static string EncodeBase64Url(string value) {
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}

--- a/IntelligenceX.Tests/Program.cs
+++ b/IntelligenceX.Tests/Program.cs
@@ -26,6 +26,7 @@ internal static partial class Program {
         failed += Run("ChatGPT usage cache trailing separator override path",
             TestChatGptUsageCacheTrailingSeparatorOverridePath);
         failed += Run("EasySession forwards auth account id", TestEasySessionBuildClientOptionsCarriesAuthAccountId);
+        failed += Run("EasySession forwards native media and auth settings", TestEasySessionBuildClientOptionsCarriesNativeMediaAndAuthSettings);
         failed += Run("EasySession forwards usage telemetry settings", TestEasySessionBuildClientOptionsCarriesUsageTelemetrySettings);
         failed += Run("Usage telemetry stable source root id normalizes paths", TestUsageTelemetryStableSourceRootIdNormalizesPaths);
         failed += Run("Usage telemetry dedupe prefers account session turn", TestUsageTelemetryDedupePrefersAccountSessionTurn);
@@ -469,6 +470,14 @@ internal static partial class Program {
         failed += Run("Native request body normalizes tools/tool_choice", TestNativeRequestBodyNormalizesToolsAndToolChoice);
         failed += Run("Native request body includes image generation tool", TestNativeRequestBodyIncludesImageGenerationTool);
         failed += Run("Native image generation output saves base64 payload", TestNativeImageGenerationOutputSavesBase64Payload);
+        failed += Run("Native image generation preserves streamed output items", TestNativeImageGenerationPreservesStreamedOutputItems);
+        failed += Run("Realtime client secret uses ChatGPT OAuth", TestRealtimeClientSecretUsesChatGptOAuth);
+        failed += Run("Codex auth store reads current OAuth bundle", TestCodexAuthStoreReadsCurrentOAuthBundle);
+        failed += Run("Realtime session payload carries voice contract", TestRealtimeSessionPayloadCarriesVoiceContract);
+        failed += Run("Realtime session validates service contract", TestRealtimeSessionValidatesServiceContract);
+        failed += Run("Realtime events project text audio and errors", TestRealtimeEventsProjectTextAudioAndErrors);
+        failed += Run("Stored ChatGPT auth takes precedence over Codex fallback", TestStoredChatGptAuthTakesPrecedenceOverCodexFallback);
+        failed += Run("ChatGPT OAuth refresh is single-flight for shared bundles", TestChatGptOAuthRefreshIsSingleFlightForSharedBundles);
         failed += Run("Treatment prompt builder includes artifacts and contract", TestTreatmentPromptBuilderIncludesArtifactsAndContract);
         failed += Run("Treatment prompt builder rejects empty request", TestTreatmentPromptBuilderRejectsEmptyRequest);
         failed += Run("Treatment prompt builder inlines local text artifacts", TestTreatmentPromptBuilderInlinesLocalTextArtifacts);

--- a/IntelligenceX/Providers/OpenAI/Auth/CodexAuthStore.cs
+++ b/IntelligenceX/Providers/OpenAI/Auth/CodexAuthStore.cs
@@ -84,6 +84,44 @@ public static class CodexAuthStore {
     }
 
     /// <summary>
+    /// Reads a ChatGPT OAuth bundle from a Codex auth.json file.
+    /// </summary>
+    /// <remarks>
+    /// The returned bundle contains sensitive tokens and must not be logged or exposed to app clients.
+    /// </remarks>
+    public static AuthBundle? TryReadBundle(string authPath) {
+        if (string.IsNullOrWhiteSpace(authPath) || !File.Exists(authPath)) {
+            return null;
+        }
+
+        try {
+            var root = JsonLite.Parse(File.ReadAllText(authPath)).AsObject();
+            var tokens = root?.GetObject("tokens");
+            var accessToken = NormalizeOptional(tokens?.GetString("access_token"));
+            if (accessToken is null) {
+                return null;
+            }
+
+            var refreshToken = NormalizeOptional(tokens?.GetString("refresh_token")) ?? string.Empty;
+            var idToken = NormalizeOptional(tokens?.GetString("id_token"));
+            var accountId = NormalizeOptional(tokens?.GetString("account_id"))
+                            ?? JwtDecoder.TryGetAccountId(accessToken)
+                            ?? (idToken is null ? null : JwtDecoder.TryGetAccountId(idToken));
+            return new AuthBundle(
+                OpenAICodexDefaults.Provider,
+                accessToken,
+                refreshToken,
+                JwtDecoder.TryGetExpiry(accessToken)) {
+                AccountId = accountId,
+                IdToken = idToken,
+                TokenType = "Bearer"
+            };
+        } catch {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Builds Codex auth.json content from an auth bundle.
     /// </summary>
     /// <param name="bundle">Auth bundle.</param>

--- a/IntelligenceX/Providers/OpenAI/Auth/JwtDecoder.cs
+++ b/IntelligenceX/Providers/OpenAI/Auth/JwtDecoder.cs
@@ -33,6 +33,28 @@ internal static class JwtDecoder {
         return NormalizeOptional(authObj?.GetString("chatgpt_plan_type"));
     }
 
+    public static DateTimeOffset? TryGetExpiry(string token) {
+        var payload = TryGetPayloadObject(token);
+        if (payload is null) {
+            return null;
+        }
+
+        var expiry = payload.GetInt64("exp");
+        if (!expiry.HasValue) {
+            var expiryText = payload.GetString("exp");
+            if (!long.TryParse(expiryText, out var parsed)) {
+                return null;
+            }
+            expiry = parsed;
+        }
+
+        try {
+            return DateTimeOffset.FromUnixTimeSeconds(expiry.Value);
+        } catch (ArgumentOutOfRangeException) {
+            return null;
+        }
+    }
+
     private static JsonObject? TryGetOpenAiAuthObject(string token) {
         var obj = TryGetPayloadObject(token);
         if (obj is null || !obj.TryGetValue(OpenAICodexDefaults.AuthClaim, out var authNode)) {

--- a/IntelligenceX/Providers/OpenAI/EasyChatOptions.cs
+++ b/IntelligenceX/Providers/OpenAI/EasyChatOptions.cs
@@ -77,4 +77,8 @@ public sealed class EasyChatOptions {
     /// Require workspace for file access when set.
     /// </summary>
     public bool? RequireWorkspaceForFileAccess { get; set; }
+    /// <summary>
+    /// Optional image-generation tool settings for this request.
+    /// </summary>
+    public ImageGenerationOptions? ImageGeneration { get; set; }
 }

--- a/IntelligenceX/Providers/OpenAI/EasySession.cs
+++ b/IntelligenceX/Providers/OpenAI/EasySession.cs
@@ -166,6 +166,7 @@ public sealed class EasySession : IDisposable
             chatOptions.ToolChoice = options.ToolChoice;
             chatOptions.ParallelToolCalls = options.ParallelToolCalls;
             chatOptions.PreviousResponseId = options.PreviousResponseId;
+            chatOptions.ImageGeneration = options.ImageGeneration?.Clone();
             if (options.RequireWorkspaceForFileAccess.HasValue) {
                 chatOptions.RequireWorkspaceForFileAccess = options.RequireWorkspaceForFileAccess.Value;
             }
@@ -244,15 +245,20 @@ public sealed class EasySession : IDisposable
         clientOptions.NativeOptions.Originator = options.NativeOptions.Originator;
         clientOptions.NativeOptions.ResponsesUrl = options.NativeOptions.ResponsesUrl;
         clientOptions.NativeOptions.ModelUrls = options.NativeOptions.ModelUrls;
+        clientOptions.NativeOptions.ChatGptApiBaseUrl = options.NativeOptions.ChatGptApiBaseUrl;
         clientOptions.NativeOptions.ClientVersion = options.NativeOptions.ClientVersion;
         clientOptions.NativeOptions.Instructions = options.NativeOptions.Instructions;
         clientOptions.NativeOptions.ReasoningEffort = options.NativeOptions.ReasoningEffort;
         clientOptions.NativeOptions.ReasoningSummary = options.NativeOptions.ReasoningSummary;
         clientOptions.NativeOptions.TextVerbosity = options.NativeOptions.TextVerbosity;
         clientOptions.NativeOptions.IncludeReasoningEncryptedContent = options.NativeOptions.IncludeReasoningEncryptedContent;
+        clientOptions.NativeOptions.EnableToolSchemaFallback = options.NativeOptions.EnableToolSchemaFallback;
+        clientOptions.NativeOptions.ImageGeneration = options.NativeOptions.ImageGeneration.Clone();
         clientOptions.NativeOptions.OAuthTimeout = options.NativeOptions.OAuthTimeout;
         clientOptions.NativeOptions.UseLocalListener = options.NativeOptions.UseLocalListener;
         clientOptions.NativeOptions.PersistCodexAuthJson = options.NativeOptions.PersistCodexAuthJson;
+        clientOptions.NativeOptions.LoadCodexAuthJson = options.NativeOptions.LoadCodexAuthJson;
+        clientOptions.NativeOptions.PreferCurrentCodexSession = options.NativeOptions.PreferCurrentCodexSession;
         clientOptions.NativeOptions.CodexHome = options.NativeOptions.CodexHome;
         clientOptions.NativeOptions.UserAgent = options.NativeOptions.UserAgent;
         clientOptions.NativeOptions.OAuth.AuthorizeUrl = options.NativeOptions.OAuth.AuthorizeUrl;

--- a/IntelligenceX/Providers/OpenAI/EasySessionOptions.cs
+++ b/IntelligenceX/Providers/OpenAI/EasySessionOptions.cs
@@ -37,7 +37,7 @@ public sealed class EasySessionOptions {
     /// <summary>
     /// Native transport options.
     /// </summary>
-    public OpenAINativeOptions NativeOptions { get; } = new();
+    public OpenAINativeOptions NativeOptions { get; } = CreateDefaultNativeOptions();
     /// <summary>
     /// OpenAI-compatible HTTP transport options (for example local providers such as Ollama/LM Studio).
     /// </summary>
@@ -222,6 +222,12 @@ public sealed class EasySessionOptions {
         return new CopilotClientOptions {
             AutoInstallCli = true,
             AutoInstallMethod = CopilotCliInstallMethod.Auto
+        };
+    }
+
+    private static OpenAINativeOptions CreateDefaultNativeOptions() {
+        return new OpenAINativeOptions {
+            PreferCurrentCodexSession = true
         };
     }
 }

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeAuthManager.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeAuthManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using IntelligenceX.OpenAI.Auth;
@@ -7,17 +8,26 @@ namespace IntelligenceX.OpenAI.Native;
 
 internal sealed class OpenAINativeAuthManager {
     private static readonly TimeSpan ExpirySkew = TimeSpan.FromMinutes(1);
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> RefreshLocks =
+        new(StringComparer.OrdinalIgnoreCase);
 
     private readonly OpenAINativeOptions _options;
     private readonly OAuthLoginService _oauth = new();
+    private readonly Func<OAuthConfig, AuthBundle, CancellationToken, Task<OAuthLoginResult>> _refreshOAuthAsync;
 
-    public OpenAINativeAuthManager(OpenAINativeOptions options) {
+    public OpenAINativeAuthManager(OpenAINativeOptions options)
+        : this(options, null) {
+    }
+
+    internal OpenAINativeAuthManager(
+        OpenAINativeOptions options,
+        Func<OAuthConfig, AuthBundle, CancellationToken, Task<OAuthLoginResult>>? refreshOAuthAsync) {
         _options = options;
+        _refreshOAuthAsync = refreshOAuthAsync ?? _oauth.RefreshAsync;
     }
 
     public async Task<AuthBundle?> TryGetValidBundleAsync(CancellationToken cancellationToken) {
-        var bundle = await _options.AuthStore.GetAsync(OpenAICodexDefaults.Provider, _options.AuthAccountId, cancellationToken)
-            .ConfigureAwait(false);
+        var bundle = await TryGetCurrentBundleAsync(cancellationToken).ConfigureAwait(false);
         if (bundle is null) {
             return null;
         }
@@ -53,12 +63,31 @@ internal sealed class OpenAINativeAuthManager {
     }
 
     public async Task<AuthBundle> RefreshAsync(AuthBundle bundle, CancellationToken cancellationToken) {
-        if (string.IsNullOrWhiteSpace(bundle.RefreshToken)) {
-            throw new InvalidOperationException("Refresh token is missing. Re-run the ChatGPT login.");
+        var accessTokenBeforeLock = bundle.AccessToken;
+        var refreshLock = RefreshLocks.GetOrAdd(
+            BuildRefreshLockKey(bundle),
+            _ => new SemaphoreSlim(1, 1));
+        await refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            var current = await TryGetCurrentBundleAsync(cancellationToken).ConfigureAwait(false);
+            if (current is not null &&
+                !string.Equals(current.AccessToken, accessTokenBeforeLock, StringComparison.Ordinal) &&
+                !IsExpiring(current)) {
+                return current;
+            }
+
+            var refreshCandidate = current ?? bundle;
+            if (string.IsNullOrWhiteSpace(refreshCandidate.RefreshToken)) {
+                throw new InvalidOperationException("Refresh token is missing. Re-run the ChatGPT login.");
+            }
+
+            var refreshed = await _refreshOAuthAsync(_options.OAuth, refreshCandidate, cancellationToken)
+                .ConfigureAwait(false);
+            await SaveBundleAsync(refreshed.Bundle, cancellationToken).ConfigureAwait(false);
+            return refreshed.Bundle;
+        } finally {
+            refreshLock.Release();
         }
-        var refreshed = await _oauth.RefreshAsync(_options.OAuth, bundle, cancellationToken).ConfigureAwait(false);
-        await SaveBundleAsync(refreshed.Bundle, cancellationToken).ConfigureAwait(false);
-        return refreshed.Bundle;
     }
 
     private async Task SaveBundleAsync(AuthBundle bundle, CancellationToken cancellationToken) {
@@ -80,6 +109,64 @@ internal sealed class OpenAINativeAuthManager {
         }
         var now = DateTimeOffset.UtcNow;
         return now >= bundle.ExpiresAt.Value.Subtract(ExpirySkew);
+    }
+
+    private AuthBundle? TryGetCodexBundle() {
+        if (!_options.LoadCodexAuthJson) {
+            return null;
+        }
+
+        var bundle = CodexAuthStore.TryReadBundle(CodexAuthStore.ResolveAuthPath(_options.CodexHome));
+        if (bundle is null || string.IsNullOrWhiteSpace(_options.AuthAccountId)) {
+            return bundle;
+        }
+
+        return string.Equals(bundle.AccountId, _options.AuthAccountId, StringComparison.OrdinalIgnoreCase)
+            ? bundle
+            : null;
+    }
+
+    internal static AuthBundle? SelectPreferredBundle(
+        AuthBundle? storedBundle,
+        AuthBundle? codexBundle,
+        bool preferCodexSession = false) {
+        if (storedBundle is null) {
+            return codexBundle;
+        }
+        if (codexBundle is null) {
+            return storedBundle;
+        }
+        if (preferCodexSession) {
+            return codexBundle;
+        }
+        if (
+            string.IsNullOrWhiteSpace(storedBundle.AccountId) ||
+            !string.Equals(storedBundle.AccountId, codexBundle.AccountId, StringComparison.OrdinalIgnoreCase)) {
+            return storedBundle;
+        }
+
+        var storedExpiry = storedBundle.ExpiresAt ?? DateTimeOffset.MinValue;
+        var codexExpiry = codexBundle.ExpiresAt ?? DateTimeOffset.MinValue;
+        return codexExpiry >= storedExpiry ? codexBundle : storedBundle;
+    }
+
+    private async Task<AuthBundle?> TryGetCurrentBundleAsync(CancellationToken cancellationToken) {
+        var storedBundle = await _options.AuthStore
+            .GetAsync(OpenAICodexDefaults.Provider, _options.AuthAccountId, cancellationToken)
+            .ConfigureAwait(false);
+        if (storedBundle is not null && string.IsNullOrWhiteSpace(storedBundle.AccountId)) {
+            storedBundle.AccountId = JwtDecoder.TryGetAccountId(storedBundle.AccessToken);
+        }
+        return SelectPreferredBundle(
+            storedBundle,
+            TryGetCodexBundle(),
+            _options.PreferCurrentCodexSession && string.IsNullOrWhiteSpace(_options.AuthAccountId));
+    }
+
+    private string BuildRefreshLockKey(AuthBundle bundle) {
+        var accountId = (_options.AuthAccountId ?? bundle.AccountId)?.Trim();
+        return OpenAICodexDefaults.Provider + "|" +
+               (string.IsNullOrWhiteSpace(accountId) ? "default" : accountId);
     }
 
     private static Task<string> DefaultPromptAsync(string prompt, CancellationToken cancellationToken) {

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeAuthManager.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeAuthManager.cs
@@ -78,6 +78,10 @@ internal sealed class OpenAINativeAuthManager {
 
             var refreshCandidate = current ?? bundle;
             if (string.IsNullOrWhiteSpace(refreshCandidate.RefreshToken)) {
+                var storedBundle = await GetStoredBundleAsync(cancellationToken).ConfigureAwait(false);
+                refreshCandidate = SelectRefreshCandidate(refreshCandidate, storedBundle);
+            }
+            if (string.IsNullOrWhiteSpace(refreshCandidate.RefreshToken)) {
                 throw new InvalidOperationException("Refresh token is missing. Re-run the ChatGPT login.");
             }
 
@@ -150,13 +154,33 @@ internal sealed class OpenAINativeAuthManager {
         return codexExpiry >= storedExpiry ? codexBundle : storedBundle;
     }
 
-    private async Task<AuthBundle?> TryGetCurrentBundleAsync(CancellationToken cancellationToken) {
+    internal static AuthBundle SelectRefreshCandidate(AuthBundle selectedBundle, AuthBundle? storedBundle) {
+        if (!string.IsNullOrWhiteSpace(selectedBundle.RefreshToken) ||
+            storedBundle is null ||
+            string.IsNullOrWhiteSpace(storedBundle.RefreshToken)) {
+            return selectedBundle;
+        }
+
+        selectedBundle.AccountId ??= JwtDecoder.TryGetAccountId(selectedBundle.AccessToken);
+        storedBundle.AccountId ??= JwtDecoder.TryGetAccountId(storedBundle.AccessToken);
+        return !string.IsNullOrWhiteSpace(selectedBundle.AccountId) &&
+               string.Equals(selectedBundle.AccountId, storedBundle.AccountId, StringComparison.OrdinalIgnoreCase)
+            ? storedBundle
+            : selectedBundle;
+    }
+
+    private async Task<AuthBundle?> GetStoredBundleAsync(CancellationToken cancellationToken) {
         var storedBundle = await _options.AuthStore
             .GetAsync(OpenAICodexDefaults.Provider, _options.AuthAccountId, cancellationToken)
             .ConfigureAwait(false);
         if (storedBundle is not null && string.IsNullOrWhiteSpace(storedBundle.AccountId)) {
             storedBundle.AccountId = JwtDecoder.TryGetAccountId(storedBundle.AccessToken);
         }
+        return storedBundle;
+    }
+
+    private async Task<AuthBundle?> TryGetCurrentBundleAsync(CancellationToken cancellationToken) {
+        var storedBundle = await GetStoredBundleAsync(cancellationToken).ConfigureAwait(false);
         return SelectPreferredBundle(
             storedBundle,
             TryGetCodexBundle(),

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeOptions.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeOptions.cs
@@ -109,6 +109,16 @@ public sealed class OpenAINativeOptions {
     /// </summary>
     public bool PersistCodexAuthJson { get; set; } = true;
     /// <summary>
+    /// Whether to use the current Codex auth.json session as a fallback when the configured auth store
+    /// has no credential, or as a fresher credential for the same ChatGPT account.
+    /// </summary>
+    public bool LoadCodexAuthJson { get; set; } = true;
+    /// <summary>
+    /// Whether the current Codex session should take precedence over a stored credential when no
+    /// <see cref="AuthAccountId"/> is configured. Enable this only for user-facing ChatGPT session flows.
+    /// </summary>
+    public bool PreferCurrentCodexSession { get; set; }
+    /// <summary>
     /// Override path to the Codex home directory.
     /// </summary>
     public string? CodexHome { get; set; }

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.OutputParsingAndFiles.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.OutputParsingAndFiles.cs
@@ -72,6 +72,42 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
         return outputs;
     }
 
+    private void AppendMissingStreamedImageOutputs(
+        List<JsonObject> outputs,
+        IReadOnlyList<JsonObject> streamedOutputs,
+        string sessionId,
+        ChatOptions options) {
+        if (streamedOutputs.Count == 0 || ContainsImageOutput(outputs)) {
+            return;
+        }
+
+        var streamedArray = new JsonArray();
+        foreach (var item in streamedOutputs) {
+            if (string.Equals(item.GetString("type"), "image_generation_call", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(item.GetString("type"), "output_image", StringComparison.OrdinalIgnoreCase)) {
+                streamedArray.Add(item);
+            }
+        }
+        if (streamedArray.Count == 0) {
+            return;
+        }
+
+        var streamedResponse = new JsonObject().Add("output", streamedArray);
+        var parsed = ParseOutputsFromResponse(streamedResponse, sessionId, options);
+        foreach (var output in parsed) {
+            outputs.Add(output);
+        }
+    }
+
+    private static bool ContainsImageOutput(IReadOnlyList<JsonObject> outputs) {
+        foreach (var output in outputs) {
+            if (string.Equals(output.GetString("type"), "image", StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static void ParseContentParts(JsonArray content, List<JsonObject> outputs) {
         foreach (var partValue in content) {
             var part = partValue.AsObject();

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.OutputParsingAndFiles.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.OutputParsingAndFiles.cs
@@ -77,7 +77,7 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
         IReadOnlyList<JsonObject> streamedOutputs,
         string sessionId,
         ChatOptions options) {
-        if (streamedOutputs.Count == 0 || ContainsImageOutput(outputs)) {
+        if (streamedOutputs.Count == 0) {
             return;
         }
 
@@ -94,18 +94,49 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
 
         var streamedResponse = new JsonObject().Add("output", streamedArray);
         var parsed = ParseOutputsFromResponse(streamedResponse, sessionId, options);
+        var addedImage = false;
         foreach (var output in parsed) {
-            outputs.Add(output);
+            if (!string.Equals(output.GetString("type"), "image", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            if (!ContainsEquivalentImageOutput(outputs, output)) {
+                outputs.Add(output);
+                addedImage = true;
+            }
+        }
+
+        if (!addedImage) {
+            return;
+        }
+        foreach (var output in parsed) {
+            if (!string.Equals(output.GetString("type"), "image", StringComparison.OrdinalIgnoreCase)) {
+                outputs.Add(output);
+            }
         }
     }
 
-    private static bool ContainsImageOutput(IReadOnlyList<JsonObject> outputs) {
+    private static bool ContainsEquivalentImageOutput(IReadOnlyList<JsonObject> outputs, JsonObject candidate) {
         foreach (var output in outputs) {
-            if (string.Equals(output.GetString("type"), "image", StringComparison.OrdinalIgnoreCase)) {
+            if (!string.Equals(output.GetString("type"), "image", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            if (HasMatchingImageIdentity(output, candidate, "id") ||
+                HasMatchingImageIdentity(output, candidate, "url") ||
+                HasMatchingImageIdentity(output, candidate, "path") ||
+                HasMatchingImageIdentity(output, candidate, "base64")) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static bool HasMatchingImageIdentity(JsonObject left, JsonObject right, string propertyName) {
+        var leftValue = left.GetString(propertyName);
+        var rightValue = right.GetString(propertyName);
+        return !string.IsNullOrWhiteSpace(leftValue) &&
+               !string.IsNullOrWhiteSpace(rightValue) &&
+               string.Equals(leftValue, rightValue, StringComparison.Ordinal);
     }
 
     private static void ParseContentParts(JsonArray content, List<JsonObject> outputs) {

--- a/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.cs
+++ b/IntelligenceX/Providers/OpenAI/Native/OpenAINativeTransport.cs
@@ -176,9 +176,21 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
         RpcCallStarted?.Invoke(this, new RpcCallStartedEventArgs("responses.create", rpcParameters));
         var sw = System.Diagnostics.Stopwatch.StartNew();
         try {
-            var turn = await SendWithModelFallbackAsync(body, requestMessages, bundle.AccessToken, accountId!, state, inputItems, trackMessages,
-                    resolvedModel, turnId, options, cancellationToken)
-                .ConfigureAwait(false);
+            TurnInfo turn;
+            try {
+                turn = await SendWithModelFallbackAsync(body, requestMessages, bundle.AccessToken, accountId!, state, inputItems, trackMessages,
+                        resolvedModel, turnId, options, cancellationToken)
+                    .ConfigureAwait(false);
+            } catch (OpenAIAuthenticationRequiredException) when (!string.IsNullOrWhiteSpace(bundle.RefreshToken)) {
+                bundle = await _auth.RefreshAsync(bundle, cancellationToken).ConfigureAwait(false);
+                accountId = bundle.AccountId ?? JwtDecoder.TryGetAccountId(bundle.AccessToken);
+                if (string.IsNullOrWhiteSpace(accountId)) {
+                    throw new InvalidOperationException("Failed to extract account id from refreshed access token.");
+                }
+                turn = await SendWithModelFallbackAsync(body, requestMessages, bundle.AccessToken, accountId!, state, inputItems, trackMessages,
+                        resolvedModel, turnId, options, cancellationToken)
+                    .ConfigureAwait(false);
+            }
             RpcCallCompleted?.Invoke(this, new RpcCallCompletedEventArgs("responses.create", sw.Elapsed, true));
             return turn;
         } catch (Exception ex) {
@@ -269,10 +281,11 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
         string? status = null;
         JsonObject? completedResponse = null;
         string? streamError = null;
+        var streamedOutputs = new List<JsonObject>();
 
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         await OpenAINativeSseParser.ParseAsync(stream, evt => {
-            HandleStreamEvent(evt, delta, ref status, ref completedResponse, ref streamError);
+            HandleStreamEvent(evt, delta, streamedOutputs, ref status, ref completedResponse, ref streamError);
             return Task.CompletedTask;
         }, cancellationToken).ConfigureAwait(false);
 
@@ -283,6 +296,7 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
         var outputs = completedResponse is not null
             ? ParseOutputsFromResponse(completedResponse, state.SessionId, options)
             : BuildOutputsFromDelta(delta.ToString());
+        AppendMissingStreamedImageOutputs(outputs, streamedOutputs, state.SessionId, options);
         if (outputs.Count == 0 && delta.Length > 0) {
             outputs.Add(new JsonObject().Add("type", "text").Add("text", delta.ToString()));
         }
@@ -431,7 +445,8 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
         throw new InvalidOperationException("Tool schema fallback exhausted without capturing an exception.");
     }
 
-    private void HandleStreamEvent(JsonObject evt, StringBuilder delta, ref string? status, ref JsonObject? completedResponse,
+    private void HandleStreamEvent(JsonObject evt, StringBuilder delta, List<JsonObject> streamedOutputs,
+        ref string? status, ref JsonObject? completedResponse,
         ref string? streamError) {
         var type = evt.GetString("type");
         if (string.IsNullOrWhiteSpace(type)) {
@@ -452,6 +467,14 @@ internal sealed partial class OpenAINativeTransport : IOpenAITransport {
             if (!string.IsNullOrWhiteSpace(piece)) {
                 delta.Append(piece);
                 DeltaReceived?.Invoke(this, piece!);
+            }
+            return;
+        }
+
+        if (string.Equals(type, "response.output_item.done", StringComparison.Ordinal)) {
+            var item = evt.GetObject("item");
+            if (item is not null) {
+                streamedOutputs.Add(item);
             }
             return;
         }

--- a/IntelligenceX/Providers/OpenAI/OpenAIModelCatalog.cs
+++ b/IntelligenceX/Providers/OpenAI/OpenAIModelCatalog.cs
@@ -12,6 +12,16 @@ public static class OpenAIModelCatalog {
     /// </summary>
     public const string DefaultModel = "gpt-5.5";
 
+    /// <summary>
+    /// Default model for low-latency text, image, and audio Realtime sessions.
+    /// </summary>
+    public const string DefaultRealtimeModel = "gpt-realtime-2.1";
+
+    /// <summary>
+    /// Current default model used by OpenAI's image-generation capability.
+    /// </summary>
+    public const string DefaultImageModel = "gpt-image-2";
+
     private static readonly string[] BaselineFallbackModels = {
         DefaultModel,
         "gpt-5.4",

--- a/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeClient.cs
+++ b/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeClient.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+using IntelligenceX.OpenAI.Auth;
+using IntelligenceX.OpenAI.Native;
+
+namespace IntelligenceX.OpenAI.Realtime;
+
+/// <summary>
+/// Mints short-lived OpenAI Realtime credentials and opens Realtime WebSocket sessions.
+/// </summary>
+/// <remarks>
+/// When no API key is supplied, this client reuses the existing ChatGPT/Codex OAuth bundle.
+/// App and iOS clients should receive only the short-lived credential returned by
+/// <see cref="CreateClientSecretAsync"/>; persisted OAuth credentials must remain in the trusted backend.
+/// </remarks>
+public sealed class OpenAIRealtimeClient : IDisposable {
+    private readonly OpenAIRealtimeOptions _options;
+    private readonly OpenAINativeOptions _chatGptOptions;
+    private readonly OpenAINativeAuthManager _authManager;
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a Realtime client.
+    /// </summary>
+    /// <param name="options">Realtime endpoint and API-key options.</param>
+    /// <param name="chatGptOptions">ChatGPT OAuth bundle options used when no API key is supplied.</param>
+    public OpenAIRealtimeClient(
+        OpenAIRealtimeOptions? options = null,
+        OpenAINativeOptions? chatGptOptions = null)
+        : this(options, chatGptOptions, new HttpClient(), ownsHttpClient: true) {
+    }
+
+    internal OpenAIRealtimeClient(
+        OpenAIRealtimeOptions? options,
+        OpenAINativeOptions? chatGptOptions,
+        HttpClient httpClient,
+        bool ownsHttpClient) {
+        _options = options ?? new OpenAIRealtimeOptions();
+        _chatGptOptions = chatGptOptions ?? new OpenAINativeOptions {
+            PreferCurrentCodexSession = true
+        };
+        _options.Validate();
+        _chatGptOptions.Validate();
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _ownsHttpClient = ownsHttpClient;
+        _authManager = new OpenAINativeAuthManager(_chatGptOptions);
+    }
+
+    /// <summary>
+    /// Mints a short-lived Realtime client credential. The returned value is sensitive and must not be persisted.
+    /// </summary>
+    public async Task<OpenAIRealtimeClientSecret> CreateClientSecretAsync(
+        OpenAIRealtimeSessionOptions? sessionOptions = null,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        var session = sessionOptions ?? new OpenAIRealtimeSessionOptions();
+        session.Validate();
+
+        var authorization = await ResolveAuthorizationAsync(cancellationToken).ConfigureAwait(false);
+        var payload = BuildClientSecretPayload(session);
+        var response = await SendClientSecretRequestAsync(payload, authorization, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode == HttpStatusCode.Unauthorized && authorization.Bundle is not null) {
+            var refreshed = await _authManager.RefreshAsync(authorization.Bundle, cancellationToken).ConfigureAwait(false);
+            authorization = new RealtimeAuthorization(refreshed.AccessToken, refreshed.AccountId, refreshed);
+            response = await SendClientSecretRequestAsync(payload, authorization, cancellationToken).ConfigureAwait(false);
+        }
+        if (!response.IsSuccessStatusCode) {
+            throw new InvalidOperationException(
+                $"OpenAI Realtime client-secret request failed with HTTP {(int)response.StatusCode}: {response.Content}");
+        }
+
+        return ParseClientSecret(response.Content, session.Model);
+    }
+
+    /// <summary>
+    /// Mints a short-lived credential and opens an authenticated Realtime WebSocket.
+    /// </summary>
+    public async Task<OpenAIRealtimeSession> ConnectAsync(
+        OpenAIRealtimeSessionOptions? sessionOptions = null,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        var session = sessionOptions ?? new OpenAIRealtimeSessionOptions();
+        session.Validate();
+        var secret = await CreateClientSecretAsync(session, cancellationToken).ConfigureAwait(false);
+        return await ConnectAsync(secret, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Opens a Realtime WebSocket with a short-lived credential received from a trusted backend.
+    /// This overload is suitable for app and iOS clients because it does not require persisted OAuth credentials.
+    /// </summary>
+    public async Task<OpenAIRealtimeSession> ConnectAsync(
+        OpenAIRealtimeClientSecret secret,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (secret is null) {
+            throw new ArgumentNullException(nameof(secret));
+        }
+        if (secret.ExpiresAt <= DateTimeOffset.UtcNow) {
+            throw new InvalidOperationException("The OpenAI Realtime client credential has expired.");
+        }
+
+        var webSocket = new ClientWebSocket();
+        webSocket.Options.SetRequestHeader("Authorization", "Bearer " + secret.Value);
+        var endpoint = BuildWebSocketUri(secret.Model);
+        try {
+            await webSocket.ConnectAsync(endpoint, cancellationToken).ConfigureAwait(false);
+            return new OpenAIRealtimeSession(webSocket, secret.Model, _options.MaxEventBytes);
+        } catch {
+            webSocket.Dispose();
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        if (_disposed) {
+            return;
+        }
+        _disposed = true;
+        if (_ownsHttpClient) {
+            _httpClient.Dispose();
+        }
+    }
+
+    internal static string BuildClientSecretPayload(OpenAIRealtimeSessionOptions session) {
+        var outputModalities = new JsonArray();
+        foreach (var modality in session.OutputModalities) {
+            outputModalities.Add(modality);
+        }
+        var sessionPayload = new JsonObject()
+            .Add("type", "realtime")
+            .Add("model", session.Model)
+            .Add("output_modalities", outputModalities);
+        if (!string.IsNullOrWhiteSpace(session.Instructions)) {
+            sessionPayload.Add("instructions", session.Instructions);
+        }
+        if (!string.IsNullOrWhiteSpace(session.Voice)) {
+            sessionPayload.Add("audio", new JsonObject()
+                .Add("output", new JsonObject()
+                    .Add("voice", session.Voice)));
+        }
+
+        var lifetimeSeconds = Math.Max(1, (int)Math.Ceiling(session.ClientSecretLifetime.TotalSeconds));
+        var payload = new JsonObject()
+            .Add("expires_after", new JsonObject()
+                .Add("anchor", "created_at")
+                .Add("seconds", lifetimeSeconds))
+            .Add("session", sessionPayload);
+        return JsonLite.Serialize(JsonValue.From(payload));
+    }
+
+    internal static OpenAIRealtimeClientSecret ParseClientSecret(string responseJson, string fallbackModel) {
+        using var document = JsonDocument.Parse(responseJson);
+        var root = document.RootElement;
+        var value = ReadRequiredString(root, "value");
+        if (!root.TryGetProperty("expires_at", out var expiresAtProperty) ||
+            !expiresAtProperty.TryGetInt64(out var expiresAtUnix)) {
+            throw new FormatException("OpenAI Realtime client-secret response did not contain expires_at.");
+        }
+
+        var model = fallbackModel;
+        if (root.TryGetProperty("session", out var session) &&
+            session.ValueKind == System.Text.Json.JsonValueKind.Object &&
+            session.TryGetProperty("model", out var modelProperty) &&
+            modelProperty.ValueKind == System.Text.Json.JsonValueKind.String &&
+            !string.IsNullOrWhiteSpace(modelProperty.GetString())) {
+            model = modelProperty.GetString()!;
+        }
+
+        return new OpenAIRealtimeClientSecret(
+            value,
+            DateTimeOffset.FromUnixTimeSeconds(expiresAtUnix),
+            model);
+    }
+
+    private async Task<RealtimeAuthorization> ResolveAuthorizationAsync(CancellationToken cancellationToken) {
+        if (!string.IsNullOrWhiteSpace(_options.ApiKey)) {
+            return new RealtimeAuthorization(_options.ApiKey!, null, null);
+        }
+
+        var bundle = await _authManager.TryGetValidBundleAsync(cancellationToken).ConfigureAwait(false);
+        if (bundle is null || string.IsNullOrWhiteSpace(bundle.AccessToken)) {
+            throw new InvalidOperationException(
+                "ChatGPT OAuth is required for Realtime when no OpenAI API key is configured. Sign in with ChatGPT first.");
+        }
+        return new RealtimeAuthorization(bundle.AccessToken, bundle.AccountId, bundle);
+    }
+
+    private async Task<ClientSecretResponse> SendClientSecretRequestAsync(
+        string payload,
+        RealtimeAuthorization authorization,
+        CancellationToken cancellationToken) {
+        using var request = new HttpRequestMessage(HttpMethod.Post, _options.ClientSecretUrl) {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json")
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authorization.Token);
+        if (!string.IsNullOrWhiteSpace(authorization.AccountId)) {
+            request.Headers.TryAddWithoutValidation("ChatGPT-Account-ID", authorization.AccountId);
+        }
+        if (!string.IsNullOrWhiteSpace(_chatGptOptions.UserAgent)) {
+            request.Headers.TryAddWithoutValidation("User-Agent", _chatGptOptions.UserAgent);
+        }
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var responseText = await ReadContentAsync(response.Content, cancellationToken).ConfigureAwait(false);
+        return new ClientSecretResponse(response.IsSuccessStatusCode, response.StatusCode, responseText);
+    }
+
+    private Uri BuildWebSocketUri(string model) {
+        var separator = _options.WebSocketUrl.IndexOf("?", StringComparison.Ordinal) >= 0 ? "&" : "?";
+        return new Uri(_options.WebSocketUrl + separator + "model=" + Uri.EscapeDataString(model), UriKind.Absolute);
+    }
+
+    private static string ReadRequiredString(JsonElement root, string propertyName) {
+        if (!root.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != System.Text.Json.JsonValueKind.String ||
+            string.IsNullOrWhiteSpace(property.GetString())) {
+            throw new FormatException($"OpenAI Realtime client-secret response did not contain {propertyName}.");
+        }
+        return property.GetString()!;
+    }
+
+    private static async Task<string> ReadContentAsync(HttpContent content, CancellationToken cancellationToken) {
+#if NETSTANDARD2_0 || NET472
+        cancellationToken.ThrowIfCancellationRequested();
+        return await content.ReadAsStringAsync().ConfigureAwait(false);
+#else
+        return await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#endif
+    }
+
+    private void ThrowIfDisposed() {
+        if (_disposed) {
+            throw new ObjectDisposedException(nameof(OpenAIRealtimeClient));
+        }
+    }
+
+    private sealed class RealtimeAuthorization {
+        internal RealtimeAuthorization(string token, string? accountId, AuthBundle? bundle) {
+            Token = token;
+            AccountId = accountId;
+            Bundle = bundle;
+        }
+
+        internal string Token { get; }
+        internal string? AccountId { get; }
+        internal AuthBundle? Bundle { get; }
+    }
+
+    private sealed class ClientSecretResponse {
+        internal ClientSecretResponse(bool isSuccessStatusCode, HttpStatusCode statusCode, string content) {
+            IsSuccessStatusCode = isSuccessStatusCode;
+            StatusCode = statusCode;
+            Content = content;
+        }
+
+        internal bool IsSuccessStatusCode { get; }
+        internal HttpStatusCode StatusCode { get; }
+        internal string Content { get; }
+    }
+}

--- a/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeClient.cs
+++ b/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeClient.cs
@@ -18,8 +18,8 @@ namespace IntelligenceX.OpenAI.Realtime;
 /// </summary>
 /// <remarks>
 /// When no API key is supplied, this client reuses the existing ChatGPT/Codex OAuth bundle.
-/// User-owned apps can keep that bundle in device-protected storage and call OpenAI directly;
-/// no IntelligenceX or Evotec relay is required.
+/// Applications can keep that bundle in device-protected storage and call OpenAI directly;
+/// no intermediary relay is required.
 /// </remarks>
 public sealed class OpenAIRealtimeClient : IDisposable {
     private readonly OpenAIRealtimeOptions _options;

--- a/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeClient.cs
+++ b/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeClient.cs
@@ -18,8 +18,8 @@ namespace IntelligenceX.OpenAI.Realtime;
 /// </summary>
 /// <remarks>
 /// When no API key is supplied, this client reuses the existing ChatGPT/Codex OAuth bundle.
-/// App and iOS clients should receive only the short-lived credential returned by
-/// <see cref="CreateClientSecretAsync"/>; persisted OAuth credentials must remain in the trusted backend.
+/// User-owned apps can keep that bundle in device-protected storage and call OpenAI directly;
+/// no IntelligenceX or Evotec relay is required.
 /// </remarks>
 public sealed class OpenAIRealtimeClient : IDisposable {
     private readonly OpenAIRealtimeOptions _options;
@@ -96,8 +96,8 @@ public sealed class OpenAIRealtimeClient : IDisposable {
     }
 
     /// <summary>
-    /// Opens a Realtime WebSocket with a short-lived credential received from a trusted backend.
-    /// This overload is suitable for app and iOS clients because it does not require persisted OAuth credentials.
+    /// Opens a Realtime WebSocket with an existing short-lived credential.
+    /// This overload is useful when another local component owns credential minting.
     /// </summary>
     public async Task<OpenAIRealtimeSession> ConnectAsync(
         OpenAIRealtimeClientSecret secret,

--- a/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeClientSecret.cs
+++ b/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeClientSecret.cs
@@ -7,7 +7,7 @@ namespace IntelligenceX.OpenAI.Realtime;
 /// </summary>
 public sealed class OpenAIRealtimeClientSecret {
     /// <summary>
-    /// Initializes a short-lived credential received from a trusted backend.
+    /// Initializes a short-lived credential created for a Realtime session.
     /// </summary>
     public OpenAIRealtimeClientSecret(string value, DateTimeOffset expiresAt, string model) {
         Value = NormalizeRequired(value, nameof(value));

--- a/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeClientSecret.cs
+++ b/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeClientSecret.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace IntelligenceX.OpenAI.Realtime;
+
+/// <summary>
+/// A short-lived credential that an app can use to establish one OpenAI Realtime connection.
+/// </summary>
+public sealed class OpenAIRealtimeClientSecret {
+    /// <summary>
+    /// Initializes a short-lived credential received from a trusted backend.
+    /// </summary>
+    public OpenAIRealtimeClientSecret(string value, DateTimeOffset expiresAt, string model) {
+        Value = NormalizeRequired(value, nameof(value));
+        ExpiresAt = expiresAt;
+        Model = NormalizeRequired(model, nameof(model));
+    }
+
+    /// <summary>
+    /// Gets the sensitive short-lived credential value. Do not log or persist it.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Gets the credential expiry time.
+    /// </summary>
+    public DateTimeOffset ExpiresAt { get; }
+
+    /// <summary>
+    /// Gets the Realtime model associated with the session.
+    /// </summary>
+    public string Model { get; }
+
+    private static string NormalizeRequired(string? value, string parameterName) {
+        var normalized = value?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized)) {
+            throw new ArgumentException(parameterName + " cannot be null or whitespace.", parameterName);
+        }
+        return normalized!;
+    }
+}

--- a/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeEvent.cs
+++ b/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeEvent.cs
@@ -56,11 +56,11 @@ public sealed class OpenAIRealtimeEvent {
         string? textDelta = null;
         string? audioDelta = null;
 
-        if (type.IndexOf("audio", StringComparison.OrdinalIgnoreCase) >= 0) {
-            audioDelta = delta;
-        } else if (type.IndexOf("text", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                   type.IndexOf("transcript", StringComparison.OrdinalIgnoreCase) >= 0) {
+        if (type.IndexOf("text", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            type.IndexOf("transcript", StringComparison.OrdinalIgnoreCase) >= 0) {
             textDelta = delta;
+        } else if (type.IndexOf("audio", StringComparison.OrdinalIgnoreCase) >= 0) {
+            audioDelta = delta;
         }
 
         string? errorMessage = null;

--- a/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeEvent.cs
+++ b/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeEvent.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Text.Json;
+
+namespace IntelligenceX.OpenAI.Realtime;
+
+/// <summary>
+/// Represents one server event received from an OpenAI Realtime WebSocket.
+/// </summary>
+public sealed class OpenAIRealtimeEvent {
+    private OpenAIRealtimeEvent(string type, string rawJson, string? textDelta, string? audioDelta, string? errorMessage) {
+        Type = type;
+        RawJson = rawJson;
+        TextDelta = textDelta;
+        AudioDelta = audioDelta;
+        ErrorMessage = errorMessage;
+    }
+
+    /// <summary>
+    /// Gets the Realtime event type.
+    /// </summary>
+    public string Type { get; }
+
+    /// <summary>
+    /// Gets the unmodified event JSON for fields not projected by this type.
+    /// </summary>
+    public string RawJson { get; }
+
+    /// <summary>
+    /// Gets a streamed text delta when the event contains one.
+    /// </summary>
+    public string? TextDelta { get; }
+
+    /// <summary>
+    /// Gets a base64-encoded streamed audio delta when the event contains one.
+    /// </summary>
+    public string? AudioDelta { get; }
+
+    /// <summary>
+    /// Gets the server error message when the event represents an error.
+    /// </summary>
+    public string? ErrorMessage { get; }
+
+    internal static OpenAIRealtimeEvent Parse(string json) {
+        if (string.IsNullOrWhiteSpace(json)) {
+            throw new ArgumentException("Realtime event JSON cannot be empty.", nameof(json));
+        }
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object) {
+            throw new FormatException("Realtime event JSON must be an object.");
+        }
+
+        var type = ReadString(root, "type") ?? "unknown";
+        var delta = ReadString(root, "delta");
+        string? textDelta = null;
+        string? audioDelta = null;
+
+        if (type.IndexOf("audio", StringComparison.OrdinalIgnoreCase) >= 0) {
+            audioDelta = delta;
+        } else if (type.IndexOf("text", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   type.IndexOf("transcript", StringComparison.OrdinalIgnoreCase) >= 0) {
+            textDelta = delta;
+        }
+
+        string? errorMessage = null;
+        if (root.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.Object) {
+            errorMessage = ReadString(error, "message");
+        }
+        errorMessage ??= ReadString(root, "message");
+
+        return new OpenAIRealtimeEvent(type, json, textDelta, audioDelta, errorMessage);
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName) {
+        return element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+    }
+}

--- a/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeOptions.cs
+++ b/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeOptions.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace IntelligenceX.OpenAI.Realtime;
+
+/// <summary>
+/// Configures OpenAI Realtime client-secret minting and WebSocket connections.
+/// </summary>
+public sealed class OpenAIRealtimeOptions {
+    /// <summary>
+    /// Endpoint used to mint short-lived Realtime client credentials.
+    /// </summary>
+    public string ClientSecretUrl { get; set; } = "https://api.openai.com/v1/realtime/client_secrets";
+
+    /// <summary>
+    /// WebSocket endpoint used for Realtime sessions.
+    /// </summary>
+    public string WebSocketUrl { get; set; } = "wss://api.openai.com/v1/realtime";
+
+    /// <summary>
+    /// Optional OpenAI API key. When omitted, the client uses the configured ChatGPT OAuth bundle.
+    /// </summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Maximum accepted Realtime event size in bytes.
+    /// </summary>
+    public int MaxEventBytes { get; set; } = 4 * 1024 * 1024;
+
+    internal void Validate() {
+        if (!Uri.TryCreate(ClientSecretUrl, UriKind.Absolute, out var clientSecretUri) ||
+            !string.Equals(clientSecretUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) {
+            throw new ArgumentException("ClientSecretUrl must be an absolute HTTPS URL.", nameof(ClientSecretUrl));
+        }
+
+        if (!Uri.TryCreate(WebSocketUrl, UriKind.Absolute, out var webSocketUri) ||
+            !string.Equals(webSocketUri.Scheme, "wss", StringComparison.OrdinalIgnoreCase)) {
+            throw new ArgumentException("WebSocketUrl must be an absolute WSS URL.", nameof(WebSocketUrl));
+        }
+
+        if (MaxEventBytes <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(MaxEventBytes), "MaxEventBytes must be positive.");
+        }
+
+        ApiKey = NormalizeOptional(ApiKey);
+    }
+
+    private static string? NormalizeOptional(string? value) {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+}

--- a/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeSession.cs
+++ b/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeSession.cs
@@ -1,0 +1,222 @@
+using System;
+using System.IO;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelligenceX.Json;
+
+namespace IntelligenceX.OpenAI.Realtime;
+
+/// <summary>
+/// Owns an active OpenAI Realtime WebSocket session.
+/// </summary>
+public sealed class OpenAIRealtimeSession : IDisposable {
+    private const int ReceiveBufferBytes = 16 * 1024;
+
+    private readonly ClientWebSocket _webSocket;
+    private readonly int _maxEventBytes;
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private readonly SemaphoreSlim _receiveLock = new(1, 1);
+    private int _disposeState;
+
+    internal OpenAIRealtimeSession(ClientWebSocket webSocket, string model, int maxEventBytes) {
+        _webSocket = webSocket ?? throw new ArgumentNullException(nameof(webSocket));
+        Model = model;
+        _maxEventBytes = maxEventBytes;
+    }
+
+    /// <summary>
+    /// Gets the connected Realtime model.
+    /// </summary>
+    public string Model { get; }
+
+    /// <summary>
+    /// Gets the current WebSocket state.
+    /// </summary>
+    public WebSocketState State => IsDisposed ? WebSocketState.Closed : _webSocket.State;
+
+    /// <summary>
+    /// Sends a user text item and optionally asks the model to respond.
+    /// </summary>
+    public async Task SendTextAsync(string text, bool requestResponse = true, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(text)) {
+            throw new ArgumentException("Text cannot be null or whitespace.", nameof(text));
+        }
+
+        var content = new JsonArray().Add(new JsonObject()
+            .Add("type", "input_text")
+            .Add("text", text));
+        var item = JsonLite.Serialize(JsonValue.From(new JsonObject()
+            .Add("type", "conversation.item.create")
+            .Add("item", new JsonObject()
+                .Add("type", "message")
+                .Add("role", "user")
+                .Add("content", content))));
+        await SendEventAsync(item, cancellationToken).ConfigureAwait(false);
+        if (requestResponse) {
+            await RequestResponseAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Sends an image URL or data URL as a user input item and optionally asks the model to respond.
+    /// </summary>
+    public async Task SendImageAsync(
+        string imageUrl,
+        bool requestResponse = true,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(imageUrl)) {
+            throw new ArgumentException("Image URL cannot be null or whitespace.", nameof(imageUrl));
+        }
+
+        var content = new JsonArray().Add(new JsonObject()
+            .Add("type", "input_image")
+            .Add("image_url", imageUrl.Trim()));
+        var item = JsonLite.Serialize(JsonValue.From(new JsonObject()
+            .Add("type", "conversation.item.create")
+            .Add("item", new JsonObject()
+                .Add("type", "message")
+                .Add("role", "user")
+                .Add("content", content))));
+        await SendEventAsync(item, cancellationToken).ConfigureAwait(false);
+        if (requestResponse) {
+            await RequestResponseAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Appends base64-encoded PCM audio bytes to the session input buffer.
+    /// </summary>
+    public Task AppendAudioAsync(byte[] audioBytes, CancellationToken cancellationToken = default) {
+        if (audioBytes is null || audioBytes.Length == 0) {
+            throw new ArgumentException("Audio bytes cannot be null or empty.", nameof(audioBytes));
+        }
+
+        var payload = new JsonObject()
+            .Add("type", "input_audio_buffer.append")
+            .Add("audio", Convert.ToBase64String(audioBytes));
+        return SendEventAsync(JsonLite.Serialize(JsonValue.From(payload)), cancellationToken);
+    }
+
+    /// <summary>
+    /// Commits the current input audio buffer and optionally asks the model to respond.
+    /// </summary>
+    public async Task CommitAudioAsync(bool requestResponse = true, CancellationToken cancellationToken = default) {
+        await SendEventAsync("{\"type\":\"input_audio_buffer.commit\"}", cancellationToken).ConfigureAwait(false);
+        if (requestResponse) {
+            await RequestResponseAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Requests a model response for the current conversation state.
+    /// </summary>
+    public Task RequestResponseAsync(CancellationToken cancellationToken = default) {
+        return SendEventAsync("{\"type\":\"response.create\"}", cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a raw Realtime client event.
+    /// </summary>
+    public async Task SendEventAsync(string eventJson, CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(eventJson)) {
+            throw new ArgumentException("Event JSON cannot be empty.", nameof(eventJson));
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(eventJson);
+        await _sendLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            ThrowIfDisposed();
+            await _webSocket.SendAsync(
+                    new ArraySegment<byte>(bytes),
+                    WebSocketMessageType.Text,
+                    endOfMessage: true,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        } finally {
+            _sendLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Receives the next complete Realtime server event. Only one receive operation may run at a time.
+    /// </summary>
+    public async Task<OpenAIRealtimeEvent?> ReceiveEventAsync(CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        await _receiveLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            ThrowIfDisposed();
+            var buffer = new byte[ReceiveBufferBytes];
+            using var stream = new MemoryStream();
+
+            while (true) {
+                var result = await _webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken)
+                    .ConfigureAwait(false);
+                if (result.MessageType == WebSocketMessageType.Close) {
+                    return null;
+                }
+                if (result.MessageType != WebSocketMessageType.Text) {
+                    throw new InvalidDataException("OpenAI Realtime returned a non-text WebSocket event.");
+                }
+
+                if (stream.Length + result.Count > _maxEventBytes) {
+                    throw new InvalidDataException("OpenAI Realtime event exceeded the configured size limit.");
+                }
+                stream.Write(buffer, 0, result.Count);
+                if (result.EndOfMessage) {
+                    break;
+                }
+            }
+
+            return OpenAIRealtimeEvent.Parse(Encoding.UTF8.GetString(stream.ToArray()));
+        } finally {
+            _receiveLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Closes the Realtime WebSocket when possible.
+    /// </summary>
+    public async Task CloseAsync(CancellationToken cancellationToken = default) {
+        if (IsDisposed) {
+            return;
+        }
+
+        await _sendLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            if (IsDisposed ||
+                _webSocket.State is WebSocketState.Closed or WebSocketState.Aborted or WebSocketState.None) {
+                return;
+            }
+            if (_webSocket.State == WebSocketState.Open || _webSocket.State == WebSocketState.CloseReceived) {
+                await _webSocket.CloseOutputAsync(
+                        WebSocketCloseStatus.NormalClosure,
+                        "Client closed",
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        } catch (ObjectDisposedException) when (IsDisposed) {
+            // A concurrent Dispose owns shutdown.
+        } finally {
+            _sendLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        if (Interlocked.Exchange(ref _disposeState, 1) != 0) {
+            return;
+        }
+        _webSocket.Dispose();
+    }
+
+    private bool IsDisposed => Volatile.Read(ref _disposeState) != 0;
+
+    private void ThrowIfDisposed() {
+        if (IsDisposed) {
+            throw new ObjectDisposedException(nameof(OpenAIRealtimeSession));
+        }
+    }
+}

--- a/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeSessionOptions.cs
+++ b/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeSessionOptions.cs
@@ -20,7 +20,7 @@ public sealed class OpenAIRealtimeSessionOptions {
     /// Output modalities requested from the model. Voice sessions normally use <c>audio</c>;
     /// text-only sessions can set this to <c>text</c>.
     /// </summary>
-    public string[] OutputModalities { get; set; } = { "audio" };
+    public string[] OutputModalities { get; set; } = new[] { "audio" };
 
     /// <summary>
     /// Optional Realtime voice name. When omitted, the service default is used.

--- a/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeSessionOptions.cs
+++ b/IntelligenceX/Providers/OpenAI/Realtime/OpenAIRealtimeSessionOptions.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace IntelligenceX.OpenAI.Realtime;
+
+/// <summary>
+/// Describes a Realtime session and its short-lived client credential.
+/// </summary>
+public sealed class OpenAIRealtimeSessionOptions {
+    /// <summary>
+    /// Realtime model identifier.
+    /// </summary>
+    public string Model { get; set; } = OpenAIModelCatalog.DefaultRealtimeModel;
+
+    /// <summary>
+    /// Optional session instructions.
+    /// </summary>
+    public string? Instructions { get; set; }
+
+    /// <summary>
+    /// Output modalities requested from the model. Voice sessions normally use <c>audio</c>;
+    /// text-only sessions can set this to <c>text</c>.
+    /// </summary>
+    public string[] OutputModalities { get; set; } = { "audio" };
+
+    /// <summary>
+    /// Optional Realtime voice name. When omitted, the service default is used.
+    /// </summary>
+    public string? Voice { get; set; }
+
+    /// <summary>
+    /// Lifetime requested for the short-lived client credential.
+    /// </summary>
+    public TimeSpan ClientSecretLifetime { get; set; } = TimeSpan.FromMinutes(2);
+
+    internal void Validate() {
+        Model = NormalizeRequired(Model, nameof(Model));
+        Instructions = NormalizeOptional(Instructions);
+        Voice = NormalizeOptional(Voice);
+
+        if (OutputModalities is null || OutputModalities.Length != 1) {
+            throw new ArgumentException(
+                "OutputModalities must contain exactly one value: 'audio' or 'text'.",
+                nameof(OutputModalities));
+        }
+
+        var modality = NormalizeRequired(OutputModalities[0], nameof(OutputModalities)).ToLowerInvariant();
+        if (!string.Equals(modality, "audio", StringComparison.Ordinal) &&
+            !string.Equals(modality, "text", StringComparison.Ordinal)) {
+            throw new ArgumentException("Output modality must be 'audio' or 'text'.", nameof(OutputModalities));
+        }
+        OutputModalities = new[] { modality };
+
+        if (ClientSecretLifetime.TotalSeconds < 10 || ClientSecretLifetime.TotalSeconds > 7200) {
+            throw new ArgumentOutOfRangeException(
+                nameof(ClientSecretLifetime),
+                "ClientSecretLifetime must be between 10 seconds and 2 hours.");
+        }
+    }
+
+    private static string NormalizeRequired(string? value, string propertyName) {
+        var normalized = value?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized)) {
+            throw new ArgumentException(propertyName + " cannot be null or whitespace.", propertyName);
+        }
+        return normalized!;
+    }
+
+    private static string? NormalizeOptional(string? value) {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+}


### PR DESCRIPTION
## Summary

- add reusable `gpt-realtime-2.1` client-secret and WebSocket support for text, image, and audio events
- let applications reuse the user's own ChatGPT/Codex OAuth session for chat, image generation, and Realtime
- keep the integration local-first: credentials remain in protected platform storage and applications communicate directly with OpenAI
- expose native image generation through EasySession and generated image references through the Chat service protocol
- harden OAuth refresh concurrency, WebSocket shutdown, Realtime validation, and multi-phase image preservation

## Privacy boundary

No intermediary account, relay, hosted IntelligenceX service, or mandatory telemetry is involved. Prompts, conversations, audio, images, tool results, and ChatGPT credentials travel directly between the host application and OpenAI. Platform adapters should use protected credential storage and a user-initiated browser login; production voice should use WebRTC while retaining the same IX session and capability contracts.

```csharp
using var realtime = new OpenAIRealtimeClient(chatGptOptions: localChatGptOptions);
using var session = await realtime.ConnectAsync(new OpenAIRealtimeSessionOptions {
    Model = OpenAIModelCatalog.DefaultRealtimeModel,
    OutputModalities = new[] { "audio" },
    Voice = "marin"
});
```

ChatGPT/Codex OAuth is treated as the user's subscription capability, not as an API-key fallback or unofficial entitlement. Voice follows the user's plan-specific allowance and Codex work continues to use the user's existing Codex budget. The newly released voice path still requires target-platform validation of authorization, refresh, reconnect, interruption, and quota behavior; this is client release hardening and does not require an intermediary backend.

## Operational note

The repository's IX PR-review and PR-monitor workflows were disabled in GitHub Actions without deleting their workflow files. Build, test, CodeQL, catalog guardrail, releases, issue review, and website workflows remain enabled.