### PR TITLE
Use PowerForge native documentation

### DIFF
--- a/IntelligenceX.PowerShell/IntelligenceX.PowerShell.csproj
+++ b/IntelligenceX.PowerShell/IntelligenceX.PowerShell.csproj
@@ -18,24 +18,10 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.8.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
     <!-- We need to remove PowerShell conflicting libraries as it will break output -->
     <Target Name="RemoveFilesAfterBuild" AfterTargets="Build">
         <Delete Files="$(OutDir)System.Management.Automation.dll" />
         <Delete Files="$(OutDir)System.Management.dll" />
-    </Target>
-
-    <!-- Copy help documentation to publish output after publish -->
-    <Target Name="CopyHelpDocumentationToPublishOutput" AfterTargets="Publish">
-        <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll-Help.xml"
-            DestinationFiles="$(PublishDir)$(AssemblyName).dll-Help.xml"
-            Condition="Exists('$(OutputPath)$(AssemblyName).dll-Help.xml')" />
     </Target>
 
     <ItemGroup>

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -59,13 +59,13 @@ Build-Module -ModuleName 'IntelligenceX' {
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable -PathReadme 'Docs\Readme.md' -Path 'Docs' -SyncExternalHelpToProjectRoot
 
     New-ConfigurationImportModule -ImportSelf -ImportRequiredModules
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = $true
+        SignModule                        = if ([string]::IsNullOrWhiteSpace($Env:SignModule)) { $true } else { [bool]::Parse($Env:SignModule) }
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
         CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
@@ -79,7 +79,7 @@ Build-Module -ModuleName 'IntelligenceX' {
         DotSourceLibraries                = $true
         NETSearchClass                    = 'IntelligenceX.PowerShell.CmdletConnectIntelligenceX'
         NETBinaryModuleDocumentation      = $true
-        RefreshPSD1Only                   = $true
+        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $false } else { [bool]::Parse($Env:RefreshPSD1Only) }
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Module/Docs/Backup-IntelligenceXThread.md
+++ b/Module/Docs/Backup-IntelligenceXThread.md
@@ -1,0 +1,81 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Backup-IntelligenceXThread
+## SYNOPSIS
+Archives an existing thread so it no longer appears in active workflows.
+
+Use this cmdlet to hide completed or obsolete conversations from normal thread listings while
+preserving history. The archive operation is non-destructive and can be used for housekeeping.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Backup-IntelligenceXThread -ThreadId <string> [-Client <IntelligenceXClient>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Archives an existing thread so it no longer appears in active workflows.
+
+Use this cmdlet to hide completed or obsolete conversations from normal thread listings while
+preserving history. The archive operation is non-destructive and can be used for housekeeping.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Backup-IntelligenceXThread -ThreadId 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -ThreadId
+Identifier of the thread to archive.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Connect-IntelligenceX.md
+++ b/Module/Docs/Connect-IntelligenceX.md
@@ -1,0 +1,161 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Connect-IntelligenceX
+## SYNOPSIS
+Connects to IntelligenceX (native or app-server) and returns a client instance.
+
+Use Native for ChatGPT OAuth login (no local Codex binary). Use AppServer to talk to a locally
+running Codex app-server process. The cmdlet sets the active default client, so subsequent cmdlets can omit -Client.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Connect-IntelligenceX [-Transport <OpenAITransportKind>] [-ExecutablePath <string>] [-Arguments <string>] [-WorkingDirectory <string>] [-Diagnostics] [-NoConfig] [-OpenAIAccountId <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Connects to IntelligenceX (native or app-server) and returns a client instance.
+
+Use Native for ChatGPT OAuth login (no local Codex binary). Use AppServer to talk to a locally
+running Codex app-server process. The cmdlet sets the active default client, so subsequent cmdlets can omit -Client.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Connect-IntelligenceX -ExecutablePath 'C:\Path'
+```
+
+
+## PARAMETERS
+
+### -Arguments
+Arguments to pass to the app-server. Defaults to 'app-server'.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Diagnostics
+Enable diagnostics output (RPC calls, login events, stderr).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutablePath
+Path to the codex executable. Defaults to 'codex' on PATH.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoConfig
+Ignore .intelligencex/config.json overrides.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OpenAIAccountId
+Optional ChatGPT account id to use when multiple auth bundles are present.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Transport
+Transport to use (Native or AppServer). Native uses ChatGPT OAuth directly.
+
+```yaml
+Type: OpenAITransportKind
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Native, AppServer, CompatibleHttp, CopilotCli
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkingDirectory
+Working directory for the app-server process.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Disconnect-IntelligenceX.md
+++ b/Module/Docs/Disconnect-IntelligenceX.md
@@ -1,0 +1,65 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Disconnect-IntelligenceX
+## SYNOPSIS
+Disconnects the active IntelligenceX client and clears local session context.
+
+Releases app-server/native client resources, clears diagnostics subscriptions, and resets
+default thread/initialization state. If no client is active, the cmdlet exits without error.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Disconnect-IntelligenceX [-Client <IntelligenceXClient>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Disconnects the active IntelligenceX client and clears local session context.
+
+Releases app-server/native client resources, clears diagnostics subscriptions, and resets
+default thread/initialization state. If no client is active, the cmdlet exits without error.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Disconnect-IntelligenceX -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to disconnect. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXAccount.md
+++ b/Module/Docs/Get-IntelligenceXAccount.md
@@ -1,0 +1,82 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXAccount
+## SYNOPSIS
+Returns the current account details.
+
+Returns the account identity for the active session, such as email and account id.
+Useful to confirm which credential bundle is currently active.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXAccount [-Client <IntelligenceXClient>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Returns the current account details.
+
+Returns the account identity for the active session, such as email and account id.
+Useful to confirm which credential bundle is currently active.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXAccount -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of typed account info.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.AccountInfo`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXCollaborationMode.md
+++ b/Module/Docs/Get-IntelligenceXCollaborationMode.md
@@ -1,0 +1,82 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXCollaborationMode
+## SYNOPSIS
+Lists collaboration modes available in the current app-server runtime.
+
+Use this cmdlet to discover valid collaboration mode values before setting them in
+configuration or passing them to review/chat workflows.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXCollaborationMode [-Client <IntelligenceXClient>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Lists collaboration modes available in the current app-server runtime.
+
+Use this cmdlet to discover valid collaboration mode values before setting them in
+configuration or passing them to review/chat workflows.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXCollaborationMode -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of typed mode models.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.CollaborationModeListResult`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXConfig.md
+++ b/Module/Docs/Get-IntelligenceXConfig.md
@@ -1,0 +1,82 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXConfig
+## SYNOPSIS
+Reads the effective app-server configuration with layer metadata.
+
+Returns merged config values plus metadata that explains where values come from
+(for example defaults, workspace files, or environment overrides).
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXConfig [-Client <IntelligenceXClient>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Reads the effective app-server configuration with layer metadata.
+
+Returns merged config values plus metadata that explains where values come from
+(for example defaults, workspace files, or environment overrides).
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXConfig -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+App-server client instance to query. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of typed config models.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.ConfigReadResult`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXConfigRequirements.md
+++ b/Module/Docs/Get-IntelligenceXConfigRequirements.md
@@ -1,0 +1,82 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXConfigRequirements
+## SYNOPSIS
+Reads server-defined constraints for supported configuration values.
+
+Returns allowed values for key settings (for example approval policy and sandbox mode)
+so scripts can validate config before writing changes.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXConfigRequirements [-Client <IntelligenceXClient>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Reads server-defined constraints for supported configuration values.
+
+Returns allowed values for key settings (for example approval policy and sandbox mode)
+so scripts can validate config before writing changes.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXConfigRequirements -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of typed requirements models.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.ConfigRequirementsReadResult`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXCopilotInstall.md
+++ b/Module/Docs/Get-IntelligenceXCopilotInstall.md
@@ -1,0 +1,65 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXCopilotInstall
+## SYNOPSIS
+Shows platform-specific installation commands for GitHub Copilot CLI.
+
+This cmdlet does not install anything. It returns suggested install command metadata
+so you can preview, log, or execute it manually.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXCopilotInstall [-Prerelease] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Shows platform-specific installation commands for GitHub Copilot CLI.
+
+This cmdlet does not install anything. It returns suggested install command metadata
+so you can preview, log, or execute it manually.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXCopilotInstall -Prerelease
+```
+
+
+## PARAMETERS
+
+### -Prerelease
+Returns commands for installing prerelease builds.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `IntelligenceX.Copilot.CopilotCliInstallCommand`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXHealth.md
+++ b/Module/Docs/Get-IntelligenceXHealth.md
@@ -1,0 +1,193 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXHealth
+## SYNOPSIS
+Runs health checks for OpenAI app-server and optional Copilot CLI.
+
+Returns health status for the active IntelligenceX client and, optionally, a Copilot CLI
+instance using explicit or config-derived options.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXHealth [-Client <IntelligenceXClient>] [-Copilot] [-NoConfig] [-CopilotCliPath <string>] [-CopilotCliUrl <string>] [-CopilotWorkingDirectory <string>] [-CopilotAutoInstall] [-CopilotInstallMethod <CopilotCliInstallMethod>] [-CopilotInstallPrerelease] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Runs health checks for OpenAI app-server and optional Copilot CLI.
+
+Returns health status for the active IntelligenceX client and, optionally, a Copilot CLI
+instance using explicit or config-derived options.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXHealth -CopilotCliPath 'C:\Path'
+```
+
+
+## PARAMETERS
+
+### -Client
+OpenAI/app-server client instance. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Copilot
+Run a Copilot CLI health check.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CopilotAutoInstall
+Auto-install Copilot CLI if missing.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CopilotCliPath
+Copilot CLI path.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CopilotCliUrl
+Copilot CLI URL (host:port).
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CopilotInstallMethod
+Copilot auto-install method to use when -CopilotAutoInstall is set.
+
+```yaml
+Type: CopilotCliInstallMethod
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Auto, Winget, Homebrew, Npm, Script
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CopilotInstallPrerelease
+Copilot auto-install prerelease.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CopilotWorkingDirectory
+Copilot CLI working directory.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoConfig
+Ignore .intelligencex/config.json overrides.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.PowerShell.HealthReportRecord`: Represents a combined health report for OpenAI and Copilot providers.
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXLoadedThread.md
+++ b/Module/Docs/Get-IntelligenceXLoadedThread.md
@@ -1,0 +1,82 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXLoadedThread
+## SYNOPSIS
+Lists threads currently loaded in the app-server process.
+
+Returns thread ids that are currently active in memory for the running app-server session.
+Useful for diagnostics and cleanup scripts.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXLoadedThread [-Client <IntelligenceXClient>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Lists threads currently loaded in the app-server process.
+
+Returns thread ids that are currently active in memory for the running app-server session.
+Useful for diagnostics and cleanup scripts.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXLoadedThread -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of typed thread-id models.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.ThreadIdListResult`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXMcpServerStatus.md
+++ b/Module/Docs/Get-IntelligenceXMcpServerStatus.md
@@ -1,0 +1,114 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXMcpServerStatus
+## SYNOPSIS
+Lists configured MCP servers with auth, tool, and resource status.
+
+Queries the app-server MCP registry and returns one page of server status data. The result includes
+Servers (current page) and NextCursor (for pagination).
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXMcpServerStatus [-Client <IntelligenceXClient>] [-Cursor <string>] [-Limit <int>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Lists configured MCP servers with auth, tool, and resource status.
+
+Queries the app-server MCP registry and returns one page of server status data. The result includes
+Servers (current page) and NextCursor (for pagination).
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXMcpServerStatus -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+App-server client instance to query. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Cursor
+Pagination cursor from a previous response (NextCursor).
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Limit
+Maximum number of server entries to return in this page.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of typed models.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.McpServerStatusListResult`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXModel.md
+++ b/Module/Docs/Get-IntelligenceXModel.md
@@ -1,0 +1,82 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXModel
+## SYNOPSIS
+Lists models available for the current transport context.
+
+Returns model metadata for the active client. Raw JSON mode is available only on app-server
+transport because native transport returns strongly typed models directly.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXModel [-Client <IntelligenceXClient>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Lists models available for the current transport context.
+
+Returns model metadata for the active client. Raw JSON mode is available only on app-server
+transport because native transport returns strongly typed models directly.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXModel -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns raw JSON-RPC payload (app-server transport only).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.ModelListResult`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXSkill.md
+++ b/Module/Docs/Get-IntelligenceXSkill.md
@@ -1,0 +1,112 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXSkill
+## SYNOPSIS
+Lists available skills.
+
+Scans for skills in the provided working directories and returns the resolved list.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXSkill [-Client <IntelligenceXClient>] [-Cwd <string[]>] [-ForceReload] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Lists available skills.
+
+Scans for skills in the provided working directories and returns the resolved list.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXSkill -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Cwd
+Working directories to scan for skills.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ForceReload
+Force reload of skills.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Return raw JSON response.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.SkillListResult`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXThread.md
+++ b/Module/Docs/Get-IntelligenceXThread.md
@@ -1,0 +1,144 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXThread
+## SYNOPSIS
+Lists available threads.
+
+Returns paged threads with optional filtering by model provider.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXThread [-Client <IntelligenceXClient>] [-Cursor <string>] [-Limit <int>] [-SortKey <string>] [-ModelProvider <string[]>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Lists available threads.
+
+Returns paged threads with optional filtering by model provider.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXThread -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Cursor
+Cursor from a previous list response.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Limit
+Maximum number of threads to return.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ModelProvider
+Filter by model providers.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Return raw JSON response.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SortKey
+Sort key (created_at or updated_at).
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.ThreadListResult`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-IntelligenceXTurnOutput.md
+++ b/Module/Docs/Get-IntelligenceXTurnOutput.md
@@ -1,0 +1,191 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-IntelligenceXTurnOutput
+## SYNOPSIS
+Extracts outputs from a turn.
+
+Filters and saves outputs from a completed turn, including images and text.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-IntelligenceXTurnOutput -Turn <TurnInfo> [-Images] [-Text] [-First <int>] [-SaveImagesTo <string>] [-DownloadUrls] [-Overwrite] [-FileNamePrefix <string>] [-PassThru] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Extracts outputs from a turn.
+
+Filters and saves outputs from a completed turn, including images and text.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-IntelligenceXTurnOutput -Turn 'Value'
+```
+
+
+## PARAMETERS
+
+### -DownloadUrls
+Download image URLs when saving images.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FileNamePrefix
+Prefix for saved image file names.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -First
+Return only the first N outputs.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Images
+Return only image outputs.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Overwrite
+Overwrite existing files when saving images.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+Output original TurnOutput objects when saving images.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SaveImagesTo
+Save image outputs to the specified directory.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Text
+Return only text outputs.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Turn
+Turn to read outputs from.
+
+```yaml
+Type: TurnInfo
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.TurnInfo`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.TurnOutput`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Initialize-IntelligenceX.md
+++ b/Module/Docs/Initialize-IntelligenceX.md
@@ -1,0 +1,113 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Initialize-IntelligenceX
+## SYNOPSIS
+Initializes the client handshake with the app-server.
+
+Sends client identity metadata (name, title, version) to app-server. Some flows require
+initialization before login, chat, or review operations.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Initialize-IntelligenceX -Name <string> -Title <string> -Version <string> [-Client <IntelligenceXClient>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Initializes the client handshake with the app-server.
+
+Sends client identity metadata (name, title, version) to app-server. Some flows require
+initialization before login, chat, or review operations.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Initialize-IntelligenceX -Name 'Name' -Title 'Value' -Version '1.0.0'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to initialize. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+Client identifier sent to the app-server (machine-friendly).
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Title
+Client display title sent to the app-server (human-friendly).
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Version
+Client version sent to the app-server for telemetry/capability context.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Install-IntelligenceXCopilotCli.md
+++ b/Module/Docs/Install-IntelligenceXCopilotCli.md
@@ -1,0 +1,97 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Install-IntelligenceXCopilotCli
+## SYNOPSIS
+Installs GitHub Copilot CLI using a selected install strategy.
+
+Executes the platform-specific installer command and optionally returns command metadata.
+Supports WhatIf/Confirm through ShouldProcess.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Install-IntelligenceXCopilotCli [-Method <CopilotCliInstallMethod>] [-Prerelease] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Installs GitHub Copilot CLI using a selected install strategy.
+
+Executes the platform-specific installer command and optionally returns command metadata.
+Supports WhatIf/Confirm through ShouldProcess.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Install-IntelligenceXCopilotCli -Method 'Value'
+```
+
+
+## PARAMETERS
+
+### -Method
+Install method to use (Auto, Winget, Brew, Apt, etc. depending on platform).
+
+```yaml
+Type: CopilotCliInstallMethod
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Auto, Winget, Homebrew, Npm, Script
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+Returns the resolved install command object after successful execution.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Prerelease
+Installs a prerelease build when available.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `IntelligenceX.Copilot.CopilotCliInstallCommand`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-IntelligenceXChat.md
+++ b/Module/Docs/Invoke-IntelligenceXChat.md
@@ -1,0 +1,553 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Invoke-IntelligenceXChat
+## SYNOPSIS
+Super-easy chat command that handles connect, init, login, thread, and send.
+
+Convenience entry point for quick chat: it connects, logs in (if needed), creates or
+reuses a thread, sends input, and returns the resulting turn. Supports streaming output and
+a simple DSL for text/image inputs.
+
+## SYNTAX
+### Text (Default)
+```powershell
+Invoke-IntelligenceXChat [-Text] <string> [-Dsl] [-Model <string>] [-Login <string>] [-ApiKey <string>] [-OpenBrowser] [-Stream] [-WaitSeconds <int>] [-NewThread] [-ClientName <string>] [-ClientTitle <string>] [-ClientVersion <string>] [-ExecutablePath <string>] [-Arguments <string>] [-WorkingDirectory <string>] [-Workspace <string>] [-AllowNetwork] [-ApprovalPolicy <string>] [-ImagePath <string>] [-ImageUrl <string>] [-Instructions <string>] [-ReasoningEffort <ReasoningEffort>] [-ReasoningSummary <ReasoningSummary>] [-TextVerbosity <TextVerbosity>] [-Temperature <double>] [-SaveImagesTo <string>] [-DownloadImageUrls] [-OverwriteImages] [-ImageFileNamePrefix <string>] [-Raw] [<CommonParameters>]
+```
+
+### Pipeline
+```powershell
+Invoke-IntelligenceXChat [-InputObject <string>] [-Dsl] [-Model <string>] [-Login <string>] [-ApiKey <string>] [-OpenBrowser] [-Stream] [-WaitSeconds <int>] [-NewThread] [-ClientName <string>] [-ClientTitle <string>] [-ClientVersion <string>] [-ExecutablePath <string>] [-Arguments <string>] [-WorkingDirectory <string>] [-Workspace <string>] [-AllowNetwork] [-ApprovalPolicy <string>] [-ImagePath <string>] [-ImageUrl <string>] [-Instructions <string>] [-ReasoningEffort <ReasoningEffort>] [-ReasoningSummary <ReasoningSummary>] [-TextVerbosity <TextVerbosity>] [-Temperature <double>] [-SaveImagesTo <string>] [-DownloadImageUrls] [-OverwriteImages] [-ImageFileNamePrefix <string>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Super-easy chat command that handles connect, init, login, thread, and send.
+
+Convenience entry point for quick chat: it connects, logs in (if needed), creates or
+reuses a thread, sends input, and returns the resulting turn. Supports streaming output and
+a simple DSL for text/image inputs.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Invoke-IntelligenceXChat -ExecutablePath 'C:\Path'
+```
+
+
+## PARAMETERS
+
+### -AllowNetwork
+Allow network access when using a workspace sandbox.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ApiKey
+API key to use when Login is ApiKey.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ApprovalPolicy
+Approval policy (for example auto).
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Arguments
+Codex app-server arguments.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClientName
+Client name for initialization.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClientTitle
+Client title for initialization.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClientVersion
+Client version for initialization.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DownloadImageUrls
+Download image URLs when saving images.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Dsl
+Parse Text as a simple DSL (lines starting with image:, url:, text:).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutablePath
+Codex executable path.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ImageFileNamePrefix
+Prefix for saved image file names.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ImagePath
+Image file path to include with the message.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ImageUrl
+Image URL to include with the message.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+Pipeline input for DSL lines (text, image, url).
+
+```yaml
+Type: String
+Parameter Sets: Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Instructions
+System instructions for the assistant.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Login
+Login method: ChatGpt, ApiKey, or None.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values: ChatGpt, ApiKey, None
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Model
+Model identifier. Defaults to the shared OpenAI default model.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NewThread
+Reset thread before sending.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OpenBrowser
+Open the login URL in the default browser.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OverwriteImages
+Overwrite existing files when saving images.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Return raw JSON response.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReasoningEffort
+Reasoning effort level.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReasoningSummary
+Reasoning summary level.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SaveImagesTo
+Save image outputs to the specified directory.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Stream
+Write streaming deltas to the host.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Temperature
+Sampling temperature.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Text
+Message text to send.
+
+```yaml
+Type: String
+Parameter Sets: Text
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TextVerbosity
+Response verbosity level.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WaitSeconds
+Wait N seconds for streaming output after sending.
+
+```yaml
+Type: Int32
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkingDirectory
+Working directory for app-server.
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Workspace
+Workspace directory for file writes (sets sandbox policy).
+
+```yaml
+Type: String
+Parameter Sets: Text, Pipeline
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.String`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.TurnInfo`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-IntelligenceXCommand.md
+++ b/Module/Docs/Invoke-IntelligenceXCommand.md
@@ -1,0 +1,176 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Invoke-IntelligenceXCommand
+## SYNOPSIS
+Executes a command through the app-server.
+
+Runs a process via the app-server with optional sandbox settings and timeout.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-IntelligenceXCommand -Command <string[]> [-Client <IntelligenceXClient>] [-WorkingDirectory <string>] [-SandboxType <string>] [-NetworkAccess] [-WritableRoot <string[]>] [-TimeoutMs <int>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Executes a command through the app-server.
+
+Runs a process via the app-server with optional sandbox settings and timeout.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Invoke-IntelligenceXCommand -Command @('Value')
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Command
+Command and arguments.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NetworkAccess
+Enable network access for sandboxed runs.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Return raw JSON response.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SandboxType
+Sandbox type for execution.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TimeoutMs
+Command timeout in milliseconds.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkingDirectory
+Working directory for the command.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WritableRoot
+Writable root paths for sandboxed runs.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.CommandExecResult`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-IntelligenceXMcpServerConfigReload.md
+++ b/Module/Docs/Invoke-IntelligenceXMcpServerConfigReload.md
@@ -1,0 +1,65 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Invoke-IntelligenceXMcpServerConfigReload
+## SYNOPSIS
+Reloads MCP server configuration in the running app-server.
+
+Refreshes MCP configuration after file changes so newly added servers, tools, and auth settings
+are visible without restarting the app-server process.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-IntelligenceXMcpServerConfigReload [-Client <IntelligenceXClient>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Reloads MCP server configuration in the running app-server.
+
+Refreshes MCP configuration after file changes so newly added servers, tools, and auth settings
+are visible without restarting the app-server process.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Invoke-IntelligenceXMcpServerConfigReload -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+App-server client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-IntelligenceXRpc.md
+++ b/Module/Docs/Invoke-IntelligenceXRpc.md
@@ -1,0 +1,97 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Invoke-IntelligenceXRpc
+## SYNOPSIS
+Invokes a raw JSON-RPC method directly against app-server.
+
+Low-level escape hatch for advanced scenarios not covered by high-level cmdlets.
+Parameters are converted from PowerShell objects/hashtables to JSON payloads.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-IntelligenceXRpc -Method <string> [-Client <IntelligenceXClient>] [-Params <Object>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Invokes a raw JSON-RPC method directly against app-server.
+
+Low-level escape hatch for advanced scenarios not covered by high-level cmdlets.
+Parameters are converted from PowerShell objects/hashtables to JSON payloads.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Invoke-IntelligenceXRpc -Method 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Method
+JSON-RPC method name (for example thread/list).
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Params
+Optional method parameters supplied as a PowerShell object/hashtable.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/New-IntelligenceXThreadFork.md
+++ b/Module/Docs/New-IntelligenceXThreadFork.md
@@ -1,0 +1,98 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# New-IntelligenceXThreadFork
+## SYNOPSIS
+Creates a new thread fork from an existing thread's history.
+
+Use this when you want to branch a conversation without mutating the original thread.
+The fork inherits prior context and gets a new thread id.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-IntelligenceXThreadFork -ThreadId <string> [-Client <IntelligenceXClient>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a new thread fork from an existing thread's history.
+
+Use this when you want to branch a conversation without mutating the original thread.
+The fork inherits prior context and gets a new thread id.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+New-IntelligenceXThreadFork -ThreadId 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of typed thread info.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ThreadId
+Identifier of the source thread to fork.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.ThreadInfo`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -1,0 +1,235 @@
+---
+Module Name: IntelligenceX
+Module Guid: 8fc3e038-c57b-44f3-bc7f-714beb3bd65a
+Download Help Link: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+Help Version: 0.1.0
+Locale: en-US
+---
+# IntelligenceX Module
+## Description
+IntelligenceX is a PowerShell module for the Codex app-server client.
+
+## IntelligenceX Cmdlets
+### [Backup-IntelligenceXThread](Backup-IntelligenceXThread.md)
+Archives an existing thread so it no longer appears in active workflows.
+
+Use this cmdlet to hide completed or obsolete conversations from normal thread listings while
+preserving history. The archive operation is non-destructive and can be used for housekeeping.
+
+### [Connect-IntelligenceX](Connect-IntelligenceX.md)
+Connects to IntelligenceX (native or app-server) and returns a client instance.
+
+Use Native for ChatGPT OAuth login (no local Codex binary). Use AppServer to talk to a locally
+running Codex app-server process. The cmdlet sets the active default client, so subsequent cmdlets can omit -Client.
+
+### [Disconnect-IntelligenceX](Disconnect-IntelligenceX.md)
+Disconnects the active IntelligenceX client and clears local session context.
+
+Releases app-server/native client resources, clears diagnostics subscriptions, and resets
+default thread/initialization state. If no client is active, the cmdlet exits without error.
+
+### [Get-IntelligenceXAccount](Get-IntelligenceXAccount.md)
+Returns the current account details.
+
+Returns the account identity for the active session, such as email and account id.
+Useful to confirm which credential bundle is currently active.
+
+### [Get-IntelligenceXCollaborationMode](Get-IntelligenceXCollaborationMode.md)
+Lists collaboration modes available in the current app-server runtime.
+
+Use this cmdlet to discover valid collaboration mode values before setting them in
+configuration or passing them to review/chat workflows.
+
+### [Get-IntelligenceXConfig](Get-IntelligenceXConfig.md)
+Reads the effective app-server configuration with layer metadata.
+
+Returns merged config values plus metadata that explains where values come from
+(for example defaults, workspace files, or environment overrides).
+
+### [Get-IntelligenceXConfigRequirements](Get-IntelligenceXConfigRequirements.md)
+Reads server-defined constraints for supported configuration values.
+
+Returns allowed values for key settings (for example approval policy and sandbox mode)
+so scripts can validate config before writing changes.
+
+### [Get-IntelligenceXCopilotInstall](Get-IntelligenceXCopilotInstall.md)
+Shows platform-specific installation commands for GitHub Copilot CLI.
+
+This cmdlet does not install anything. It returns suggested install command metadata
+so you can preview, log, or execute it manually.
+
+### [Get-IntelligenceXHealth](Get-IntelligenceXHealth.md)
+Runs health checks for OpenAI app-server and optional Copilot CLI.
+
+Returns health status for the active IntelligenceX client and, optionally, a Copilot CLI
+instance using explicit or config-derived options.
+
+### [Get-IntelligenceXLoadedThread](Get-IntelligenceXLoadedThread.md)
+Lists threads currently loaded in the app-server process.
+
+Returns thread ids that are currently active in memory for the running app-server session.
+Useful for diagnostics and cleanup scripts.
+
+### [Get-IntelligenceXMcpServerStatus](Get-IntelligenceXMcpServerStatus.md)
+Lists configured MCP servers with auth, tool, and resource status.
+
+Queries the app-server MCP registry and returns one page of server status data. The result includes
+Servers (current page) and NextCursor (for pagination).
+
+### [Get-IntelligenceXModel](Get-IntelligenceXModel.md)
+Lists models available for the current transport context.
+
+Returns model metadata for the active client. Raw JSON mode is available only on app-server
+transport because native transport returns strongly typed models directly.
+
+### [Get-IntelligenceXSkill](Get-IntelligenceXSkill.md)
+Lists available skills.
+
+Scans for skills in the provided working directories and returns the resolved list.
+
+### [Get-IntelligenceXThread](Get-IntelligenceXThread.md)
+Lists available threads.
+
+Returns paged threads with optional filtering by model provider.
+
+### [Get-IntelligenceXTurnOutput](Get-IntelligenceXTurnOutput.md)
+Extracts outputs from a turn.
+
+Filters and saves outputs from a completed turn, including images and text.
+
+### [Initialize-IntelligenceX](Initialize-IntelligenceX.md)
+Initializes the client handshake with the app-server.
+
+Sends client identity metadata (name, title, version) to app-server. Some flows require
+initialization before login, chat, or review operations.
+
+### [Install-IntelligenceXCopilotCli](Install-IntelligenceXCopilotCli.md)
+Installs GitHub Copilot CLI using a selected install strategy.
+
+Executes the platform-specific installer command and optionally returns command metadata.
+Supports WhatIf/Confirm through ShouldProcess.
+
+### [Invoke-IntelligenceXChat](Invoke-IntelligenceXChat.md)
+Super-easy chat command that handles connect, init, login, thread, and send.
+
+Convenience entry point for quick chat: it connects, logs in (if needed), creates or
+reuses a thread, sends input, and returns the resulting turn. Supports streaming output and
+a simple DSL for text/image inputs.
+
+### [Invoke-IntelligenceXCommand](Invoke-IntelligenceXCommand.md)
+Executes a command through the app-server.
+
+Runs a process via the app-server with optional sandbox settings and timeout.
+
+### [Invoke-IntelligenceXMcpServerConfigReload](Invoke-IntelligenceXMcpServerConfigReload.md)
+Reloads MCP server configuration in the running app-server.
+
+Refreshes MCP configuration after file changes so newly added servers, tools, and auth settings
+are visible without restarting the app-server process.
+
+### [Invoke-IntelligenceXRpc](Invoke-IntelligenceXRpc.md)
+Invokes a raw JSON-RPC method directly against app-server.
+
+Low-level escape hatch for advanced scenarios not covered by high-level cmdlets.
+Parameters are converted from PowerShell objects/hashtables to JSON payloads.
+
+### [New-IntelligenceXThreadFork](New-IntelligenceXThreadFork.md)
+Creates a new thread fork from an existing thread's history.
+
+Use this when you want to branch a conversation without mutating the original thread.
+The fork inherits prior context and gets a new thread id.
+
+### [Request-IntelligenceXUserInput](Request-IntelligenceXUserInput.md)
+Requests user input through the app-server.
+
+Prompts for one to three questions and returns collected answers in order.
+Useful for interactive script checkpoints that need explicit user confirmation or values.
+
+### [Restore-IntelligenceXThread](Restore-IntelligenceXThread.md)
+Rolls back the last N turns from a thread.
+
+Removes recent turns from a thread so you can re-run, correct, or branch from an earlier
+conversation state.
+
+### [Resume-IntelligenceXThread](Resume-IntelligenceXThread.md)
+Resumes an existing thread so new messages can be sent to it.
+
+Loads thread context back into the active app-server session and returns thread metadata.
+Useful after reconnecting or when switching between multiple threads.
+
+### [Send-IntelligenceXFeedback](Send-IntelligenceXFeedback.md)
+Uploads textual feedback to the app-server feedback endpoint.
+
+Use this cmdlet to send reproduction notes, quality feedback, or analyzer observations
+collected during reviews and local runs.
+
+### [Send-IntelligenceXMessage](Send-IntelligenceXMessage.md)
+Sends a message to a thread and starts a turn.
+
+Queues a user message on an existing thread. Returns the created turn so you can
+poll for output with Get-IntelligenceXTurnOutput.
+
+### [Set-IntelligenceXConfigBatch](Set-IntelligenceXConfigBatch.md)
+Writes multiple app-server configuration values in one request.
+
+Sends a batch of key/value updates. This is useful for related settings you want to apply together.
+Hashtable values are converted to JSON before sending.
+
+### [Set-IntelligenceXConfigValue](Set-IntelligenceXConfigValue.md)
+Writes a single app-server configuration value.
+
+Updates one config key on the app-server. PowerShell values are converted to JSON before sending.
+Use Get-IntelligenceXConfig to verify the effective result and layer origin.
+
+### [Set-IntelligenceXSkill](Set-IntelligenceXSkill.md)
+Enables or disables a skill entry in app-server skill configuration.
+
+Updates the persisted skill config for a specific skill path so future tool runs include
+or exclude that skill.
+
+### [Start-IntelligenceXApiKeyLogin](Start-IntelligenceXApiKeyLogin.md)
+Authenticates the active client with an OpenAI API key.
+
+Stores the API key in the active client for API-based requests. Use only if ChatGPT OAuth
+is not desired or available.
+
+### [Start-IntelligenceXChatGptLogin](Start-IntelligenceXChatGptLogin.md)
+Starts the ChatGPT login flow and returns the authorization URL.
+
+Opens the browser to complete the ChatGPT OAuth flow. Pair with Wait-IntelligenceXLogin
+to poll for completion and store the resulting credentials.
+
+### [Start-IntelligenceXMcpOAuthLogin](Start-IntelligenceXMcpOAuthLogin.md)
+Starts an MCP OAuth login flow and returns the browser authorization URL.
+
+Use this cmdlet when an MCP server reports OAuth auth status. The response includes a
+LoginId and AuthUrl you can open in a browser.
+
+### [Start-IntelligenceXReview](Start-IntelligenceXReview.md)
+Starts a review flow for a thread.
+
+Triggers the app-server review pipeline for a thread and target. Use TargetType to
+choose what to review (uncommitted changes, a branch, a commit, or custom text).
+
+### [Start-IntelligenceXThread](Start-IntelligenceXThread.md)
+Creates a new conversation thread.
+
+Starts a fresh thread on the app-server with a selected model and optional execution
+settings like sandbox and approval policy.
+
+### [Stop-IntelligenceXTurn](Stop-IntelligenceXTurn.md)
+Interrupts a running turn for a thread.
+
+Requests cancellation for an in-progress turn. Use this for long-running responses,
+accidental prompts, or when you need to restart execution with different instructions.
+
+### [Wait-IntelligenceXLogin](Wait-IntelligenceXLogin.md)
+Waits for the login flow to complete.
+
+Polls the app-server for login completion. Use after Start-IntelligenceXChatGptLogin.
+
+### [Watch-IntelligenceXEvent](Watch-IntelligenceXEvent.md)
+Watches JSON-RPC notifications from the app-server.
+
+Streams notification events until cancelled. Use method filters to observe specific
+protocol events such as turn progress, login completion, or status changes.

--- a/Module/Docs/Request-IntelligenceXUserInput.md
+++ b/Module/Docs/Request-IntelligenceXUserInput.md
@@ -1,0 +1,98 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Request-IntelligenceXUserInput
+## SYNOPSIS
+Requests user input through the app-server.
+
+Prompts for one to three questions and returns collected answers in order.
+Useful for interactive script checkpoints that need explicit user confirmation or values.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Request-IntelligenceXUserInput -Questions <string[]> [-Client <IntelligenceXClient>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Requests user input through the app-server.
+
+Prompts for one to three questions and returns collected answers in order.
+Useful for interactive script checkpoints that need explicit user confirmation or values.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Request-IntelligenceXUserInput -Questions @('Value')
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Questions
+Questions to ask (minimum 1, maximum 3).
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of typed response data.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.UserInputResponse`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Restore-IntelligenceXThread.md
+++ b/Module/Docs/Restore-IntelligenceXThread.md
@@ -1,0 +1,114 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Restore-IntelligenceXThread
+## SYNOPSIS
+Rolls back the last N turns from a thread.
+
+Removes recent turns from a thread so you can re-run, correct, or branch from an earlier
+conversation state.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Restore-IntelligenceXThread -ThreadId <string> -Turns <int> [-Client <IntelligenceXClient>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Rolls back the last N turns from a thread.
+
+Removes recent turns from a thread so you can re-run, correct, or branch from an earlier
+conversation state.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Restore-IntelligenceXThread -ThreadId 'Value' -Turns 1
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of typed thread info.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ThreadId
+Identifier of the thread to modify.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Turns
+Number of most recent turns to remove.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.ThreadInfo`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Resume-IntelligenceXThread.md
+++ b/Module/Docs/Resume-IntelligenceXThread.md
@@ -1,0 +1,98 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Resume-IntelligenceXThread
+## SYNOPSIS
+Resumes an existing thread so new messages can be sent to it.
+
+Loads thread context back into the active app-server session and returns thread metadata.
+Useful after reconnecting or when switching between multiple threads.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Resume-IntelligenceXThread -ThreadId <string> [-Client <IntelligenceXClient>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Resumes an existing thread so new messages can be sent to it.
+
+Loads thread context back into the active app-server session and returns thread metadata.
+Useful after reconnecting or when switching between multiple threads.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Resume-IntelligenceXThread -ThreadId 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of typed thread info.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ThreadId
+Identifier of the thread to resume.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.ThreadInfo`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Send-IntelligenceXFeedback.md
+++ b/Module/Docs/Send-IntelligenceXFeedback.md
@@ -1,0 +1,81 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Send-IntelligenceXFeedback
+## SYNOPSIS
+Uploads textual feedback to the app-server feedback endpoint.
+
+Use this cmdlet to send reproduction notes, quality feedback, or analyzer observations
+collected during reviews and local runs.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Send-IntelligenceXFeedback -Content <string> [-Client <IntelligenceXClient>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Uploads textual feedback to the app-server feedback endpoint.
+
+Use this cmdlet to send reproduction notes, quality feedback, or analyzer observations
+collected during reviews and local runs.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Send-IntelligenceXFeedback -Content 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Content
+Feedback text content to upload.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Send-IntelligenceXMessage.md
+++ b/Module/Docs/Send-IntelligenceXMessage.md
@@ -1,0 +1,210 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Send-IntelligenceXMessage
+## SYNOPSIS
+Sends a message to a thread and starts a turn.
+
+Queues a user message on an existing thread. Returns the created turn so you can
+poll for output with Get-IntelligenceXTurnOutput.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Send-IntelligenceXMessage -ThreadId <string> -Text <string> [-Client <IntelligenceXClient>] [-Model <string>] [-CurrentDirectory <string>] [-ApprovalPolicy <string>] [-SandboxType <string>] [-NetworkAccess] [-WritableRoot <string[]>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Sends a message to a thread and starts a turn.
+
+Queues a user message on an existing thread. Returns the created turn so you can
+poll for output with Get-IntelligenceXTurnOutput.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Send-IntelligenceXMessage -ThreadId 'Value' -Text 'Value'
+```
+
+
+## PARAMETERS
+
+### -ApprovalPolicy
+Approval policy name to use.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -CurrentDirectory
+Working directory to pass to the app-server.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Model
+Optional model override.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NetworkAccess
+Enable network access for sandboxed runs.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Return raw JSON response.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SandboxType
+Sandbox type (for example 'workspace' or 'danger-full-access').
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Text
+Message text to send.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ThreadId
+Thread identifier to send the message to.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WritableRoot
+Writable root paths for sandboxed runs.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.TurnInfo`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Set-IntelligenceXConfigBatch.md
+++ b/Module/Docs/Set-IntelligenceXConfigBatch.md
@@ -1,0 +1,81 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Set-IntelligenceXConfigBatch
+## SYNOPSIS
+Writes multiple app-server configuration values in one request.
+
+Sends a batch of key/value updates. This is useful for related settings you want to apply together.
+Hashtable values are converted to JSON before sending.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Set-IntelligenceXConfigBatch -Values <hashtable> [-Client <IntelligenceXClient>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Writes multiple app-server configuration values in one request.
+
+Sends a batch of key/value updates. This is useful for related settings you want to apply together.
+Hashtable values are converted to JSON before sending.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Set-IntelligenceXConfigBatch -Values @{}
+```
+
+
+## PARAMETERS
+
+### -Client
+App-server client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Values
+Hashtable of configuration key/value pairs to write.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Set-IntelligenceXConfigValue.md
+++ b/Module/Docs/Set-IntelligenceXConfigValue.md
@@ -1,0 +1,97 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Set-IntelligenceXConfigValue
+## SYNOPSIS
+Writes a single app-server configuration value.
+
+Updates one config key on the app-server. PowerShell values are converted to JSON before sending.
+Use Get-IntelligenceXConfig to verify the effective result and layer origin.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Set-IntelligenceXConfigValue -Key <string> -Value <Object> [-Client <IntelligenceXClient>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Writes a single app-server configuration value.
+
+Updates one config key on the app-server. PowerShell values are converted to JSON before sending.
+Use Get-IntelligenceXConfig to verify the effective result and layer origin.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Set-IntelligenceXConfigValue -Key 'Value' -Value 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+App-server client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Key
+Configuration key to write.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Value
+Configuration value. Converted to JSON (string, number, boolean, array, object).
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Set-IntelligenceXSkill.md
+++ b/Module/Docs/Set-IntelligenceXSkill.md
@@ -1,0 +1,97 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Set-IntelligenceXSkill
+## SYNOPSIS
+Enables or disables a skill entry in app-server skill configuration.
+
+Updates the persisted skill config for a specific skill path so future tool runs include
+or exclude that skill.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Set-IntelligenceXSkill -Path <string> -Enabled <bool> [-Client <IntelligenceXClient>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Enables or disables a skill entry in app-server skill configuration.
+
+Updates the persisted skill config for a specific skill path so future tool runs include
+or exclude that skill.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Set-IntelligenceXSkill -Path 'C:\Path' -Enabled $true
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Enabled
+Set to $true to enable, $false to disable.
+
+```yaml
+Type: Boolean
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+Path to the skill configuration entry.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Start-IntelligenceXApiKeyLogin.md
+++ b/Module/Docs/Start-IntelligenceXApiKeyLogin.md
@@ -1,0 +1,81 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Start-IntelligenceXApiKeyLogin
+## SYNOPSIS
+Authenticates the active client with an OpenAI API key.
+
+Stores the API key in the active client for API-based requests. Use only if ChatGPT OAuth
+is not desired or available.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Start-IntelligenceXApiKeyLogin -ApiKey <string> [-Client <IntelligenceXClient>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Authenticates the active client with an OpenAI API key.
+
+Stores the API key in the active client for API-based requests. Use only if ChatGPT OAuth
+is not desired or available.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Start-IntelligenceXApiKeyLogin -ApiKey 'Value'
+```
+
+
+## PARAMETERS
+
+### -ApiKey
+OpenAI API key used for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Start-IntelligenceXChatGptLogin.md
+++ b/Module/Docs/Start-IntelligenceXChatGptLogin.md
@@ -1,0 +1,82 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Start-IntelligenceXChatGptLogin
+## SYNOPSIS
+Starts the ChatGPT login flow and returns the authorization URL.
+
+Opens the browser to complete the ChatGPT OAuth flow. Pair with Wait-IntelligenceXLogin
+to poll for completion and store the resulting credentials.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Start-IntelligenceXChatGptLogin [-Client <IntelligenceXClient>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Starts the ChatGPT login flow and returns the authorization URL.
+
+Opens the browser to complete the ChatGPT OAuth flow. Pair with Wait-IntelligenceXLogin
+to poll for completion and store the resulting credentials.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Start-IntelligenceXChatGptLogin -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of typed login data.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.ChatGptLoginStart`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Start-IntelligenceXMcpOAuthLogin.md
+++ b/Module/Docs/Start-IntelligenceXMcpOAuthLogin.md
@@ -1,0 +1,114 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Start-IntelligenceXMcpOAuthLogin
+## SYNOPSIS
+Starts an MCP OAuth login flow and returns the browser authorization URL.
+
+Use this cmdlet when an MCP server reports OAuth auth status. The response includes a
+LoginId and AuthUrl you can open in a browser.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Start-IntelligenceXMcpOAuthLogin [-Client <IntelligenceXClient>] [-ServerId <string>] [-ServerName <string>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Starts an MCP OAuth login flow and returns the browser authorization URL.
+
+Use this cmdlet when an MCP server reports OAuth auth status. The response includes a
+LoginId and AuthUrl you can open in a browser.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Start-IntelligenceXMcpOAuthLogin -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+App-server client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Raw
+Returns the raw JSON-RPC payload instead of a typed model.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerId
+MCP server identifier to start login for.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+MCP server name to start login for.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.McpOauthLoginStart`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Start-IntelligenceXReview.md
+++ b/Module/Docs/Start-IntelligenceXReview.md
@@ -1,0 +1,146 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Start-IntelligenceXReview
+## SYNOPSIS
+Starts a review flow for a thread.
+
+Triggers the app-server review pipeline for a thread and target. Use TargetType to
+choose what to review (uncommitted changes, a branch, a commit, or custom text).
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Start-IntelligenceXReview -ThreadId <string> -Delivery <string> -TargetType <string> [-Client <IntelligenceXClient>] [-TargetValue <string>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Starts a review flow for a thread.
+
+Triggers the app-server review pipeline for a thread and target. Use TargetType to
+choose what to review (uncommitted changes, a branch, a commit, or custom text).
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Start-IntelligenceXReview -ThreadId 'Value' -Delivery 'Value' -TargetType 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Delivery
+Delivery mode (for example immediate).
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Return raw JSON response.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetType
+Target type: uncommittedChanges, baseBranch, commit, custom.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetValue
+Target value (branch name, commit SHA, or custom text).
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ThreadId
+Thread identifier.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.ReviewStartResult`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Start-IntelligenceXThread.md
+++ b/Module/Docs/Start-IntelligenceXThread.md
@@ -1,0 +1,146 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Start-IntelligenceXThread
+## SYNOPSIS
+Creates a new conversation thread.
+
+Starts a fresh thread on the app-server with a selected model and optional execution
+settings like sandbox and approval policy.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Start-IntelligenceXThread -Model <string> [-Client <IntelligenceXClient>] [-CurrentDirectory <string>] [-ApprovalPolicy <string>] [-Sandbox <string>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a new conversation thread.
+
+Starts a fresh thread on the app-server with a selected model and optional execution
+settings like sandbox and approval policy.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Start-IntelligenceXThread -Model 'Value'
+```
+
+
+## PARAMETERS
+
+### -ApprovalPolicy
+Approval policy name to use.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -CurrentDirectory
+Working directory to pass to the app-server.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Model
+Model identifier to use (for example gpt-5.4).
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Return raw JSON response.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Sandbox
+Sandbox mode to use (for example 'workspace' or 'danger-full-access').
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.OpenAI.AppServer.Models.ThreadInfo`
+- `IntelligenceX.Json.JsonValue`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Stop-IntelligenceXTurn.md
+++ b/Module/Docs/Stop-IntelligenceXTurn.md
@@ -1,0 +1,97 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Stop-IntelligenceXTurn
+## SYNOPSIS
+Interrupts a running turn for a thread.
+
+Requests cancellation for an in-progress turn. Use this for long-running responses,
+accidental prompts, or when you need to restart execution with different instructions.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Stop-IntelligenceXTurn -ThreadId <string> -TurnId <string> [-Client <IntelligenceXClient>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Interrupts a running turn for a thread.
+
+Requests cancellation for an in-progress turn. Use this for long-running responses,
+accidental prompts, or when you need to restart execution with different instructions.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Stop-IntelligenceXTurn -ThreadId 'Value' -TurnId 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -ThreadId
+Identifier of the thread that owns the running turn.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TurnId
+Identifier of the turn to interrupt.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Wait-IntelligenceXLogin.md
+++ b/Module/Docs/Wait-IntelligenceXLogin.md
@@ -1,0 +1,95 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Wait-IntelligenceXLogin
+## SYNOPSIS
+Waits for the login flow to complete.
+
+Polls the app-server for login completion. Use after Start-IntelligenceXChatGptLogin.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Wait-IntelligenceXLogin [-Client <IntelligenceXClient>] [-LoginId <string>] [-TimeoutSeconds <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Waits for the login flow to complete.
+
+Polls the app-server for login completion. Use after Start-IntelligenceXChatGptLogin.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Wait-IntelligenceXLogin -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -LoginId
+Optional login identifier to wait for.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TimeoutSeconds
+Maximum wait time in seconds before cancellation.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Watch-IntelligenceXEvent.md
+++ b/Module/Docs/Watch-IntelligenceXEvent.md
@@ -1,0 +1,81 @@
+---
+external help file: IntelligenceX-help.xml
+Module Name: IntelligenceX
+online version: https://github.com/EvotecIT/IntelligenceX/blob/master/README.md
+schema: 2.0.0
+---
+# Watch-IntelligenceXEvent
+## SYNOPSIS
+Watches JSON-RPC notifications from the app-server.
+
+Streams notification events until cancelled. Use method filters to observe specific
+protocol events such as turn progress, login completion, or status changes.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Watch-IntelligenceXEvent [-Client <IntelligenceXClient>] [-Method <string[]>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Watches JSON-RPC notifications from the app-server.
+
+Streams notification events until cancelled. Use method filters to observe specific
+protocol events such as turn progress, login completion, or status changes.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Watch-IntelligenceXEvent -Client 'Value'
+```
+
+
+## PARAMETERS
+
+### -Client
+Client instance to use. Defaults to the active client.
+
+```yaml
+Type: IntelligenceXClient
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Method
+Optional JSON-RPC method filter list. Matching is case-insensitive.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `IntelligenceX.OpenAI.IntelligenceXClient`
+
+## OUTPUTS
+
+- `IntelligenceX.PowerShell.RpcNotificationRecord`: Represents a JSON-RPC notification record for PowerShell consumers.
+
+## RELATED LINKS
+
+- None

--- a/Module/en-US/IntelligenceX-help.xml
+++ b/Module/en-US/IntelligenceX-help.xml
@@ -1,0 +1,6439 @@
+<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Backup-IntelligenceXThread</command:name>
+      <command:verb>Backup</command:verb>
+      <command:noun>IntelligenceXThread</command:noun>
+      <maml:description>
+        <maml:para>Archives an existing thread so it no longer appears in active workflows.</maml:para>
+        <maml:para>Use this cmdlet to hide completed or obsolete conversations from normal thread listings while&#xD;
+preserving history. The archive operation is non-destructive and can be used for housekeeping.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Archives an existing thread so it no longer appears in active workflows.</maml:para>
+      <maml:para>Use this cmdlet to hide completed or obsolete conversations from normal thread listings while&#xD;
+preserving history. The archive operation is non-destructive and can be used for housekeeping.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Backup-IntelligenceXThread</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ThreadId</maml:name>
+          <maml:description>
+            <maml:para>Identifier of the thread to archive.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ThreadId</maml:name>
+        <maml:description>
+          <maml:para>Identifier of the thread to archive.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Backup-IntelligenceXThread -ThreadId 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Connect-IntelligenceX</command:name>
+      <command:verb>Connect</command:verb>
+      <command:noun>IntelligenceX</command:noun>
+      <maml:description>
+        <maml:para>Connects to IntelligenceX (native or app-server) and returns a client instance.</maml:para>
+        <maml:para>Use Native for ChatGPT OAuth login (no local Codex binary). Use AppServer to talk to a locally&#xD;
+running Codex app-server process. The cmdlet sets the active default client, so subsequent cmdlets can omit -Client.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Connects to IntelligenceX (native or app-server) and returns a client instance.</maml:para>
+      <maml:para>Use Native for ChatGPT OAuth login (no local Codex binary). Use AppServer to talk to a locally&#xD;
+running Codex app-server process. The cmdlet sets the active default client, so subsequent cmdlets can omit -Client.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Connect-IntelligenceX</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Arguments</maml:name>
+          <maml:description>
+            <maml:para>Arguments to pass to the app-server. Defaults to 'app-server'.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Diagnostics</maml:name>
+          <maml:description>
+            <maml:para>Enable diagnostics output (RPC calls, login events, stderr).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExecutablePath</maml:name>
+          <maml:description>
+            <maml:para>Path to the codex executable. Defaults to 'codex' on PATH.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoConfig</maml:name>
+          <maml:description>
+            <maml:para>Ignore .intelligencex/config.json overrides.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OpenAIAccountId</maml:name>
+          <maml:description>
+            <maml:para>Optional ChatGPT account id to use when multiple auth bundles are present.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Transport</maml:name>
+          <maml:description>
+            <maml:para>Transport to use (Native or AppServer). Native uses ChatGPT OAuth directly.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">OpenAITransportKind</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Native</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AppServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CompatibleHttp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CopilotCli</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>OpenAITransportKind</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WorkingDirectory</maml:name>
+          <maml:description>
+            <maml:para>Working directory for the app-server process.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Arguments</maml:name>
+        <maml:description>
+          <maml:para>Arguments to pass to the app-server. Defaults to 'app-server'.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Diagnostics</maml:name>
+        <maml:description>
+          <maml:para>Enable diagnostics output (RPC calls, login events, stderr).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExecutablePath</maml:name>
+        <maml:description>
+          <maml:para>Path to the codex executable. Defaults to 'codex' on PATH.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoConfig</maml:name>
+        <maml:description>
+          <maml:para>Ignore .intelligencex/config.json overrides.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OpenAIAccountId</maml:name>
+        <maml:description>
+          <maml:para>Optional ChatGPT account id to use when multiple auth bundles are present.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Transport</maml:name>
+        <maml:description>
+          <maml:para>Transport to use (Native or AppServer). Native uses ChatGPT OAuth directly.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">OpenAITransportKind</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Native</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AppServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompatibleHttp</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CopilotCli</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>OpenAITransportKind</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WorkingDirectory</maml:name>
+        <maml:description>
+          <maml:para>Working directory for the app-server process.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Connect-IntelligenceX -ExecutablePath 'C:\Path'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Disconnect-IntelligenceX</command:name>
+      <command:verb>Disconnect</command:verb>
+      <command:noun>IntelligenceX</command:noun>
+      <maml:description>
+        <maml:para>Disconnects the active IntelligenceX client and clears local session context.</maml:para>
+        <maml:para>Releases app-server/native client resources, clears diagnostics subscriptions, and resets&#xD;
+default thread/initialization state. If no client is active, the cmdlet exits without error.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Disconnects the active IntelligenceX client and clears local session context.</maml:para>
+      <maml:para>Releases app-server/native client resources, clears diagnostics subscriptions, and resets&#xD;
+default thread/initialization state. If no client is active, the cmdlet exits without error.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Disconnect-IntelligenceX</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to disconnect. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to disconnect. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Disconnect-IntelligenceX -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXAccount</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXAccount</command:noun>
+      <maml:description>
+        <maml:para>Returns the current account details.</maml:para>
+        <maml:para>Returns the account identity for the active session, such as email and account id.&#xD;
+Useful to confirm which credential bundle is currently active.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Returns the current account details.</maml:para>
+      <maml:para>Returns the account identity for the active session, such as email and account id.&#xD;
+Useful to confirm which credential bundle is currently active.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXAccount</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of typed account info.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of typed account info.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.AccountInfo</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXAccount -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXCollaborationMode</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXCollaborationMode</command:noun>
+      <maml:description>
+        <maml:para>Lists collaboration modes available in the current app-server runtime.</maml:para>
+        <maml:para>Use this cmdlet to discover valid collaboration mode values before setting them in&#xD;
+configuration or passing them to review/chat workflows.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Lists collaboration modes available in the current app-server runtime.</maml:para>
+      <maml:para>Use this cmdlet to discover valid collaboration mode values before setting them in&#xD;
+configuration or passing them to review/chat workflows.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXCollaborationMode</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of typed mode models.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of typed mode models.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.CollaborationModeListResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXCollaborationMode -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXConfig</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXConfig</command:noun>
+      <maml:description>
+        <maml:para>Reads the effective app-server configuration with layer metadata.</maml:para>
+        <maml:para>Returns merged config values plus metadata that explains where values come from&#xD;
+(for example defaults, workspace files, or environment overrides).</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Reads the effective app-server configuration with layer metadata.</maml:para>
+      <maml:para>Returns merged config values plus metadata that explains where values come from&#xD;
+(for example defaults, workspace files, or environment overrides).</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXConfig</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>App-server client instance to query. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of typed config models.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>App-server client instance to query. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of typed config models.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.ConfigReadResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXConfig -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXConfigRequirements</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXConfigRequirements</command:noun>
+      <maml:description>
+        <maml:para>Reads server-defined constraints for supported configuration values.</maml:para>
+        <maml:para>Returns allowed values for key settings (for example approval policy and sandbox mode)&#xD;
+so scripts can validate config before writing changes.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Reads server-defined constraints for supported configuration values.</maml:para>
+      <maml:para>Returns allowed values for key settings (for example approval policy and sandbox mode)&#xD;
+so scripts can validate config before writing changes.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXConfigRequirements</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of typed requirements models.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of typed requirements models.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.ConfigRequirementsReadResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXConfigRequirements -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXCopilotInstall</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXCopilotInstall</command:noun>
+      <maml:description>
+        <maml:para>Shows platform-specific installation commands for GitHub Copilot CLI.</maml:para>
+        <maml:para>This cmdlet does not install anything. It returns suggested install command metadata&#xD;
+so you can preview, log, or execute it manually.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Shows platform-specific installation commands for GitHub Copilot CLI.</maml:para>
+      <maml:para>This cmdlet does not install anything. It returns suggested install command metadata&#xD;
+so you can preview, log, or execute it manually.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXCopilotInstall</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Prerelease</maml:name>
+          <maml:description>
+            <maml:para>Returns commands for installing prerelease builds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Prerelease</maml:name>
+        <maml:description>
+          <maml:para>Returns commands for installing prerelease builds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Copilot.CopilotCliInstallCommand</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXCopilotInstall -Prerelease</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXHealth</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXHealth</command:noun>
+      <maml:description>
+        <maml:para>Runs health checks for OpenAI app-server and optional Copilot CLI.</maml:para>
+        <maml:para>Returns health status for the active IntelligenceX client and, optionally, a Copilot CLI&#xD;
+instance using explicit or config-derived options.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Runs health checks for OpenAI app-server and optional Copilot CLI.</maml:para>
+      <maml:para>Returns health status for the active IntelligenceX client and, optionally, a Copilot CLI&#xD;
+instance using explicit or config-derived options.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXHealth</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>OpenAI/app-server client instance. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Copilot</maml:name>
+          <maml:description>
+            <maml:para>Run a Copilot CLI health check.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CopilotAutoInstall</maml:name>
+          <maml:description>
+            <maml:para>Auto-install Copilot CLI if missing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CopilotCliPath</maml:name>
+          <maml:description>
+            <maml:para>Copilot CLI path.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CopilotCliUrl</maml:name>
+          <maml:description>
+            <maml:para>Copilot CLI URL (host:port).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CopilotInstallMethod</maml:name>
+          <maml:description>
+            <maml:para>Copilot auto-install method to use when -CopilotAutoInstall is set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">CopilotCliInstallMethod</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Winget</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Homebrew</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Npm</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Script</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>CopilotCliInstallMethod</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CopilotInstallPrerelease</maml:name>
+          <maml:description>
+            <maml:para>Copilot auto-install prerelease.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CopilotWorkingDirectory</maml:name>
+          <maml:description>
+            <maml:para>Copilot CLI working directory.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoConfig</maml:name>
+          <maml:description>
+            <maml:para>Ignore .intelligencex/config.json overrides.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>OpenAI/app-server client instance. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Copilot</maml:name>
+        <maml:description>
+          <maml:para>Run a Copilot CLI health check.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CopilotAutoInstall</maml:name>
+        <maml:description>
+          <maml:para>Auto-install Copilot CLI if missing.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CopilotCliPath</maml:name>
+        <maml:description>
+          <maml:para>Copilot CLI path.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CopilotCliUrl</maml:name>
+        <maml:description>
+          <maml:para>Copilot CLI URL (host:port).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CopilotInstallMethod</maml:name>
+        <maml:description>
+          <maml:para>Copilot auto-install method to use when -CopilotAutoInstall is set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">CopilotCliInstallMethod</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Winget</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Homebrew</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Npm</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Script</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>CopilotCliInstallMethod</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CopilotInstallPrerelease</maml:name>
+        <maml:description>
+          <maml:para>Copilot auto-install prerelease.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CopilotWorkingDirectory</maml:name>
+        <maml:description>
+          <maml:para>Copilot CLI working directory.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoConfig</maml:name>
+        <maml:description>
+          <maml:para>Ignore .intelligencex/config.json overrides.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.PowerShell.HealthReportRecord</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>Represents a combined health report for OpenAI and Copilot providers.</maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXHealth -CopilotCliPath 'C:\Path'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXLoadedThread</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXLoadedThread</command:noun>
+      <maml:description>
+        <maml:para>Lists threads currently loaded in the app-server process.</maml:para>
+        <maml:para>Returns thread ids that are currently active in memory for the running app-server session.&#xD;
+Useful for diagnostics and cleanup scripts.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Lists threads currently loaded in the app-server process.</maml:para>
+      <maml:para>Returns thread ids that are currently active in memory for the running app-server session.&#xD;
+Useful for diagnostics and cleanup scripts.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXLoadedThread</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of typed thread-id models.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of typed thread-id models.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.ThreadIdListResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXLoadedThread -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXMcpServerStatus</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXMcpServerStatus</command:noun>
+      <maml:description>
+        <maml:para>Lists configured MCP servers with auth, tool, and resource status.</maml:para>
+        <maml:para>Queries the app-server MCP registry and returns one page of server status data. The result includes&#xD;
+Servers (current page) and NextCursor (for pagination).</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Lists configured MCP servers with auth, tool, and resource status.</maml:para>
+      <maml:para>Queries the app-server MCP registry and returns one page of server status data. The result includes&#xD;
+Servers (current page) and NextCursor (for pagination).</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXMcpServerStatus</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>App-server client instance to query. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Cursor</maml:name>
+          <maml:description>
+            <maml:para>Pagination cursor from a previous response (NextCursor).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Limit</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of server entries to return in this page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of typed models.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>App-server client instance to query. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Cursor</maml:name>
+        <maml:description>
+          <maml:para>Pagination cursor from a previous response (NextCursor).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Limit</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of server entries to return in this page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of typed models.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.McpServerStatusListResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXMcpServerStatus -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXModel</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXModel</command:noun>
+      <maml:description>
+        <maml:para>Lists models available for the current transport context.</maml:para>
+        <maml:para>Returns model metadata for the active client. Raw JSON mode is available only on app-server&#xD;
+transport because native transport returns strongly typed models directly.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Lists models available for the current transport context.</maml:para>
+      <maml:para>Returns model metadata for the active client. Raw JSON mode is available only on app-server&#xD;
+transport because native transport returns strongly typed models directly.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXModel</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns raw JSON-RPC payload (app-server transport only).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns raw JSON-RPC payload (app-server transport only).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.ModelListResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXModel -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXSkill</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXSkill</command:noun>
+      <maml:description>
+        <maml:para>Lists available skills.</maml:para>
+        <maml:para>Scans for skills in the provided working directories and returns the resolved list.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Lists available skills.</maml:para>
+      <maml:para>Scans for skills in the provided working directories and returns the resolved list.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXSkill</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Cwd</maml:name>
+          <maml:description>
+            <maml:para>Working directories to scan for skills.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ForceReload</maml:name>
+          <maml:description>
+            <maml:para>Force reload of skills.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Return raw JSON response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Cwd</maml:name>
+        <maml:description>
+          <maml:para>Working directories to scan for skills.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ForceReload</maml:name>
+        <maml:description>
+          <maml:para>Force reload of skills.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Return raw JSON response.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.SkillListResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXSkill -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXThread</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXThread</command:noun>
+      <maml:description>
+        <maml:para>Lists available threads.</maml:para>
+        <maml:para>Returns paged threads with optional filtering by model provider.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Lists available threads.</maml:para>
+      <maml:para>Returns paged threads with optional filtering by model provider.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXThread</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Cursor</maml:name>
+          <maml:description>
+            <maml:para>Cursor from a previous list response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Limit</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of threads to return.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ModelProvider</maml:name>
+          <maml:description>
+            <maml:para>Filter by model providers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Return raw JSON response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SortKey</maml:name>
+          <maml:description>
+            <maml:para>Sort key (created_at or updated_at).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Cursor</maml:name>
+        <maml:description>
+          <maml:para>Cursor from a previous list response.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Limit</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of threads to return.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ModelProvider</maml:name>
+        <maml:description>
+          <maml:para>Filter by model providers.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Return raw JSON response.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SortKey</maml:name>
+        <maml:description>
+          <maml:para>Sort key (created_at or updated_at).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.ThreadListResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXThread -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-IntelligenceXTurnOutput</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>IntelligenceXTurnOutput</command:noun>
+      <maml:description>
+        <maml:para>Extracts outputs from a turn.</maml:para>
+        <maml:para>Filters and saves outputs from a completed turn, including images and text.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Extracts outputs from a turn.</maml:para>
+      <maml:para>Filters and saves outputs from a completed turn, including images and text.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-IntelligenceXTurnOutput</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DownloadUrls</maml:name>
+          <maml:description>
+            <maml:para>Download image URLs when saving images.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileNamePrefix</maml:name>
+          <maml:description>
+            <maml:para>Prefix for saved image file names.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>First</maml:name>
+          <maml:description>
+            <maml:para>Return only the first N outputs.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Images</maml:name>
+          <maml:description>
+            <maml:para>Return only image outputs.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Overwrite</maml:name>
+          <maml:description>
+            <maml:para>Overwrite existing files when saving images.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PassThru</maml:name>
+          <maml:description>
+            <maml:para>Output original TurnOutput objects when saving images.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SaveImagesTo</maml:name>
+          <maml:description>
+            <maml:para>Save image outputs to the specified directory.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Text</maml:name>
+          <maml:description>
+            <maml:para>Return only text outputs.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Turn</maml:name>
+          <maml:description>
+            <maml:para>Turn to read outputs from.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">TurnInfo</command:parameterValue>
+          <dev:type>
+            <maml:name>TurnInfo</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DownloadUrls</maml:name>
+        <maml:description>
+          <maml:para>Download image URLs when saving images.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FileNamePrefix</maml:name>
+        <maml:description>
+          <maml:para>Prefix for saved image file names.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>First</maml:name>
+        <maml:description>
+          <maml:para>Return only the first N outputs.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Images</maml:name>
+        <maml:description>
+          <maml:para>Return only image outputs.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Overwrite</maml:name>
+        <maml:description>
+          <maml:para>Overwrite existing files when saving images.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PassThru</maml:name>
+        <maml:description>
+          <maml:para>Output original TurnOutput objects when saving images.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SaveImagesTo</maml:name>
+        <maml:description>
+          <maml:para>Save image outputs to the specified directory.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Text</maml:name>
+        <maml:description>
+          <maml:para>Return only text outputs.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Turn</maml:name>
+        <maml:description>
+          <maml:para>Turn to read outputs from.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">TurnInfo</command:parameterValue>
+        <dev:type>
+          <maml:name>TurnInfo</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.TurnInfo</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.TurnOutput</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-IntelligenceXTurnOutput -Turn 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Initialize-IntelligenceX</command:name>
+      <command:verb>Initialize</command:verb>
+      <command:noun>IntelligenceX</command:noun>
+      <maml:description>
+        <maml:para>Initializes the client handshake with the app-server.</maml:para>
+        <maml:para>Sends client identity metadata (name, title, version) to app-server. Some flows require&#xD;
+initialization before login, chat, or review operations.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Initializes the client handshake with the app-server.</maml:para>
+      <maml:para>Sends client identity metadata (name, title, version) to app-server. Some flows require&#xD;
+initialization before login, chat, or review operations.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Initialize-IntelligenceX</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to initialize. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Client identifier sent to the app-server (machine-friendly).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Title</maml:name>
+          <maml:description>
+            <maml:para>Client display title sent to the app-server (human-friendly).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Version</maml:name>
+          <maml:description>
+            <maml:para>Client version sent to the app-server for telemetry/capability context.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to initialize. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Client identifier sent to the app-server (machine-friendly).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Title</maml:name>
+        <maml:description>
+          <maml:para>Client display title sent to the app-server (human-friendly).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Version</maml:name>
+        <maml:description>
+          <maml:para>Client version sent to the app-server for telemetry/capability context.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Initialize-IntelligenceX -Name 'Name' -Title 'Value' -Version '1.0.0'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Install-IntelligenceXCopilotCli</command:name>
+      <command:verb>Install</command:verb>
+      <command:noun>IntelligenceXCopilotCli</command:noun>
+      <maml:description>
+        <maml:para>Installs GitHub Copilot CLI using a selected install strategy.</maml:para>
+        <maml:para>Executes the platform-specific installer command and optionally returns command metadata.&#xD;
+Supports WhatIf/Confirm through ShouldProcess.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Installs GitHub Copilot CLI using a selected install strategy.</maml:para>
+      <maml:para>Executes the platform-specific installer command and optionally returns command metadata.&#xD;
+Supports WhatIf/Confirm through ShouldProcess.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Install-IntelligenceXCopilotCli</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Method</maml:name>
+          <maml:description>
+            <maml:para>Install method to use (Auto, Winget, Brew, Apt, etc. depending on platform).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">CopilotCliInstallMethod</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Winget</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Homebrew</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Npm</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Script</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>CopilotCliInstallMethod</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PassThru</maml:name>
+          <maml:description>
+            <maml:para>Returns the resolved install command object after successful execution.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Prerelease</maml:name>
+          <maml:description>
+            <maml:para>Installs a prerelease build when available.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Method</maml:name>
+        <maml:description>
+          <maml:para>Install method to use (Auto, Winget, Brew, Apt, etc. depending on platform).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">CopilotCliInstallMethod</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Winget</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Homebrew</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Npm</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Script</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>CopilotCliInstallMethod</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PassThru</maml:name>
+        <maml:description>
+          <maml:para>Returns the resolved install command object after successful execution.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Prerelease</maml:name>
+        <maml:description>
+          <maml:para>Installs a prerelease build when available.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Copilot.CopilotCliInstallCommand</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Install-IntelligenceXCopilotCli -Method 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-IntelligenceXChat</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>IntelligenceXChat</command:noun>
+      <maml:description>
+        <maml:para>Super-easy chat command that handles connect, init, login, thread, and send.</maml:para>
+        <maml:para>Convenience entry point for quick chat: it connects, logs in (if needed), creates or&#xD;
+reuses a thread, sends input, and returns the resulting turn. Supports streaming output and&#xD;
+a simple DSL for text/image inputs.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Super-easy chat command that handles connect, init, login, thread, and send.</maml:para>
+      <maml:para>Convenience entry point for quick chat: it connects, logs in (if needed), creates or&#xD;
+reuses a thread, sends input, and returns the resulting turn. Supports streaming output and&#xD;
+a simple DSL for text/image inputs.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="Text">
+        <maml:name>Invoke-IntelligenceXChat</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AllowNetwork</maml:name>
+          <maml:description>
+            <maml:para>Allow network access when using a workspace sandbox.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para>API key to use when Login is ApiKey.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApprovalPolicy</maml:name>
+          <maml:description>
+            <maml:para>Approval policy (for example auto).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Arguments</maml:name>
+          <maml:description>
+            <maml:para>Codex app-server arguments.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientName</maml:name>
+          <maml:description>
+            <maml:para>Client name for initialization.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientTitle</maml:name>
+          <maml:description>
+            <maml:para>Client title for initialization.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientVersion</maml:name>
+          <maml:description>
+            <maml:para>Client version for initialization.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DownloadImageUrls</maml:name>
+          <maml:description>
+            <maml:para>Download image URLs when saving images.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Dsl</maml:name>
+          <maml:description>
+            <maml:para>Parse Text as a simple DSL (lines starting with image:, url:, text:).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExecutablePath</maml:name>
+          <maml:description>
+            <maml:para>Codex executable path.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ImageFileNamePrefix</maml:name>
+          <maml:description>
+            <maml:para>Prefix for saved image file names.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ImagePath</maml:name>
+          <maml:description>
+            <maml:para>Image file path to include with the message.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ImageUrl</maml:name>
+          <maml:description>
+            <maml:para>Image URL to include with the message.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Instructions</maml:name>
+          <maml:description>
+            <maml:para>System instructions for the assistant.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Login</maml:name>
+          <maml:description>
+            <maml:para>Login method: ChatGpt, ApiKey, or None.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">ChatGpt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ApiKey</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Model</maml:name>
+          <maml:description>
+            <maml:para>Model identifier. Defaults to the shared OpenAI default model.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NewThread</maml:name>
+          <maml:description>
+            <maml:para>Reset thread before sending.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OpenBrowser</maml:name>
+          <maml:description>
+            <maml:para>Open the login URL in the default browser.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OverwriteImages</maml:name>
+          <maml:description>
+            <maml:para>Overwrite existing files when saving images.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Return raw JSON response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReasoningEffort</maml:name>
+          <maml:description>
+            <maml:para>Reasoning effort level.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReasoningSummary</maml:name>
+          <maml:description>
+            <maml:para>Reasoning summary level.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SaveImagesTo</maml:name>
+          <maml:description>
+            <maml:para>Save image outputs to the specified directory.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Stream</maml:name>
+          <maml:description>
+            <maml:para>Write streaming deltas to the host.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Temperature</maml:name>
+          <maml:description>
+            <maml:para>Sampling temperature.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Text</maml:name>
+          <maml:description>
+            <maml:para>Message text to send.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TextVerbosity</maml:name>
+          <maml:description>
+            <maml:para>Response verbosity level.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WaitSeconds</maml:name>
+          <maml:description>
+            <maml:para>Wait N seconds for streaming output after sending.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WorkingDirectory</maml:name>
+          <maml:description>
+            <maml:para>Working directory for app-server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Workspace</maml:name>
+          <maml:description>
+            <maml:para>Workspace directory for file writes (sets sandbox policy).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Pipeline">
+        <maml:name>Invoke-IntelligenceXChat</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AllowNetwork</maml:name>
+          <maml:description>
+            <maml:para>Allow network access when using a workspace sandbox.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para>API key to use when Login is ApiKey.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApprovalPolicy</maml:name>
+          <maml:description>
+            <maml:para>Approval policy (for example auto).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Arguments</maml:name>
+          <maml:description>
+            <maml:para>Codex app-server arguments.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientName</maml:name>
+          <maml:description>
+            <maml:para>Client name for initialization.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientTitle</maml:name>
+          <maml:description>
+            <maml:para>Client title for initialization.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientVersion</maml:name>
+          <maml:description>
+            <maml:para>Client version for initialization.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DownloadImageUrls</maml:name>
+          <maml:description>
+            <maml:para>Download image URLs when saving images.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Dsl</maml:name>
+          <maml:description>
+            <maml:para>Parse Text as a simple DSL (lines starting with image:, url:, text:).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExecutablePath</maml:name>
+          <maml:description>
+            <maml:para>Codex executable path.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ImageFileNamePrefix</maml:name>
+          <maml:description>
+            <maml:para>Prefix for saved image file names.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ImagePath</maml:name>
+          <maml:description>
+            <maml:para>Image file path to include with the message.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ImageUrl</maml:name>
+          <maml:description>
+            <maml:para>Image URL to include with the message.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>InputObject</maml:name>
+          <maml:description>
+            <maml:para>Pipeline input for DSL lines (text, image, url).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Instructions</maml:name>
+          <maml:description>
+            <maml:para>System instructions for the assistant.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Login</maml:name>
+          <maml:description>
+            <maml:para>Login method: ChatGpt, ApiKey, or None.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">ChatGpt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ApiKey</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Model</maml:name>
+          <maml:description>
+            <maml:para>Model identifier. Defaults to the shared OpenAI default model.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NewThread</maml:name>
+          <maml:description>
+            <maml:para>Reset thread before sending.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OpenBrowser</maml:name>
+          <maml:description>
+            <maml:para>Open the login URL in the default browser.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OverwriteImages</maml:name>
+          <maml:description>
+            <maml:para>Overwrite existing files when saving images.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Return raw JSON response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReasoningEffort</maml:name>
+          <maml:description>
+            <maml:para>Reasoning effort level.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReasoningSummary</maml:name>
+          <maml:description>
+            <maml:para>Reasoning summary level.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SaveImagesTo</maml:name>
+          <maml:description>
+            <maml:para>Save image outputs to the specified directory.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Stream</maml:name>
+          <maml:description>
+            <maml:para>Write streaming deltas to the host.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Temperature</maml:name>
+          <maml:description>
+            <maml:para>Sampling temperature.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TextVerbosity</maml:name>
+          <maml:description>
+            <maml:para>Response verbosity level.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WaitSeconds</maml:name>
+          <maml:description>
+            <maml:para>Wait N seconds for streaming output after sending.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WorkingDirectory</maml:name>
+          <maml:description>
+            <maml:para>Working directory for app-server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Workspace</maml:name>
+          <maml:description>
+            <maml:para>Workspace directory for file writes (sets sandbox policy).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AllowNetwork</maml:name>
+        <maml:description>
+          <maml:para>Allow network access when using a workspace sandbox.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ApiKey</maml:name>
+        <maml:description>
+          <maml:para>API key to use when Login is ApiKey.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ApprovalPolicy</maml:name>
+        <maml:description>
+          <maml:para>Approval policy (for example auto).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Arguments</maml:name>
+        <maml:description>
+          <maml:para>Codex app-server arguments.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ClientName</maml:name>
+        <maml:description>
+          <maml:para>Client name for initialization.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ClientTitle</maml:name>
+        <maml:description>
+          <maml:para>Client title for initialization.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ClientVersion</maml:name>
+        <maml:description>
+          <maml:para>Client version for initialization.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DownloadImageUrls</maml:name>
+        <maml:description>
+          <maml:para>Download image URLs when saving images.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Dsl</maml:name>
+        <maml:description>
+          <maml:para>Parse Text as a simple DSL (lines starting with image:, url:, text:).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExecutablePath</maml:name>
+        <maml:description>
+          <maml:para>Codex executable path.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ImageFileNamePrefix</maml:name>
+        <maml:description>
+          <maml:para>Prefix for saved image file names.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ImagePath</maml:name>
+        <maml:description>
+          <maml:para>Image file path to include with the message.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ImageUrl</maml:name>
+        <maml:description>
+          <maml:para>Image URL to include with the message.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>InputObject</maml:name>
+        <maml:description>
+          <maml:para>Pipeline input for DSL lines (text, image, url).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Instructions</maml:name>
+        <maml:description>
+          <maml:para>System instructions for the assistant.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Login</maml:name>
+        <maml:description>
+          <maml:para>Login method: ChatGpt, ApiKey, or None.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">ChatGpt</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ApiKey</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Model</maml:name>
+        <maml:description>
+          <maml:para>Model identifier. Defaults to the shared OpenAI default model.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NewThread</maml:name>
+        <maml:description>
+          <maml:para>Reset thread before sending.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OpenBrowser</maml:name>
+        <maml:description>
+          <maml:para>Open the login URL in the default browser.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OverwriteImages</maml:name>
+        <maml:description>
+          <maml:para>Overwrite existing files when saving images.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Return raw JSON response.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ReasoningEffort</maml:name>
+        <maml:description>
+          <maml:para>Reasoning effort level.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ReasoningSummary</maml:name>
+        <maml:description>
+          <maml:para>Reasoning summary level.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SaveImagesTo</maml:name>
+        <maml:description>
+          <maml:para>Save image outputs to the specified directory.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Stream</maml:name>
+        <maml:description>
+          <maml:para>Write streaming deltas to the host.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Temperature</maml:name>
+        <maml:description>
+          <maml:para>Sampling temperature.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Text</maml:name>
+        <maml:description>
+          <maml:para>Message text to send.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TextVerbosity</maml:name>
+        <maml:description>
+          <maml:para>Response verbosity level.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WaitSeconds</maml:name>
+        <maml:description>
+          <maml:para>Wait N seconds for streaming output after sending.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WorkingDirectory</maml:name>
+        <maml:description>
+          <maml:para>Working directory for app-server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Workspace</maml:name>
+        <maml:description>
+          <maml:para>Workspace directory for file writes (sets sandbox policy).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.TurnInfo</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Invoke-IntelligenceXChat -ExecutablePath 'C:\Path'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-IntelligenceXCommand</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>IntelligenceXCommand</command:noun>
+      <maml:description>
+        <maml:para>Executes a command through the app-server.</maml:para>
+        <maml:para>Runs a process via the app-server with optional sandbox settings and timeout.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Executes a command through the app-server.</maml:para>
+      <maml:para>Runs a process via the app-server with optional sandbox settings and timeout.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-IntelligenceXCommand</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Command</maml:name>
+          <maml:description>
+            <maml:para>Command and arguments.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NetworkAccess</maml:name>
+          <maml:description>
+            <maml:para>Enable network access for sandboxed runs.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Return raw JSON response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SandboxType</maml:name>
+          <maml:description>
+            <maml:para>Sandbox type for execution.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeoutMs</maml:name>
+          <maml:description>
+            <maml:para>Command timeout in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WorkingDirectory</maml:name>
+          <maml:description>
+            <maml:para>Working directory for the command.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WritableRoot</maml:name>
+          <maml:description>
+            <maml:para>Writable root paths for sandboxed runs.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Command</maml:name>
+        <maml:description>
+          <maml:para>Command and arguments.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NetworkAccess</maml:name>
+        <maml:description>
+          <maml:para>Enable network access for sandboxed runs.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Return raw JSON response.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SandboxType</maml:name>
+        <maml:description>
+          <maml:para>Sandbox type for execution.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TimeoutMs</maml:name>
+        <maml:description>
+          <maml:para>Command timeout in milliseconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WorkingDirectory</maml:name>
+        <maml:description>
+          <maml:para>Working directory for the command.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WritableRoot</maml:name>
+        <maml:description>
+          <maml:para>Writable root paths for sandboxed runs.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.CommandExecResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Invoke-IntelligenceXCommand -Command @('Value')</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-IntelligenceXMcpServerConfigReload</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>IntelligenceXMcpServerConfigReload</command:noun>
+      <maml:description>
+        <maml:para>Reloads MCP server configuration in the running app-server.</maml:para>
+        <maml:para>Refreshes MCP configuration after file changes so newly added servers, tools, and auth settings&#xD;
+are visible without restarting the app-server process.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Reloads MCP server configuration in the running app-server.</maml:para>
+      <maml:para>Refreshes MCP configuration after file changes so newly added servers, tools, and auth settings&#xD;
+are visible without restarting the app-server process.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-IntelligenceXMcpServerConfigReload</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>App-server client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>App-server client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Invoke-IntelligenceXMcpServerConfigReload -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-IntelligenceXRpc</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>IntelligenceXRpc</command:noun>
+      <maml:description>
+        <maml:para>Invokes a raw JSON-RPC method directly against app-server.</maml:para>
+        <maml:para>Low-level escape hatch for advanced scenarios not covered by high-level cmdlets.&#xD;
+Parameters are converted from PowerShell objects/hashtables to JSON payloads.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Invokes a raw JSON-RPC method directly against app-server.</maml:para>
+      <maml:para>Low-level escape hatch for advanced scenarios not covered by high-level cmdlets.&#xD;
+Parameters are converted from PowerShell objects/hashtables to JSON payloads.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-IntelligenceXRpc</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Method</maml:name>
+          <maml:description>
+            <maml:para>JSON-RPC method name (for example thread/list).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Params</maml:name>
+          <maml:description>
+            <maml:para>Optional method parameters supplied as a PowerShell object/hashtable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Method</maml:name>
+        <maml:description>
+          <maml:para>JSON-RPC method name (for example thread/list).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Params</maml:name>
+        <maml:description>
+          <maml:para>Optional method parameters supplied as a PowerShell object/hashtable.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Invoke-IntelligenceXRpc -Method 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-IntelligenceXThreadFork</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>IntelligenceXThreadFork</command:noun>
+      <maml:description>
+        <maml:para>Creates a new thread fork from an existing thread's history.</maml:para>
+        <maml:para>Use this when you want to branch a conversation without mutating the original thread.&#xD;
+The fork inherits prior context and gets a new thread id.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a new thread fork from an existing thread's history.</maml:para>
+      <maml:para>Use this when you want to branch a conversation without mutating the original thread.&#xD;
+The fork inherits prior context and gets a new thread id.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-IntelligenceXThreadFork</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of typed thread info.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ThreadId</maml:name>
+          <maml:description>
+            <maml:para>Identifier of the source thread to fork.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of typed thread info.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ThreadId</maml:name>
+        <maml:description>
+          <maml:para>Identifier of the source thread to fork.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.ThreadInfo</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-IntelligenceXThreadFork -ThreadId 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Request-IntelligenceXUserInput</command:name>
+      <command:verb>Request</command:verb>
+      <command:noun>IntelligenceXUserInput</command:noun>
+      <maml:description>
+        <maml:para>Requests user input through the app-server.</maml:para>
+        <maml:para>Prompts for one to three questions and returns collected answers in order.&#xD;
+Useful for interactive script checkpoints that need explicit user confirmation or values.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Requests user input through the app-server.</maml:para>
+      <maml:para>Prompts for one to three questions and returns collected answers in order.&#xD;
+Useful for interactive script checkpoints that need explicit user confirmation or values.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Request-IntelligenceXUserInput</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Questions</maml:name>
+          <maml:description>
+            <maml:para>Questions to ask (minimum 1, maximum 3).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of typed response data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Questions</maml:name>
+        <maml:description>
+          <maml:para>Questions to ask (minimum 1, maximum 3).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of typed response data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.UserInputResponse</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Request-IntelligenceXUserInput -Questions @('Value')</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Restore-IntelligenceXThread</command:name>
+      <command:verb>Restore</command:verb>
+      <command:noun>IntelligenceXThread</command:noun>
+      <maml:description>
+        <maml:para>Rolls back the last N turns from a thread.</maml:para>
+        <maml:para>Removes recent turns from a thread so you can re-run, correct, or branch from an earlier&#xD;
+conversation state.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Rolls back the last N turns from a thread.</maml:para>
+      <maml:para>Removes recent turns from a thread so you can re-run, correct, or branch from an earlier&#xD;
+conversation state.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Restore-IntelligenceXThread</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of typed thread info.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ThreadId</maml:name>
+          <maml:description>
+            <maml:para>Identifier of the thread to modify.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Turns</maml:name>
+          <maml:description>
+            <maml:para>Number of most recent turns to remove.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of typed thread info.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ThreadId</maml:name>
+        <maml:description>
+          <maml:para>Identifier of the thread to modify.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Turns</maml:name>
+        <maml:description>
+          <maml:para>Number of most recent turns to remove.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.ThreadInfo</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Restore-IntelligenceXThread -ThreadId 'Value' -Turns 1</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Resume-IntelligenceXThread</command:name>
+      <command:verb>Resume</command:verb>
+      <command:noun>IntelligenceXThread</command:noun>
+      <maml:description>
+        <maml:para>Resumes an existing thread so new messages can be sent to it.</maml:para>
+        <maml:para>Loads thread context back into the active app-server session and returns thread metadata.&#xD;
+Useful after reconnecting or when switching between multiple threads.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Resumes an existing thread so new messages can be sent to it.</maml:para>
+      <maml:para>Loads thread context back into the active app-server session and returns thread metadata.&#xD;
+Useful after reconnecting or when switching between multiple threads.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Resume-IntelligenceXThread</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of typed thread info.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ThreadId</maml:name>
+          <maml:description>
+            <maml:para>Identifier of the thread to resume.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of typed thread info.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ThreadId</maml:name>
+        <maml:description>
+          <maml:para>Identifier of the thread to resume.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.ThreadInfo</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Resume-IntelligenceXThread -ThreadId 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Send-IntelligenceXFeedback</command:name>
+      <command:verb>Send</command:verb>
+      <command:noun>IntelligenceXFeedback</command:noun>
+      <maml:description>
+        <maml:para>Uploads textual feedback to the app-server feedback endpoint.</maml:para>
+        <maml:para>Use this cmdlet to send reproduction notes, quality feedback, or analyzer observations&#xD;
+collected during reviews and local runs.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Uploads textual feedback to the app-server feedback endpoint.</maml:para>
+      <maml:para>Use this cmdlet to send reproduction notes, quality feedback, or analyzer observations&#xD;
+collected during reviews and local runs.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Send-IntelligenceXFeedback</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Content</maml:name>
+          <maml:description>
+            <maml:para>Feedback text content to upload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Content</maml:name>
+        <maml:description>
+          <maml:para>Feedback text content to upload.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Send-IntelligenceXFeedback -Content 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Send-IntelligenceXMessage</command:name>
+      <command:verb>Send</command:verb>
+      <command:noun>IntelligenceXMessage</command:noun>
+      <maml:description>
+        <maml:para>Sends a message to a thread and starts a turn.</maml:para>
+        <maml:para>Queues a user message on an existing thread. Returns the created turn so you can&#xD;
+poll for output with Get-IntelligenceXTurnOutput.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Sends a message to a thread and starts a turn.</maml:para>
+      <maml:para>Queues a user message on an existing thread. Returns the created turn so you can&#xD;
+poll for output with Get-IntelligenceXTurnOutput.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Send-IntelligenceXMessage</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApprovalPolicy</maml:name>
+          <maml:description>
+            <maml:para>Approval policy name to use.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CurrentDirectory</maml:name>
+          <maml:description>
+            <maml:para>Working directory to pass to the app-server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Model</maml:name>
+          <maml:description>
+            <maml:para>Optional model override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NetworkAccess</maml:name>
+          <maml:description>
+            <maml:para>Enable network access for sandboxed runs.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Return raw JSON response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SandboxType</maml:name>
+          <maml:description>
+            <maml:para>Sandbox type (for example 'workspace' or 'danger-full-access').</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Text</maml:name>
+          <maml:description>
+            <maml:para>Message text to send.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ThreadId</maml:name>
+          <maml:description>
+            <maml:para>Thread identifier to send the message to.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WritableRoot</maml:name>
+          <maml:description>
+            <maml:para>Writable root paths for sandboxed runs.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ApprovalPolicy</maml:name>
+        <maml:description>
+          <maml:para>Approval policy name to use.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CurrentDirectory</maml:name>
+        <maml:description>
+          <maml:para>Working directory to pass to the app-server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Model</maml:name>
+        <maml:description>
+          <maml:para>Optional model override.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NetworkAccess</maml:name>
+        <maml:description>
+          <maml:para>Enable network access for sandboxed runs.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Return raw JSON response.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SandboxType</maml:name>
+        <maml:description>
+          <maml:para>Sandbox type (for example 'workspace' or 'danger-full-access').</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Text</maml:name>
+        <maml:description>
+          <maml:para>Message text to send.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ThreadId</maml:name>
+        <maml:description>
+          <maml:para>Thread identifier to send the message to.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WritableRoot</maml:name>
+        <maml:description>
+          <maml:para>Writable root paths for sandboxed runs.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.TurnInfo</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Send-IntelligenceXMessage -ThreadId 'Value' -Text 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Set-IntelligenceXConfigBatch</command:name>
+      <command:verb>Set</command:verb>
+      <command:noun>IntelligenceXConfigBatch</command:noun>
+      <maml:description>
+        <maml:para>Writes multiple app-server configuration values in one request.</maml:para>
+        <maml:para>Sends a batch of key/value updates. This is useful for related settings you want to apply together.&#xD;
+Hashtable values are converted to JSON before sending.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Writes multiple app-server configuration values in one request.</maml:para>
+      <maml:para>Sends a batch of key/value updates. This is useful for related settings you want to apply together.&#xD;
+Hashtable values are converted to JSON before sending.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Set-IntelligenceXConfigBatch</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>App-server client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Values</maml:name>
+          <maml:description>
+            <maml:para>Hashtable of configuration key/value pairs to write.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>App-server client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Values</maml:name>
+        <maml:description>
+          <maml:para>Hashtable of configuration key/value pairs to write.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Set-IntelligenceXConfigBatch -Values @{}</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Set-IntelligenceXConfigValue</command:name>
+      <command:verb>Set</command:verb>
+      <command:noun>IntelligenceXConfigValue</command:noun>
+      <maml:description>
+        <maml:para>Writes a single app-server configuration value.</maml:para>
+        <maml:para>Updates one config key on the app-server. PowerShell values are converted to JSON before sending.&#xD;
+Use Get-IntelligenceXConfig to verify the effective result and layer origin.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Writes a single app-server configuration value.</maml:para>
+      <maml:para>Updates one config key on the app-server. PowerShell values are converted to JSON before sending.&#xD;
+Use Get-IntelligenceXConfig to verify the effective result and layer origin.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Set-IntelligenceXConfigValue</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>App-server client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Key</maml:name>
+          <maml:description>
+            <maml:para>Configuration key to write.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Value</maml:name>
+          <maml:description>
+            <maml:para>Configuration value. Converted to JSON (string, number, boolean, array, object).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>App-server client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Key</maml:name>
+        <maml:description>
+          <maml:para>Configuration key to write.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Value</maml:name>
+        <maml:description>
+          <maml:para>Configuration value. Converted to JSON (string, number, boolean, array, object).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Set-IntelligenceXConfigValue -Key 'Value' -Value 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Set-IntelligenceXSkill</command:name>
+      <command:verb>Set</command:verb>
+      <command:noun>IntelligenceXSkill</command:noun>
+      <maml:description>
+        <maml:para>Enables or disables a skill entry in app-server skill configuration.</maml:para>
+        <maml:para>Updates the persisted skill config for a specific skill path so future tool runs include&#xD;
+or exclude that skill.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Enables or disables a skill entry in app-server skill configuration.</maml:para>
+      <maml:para>Updates the persisted skill config for a specific skill path so future tool runs include&#xD;
+or exclude that skill.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Set-IntelligenceXSkill</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Enabled</maml:name>
+          <maml:description>
+            <maml:para>Set to $true to enable, $false to disable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Path</maml:name>
+          <maml:description>
+            <maml:para>Path to the skill configuration entry.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Enabled</maml:name>
+        <maml:description>
+          <maml:para>Set to $true to enable, $false to disable.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+        <dev:type>
+          <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Path</maml:name>
+        <maml:description>
+          <maml:para>Path to the skill configuration entry.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Set-IntelligenceXSkill -Path 'C:\Path' -Enabled $true</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Start-IntelligenceXApiKeyLogin</command:name>
+      <command:verb>Start</command:verb>
+      <command:noun>IntelligenceXApiKeyLogin</command:noun>
+      <maml:description>
+        <maml:para>Authenticates the active client with an OpenAI API key.</maml:para>
+        <maml:para>Stores the API key in the active client for API-based requests. Use only if ChatGPT OAuth&#xD;
+is not desired or available.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Authenticates the active client with an OpenAI API key.</maml:para>
+      <maml:para>Stores the API key in the active client for API-based requests. Use only if ChatGPT OAuth&#xD;
+is not desired or available.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Start-IntelligenceXApiKeyLogin</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para>OpenAI API key used for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ApiKey</maml:name>
+        <maml:description>
+          <maml:para>OpenAI API key used for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Start-IntelligenceXApiKeyLogin -ApiKey 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Start-IntelligenceXChatGptLogin</command:name>
+      <command:verb>Start</command:verb>
+      <command:noun>IntelligenceXChatGptLogin</command:noun>
+      <maml:description>
+        <maml:para>Starts the ChatGPT login flow and returns the authorization URL.</maml:para>
+        <maml:para>Opens the browser to complete the ChatGPT OAuth flow. Pair with Wait-IntelligenceXLogin&#xD;
+to poll for completion and store the resulting credentials.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Starts the ChatGPT login flow and returns the authorization URL.</maml:para>
+      <maml:para>Opens the browser to complete the ChatGPT OAuth flow. Pair with Wait-IntelligenceXLogin&#xD;
+to poll for completion and store the resulting credentials.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Start-IntelligenceXChatGptLogin</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of typed login data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of typed login data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.ChatGptLoginStart</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Start-IntelligenceXChatGptLogin -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Start-IntelligenceXMcpOAuthLogin</command:name>
+      <command:verb>Start</command:verb>
+      <command:noun>IntelligenceXMcpOAuthLogin</command:noun>
+      <maml:description>
+        <maml:para>Starts an MCP OAuth login flow and returns the browser authorization URL.</maml:para>
+        <maml:para>Use this cmdlet when an MCP server reports OAuth auth status. The response includes a&#xD;
+LoginId and AuthUrl you can open in a browser.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Starts an MCP OAuth login flow and returns the browser authorization URL.</maml:para>
+      <maml:para>Use this cmdlet when an MCP server reports OAuth auth status. The response includes a&#xD;
+LoginId and AuthUrl you can open in a browser.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Start-IntelligenceXMcpOAuthLogin</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>App-server client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Returns the raw JSON-RPC payload instead of a typed model.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ServerId</maml:name>
+          <maml:description>
+            <maml:para>MCP server identifier to start login for.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ServerName</maml:name>
+          <maml:description>
+            <maml:para>MCP server name to start login for.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>App-server client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Returns the raw JSON-RPC payload instead of a typed model.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ServerId</maml:name>
+        <maml:description>
+          <maml:para>MCP server identifier to start login for.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ServerName</maml:name>
+        <maml:description>
+          <maml:para>MCP server name to start login for.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.McpOauthLoginStart</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Start-IntelligenceXMcpOAuthLogin -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Start-IntelligenceXReview</command:name>
+      <command:verb>Start</command:verb>
+      <command:noun>IntelligenceXReview</command:noun>
+      <maml:description>
+        <maml:para>Starts a review flow for a thread.</maml:para>
+        <maml:para>Triggers the app-server review pipeline for a thread and target. Use TargetType to&#xD;
+choose what to review (uncommitted changes, a branch, a commit, or custom text).</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Starts a review flow for a thread.</maml:para>
+      <maml:para>Triggers the app-server review pipeline for a thread and target. Use TargetType to&#xD;
+choose what to review (uncommitted changes, a branch, a commit, or custom text).</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Start-IntelligenceXReview</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Delivery</maml:name>
+          <maml:description>
+            <maml:para>Delivery mode (for example immediate).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Return raw JSON response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TargetType</maml:name>
+          <maml:description>
+            <maml:para>Target type: uncommittedChanges, baseBranch, commit, custom.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TargetValue</maml:name>
+          <maml:description>
+            <maml:para>Target value (branch name, commit SHA, or custom text).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ThreadId</maml:name>
+          <maml:description>
+            <maml:para>Thread identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Delivery</maml:name>
+        <maml:description>
+          <maml:para>Delivery mode (for example immediate).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Return raw JSON response.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TargetType</maml:name>
+        <maml:description>
+          <maml:para>Target type: uncommittedChanges, baseBranch, commit, custom.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TargetValue</maml:name>
+        <maml:description>
+          <maml:para>Target value (branch name, commit SHA, or custom text).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ThreadId</maml:name>
+        <maml:description>
+          <maml:para>Thread identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.ReviewStartResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Start-IntelligenceXReview -ThreadId 'Value' -Delivery 'Value' -TargetType 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Start-IntelligenceXThread</command:name>
+      <command:verb>Start</command:verb>
+      <command:noun>IntelligenceXThread</command:noun>
+      <maml:description>
+        <maml:para>Creates a new conversation thread.</maml:para>
+        <maml:para>Starts a fresh thread on the app-server with a selected model and optional execution&#xD;
+settings like sandbox and approval policy.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a new conversation thread.</maml:para>
+      <maml:para>Starts a fresh thread on the app-server with a selected model and optional execution&#xD;
+settings like sandbox and approval policy.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Start-IntelligenceXThread</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApprovalPolicy</maml:name>
+          <maml:description>
+            <maml:para>Approval policy name to use.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CurrentDirectory</maml:name>
+          <maml:description>
+            <maml:para>Working directory to pass to the app-server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Model</maml:name>
+          <maml:description>
+            <maml:para>Model identifier to use (for example gpt-5.4).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Return raw JSON response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Sandbox</maml:name>
+          <maml:description>
+            <maml:para>Sandbox mode to use (for example 'workspace' or 'danger-full-access').</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ApprovalPolicy</maml:name>
+        <maml:description>
+          <maml:para>Approval policy name to use.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CurrentDirectory</maml:name>
+        <maml:description>
+          <maml:para>Working directory to pass to the app-server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Model</maml:name>
+        <maml:description>
+          <maml:para>Model identifier to use (for example gpt-5.4).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Return raw JSON response.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Sandbox</maml:name>
+        <maml:description>
+          <maml:para>Sandbox mode to use (for example 'workspace' or 'danger-full-access').</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.AppServer.Models.ThreadInfo</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.Json.JsonValue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Start-IntelligenceXThread -Model 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Stop-IntelligenceXTurn</command:name>
+      <command:verb>Stop</command:verb>
+      <command:noun>IntelligenceXTurn</command:noun>
+      <maml:description>
+        <maml:para>Interrupts a running turn for a thread.</maml:para>
+        <maml:para>Requests cancellation for an in-progress turn. Use this for long-running responses,&#xD;
+accidental prompts, or when you need to restart execution with different instructions.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Interrupts a running turn for a thread.</maml:para>
+      <maml:para>Requests cancellation for an in-progress turn. Use this for long-running responses,&#xD;
+accidental prompts, or when you need to restart execution with different instructions.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Stop-IntelligenceXTurn</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ThreadId</maml:name>
+          <maml:description>
+            <maml:para>Identifier of the thread that owns the running turn.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TurnId</maml:name>
+          <maml:description>
+            <maml:para>Identifier of the turn to interrupt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ThreadId</maml:name>
+        <maml:description>
+          <maml:para>Identifier of the thread that owns the running turn.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TurnId</maml:name>
+        <maml:description>
+          <maml:para>Identifier of the turn to interrupt.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Stop-IntelligenceXTurn -ThreadId 'Value' -TurnId 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Wait-IntelligenceXLogin</command:name>
+      <command:verb>Wait</command:verb>
+      <command:noun>IntelligenceXLogin</command:noun>
+      <maml:description>
+        <maml:para>Waits for the login flow to complete.</maml:para>
+        <maml:para>Polls the app-server for login completion. Use after Start-IntelligenceXChatGptLogin.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Waits for the login flow to complete.</maml:para>
+      <maml:para>Polls the app-server for login completion. Use after Start-IntelligenceXChatGptLogin.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Wait-IntelligenceXLogin</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LoginId</maml:name>
+          <maml:description>
+            <maml:para>Optional login identifier to wait for.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeoutSeconds</maml:name>
+          <maml:description>
+            <maml:para>Maximum wait time in seconds before cancellation.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>LoginId</maml:name>
+        <maml:description>
+          <maml:para>Optional login identifier to wait for.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TimeoutSeconds</maml:name>
+        <maml:description>
+          <maml:para>Maximum wait time in seconds before cancellation.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Wait-IntelligenceXLogin -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Watch-IntelligenceXEvent</command:name>
+      <command:verb>Watch</command:verb>
+      <command:noun>IntelligenceXEvent</command:noun>
+      <maml:description>
+        <maml:para>Watches JSON-RPC notifications from the app-server.</maml:para>
+        <maml:para>Streams notification events until cancelled. Use method filters to observe specific&#xD;
+protocol events such as turn progress, login completion, or status changes.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Watches JSON-RPC notifications from the app-server.</maml:para>
+      <maml:para>Streams notification events until cancelled. Use method filters to observe specific&#xD;
+protocol events such as turn progress, login completion, or status changes.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Watch-IntelligenceXEvent</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Client</maml:name>
+          <maml:description>
+            <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+          <dev:type>
+            <maml:name>IntelligenceXClient</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Method</maml:name>
+          <maml:description>
+            <maml:para>Optional JSON-RPC method filter list. Matching is case-insensitive.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Client</maml:name>
+        <maml:description>
+          <maml:para>Client instance to use. Defaults to the active client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IntelligenceXClient</command:parameterValue>
+        <dev:type>
+          <maml:name>IntelligenceXClient</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Method</maml:name>
+        <maml:description>
+          <maml:para>Optional JSON-RPC method filter list. Matching is case-insensitive.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>IntelligenceX.OpenAI.IntelligenceXClient</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>IntelligenceX.PowerShell.RpcNotificationRecord</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>Represents a JSON-RPC notification record for PowerShell consumers.</maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Watch-IntelligenceXEvent -Client 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+</helpItems>


### PR DESCRIPTION
## Summary

- remove the redundant XmlDoc2CmdletDoc package and publish-copy target
- generate Markdown and external MAML through PSPublishModule/PowerForge
- keep the compiler XML file as the native documentation source

## Validation

- Release target-framework builds completed with zero warnings and errors
- PowerForge verified 38 Markdown command pages against 38 MAML commands
- the packed module contains its external help file
- repeated documentation generation is idempotent after repository line-ending normalization