### PR TITLE
Fix PowerForge runtime pins

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -27,7 +27,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 4d4cc085cfadd4a17f56e2de019f9b1958d45a96
+      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/github-housekeeping.yml
+++ b/.github/workflows/github-housekeeping.yml
@@ -24,7 +24,7 @@ jobs:
     with:
       config-path: ./.powerforge/github-housekeeping.json
       apply: ${{ (github.event_name == 'workflow_dispatch' && inputs.apply == 'true') || (github.event_name != 'workflow_dispatch' && vars.POWERFORGE_GITHUB_HOUSEKEEPING_APPLY == 'true') }}
-      powerforge-ref: 4d4cc085cfadd4a17f56e2de019f9b1958d45a96
+      powerforge-ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
       report-artifact-name: github-housekeeping-reports
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -17,4 +17,4 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.IX_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 4d4cc085cfadd4a17f56e2de019f9b1958d45a96
+      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037


### PR DESCRIPTION
## Summary

Align the IntelligenceX website CI, deployment, and GitHub-housekeeping runtime pins with the immutable PowerForge commit already used by their reusable workflows.

This prevents the source runner from restoring the older Magick.NET 14.14.0 dependency graph that fails NuGet audit enforcement.

## Validation

- Verified all three consumer runtime pins use `c6451c9d264a81c7f179b38f6e4d2b62f0784037`.
- Verified the referenced PowerForge website workflow files exist at that commit.
- Ran `git diff --check`.